### PR TITLE
fix(auth): replace prefix match with exact equality in is_public_route

### DIFF
--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -84,6 +84,7 @@ pub fn is_public_route(path: &str) -> bool {
     const PUBLIC_ROUTES: &[&str] = &[
         "/health",
         "/auth/login",
+        "/auth/login/callback",
         "/auth/register",
         "/auth/forgot-password",
         "/auth/reset-password",
@@ -92,9 +93,7 @@ pub fn is_public_route(path: &str) -> bool {
         "/openapi.json",
     ];
 
-    PUBLIC_ROUTES
-        .iter()
-        .any(|&route| path == route || path.starts_with(&format!("{route}/")))
+    PUBLIC_ROUTES.contains(&path)
 }
 
 /// Check if a route requires admin privileges


### PR DESCRIPTION
## Summary

- **SEC-04**: `is_public_route()` used `starts_with()` which allowed `/health/detailed` (and any other sub-path of a listed public route) to bypass authentication
- Replaced with `slice::contains()` for exact path equality — no sub-path can bypass auth unless it is explicitly listed
- Added `/auth/login/callback` explicitly to PUBLIC_ROUTES to preserve the OAuth2 callback flow

## Security Impact

Before this fix, `GET /health/detailed` was accessible without a valid token. That endpoint exposes storage subsystem status (database/Redis/file/vector DB health), provider count and health details, CPU/memory usage, and service uptime — sufficient to fingerprint the deployment topology.

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all 7864 tests pass (including `test_is_public_route` which asserts `/health/detailed` is not public and `/auth/login/callback` is public)