### PR TITLE
fix: gate virtual_keys module behind gateway feature flag

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -45,5 +45,6 @@ pub mod types;
 // - user_management: get_user, create_user, get_team, create_team, etc.
 // NOTE: user_management requires database method implementations.
 // pub mod user_management;
+#[cfg(feature = "gateway")]
 pub mod virtual_keys; // Database methods implemented as stubs in storage/database/seaorm_db/virtual_key_ops.rs
 pub mod webhooks;


### PR DESCRIPTION
## Problem

`src/core/mod.rs` unconditionally compiled `pub mod virtual_keys`, but `src/core/virtual_keys/manager.rs` imports `crate::storage::database::Database` which is only available when the `gateway` feature is active (since `src/lib.rs` gates `pub mod storage` behind `#[cfg(feature = "gateway")]`). This broke lite/no-default-features builds with unresolved `crate::storage` symbols.

## Fix

Add `#[cfg(feature = "gateway")]` attribute to the `virtual_keys` module declaration in `src/core/mod.rs`, matching how other storage-dependent modules are gated.

## Verification

- `cargo check --no-default-features` — passes (was broken before)
- `cargo check` (default features) — passes
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` — passes
- `cargo test` — 95 passed, 0 failed