### PR TITLE
fix(security): reject empty OAuth allowed_origins instead of permitting all

### DIFF
--- a/src/auth/oauth/config.rs
+++ b/src/auth/oauth/config.rs
@@ -412,8 +412,8 @@ pub struct OAuthGatewayConfig {
     pub auto_create_users: bool,
 
     /// Allowed origins for post-login client redirects (scheme + host, e.g. "https://app.example.com").
-    /// If non-empty, `client_redirect` URIs must match one of these origins; otherwise the redirect
-    /// is silently replaced with `/`. An empty list disables the whitelist check (permissive).
+    /// `client_redirect` URIs must match one of these origins; otherwise the redirect is rejected.
+    /// An empty list rejects all client redirects — origins must be configured explicitly.
     #[serde(default)]
     pub allowed_redirect_origins: Vec<String>,
 }

--- a/src/auth/oauth/handlers.rs
+++ b/src/auth/oauth/handlers.rs
@@ -130,12 +130,17 @@ pub struct LoginQuery {
 
 /// Returns `true` when `redirect_uri` is safe to follow.
 ///
-/// If `allowed_origins` is empty the whitelist is disabled (permissive).
-/// Otherwise the URI's origin (scheme + host + optional port) must exactly
-/// match one of the entries in `allowed_origins`.
+/// If `allowed_origins` is empty all redirects are rejected — origins must be
+/// explicitly configured. Otherwise the URI's origin (scheme + host + optional
+/// port) must exactly match one of the entries in `allowed_origins`.
 fn is_redirect_origin_allowed(redirect_uri: &str, allowed_origins: &[String]) -> bool {
     if allowed_origins.is_empty() {
-        return true;
+        warn!(
+            "OAuth allowed_redirect_origins is empty; rejecting redirect to '{}'. \
+             Configure allowed_redirect_origins explicitly to permit client redirects.",
+            redirect_uri
+        );
+        return false;
     }
     let Ok(parsed) = url::Url::parse(redirect_uri) else {
         return false;
@@ -668,5 +673,55 @@ mod tests {
         let debug_str = format!("{:?}", state);
         assert!(debug_str.contains("OAuthState"));
         assert!(debug_str.contains("google"));
+    }
+
+    #[test]
+    fn test_empty_allowed_origins_rejects_all() {
+        let empty: Vec<String> = vec![];
+        assert!(!is_redirect_origin_allowed(
+            "https://evil.com/callback",
+            &empty
+        ));
+        assert!(!is_redirect_origin_allowed(
+            "https://app.example.com",
+            &empty
+        ));
+    }
+
+    #[test]
+    fn test_allowed_origins_permits_matching() {
+        let origins = vec!["https://app.example.com".to_string()];
+        assert!(is_redirect_origin_allowed(
+            "https://app.example.com/callback?foo=bar",
+            &origins
+        ));
+    }
+
+    #[test]
+    fn test_allowed_origins_rejects_non_matching() {
+        let origins = vec!["https://app.example.com".to_string()];
+        assert!(!is_redirect_origin_allowed(
+            "https://evil.com/callback",
+            &origins
+        ));
+    }
+
+    #[test]
+    fn test_allowed_origins_with_port() {
+        let origins = vec!["http://localhost:3000".to_string()];
+        assert!(is_redirect_origin_allowed(
+            "http://localhost:3000/cb",
+            &origins
+        ));
+        assert!(!is_redirect_origin_allowed(
+            "http://localhost:4000/cb",
+            &origins
+        ));
+    }
+
+    #[test]
+    fn test_invalid_redirect_uri_rejected() {
+        let origins = vec!["https://app.example.com".to_string()];
+        assert!(!is_redirect_origin_allowed("not-a-url", &origins));
     }
 }


### PR DESCRIPTION
## Summary
- Empty `allowed_redirect_origins` now **rejects all** client redirects instead of permitting all origins (open redirect vulnerability).
- Adds `tracing::warn!` log when a redirect is rejected due to empty configuration, guiding operators to configure origins explicitly.
- Updates doc comments on `is_redirect_origin_allowed()` and the `allowed_redirect_origins` config field.

Closes #241

## Test plan
- [x] `test_empty_allowed_origins_rejects_all` — verifies empty list rejects any URI
- [x] `test_allowed_origins_permits_matching` — verifies configured origin allows matching redirect
- [x] `test_allowed_origins_rejects_non_matching` — verifies non-matching origin is rejected
- [x] `test_allowed_origins_with_port` — verifies port-specific matching
- [x] `test_invalid_redirect_uri_rejected` — verifies unparseable URIs are rejected
- [x] All 102 existing OAuth tests continue to pass