### PR TITLE
fix(config): correct boolean merge logic in config system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,7 +3045,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litellm-rs"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litellm-rs"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 rust-version = "1.88"
 authors = ["lifcc"]

--- a/src/config/models/auth.rs
+++ b/src/config/models/auth.rs
@@ -42,11 +42,11 @@ impl Default for AuthConfig {
 impl AuthConfig {
     /// Merge auth configurations
     pub fn merge(mut self, other: Self) -> Self {
-        if !other.enable_jwt {
-            self.enable_jwt = other.enable_jwt;
+        if other.enable_jwt {
+            self.enable_jwt = true;
         }
-        if !other.enable_api_key {
-            self.enable_api_key = other.enable_api_key;
+        if other.enable_api_key {
+            self.enable_api_key = true;
         }
         if !other.jwt_secret.is_empty() {
             self.jwt_secret = other.jwt_secret;

--- a/src/config/models/cache.rs
+++ b/src/config/models/cache.rs
@@ -39,7 +39,7 @@ impl CacheConfig {
     /// Merge cache configurations
     pub fn merge(mut self, other: Self) -> Self {
         if other.enabled {
-            self.enabled = other.enabled;
+            self.enabled = true;
         }
         if other.ttl != default_cache_ttl() {
             self.ttl = other.ttl;
@@ -48,7 +48,7 @@ impl CacheConfig {
             self.max_size = other.max_size;
         }
         if other.semantic_cache {
-            self.semantic_cache = other.semantic_cache;
+            self.semantic_cache = true;
         }
         if other.similarity_threshold != default_similarity_threshold() {
             self.similarity_threshold = other.similarity_threshold;

--- a/src/config/models/enterprise.rs
+++ b/src/config/models/enterprise.rs
@@ -22,16 +22,16 @@ impl EnterpriseConfig {
     /// Merge enterprise configurations
     pub fn merge(mut self, other: Self) -> Self {
         if other.enabled {
-            self.enabled = other.enabled;
+            self.enabled = true;
         }
         if other.sso.is_some() {
             self.sso = other.sso;
         }
         if other.audit_logging {
-            self.audit_logging = other.audit_logging;
+            self.audit_logging = true;
         }
         if other.advanced_analytics {
-            self.advanced_analytics = other.advanced_analytics;
+            self.advanced_analytics = true;
         }
         self
     }

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -73,7 +73,7 @@ impl DatabaseConfig {
             self.connection_timeout = other.connection_timeout;
         }
         if other.ssl {
-            self.ssl = other.ssl;
+            self.ssl = true;
         }
         if other.enabled {
             self.enabled = true;
@@ -126,10 +126,11 @@ impl RedisConfig {
             self.connection_timeout = other.connection_timeout;
         }
         if other.cluster {
-            self.cluster = other.cluster;
+            self.cluster = true;
         }
-        if !other.enabled {
-            self.enabled = false;
+        // Redis defaults to enabled=true, so we need to handle both enable and disable
+        if other.enabled != default_redis_enabled() {
+            self.enabled = other.enabled;
         }
         self
     }


### PR DESCRIPTION
## Problem

Config merge logic was inverted - features were disabled when they should be enabled, preventing environment variable overrides from working correctly.

## Changes

Fixed boolean merge logic in the following files:
- `src/config/models/auth.rs`: Fixed `enable_jwt` and `enable_api_key` merge logic
- `src/config/models/cache.rs`: Simplified `enabled` and `semantic_cache` merge logic  
- `src/config/models/enterprise.rs`: Simplified `enabled`, `audit_logging`, and `advanced_analytics` merge logic
- `src/config/models/storage.rs`: Fixed `ssl`, `cluster`, and `enabled` merge logic for `DatabaseConfig`
- `src/config/models/storage.rs`: Fixed `RedisConfig` enabled merge to handle both enable/disable cases

## Before
```rust
if !other.enable_jwt {
    self.enable_jwt = other.enable_jwt;
}
```

## After
```rust
if other.enable_jwt {
    self.enable_jwt = true;
}
```

## Impact

Environment variable overrides now correctly enable features that default to disabled.

## Testing

- ✅ `cargo check --all-features` passes
- ✅ `cargo test --all-features` passes (10276 tests)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` passes

Fixes #59