### PR TITLE
fix(auth): separate access and refresh token verification (#188)

### DIFF
--- a/src/auth/jwt/handler.rs
+++ b/src/auth/jwt/handler.rs
@@ -114,29 +114,43 @@ impl JwtHandler {
         })
     }
 
-    /// Verify and decode a token
-    pub async fn verify_token(&self, token: &str) -> Result<Claims> {
+    /// Verify and decode an access token
+    ///
+    /// Only accepts tokens with the "api" audience claim, preventing
+    /// refresh tokens from being used as access tokens.
+    pub async fn verify_access_token(&self, token: &str) -> Result<Claims> {
         let mut validation = Validation::new(self.algorithm);
         validation.set_issuer(&[&self.issuer]);
-        validation.set_audience(&["api", "refresh"]);
+        validation.set_audience(&["api"]);
 
         let token_data = decode::<Claims>(token, &self.decoding_key, &validation).map_err(|e| {
             warn!("JWT verification failed: {}", e);
             GatewayError::Auth(format!("JWT error: {}", e))
         })?;
 
-        debug!("Token verified for user: {}", token_data.claims.sub);
+        debug!("Access token verified for user: {}", token_data.claims.sub);
         Ok(token_data.claims)
     }
 
     /// Verify a refresh token and return user ID
+    ///
+    /// Only accepts tokens with the "refresh" audience claim, preventing
+    /// access tokens from being used as refresh tokens.
     pub async fn verify_refresh_token(&self, token: &str) -> Result<Uuid> {
-        let claims = self.verify_token(token).await?;
+        let mut validation = Validation::new(self.algorithm);
+        validation.set_issuer(&[&self.issuer]);
+        validation.set_audience(&["refresh"]);
 
-        if !matches!(claims.token_type, TokenType::Refresh) {
+        let token_data = decode::<Claims>(token, &self.decoding_key, &validation).map_err(|e| {
+            warn!("JWT verification failed: {}", e);
+            GatewayError::Auth(format!("JWT error: {}", e))
+        })?;
+
+        if !matches!(token_data.claims.token_type, TokenType::Refresh) {
             return Err(GatewayError::auth("Invalid token type for refresh"));
         }
 
-        Ok(claims.sub)
+        debug!("Refresh token verified for user: {}", token_data.claims.sub);
+        Ok(token_data.claims.sub)
     }
 }

--- a/src/auth/jwt/tests.rs
+++ b/src/auth/jwt/tests.rs
@@ -38,7 +38,7 @@ async fn test_create_and_verify_access_token() {
         .await
         .unwrap();
 
-    let claims = handler.verify_token(&token).await.unwrap();
+    let claims = handler.verify_access_token(&token).await.unwrap();
     assert_eq!(claims.sub, user_id);
     assert_eq!(claims.role, "user");
     assert_eq!(claims.permissions, vec!["read"]);
@@ -68,7 +68,7 @@ async fn test_create_token_pair() {
 
     // Verify both tokens
     let access_claims = handler
-        .verify_token(&token_pair.access_token)
+        .verify_access_token(&token_pair.access_token)
         .await
         .unwrap();
     let refresh_user_id = handler
@@ -141,27 +141,48 @@ async fn test_invalid_token_verification() {
     let handler = create_test_handler().await;
     let invalid_token = "invalid.jwt.token";
 
-    let result = handler.verify_token(invalid_token).await;
+    let result = handler.verify_access_token(invalid_token).await;
     assert!(result.is_err());
 }
 
-/// Verify that a refresh token passes verify_token() but has TokenType::Refresh,
-/// which means authenticate_jwt() will reject it via the token_type guard.
+/// Verify that verify_access_token() rejects a refresh token at the audience level,
+/// preventing token type confusion before any token_type field check.
 #[tokio::test]
-async fn test_refresh_token_rejected_as_access() {
+async fn test_refresh_token_rejected_by_verify_access_token() {
     let handler = create_test_handler().await;
     let user_id = Uuid::new_v4();
 
     let refresh_token = handler.create_refresh_token(user_id, None).await.unwrap();
 
-    // verify_token accepts refresh tokens (it allows both "api" and "refresh" audiences)
-    let claims = handler.verify_token(&refresh_token).await.unwrap();
-    assert_eq!(claims.sub, user_id);
-
-    // But the token_type is Refresh, NOT Access — authenticate_jwt rejects this
+    // verify_access_token must reject refresh tokens (audience mismatch: "refresh" vs "api")
+    let result = handler.verify_access_token(&refresh_token).await;
     assert!(
-        !matches!(claims.token_type, TokenType::Access),
-        "refresh token must not be treated as an access token"
+        result.is_err(),
+        "refresh token must be rejected by verify_access_token"
     );
-    assert!(matches!(claims.token_type, TokenType::Refresh));
+}
+
+/// Verify that verify_refresh_token() rejects an access token at the audience level.
+#[tokio::test]
+async fn test_access_token_rejected_by_verify_refresh_token() {
+    let handler = create_test_handler().await;
+    let user_id = Uuid::new_v4();
+
+    let access_token = handler
+        .create_access_token(
+            user_id,
+            "user".to_string(),
+            vec!["read".to_string()],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // verify_refresh_token must reject access tokens (audience mismatch: "api" vs "refresh")
+    let result = handler.verify_refresh_token(&access_token).await;
+    assert!(
+        result.is_err(),
+        "access token must be rejected by verify_refresh_token"
+    );
 }

--- a/src/auth/system.rs
+++ b/src/auth/system.rs
@@ -84,7 +84,7 @@ impl AuthSystem {
         token: &str,
         mut context: RequestContext,
     ) -> Result<AuthResult> {
-        match self.jwt.verify_token(token).await {
+        match self.jwt.verify_access_token(token).await {
             Ok(claims) => {
                 // Reject non-access tokens (e.g. refresh, password reset)
                 if !matches!(claims.token_type, TokenType::Access) {

--- a/src/auth/user_management.rs
+++ b/src/auth/user_management.rs
@@ -74,7 +74,7 @@ impl AuthSystem {
         info!("User logout");
 
         // Extract session ID from token
-        if let Ok(claims) = self.jwt.verify_token(session_token).await
+        if let Ok(claims) = self.jwt.verify_access_token(session_token).await
             && let Some(session_id) = claims.session_id
         {
             // Store invalidated session (in practice, you'd use Redis or similar)


### PR DESCRIPTION
## Summary

- Split `verify_token()` into `verify_access_token()` and `verify_refresh_token()`, each validating only its specific JWT audience claim (`"api"` or `"refresh"`)
- Previously, `verify_token()` accepted both audiences, allowing a refresh token to pass verification where an access token was expected (token type confusion)
- Updated all callers: `authenticate_jwt()` and `logout()` now use `verify_access_token()`, token refresh endpoint continues using `verify_refresh_token()`
- Added test confirming refresh tokens are rejected by `verify_access_token()` and access tokens are rejected by `verify_refresh_token()`

Fixes #188

## Test plan

- [x] `cargo check --all-features` passes
- [x] `cargo test --all-features` — all 96 tests pass
- [x] `cargo fmt --all` — no formatting issues
- [x] Clippy clean on changed files (pre-existing `collapsible_if` warnings in unrelated files)
- [x] `test_refresh_token_rejected_by_verify_access_token` confirms audience-level rejection
- [x] `test_access_token_rejected_by_verify_refresh_token` confirms reverse direction rejection