### PR TITLE
[LRS-OPT-10] quality(test): remove tautological assertions and add simple guard script

### DIFF
--- a/scripts/guards/check_tautological_assertions.sh
+++ b/scripts/guards/check_tautological_assertions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+GUARDED_PATHS=(
+  "src/server/tests.rs"
+  "tests/integration/router_tests.rs"
+  "src/core/cost/providers/anthropic.rs"
+)
+
+search_matches() {
+  local pattern="$1"
+  if command -v rg >/dev/null 2>&1; then
+    rg -n --no-heading --color never "$pattern" "${GUARDED_PATHS[@]}" || true
+    return
+  fi
+
+  if command -v grep >/dev/null 2>&1; then
+    grep -n -E -- "$pattern" "${GUARDED_PATHS[@]}" || true
+    return
+  fi
+
+  echo "Tautology guard failed: neither 'rg' nor 'grep' is available in PATH." >&2
+  exit 1
+}
+
+assert_no_match() {
+  local title="$1"
+  local pattern="$2"
+  local matches
+
+  matches="$(search_matches "$pattern")"
+  if [[ -n "${matches//[[:space:]]/}" ]]; then
+    echo "Tautology guard failed: ${title}"
+    printf '%s\n' "$matches"
+    exit 1
+  fi
+}
+
+assert_no_match \
+  "found assert!(x.is_some() || x.is_none()) pattern" \
+  'assert![[:space:]]*\([[:space:]]*[^)]*\.is_some\(\)[[:space:]]*\|\|[[:space:]]*[^)]*\.is_none\(\)[[:space:]]*\)'
+
+assert_no_match \
+  "found assert!(x.is_ok() || x.is_err()) pattern" \
+  'assert![[:space:]]*\([[:space:]]*[^)]*\.is_ok\(\)[[:space:]]*\|\|[[:space:]]*[^)]*\.is_err\(\)[[:space:]]*\)'
+
+echo "Tautological assertion guard passed."

--- a/src/core/cost/providers/anthropic.rs
+++ b/src/core/cost/providers/anthropic.rs
@@ -113,9 +113,9 @@ mod tests {
         let usage = UsageTokens::new(1000, 500);
         let result = cost_per_token("claude-3-opus-20240229", &usage);
 
-        // Should return Ok for known Anthropic model
-        assert!(result.is_ok() || result.is_err());
-        // We don't test exact values as they may change
+        let (input_cost, output_cost) = result.expect("known Anthropic model should be priced");
+        assert!(input_cost > 0.0);
+        assert!(output_cost > 0.0);
     }
 
     #[test]
@@ -123,7 +123,9 @@ mod tests {
         let usage = UsageTokens::new(1000, 500);
         let result = cost_per_token("claude-3-sonnet-20240229", &usage);
 
-        assert!(result.is_ok() || result.is_err());
+        let (input_cost, output_cost) = result.expect("known Anthropic model should be priced");
+        assert!(input_cost > 0.0);
+        assert!(output_cost > 0.0);
     }
 
     #[test]
@@ -131,7 +133,9 @@ mod tests {
         let usage = UsageTokens::new(1000, 500);
         let result = cost_per_token("claude-3-haiku-20240307", &usage);
 
-        assert!(result.is_ok() || result.is_err());
+        let (input_cost, output_cost) = result.expect("known Anthropic model should be priced");
+        assert!(input_cost > 0.0);
+        assert!(output_cost > 0.0);
     }
 
     #[test]
