### PR TITLE
feat(anthropic): add beta headers, structured outputs, and built-in tool types

### DIFF
--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -21,7 +21,7 @@ use crate::core::types::{
     responses::{ChatChoice, ChatResponse, Usage},
 };
 
-use super::config::AnthropicConfig;
+use super::config::{AnthropicConfig, beta};
 use super::error::{
     anthropic_api_error, anthropic_auth_error, anthropic_network_error, anthropic_parse_error,
     anthropic_rate_limit_error,
@@ -61,14 +61,34 @@ impl AnthropicClient {
 
     /// Request
     pub async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, ProviderError> {
-        // Request
+        let using_json_schema = request
+            .response_format
+            .as_ref()
+            .map(|f| f.format_type == "json_schema")
+            .unwrap_or(false);
+
+        let beta_features = self.collect_beta_features(&request);
         let anthropic_request = self.transform_chat_request(&request)?;
+        let response = self
+            .send_request("/v1/messages", anthropic_request, &beta_features)
+            .await?;
+        let mut chat_response = self.transform_chat_response(response)?;
 
-        // Request
-        let response = self.send_request("/v1/messages", anthropic_request).await?;
+        // For json_schema mode: surface the "json_response" tool-call input as
+        // regular text content so callers see a uniform ChatResponse.
+        if using_json_schema
+            && let Some(choice) = chat_response.choices.first_mut()
+            && let Some(tool_calls) = choice.message.tool_calls.take()
+            && let Some(tc) = tool_calls
+                .into_iter()
+                .find(|t| t.function.name == "json_response")
+        {
+            choice.message.content = Some(crate::core::types::message::MessageContent::Text(
+                tc.function.arguments,
+            ));
+        }
 
-        // Response
-        self.transform_chat_response(response)
+        Ok(chat_response)
     }
 
     /// Request
@@ -76,19 +96,42 @@ impl AnthropicClient {
         &self,
         request: ChatRequest,
     ) -> Result<reqwest::Response, ProviderError> {
-        // Request
+        let beta_features = self.collect_beta_features(&request);
         let mut anthropic_request = self.transform_chat_request(&request)?;
         anthropic_request["stream"] = json!(true);
-
-        // Request
-        self.send_stream_request("/v1/messages", anthropic_request)
+        self.send_stream_request("/v1/messages", anthropic_request, &beta_features)
             .await
     }
 
+    /// Collect `anthropic-beta` feature identifiers for the given request.
+    ///
+    /// Starts from the explicit list in `config.beta_features` and appends
+    /// any features that can be auto-detected from the request parameters.
+    fn collect_beta_features(&self, request: &ChatRequest) -> Vec<String> {
+        let mut features = self.config.beta_features.clone();
+
+        // Auto-detect: extended thinking requires the interleaved-thinking beta.
+        if let Some(thinking) = &request.thinking
+            && thinking.enabled
+        {
+            let key = beta::EXTENDED_THINKING.to_string();
+            if !features.contains(&key) {
+                features.push(key);
+            }
+        }
+
+        features
+    }
+
     /// Request
-    async fn send_request(&self, endpoint: &str, body: Value) -> Result<Value, ProviderError> {
+    async fn send_request(
+        &self,
+        endpoint: &str,
+        body: Value,
+        beta_features: &[String],
+    ) -> Result<Value, ProviderError> {
         let url = format!("{}{}", self.config.base_url.trim_end_matches('/'), endpoint);
-        let headers = self.get_request_headers();
+        let headers = self.get_request_headers(beta_features);
 
         let response = timeout(
             Duration::from_secs(self.config.request_timeout),
@@ -106,9 +149,10 @@ impl AnthropicClient {
         &self,
         endpoint: &str,
         body: Value,
+        beta_features: &[String],
     ) -> Result<Response, ProviderError> {
         let url = format!("{}{}", self.config.base_url.trim_end_matches('/'), endpoint);
-        let headers = self.get_request_headers();
+        let headers = self.get_request_headers(beta_features);
 
         let response = timeout(
             Duration::from_secs(self.config.request_timeout),
@@ -132,8 +176,12 @@ impl AnthropicClient {
     }
 
     /// Build request headers using the unified HeaderPair pattern.
-    fn get_request_headers(&self) -> Vec<HeaderPair> {
-        let mut headers = Vec::with_capacity(5);
+    ///
+    /// `beta_features` is a list of `anthropic-beta` identifiers collected by
+    /// [`Self::collect_beta_features`].  When non-empty they are joined with
+    /// commas and sent as a single `anthropic-beta` header.
+    fn get_request_headers(&self, beta_features: &[String]) -> Vec<HeaderPair> {
+        let mut headers = Vec::with_capacity(6);
 
         // Authentication header
         if let Some(ref api_key) = self.config.api_key {
@@ -142,6 +190,11 @@ impl AnthropicClient {
 
         // Version header
         headers.push(header("anthropic-version", self.config.api_version.clone()));
+
+        // Beta features header (only when at least one feature is requested)
+        if !beta_features.is_empty() {
+            headers.push(header("anthropic-beta", beta_features.join(",")));
+        }
 
         // Content type and user agent - zero allocation for static values
         headers.push(header_static("Content-Type", "application/json"));
@@ -238,6 +291,29 @@ impl AnthropicClient {
             if let Some(tool_choice) = &request.tool_choice {
                 anthropic_request["tool_choice"] = self.transform_tool_choice(tool_choice)?;
             }
+        }
+
+        // JSON schema structured output: use tool-based extraction.
+        // A virtual tool named "json_response" is injected and forced so that
+        // Anthropic returns the structured data as the tool's input object.
+        if let Some(response_format) = &request.response_format
+            && response_format.format_type == "json_schema"
+            && let Some(schema) = &response_format.json_schema
+        {
+            let existing = anthropic_request
+                .get("tools")
+                .and_then(|t| t.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let mut tools = existing;
+            tools.push(json!({
+                "name": "json_response",
+                "description": "Return a structured JSON response conforming to the provided schema.",
+                "input_schema": schema
+            }));
+            anthropic_request["tools"] = json!(tools);
+            anthropic_request["tool_choice"] =
+                json!({"type": "tool", "name": "json_response"});
         }
 
         // Add thinking configuration
@@ -638,7 +714,7 @@ mod tests {
     fn test_header_building() {
         let config = AnthropicConfig::new_test("test-key");
         let client = AnthropicClient::new(config).unwrap();
-        let headers = client.get_request_headers();
+        let headers = client.get_request_headers(&[]);
 
         // Anthropic uses x-api-key header instead of Authorization
         assert!(has_header(&headers, "x-api-key"));
@@ -651,7 +727,7 @@ mod tests {
     fn test_header_content_type() {
         let config = AnthropicConfig::new_test("test-key");
         let client = AnthropicClient::new(config).unwrap();
-        let headers = client.get_request_headers();
+        let headers = client.get_request_headers(&[]);
 
         assert_eq!(
             get_header(&headers, "Content-Type").unwrap(),
@@ -663,7 +739,7 @@ mod tests {
     fn test_header_user_agent() {
         let config = AnthropicConfig::new_test("test-key");
         let client = AnthropicClient::new(config).unwrap();
-        let headers = client.get_request_headers();
+        let headers = client.get_request_headers(&[]);
 
         assert_eq!(
             get_header(&headers, "User-Agent").unwrap(),
@@ -678,7 +754,7 @@ mod tests {
             .custom_headers
             .insert("X-Custom-Header".to_string(), "custom-value".to_string());
         let client = AnthropicClient::new(config).unwrap();
-        let headers = client.get_request_headers();
+        let headers = client.get_request_headers(&[]);
 
         assert!(has_header(&headers, "X-Custom-Header"));
     }

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -8,6 +8,16 @@ use std::env;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::ProviderConfig;
 
+/// Known `anthropic-beta` header values for Anthropic API feature gating.
+pub mod beta {
+    /// Extended (interleaved) thinking support.
+    pub const EXTENDED_THINKING: &str = "interleaved-thinking-2025-05-14";
+    /// Computer use tool support.
+    pub const COMPUTER_USE: &str = "computer-use-2025-01-24";
+    /// Citations support for grounded responses.
+    pub const CITATIONS: &str = "citations-2025-01-15";
+}
+
 /// Configuration
 #[derive(Debug, Clone)]
 pub struct AnthropicConfig {
@@ -37,6 +47,12 @@ pub struct AnthropicConfig {
     pub enable_computer_use: bool,
     /// Enable experimental features
     pub enable_experimental: bool,
+    /// Explicit `anthropic-beta` feature identifiers to include in every request.
+    ///
+    /// Well-known values are available in the [`beta`] module.  Additional
+    /// beta features detected from the request (e.g. extended thinking) are
+    /// added automatically and do not need to be listed here.
+    pub beta_features: Vec<String>,
 }
 
 impl Default for AnthropicConfig {
@@ -55,6 +71,7 @@ impl Default for AnthropicConfig {
             enable_cache_control: true,
             enable_computer_use: false, // Default disabled
             enable_experimental: false,
+            beta_features: Vec::new(),
         }
     }
 }
@@ -128,6 +145,16 @@ impl AnthropicConfig {
             config.enable_experimental = experimental.parse().unwrap_or(false);
         }
 
+        // Comma-separated beta feature identifiers, e.g.
+        // ANTHROPIC_BETA_FEATURES="interleaved-thinking-2025-05-14,citations-2025-01-15"
+        if let Ok(betas) = env::var("ANTHROPIC_BETA_FEATURES") {
+            config.beta_features = betas
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+
         Ok(config)
     }
 
@@ -188,6 +215,17 @@ impl AnthropicConfig {
     /// Enable experimental features
     pub fn with_experimental(mut self, enabled: bool) -> Self {
         self.enable_experimental = enabled;
+        self
+    }
+
+    /// Append a beta feature identifier sent in the `anthropic-beta` header.
+    ///
+    /// Well-known identifiers are in [`beta`].  Duplicates are ignored.
+    pub fn with_beta_feature(mut self, feature: impl Into<String>) -> Self {
+        let f = feature.into();
+        if !self.beta_features.contains(&f) {
+            self.beta_features.push(f);
+        }
         self
     }
 

--- a/src/core/types/tools.rs
+++ b/src/core/types/tools.rs
@@ -102,6 +102,31 @@ pub struct ResponseFormat {
     pub response_type: Option<String>,
 }
 
+/// Anthropic server-side built-in tool type identifiers.
+///
+/// These represent tools hosted by Anthropic that do not require
+/// a client-side function definition (no `input_schema` needed).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AnthropicBuiltinToolType {
+    /// Web search tool (released 2025-03-05)
+    #[serde(rename = "web_search_20250305")]
+    WebSearch,
+    /// Computer use tool (released 2025-01-24)
+    #[serde(rename = "computer_20250124")]
+    ComputerUse,
+}
+
+/// An Anthropic server-side (built-in) tool that is executed by Anthropic
+/// without a client-provided function implementation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicBuiltinTool {
+    /// Tool type identifier
+    #[serde(rename = "type")]
+    pub tool_type: AnthropicBuiltinToolType,
+    /// Tool name used when referencing the tool in messages
+    pub name: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Fixes #284. Implements Anthropic H-1 through H-4:

- **Beta headers (H-1)**: Add `beta` module with `EXTENDED_THINKING`, `COMPUTER_USE`, `CITATIONS` constants. Add `beta_features: Vec<String>` to `AnthropicConfig` with `with_beta_feature()` builder and `ANTHROPIC_BETA_FEATURES` env-var support. The `anthropic-beta` header is sent automatically when beta features are present; extended thinking auto-adds the `interleaved-thinking-2025-05-14` beta.
- **Structured outputs (H-2)**: `response_format.format_type == "json_schema"` is transformed into tool-based extraction — a virtual `json_response` tool is injected with the provided schema and forced via `tool_choice`; the response extraction surfaces the JSON as plain text content in `ChatResponse`.
- **Built-in tool types (H-3/H-4)**: Add `AnthropicBuiltinToolType` enum (`WebSearch` → `web_search_20250305`, `ComputerUse` → `computer_20250124`) and `AnthropicBuiltinTool` struct to `tools.rs` for representing Anthropic server-side tools.

## Test plan

- [x] `cargo check --all-features` passes
- [x] `cargo fmt --all` applied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 95 tests pass, 0 failed
- [ ] Manual: set `ANTHROPIC_BETA_FEATURES=interleaved-thinking-2025-05-14` and verify header is sent
- [ ] Manual: pass `response_format = { type: "json_schema", json_schema: {...} }` and verify structured JSON is returned