### PR TITLE
fix(sdk): implement atomic round-robin rotation in LoadBalancer

### DIFF
--- a/src/sdk/client/routing.rs
+++ b/src/sdk/client/routing.rs
@@ -49,6 +49,8 @@ impl LLMClient {
 }
 
 // Load balancer implementation
+use std::sync::atomic::Ordering;
+
 use super::types::LoadBalancer;
 
 impl LoadBalancer {
@@ -67,8 +69,9 @@ impl LoadBalancer {
 
         match self.strategy {
             LoadBalancingStrategy::RoundRobin => {
-                // Simple round-robin: select first available provider
-                Ok(enabled_providers[0])
+                let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed)
+                    % enabled_providers.len();
+                Ok(enabled_providers[idx])
             }
             LoadBalancingStrategy::WeightedRandom => {
                 // Weighted random selection

--- a/src/sdk/client/types.rs
+++ b/src/sdk/client/types.rs
@@ -1,5 +1,6 @@
 //! Type definitions for the LLM client
 
+use std::sync::atomic::AtomicUsize;
 use std::time::SystemTime;
 
 /// Provider statistics
@@ -18,6 +19,7 @@ pub struct ProviderStats {
 #[derive(Debug)]
 pub struct LoadBalancer {
     pub(crate) strategy: LoadBalancingStrategy,
+    pub(crate) round_robin_counter: AtomicUsize,
 }
 
 /// Load balancing strategy
@@ -31,7 +33,10 @@ pub enum LoadBalancingStrategy {
 
 impl LoadBalancer {
     pub(crate) fn new(strategy: LoadBalancingStrategy) -> Self {
-        Self { strategy }
+        Self {
+            strategy,
+            round_robin_counter: AtomicUsize::new(0),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `AtomicUsize round_robin_counter` field to `LoadBalancer` struct
- Fix `RoundRobin` strategy to use `fetch_add(1, Relaxed) % len` so requests rotate evenly across all enabled providers
- Previously the strategy always returned `enabled_providers[0]`, making it functionally identical to first-available

## Test plan
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — 7865 + 144 + 95 tests pass