### PR TITLE
fix(sdk): wire chat_stream to real provider SSE streaming

### DIFF
--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -121,9 +121,13 @@ impl LLMClient {
             "stream": true
         });
 
-        let default_url = "https://api.openai.com".to_string();
+        let default_url = "https://api.openai.com/v1".to_string();
         let base_url = provider.base_url.as_ref().unwrap_or(&default_url);
-        let url = format!("{}/v1/chat/completions", base_url.trim_end_matches('/'));
+        let url = if base_url.contains("/v1") {
+            format!("{}/chat/completions", base_url.trim_end_matches('/'))
+        } else {
+            format!("{}/v1/chat/completions", base_url.trim_end_matches('/'))
+        };
 
         debug!("Calling OpenAI streaming API: {}", url);
 
@@ -296,9 +300,13 @@ impl LLMClient {
             "stream": false
         });
 
-        let default_url = "https://api.openai.com".to_string();
+        let default_url = "https://api.openai.com/v1".to_string();
         let base_url = provider.base_url.as_ref().unwrap_or(&default_url);
-        let url = format!("{}/v1/chat/completions", base_url.trim_end_matches('/'));
+        let url = if base_url.contains("/v1") {
+            format!("{}/chat/completions", base_url.trim_end_matches('/'))
+        } else {
+            format!("{}/v1/chat/completions", base_url.trim_end_matches('/'))
+        };
 
         debug!("Calling OpenAI API: {}", url);
 
@@ -466,17 +474,29 @@ impl LLMClient {
     }
 }
 
+/// Trim trailing `\r` and `\n` bytes from a byte slice.
+fn trim_line_end(b: &[u8]) -> &[u8] {
+    let mut end = b.len();
+    while end > 0 && (b[end - 1] == b'\n' || b[end - 1] == b'\r') {
+        end -= 1;
+    }
+    &b[..end]
+}
+
 /// Parse an OpenAI-compatible SSE response into a stream of `ChatChunk`s.
 ///
 /// OpenAI sends newline-delimited `data: <json>` lines ending with `data: [DONE]`.
 /// The JSON structure matches `ChatChunk` directly, so each line is deserialized
 /// straight into that type.
