### PR TITLE
fix(security): add rate limiting and unify error messages for registration

### DIFF
--- a/src/server/routes/auth/register.rs
+++ b/src/server/routes/auth/register.rs
@@ -51,7 +51,7 @@ pub async fn register(
 
     // Probabilistic cleanup: every 100th request, purge stale entries
     let count = REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
-    if count % 100 == 0 {
+    if count.is_multiple_of(100) {
         limiter.cleanup_old_entries();
     }
 


### PR DESCRIPTION
## Summary
- Added IP-based rate limiting to `/auth/register` (10 attempts/hour per IP via `AuthRateLimiter`)
- Unified error messages: "Username already exists" / "Email already exists" → generic message to prevent enumeration
- HTTP 409 for duplicate accounts, HTTP 429 with `Retry-After` for rate-limited requests
- Successful registration resets rate limit counter for that IP

Closes #38

## Test plan
- [x] `cargo test --all-features` passes (10,514 tests)
- [x] No new clippy warnings
- [ ] Manual: rapid registration attempts → should get 429 after 10th
- [ ] Manual: duplicate username/email → should get generic error message