### PR TITLE
fix(security): CORS empty origins list no longer defaults to wildcard '*'

### DIFF
--- a/src/config/builder/server_builder.rs
+++ b/src/config/builder/server_builder.rs
@@ -74,11 +74,7 @@ impl ServerConfigBuilder {
             tls: None,
             cors: crate::config::models::server::CorsConfig {
                 enabled: self.enable_cors,
-                allowed_origins: if self.cors_origins.is_empty() {
-                    vec!["*".to_string()]
-                } else {
-                    self.cors_origins
-                },
+                allowed_origins: self.cors_origins,
                 allowed_methods: vec!["GET".to_string(), "POST".to_string(), "OPTIONS".to_string()],
                 allowed_headers: vec!["Content-Type".to_string(), "Authorization".to_string()],
                 max_age: 3600,
@@ -268,7 +264,7 @@ mod tests {
         let config = ServerConfigBuilder::new().enable_cors().build();
 
         assert!(config.cors.enabled);
-        assert_eq!(config.cors.allowed_origins, vec!["*"]);
+        assert!(config.cors.allowed_origins.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes `ServerConfigBuilder::build()` silently producing `allowed_origins: ["*"]` when `cors_origins` is empty
- Empty list now means **deny all cross-origin** (fail-safe default) instead of **allow any origin**
- Updates the test `test_server_config_builder_build_cors_default_origins` to assert the new behaviour

## Motivation
Any code path that calls `ServerConfigBuilder::new().build()` without explicitly configuring origins was silently creating a fully-open CORS policy. This is a security risk (SEC-08 / fail-open default).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check --lib --bins --tests`
- [x] `cargo clippy --lib --bins --tests -- -D warnings`
- [x] `cargo test --lib -- config::builder` — all 99 tests pass, including the updated CORS test

Closes #81