### PR TITLE
fix: implement user_management DB ops and wire TeamManager to persistent storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rs"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litellm-rs"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2024"
 rust-version = "1.88"
 authors = ["lifcc"]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -4,8 +4,9 @@
 
 use crate::config::Config;
 use crate::core::budget::UnifiedBudgetLimits;
-use crate::core::teams::{InMemoryTeamRepository, TeamManager};
+use crate::core::teams::TeamManager;
 use crate::services::pricing::PricingService;
+use crate::storage::database::SeaOrmTeamRepository;
 use crate::utils::sync::AtomicValue;
 use std::sync::Arc;
 
@@ -45,7 +46,9 @@ impl AppState {
         storage: crate::storage::StorageLayer,
         pricing: Arc<PricingService>,
     ) -> Self {
-        let team_manager = Arc::new(TeamManager::new(Arc::new(InMemoryTeamRepository::new())));
+        let team_manager = Arc::new(TeamManager::new(Arc::new(SeaOrmTeamRepository::new(
+            storage.database.clone(),
+        ))));
         Self {
             config: AtomicValue::new(config),
             auth: Arc::new(auth),

--- a/src/storage/database/migration/m20240301_000001_create_user_management_tables.rs
+++ b/src/storage/database/migration/m20240301_000001_create_user_management_tables.rs
@@ -1,0 +1,148 @@
+//! Migration: create user management tables
+//!
+//! Creates the `um_users`, `um_teams`, and `um_organizations` tables used by
+//! the user_management module. Each row stores a JSON snapshot of the domain
+//! object so the schema stays stable while the domain evolves.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(UmUsers::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(UmUsers::UserId)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(UmUsers::Email)
+                            .string()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(UmUsers::Data).text().not_null())
+                    .col(
+                        ColumnDef::new(UmUsers::Spend)
+                            .double()
+                            .not_null()
+                            .default(0.0),
+                    )
+                    .col(
+                        ColumnDef::new(UmUsers::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(UmTeams::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(UmTeams::TeamId)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(UmTeams::Data).text().not_null())
+                    .col(
+                        ColumnDef::new(UmTeams::Spend)
+                            .double()
+                            .not_null()
+                            .default(0.0),
+                    )
+                    .col(
+                        ColumnDef::new(UmTeams::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(UmOrganizations::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(UmOrganizations::OrganizationId)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(UmOrganizations::Data).text().not_null())
+                    .col(
+                        ColumnDef::new(UmOrganizations::Spend)
+                            .double()
+                            .not_null()
+                            .default(0.0),
+                    )
+                    .col(
+                        ColumnDef::new(UmOrganizations::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(UmOrganizations::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(UmTeams::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(UmUsers::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum UmUsers {
+    Table,
+    UserId,
+    Email,
+    Data,
+    Spend,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum UmTeams {
+    Table,
+    TeamId,
+    Data,
+    Spend,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum UmOrganizations {
+    Table,
+    OrganizationId,
+    Data,
+    Spend,
+    CreatedAt,
+}

--- a/src/storage/database/migration/m20240301_000002_create_teams_table.rs
+++ b/src/storage/database/migration/m20240301_000002_create_teams_table.rs
@@ -1,0 +1,86 @@
+//! Migration: create gateway teams and team_members tables
+//!
+//! Backs the `TeamRepository` implementation so `TeamManager` state is
+//! persisted across restarts. Team and member data is stored as a JSON
+//! snapshot alongside the indexed columns required for efficient lookups.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Teams::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Teams::Id).string().not_null().primary_key())
+                    .col(ColumnDef::new(Teams::Name).string().not_null().unique_key())
+                    .col(ColumnDef::new(Teams::Data).text().not_null())
+                    .col(
+                        ColumnDef::new(Teams::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(TeamMembers::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(TeamMembers::TeamId).string().not_null())
+                    .col(ColumnDef::new(TeamMembers::UserId).string().not_null())
+                    .col(ColumnDef::new(TeamMembers::Data).text().not_null())
+                    .col(
+                        ColumnDef::new(TeamMembers::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(TeamMembers::TeamId)
+                            .col(TeamMembers::UserId),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(TeamMembers::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Teams::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Teams {
+    Table,
+    Id,
+    Name,
+    Data,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum TeamMembers {
+    Table,
+    TeamId,
+    UserId,
+    Data,
+    CreatedAt,
+}

--- a/src/storage/database/migration/mod.rs
+++ b/src/storage/database/migration/mod.rs
@@ -5,6 +5,8 @@ mod m20240101_000002_create_password_reset_tokens_table;
 mod m20240101_000003_create_batches_table;
 mod m20240101_000004_create_user_sessions_table;
 mod m20240101_000005_create_api_keys_table;
+mod m20240301_000001_create_user_management_tables;
+mod m20240301_000002_create_teams_table;
 
 /// Database migrator for SeaORM
 pub struct Migrator;
@@ -18,6 +20,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20240101_000003_create_batches_table::Migration),
             Box::new(m20240101_000004_create_user_sessions_table::Migration),
             Box::new(m20240101_000005_create_api_keys_table::Migration),
+            Box::new(m20240301_000001_create_user_management_tables::Migration),
+            Box::new(m20240301_000002_create_teams_table::Migration),
         ]
     }
 }

--- a/src/storage/database/mod.rs
+++ b/src/storage/database/mod.rs
@@ -12,7 +12,7 @@ pub mod seaorm_db;
 
 // Re-export the main database interface
 pub use seaorm_db::SeaOrmDatabase as Database;
-pub use seaorm_db::{DatabaseBackendType, DatabaseStats};
+pub use seaorm_db::{DatabaseBackendType, DatabaseStats, SeaOrmTeamRepository};
 
 /// Returns the default absolute path for the SQLite fallback database.
 ///

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -3,6 +3,7 @@ mod analytics_ops;
 mod api_key_ops;
 mod batch_ops;
 mod connection;
+mod team_repository;
 mod token_ops;
 mod types;
 mod user_management_ops;
@@ -10,4 +11,5 @@ mod user_ops;
 mod virtual_key_ops;
 
 // Re-export public types
+pub use team_repository::SeaOrmTeamRepository;
 pub use types::{DatabaseBackendType, DatabaseStats, SeaOrmDatabase};

--- a/src/storage/database/seaorm_db/team_repository.rs
+++ b/src/storage/database/seaorm_db/team_repository.rs
@@ -1,0 +1,380 @@
+//! SeaORM-backed TeamRepository implementation
+//!
+//! Stores `core::models::team::{Team, TeamMember}` as JSON snapshots in the
+//! `teams` and `team_members` tables created by migration
+//! `m20240301_000002_create_teams_table`.  Works with both SQLite and
+//! PostgreSQL backends via the live `SeaOrmDatabase` connection.
+
+use crate::core::models::team::{Team, TeamMember, TeamRole, TeamStatus};
+use crate::core::teams::repository::TeamRepository;
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use async_trait::async_trait;
+use sea_orm::{ConnectionTrait, DbBackend, Statement, Value};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::types::{DatabaseBackendType, SeaOrmDatabase};
+
+/// SeaORM-backed team repository (supports SQLite and PostgreSQL).
+pub struct SeaOrmTeamRepository {
+    db: Arc<SeaOrmDatabase>,
+}
+
+impl SeaOrmTeamRepository {
+    /// Create a new repository wrapping the given database connection.
+    pub fn new(db: Arc<SeaOrmDatabase>) -> Self {
+        Self { db }
+    }
+
+    fn backend(&self) -> DbBackend {
+        match self.db.backend_type {
+            DatabaseBackendType::PostgreSQL => DbBackend::Postgres,
+            DatabaseBackendType::SQLite => DbBackend::Sqlite,
+        }
+    }
+
+    /// Return the positional placeholder for parameter `n` (1-based).
+    fn ph(&self, n: usize) -> String {
+        match self.db.backend_type {
+            DatabaseBackendType::PostgreSQL => format!("${}", n),
+            DatabaseBackendType::SQLite => "?".to_string(),
+        }
+    }
+
+    fn to_json<T: serde::Serialize>(v: &T) -> Result<String> {
+        serde_json::to_string(v).map_err(|e| GatewayError::Internal(e.to_string()))
+    }
+
+    fn from_json<T: serde::de::DeserializeOwned>(s: &str) -> Result<T> {
+        serde_json::from_str(s).map_err(|e| GatewayError::Internal(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl TeamRepository for SeaOrmTeamRepository {
+    async fn create(&self, team: Team) -> Result<Team> {
+        let id = team.id().to_string();
+        let name = team.name.clone();
+        let data = Self::to_json(&team)?;
+        let sql = format!(
+            "INSERT INTO teams (id, name, data) VALUES ({}, {}, {})",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(id))),
+                Value::String(Some(Box::new(name))),
+                Value::String(Some(Box::new(data))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(team)
+    }
+
+    async fn get(&self, id: Uuid) -> Result<Option<Team>> {
+        let sql = format!("SELECT data FROM teams WHERE id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(id.to_string())))],
+        );
+        match self
+            .db
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(GatewayError::from)?
+        {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::from_json(&data)?))
+            }
+        }
+    }
+
+    async fn get_by_name(&self, name: &str) -> Result<Option<Team>> {
+        let sql = format!("SELECT data FROM teams WHERE name = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(name.to_owned())))],
+        );
+        match self
+            .db
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(GatewayError::from)?
+        {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::from_json(&data)?))
+            }
+        }
+    }
+
+    async fn update(&self, mut team: Team) -> Result<Team> {
+        team.metadata.touch();
+        let data = Self::to_json(&team)?;
+        let name = team.name.clone();
+        let id = team.id().to_string();
+        let sql = format!(
+            "UPDATE teams SET name = {}, data = {} WHERE id = {}",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(name))),
+                Value::String(Some(Box::new(data))),
+                Value::String(Some(Box::new(id))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(team)
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<()> {
+        let id_str = id.to_string();
+        // Remove members before the team row (no DB-level FK constraint).
+        let sql = format!("DELETE FROM team_members WHERE team_id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(id_str.clone())))],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+
+        let sql = format!("DELETE FROM teams WHERE id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(id_str)))],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
+    }
+
+    async fn list(&self, offset: u32, limit: u32) -> Result<(Vec<Team>, u64)> {
+        let count_stmt = Statement::from_string(
+            self.backend(),
+            "SELECT COUNT(*) as cnt FROM teams".to_owned(),
+        );
+        let total: u64 = self
+            .db
+            .db
+            .query_one(count_stmt)
+            .await
+            .map_err(GatewayError::from)?
+            .map(|r| r.try_get::<i64>("", "cnt").unwrap_or(0) as u64)
+            .unwrap_or(0);
+
+        let sql = format!(
+            "SELECT data FROM teams ORDER BY created_at ASC LIMIT {} OFFSET {}",
+            self.ph(1),
+            self.ph(2)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::BigUnsigned(Some(limit as u64)),
+                Value::BigUnsigned(Some(offset as u64)),
+            ],
+        );
+        let rows = self
+            .db
+            .db
+            .query_all(stmt)
+            .await
+            .map_err(GatewayError::from)?;
+        let teams: Result<Vec<Team>> = rows
+            .into_iter()
+            .filter_map(|row| {
+                row.try_get::<String>("", "data")
+                    .ok()
+                    .map(|d| Self::from_json::<Team>(&d))
+            })
+            .filter(|t| !matches!(t, Ok(team) if matches!(team.status, TeamStatus::Deleted)))
+            .collect();
+        Ok((teams?, total))
+    }
+
+    async fn count(&self) -> Result<u64> {
+        let stmt = Statement::from_string(
+            self.backend(),
+            "SELECT COUNT(*) as cnt FROM teams".to_owned(),
+        );
+        Ok(self
+            .db
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(GatewayError::from)?
+            .map(|r| r.try_get::<i64>("", "cnt").unwrap_or(0) as u64)
+            .unwrap_or(0))
+    }
+
+    async fn add_member(&self, member: TeamMember) -> Result<TeamMember> {
+        let team_id = member.team_id.to_string();
+        let user_id = member.user_id.to_string();
+        let data = Self::to_json(&member)?;
+        let sql = format!(
+            "INSERT INTO team_members (team_id, user_id, data) VALUES ({}, {}, {})",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team_id))),
+                Value::String(Some(Box::new(user_id))),
+                Value::String(Some(Box::new(data))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(member)
+    }
+
+    async fn get_member(&self, team_id: Uuid, user_id: Uuid) -> Result<Option<TeamMember>> {
+        let sql = format!(
+            "SELECT data FROM team_members WHERE team_id = {} AND user_id = {}",
+            self.ph(1),
+            self.ph(2)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team_id.to_string()))),
+                Value::String(Some(Box::new(user_id.to_string()))),
+            ],
+        );
+        match self
+            .db
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(GatewayError::from)?
+        {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::from_json(&data)?))
+            }
+        }
+    }
+
+    async fn update_member_role(
+        &self,
+        team_id: Uuid,
+        user_id: Uuid,
+        role: TeamRole,
+    ) -> Result<TeamMember> {
+        let mut member = self.get_member(team_id, user_id).await?.ok_or_else(|| {
+            GatewayError::NotFound(format!("Member {} not found in team {}", user_id, team_id))
+        })?;
+        member.role = role;
+        member.metadata.touch();
+        let data = Self::to_json(&member)?;
+        let sql = format!(
+            "UPDATE team_members SET data = {} WHERE team_id = {} AND user_id = {}",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(data))),
+                Value::String(Some(Box::new(team_id.to_string()))),
+                Value::String(Some(Box::new(user_id.to_string()))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(member)
+    }
+
+    async fn remove_member(&self, team_id: Uuid, user_id: Uuid) -> Result<()> {
+        let sql = format!(
+            "DELETE FROM team_members WHERE team_id = {} AND user_id = {}",
+            self.ph(1),
+            self.ph(2)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team_id.to_string()))),
+                Value::String(Some(Box::new(user_id.to_string()))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
+    }
+
+    async fn list_members(&self, team_id: Uuid) -> Result<Vec<TeamMember>> {
+        let sql = format!(
+            "SELECT data FROM team_members WHERE team_id = {}",
+            self.ph(1)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(team_id.to_string())))],
+        );
+        let rows = self
+            .db
+            .db
+            .query_all(stmt)
+            .await
+            .map_err(GatewayError::from)?;
+        rows.into_iter()
+            .map(|row| {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Self::from_json(&data)
+            })
+            .collect()
+    }
+
+    async fn get_user_teams(&self, user_id: Uuid) -> Result<Vec<Team>> {
+        let sql = format!(
+            "SELECT team_id FROM team_members WHERE user_id = {}",
+            self.ph(1)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(user_id.to_string())))],
+        );
+        let rows = self
+            .db
+            .db
+            .query_all(stmt)
+            .await
+            .map_err(GatewayError::from)?;
+        let mut teams = Vec::new();
+        for row in rows {
+            let tid: String = row.try_get("", "team_id").map_err(GatewayError::from)?;
+            let team_id = tid
+                .parse::<Uuid>()
+                .map_err(|e| GatewayError::Internal(format!("invalid team uuid {}: {}", tid, e)))?;
+            if let Some(team) = self.get(team_id).await? {
+                teams.push(team);
+            }
+        }
+        Ok(teams)
+    }
+}

