### PR TITLE
chore(deps): deduplicate rand ecosystem versions (#194)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +2960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,34 +3357,40 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
+ "http 1.4.0",
+ "http-body-util",
  "httparse",
  "humantime",
  "hyper 1.8.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -3783,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -3965,30 +3986,31 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+checksum = "b36964393906eb775b89b25b05b7b95685b8dd14062f1663a31ff93e75c452e5"
 dependencies = [
  "arc-swap",
- "async-trait",
+ "arcstr",
  "backon",
  "bytes",
+ "cfg-if",
  "combine",
  "crc16",
- "futures",
+ "futures-channel",
  "futures-util",
- "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.9.2",
  "ryu",
  "sha1_smol",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4234,9 +4256,9 @@ dependencies = [
 
 [[package]]
 name = "rustify_derive"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07d43b2dbdbd99aaed648192098f0f413b762f0f352667153934ef3955f1793"
+checksum = "78ea7fda74240f7410d0198b603a8a2f662acc7d76b6667a49f9b162cd8d9b4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4297,15 +4319,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4801,27 +4814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -6416,6 +6408,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,13 +68,13 @@ rmp-serde = "1.3"
 # NOTE: default-features = false is critical to avoid pulling in sqlx-mysql and its vulnerable RSA dependency
 sea-orm = { version = "1.1", features = ["macros", "with-chrono", "with-uuid", "with-json"], default-features = false, optional = true }
 sea-orm-migration = { version = "1.1", default-features = false, optional = true }
-redis = { version = "0.27", features = ["tokio-comp", "cluster", "streams", "aio", "connection-manager"], optional = true }
+redis = { version = "1.0", features = ["tokio-comp", "cluster", "streams", "aio", "connection-manager"], optional = true }
 
 # Caching
 lru = "0.16"
 
 # Object storage (S3 compatible)
-object_store = { version = "0.11", features = ["aws", "gcp", "azure"], optional = true }
+object_store = { version = "0.13", features = ["aws", "gcp", "azure"], optional = true }
 aws-sdk-s3 = { version = "1.120", optional = true }
 aws-sdk-secretsmanager = { version = "1.70", optional = true }
 aws-config = { version = "1.5", optional = true }

--- a/src/core/cache/cloud/azure_blob.rs
+++ b/src/core/cache/cloud/azure_blob.rs
@@ -5,9 +5,9 @@
 #[cfg(feature = "s3")]
 mod implementation {
     use async_trait::async_trait;
-    use object_store::ObjectStore;
     use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
     use object_store::path::Path;
+    use object_store::{ObjectStore, ObjectStoreExt};
     use serde::{Serialize, de::DeserializeOwned};
     use std::sync::Arc;
     use std::time::Duration;

--- a/src/core/cache/cloud/gcs.rs
+++ b/src/core/cache/cloud/gcs.rs
@@ -5,9 +5,9 @@
 #[cfg(feature = "s3")]
 mod implementation {
     use async_trait::async_trait;
-    use object_store::ObjectStore;
     use object_store::gcp::GoogleCloudStorageBuilder;
     use object_store::path::Path;
+    use object_store::{ObjectStore, ObjectStoreExt};
     use serde::{Serialize, de::DeserializeOwned};
     use std::sync::Arc;
     use std::time::Duration;

--- a/src/storage/redis/cache.rs
+++ b/src/storage/redis/cache.rs
@@ -18,7 +18,7 @@ impl RedisPool {
             let result: RedisResult<String> = c.get(key).await;
             match result {
                 Ok(value) => Ok(Some(value)),
-                Err(e) if e.kind() == redis::ErrorKind::TypeError => Ok(None),
+                Err(e) if e.kind() == redis::ErrorKind::UnexpectedReturnType => Ok(None),
                 Err(e) => Err(GatewayError::from(e)),
             }
         } else {

--- a/src/storage/redis/collections.rs
+++ b/src/storage/redis/collections.rs
@@ -33,7 +33,7 @@ impl RedisPool {
             let result: RedisResult<String> = c.rpop(key, None).await;
             match result {
                 Ok(value) => Ok(Some(value)),
-                Err(e) if e.kind() == redis::ErrorKind::TypeError => Ok(None),
+                Err(e) if e.kind() == redis::ErrorKind::UnexpectedReturnType => Ok(None),
                 Err(e) => Err(GatewayError::from(e)),
             }
         } else {

--- a/src/storage/redis/hash.rs
+++ b/src/storage/redis/hash.rs
@@ -37,7 +37,7 @@ impl RedisPool {
             let result: RedisResult<String> = c.hget(key, field).await;
             match result {
                 Ok(value) => Ok(Some(value)),
-                Err(e) if e.kind() == redis::ErrorKind::TypeError => Ok(None),
+                Err(e) if e.kind() == redis::ErrorKind::UnexpectedReturnType => Ok(None),
                 Err(e) => Err(GatewayError::from(e)),
             }
         } else {

--- a/src/storage/redis/pool.rs
+++ b/src/storage/redis/pool.rs
@@ -54,8 +54,9 @@ impl RedisPool {
 
         let client = Client::open(config.url.as_str()).map_err(GatewayError::from)?;
 
-        let async_config = AsyncConnectionConfig::new()
-            .set_connection_timeout(std::time::Duration::from_secs(config.connection_timeout));
+        let async_config = AsyncConnectionConfig::new().set_connection_timeout(Some(
+            std::time::Duration::from_secs(config.connection_timeout),
+        ));
 
         let connection_manager = client
             .get_multiplexed_async_connection_with_config(&async_config)


### PR DESCRIPTION
Fixes #194

## Summary

- Upgrade `redis` from 0.27 to 1.0, removing it as a `rand 0.8` consumer
- Upgrade `object_store` from 0.11 to 0.13, which migrated to `rand 0.9`
- Adapt code for redis 1.0 API changes (`ErrorKind::TypeError` -> `UnexpectedReturnType`, `set_connection_timeout` now takes `Option<Duration>`)
- Adapt code for object_store 0.13 API changes (import `ObjectStoreExt` for trait methods on `Arc<dyn ObjectStore>`)

## Remaining rand 0.8 consumers

Two dependencies still require `rand 0.8` with no stable upgrade path:
- `actix-multipart 0.7.2` (latest version)
- `sqlx-postgres 0.8.6` via `sea-orm 1.1` (sqlx 0.9 is alpha, sea-orm 2.0 is RC)

Full elimination of `rand 0.8` will be possible once these upstream crates release stable versions with `rand 0.9` support.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo test --all-features` (10,122 tests pass)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (7 pre-existing warnings unrelated to this PR)