### PR TITLE
fix(api): GET /auth/me incorrectly registered as POST method

### DIFF
--- a/src/server/routes/auth/mod.rs
+++ b/src/server/routes/auth/mod.rs
@@ -41,6 +41,6 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/reset-password", web::post().to(reset_password))
             .route("/verify-email", web::post().to(verify_email))
             .route("/change-password", web::post().to(change_password))
-            .route("/me", web::post().to(get_current_user)),
+            .route("/me", web::get().to(get_current_user)),
     );
 }


### PR DESCRIPTION
## Summary
- Fixes `GET /auth/me` endpoint that was incorrectly registered as `POST`
- Changed `web::post()` to `web::get()` in `src/server/routes/auth/mod.rs:44`

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check --lib --bins --tests`
- [x] `cargo clippy --lib --bins --tests -- -D warnings`
- [x] `cargo test --lib --bins` — 7670 tests pass

Closes #87