--- a/src/storage/database/seaorm_db/user_management_ops.rs
+++ b/src/storage/database/seaorm_db/user_management_ops.rs
@@ -1,112 +1,362 @@
 //! User management database operations
 //!
-//! Stub implementations — database schema for user management is not yet migrated.
-//! Each method returns `GatewayError::NotImplemented` until the migration lands.
+//! Stores user-management domain objects as JSON snapshots in the
+//! `um_users`, `um_teams`, and `um_organizations` tables created by
+//! migration `m20240301_000001_create_user_management_tables`.
 
 use crate::core::user_management::{Organization, Team, User};
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use sea_orm::{ConnectionTrait, DbBackend, Statement, Value};
+use tracing::debug;
 
-use super::types::SeaOrmDatabase;
+use super::types::{DatabaseBackendType, SeaOrmDatabase};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+impl SeaOrmDatabase {
+    /// Return the sea_orm DbBackend matching the live connection.
+    fn db_backend(&self) -> DbBackend {
+        match self.backend_type {
+            DatabaseBackendType::PostgreSQL => DbBackend::Postgres,
+            DatabaseBackendType::SQLite => DbBackend::Sqlite,
+        }
+    }
+
+    /// Return the positional placeholder for parameter `n` (1-based).
+    ///
+    /// SQLite uses `?`; PostgreSQL uses `$N`.
+    fn ph(&self, n: usize) -> String {
+        match self.backend_type {
+            DatabaseBackendType::PostgreSQL => format!("${}", n),
+            DatabaseBackendType::SQLite => "?".to_string(),
+        }
+    }
+
+    fn deserialize<T: serde::de::DeserializeOwned>(data: &str) -> Result<T> {
+        serde_json::from_str(data).map_err(|e| GatewayError::Internal(e.to_string()))
+    }
+
+    fn serialize<T: serde::Serialize>(value: &T) -> Result<String> {
+        serde_json::to_string(value).map_err(|e| GatewayError::Internal(e.to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User operations
+// ---------------------------------------------------------------------------
 
 impl SeaOrmDatabase {
     /// Retrieve a user management user by their string ID.
-    pub async fn get_user(&self, _user_id: &str) -> Result<Option<User>> {
-        Err(GatewayError::not_implemented(
-            "user_management: get_user not yet implemented",
-        ))
+    pub async fn get_user(&self, user_id: &str) -> Result<Option<User>> {
+        debug!("um: get_user {}", user_id);
+        let sql = format!("SELECT data FROM um_users WHERE user_id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [Value::String(Some(Box::new(user_id.to_owned())))],
+        );
+        match self.db.query_one(stmt).await.map_err(GatewayError::from)? {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::deserialize(&data)?))
+            }
+        }
     }
 
     /// Retrieve a user management user by their email address.
-    pub async fn get_user_by_email(&self, _email: &str) -> Result<Option<User>> {
-        Err(GatewayError::not_implemented(
-            "user_management: get_user_by_email not yet implemented",
-        ))
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<User>> {
+        debug!("um: get_user_by_email {}", email);
+        let sql = format!("SELECT data FROM um_users WHERE email = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [Value::String(Some(Box::new(email.to_owned())))],
+        );
+        match self.db.query_one(stmt).await.map_err(GatewayError::from)? {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::deserialize(&data)?))
+            }
+        }
     }
 
     /// Persist a new user management user to the database.
     ///
     /// Named `um_create_user` to avoid colliding with the existing
     /// `create_user` method which operates on a different `User` type.
-    pub async fn um_create_user(&self, _user: &User) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: um_create_user not yet implemented",
-        ))
+    pub async fn um_create_user(&self, user: &User) -> Result<()> {
+        debug!("um: um_create_user {}", user.user_id);
+        let data = Self::serialize(user)?;
+        let sql = format!(
+            "INSERT INTO um_users (user_id, email, data, spend) VALUES ({}, {}, {}, {})",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3),
+            self.ph(4),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(user.user_id.clone()))),
+                Value::String(Some(Box::new(user.email.clone()))),
+                Value::String(Some(Box::new(data))),
+                Value::Double(Some(user.spend)),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// Persist all mutable fields of a user management user (full update).
-    pub async fn update_user(&self, _user: &User) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: update_user not yet implemented",
-        ))
+    pub async fn update_user(&self, user: &User) -> Result<()> {
+        debug!("um: update_user {}", user.user_id);
+        let data = Self::serialize(user)?;
+        let sql = format!(
+            "UPDATE um_users SET email = {}, data = {}, spend = {} WHERE user_id = {}",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3),
+            self.ph(4),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(user.email.clone()))),
+                Value::String(Some(Box::new(data))),
+                Value::Double(Some(user.spend)),
+                Value::String(Some(Box::new(user.user_id.clone()))),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// Remove a user management user from the database by their string ID.
-    pub async fn delete_user(&self, _user_id: &str) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: delete_user not yet implemented",
-        ))
+    pub async fn delete_user(&self, user_id: &str) -> Result<()> {
+        debug!("um: delete_user {}", user_id);
+        let sql = format!("DELETE FROM um_users WHERE user_id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [Value::String(Some(Box::new(user_id.to_owned())))],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// Add `cost` to the recorded spend for the given user ID.
-    pub async fn update_user_spend(&self, _user_id: &str, _cost: f64) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: update_user_spend not yet implemented",
-        ))
+    pub async fn update_user_spend(&self, user_id: &str, cost: f64) -> Result<()> {
+        debug!("um: update_user_spend {} += {}", user_id, cost);
+        let sql = format!(
+            "UPDATE um_users SET spend = spend + {} WHERE user_id = {}",
+            self.ph(1),
+            self.ph(2),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::Double(Some(cost)),
+                Value::String(Some(Box::new(user_id.to_owned()))),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// List user management users with offset-based pagination.
-    pub async fn list_users(&self, _offset: u32, _limit: u32) -> Result<Vec<User>> {
-        Err(GatewayError::not_implemented(
-            "user_management: list_users not yet implemented",
-        ))
+    pub async fn list_users(&self, offset: u32, limit: u32) -> Result<Vec<User>> {
+        debug!("um: list_users offset={} limit={}", offset, limit);
+        let sql = format!(
+            "SELECT data FROM um_users ORDER BY created_at ASC LIMIT {} OFFSET {}",
+            self.ph(1),
+            self.ph(2),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::BigUnsigned(Some(limit as u64)),
+                Value::BigUnsigned(Some(offset as u64)),
+            ],
+        );
+        let rows = self.db.query_all(stmt).await.map_err(GatewayError::from)?;
+        rows.into_iter()
+            .map(|row| {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Self::deserialize(&data)
+            })
+            .collect()
     }
+}
 
+// ---------------------------------------------------------------------------
+// Team operations (user_management::Team — distinct from core::models::Team)
+// ---------------------------------------------------------------------------
+
+impl SeaOrmDatabase {
     /// Retrieve a team by its string ID.
-    pub async fn get_team(&self, _team_id: &str) -> Result<Option<Team>> {
-        Err(GatewayError::not_implemented(
-            "user_management: get_team not yet implemented",
-        ))
+    pub async fn get_team(&self, team_id: &str) -> Result<Option<Team>> {
+        debug!("um: get_team {}", team_id);
+        let sql = format!("SELECT data FROM um_teams WHERE team_id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [Value::String(Some(Box::new(team_id.to_owned())))],
+        );
+        match self.db.query_one(stmt).await.map_err(GatewayError::from)? {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::deserialize(&data)?))
+            }
+        }
     }
 
     /// Persist a new team to the database.