@@ -318,22 +322,24 @@ mod tests {
     #[test]
     fn test_anthropic_cost_with_prefix() {
         // Test model with anthropic/ prefix
-        let result = calculate_anthropic_cost("anthropic/claude-3-opus-20240229", 1000, 500);
-        // May or may not work depending on implementation
-        assert!(result.is_some() || result.is_none());
+        let prefixed = calculate_anthropic_cost("anthropic/claude-3-opus-20240229", 1000, 500);
+        let canonical = calculate_anthropic_cost("claude-3-opus-20240229", 1000, 500);
+
+        assert_eq!(prefixed, canonical);
+        assert!(prefixed.is_some());
     }
 
     #[test]
     fn test_anthropic_cost_claude_2() {
         let result = calculate_anthropic_cost("claude-2.1", 1000, 500);
-        // Should work if model is in pricing database
-        assert!(result.is_some() || result.is_none());
+        let cost = result.expect("claude-2.1 should have anthropic pricing");
+        assert!(cost > 0.0);
     }
 
     #[test]
     fn test_anthropic_cost_claude_instant() {
         let result = calculate_anthropic_cost("claude-instant-1.2", 1000, 500);
-        // Should work if model is in pricing database
-        assert!(result.is_some() || result.is_none());
+        let cost = result.expect("claude-instant-1.2 should have anthropic pricing");
+        assert!(cost > 0.0);
     }
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3,24 +3,22 @@
 //! This module contains all tests for the server components.
 
 #[cfg(test)]
-use crate::server::HttpServer;
 use crate::server::builder::ServerBuilder;
 use crate::server::types::ServerRequestMetrics;
+use crate::utils::error::gateway_error::GatewayError;
 
-#[test]
-fn test_server_builder() {
-    let _builder = ServerBuilder::new();
-    // ServerBuilder exists and can be instantiated
-}
+#[tokio::test]
+async fn test_server_builder_requires_config() {
+    let result = ServerBuilder::new().build().await;
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("builder without configuration should fail"),
+    };
 
-#[test]
-fn test_app_state_creation() {
-    // Basic test to ensure module compiles
-    // HttpServer requires config, so we just test that the type exists
-    assert_eq!(
-        std::mem::size_of::<HttpServer>(),
-        std::mem::size_of::<HttpServer>()
-    );
+    match error {
+        GatewayError::Config(message) => assert_eq!(message, "Configuration is required"),
+        other => panic!("expected config error, got: {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace tautological assertions in scoped tests with behavior assertions.
- Add a lightweight grep-based guard script to prevent tautological test assertions from reappearing.

## Scope / Path Mapping
- Requested scope file `tests/integration/router_tests.rs` exists, but audit reference `tests/integration/router_tests.rs:442` is stale (current file is 92 lines and already has no tautological assertion).
- Requested planning doc `docs/plan/symphony-first-batch-issues-2026-03-06.md` is not present in this repo snapshot; used `docs/refactor/03-testing.md` as the source of known tautology locations.

## Changes
- `src/server/tests.rs`
  - Replaced self-compare tautology with a behavior check asserting `ServerBuilder::build()` without config returns `GatewayError::Config("Configuration is required")`.
- `src/core/cost/providers/anthropic.rs`
  - Replaced tautological assertions (`is_some || is_none`, `is_ok || is_err`) with behavior assertions:
    - known models must resolve to priced positive costs
    - prefixed model result must match canonical model result
- `scripts/guards/check_tautological_assertions.sh`
  - Added guard for tautological assertion patterns in scoped files:
    - `assert!(x.is_some() || x.is_none())`
    - `assert!(x.is_ok() || x.is_err())`

## Acceptance Criteria Mapping
1. Replace always-true assertions with behavior assertions. ✅
2. No `assert!(x.is_some() || x.is_none())` style remains in touched scope. ✅
3. Add lightweight grep-based guard in CI or local guard scripts. ✅ (local guard script added)

## Validation
- `cargo test --lib server::tests:: --features "postgres sqlite redis s3 metrics tracing websockets analytics"` ✅
- `cargo test --lib core::cost::providers::anthropic::tests:: --features "postgres sqlite redis s3 metrics tracing websockets analytics"` ✅
- `cargo test --test lib integration::router_tests:: --features "postgres sqlite redis s3 metrics tracing websockets analytics"` ✅
- `bash scripts/guards/check_tautological_assertions.sh` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings` ✅
- `cargo test --workspace --features "postgres sqlite redis s3 metrics tracing websockets analytics"` ✅
- `cargo test core::router::gateway_config::tests:: --lib` ✅
- `bash scripts/guards/check_schema_duplicates.sh` ✅
- `bash scripts/guards/check_api_runtime_boundary.sh` ✅

## Risk & Regression Focus
- Stronger anthropic assertions now require known model pricing entries to remain present; if pricing tables are intentionally changed/removed, tests will fail loudly.
- Guard script currently scopes to targeted files/patterns for this issue; broader repo-wide policy can be expanded in follow-up if desired.

Linear: FUT-63
