### PR TITLE
fix(security): use SHA-256 for rate limit key hashing

### DIFF
--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -182,10 +182,9 @@ fn get_client_identifier(req: &ServiceRequest) -> String {
         .or_else(|| req.headers().get("authorization"))
         .and_then(|h| h.to_str().ok())
     {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        api_key.hash(&mut hasher);
-        format!("{}:{:x}", ip, hasher.finish())
+        use sha2::{Digest, Sha256};
+        let hash = Sha256::digest(api_key.as_bytes());
+        format!("{}:{:x}", ip, hash)
     } else {
         format!("ip:{}", ip)
     }


### PR DESCRIPTION
## Summary
- Replace `DefaultHasher` (non-cryptographic) with `SHA-256` in rate limit key generation
- `DefaultHasher` allows trivial hash collision attacks — attacker could share another user's rate limit bucket
- `sha2` crate already a dependency, zero new deps added

Closes #36

## Test plan
- [x] `cargo test --all-features` passes (100 tests)
- [x] No new clippy warnings in modified file
- [ ] Rate limiting still functions correctly under load