### PR TITLE
fix(auth): guard is_admin_route() against prefix confusion (SEC-04, #391)

### DIFF
--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -100,7 +100,9 @@ pub fn is_public_route(path: &str) -> bool {
 pub fn is_admin_route(path: &str) -> bool {
     const ADMIN_ROUTES: &[&str] = &["/admin", "/api/admin"];
 
-    ADMIN_ROUTES.iter().any(|&route| path.starts_with(route))
+    ADMIN_ROUTES
+        .iter()
+        .any(|&route| path == route || path.starts_with(&format!("{route}/")))
 }
 
 /// Check if a route is for API access
@@ -114,4 +116,38 @@ pub fn is_api_route(path: &str) -> bool {
     ];
 
     API_ROUTES.iter().any(|&route| path.starts_with(route))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_admin_route_exact_match() {
+        assert!(is_admin_route("/admin"));
+        assert!(is_admin_route("/api/admin"));
+    }
+
+    #[test]
+    fn test_is_admin_route_sub_paths() {
+        assert!(is_admin_route("/admin/users"));
+        assert!(is_admin_route("/admin/settings"));
+        assert!(is_admin_route("/api/admin/users"));
+    }
+
+    #[test]
+    fn test_is_admin_route_no_prefix_confusion() {
+        // Regression: bare starts_with() without separator allowed these
+        assert!(!is_admin_route("/adminevil"));
+        assert!(!is_admin_route("/api/adminevil"));
+        assert!(!is_admin_route("/administrator"));
+        assert!(!is_admin_route("/api/adminsecret"));
+    }
+
+    #[test]
+    fn test_is_admin_route_unrelated_paths() {
+        assert!(!is_admin_route("/health"));
+        assert!(!is_admin_route("/v1/chat/completions"));
+        assert!(!is_admin_route("/auth/login"));
+    }
 }


### PR DESCRIPTION
## Summary

- Replace bare `starts_with(route)` with `path == route || path.starts_with(&format!("{route}/"))` in `is_admin_route()`
- Prevents `/adminevil` and `/api/adminevil` from being misclassified as admin routes
- Adds 4 regression tests covering exact match, sub-paths, and false-positive paths

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test is_admin_route` — 5 tests pass (4 new + 1 existing)