### PR TITLE
fix: remove unwrap() panics in openai provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,7 +3056,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rs"
-version = "0.4.8"
+version = "0.4.10"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litellm-rs"
-version = "0.4.8"
+version = "0.4.10"
 edition = "2024"
 rust-version = "1.88"
 authors = ["lifcc"]

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -201,8 +201,10 @@ impl OpenAIProvider {
 
         // Add optional parameters
         if let Some(temp) = request.temperature {
-            openai_request["temperature"] =
-                Value::Number(serde_json::Number::from_f64(temp as f64).unwrap());
+            openai_request["temperature"] = Value::Number(
+                serde_json::Number::from_f64(temp as f64)
+                    .unwrap_or_else(|| serde_json::Number::from(0)),
+            );
         }
 
         if let Some(max_tokens) = request.max_tokens {
@@ -215,8 +217,10 @@ impl OpenAIProvider {
         }
 
         if let Some(top_p) = request.top_p {
-            openai_request["top_p"] =
-                Value::Number(serde_json::Number::from_f64(top_p as f64).unwrap());
+            openai_request["top_p"] = Value::Number(
+                serde_json::Number::from_f64(top_p as f64)
+                    .unwrap_or_else(|| serde_json::Number::from(0)),
+            );
         }
 
         if let Some(tools) = request.tools {


### PR DESCRIPTION
## Summary
- Replace `from_f64().unwrap()` with `from_f64().unwrap_or_else(|| Number::from(0))` for `temperature` and `top_p` in `src/core/providers/openai/client.rs`
- `serde_json::Number::from_f64()` returns `None` for NaN/Infinity, which caused panics on malformed user input

Closes #79

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --all-features` passes (10251 tests ok)