-    pub async fn create_team(&self, _team: &Team) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: create_team not yet implemented",
-        ))
+    pub async fn create_team(&self, team: &Team) -> Result<()> {
+        debug!("um: create_team {}", team.team_id);
+        let data = Self::serialize(team)?;
+        let sql = format!(
+            "INSERT INTO um_teams (team_id, data, spend) VALUES ({}, {}, {})",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team.team_id.clone()))),
+                Value::String(Some(Box::new(data))),
+                Value::Double(Some(team.spend)),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// Persist all mutable fields of a team (full update).
-    pub async fn update_team(&self, _team: &Team) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: update_team not yet implemented",
-        ))
+    pub async fn update_team(&self, team: &Team) -> Result<()> {
+        debug!("um: update_team {}", team.team_id);
+        let data = Self::serialize(team)?;
+        let sql = format!(
+            "UPDATE um_teams SET data = {}, spend = {} WHERE team_id = {}",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(data))),
+                Value::Double(Some(team.spend)),
+                Value::String(Some(Box::new(team.team_id.clone()))),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// Add `cost` to the recorded spend for the given team ID.
-    pub async fn update_team_spend(&self, _team_id: &str, _cost: f64) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: update_team_spend not yet implemented",
-        ))
+    pub async fn update_team_spend(&self, team_id: &str, cost: f64) -> Result<()> {
+        debug!("um: update_team_spend {} += {}", team_id, cost);
+        let sql = format!(
+            "UPDATE um_teams SET spend = spend + {} WHERE team_id = {}",
+            self.ph(1),
+            self.ph(2),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::Double(Some(cost)),
+                Value::String(Some(Box::new(team_id.to_owned()))),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// List teams with offset-based pagination.
-    pub async fn list_teams(&self, _offset: u32, _limit: u32) -> Result<Vec<Team>> {
-        Err(GatewayError::not_implemented(
-            "user_management: list_teams not yet implemented",
-        ))
+    pub async fn list_teams(&self, offset: u32, limit: u32) -> Result<Vec<Team>> {
+        debug!("um: list_teams offset={} limit={}", offset, limit);
+        let sql = format!(
+            "SELECT data FROM um_teams ORDER BY created_at ASC LIMIT {} OFFSET {}",
+            self.ph(1),
+            self.ph(2),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::BigUnsigned(Some(limit as u64)),
+                Value::BigUnsigned(Some(offset as u64)),
+            ],
+        );
+        let rows = self.db.query_all(stmt).await.map_err(GatewayError::from)?;
+        rows.into_iter()
+            .map(|row| {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Self::deserialize(&data)
+            })
+            .collect()
     }
+}
 
+// ---------------------------------------------------------------------------
+// Organization operations
+// ---------------------------------------------------------------------------
+
+impl SeaOrmDatabase {
     /// Persist a new organization to the database.
-    pub async fn create_organization(&self, _organization: &Organization) -> Result<()> {
-        Err(GatewayError::not_implemented(
-            "user_management: create_organization not yet implemented",
-        ))
+    pub async fn create_organization(&self, organization: &Organization) -> Result<()> {
+        debug!("um: create_organization {}", organization.organization_id);
+        let data = Self::serialize(organization)?;
+        let sql = format!(
+            "INSERT INTO um_organizations (organization_id, data, spend) VALUES ({}, {}, {})",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3),
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(organization.organization_id.clone()))),
+                Value::String(Some(Box::new(data))),
+                Value::Double(Some(organization.spend)),
+            ],
+        );
+        self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
     }
 
     /// Retrieve an organization by its string ID.
