### PR TITLE
fix: deep-merge reasoning object; make effort/max_tokens mutually exclusive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litellm-rs"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2024"
 rust-version = "1.88"
 authors = ["lifcc"]

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -293,10 +293,27 @@ impl OpenAILikeProvider {
             for (key, value) in request.extra_params {
                 obj.insert(key, value);
             }
-            // Merge OpenRouter reasoning params (reasoning.effort etc.)
+            // Merge OpenRouter reasoning params without overwriting user-supplied nested keys.
+            // If both extra_params and the thinking transform produced a "reasoning" object,
+            // merge their inner keys so that user-provided flags (e.g. "exclude") are preserved.
             if let Some(Value::Object(params)) = openrouter_thinking_params {
                 for (key, value) in params {
-                    obj.insert(key, value);
+                    match obj.get_mut(&key) {
+                        Some(Value::Object(existing)) if value.is_object() => {
+                            // Deep merge: add thinking-param keys not already set by the user.
+                            if let Value::Object(incoming) = value {
+                                for (k, v) in incoming {
+                                    existing.entry(k).or_insert(v);
+                                }
+                            }
+                        }
+                        Some(_) => {
+                            // User already set this top-level key via extra_params; keep it.
+                        }
+                        None => {
+                            obj.insert(key, value);
+                        }
+                    }
                 }
             }
         }

--- a/src/core/providers/thinking/providers.rs
+++ b/src/core/providers/thinking/providers.rs
@@ -464,7 +464,9 @@ pub mod openrouter_thinking {
             "deepseek" => deepseek_thinking::transform_config(config, model),
             "gemini" => gemini_thinking::transform_config(config, model),
             _ => {
-                // Use OpenRouter's native reasoning object for generic/unknown models
+                // Use OpenRouter's native reasoning object for generic/unknown models.
+                // `effort` and `max_tokens` are alternative controls on OpenRouter;
+                // sending both causes validation failures on stricter backends.
                 let mut params = serde_json::Map::new();
                 if let Some(effort) = &config.effort {
                     let effort_str = match effort {
@@ -474,9 +476,11 @@ pub mod openrouter_thinking {
                     };
                     let mut reasoning = serde_json::Map::new();
                     reasoning.insert("effort".into(), effort_str.into());
-                    if let Some(budget) = config.budget_tokens {
-                        reasoning.insert("max_tokens".into(), budget.into());
-                    }
+                    // Do not set max_tokens when effort is present; they are mutually exclusive.
+                    params.insert("reasoning".into(), Value::Object(reasoning));
+                } else if let Some(budget) = config.budget_tokens {
+                    let mut reasoning = serde_json::Map::new();
+                    reasoning.insert("max_tokens".into(), budget.into());
                     params.insert("reasoning".into(), Value::Object(reasoning));
                 }
                 Ok(Value::Object(params))

--- a/src/core/providers/thinking/tests.rs
+++ b/src/core/providers/thinking/tests.rs
@@ -844,13 +844,43 @@ fn test_openrouter_transform_config_unknown() {
         Some("high"),
         "reasoning.effort should be 'high' for High effort"
     );
+    // When effort is set, max_tokens must NOT be emitted; they are mutually exclusive on OpenRouter.
+    assert!(
+        result
+            .get("reasoning")
+            .and_then(|r| r.get("max_tokens"))
+            .is_none(),
+        "reasoning.max_tokens must not be set when effort is also set"
+    );
+}
+
+#[test]
+fn test_openrouter_transform_config_unknown_budget_only() {
+    let config = ThinkingConfig {
+        enabled: true,
+        budget_tokens: Some(8000),
+        effort: None,
+        include_thinking: true,
+        extra_params: Default::default(),
+    };
+
+    let Ok(result) = openrouter_thinking::transform_config(&config, "unknown-model") else {
+        panic!("transform_config must succeed for unknown-model");
+    };
     assert_eq!(
         result
             .get("reasoning")
             .and_then(|r| r.get("max_tokens"))
             .and_then(|v| v.as_u64()),
-        Some(10000),
-        "reasoning.max_tokens should equal budget_tokens"
+        Some(8000),
+        "reasoning.max_tokens should equal budget_tokens when effort is None"
+    );
+    assert!(
+        result
+            .get("reasoning")
+            .and_then(|r| r.get("effort"))
+            .is_none(),
+        "reasoning.effort must not be set when effort is None"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes two correctness issues in OpenRouter reasoning support introduced in #299:

- **provider.rs**: `extra_params["reasoning"]` was silently overwritten when `ThinkingConfig` also produced a `reasoning` object. Now deep-merges nested keys so user-provided flags (e.g. `exclude`) survive alongside `effort` / `max_tokens` from the thinking transform. User keys always win on conflict (`or_insert` semantics).
- **providers.rs**: OpenRouter documents `reasoning.effort` and `reasoning.max_tokens` as **alternative** controls. Sending both can trigger validation failures on stricter model backends. Now only `effort` is emitted when effort is set; `max_tokens` is only emitted in the `effort == None` path.

## Test plan

- [x] Updated `test_openrouter_transform_config_unknown` — asserts `max_tokens` is absent when `effort` is set
- [x] Added `test_openrouter_transform_config_unknown_budget_only` — asserts `max_tokens` is emitted and `effort` is absent when only `budget_tokens` is provided
- [x] All 27 openrouter tests pass (`cargo test openrouter`)
- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` clean