### PR TITLE
fix(security): reject refresh tokens in authenticate_jwt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litellm-rs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litellm-rs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.88"
 authors = ["lifcc"]

--- a/src/auth/jwt/tests.rs
+++ b/src/auth/jwt/tests.rs
@@ -144,3 +144,24 @@ async fn test_invalid_token_verification() {
     let result = handler.verify_token(invalid_token).await;
     assert!(result.is_err());
 }
+
+/// Verify that a refresh token passes verify_token() but has TokenType::Refresh,
+/// which means authenticate_jwt() will reject it via the token_type guard.
+#[tokio::test]
+async fn test_refresh_token_rejected_as_access() {
+    let handler = create_test_handler().await;
+    let user_id = Uuid::new_v4();
+
+    let refresh_token = handler.create_refresh_token(user_id, None).await.unwrap();
+
+    // verify_token accepts refresh tokens (it allows both "api" and "refresh" audiences)
+    let claims = handler.verify_token(&refresh_token).await.unwrap();
+    assert_eq!(claims.sub, user_id);
+
+    // But the token_type is Refresh, NOT Access — authenticate_jwt rejects this
+    assert!(
+        !matches!(claims.token_type, TokenType::Access),
+        "refresh token must not be treated as an access token"
+    );
+    assert!(matches!(claims.token_type, TokenType::Refresh));
+}

--- a/src/auth/system.rs
+++ b/src/auth/system.rs
@@ -1,6 +1,7 @@
 //! Core authentication system implementation
 
 use super::types::{AuthMethod, AuthResult, AuthzResult};
+use crate::auth::jwt::types::TokenType;
 use crate::config::models::auth::AuthConfig;
 use crate::core::models::user::types::{User, UserRole};
 use crate::core::types::context::RequestContext;
@@ -85,6 +86,18 @@ impl AuthSystem {
     ) -> Result<AuthResult> {
         match self.jwt.verify_token(token).await {
             Ok(claims) => {
+                // Reject non-access tokens (e.g. refresh, password reset)
+                if !matches!(claims.token_type, TokenType::Access) {
+                    return Ok(AuthResult {
+                        success: false,
+                        user: None,
+                        api_key: None,
+                        session: None,
+                        error: Some("Invalid token type: expected access token".to_string()),
+                        context,
+                    });
+                }
+
                 // Get user from database
                 if let Ok(Some(user)) = self.storage.db().find_user_by_id(claims.sub).await {
                     if user.is_active() {


### PR DESCRIPTION
## Summary
- Add `token_type` check in `authenticate_jwt()` — refresh tokens are now rejected
- Previously, `verify_token()` accepted both `aud: "api"` and `aud: "refresh"` but never checked `claims.token_type`, allowing refresh tokens to be used as access tokens
- Added unit test `test_refresh_token_rejected_as_access`

Closes #35

## Test plan
- [x] `cargo test --all-features` passes
- [x] New test verifies refresh token rejection
- [ ] Manual: attempt API call with refresh token → should get auth error