### PR TITLE
feat(core): enable user_management module with stub DB implementations

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -40,11 +40,7 @@ pub mod streaming;
 pub mod teams; // Team management module
 pub mod traits;
 pub mod types;
-// User and team management - disabled until database methods are implemented
-// These modules require the following database methods to be implemented:
-// - user_management: get_user, create_user, get_team, create_team, etc.
-// NOTE: user_management requires database method implementations.
-// pub mod user_management;
+pub mod user_management; // DB methods implemented as stubs in storage/database/seaorm_db/user_management_ops.rs
 #[cfg(feature = "gateway")]
 pub mod virtual_keys; // Database methods implemented as stubs in storage/database/seaorm_db/virtual_key_ops.rs
 pub mod webhooks;

--- a/src/core/user_management/manager.rs
+++ b/src/core/user_management/manager.rs
@@ -80,7 +80,9 @@ impl UserManager {
         organization_id: Option<String>,
         creator_id: String,
     ) -> Result<Team> {
-        self.team_ops.create_team(team_name, description, organization_id, creator_id).await
+        self.team_ops
+            .create_team(team_name, description, organization_id, creator_id)
+            .await
     }
 
     /// Get team by ID
@@ -122,7 +124,9 @@ impl UserManager {
         description: Option<String>,
         creator_id: String,
     ) -> Result<Organization> {
-        self.team_ops.create_organization(organization_name, description, creator_id).await
+        self.team_ops
+            .create_organization(organization_name, description, creator_id)
+            .await
     }
 
     /// Get organization by ID

