### PR TITLE
feat(router): add atomic routing metrics counters

### DIFF
--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -126,6 +126,8 @@ impl Router {
             let is_fallback = model_idx > 0;
 
             if is_fallback {
+                self.fallback_triggered_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::info!(
                     original_model = %model_name,
                     fallback_model = %model,

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -42,4 +42,4 @@ pub use budget_routing::{BudgetAwareRouter, BudgetAwareRouting, RequestBudgetChe
 pub use config::{RouterConfig, RoutingStrategy as UnifiedRoutingStrategy};
 pub use error::{CooldownReason, RouterError};
 pub use fallback::{ExecutionResult, FallbackConfig, FallbackType};
-pub use unified::Router as UnifiedRouter;
+pub use unified::{Router as UnifiedRouter, RoutingMetrics};

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -157,10 +157,12 @@ impl Router {
         .cloned()
         .ok_or_else(|| RouterError::NoAvailableDeployment(model_name.to_string()))?;
 
-        // 6. Increment active_requests counter
+        // 6. Increment active_requests counter and routing metrics
         if let Some(deployment) = self.deployments.get(&selected_id) {
             deployment.state.active_requests.fetch_add(1, Relaxed);
         }
+        self.provider_selected_count.fetch_add(1, Relaxed);
+        self.strategy_used_count.fetch_add(1, Relaxed);
 
         tracing::debug!(
             model = %model_name,

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -12,8 +12,19 @@ use crate::core::providers::unified_provider::ProviderError;
 use dashmap::DashMap;
 use dashmap::mapref::one::Ref;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed};
 use std::time::Duration;
+
+/// Snapshot of routing metrics counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoutingMetrics {
+    /// Total number of deployments selected via `select_deployment`.
+    pub provider_selected: u64,
+    /// Total number of strategy evaluations (one per `select_deployment` call).
+    pub strategy_used: u64,
+    /// Total number of fallback model attempts in `execute`.
+    pub fallback_triggered: u64,
+}
 
 /// Unified Router
 ///
@@ -38,6 +49,15 @@ pub struct Router {
 
     /// Round-robin counters (per model, for RoundRobin strategy)
     pub(crate) round_robin_counters: DashMap<String, AtomicUsize>,
+
+    /// Atomic counter: number of times a provider was selected.
+    pub(crate) provider_selected_count: AtomicU64,
+
+    /// Atomic counter: number of times a routing strategy was evaluated.
+    pub(crate) strategy_used_count: AtomicU64,
+
+    /// Atomic counter: number of fallback model attempts.
+    pub(crate) fallback_triggered_count: AtomicU64,
 }
 
 impl Router {
@@ -50,6 +70,9 @@ impl Router {
             config,
             fallback_config: FallbackConfig::default(),
             round_robin_counters: DashMap::new(),
+            provider_selected_count: AtomicU64::new(0),
+            strategy_used_count: AtomicU64::new(0),
+            fallback_triggered_count: AtomicU64::new(0),
         }
     }
 
@@ -67,6 +90,15 @@ impl Router {
     /// Get the router configuration
     pub fn config(&self) -> &RouterConfig {
         &self.config
+    }
+
+    /// Return a snapshot of the routing metrics counters.
+    pub fn routing_metrics(&self) -> RoutingMetrics {
+        RoutingMetrics {
+            provider_selected: self.provider_selected_count.load(Relaxed),
+            strategy_used: self.strategy_used_count.load(Relaxed),
+            fallback_triggered: self.fallback_triggered_count.load(Relaxed),
+        }
     }
 
     // ========== Deployment Management ==========


### PR DESCRIPTION
## Summary
- Add `provider_selected`, `strategy_used`, `fallback_triggered` AtomicU64 counters to Router struct
- Increment `provider_selected` and `strategy_used` in `select_deployment()`
- Increment `fallback_triggered` in `execute()` when a fallback model is tried
- Expose via `Router::routing_metrics()` returning a `RoutingMetrics` snapshot struct

## Test plan
- [x] All existing router tests pass (50+ tests)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo check --all-features` clean

Closes #350