### PR TITLE
[LRS-OPT-FMT] chore: resolve pre-existing rustfmt drift in router strategy

### DIFF
--- a/src/core/router/strategy_impl.rs
+++ b/src/core/router/strategy_impl.rs
@@ -84,9 +84,7 @@ pub fn weighted_random_from_context<'id>(
 }
 
 /// Select deployment with fewest active requests (LeastBusy) using snapshot contexts.
-pub fn least_busy_from_context<'id>(
-    contexts: &[RoutingContext<'id>],
-) -> Option<&'id DeploymentId> {
+pub fn least_busy_from_context<'id>(contexts: &[RoutingContext<'id>]) -> Option<&'id DeploymentId> {
     if contexts.is_empty() {
         return None;
     }


### PR DESCRIPTION
## Summary
- apply rustfmt normalization in `src/core/router/strategy_impl.rs`
- remove repository-wide formatting drift that blocks `cargo fmt --all -- --check`

## Scope
- file changed:
  - `src/core/router/strategy_impl.rs`

## Validation
- `cargo fmt --all -- --check` ✅

## Why this PR
- unblocks FUT-57 and other branches whose lint gate fails due this pre-existing format-only diff
