### PR TITLE
fix(server): mount missing auth/keys/teams/budget/health routes in create_app

### DIFF
--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,15 +1,3 @@
 //! HTTP route handlers
 //!
 //! This module provides HTTP route handler functions.
-
-use actix_web::HttpResponse;
-use serde_json::json;
-
-/// Health check endpoint handler
-pub async fn health_check() -> HttpResponse {
-    HttpResponse::Ok().json(json!({
-        "status": "healthy",
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-        "version": env!("CARGO_PKG_VERSION")
-    }))
-}

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -4,8 +4,7 @@
 
 use crate::config::Config;
 use crate::config::models::server::ServerConfig;
-use crate::server::handlers::health_check;
-use crate::server::middleware::{AuthMiddleware, RequestIdMiddleware};
+use crate::server::middleware::{AuthMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware};
 use crate::server::routes;
 use crate::server::state::AppState;
 use crate::services::pricing::PricingService;
@@ -134,14 +133,22 @@ impl HttpServer {
             }
         }
 
+        let budget_limits = web::Data::new(Arc::clone(&state.budget_limits));
+
         App::new()
             .app_data(state)
+            .app_data(budget_limits)
             .wrap(cors)
             .wrap(Logger::default())
             .wrap(DefaultHeaders::new().add(("Server", "LiteLLM-RS")))
+            .wrap(SecurityHeadersMiddleware)
             .wrap(AuthMiddleware)
             .wrap(RequestIdMiddleware)
-            .route("/health", web::get().to(health_check))
+            .configure(routes::health::configure_routes)
+            .configure(routes::auth::configure_routes)
+            .configure(routes::keys::configure_routes)
+            .configure(routes::teams::configure_routes)
+            .configure(routes::budget::configure_budget_routes)
             .configure(routes::ai::configure_routes)
             .configure(routes::pricing::configure_pricing_routes)
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -3,6 +3,7 @@
 //! This module provides the AppState struct and its implementations.
 
 use crate::config::Config;
+use crate::core::budget::UnifiedBudgetLimits;
 use crate::services::pricing::PricingService;
 use std::sync::Arc;
 
@@ -23,6 +24,8 @@ pub struct AppState {
     pub storage: Arc<crate::storage::StorageLayer>,
     /// Unified pricing service
     pub pricing: Arc<PricingService>,
+    /// Budget limits for provider and model cost tracking
+    pub budget_limits: Arc<UnifiedBudgetLimits>,
 }
 
 impl AppState {
@@ -40,6 +43,7 @@ impl AppState {
             unified_router: Arc::new(unified_router),
             storage: Arc::new(storage),
             pricing,
+            budget_limits: Arc::new(UnifiedBudgetLimits::new()),
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #85

- Mount `routes::auth::configure_routes`, `routes::health::configure_routes`, `routes::keys::configure_routes`, `routes::teams::configure_routes`, and `routes::budget::configure_budget_routes` in `create_app()` — these were defined but unreachable at runtime
- Add `SecurityHeadersMiddleware` to the middleware stack
- Add `UnifiedBudgetLimits` to `AppState` and register it as `web::Data` so budget route handlers have the data they need
- Remove the duplicate inline `health_check` handler from `handlers.rs`; the proper versioned handler in `routes/health.rs` is now used

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo check` (lib) — clean
- [x] `cargo clippy --lib --bins -- -D warnings` — clean
- [x] `cargo test --lib` — 7670 passed, 0 failed