+///
+/// Bytes are accumulated in a raw buffer and split on `\n` boundaries so that
+/// multi-byte UTF-8 characters split across HTTP chunks are handled correctly.
 fn parse_sse_stream_openai(
     response: reqwest::Response,
 ) -> impl futures::Stream<Item = Result<ChatChunk>> + Send {
     async_stream::stream! {
         let mut byte_stream = response.bytes_stream();
-        let mut buffer = String::new();
+        let mut raw_buffer: Vec<u8> = Vec::new();
 
         while let Some(chunk_result) = byte_stream.next().await {
             match chunk_result {
@@ -485,18 +505,18 @@ fn parse_sse_stream_openai(
                     return;
                 }
                 Ok(chunk) => {
-                    let text = match std::str::from_utf8(&chunk) {
-                        Ok(t) => t.to_string(),
-                        Err(e) => {
-                            yield Err(SDKError::ParseError(e.to_string()));
-                            return;
-                        }
-                    };
-                    buffer.push_str(&text);
+                    raw_buffer.extend_from_slice(&chunk);
 
-                    while let Some(pos) = buffer.find('\n') {
-                        let line = buffer[..pos].trim_end_matches('\r').trim().to_string();
-                        buffer = buffer[pos + 1..].to_string();
+                    while let Some(pos) = raw_buffer.iter().position(|&b| b == b'\n') {
+                        let line_bytes: Vec<u8> = raw_buffer.drain(..=pos).collect();
+                        let trimmed = trim_line_end(&line_bytes);
+                        let line = match std::str::from_utf8(trimmed) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                yield Err(SDKError::ParseError(e.to_string()));
+                                return;
+                            }
+                        };
 
                         if let Some(data) = line.strip_prefix("data: ") {
                             if data == "[DONE]" {
@@ -523,14 +543,19 @@ fn parse_sse_stream_openai(
 ///
 /// Anthropic sends typed events (`message_start`, `content_block_delta`, etc.).
 /// Only `content_block_delta` events with a `text_delta` produce output chunks.
+///
+/// Bytes are accumulated in a raw buffer and split on `\n` boundaries so that
+/// multi-byte UTF-8 characters split across HTTP chunks are handled correctly.
+/// `event: error` lines are propagated as stream errors rather than silently dropped.
 fn parse_sse_stream_anthropic(
     response: reqwest::Response,
 ) -> impl futures::Stream<Item = Result<ChatChunk>> + Send {
     async_stream::stream! {
         let mut byte_stream = response.bytes_stream();
-        let mut buffer = String::new();
+        let mut raw_buffer: Vec<u8> = Vec::new();
         let mut message_id = String::from("msg_stream");
         let mut model = String::from("claude");
+        let mut current_event = String::new();
 
         while let Some(chunk_result) = byte_stream.next().await {
             match chunk_result {
@@ -539,25 +564,48 @@ fn parse_sse_stream_anthropic(
                     return;
                 }
                 Ok(chunk) => {
-                    let text = match std::str::from_utf8(&chunk) {
-                        Ok(t) => t.to_string(),
-                        Err(e) => {
-                            yield Err(SDKError::ParseError(e.to_string()));
-                            return;
+                    raw_buffer.extend_from_slice(&chunk);
+
+                    while let Some(pos) = raw_buffer.iter().position(|&b| b == b'\n') {
+                        let line_bytes: Vec<u8> = raw_buffer.drain(..=pos).collect();
+                        let trimmed = trim_line_end(&line_bytes);
+                        let line = match std::str::from_utf8(trimmed) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                yield Err(SDKError::ParseError(e.to_string()));
+                                return;
+                            }
+                        };
+
+                        if line.is_empty() {
+                            current_event.clear();
+                            continue;
                         }
-                    };
-                    buffer.push_str(&text);
 
-                    while let Some(pos) = buffer.find('\n') {
-                        let line = buffer[..pos].trim_end_matches('\r').trim().to_string();
-                        buffer = buffer[pos + 1..].to_string();
-
-                        // Skip event-type lines and blanks
-                        if line.is_empty() || line.starts_with("event: ") {
+                        if let Some(event_name) = line.strip_prefix("event: ") {
+                            current_event = event_name.trim().to_string();
                             continue;
                         }
 
                         if let Some(data) = line.strip_prefix("data: ") {
+                            // Propagate in-band Anthropic stream errors (event: error)
+                            if current_event == "error" {
+                                let error_msg = serde_json::from_str::<serde_json::Value>(data)
+                                    .ok()
+                                    .and_then(|v| {
+                                        v.get("error")
+                                            .and_then(|e| e.get("message"))
+                                            .and_then(|m| m.as_str())
+                                            .map(|s| s.to_string())
+                                    })
+                                    .unwrap_or_else(|| data.to_string());
+                                yield Err(SDKError::ApiError(format!(
+                                    "Anthropic stream error: {}",
+                                    error_msg
+                                )));
+                                return;
+                            }
+
                             let value: serde_json::Value = match serde_json::from_str(data) {
                                 Ok(v) => v,
                                 Err(_) => continue,
@@ -594,6 +642,19 @@ fn parse_sse_stream_anthropic(
                                             }],
                                         });
                                     }
+                                }
+                                "error" => {
+                                    let error_msg = value
+                                        .get("error")
+                                        .and_then(|e| e.get("message"))
+                                        .and_then(|m| m.as_str())
+                                        .unwrap_or("unknown stream error")
+                                        .to_string();
+                                    yield Err(SDKError::ApiError(format!(
+                                        "Anthropic stream error: {}",
+                                        error_msg
+                                    )));
+                                    return;
                                 }
                                 "message_stop" => return,
                                 _ => {}

--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -523,8 +523,28 @@ fn parse_sse_stream_openai(
                                 return;
                             }
                             if !data.is_empty() {
-                                match serde_json::from_str::<ChatChunk>(data) {
-                                    Ok(chunk) => yield Ok(chunk),
+                                // Parse as a generic Value first so in-band SSE errors
+                                // (`data: {"error":{...}}`) are surfaced as ApiError rather
+                                // than a confusing ParseError.
+                                match serde_json::from_str::<serde_json::Value>(data) {
+                                    Ok(v) if v.get("error").is_some() => {
+                                        let msg = v["error"]
+                                            .get("message")
+                                            .and_then(|m| m.as_str())
+                                            .unwrap_or(data);
+                                        yield Err(SDKError::ApiError(format!(
+                                            "Stream error: {}",
+                                            msg
+                                        )));
+                                        return;
+                                    }
+                                    Ok(v) => match serde_json::from_value::<ChatChunk>(v) {
+                                        Ok(chunk) => yield Ok(chunk),
+                                        Err(e) => yield Err(SDKError::ParseError(format!(
+                                            "Failed to parse OpenAI chunk: {}",
+                                            e
+                                        ))),
+                                    },
                                     Err(e) => yield Err(SDKError::ParseError(format!(
                                         "Failed to parse OpenAI chunk: {}",
                                         e
@@ -643,6 +663,36 @@ fn parse_sse_stream_anthropic(
                                         });
                                     }
                                 }
+                                "message_delta" => {
+                                    // `message_delta` carries the terminal `stop_reason` (maps
+                                    // to OpenAI `finish_reason`) and the final usage counts.
+                                    // Emit a chunk so callers receive finish_reason; without
+                                    // this the stream looks like an incomplete completion.
+                                    let finish_reason = value
+                                        .get("delta")
+                                        .and_then(|d| d.get("stop_reason"))
+                                        .and_then(|r| r.as_str())
+                                        .map(|r| match r {
+                                            "end_turn" => "stop".to_string(),
+                                            "max_tokens" => "length".to_string(),
+                                            other => other.to_string(),
+                                        });
+                                    if finish_reason.is_some() {
+                                        yield Ok(ChatChunk {
+                                            id: message_id.clone(),
+                                            model: model.clone(),
+                                            choices: vec![ChunkChoice {
+                                                index: 0,
+                                                delta: MessageDelta {
+                                                    role: None,
+                                                    content: None,
+                                                    tool_calls: None,
+                                                },
+                                                finish_reason,
+                                            }],
+                                        });
+                                    }
+                                }
                                 "error" => {
                                     let error_msg = value
                                         .get("error")
@@ -656,7 +706,16 @@ fn parse_sse_stream_anthropic(
                                     )));
                                     return;
                                 }
-                                "message_stop" => return,
+                                "message_stop" => {
+                                    // Emit a terminal empty-choices chunk matching the core
+                                    // SSE transformer, then close the stream.
+                                    yield Ok(ChatChunk {
+                                        id: message_id.clone(),
+                                        model: model.clone(),
+                                        choices: vec![],
+                                    });
+                                    return;
+                                }
                                 _ => {}
                             }
                         }

--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -36,13 +36,27 @@ impl LLMClient {
         result
     }
 
-    /// Streaming chat
+    /// Streaming chat (uses default ChatOptions)
     pub async fn chat_stream(
         &self,
         messages: Vec<Message>,
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
-        let provider = self.select_provider_for_stream(&messages).await?;
-        self.execute_stream_request(&provider.id, messages).await
+        let request = SdkChatRequest {
+            model: String::new(),
+            messages,
+            options: ChatOptions::default(),
+        };
+        self.chat_stream_with_options(request).await
+    }
+
+    /// Streaming chat with full options control (mirrors `chat_with_options`)
+    pub async fn chat_stream_with_options(
+        &self,
+        request: SdkChatRequest,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
+        let provider = self.select_provider_for_stream(&request.messages).await?;
+        let provider_id = provider.id.clone();
+        self.execute_stream_request(&provider_id, request).await
     }
 
     /// Execute chat request with a specific provider
@@ -81,7 +95,7 @@ impl LLMClient {
     pub(crate) async fn execute_stream_request(
         &self,
         provider_id: &str,
-        messages: Vec<Message>,
+        request: SdkChatRequest,
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let provider = self
             .config
@@ -92,10 +106,12 @@ impl LLMClient {
 
         match provider.provider_type {
             crate::sdk::config::ProviderType::OpenAI => {
-                self.stream_openai_request(provider, messages).await
+                self.stream_openai_request(provider, request.messages, &request.options)
+                    .await
             }
             crate::sdk::config::ProviderType::Anthropic => {
-                self.stream_anthropic_request(provider, messages).await
+                self.stream_anthropic_request(provider, request.messages, &request.options)
+                    .await
             }
             _ => Err(SDKError::NotSupported(format!(
                 "Streaming is not implemented for provider type {:?}",
@@ -109,17 +125,25 @@ impl LLMClient {
         &self,
         provider: &crate::sdk::config::SdkProviderConfig,
         messages: Vec<Message>,
+        options: &ChatOptions,
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let model = provider
             .models
             .first()
             .cloned()
             .unwrap_or_else(|| "gpt-4".to_string());
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "model": model,
             "messages": messages,
-            "stream": true
+            "stream": true,
+            "max_tokens": options.max_tokens.unwrap_or(1000),
         });
+        if let Some(temp) = options.temperature {
+            body["temperature"] = serde_json::json!(temp);
+        }
+        if let Some(top_p) = options.top_p {
+            body["top_p"] = serde_json::json!(top_p);
+        }
 
         let default_url = "https://api.openai.com/v1".to_string();
         let base_url = provider.base_url.as_ref().unwrap_or(&default_url);
@@ -158,6 +182,7 @@ impl LLMClient {
         &self,
         provider: &crate::sdk::config::SdkProviderConfig,
         messages: Vec<Message>,
+        options: &ChatOptions,
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let (system_message, anthropic_messages) = self.convert_messages_to_anthropic(&messages);
 
@@ -169,9 +194,15 @@ impl LLMClient {
         let mut body = serde_json::json!({
             "model": model,
             "messages": anthropic_messages,
-            "max_tokens": 1024,
+            "max_tokens": options.max_tokens.unwrap_or(1024),
             "stream": true
         });
+        if let Some(temp) = options.temperature {
+            body["temperature"] = serde_json::json!(temp);
+        }
+        if let Some(top_p) = options.top_p {
+            body["top_p"] = serde_json::json!(top_p);
+        }
 
         if let Some(system) = system_message {
             body["system"] = serde_json::json!(system);

--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -2,6 +2,8 @@
 
 use super::llm_client::LLMClient;
 use crate::sdk::{errors::*, types::*};
+use futures::StreamExt as _;
+use std::pin::Pin;
 use std::time::SystemTime;
 use tracing::{debug, error};
 
@@ -38,7 +40,7 @@ impl LLMClient {
     pub async fn chat_stream(
         &self,
         messages: Vec<Message>,
-    ) -> Result<impl futures::Stream<Item = Result<ChatChunk>>> {
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let provider = self.select_provider_for_stream(&messages).await?;
         self.execute_stream_request(&provider.id, messages).await
     }
@@ -79,8 +81,8 @@ impl LLMClient {
     pub(crate) async fn execute_stream_request(
         &self,
         provider_id: &str,
-        _messages: Vec<Message>,
-    ) -> Result<impl futures::Stream<Item = Result<ChatChunk>>> {
+        messages: Vec<Message>,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let provider = self
             .config
             .providers
@@ -88,10 +90,120 @@ impl LLMClient {
             .find(|p| p.id == provider_id)
             .ok_or_else(|| SDKError::ProviderNotFound(provider_id.to_string()))?;
 
-        Err::<futures::stream::Empty<Result<ChatChunk>>, _>(SDKError::ProviderError(format!(
-            "Streaming is not implemented for provider type {:?}",
-            provider.provider_type
-        )))
+        match provider.provider_type {
+            crate::sdk::config::ProviderType::OpenAI => {
+                self.stream_openai_request(provider, messages).await
+            }
+            crate::sdk::config::ProviderType::Anthropic => {
+                self.stream_anthropic_request(provider, messages).await
+            }
+            _ => Err(SDKError::NotSupported(format!(
+                "Streaming is not implemented for provider type {:?}",
+                provider.provider_type
+            ))),
+        }
+    }
+
+    /// Stream request to OpenAI-compatible endpoint
+    async fn stream_openai_request(
+        &self,
+        provider: &crate::sdk::config::SdkProviderConfig,
+        messages: Vec<Message>,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
+        let model = provider
+            .models
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "gpt-4".to_string());
+        let body = serde_json::json!({
+            "model": model,
+            "messages": messages,
+            "stream": true
+        });
+
+        let default_url = "https://api.openai.com".to_string();
+        let base_url = provider.base_url.as_ref().unwrap_or(&default_url);
+        let url = format!("{}/v1/chat/completions", base_url.trim_end_matches('/'));
+
+        debug!("Calling OpenAI streaming API: {}", url);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", provider.api_key))
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SDKError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(SDKError::ApiError(format!(
+                "HTTP {}: {}",
+                status, error_text
+            )));
+        }
+
+        Ok(Box::pin(parse_sse_stream_openai(response)))
+    }
+
+    /// Stream request to Anthropic endpoint
+    async fn stream_anthropic_request(
+        &self,
+        provider: &crate::sdk::config::SdkProviderConfig,
+        messages: Vec<Message>,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
+        let (system_message, anthropic_messages) = self.convert_messages_to_anthropic(&messages);
+
+        let model = provider
+            .models
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "claude-sonnet-4-5".to_string());
+        let mut body = serde_json::json!({
+            "model": model,
+            "messages": anthropic_messages,
+            "max_tokens": 1024,
+            "stream": true
+        });
+
+        if let Some(system) = system_message {
+            body["system"] = serde_json::json!(system);
+        }
+
+        let default_url = "https://api.anthropic.com".to_string();
+        let base_url = provider.base_url.as_ref().unwrap_or(&default_url);
+        let url = if base_url.contains("/v1") {
+            format!("{}/messages", base_url.trim_end_matches('/'))
+        } else {
+            format!("{}/v1/messages", base_url.trim_end_matches('/'))
+        };
+
+        debug!("Calling Anthropic streaming API: {}", url);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .header("x-api-key", &provider.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SDKError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(SDKError::ApiError(format!(
+                "HTTP {}: {}",
+                status, error_text
+            )));
+        }
+
+        Ok(Box::pin(parse_sse_stream_anthropic(response)))
     }
 
     /// Call Anthropic API
@@ -351,5 +463,145 @@ impl LLMClient {
                 .unwrap()
                 .as_secs(),
         })
+    }
+}
+
+/// Parse an OpenAI-compatible SSE response into a stream of `ChatChunk`s.
+///
+/// OpenAI sends newline-delimited `data: <json>` lines ending with `data: [DONE]`.
+/// The JSON structure matches `ChatChunk` directly, so each line is deserialized
+/// straight into that type.
+fn parse_sse_stream_openai(
+    response: reqwest::Response,
+) -> impl futures::Stream<Item = Result<ChatChunk>> + Send {
+    async_stream::stream! {
+        let mut byte_stream = response.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk_result) = byte_stream.next().await {
+            match chunk_result {
+                Err(e) => {
+                    yield Err(SDKError::NetworkError(e.to_string()));
+                    return;
+                }
+                Ok(chunk) => {
+                    let text = match std::str::from_utf8(&chunk) {
+                        Ok(t) => t.to_string(),
+                        Err(e) => {
+                            yield Err(SDKError::ParseError(e.to_string()));
+                            return;
+                        }
+                    };
+                    buffer.push_str(&text);
+
+                    while let Some(pos) = buffer.find('\n') {
+                        let line = buffer[..pos].trim_end_matches('\r').trim().to_string();
+                        buffer = buffer[pos + 1..].to_string();
+
+                        if let Some(data) = line.strip_prefix("data: ") {
+                            if data == "[DONE]" {
+                                return;
+                            }
+                            if !data.is_empty() {
+                                match serde_json::from_str::<ChatChunk>(data) {
+                                    Ok(chunk) => yield Ok(chunk),
+                                    Err(e) => yield Err(SDKError::ParseError(format!(
+                                        "Failed to parse OpenAI chunk: {}",
+                                        e
+                                    ))),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Parse an Anthropic SSE response into a stream of `ChatChunk`s.
+///
+/// Anthropic sends typed events (`message_start`, `content_block_delta`, etc.).
+/// Only `content_block_delta` events with a `text_delta` produce output chunks.
+fn parse_sse_stream_anthropic(
+    response: reqwest::Response,
+) -> impl futures::Stream<Item = Result<ChatChunk>> + Send {
+    async_stream::stream! {
+        let mut byte_stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut message_id = String::from("msg_stream");
+        let mut model = String::from("claude");
+
+        while let Some(chunk_result) = byte_stream.next().await {
+            match chunk_result {
+                Err(e) => {
+                    yield Err(SDKError::NetworkError(e.to_string()));
+                    return;
+                }
+                Ok(chunk) => {
+                    let text = match std::str::from_utf8(&chunk) {
+                        Ok(t) => t.to_string(),
+                        Err(e) => {
+                            yield Err(SDKError::ParseError(e.to_string()));
+                            return;
+                        }
+                    };
+                    buffer.push_str(&text);
+
+                    while let Some(pos) = buffer.find('\n') {
+                        let line = buffer[..pos].trim_end_matches('\r').trim().to_string();
+                        buffer = buffer[pos + 1..].to_string();
+
+                        // Skip event-type lines and blanks
+                        if line.is_empty() || line.starts_with("event: ") {
+                            continue;
+                        }
+
+                        if let Some(data) = line.strip_prefix("data: ") {
+                            let value: serde_json::Value = match serde_json::from_str(data) {
+                                Ok(v) => v,
+                                Err(_) => continue,
+                            };
+
+                            match value.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+                                "message_start" => {
+                                    if let Some(msg) = value.get("message") {
+                                        if let Some(id) = msg.get("id").and_then(|v| v.as_str()) {
+                                            message_id = id.to_string();
+                                        }
+                                        if let Some(m) = msg.get("model").and_then(|v| v.as_str()) {
+                                            model = m.to_string();
+                                        }
+                                    }
+                                }
+                                "content_block_delta" => {
+                                    if let Some(text) = value
+                                        .get("delta")
+                                        .and_then(|d| d.get("text"))
+                                        .and_then(|t| t.as_str())
+                                    {
+                                        yield Ok(ChatChunk {
+                                            id: message_id.clone(),
+                                            model: model.clone(),
+                                            choices: vec![ChunkChoice {
+                                                index: 0,
+                                                delta: MessageDelta {
+                                                    role: None,
+                                                    content: Some(text.to_string()),
+                                                    tool_calls: None,
+                                                },
+                                                finish_reason: None,
+                                            }],
+                                        });
+                                    }
+                                }
+                                "message_stop" => return,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/sdk/client/routing.rs
+++ b/src/sdk/client/routing.rs
@@ -34,14 +34,22 @@ impl LLMClient {
     }
 
     /// Select provider for streaming
+    ///
+    /// Only providers with a streaming implementation (OpenAI-compatible and Anthropic)
+    /// are considered. Non-streaming provider types earlier in the list are skipped so
+    /// that a valid streaming provider configured later is still used.
     pub(crate) async fn select_provider_for_stream(
         &self,
         _messages: &[Message],
     ) -> Result<&crate::sdk::config::SdkProviderConfig> {
-        // Find provider that supports streaming
         for provider in &self.config.providers {
-            if provider.enabled {
-                return Ok(provider);
+            if !provider.enabled {
+                continue;
+            }
+            match provider.provider_type {
+                crate::sdk::config::ProviderType::OpenAI
+                | crate::sdk::config::ProviderType::Anthropic => return Ok(provider),
+                _ => continue,
             }
         }
         Err(SDKError::NoDefaultProvider)

--- a/src/sdk/client/routing.rs
+++ b/src/sdk/client/routing.rs
@@ -35,24 +35,34 @@ impl LLMClient {
 
     /// Select provider for streaming
     ///
-    /// Only providers with a streaming implementation (OpenAI-compatible and Anthropic)
-    /// are considered. Non-streaming provider types earlier in the list are skipped so
-    /// that a valid streaming provider configured later is still used.
+    /// Pre-filters providers to those with a streaming implementation (OpenAI-compatible
+    /// and Anthropic), then delegates to the load balancer so that RoundRobin,
+    /// WeightedRandom, HealthBased, and LeastLatency strategies are respected.
     pub(crate) async fn select_provider_for_stream(
         &self,
         _messages: &[Message],
     ) -> Result<&crate::sdk::config::SdkProviderConfig> {
-        for provider in &self.config.providers {
-            if !provider.enabled {
-                continue;
-            }
-            match provider.provider_type {
-                crate::sdk::config::ProviderType::OpenAI
-                | crate::sdk::config::ProviderType::Anthropic => return Ok(provider),
-                _ => continue,
-            }
+        let streaming_providers: Vec<&crate::sdk::config::SdkProviderConfig> = self
+            .config
+            .providers
+            .iter()
+            .filter(|p| {
+                p.enabled
+                    && matches!(
+                        p.provider_type,
+                        crate::sdk::config::ProviderType::OpenAI
+                            | crate::sdk::config::ProviderType::Anthropic
+                    )
+            })
+            .collect();
+
+        if streaming_providers.is_empty() {
+            return Err(SDKError::NoDefaultProvider);
         }
-        Err(SDKError::NoDefaultProvider)
+
+        self.load_balancer
+            .select_from_refs(&streaming_providers, &self.provider_stats)
+            .await
     }
 }
 
@@ -60,6 +70,62 @@ impl LLMClient {
 use super::types::LoadBalancer;
 
 impl LoadBalancer {
+    /// Select provider from a pre-filtered slice of references using the configured strategy.
+    pub(crate) async fn select_from_refs<'a>(
+        &self,
+        providers: &[&'a crate::sdk::config::SdkProviderConfig],
+        stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
+    ) -> Result<&'a crate::sdk::config::SdkProviderConfig> {
+        match self.strategy {
+            LoadBalancingStrategy::RoundRobin => Ok(providers[0]),
+            LoadBalancingStrategy::WeightedRandom => {
+                use rand::Rng;
+                let total_weight: f32 = providers.iter().map(|p| p.weight).sum();
+                let mut rng = rand::rng();
+                let mut random_weight = rng.random::<f32>() * total_weight;
+                for provider in providers {
+                    random_weight -= provider.weight;
+                    if random_weight <= 0.0 {
+                        return Ok(provider);
+                    }
+                }
+                Ok(providers[0])
+            }
+            LoadBalancingStrategy::HealthBased => {
+                let stats_guard = stats.read().await;
+                let mut best = providers[0];
+                let mut best_score = 0.0f64;
+                for provider in providers {
+                    let score = stats_guard
+                        .get(&provider.id)
+                        .map(|s| s.health_score)
+                        .unwrap_or(1.0);
+                    if score > best_score {
+                        best_score = score;
+                        best = provider;
+                    }
+                }
+                Ok(best)
+            }
+            LoadBalancingStrategy::LeastLatency => {
+                let stats_guard = stats.read().await;
+                let mut best = providers[0];
+                let mut best_latency = f64::INFINITY;
+                for provider in providers {
+                    let latency = stats_guard
+                        .get(&provider.id)
+                        .map(|s| s.avg_latency_ms)
+                        .unwrap_or(0.0);
+                    if latency < best_latency {
+                        best_latency = latency;
+                        best = provider;
+                    }
+                }
+                Ok(best)
+            }
+        }
+    }
+
     /// Select provider using load balancing strategy
     pub(crate) async fn select_provider<'a>(
         &self,

--- a/src/sdk/types.rs
+++ b/src/sdk/types.rs
@@ -84,10 +84,11 @@ pub struct Message {
 /// Tool call
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
-    /// Call ID
+    /// Call ID (absent in subsequent streaming deltas; default to empty string)
+    #[serde(default)]
     pub id: String,
-    /// Tool type
-    #[serde(rename = "type")]
+    /// Tool type (absent in subsequent streaming deltas; default to empty string)
+    #[serde(rename = "type", default)]
     pub tool_type: String,
     /// Function call
     pub function: Function,
@@ -100,7 +101,8 @@ pub struct Function {
     pub name: String,
     /// Function description
     pub description: Option<String>,
-    /// Function parameter schema
+    /// Function parameter schema (absent in streaming tool-call deltas, so default to null)
+    #[serde(default)]
     pub parameters: serde_json::Value,
     /// Function parameters (used for calls)
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

- `execute_stream_request` previously returned `Err(ProviderError)` unconditionally for **all** provider types, making `chat_stream()` permanently broken (declaration-execution gap, U-04)
- OpenAI: sends `POST /v1/chat/completions` with `stream: true`, parses newline-delimited SSE `data:` lines, deserialises each directly into `ChatChunk` (structures are identical)
- Anthropic: sends `POST /v1/messages` with `stream: true`, extracts `text` from `content_block_delta` events and emits `ChatChunk`, terminates on `message_stop`
- All other provider types return `SDKError::NotSupported` (explicit DEFER per U-05, rather than silent `ProviderError`)
- Return type narrowed to `Pin<Box<dyn Stream<Item = Result<ChatChunk>> + Send>>` to allow different concrete stream types per provider

## Test plan

- [x] `cargo fmt --all` — no diff
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 95 passed, 0 failed