### PR TITLE
feat: enable virtual_keys module (#257)

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -42,9 +42,8 @@ pub mod traits;
 pub mod types;
 // User and team management - disabled until database methods are implemented
 // These modules require the following database methods to be implemented:
-// - virtual_keys: store_virtual_key, get_virtual_key, update_virtual_key, etc.
 // - user_management: get_user, create_user, get_team, create_team, etc.
-// NOTE: Requires database method implementations (virtual_keys, user_management).
+// NOTE: user_management requires database method implementations.
 // pub mod user_management;
-// pub mod virtual_keys;
+pub mod virtual_keys; // Database methods implemented as stubs in storage/database/seaorm_db/virtual_key_ops.rs
 pub mod webhooks;

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -241,20 +241,21 @@ impl AnthropicClient {
         }
 
         // Add thinking configuration
-        if let Some(thinking) = &request.thinking {
-            if thinking.enabled && model_spec.features.contains(&ModelFeature::ThinkingMode) {
-                let budget = thinking.budget_tokens.unwrap_or(10_000);
-                // Anthropic requires max_tokens > budget_tokens. If the default (4096)
-                // is not greater than budget_tokens, raise max_tokens to budget + 1.
-                let current_max = request.max_tokens.unwrap_or(4096);
-                if current_max <= budget {
-                    anthropic_request["max_tokens"] = json!(budget + 1);
-                }
-                anthropic_request["thinking"] = json!({
-                    "type": "enabled",
-                    "budget_tokens": budget
-                });
+        if let Some(thinking) = &request.thinking
+            && thinking.enabled
+            && model_spec.features.contains(&ModelFeature::ThinkingMode)
+        {
+            let budget = thinking.budget_tokens.unwrap_or(10_000);
+            // Anthropic requires max_tokens > budget_tokens. If the default (4096)
+            // is not greater than budget_tokens, raise max_tokens to budget + 1.
+            let current_max = request.max_tokens.unwrap_or(4096);
+            if current_max <= budget {
+                anthropic_request["max_tokens"] = json!(budget + 1);
             }
+            anthropic_request["thinking"] = json!({
+                "type": "enabled",
+                "budget_tokens": budget
+            });
         }
 
         Ok(anthropic_request)

--- a/src/core/virtual_keys/manager.rs
+++ b/src/core/virtual_keys/manager.rs
@@ -98,10 +98,10 @@ impl VirtualKeyManager {
         // Check cache first
         {
             let data = self.key_data.read().await;
-            if let Some(key) = data.cache.get(&key_hash) {
-                if self.is_key_valid(key) {
-                    return Ok(key.clone());
-                }
+            if let Some(key) = data.cache.get(&key_hash)
+                && self.is_key_valid(key)
+            {
+                return Ok(key.clone());
             }
         }
 
@@ -142,11 +142,7 @@ impl VirtualKeyManager {
     }
 
     /// Check rate limits for a key
-    pub async fn check_rate_limits(
-        &self,
-        key: &VirtualKey,
-        tokens_requested: u32,
-    ) -> Result<()> {
+    pub async fn check_rate_limits(&self, key: &VirtualKey, tokens_requested: u32) -> Result<()> {
         if let Some(rate_limits) = &key.rate_limits {
             let mut data = self.key_data.write().await;
             let state = data
@@ -169,48 +165,39 @@ impl VirtualKeyManager {
             }
 
             // Check RPM
-            if let Some(rpm) = rate_limits.rpm {
-                if state.request_count >= rpm {
-                    return Err(GatewayError::RateLimit {
-                        message: format!(
-                            "Rate limit exceeded: {} requests per minute",
-                            rpm
-                        ),
-                        retry_after: Some(60),
-                        rpm_limit: Some(rpm),
-                        tpm_limit: rate_limits.tpm,
-                    });
-                }
+            if let Some(rpm) = rate_limits.rpm
+                && state.request_count >= rpm
+            {
+                return Err(GatewayError::RateLimit {
+                    message: format!("Rate limit exceeded: {} requests per minute", rpm),
+                    retry_after: Some(60),
+                    rpm_limit: Some(rpm),
+                    tpm_limit: rate_limits.tpm,
+                });
             }
 
             // Check TPM
-            if let Some(tpm) = rate_limits.tpm {
-                if state.token_count + tokens_requested > tpm {
-                    return Err(GatewayError::RateLimit {
-                        message: format!(
-                            "Token rate limit exceeded: {} tokens per minute",
-                            tpm
-                        ),
-                        retry_after: Some(60),
-                        rpm_limit: rate_limits.rpm,
-                        tpm_limit: Some(tpm),
-                    });
-                }
+            if let Some(tpm) = rate_limits.tpm
+                && state.token_count + tokens_requested > tpm
+            {
+                return Err(GatewayError::RateLimit {
+                    message: format!("Token rate limit exceeded: {} tokens per minute", tpm),
+                    retry_after: Some(60),
+                    rpm_limit: rate_limits.rpm,
+                    tpm_limit: Some(tpm),
+                });
             }
 
             // Check parallel requests
-            if let Some(max_parallel) = rate_limits.max_parallel_requests {
-                if state.parallel_requests >= max_parallel {
-                    return Err(GatewayError::RateLimit {
-                        message: format!(
-                            "Too many parallel requests: max {}",
-                            max_parallel
-                        ),
-                        retry_after: Some(1),
-                        rpm_limit: rate_limits.rpm,
-                        tpm_limit: rate_limits.tpm,
-                    });
-                }
+            if let Some(max_parallel) = rate_limits.max_parallel_requests
+                && state.parallel_requests >= max_parallel
+            {
+                return Err(GatewayError::RateLimit {
+                    message: format!("Too many parallel requests: max {}", max_parallel),
+                    retry_after: Some(1),
+                    rpm_limit: rate_limits.rpm,
+                    tpm_limit: rate_limits.tpm,
+                });
             }
 
             // Update counters
@@ -225,22 +212,22 @@ impl VirtualKeyManager {
     /// Record request completion (for parallel request tracking)
     pub async fn record_request_completion(&self, key_id: &str) {
         let mut data = self.key_data.write().await;
-        if let Some(state) = data.rate_limits.get_mut(key_id) {
-            if state.parallel_requests > 0 {
-                state.parallel_requests -= 1;
-            }
+        if let Some(state) = data.rate_limits.get_mut(key_id)
+            && state.parallel_requests > 0
+        {
+            state.parallel_requests -= 1;
         }
     }
 
     /// Check budget limits
     pub async fn check_budget(&self, key: &VirtualKey, cost: f64) -> Result<()> {
-        if let Some(max_budget) = key.max_budget {
-            if key.spend + cost > max_budget {
-                return Err(GatewayError::BudgetExceeded(format!(
-                    "Budget exceeded: ${:.2} + ${:.2} > ${:.2}",
-                    key.spend, cost, max_budget
-                )));
-            }
+        if let Some(max_budget) = key.max_budget
+            && key.spend + cost > max_budget
+        {
+            return Err(GatewayError::Forbidden(format!(
+                "Budget exceeded: ${:.2} + ${:.2} > ${:.2}",
+                key.spend, cost, max_budget
+            )));
         }
         Ok(())
     }
@@ -373,10 +360,10 @@ impl VirtualKeyManager {
             return false;
         }
 
-        if let Some(expires_at) = key.expires_at {
-            if Utc::now() > expires_at {
-                return false;
-            }
+        if let Some(expires_at) = key.expires_at
+            && Utc::now() > expires_at
+        {
+            return false;
         }
 
         true

--- a/src/core/virtual_keys/requests.rs
+++ b/src/core/virtual_keys/requests.rs
@@ -642,10 +642,7 @@ mod tests {
             max_budget: Some(200.0),
             budget_duration: None,
             rate_limits: Some(create_test_rate_limits()),
-            permissions: Some(vec![
-                Permission::ChatCompletion,
-                Permission::Embedding,
-            ]),
+            permissions: Some(vec![Permission::ChatCompletion, Permission::Embedding]),
             metadata: None,
             expires_at: None,
             is_active: None,
@@ -681,13 +678,13 @@ mod tests {
 
     #[test]
     fn test_permission_combinations() {
-        let basic_perms = vec![Permission::ChatCompletion];
-        let standard_perms = vec![
+        let basic_perms = [Permission::ChatCompletion];
+        let standard_perms = [
             Permission::ChatCompletion,
             Permission::TextCompletion,
             Permission::Embedding,
         ];
-        let admin_perms = vec![
+        let admin_perms = [
             Permission::ChatCompletion,
             Permission::TextCompletion,
             Permission::Embedding,

--- a/src/core/virtual_keys/tests.rs
+++ b/src/core/virtual_keys/tests.rs
@@ -1,267 +1,265 @@
 //! Tests for virtual keys module
 
-#[cfg(test)]
-mod tests {
-    use super::super::requests::CreateKeyRequest;
-    use super::super::types::{KeyGenerationSettings, Permission, RateLimits, VirtualKey};
-    use chrono::{Duration, Utc};
-    use std::collections::HashMap;
+use super::requests::CreateKeyRequest;
+use super::types::{KeyGenerationSettings, Permission, RateLimits, VirtualKey};
+use chrono::{Duration, Utc};
+use rand::Rng;
+use std::collections::HashMap;
 
-    /// Test API key generation format
-    #[test]
-    fn test_key_generation_format() {
-        let settings = KeyGenerationSettings::default();
+/// Test API key generation format
+#[test]
+fn test_key_generation_format() {
+    let settings = KeyGenerationSettings::default();
 
-        // Test key generation directly without VirtualKeyManager
-        let key = format!(
-            "{}{}",
-            settings.key_prefix,
-            (0..32)
-                .map(|_| {
-                    let idx = rand::random::<usize>() % 36;
-                    if idx < 10 {
-                        (b'0' + idx as u8) as char
-                    } else {
-                        (b'a' + (idx - 10) as u8) as char
-                    }
-                })
-                .collect::<String>()
-        );
+    // Test key generation directly without VirtualKeyManager
+    let key = format!(
+        "{}{}",
+        settings.key_prefix,
+        (0..32)
+            .map(|_| {
+                let idx = rand::rng().random_range(0usize..36);
+                if idx < 10 {
+                    (b'0' + idx as u8) as char
+                } else {
+                    (b'a' + (idx - 10) as u8) as char
+                }
+            })
+            .collect::<String>()
+    );
 
-        assert!(key.starts_with("sk-"));
-        assert_eq!(key.len(), 35); // "sk-" + 32 chars
-    }
+    assert!(key.starts_with("sk-"));
+    assert_eq!(key.len(), 35); // "sk-" + 32 chars
+}
 
-    /// Test that key hashing is deterministic
-    #[test]
-    fn test_key_hashing_deterministic() {
-        use sha2::{Digest, Sha256};
+/// Test that key hashing is deterministic
+#[test]
+fn test_key_hashing_deterministic() {
+    use sha2::{Digest, Sha256};
 
-        let key = "sk-test123";
+    let key = "sk-test123";
 
-        // Hash using the same algorithm as VirtualKeyManager
-        let hash1 = {
-            let mut hasher = Sha256::new();
-            hasher.update(key.as_bytes());
-            hex::encode(hasher.finalize())
-        };
+    // Hash using the same algorithm as VirtualKeyManager
+    let hash1 = {
+        let mut hasher = Sha256::new();
+        hasher.update(key.as_bytes());
+        hex::encode(hasher.finalize())
+    };
 
-        let hash2 = {
-            let mut hasher = Sha256::new();
-            hasher.update(key.as_bytes());
-            hex::encode(hasher.finalize())
-        };
+    let hash2 = {
+        let mut hasher = Sha256::new();
+        hasher.update(key.as_bytes());
+        hex::encode(hasher.finalize())
+    };
 
-        assert_eq!(hash1, hash2);
-        assert_ne!(hash1, key);
-        assert_eq!(hash1.len(), 64); // SHA-256 produces 64 hex chars
-    }
+    assert_eq!(hash1, hash2);
+    assert_ne!(hash1, key);
+    assert_eq!(hash1.len(), 64); // SHA-256 produces 64 hex chars
+}
 
-    /// Test that different keys produce different hashes
-    #[test]
-    fn test_key_hashing_uniqueness() {
-        use sha2::{Digest, Sha256};
+/// Test that different keys produce different hashes
+#[test]
+fn test_key_hashing_uniqueness() {
+    use sha2::{Digest, Sha256};
 
-        let hash_key = |key: &str| -> String {
-            let mut hasher = Sha256::new();
-            hasher.update(key.as_bytes());
-            hex::encode(hasher.finalize())
-        };
+    let hash_key = |key: &str| -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(key.as_bytes());
+        hex::encode(hasher.finalize())
+    };
 
-        let hash1 = hash_key("sk-key1");
-        let hash2 = hash_key("sk-key2");
+    let hash1 = hash_key("sk-key1");
+    let hash2 = hash_key("sk-key2");
 
-        assert_ne!(hash1, hash2);
-    }
+    assert_ne!(hash1, hash2);
+}
 
-    /// Test VirtualKey validation logic
-    #[test]
-    fn test_key_validation_active() {
-        let active_key = VirtualKey {
-            key_id: "test".to_string(),
-            key_hash: "hash".to_string(),
-            key_alias: None,
-            user_id: "user1".to_string(),
-            team_id: None,
-            organization_id: None,
-            models: vec![],
-            max_budget: None,
-            spend: 0.0,
-            budget_duration: None,
-            budget_reset_at: None,
-            rate_limits: None,
-            permissions: vec![],
-            metadata: HashMap::new(),
-            expires_at: None,
-            is_active: true,
-            created_at: Utc::now(),
-            last_used_at: None,
-            usage_count: 0,
-            tags: vec![],
-        };
+/// Test VirtualKey validation logic
+#[test]
+fn test_key_validation_active() {
+    let active_key = VirtualKey {
+        key_id: "test".to_string(),
+        key_hash: "hash".to_string(),
+        key_alias: None,
+        user_id: "user1".to_string(),
+        team_id: None,
+        organization_id: None,
+        models: vec![],
+        max_budget: None,
+        spend: 0.0,
+        budget_duration: None,
+        budget_reset_at: None,
+        rate_limits: None,
+        permissions: vec![],
+        metadata: HashMap::new(),
+        expires_at: None,
+        is_active: true,
+        created_at: Utc::now(),
+        last_used_at: None,
+        usage_count: 0,
+        tags: vec![],
+    };
 
-        // Active key with no expiration should be valid
-        assert!(active_key.is_active);
-        assert!(active_key.expires_at.is_none() || active_key.expires_at.unwrap() > Utc::now());
-    }
+    // Active key with no expiration should be valid
+    assert!(active_key.is_active);
+    assert!(active_key.expires_at.is_none() || active_key.expires_at.unwrap() > Utc::now());
+}
 
-    /// Test VirtualKey validation for inactive keys
-    #[test]
-    fn test_key_validation_inactive() {
-        let inactive_key = VirtualKey {
-            key_id: "test".to_string(),
-            key_hash: "hash".to_string(),
-            key_alias: None,
-            user_id: "user1".to_string(),
-            team_id: None,
-            organization_id: None,
-            models: vec![],
-            max_budget: None,
-            spend: 0.0,
-            budget_duration: None,
-            budget_reset_at: None,
-            rate_limits: None,
-            permissions: vec![],
-            metadata: HashMap::new(),
-            expires_at: None,
-            is_active: false,
-            created_at: Utc::now(),
-            last_used_at: None,
-            usage_count: 0,
-            tags: vec![],
-        };
+/// Test VirtualKey validation for inactive keys
+#[test]
+fn test_key_validation_inactive() {
+    let inactive_key = VirtualKey {
+        key_id: "test".to_string(),
+        key_hash: "hash".to_string(),
+        key_alias: None,
+        user_id: "user1".to_string(),
+        team_id: None,
+        organization_id: None,
+        models: vec![],
+        max_budget: None,
+        spend: 0.0,
+        budget_duration: None,
+        budget_reset_at: None,
+        rate_limits: None,
+        permissions: vec![],
+        metadata: HashMap::new(),
+        expires_at: None,
+        is_active: false,
+        created_at: Utc::now(),
+        last_used_at: None,
+        usage_count: 0,
+        tags: vec![],
+    };
 
-        assert!(!inactive_key.is_active);
-    }
+    assert!(!inactive_key.is_active);
+}
 
-    /// Test VirtualKey validation for expired keys
-    #[test]
-    fn test_key_validation_expired() {
-        let expired_key = VirtualKey {
-            key_id: "test".to_string(),
-            key_hash: "hash".to_string(),
-            key_alias: None,
-            user_id: "user1".to_string(),
-            team_id: None,
-            organization_id: None,
-            models: vec![],
-            max_budget: None,
-            spend: 0.0,
-            budget_duration: None,
-            budget_reset_at: None,
-            rate_limits: None,
-            permissions: vec![],
-            metadata: HashMap::new(),
-            expires_at: Some(Utc::now() - Duration::hours(1)),
-            is_active: true,
-            created_at: Utc::now(),
-            last_used_at: None,
-            usage_count: 0,
-            tags: vec![],
-        };
+/// Test VirtualKey validation for expired keys
+#[test]
+fn test_key_validation_expired() {
+    let expired_key = VirtualKey {
+        key_id: "test".to_string(),
+        key_hash: "hash".to_string(),
+        key_alias: None,
+        user_id: "user1".to_string(),
+        team_id: None,
+        organization_id: None,
+        models: vec![],
+        max_budget: None,
+        spend: 0.0,
+        budget_duration: None,
+        budget_reset_at: None,
+        rate_limits: None,
+        permissions: vec![],
+        metadata: HashMap::new(),
+        expires_at: Some(Utc::now() - Duration::hours(1)),
+        is_active: true,
+        created_at: Utc::now(),
+        last_used_at: None,
+        usage_count: 0,
+        tags: vec![],
+    };
 
-        // Key is active but expired
-        assert!(expired_key.is_active);
-        assert!(expired_key.expires_at.unwrap() < Utc::now());
-    }
+    // Key is active but expired
+    assert!(expired_key.is_active);
+    assert!(expired_key.expires_at.unwrap() < Utc::now());
+}
 
-    /// Test VirtualKey with future expiration
-    #[test]
-    fn test_key_validation_not_expired() {
-        let future_key = VirtualKey {
-            key_id: "test".to_string(),
-            key_hash: "hash".to_string(),
-            key_alias: None,
-            user_id: "user1".to_string(),
-            team_id: None,
-            organization_id: None,
-            models: vec![],
-            max_budget: None,
-            spend: 0.0,
-            budget_duration: None,
-            budget_reset_at: None,
-            rate_limits: None,
-            permissions: vec![],
-            metadata: HashMap::new(),
-            expires_at: Some(Utc::now() + Duration::hours(24)),
-            is_active: true,
-            created_at: Utc::now(),
-            last_used_at: None,
-            usage_count: 0,
-            tags: vec![],
-        };
+/// Test VirtualKey with future expiration
+#[test]
+fn test_key_validation_not_expired() {
+    let future_key = VirtualKey {
+        key_id: "test".to_string(),
+        key_hash: "hash".to_string(),
+        key_alias: None,
+        user_id: "user1".to_string(),
+        team_id: None,
+        organization_id: None,
+        models: vec![],
+        max_budget: None,
+        spend: 0.0,
+        budget_duration: None,
+        budget_reset_at: None,
+        rate_limits: None,
+        permissions: vec![],
+        metadata: HashMap::new(),
+        expires_at: Some(Utc::now() + Duration::hours(24)),
+        is_active: true,
+        created_at: Utc::now(),
+        last_used_at: None,
+        usage_count: 0,
+        tags: vec![],
+    };
 
-        assert!(future_key.is_active);
-        assert!(future_key.expires_at.unwrap() > Utc::now());
-    }
+    assert!(future_key.is_active);
+    assert!(future_key.expires_at.unwrap() > Utc::now());
+}
 
-    /// Test KeyGenerationSettings defaults
-    #[test]
-    fn test_key_generation_settings_defaults() {
-        let settings = KeyGenerationSettings::default();
+/// Test KeyGenerationSettings defaults
+#[test]
+fn test_key_generation_settings_defaults() {
+    let settings = KeyGenerationSettings::default();
 
-        assert_eq!(settings.key_prefix, "sk-");
-        assert!(!settings.default_permissions.is_empty());
-        assert!(settings.default_budget.is_some());
-        assert!(settings.default_rate_limits.is_some());
-    }
+    assert_eq!(settings.key_prefix, "sk-");
+    assert!(!settings.default_permissions.is_empty());
+    assert!(settings.default_budget.is_some());
+    assert!(settings.default_rate_limits.is_some());
+}
 
-    /// Test RateLimits structure
-    #[test]
-    fn test_rate_limits_structure() {
-        let rate_limits = RateLimits {
-            rpm: Some(60),
-            rph: Some(3600),
-            rpd: Some(86400),
-            tpm: Some(100000),
-            tph: Some(6000000),
-            tpd: Some(144000000),
-            max_parallel_requests: Some(10),
-        };
+/// Test RateLimits structure
+#[test]
+fn test_rate_limits_structure() {
+    let rate_limits = RateLimits {
+        rpm: Some(60),
+        rph: Some(3600),
+        rpd: Some(86400),
+        tpm: Some(100000),
+        tph: Some(6000000),
+        tpd: Some(144000000),
+        max_parallel_requests: Some(10),
+    };
 
-        assert_eq!(rate_limits.rpm, Some(60));
-        assert_eq!(rate_limits.max_parallel_requests, Some(10));
-    }
+    assert_eq!(rate_limits.rpm, Some(60));
+    assert_eq!(rate_limits.max_parallel_requests, Some(10));
+}
 
-    /// Test Permission enum variants
-    #[test]
-    fn test_permission_variants() {
-        let perms = vec![
-            Permission::ChatCompletion,
-            Permission::TextCompletion,
-            Permission::Embedding,
-            Permission::ImageGeneration,
-            Permission::ModelAccess("gpt-4".to_string()),
-            Permission::Admin,
-            Permission::KeyManagement,
-            Permission::ViewUsage,
-            Permission::TeamManagement,
-            Permission::Custom("custom_perm".to_string()),
-        ];
+/// Test Permission enum variants
+#[test]
+fn test_permission_variants() {
+    let perms = vec![
+        Permission::ChatCompletion,
+        Permission::TextCompletion,
+        Permission::Embedding,
+        Permission::ImageGeneration,
+        Permission::ModelAccess("gpt-4".to_string()),
+        Permission::Admin,
+        Permission::KeyManagement,
+        Permission::ViewUsage,
+        Permission::TeamManagement,
+        Permission::Custom("custom_perm".to_string()),
+    ];
 
-        assert_eq!(perms.len(), 10);
-        assert!(perms.contains(&Permission::Admin));
-    }
+    assert_eq!(perms.len(), 10);
+    assert!(perms.contains(&Permission::Admin));
+}
 
-    /// Test CreateKeyRequest builder pattern
-    #[test]
-    fn test_create_key_request() {
-        let request = CreateKeyRequest {
-            user_id: "user123".to_string(),
-            key_alias: Some("my-key".to_string()),
-            team_id: None,
-            models: vec!["gpt-4".to_string()],
-            max_budget: Some(100.0),
-            budget_duration: Some("1d".to_string()),
-            rate_limits: None,
-            permissions: vec![Permission::ChatCompletion],
-            metadata: HashMap::new(),
-            expires_at: None,
-            tags: vec!["production".to_string()],
-        };
+/// Test CreateKeyRequest builder pattern
+#[test]
+fn test_create_key_request() {
+    let request = CreateKeyRequest {
+        user_id: "user123".to_string(),
+        key_alias: Some("my-key".to_string()),
+        team_id: None,
+        models: vec!["gpt-4".to_string()],
+        max_budget: Some(100.0),
+        budget_duration: Some("1d".to_string()),
+        rate_limits: None,
+        permissions: vec![Permission::ChatCompletion],
+        metadata: HashMap::new(),
+        expires_at: None,
+        tags: vec!["production".to_string()],
+    };
 
-        assert_eq!(request.user_id, "user123");
-        assert_eq!(request.key_alias, Some("my-key".to_string()));
-        assert_eq!(request.models.len(), 1);
-    }
+    assert_eq!(request.user_id, "user123");
+    assert_eq!(request.key_alias, Some("my-key".to_string()));
+    assert_eq!(request.models.len(), 1);
 }

--- a/src/core/virtual_keys/types.rs
+++ b/src/core/virtual_keys/types.rs
@@ -276,7 +276,10 @@ mod tests {
         };
 
         assert_eq!(key.metadata.len(), 2);
-        assert_eq!(key.metadata.get("environment"), Some(&"production".to_string()));
+        assert_eq!(
+            key.metadata.get("environment"),
+            Some(&"production".to_string())
+        );
     }
 
     #[test]
@@ -575,9 +578,21 @@ mod tests {
     fn test_key_generation_settings_default_permissions() {
         let settings = KeyGenerationSettings::default();
 
-        assert!(settings.default_permissions.contains(&Permission::ChatCompletion));
-        assert!(settings.default_permissions.contains(&Permission::TextCompletion));
-        assert!(settings.default_permissions.contains(&Permission::Embedding));
+        assert!(
+            settings
+                .default_permissions
+                .contains(&Permission::ChatCompletion)
+        );
+        assert!(
+            settings
+                .default_permissions
+                .contains(&Permission::TextCompletion)
+        );
+        assert!(
+            settings
+                .default_permissions
+                .contains(&Permission::Embedding)
+        );
     }
 
     #[test]
@@ -686,7 +701,10 @@ mod tests {
         // Check if under limits
         let under_rpm = limits.rpm.map(|l| state.request_count < l).unwrap_or(true);
         let under_tpm = limits.tpm.map(|l| state.token_count < l).unwrap_or(true);
-        let under_parallel = limits.max_parallel_requests.map(|l| state.parallel_requests < l).unwrap_or(true);
+        let under_parallel = limits
+            .max_parallel_requests
+            .map(|l| state.parallel_requests < l)
+            .unwrap_or(true);
 
         assert!(under_rpm);
         assert!(under_tpm);
@@ -713,9 +731,15 @@ mod tests {
         };
 
         // Check if over limits
-        let over_rpm = limits.rpm.map(|l| state.request_count >= l).unwrap_or(false);
+        let over_rpm = limits
+            .rpm
+            .map(|l| state.request_count >= l)
+            .unwrap_or(false);
         let over_tpm = limits.tpm.map(|l| state.token_count >= l).unwrap_or(false);
-        let over_parallel = limits.max_parallel_requests.map(|l| state.parallel_requests >= l).unwrap_or(false);
+        let over_parallel = limits
+            .max_parallel_requests
+            .map(|l| state.parallel_requests >= l)
+            .unwrap_or(false);
 
         assert!(over_rpm);
         assert!(over_tpm);
@@ -727,7 +751,10 @@ mod tests {
         let key = create_test_virtual_key();
 
         let cost = 10.0;
-        let would_exceed = key.max_budget.map(|b| key.spend + cost > b).unwrap_or(false);
+        let would_exceed = key
+            .max_budget
+            .map(|b| key.spend + cost > b)
+            .unwrap_or(false);
 
         assert!(!would_exceed); // 25 + 10 = 35 < 100
     }
@@ -738,7 +765,10 @@ mod tests {
         key.spend = 95.0;
 
         let cost = 10.0;
-        let would_exceed = key.max_budget.map(|b| key.spend + cost > b).unwrap_or(false);
+        let would_exceed = key
+            .max_budget
+            .map(|b| key.spend + cost > b)
+            .unwrap_or(false);
 
         assert!(would_exceed); // 95 + 10 = 105 > 100
     }
@@ -747,8 +777,7 @@ mod tests {
     fn test_key_validity_check() {
         let key = create_test_virtual_key();
 
-        let is_valid = key.is_active
-            && key.expires_at.map(|e| Utc::now() < e).unwrap_or(true);
+        let is_valid = key.is_active && key.expires_at.map(|e| Utc::now() < e).unwrap_or(true);
 
         assert!(is_valid);
     }
@@ -758,8 +787,7 @@ mod tests {
         let mut key = create_test_virtual_key();
         key.is_active = false;
 
-        let is_valid = key.is_active
-            && key.expires_at.map(|e| Utc::now() < e).unwrap_or(true);
+        let is_valid = key.is_active && key.expires_at.map(|e| Utc::now() < e).unwrap_or(true);
 
         assert!(!is_valid);
     }

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -6,6 +6,7 @@ mod connection;
 mod token_ops;
 mod types;
 mod user_ops;
+mod virtual_key_ops;
 
 // Re-export public types
 pub use types::{DatabaseBackendType, DatabaseStats, SeaOrmDatabase};

--- a/src/storage/database/seaorm_db/virtual_key_ops.rs
+++ b/src/storage/database/seaorm_db/virtual_key_ops.rs
@@ -1,0 +1,74 @@
+//! Virtual key database operations
+//!
+//! Stub implementations — database schema for virtual keys is not yet migrated.
+//! Each method returns `GatewayError::NotImplemented` until the migration lands.
+
+use crate::core::virtual_keys::VirtualKey;
+use crate::utils::error::gateway_error::{GatewayError, Result};
+
+use super::types::SeaOrmDatabase;
+
+impl SeaOrmDatabase {
+    /// Store a new virtual key in the database.
+    pub async fn store_virtual_key(&self, _key: &VirtualKey) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: store_virtual_key not yet implemented",
+        ))
+    }
+
+    /// Retrieve a virtual key by its hash.
+    pub async fn get_virtual_key(&self, _key_hash: &str) -> Result<Option<VirtualKey>> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: get_virtual_key not yet implemented",
+        ))
+    }
+
+    /// Update the usage statistics (last_used_at, usage_count) for a virtual key.
+    pub async fn update_virtual_key_usage(&self, _key: &VirtualKey) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: update_virtual_key_usage not yet implemented",
+        ))
+    }
+
+    /// Add `cost` to the recorded spend for the given key ID.
+    pub async fn update_key_spend(&self, _key_id: &str, _cost: f64) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: update_key_spend not yet implemented",
+        ))
+    }
+
+    /// List all virtual keys owned by a user.
+    pub async fn list_user_keys(&self, _user_id: &str) -> Result<Vec<VirtualKey>> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: list_user_keys not yet implemented",
+        ))
+    }
+
+    /// Retrieve a virtual key by its opaque key ID.
+    pub async fn get_virtual_key_by_id(&self, _key_id: &str) -> Result<Option<VirtualKey>> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: get_virtual_key_by_id not yet implemented",
+        ))
+    }
+
+    /// Persist all mutable fields of a virtual key (full update).
+    pub async fn update_virtual_key(&self, _key: &VirtualKey) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: update_virtual_key not yet implemented",
+        ))
+    }
+
+    /// Remove a virtual key from the database by its key ID.
+    pub async fn delete_virtual_key(&self, _key_id: &str) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: delete_virtual_key not yet implemented",
+        ))
+    }
+
+    /// Return all virtual keys whose budget reset timestamp has passed.
+    pub async fn get_keys_with_expired_budgets(&self) -> Result<Vec<VirtualKey>> {
+        Err(GatewayError::not_implemented(
+            "virtual_keys: get_keys_with_expired_budgets not yet implemented",
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- Uncomments `pub mod virtual_keys` in `src/core/mod.rs` (fixes #257)
- Adds `src/storage/database/seaorm_db/virtual_key_ops.rs` with stub implementations for all 9 database methods the module requires — each returns `GatewayError::not_implemented(...)` until the migration lands
- Fixes pre-existing compile errors exposed by enabling the module:
  - `GatewayError::BudgetExceeded` → `GatewayError::Forbidden` (variant didn't exist)
  - 7 collapsible nested-`if` patterns in `manager.rs` and `client.rs`
  - Redundant `mod tests {}` wrapper in `tests.rs` (module-same-name-as-file)
  - `rand::random::<usize>()` incompatible with rand 0.9 → `rand::rng().random_range(...)`
  - `vec![]` macros replaced with array literals in tests

## Test plan

- [x] `cargo check --all-features` — passes
- [x] `cargo fmt --all` — no diff
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 95 passed, 0 failed