### PR TITLE
server: wire rate limiting and batch route stubs

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -4,7 +4,10 @@
 
 use crate::config::Config;
 use crate::config::models::server::ServerConfig;
-use crate::server::middleware::{AuthMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware};
+use crate::core::rate_limiter::{get_global_rate_limiter, init_global_rate_limiter};
+use crate::server::middleware::{
+    AuthMiddleware, RateLimitMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware,
+};
 use crate::server::routes;
 use crate::server::state::AppState;
 use crate::services::pricing::PricingService;
@@ -12,7 +15,7 @@ use crate::utils::error::gateway_error::{GatewayError, Result};
 use actix_cors::Cors;
 use actix_web::{
     App, HttpServer as ActixHttpServer,
-    middleware::{DefaultHeaders, Logger},
+    middleware::{Condition, DefaultHeaders, Logger},
     web,
 };
 use std::sync::Arc;
@@ -94,7 +97,16 @@ impl HttpServer {
         info!("Setting up routes and middleware");
 
         let cfg = state.config.load();
+        if cfg.gateway.rate_limit.enabled && get_global_rate_limiter().is_none() {
+            init_global_rate_limiter(cfg.gateway.rate_limit.clone());
+            info!(
+                "Global rate limiter initialized (strategy={:?}, rpm={})",
+                cfg.gateway.rate_limit.strategy, cfg.gateway.rate_limit.default_rpm
+            );
+        }
         let cors_config = &cfg.gateway.server.cors;
+        let rate_limit_enabled = cfg.gateway.rate_limit.enabled;
+        let rate_limit_rpm = cfg.gateway.rate_limit.default_rpm;
         let mut cors = Cors::default();
 
         if cors_config.enabled {
@@ -144,6 +156,10 @@ impl HttpServer {
             .wrap(DefaultHeaders::new().add(("Server", "LiteLLM-RS")))
             .wrap(SecurityHeadersMiddleware)
             .wrap(AuthMiddleware)
+            .wrap(Condition::new(
+                rate_limit_enabled,
+                RateLimitMiddleware::new(rate_limit_rpm),
+            ))
             .wrap(RequestIdMiddleware)
             .configure(routes::health::configure_routes)
             .configure(routes::auth::configure_routes)

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -4,9 +4,12 @@ use crate::auth::AuthMethod;
 use crate::core::models::{ApiKey, user::types::User};
 use crate::core::types::context::RequestContext;
 use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
-use crate::server::middleware::helpers::{extract_auth_method, is_public_route};
+use crate::server::middleware::helpers::{
+    extract_auth_method_with_api_key_header, is_public_route,
+};
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
+use actix_web::http::header::{HeaderMap, HeaderName};
 use actix_web::{HttpMessage, HttpRequest, web};
 use futures::future::{Ready, ready};
 use std::collections::HashMap;
@@ -62,11 +65,6 @@ where
             // avoiding a per-request String allocation for the path.
             let is_public = is_public_route(req.path());
 
-            let context = build_request_context(&mut req);
-            let auth_method = extract_auth_method(req.headers());
-            let client_id = get_client_identifier(&req);
-            let rate_limiter = get_auth_rate_limiter();
-
             let app_state = match req.app_data::<web::Data<AppState>>().cloned() {
                 Some(state) => state,
                 None => {
@@ -75,14 +73,23 @@ where
                     ));
                 }
             };
+            let cfg = app_state.config.load();
+            let enable_jwt = cfg.auth().enable_jwt;
+            let enable_api_key = cfg.auth().enable_api_key;
+            let api_key_header = cfg.auth().api_key_header.clone();
+
+            let context = build_request_context(&mut req);
+            let auth_method =
+                extract_auth_method_with_api_key_header(req.headers(), api_key_header.as_str());
+            let client_id = get_client_identifier(&req, api_key_header.as_str());
+            let rate_limiter = get_auth_rate_limiter();
 
             if is_public {
                 req.extensions_mut().insert(context);
                 return service.call(req).await;
             }
 
-            let cfg = app_state.config.load();
-            let auth_enabled = cfg.auth().enable_jwt || cfg.auth().enable_api_key;
+            let auth_enabled = enable_jwt || enable_api_key;
             if !auth_enabled {
                 req.extensions_mut().insert(context);
                 return service.call(req).await;
@@ -96,13 +103,13 @@ where
             }
 
             let auth_method = match auth_method {
-                AuthMethod::Jwt(_) if !cfg.auth().enable_jwt => {
+                AuthMethod::Jwt(_) if !enable_jwt => {
                     rate_limiter.record_failure(&client_id);
                     return Err(actix_web::error::ErrorUnauthorized(
                         "JWT authentication disabled",
                     ));
                 }
-                AuthMethod::ApiKey(_) if !cfg.auth().enable_api_key => {
+                AuthMethod::ApiKey(_) if !enable_api_key => {
                     rate_limiter.record_failure(&client_id);
                     return Err(actix_web::error::ErrorUnauthorized(
                         "API key authentication disabled",
@@ -167,25 +174,38 @@ pub fn get_request_context(req: &HttpRequest) -> Result<RequestContext, actix_we
 }
 
 /// Extract a client identifier for rate limiting
-fn get_client_identifier(req: &ServiceRequest) -> String {
+fn get_client_identifier(req: &ServiceRequest, api_key_header: &str) -> String {
     let ip = req
         .connection_info()
         .peer_addr()
         .map(|s| s.to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    if let Some(api_key) = req
-        .headers()
-        .get("x-api-key")
-        .or_else(|| req.headers().get("authorization"))
-        .and_then(|h| h.to_str().ok())
-    {
+    let api_key = get_header_value(req.headers(), api_key_header)
+        .or_else(|| {
+            if api_key_header.eq_ignore_ascii_case("x-api-key") {
+                None
+            } else {
+                get_header_value(req.headers(), "x-api-key")
+            }
+        })
+        .or_else(|| get_header_value(req.headers(), "authorization"));
+
+    if let Some(api_key) = api_key {
         use sha2::{Digest, Sha256};
         let hash = Sha256::digest(api_key.as_bytes());
         format!("{}:{:x}", ip, hash)
     } else {
         format!("ip:{}", ip)
     }
+}
+
+fn get_header_value(headers: &HeaderMap, header_name: &str) -> Option<String> {
+    let header_name = HeaderName::try_from(header_name.trim()).ok()?;
+    headers
+        .get(&header_name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
 }
 
 fn build_request_context(req: &mut ServiceRequest) -> RequestContext {

--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -2,9 +2,24 @@
 
 use crate::auth::AuthMethod;
 use actix_web::http::header::HeaderMap;
+use actix_web::http::header::HeaderName;
 
 /// Extract authentication method from headers
 pub fn extract_auth_method(headers: &HeaderMap) -> AuthMethod {
+    extract_auth_method_with_api_key_header(headers, "x-api-key")
+}
+
+/// Extract authentication method from headers using a configured API key header.
+///
+/// Priority:
+/// 1. `Authorization` header (`Bearer <jwt>`, `ApiKey <key>`, or raw `gw-...`)
+/// 2. Configured API key header
+/// 3. `X-API-Key` (backward-compatible fallback)
+/// 4. `session=` cookie
+pub fn extract_auth_method_with_api_key_header(
+    headers: &HeaderMap,
+    api_key_header: &str,
+) -> AuthMethod {
     // Check Authorization header
     if let Some(auth_header) = headers.get("authorization")
         && let Ok(auth_str) = auth_header.to_str()
@@ -20,11 +35,16 @@ pub fn extract_auth_method(headers: &HeaderMap) -> AuthMethod {
         }
     }
 
-    // Check X-API-Key header
-    if let Some(api_key_header) = headers.get("x-api-key")
-        && let Ok(key) = api_key_header.to_str()
+    // Check configured API key header (unless it overlaps with Authorization/Cookie).
+    if let Some(key) = get_header_value(headers, api_key_header) {
+        return AuthMethod::ApiKey(key);
+    }
+
+    // Backward-compatible fallback.
+    if !api_key_header.eq_ignore_ascii_case("x-api-key")
+        && let Some(key) = get_header_value(headers, "x-api-key")
     {
-        return AuthMethod::ApiKey(key.to_string());
+        return AuthMethod::ApiKey(key);
     }
 
     // Check session cookie
@@ -41,6 +61,22 @@ pub fn extract_auth_method(headers: &HeaderMap) -> AuthMethod {
     }
 
     AuthMethod::None
+}
+
+fn get_header_value(headers: &HeaderMap, header_name: &str) -> Option<String> {
+    let trimmed = header_name.trim();
+    if trimmed.is_empty()
+        || trimmed.eq_ignore_ascii_case("authorization")
+        || trimmed.eq_ignore_ascii_case("cookie")
+    {
+        return None;
+    }
+
+    let header_name = HeaderName::try_from(trimmed).ok()?;
+    headers
+        .get(&header_name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
 }
 
 /// Check if a route is public (doesn't require authentication)

--- a/src/server/middleware/mod.rs
+++ b/src/server/middleware/mod.rs
@@ -23,7 +23,10 @@ mod tests;
 // Re-export all middleware
 pub use auth::{AuthMiddleware, AuthMiddlewareService, get_request_context};
 pub use auth_rate_limiter::{AuthRateLimiter, get_auth_rate_limiter};
-pub use helpers::{extract_auth_method, is_admin_route, is_api_route, is_public_route};
+pub use helpers::{
+    extract_auth_method, extract_auth_method_with_api_key_header, is_admin_route, is_api_route,
+    is_public_route,
+};
 pub use metrics::{MetricsMiddleware, MetricsMiddlewareService, MiddlewareRequestMetrics};
 pub use rate_limit::{RateLimitMiddleware, RateLimitMiddlewareService};
 pub use request_id::{RequestIdMiddleware, RequestIdMiddlewareService};

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -4,6 +4,7 @@ use crate::core::rate_limiter::get_global_rate_limiter;
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::http::StatusCode;
+use actix_web::http::header::HeaderName;
 use actix_web::web;
 use actix_web::{HttpResponse, ResponseError};
 use dashmap::DashMap;
@@ -147,15 +148,21 @@ fn parse_peer_ip(peer: &str) -> String {
 /// Extract a client identifier from the request.
 ///
 /// Priority:
-/// 1. `Authorization` header value (API key / Bearer token) — identifies the authenticated caller
-/// 2. `X-Forwarded-For` first address — only when peer IP is in `trusted_proxies`
-/// 3. Direct peer address from connection info
-fn extract_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> String {
-    if let Some(auth) = req.headers().get("Authorization")
-        && let Ok(val) = auth.to_str()
-    {
+/// 1. Configured API key header value
+/// 2. `Authorization` header value (API key / Bearer token)
+/// 3. `X-Forwarded-For` first address — only when peer IP is in `trusted_proxies`
+/// 4. Direct peer address from connection info
+fn extract_client_key(
+    req: &ServiceRequest,
+    trusted_proxies: &[String],
+    api_key_header: &str,
+) -> String {
+    let auth_token = header_value(req.headers(), api_key_header)
+        .or_else(|| header_value(req.headers(), "Authorization"));
+
+    if let Some(token) = auth_token {
         // Hash the token so raw secrets never reside in memory as map keys
-        let hash = Sha256::digest(val.as_bytes());
+        let hash = Sha256::digest(token.as_bytes());
         return format!("auth:{:x}", hash);
     }
 
@@ -175,6 +182,14 @@ fn extract_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> Strin
     peer_ip
 }
 
+fn header_value(headers: &actix_web::http::header::HeaderMap, header_name: &str) -> Option<String> {
+    let header_name = HeaderName::try_from(header_name.trim()).ok()?;
+    headers
+        .get(&header_name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
 impl<S, B> Service<ServiceRequest> for RateLimitMiddlewareService<S>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
@@ -189,16 +204,22 @@ where
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let app_state = req.app_data::<web::Data<AppState>>().cloned();
-        let trusted_proxies: Vec<String> = app_state
-            .as_ref()
-            .map(|s| s.config.load().server().trusted_proxies.clone())
-            .unwrap_or_default();
+        let (trusted_proxies, api_key_header): (Vec<String>, String) = match app_state.as_ref() {
+            Some(state) => {
+                let cfg = state.config.load();
+                (
+                    cfg.server().trusted_proxies.clone(),
+                    cfg.auth().api_key_header.clone(),
+                )
+            }
+            None => (Vec::new(), "x-api-key".to_string()),
+        };
         let requests_per_minute = self.requests_per_minute;
         let start_time = Instant::now();
         let path = req.path().to_string();
         let method = req.method().to_string();
 
-        let client_key = extract_client_key(&req, &trusted_proxies);
+        let client_key = extract_client_key(&req, &trusted_proxies, &api_key_header);
 
         // --- Try global rate limiter first ---
         if let Some(global_limiter) = get_global_rate_limiter() {

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -1,7 +1,10 @@
 //! Middleware tests
 
 use super::auth_rate_limiter::AuthRateLimiter;
-use super::helpers::{extract_auth_method, is_admin_route, is_api_route, is_public_route};
+use super::helpers::{
+    extract_auth_method, extract_auth_method_with_api_key_header, is_admin_route, is_api_route,
+    is_public_route,
+};
 use crate::auth::AuthMethod;
 use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 
@@ -39,6 +42,30 @@ fn test_extract_auth_method_x_api_key() {
 
     let auth_method = extract_auth_method(&headers);
     assert!(matches!(auth_method, AuthMethod::ApiKey(key) if key == "key123"));
+}
+
+#[test]
+fn test_extract_auth_method_custom_api_key_header() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("x-gateway-api-key"),
+        HeaderValue::from_static("gw-custom-123"),
+    );
+
+    let auth_method = extract_auth_method_with_api_key_header(&headers, "x-gateway-api-key");
+    assert!(matches!(auth_method, AuthMethod::ApiKey(key) if key == "gw-custom-123"));
+}
+
+#[test]
+fn test_extract_auth_method_custom_header_fallback_x_api_key() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("x-api-key"),
+        HeaderValue::from_static("fallback-key"),
+    );
+
+    let auth_method = extract_auth_method_with_api_key_header(&headers, "x-gateway-api-key");
+    assert!(matches!(auth_method, AuthMethod::ApiKey(key) if key == "fallback-key"));
 }
 
 #[test]

--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -1,0 +1,50 @@
+//! Batch API route handlers.
+//!
+//! These endpoints are mounted to keep OpenAI-compatible batch paths stable.
+//! Business logic is not implemented yet, so handlers return explicit 501.
+
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::{HttpResponse, ResponseError, Result as ActixResult, web};
+use tracing::warn;
+
+/// Create a batch request.
+pub async fn create_batch() -> ActixResult<HttpResponse> {
+    warn!("Batch create endpoint is not implemented");
+    Ok(
+        GatewayError::not_implemented("Batch create endpoint is not implemented yet")
+            .error_response(),
+    )
+}
+
+/// List batches.
+pub async fn list_batches() -> ActixResult<HttpResponse> {
+    warn!("Batch list endpoint is not implemented");
+    Ok(
+        GatewayError::not_implemented("Batch list endpoint is not implemented yet")
+            .error_response(),
+    )
+}
+
+/// Get a batch by ID.
+pub async fn get_batch(batch_id: web::Path<String>) -> ActixResult<HttpResponse> {
+    warn!(
+        batch_id = %batch_id.as_str(),
+        "Batch retrieve endpoint is not implemented"
+    );
+    Ok(
+        GatewayError::not_implemented("Batch retrieve endpoint is not implemented yet")
+            .error_response(),
+    )
+}
+
+/// Cancel a batch by ID.
+pub async fn cancel_batch(batch_id: web::Path<String>) -> ActixResult<HttpResponse> {
+    warn!(
+        batch_id = %batch_id.as_str(),
+        "Batch cancel endpoint is not implemented"
+    );
+    Ok(
+        GatewayError::not_implemented("Batch cancel endpoint is not implemented yet")
+            .error_response(),
+    )
+}

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -4,6 +4,7 @@
 
 // Module declarations
 mod audio;
+mod batches;
 mod chat;
 mod context;
 mod embeddings;
@@ -15,6 +16,7 @@ mod responses_stream;
 
 // Public re-exports for backward compatibility
 pub use audio::{audio_speech, audio_transcriptions, audio_translations};
+pub use batches::{cancel_batch, create_batch, get_batch, list_batches};
 pub use chat::chat_completions;
 pub use context::{
     check_permission, get_authenticated_api_key, get_authenticated_user, get_request_context,
@@ -37,6 +39,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/responses", web::post().to(create_response))
             // Embeddings
             .route("/embeddings", web::post().to(embeddings))
+            // Batch processing
+            .route("/batches", web::post().to(create_batch))
+            .route("/batches", web::get().to(list_batches))
+            .route("/batches/{batch_id}", web::get().to(get_batch))
+            .route("/batches/{batch_id}/cancel", web::post().to(cancel_batch))
             // Image generation
             .route("/images/generations", web::post().to(image_generations))
             // Models
@@ -55,13 +62,42 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use crate::core::types::context::RequestContext;
+    use actix_web::{App, http::StatusCode, test};
 
-    #[test]
-    fn test_get_request_context() {
+    #[actix_web::test]
+    async fn test_get_request_context() {
         // This test would need a mock HttpRequest in a real implementation
         // For now, we'll test the basic functionality
         let context = RequestContext::new();
         assert!(!context.request_id.is_empty());
         assert!(context.user_agent.is_none());
+    }
+
+    #[actix_web::test]
+    async fn test_batch_routes_mounted_with_expected_methods() {
+        let app = test::init_service(App::new().configure(super::configure_routes)).await;
+
+        let create_req = test::TestRequest::post()
+            .uri("/v1/batches")
+            .set_json(serde_json::json!({}))
+            .to_request();
+        let create_resp = test::call_service(&app, create_req).await;
+        assert_eq!(create_resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let list_req = test::TestRequest::get().uri("/v1/batches").to_request();
+        let list_resp = test::call_service(&app, list_req).await;
+        assert_eq!(list_resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let get_req = test::TestRequest::get()
+            .uri("/v1/batches/batch_test")
+            .to_request();
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let cancel_req = test::TestRequest::post()
+            .uri("/v1/batches/batch_test/cancel")
+            .to_request();
+        let cancel_resp = test::call_service(&app, cancel_req).await;
+        assert_eq!(cancel_resp.status(), StatusCode::NOT_IMPLEMENTED);
     }
 }

--- a/src/server/routes/keys/handlers.rs
+++ b/src/server/routes/keys/handlers.rs
@@ -10,7 +10,7 @@ use crate::core::keys::KeyManager;
 use crate::core::keys::{CreateKeyConfig, KeyStatus, UpdateKeyConfig};
 use crate::core::models::user::types::{User, UserRole};
 use crate::core::types::context::RequestContext;
-use crate::server::middleware::extract_auth_method;
+use crate::server::middleware::extract_auth_method_with_api_key_header;
 use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
@@ -86,7 +86,9 @@ async fn authenticate_request(
     req: &HttpRequest,
     state: &web::Data<AppState>,
 ) -> Result<Option<AuthResult>, HttpResponse> {
-    let auth_method = extract_auth_method(req.headers());
+    let api_key_header = state.config.load().auth().api_key_header.clone();
+    let auth_method =
+        extract_auth_method_with_api_key_header(req.headers(), api_key_header.as_str());
 
     if matches!(auth_method, AuthMethod::None) {
         return Ok(None);


### PR DESCRIPTION
## Summary
- wire global rate-limit middleware into HTTP app when enabled
- respect configurable auth `api_key_header` with safe fallback to `x-api-key`
- mount `/v1/batches` route stubs (explicit 501) and add route coverage tests