### PR TITLE
feat: replace wildcard re-exports with explicit pub use in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,16 @@ pub use core::streaming::types::{
 pub use core::types::message::{MessageContent, MessageRole};
 
 // Export core functionality
-pub use core::models::{RequestContext, openai::*};
+pub use core::models::RequestContext;
+pub use core::models::openai::{
+    AudioContent, AudioDelta, AudioParams, CacheControl, ChatChoice, ChatChoiceDelta,
+    ChatCompletionChoice, ChatCompletionRequest, ChatCompletionResponse, ChatMessage,
+    ChatMessageDelta, CompletionChoice, CompletionRequest, CompletionTokensDetails, ContentLogprob,
+    DocumentSource, EmbeddingObject, EmbeddingRequest, EmbeddingUsage, Function, FunctionCallDelta,
+    ImageGenerationRequest, ImageGenerationResponse, ImageObject, ImageSource, ImageUrl, Logprobs,
+    Model, ModelListResponse, PromptTokensDetails, ResponseFormat, StreamOptions, Tool,
+    ToolCallDelta, ToolChoice, ToolChoiceFunction, ToolChoiceFunctionSpec, TopLogprob,
+};
 pub use core::providers::{Provider, ProviderError, ProviderRegistry, ProviderType};
 
 // Export unified router


### PR DESCRIPTION
## Summary

- Replaces `pub use core::models::{RequestContext, openai::*}` in `src/lib.rs` with an explicit `pub use core::models::openai::{...}` listing all 33 individual public items
- Excludes `EmbeddingResponse` from the new explicit list as it is already re-exported on the same line by `core::embedding`, avoiding a duplicate-import compile error
- All other previously wildcard-re-exported items (`AudioContent`, `ChatMessage`, `ChatCompletionRequest`, `ChatCompletionResponse`, tool/function types, model/response types, etc.) are now listed explicitly

Closes #276.

## Test plan

- [x] `cargo check --all-features` passes
- [x] `cargo fmt --all` applied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (95 tests, 0 failures)