### PR TITLE
Specify Anthropic key with `x-api-key` header

### DIFF
--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -138,8 +138,8 @@ impl AnthropicClient {
 
         // Authentication header
         if let Some(ref api_key) = self.config.api_key {
-            if let Ok(auth_header) = format!("Bearer {}", api_key).parse() {
-                headers.insert("Authorization", auth_header);
+            if let Ok(api_key_header) = api_key.parse() {
+                headers.insert("x-api-key", api_key_header);
             }
         }
 


### PR DESCRIPTION
This PR represents the first half of #2.