--- a/src/core/user_management/roles.rs
+++ b/src/core/user_management/roles.rs
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_user_role_all_variants_distinct() {
-        let roles = vec![
+        let roles = [
             UserRole::SuperAdmin,
             UserRole::OrgAdmin,
             UserRole::TeamAdmin,
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_team_role_all_variants_distinct() {
-        let roles = vec![
+        let roles = [
             TeamRole::Owner,
             TeamRole::Admin,
             TeamRole::Member,

--- a/src/core/user_management/team_ops.rs
+++ b/src/core/user_management/team_ops.rs
@@ -72,14 +72,22 @@ impl TeamOperations {
         user_id: &str,
         role: TeamRole,
     ) -> Result<()> {
-        info!("Adding user {} to team {} with role {:?}", user_id, team_id, role);
+        info!(
+            "Adding user {} to team {} with role {:?}",
+            user_id, team_id, role
+        );
 
-        let mut team = self.database.get_team(team_id).await?
+        let mut team = self
+            .database
+            .get_team(team_id)
+            .await?
             .ok_or_else(|| GatewayError::NotFound("Team not found".to_string()))?;
 
         // Check if user is already a member
         if team.members.iter().any(|m| m.user_id == user_id) {
-            return Err(GatewayError::Conflict("User is already a team member".to_string()));
+            return Err(GatewayError::Conflict(
+                "User is already a team member".to_string(),
+            ));
         }
 
         // Add member
@@ -105,7 +113,10 @@ impl TeamOperations {
     pub async fn remove_user_from_team(&self, team_id: &str, user_id: &str) -> Result<()> {
         info!("Removing user {} from team {}", user_id, team_id);
 
-        let mut team = self.database.get_team(team_id).await?
+        let mut team = self
+            .database
+            .get_team(team_id)
+            .await?
             .ok_or_else(|| GatewayError::NotFound("Team not found".to_string()))?;
 
         // Remove member
@@ -158,7 +169,10 @@ impl TeamOperations {
         };
 
         self.database.create_organization(&organization).await?;
-        info!("Organization created successfully: {}", organization.organization_id);
+        info!(
+            "Organization created successfully: {}",
+            organization.organization_id
+        );
         Ok(organization)
     }
 

--- a/src/core/user_management/tests.rs
+++ b/src/core/user_management/tests.rs
@@ -1,133 +1,130 @@
 //! Tests for user management module
 
-#[cfg(test)]
-mod tests {
-    use super::super::roles::{TeamRole, UserRole};
-    use super::super::settings::TeamSettings;
-    use super::super::types::{Team, TeamMember};
-    use chrono::Utc;
-    use std::collections::HashMap;
+use super::roles::{TeamRole, UserRole};
+use super::settings::TeamSettings;
+use super::types::{Team, TeamMember};
+use chrono::Utc;
+use std::collections::HashMap;
 
-    /// Test UserRole enum equality and variants
-    #[test]
-    fn test_user_roles() {
-        assert_eq!(UserRole::SuperAdmin, UserRole::SuperAdmin);
-        assert_ne!(UserRole::User, UserRole::OrgAdmin);
+/// Test UserRole enum equality and variants
+#[test]
+fn test_user_roles() {
+    assert_eq!(UserRole::SuperAdmin, UserRole::SuperAdmin);
+    assert_ne!(UserRole::User, UserRole::OrgAdmin);
 
-        // Test all variants exist
-        let roles = vec![
-            UserRole::SuperAdmin,
-            UserRole::OrgAdmin,
-            UserRole::TeamAdmin,
-            UserRole::User,
-            UserRole::ReadOnly,
-            UserRole::ServiceAccount,
-        ];
-        assert_eq!(roles.len(), 6);
-    }
+    // Test all variants exist
+    let roles = [
+        UserRole::SuperAdmin,
+        UserRole::OrgAdmin,
+        UserRole::TeamAdmin,
+        UserRole::User,
+        UserRole::ReadOnly,
+        UserRole::ServiceAccount,
+    ];
+    assert_eq!(roles.len(), 6);
+}
 
-    /// Test TeamRole enum equality and variants
-    #[test]
-    fn test_team_roles() {
-        assert_eq!(TeamRole::Owner, TeamRole::Owner);
-        assert_ne!(TeamRole::Member, TeamRole::Admin);
+/// Test TeamRole enum equality and variants
+#[test]
+fn test_team_roles() {
+    assert_eq!(TeamRole::Owner, TeamRole::Owner);
+    assert_ne!(TeamRole::Member, TeamRole::Admin);
 
-        // Test all variants exist
-        let roles = vec![
-            TeamRole::Owner,
-            TeamRole::Admin,
-            TeamRole::Member,
-            TeamRole::ReadOnly,
-        ];
-        assert_eq!(roles.len(), 4);
-    }
+    // Test all variants exist
+    let roles = [
+        TeamRole::Owner,
+        TeamRole::Admin,
+        TeamRole::Member,
+        TeamRole::ReadOnly,
+    ];
+    assert_eq!(roles.len(), 4);
+}
 
-    /// Test Team structure
-    #[test]
-    fn test_team_structure() {
-        let owner = TeamMember {
-            user_id: "owner123".to_string(),
-            role: TeamRole::Owner,
-            joined_at: Utc::now(),
-            is_active: true,
-        };
+/// Test Team structure
+#[test]
+fn test_team_structure() {
+    let owner = TeamMember {
+        user_id: "owner123".to_string(),
+        role: TeamRole::Owner,
+        joined_at: Utc::now(),
+        is_active: true,
+    };
 
-        let team = Team {
-            team_id: "team123".to_string(),
-            team_name: "Test Team".to_string(),
-            description: Some("A test team".to_string()),
-            organization_id: None,
-            members: vec![owner.clone()],
-            permissions: vec![],
-            models: vec![],
-            max_budget: Some(1000.0),
-            spend: 0.0,
-            budget_duration: Some("1m".to_string()),
-            budget_reset_at: None,
-            metadata: HashMap::new(),
-            is_active: true,
-            created_at: Utc::now(),
-            settings: TeamSettings::default(),
-        };
+    let team = Team {
+        team_id: "team123".to_string(),
+        team_name: "Test Team".to_string(),
+        description: Some("A test team".to_string()),
+        organization_id: None,
+        members: vec![owner.clone()],
+        permissions: vec![],
+        models: vec![],
+        max_budget: Some(1000.0),
+        spend: 0.0,
+        budget_duration: Some("1m".to_string()),
+        budget_reset_at: None,
+        metadata: HashMap::new(),
+        is_active: true,
+        created_at: Utc::now(),
+        settings: TeamSettings::default(),
+    };
 
-        assert_eq!(team.team_name, "Test Team");
-        assert_eq!(team.members.len(), 1);
-        assert_eq!(team.members[0].role, TeamRole::Owner);
-    }
+    assert_eq!(team.team_name, "Test Team");
+    assert_eq!(team.members.len(), 1);
+    assert_eq!(team.members[0].role, TeamRole::Owner);
+}
 
-    /// Test TeamMember role assignment
-    #[test]
-    fn test_team_member_roles() {
-        let owner = TeamMember {
-            user_id: "u1".to_string(),
-            role: TeamRole::Owner,
-            joined_at: Utc::now(),
-            is_active: true,
-        };
+/// Test TeamMember role assignment
+#[test]
+fn test_team_member_roles() {
+    let owner = TeamMember {
+        user_id: "u1".to_string(),
+        role: TeamRole::Owner,
+        joined_at: Utc::now(),
+        is_active: true,
+    };
 
-        let admin = TeamMember {
-            user_id: "u2".to_string(),
-            role: TeamRole::Admin,
-            joined_at: Utc::now(),
-            is_active: true,
-        };
+    let admin = TeamMember {
+        user_id: "u2".to_string(),
+        role: TeamRole::Admin,
+        joined_at: Utc::now(),
+        is_active: true,
+    };
 
-        let member = TeamMember {
-            user_id: "u3".to_string(),
-            role: TeamRole::Member,
-            joined_at: Utc::now(),
-            is_active: true,
-        };
+    let member = TeamMember {
+        user_id: "u3".to_string(),
+        role: TeamRole::Member,
+        joined_at: Utc::now(),
+        is_active: true,
+    };
 
-        assert_eq!(owner.role, TeamRole::Owner);
-        assert_eq!(admin.role, TeamRole::Admin);
-        assert_eq!(member.role, TeamRole::Member);
-    }
+    assert_eq!(owner.role, TeamRole::Owner);
+    assert_eq!(admin.role, TeamRole::Admin);
+    assert_eq!(member.role, TeamRole::Member);
+}
 
-    /// Test TeamSettings default values
-    #[test]
-    fn test_team_settings_defaults() {
-        let settings = TeamSettings::default();
+/// Test TeamSettings default values
+#[test]
+fn test_team_settings_defaults() {
+    let settings = TeamSettings::default();
 
-        // Verify default settings are reasonable
-        assert!(settings.auto_approve_members);
-        assert_eq!(settings.high_cost_threshold, Some(10.0));
-    }
+    // Verify default settings are reasonable
+    assert!(settings.auto_approve_members);
+    assert_eq!(settings.high_cost_threshold, Some(10.0));
+}
 
-    /// Test UserRole hierarchy (conceptually)
-    #[test]
-    fn test_user_role_hierarchy() {
-        // SuperAdmin > OrgAdmin > TeamAdmin > User > ReadOnly
-        let super_admin = UserRole::SuperAdmin;
-        let org_admin = UserRole::OrgAdmin;
-        let team_admin = UserRole::TeamAdmin;
-        let user = UserRole::User;
-        let read_only = UserRole::ReadOnly;
+/// Test UserRole hierarchy (conceptually)
+#[test]
+fn test_user_role_hierarchy() {
+    // SuperAdmin > OrgAdmin > TeamAdmin > User > ReadOnly
+    let super_admin = UserRole::SuperAdmin;
+    let org_admin = UserRole::OrgAdmin;
+    let team_admin = UserRole::TeamAdmin;
+    let user = UserRole::User;
+    let read_only = UserRole::ReadOnly;
 
-        // Verify they are distinct
-        assert_ne!(super_admin, org_admin);
-        assert_ne!(org_admin, team_admin);
-        assert_ne!(team_admin, user);
-        assert_ne!(user, read_only);
-    }
+    // Verify they are distinct
+    assert_ne!(super_admin, org_admin);
+    assert_ne!(org_admin, team_admin);
+    assert_ne!(team_admin, user);
+    assert_ne!(user, read_only);
 }

--- a/src/core/user_management/types.rs
+++ b/src/core/user_management/types.rs
@@ -285,10 +285,15 @@ mod tests {
     #[test]
     fn test_user_with_metadata() {
         let mut user = create_test_user();
-        user.metadata.insert("department".to_string(), "engineering".to_string());
-        user.metadata.insert("location".to_string(), "remote".to_string());
+        user.metadata
+            .insert("department".to_string(), "engineering".to_string());
+        user.metadata
+            .insert("location".to_string(), "remote".to_string());
 
-        assert_eq!(user.metadata.get("department"), Some(&"engineering".to_string()));
+        assert_eq!(
+            user.metadata.get("department"),
+            Some(&"engineering".to_string())
+        );
     }
 
     #[test]
@@ -540,10 +545,7 @@ mod tests {
     #[test]
     fn test_organization_with_multiple_admins() {
         let mut org = create_test_organization();
-        org.admins = vec![
-            "admin-1".to_string(),
-            "admin-2".to_string(),
-        ];
+        org.admins = vec!["admin-1".to_string(), "admin-2".to_string()];
 
         assert_eq!(org.admins.len(), 2);
     }
@@ -653,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_spend_aggregation_simulation() {
-        let users = vec![
+        let users = [
             User {
                 spend: 100.0,
                 ..create_test_user()

--- a/src/core/user_management/user_ops.rs
+++ b/src/core/user_management/user_ops.rs
@@ -51,7 +51,7 @@ impl UserOperations {
             preferences: UserPreferences::default(),
         };
 
-        self.database.create_user(&user).await?;
+        self.database.um_create_user(&user).await?;
         info!("User created successfully: {}", user.user_id);
         Ok(user)
     }
@@ -79,7 +79,10 @@ impl UserOperations {
 
     /// Check if user has permission
     pub async fn check_permission(&self, user_id: &str, permission: &str) -> Result<bool> {
-        let user = self.database.get_user(user_id).await?
+        let user = self
+            .database
+            .get_user(user_id)
+            .await?
             .ok_or_else(|| GatewayError::NotFound("User not found".to_string()))?;
 
         // Super admin has all permissions
@@ -94,10 +97,10 @@ impl UserOperations {
 
         // Check team permissions
         for team_id in &user.teams {
-            if let Some(team) = self.database.get_team(team_id).await? {
-                if team.permissions.contains(&permission.to_string()) {
-                    return Ok(true);
-                }
+            if let Some(team) = self.database.get_team(team_id).await?
+                && team.permissions.contains(&permission.to_string())
+            {
+                return Ok(true);
             }
         }
 
@@ -116,7 +119,10 @@ impl UserOperations {
 
     /// Get user teams
     pub async fn get_user_teams(&self, user_id: &str) -> Result<Vec<Team>> {
-        let user = self.database.get_user(user_id).await?
+        let user = self
+            .database
+            .get_user(user_id)
+            .await?
             .ok_or_else(|| GatewayError::NotFound("User not found".to_string()))?;
 
         let mut teams = Vec::new();

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -5,6 +5,7 @@ mod batch_ops;
 mod connection;
 mod token_ops;
 mod types;
+mod user_management_ops;
 mod user_ops;
 mod virtual_key_ops;
 

--- a/src/storage/database/seaorm_db/user_management_ops.rs
+++ b/src/storage/database/seaorm_db/user_management_ops.rs
@@ -1,0 +1,112 @@
+//! User management database operations
+//!
+//! Stub implementations — database schema for user management is not yet migrated.
+//! Each method returns `GatewayError::NotImplemented` until the migration lands.
+
+use crate::core::user_management::{Organization, Team, User};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+
+use super::types::SeaOrmDatabase;
+
+impl SeaOrmDatabase {
+    /// Retrieve a user management user by their string ID.
+    pub async fn get_user(&self, _user_id: &str) -> Result<Option<User>> {
+        Err(GatewayError::not_implemented(
+            "user_management: get_user not yet implemented",
+        ))
+    }
+
+    /// Retrieve a user management user by their email address.
+    pub async fn get_user_by_email(&self, _email: &str) -> Result<Option<User>> {
+        Err(GatewayError::not_implemented(
+            "user_management: get_user_by_email not yet implemented",
+        ))
+    }
+
+    /// Persist a new user management user to the database.
+    ///
+    /// Named `um_create_user` to avoid colliding with the existing
+    /// `create_user` method which operates on a different `User` type.
+    pub async fn um_create_user(&self, _user: &User) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: um_create_user not yet implemented",
+        ))
+    }
+
+    /// Persist all mutable fields of a user management user (full update).
+    pub async fn update_user(&self, _user: &User) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: update_user not yet implemented",
+        ))
+    }
+
+    /// Remove a user management user from the database by their string ID.
+    pub async fn delete_user(&self, _user_id: &str) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: delete_user not yet implemented",
+        ))
+    }
+
+    /// Add `cost` to the recorded spend for the given user ID.
+    pub async fn update_user_spend(&self, _user_id: &str, _cost: f64) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: update_user_spend not yet implemented",
+        ))
+    }
+
+    /// List user management users with offset-based pagination.
+    pub async fn list_users(&self, _offset: u32, _limit: u32) -> Result<Vec<User>> {
+        Err(GatewayError::not_implemented(
+            "user_management: list_users not yet implemented",
+        ))
+    }
+
+    /// Retrieve a team by its string ID.
+    pub async fn get_team(&self, _team_id: &str) -> Result<Option<Team>> {
+        Err(GatewayError::not_implemented(
+            "user_management: get_team not yet implemented",
+        ))
+    }
+
+    /// Persist a new team to the database.
+    pub async fn create_team(&self, _team: &Team) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: create_team not yet implemented",
+        ))
+    }
+
+    /// Persist all mutable fields of a team (full update).
+    pub async fn update_team(&self, _team: &Team) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: update_team not yet implemented",
+        ))
+    }
+
+    /// Add `cost` to the recorded spend for the given team ID.
+    pub async fn update_team_spend(&self, _team_id: &str, _cost: f64) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: update_team_spend not yet implemented",
+        ))
+    }
+
+    /// List teams with offset-based pagination.
+    pub async fn list_teams(&self, _offset: u32, _limit: u32) -> Result<Vec<Team>> {
+        Err(GatewayError::not_implemented(
+            "user_management: list_teams not yet implemented",
+        ))
+    }
+
+    /// Persist a new organization to the database.
+    pub async fn create_organization(&self, _organization: &Organization) -> Result<()> {
+        Err(GatewayError::not_implemented(
+            "user_management: create_organization not yet implemented",
+        ))
+    }
+
+    /// Retrieve an organization by its string ID.
+    pub async fn get_organization(&self, _organization_id: &str) -> Result<Option<Organization>> {
+        Err(GatewayError::not_implemented(
+            "user_management: get_organization not yet implemented",
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #256.

- **`src/core/mod.rs`**: Uncomment `pub mod user_management`
- **`src/storage/database/seaorm_db/user_management_ops.rs`**: New file implementing 14 stub DB methods on `SeaOrmDatabase` (each returns `GatewayError::not_implemented(...)`):
  - `get_user`, `get_user_by_email`, `um_create_user`, `update_user`, `delete_user`, `update_user_spend`, `list_users`
  - `get_team`, `create_team`, `update_team`, `update_team_spend`, `list_teams`
  - `create_organization`, `get_organization`
- **`src/storage/database/seaorm_db/mod.rs`**: Register new `user_management_ops` sub-module
- **`src/core/user_management/user_ops.rs`**: Call `um_create_user` instead of `create_user` to avoid name collision with the existing `create_user` method which operates on a different `User` type
- **Pre-existing clippy fixes** (only surfaced when the module was enabled):
  - `clippy::useless_vec`: `vec![]` → array literals in `roles.rs`, `tests.rs`, `types.rs`
  - `clippy::module_inception`: Remove inner `mod tests {}` wrapper in `tests.rs`
  - `clippy::collapsible_if`: Collapse nested `if let`/`if` in `user_ops.rs`

## Test plan

- [x] `cargo check --all-features` — passes
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes
- [x] `cargo test --workspace` — 95 passed, 0 failed