-    pub async fn get_organization(&self, _organization_id: &str) -> Result<Option<Organization>> {
-        Err(GatewayError::not_implemented(
-            "user_management: get_organization not yet implemented",
-        ))
+    pub async fn get_organization(&self, organization_id: &str) -> Result<Option<Organization>> {
+        debug!("um: get_organization {}", organization_id);
+        let sql = format!(
+            "SELECT data FROM um_organizations WHERE organization_id = {}",
+            self.ph(1)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [Value::String(Some(Box::new(organization_id.to_owned())))],
+        );
+        match self.db.query_one(stmt).await.map_err(GatewayError::from)? {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::deserialize(&data)?))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Addresses two issues flagged in the round-1 review of PR #296:

**Issue 1 — `user_management_ops.rs` stubs (lines 13–107)**

All 12 methods returned `GatewayError::not_implemented`, making the
`user_management` module completely non-functional at runtime. Fixed by:

- Adding migration `m20240301_000001_create_user_management_tables` that
  creates `um_users`, `um_teams`, and `um_organizations` tables with
  JSON snapshot storage (`data TEXT`) and indexed scalar columns (`email`,
  `spend`).
- Replacing every stub in `user_management_ops.rs` with a real SeaORM
  raw-SQL implementation. Placeholders are generated via a `ph(n)` helper
  that emits `$N` for PostgreSQL and `?` for SQLite, so both backends work.

**Issue 2 — `state.rs:48` in-memory `TeamManager`**

`TeamManager` was wired to `InMemoryTeamRepository`, discarding all team
state on restart (issue #256). Fixed by:

- Adding migration `m20240301_000002_create_teams_table` that creates
  `teams` and `team_members` tables.
- Creating `SeaOrmTeamRepository` (`seaorm_db/team_repository.rs`) — a
  full `TeamRepository` trait implementation backed by the live
  `SeaOrmDatabase` connection with JSON snapshot storage.
- Updating `AppState::new_with_unified_router` to construct `TeamManager`
  with `SeaOrmTeamRepository::new(storage.database.clone())` instead of
  `InMemoryTeamRepository`.

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets --features sqlite` — clean
- [x] `cargo test --features sqlite` — 95 passed, 0 failed
- [x] `cargo fmt --all` applied before commit