### PR TITLE
refactor(storage): wire orphan pricing migration into SeaORM Migrator

### DIFF
--- a/src/storage/database/migration/mod.rs
+++ b/src/storage/database/migration/mod.rs
@@ -5,6 +5,7 @@ mod m20240101_000002_create_password_reset_tokens_table;
 mod m20240101_000003_create_batches_table;
 mod m20240101_000004_create_user_sessions_table;
 mod m20240101_000005_create_api_keys_table;
+mod m20240201_000001_create_pricing_tables;
 mod m20240301_000001_create_user_management_tables;
 mod m20240301_000002_create_teams_table;
 
@@ -20,6 +21,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240101_000003_create_batches_table::Migration),
             Box::new(m20240101_000004_create_user_sessions_table::Migration),
             Box::new(m20240101_000005_create_api_keys_table::Migration),
+            Box::new(m20240201_000001_create_pricing_tables::Migration),
             Box::new(m20240301_000001_create_user_management_tables::Migration),
             Box::new(m20240301_000002_create_teams_table::Migration),
         ]


### PR DESCRIPTION
## Summary
- The `m20240201_000001_create_pricing_tables` migration file existed on disk but was never registered in the SeaORM `Migrator`, making it unreachable
- Add the missing `mod` declaration and `Migrator::migrations()` entry so the pricing tables are created during database migration
- Migration is inserted in correct chronological order (between the 0101 and 0301 series)

## Context
The original issue (#356) referenced removing a legacy `migrations.rs` file, but that file no longer exists. The actual remaining problem was this orphan migration file that existed on disk but was not wired into the single SeaORM migration system.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo check --all-features`

Closes #356