### PR TITLE
fix(macros): remove dead helper functions from provider_config! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rs"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "actix-cors",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litellm-rs"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2024"
 rust-version = "1.88"
 authors = ["lifcc"]

--- a/src/core/providers/macros/basic_macros.rs
+++ b/src/core/providers/macros/basic_macros.rs
@@ -131,14 +131,6 @@ macro_rules! provider_config {
             }
         }
 
-        $(
-            $(
-                #[allow(dead_code)]
-                fn $field() -> $field_type {
-                    provider_config!(@default $field_type $(, $default)?)
-                }
-            )?
-        )*
     };
 
     (@default $field_type:ty) => {


### PR DESCRIPTION
## Summary

- Removes the unreachable per-field helper function generation block from the `provider_config!` macro in `src/core/providers/macros/basic_macros.rs`
- The generated functions were never called due to a naming mismatch: the serde `default = concat!("default_", stringify!($field))` attribute expected `default_<field>` names, while the macro emitted bare `<field>` names
- This eliminates the last remaining `#[allow(dead_code)]` suppression, bringing the count to zero and closing #278

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 95 passed, 0 failed
- [x] `cargo check --all-features` — clean

Closes #278