### PR TITLE
feat(openai): add store/metadata/service_tier params, update image models, mark deprecated (#283)

### DIFF
--- a/src/core/completion/conversion.rs
+++ b/src/core/completion/conversion.rs
@@ -39,6 +39,9 @@ pub fn convert_to_chat_completion_request(
         top_logprobs: options.top_logprobs,
         thinking: None,
         reasoning_effort: None,
+        store: None,
+        metadata: None,
+        service_tier: None,
         extra_params: options.extra_params,
     })
 }

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -263,6 +263,9 @@ impl LLMProvider for GeminiProvider {
             function_call: None,
             thinking: None,
             reasoning_effort: None,
+            store: None,
+            metadata: None,
+            service_tier: None,
             extra_params: std::collections::HashMap::new(),
         };
 
@@ -360,6 +363,9 @@ impl LLMProvider for GeminiProvider {
             function_call: None,
             thinking: None,
             reasoning_effort: None,
+            store: None,
+            metadata: None,
+            service_tier: None,
             extra_params: std::collections::HashMap::new(),
         };
 

--- a/src/core/providers/openai/advanced_chat.rs
+++ b/src/core/providers/openai/advanced_chat.rs
@@ -170,6 +170,14 @@ pub struct AdvancedChatRequest {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
+
+    /// Whether to store the response for model improvement
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+
+    /// Service tier for the request ("default" or "flex")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 /// Advanced chat response with reasoning and structured output
@@ -712,6 +720,8 @@ mod tests {
             top_logprobs: None,
             user: None,
             metadata: None,
+            store: None,
+            service_tier: None,
         };
 
         assert!(AdvancedChatUtils::validate_request(&request).is_ok());

--- a/src/core/providers/openai/images.rs
+++ b/src/core/providers/openai/images.rs
@@ -233,7 +233,7 @@ impl OpenAIImageUtils {
 
     /// Get supported models for image generation
     pub fn get_generation_models() -> Vec<&'static str> {
-        vec!["dall-e-2", "dall-e-3"]
+        vec!["dall-e-2", "dall-e-3", "gpt-image-1", "gpt-image-1.5"]
     }
 
     /// Get supported models for image editing

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -47,6 +47,15 @@ pub struct OpenAIChatRequest {
     /// Reasoning effort for o-series and GPT-5.x models ("low", "medium", "high")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
+    /// Whether to store the response for model improvement
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+    /// Key-value metadata to attach to the request
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<std::collections::HashMap<String, String>>,
+    /// Service tier for the request ("default" or "flex")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 /// OpenAI Message

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -340,6 +340,21 @@ impl OpenAIModelRegistry {
                 metadata: HashMap::new(),
             };
 
+            // Mark known deprecated/removed models
+            if matches!(
+                id,
+                "gpt-3.5-turbo"
+                    | "gpt-3.5-turbo-0125"
+                    | "o1-preview"
+                    | "o1-mini"
+                    | "o1-mini-2024-09-12"
+                    | "codex-mini-latest"
+            ) {
+                model_info
+                    .metadata
+                    .insert("deprecated".to_string(), serde_json::json!(true));
+            }
+
             let features = self.detect_features(&model_info);
             model_info.capabilities = features
                 .iter()

--- a/src/core/providers/openai/transformer/request.rs
+++ b/src/core/providers/openai/transformer/request.rs
@@ -59,6 +59,9 @@ impl OpenAIRequestTransformer {
             response_format,
             seed: request.seed,
             reasoning_effort: request.reasoning_effort,
+            store: request.store,
+            metadata: request.metadata,
+            service_tier: request.service_tier,
         })
     }
 

--- a/src/core/types/chat.rs
+++ b/src/core/types/chat.rs
@@ -145,6 +145,15 @@ pub struct ChatRequest {
     /// Reasoning effort for OpenAI o-series and GPT-5.x models ("low", "medium", "high")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
+    /// Whether to store the response for model improvement (OpenAI)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+    /// Key-value metadata to attach to the request (OpenAI)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    /// Service tier for the request ("default" or "flex") (OpenAI)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
     /// Thinking/reasoning configuration
     ///
     /// Enable and configure thinking mode for supported models:

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -387,6 +387,9 @@ fn build_core_chat_request(
         top_logprobs: request.top_logprobs,
         thinking: None,
         reasoning_effort: request.reasoning_effort,
+        store: None,
+        metadata: None,
+        service_tier: None,
         extra_params,
     })
 }


### PR DESCRIPTION
## Summary

- Add `store`, `metadata`, `service_tier` fields to `ChatRequest` and `OpenAIChatRequest` for OpenAI API compliance
- Propagate new fields through the OpenAI request transformer
- Add `store` and `service_tier` fields to `AdvancedChatRequest` (which already had `metadata`)
- Add `gpt-image-1` and `gpt-image-1.5` to `get_generation_models()` in images.rs
- Mark `gpt-3.5-turbo`, `o1-preview`, `o1-mini`, `codex-mini-latest` as `deprecated: true` in model registry metadata

Closes #283

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 95 passed, 0 failed
- [x] `cargo check --all-features` — clean