### PR TITLE
fix(errors): replace Box<dyn Error> with typed errors at trait boundaries

### DIFF
--- a/src/core/traits/middleware.rs
+++ b/src/core/traits/middleware.rs
@@ -33,12 +33,11 @@ pub trait Middleware<Req, Resp>: Send + Sync {
 #[async_trait]
 pub trait MiddlewareNext<Req, Resp>: Send + Sync {
     /// Call the next handler in the chain
-    async fn call(&self, request: Req) -> Result<Resp, Box<dyn std::error::Error + Send + Sync>>;
+    async fn call(&self, request: Req) -> Result<Resp, MiddlewareError>;
 }
 
 // Type aliases for cleaner types
-type BoxedError = Box<dyn std::error::Error + Send + Sync>;
-type BoxedMiddleware<Req, Resp> = Box<dyn Middleware<Req, Resp, Error = BoxedError>>;
+type BoxedMiddleware<Req, Resp> = Box<dyn Middleware<Req, Resp, Error = MiddlewareError>>;
 type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Middleware chain/stack
@@ -72,13 +71,10 @@ where
         &self,
         request: Req,
         final_handler: F,
-    ) -> Result<Resp, Box<dyn std::error::Error + Send + Sync>>
+    ) -> Result<Resp, MiddlewareError>
     where
         F: FnOnce(Req) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<Resp, Box<dyn std::error::Error + Send + Sync>>>
-            + Send
-            + Sync
-            + 'static,
+        Fut: Future<Output = Result<Resp, MiddlewareError>> + Send + Sync + 'static,
     {
         let handler = Box::new(FinalHandler::new(final_handler));
         self.execute_chain(request, 0, handler).await
@@ -90,7 +86,7 @@ where
         request: Req,
         index: usize,
         final_handler: Box<dyn MiddlewareNext<Req, Resp>>,
-    ) -> BoxedFuture<'_, Result<Resp, BoxedError>> {
+    ) -> BoxedFuture<'_, Result<Resp, MiddlewareError>> {
         Box::pin(async move {
             if index >= self.middlewares.len() {
                 // Execute final handler
@@ -106,10 +102,9 @@ where
 
                 // NOTE: Middleware execution disabled; type constraints not yet resolved.
                 // self.middlewares[index].process(request, next).await
-                Err(Box::new(std::io::Error::other(
-                    "Middleware system temporarily disabled",
+                Err(MiddlewareError::ExecutionFailed(
+                    "Middleware system temporarily disabled".to_string(),
                 ))
-                    as Box<dyn std::error::Error + Send + Sync>)
             }
         })
     }
@@ -144,14 +139,16 @@ impl<F, Fut, Req, Resp> FinalHandler<F, Fut, Req, Resp> {
 impl<F, Fut, Req, Resp> MiddlewareNext<Req, Resp> for FinalHandler<F, Fut, Req, Resp>
 where
     F: FnOnce(Req) -> Fut + Send + Sync,
-    Fut: Future<Output = Result<Resp, Box<dyn std::error::Error + Send + Sync>>> + Send + Sync,
+    Fut: Future<Output = Result<Resp, MiddlewareError>> + Send + Sync,
     Req: Send + Sync,
     Resp: Send + Sync,
 {
-    async fn call(&self, _request: Req) -> Result<Resp, Box<dyn std::error::Error + Send + Sync>> {
+    async fn call(&self, _request: Req) -> Result<Resp, MiddlewareError> {
         // FnOnce can only be called once, but trait methods may be called multiple times
         // This requires a more complex design with interior mutability
-        Err("FinalHandler: FnOnce handling not yet implemented".into())
+        Err(MiddlewareError::ExecutionFailed(
+            "FinalHandler: FnOnce handling not yet implemented".to_string(),
+        ))
     }
 }
 
@@ -169,9 +166,11 @@ where
     Req: Clone + Send + Sync + 'static,
     Resp: Send + Sync + 'static,
 {
-    async fn call(&self, _request: Req) -> Result<Resp, Box<dyn std::error::Error + Send + Sync>> {
+    async fn call(&self, _request: Req) -> Result<Resp, MiddlewareError> {
         // This requires redesign due to lifetime issues with recursive middleware chains
-        Err("NextHandler: next handler not yet implemented".into())
+        Err(MiddlewareError::ExecutionFailed(
+            "NextHandler: next handler not yet implemented".to_string(),
+        ))
     }
 }
 

--- a/src/core/traits/provider/handle.rs
+++ b/src/core/traits/provider/handle.rs
@@ -4,6 +4,7 @@
 
 use crate::core::types::health::HealthStatus;
 use crate::core::types::{chat::ChatRequest, context::RequestContext, responses::ChatResponse};
+use crate::utils::error::gateway_error::GatewayError;
 
 use super::llm_provider::trait_definition::LLMProvider;
 
@@ -109,13 +110,12 @@ impl ProviderHandle {
         &self,
         _request: ChatRequest,
         _context: RequestContext,
-    ) -> Result<ChatResponse, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<ChatResponse, GatewayError> {
         // This is a simplified implementation - in a real system,
         // you'd need to properly downcast and handle the provider
-        Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Provider chat_completion not implemented",
-        )))
+        Err(GatewayError::Internal(
+            "Provider chat_completion not implemented".to_string(),
+        ))
     }
 
     /// Check if model is supported
@@ -174,7 +174,7 @@ impl ProviderHandle {
         _model: &str,
         _input: u32,
         _output: u32,
-    ) -> Result<f64, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<f64, GatewayError> {
         // Simplified implementation
         Ok(0.0)
     }
@@ -186,9 +186,7 @@ impl ProviderHandle {
     ///
     /// # Note
     /// Simplified implementation - returns 100ms
-    pub async fn get_average_latency(
-        &self,
-    ) -> Result<std::time::Duration, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_average_latency(&self) -> Result<std::time::Duration, GatewayError> {
         // Simplified implementation
         Ok(std::time::Duration::from_millis(100))
     }
@@ -200,7 +198,7 @@ impl ProviderHandle {
     ///
     /// # Note
     /// Simplified implementation - returns 1.0 (100%)
-    pub async fn get_success_rate(&self) -> Result<f32, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_success_rate(&self) -> Result<f32, GatewayError> {
         // Simplified implementation
         Ok(1.0)
     }


### PR DESCRIPTION
## Summary
- Replace `Box<dyn std::error::Error + Send + Sync>` with concrete typed errors in two files:
  - `src/core/traits/provider/handle.rs`: use `GatewayError` for `chat_completion`, `calculate_cost`, `get_average_latency`, `get_success_rate`
  - `src/core/traits/middleware.rs`: use `MiddlewareError` for `MiddlewareNext::call()`, `MiddlewareStack::execute()`, `FinalHandler`, and `NextHandler`
- Preserves semantic error information that was lost with type-erased `Box<dyn Error>`
- Callers can now match on specific error variants instead of downcasting

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib -- middleware_error` (6 tests pass)
- [x] `cargo test --all-features --lib -- provider_handle` (1 test passes)
- [x] Full build with all features passes

Closes #359