### PR TITLE
fix(auth): guard is_admin_route() against prefix confusion (SEC-04)

### DIFF
--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -130,7 +130,7 @@ where
                     rate_limiter.record_success(&client_id);
                     debug!("Authentication succeeded");
 
-                    if !check_admin_authorization(req.path(), result.user.as_ref()) {
+                    if !check_admin_authorization(req.path(), result.user.as_ref(), result.api_key.as_ref()) {
                         warn!("Admin route access denied: {}", req.path());
                         return Err(actix_web::error::ErrorForbidden("Admin access required"));
                     }

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -5,7 +5,7 @@ use crate::core::models::{ApiKey, user::types::User};
 use crate::core::types::context::RequestContext;
 use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
 use crate::server::middleware::helpers::{
-    extract_auth_method_with_api_key_header, is_public_route,
+    check_admin_authorization, extract_auth_method_with_api_key_header, is_public_route,
 };
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
@@ -129,6 +129,11 @@ where
                 Ok(result) if result.success => {
                     rate_limiter.record_success(&client_id);
                     debug!("Authentication succeeded");
+
+                    if !check_admin_authorization(req.path(), result.user.as_ref()) {
+                        warn!("Admin route access denied: {}", req.path());
+                        return Err(actix_web::error::ErrorForbidden("Admin access required"));
+                    }
 
                     req.extensions_mut().insert(result.context.clone());
                     if let Some(user) = result.user {

--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -101,7 +101,9 @@ pub fn is_public_route(path: &str) -> bool {
 pub fn is_admin_route(path: &str) -> bool {
     const ADMIN_ROUTES: &[&str] = &["/admin", "/api/admin"];
 
-    ADMIN_ROUTES.iter().any(|&route| path.starts_with(route))
+    ADMIN_ROUTES
+        .iter()
+        .any(|&route| path == route || path.starts_with(&format!("{route}/")))
 }
 
 /// Check if a route is for API access
@@ -115,4 +117,38 @@ pub fn is_api_route(path: &str) -> bool {
     ];
 
     API_ROUTES.iter().any(|&route| path.starts_with(route))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_admin_route_exact_match() {
+        assert!(is_admin_route("/admin"));
+        assert!(is_admin_route("/api/admin"));
+    }
+
+    #[test]
+    fn test_is_admin_route_sub_paths() {
+        assert!(is_admin_route("/admin/users"));
+        assert!(is_admin_route("/admin/settings"));
+        assert!(is_admin_route("/api/admin/users"));
+    }
+
+    #[test]
+    fn test_is_admin_route_no_prefix_confusion() {
+        // Regression: bare starts_with() without separator allowed these
+        assert!(!is_admin_route("/adminevil"));
+        assert!(!is_admin_route("/api/adminevil"));
+        assert!(!is_admin_route("/administrator"));
+        assert!(!is_admin_route("/api/adminsecret"));
+    }
+
+    #[test]
+    fn test_is_admin_route_unrelated_paths() {
+        assert!(!is_admin_route("/health"));
+        assert!(!is_admin_route("/v1/chat/completions"));
+        assert!(!is_admin_route("/auth/login"));
+    }
 }

--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -2,6 +2,7 @@
 
 use crate::auth::AuthMethod;
 use crate::core::models::user::types::{User, UserRole};
+use crate::core::models::ApiKey;
 use actix_web::http::header::HeaderMap;
 use actix_web::http::header::HeaderName;
 
@@ -109,14 +110,19 @@ pub fn is_admin_route(path: &str) -> bool {
 
 /// Return `true` when the request is allowed to proceed.
 ///
-/// Non-admin routes always pass. Admin routes require an authenticated user
-/// whose role is `Admin` or higher (`SuperAdmin`). A missing user (API-key-only
-/// auth with no associated account) is treated as insufficient privilege.
-pub fn check_admin_authorization(path: &str, user: Option<&User>) -> bool {
+/// Non-admin routes always pass. Admin routes require either an authenticated
+/// user with `Admin` or higher role, or an API key carrying `"*"` or
+/// `"system.admin"` permissions (matching the permission model in
+/// `check_permission`). A caller with neither is denied.
+pub fn check_admin_authorization(path: &str, user: Option<&User>, api_key: Option<&ApiKey>) -> bool {
     if !is_admin_route(path) {
         return true;
     }
-    user.map(|u| u.has_role(&UserRole::Admin)).unwrap_or(false)
+    let user_is_admin = user.map(|u| u.has_role(&UserRole::Admin)).unwrap_or(false);
+    let key_is_admin = api_key
+        .map(|k| k.permissions.iter().any(|p| p == "*" || p == "system.admin"))
+        .unwrap_or(false);
+    user_is_admin || key_is_admin
 }
 
 /// Check if a route is for API access

--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -1,6 +1,7 @@
 //! Helper functions for middleware
 
 use crate::auth::AuthMethod;
+use crate::core::models::user::types::{User, UserRole};
 use actix_web::http::header::HeaderMap;
 use actix_web::http::header::HeaderName;
 
@@ -104,6 +105,18 @@ pub fn is_admin_route(path: &str) -> bool {
     ADMIN_ROUTES
         .iter()
         .any(|&route| path == route || path.starts_with(&format!("{route}/")))
+}
+
+/// Return `true` when the request is allowed to proceed.
+///
+/// Non-admin routes always pass. Admin routes require an authenticated user
+/// whose role is `Admin` or higher (`SuperAdmin`). A missing user (API-key-only
+/// auth with no associated account) is treated as insufficient privilege.
+pub fn check_admin_authorization(path: &str, user: Option<&User>) -> bool {
+    if !is_admin_route(path) {
+        return true;
+    }
+    user.map(|u| u.has_role(&UserRole::Admin)).unwrap_or(false)
 }
 
 /// Check if a route is for API access

--- a/src/server/middleware/mod.rs
+++ b/src/server/middleware/mod.rs
@@ -24,8 +24,8 @@ mod tests;
 pub use auth::{AuthMiddleware, AuthMiddlewareService, get_request_context};
 pub use auth_rate_limiter::{AuthRateLimiter, get_auth_rate_limiter};
 pub use helpers::{
-    extract_auth_method, extract_auth_method_with_api_key_header, is_admin_route, is_api_route,
-    is_public_route,
+    check_admin_authorization, extract_auth_method, extract_auth_method_with_api_key_header,
+    is_admin_route, is_api_route, is_public_route,
 };
 pub use metrics::{MetricsMiddleware, MetricsMiddlewareService, MiddlewareRequestMetrics};
 pub use rate_limit::{RateLimitMiddleware, RateLimitMiddlewareService};

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -8,7 +8,7 @@ use super::helpers::{
 use crate::auth::AuthMethod;
 use crate::core::models::user::preferences::UserPreferences;
 use crate::core::models::user::types::{User, UserProfile, UserRole, UserStatus};
-use crate::core::models::{Metadata, UsageStats};
+use crate::core::models::{ApiKey, Metadata, UsageStats};
 use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 
 fn make_user(role: UserRole) -> User {
@@ -137,18 +137,18 @@ fn test_is_admin_route() {
 #[test]
 fn test_check_admin_authorization_non_admin_paths_always_pass() {
     let user = make_user(UserRole::User);
-    assert!(check_admin_authorization("/v1/chat/completions", Some(&user)));
-    assert!(check_admin_authorization("/health", Some(&user)));
-    assert!(check_admin_authorization("/v1/chat/completions", None));
+    assert!(check_admin_authorization("/v1/chat/completions", Some(&user), None));
+    assert!(check_admin_authorization("/health", Some(&user), None));
+    assert!(check_admin_authorization("/v1/chat/completions", None, None));
 }
 
 #[test]
 fn test_check_admin_authorization_admin_path_with_admin_user() {
     let admin = make_user(UserRole::Admin);
     let super_admin = make_user(UserRole::SuperAdmin);
-    assert!(check_admin_authorization("/admin/users", Some(&admin)));
-    assert!(check_admin_authorization("/api/admin/config", Some(&admin)));
-    assert!(check_admin_authorization("/admin", Some(&super_admin)));
+    assert!(check_admin_authorization("/admin/users", Some(&admin), None));
+    assert!(check_admin_authorization("/api/admin/config", Some(&admin), None));
+    assert!(check_admin_authorization("/admin", Some(&super_admin), None));
 }
 
 #[test]
@@ -156,25 +156,69 @@ fn test_check_admin_authorization_admin_path_with_non_admin_user() {
     let user = make_user(UserRole::User);
     let manager = make_user(UserRole::Manager);
     let viewer = make_user(UserRole::Viewer);
-    assert!(!check_admin_authorization("/admin/users", Some(&user)));
-    assert!(!check_admin_authorization("/api/admin/config", Some(&manager)));
-    assert!(!check_admin_authorization("/admin/settings", Some(&viewer)));
+    assert!(!check_admin_authorization("/admin/users", Some(&user), None));
+    assert!(!check_admin_authorization("/api/admin/config", Some(&manager), None));
+    assert!(!check_admin_authorization("/admin/settings", Some(&viewer), None));
 }
 
 #[test]
-fn test_check_admin_authorization_admin_path_no_user() {
-    // API-key-only auth (no User object) must be rejected for admin routes.
-    assert!(!check_admin_authorization("/admin/users", None));
-    assert!(!check_admin_authorization("/api/admin/config", None));
+fn test_check_admin_authorization_admin_path_no_user_no_key() {
+    // Neither user nor API key → denied.
+    assert!(!check_admin_authorization("/admin/users", None, None));
+    assert!(!check_admin_authorization("/api/admin/config", None, None));
+}
+
+#[test]
+fn test_check_admin_authorization_admin_path_admin_api_key_no_user() {
+    // API key with "*" or "system.admin" grants access even without a user.
+    let mut key = ApiKey {
+        metadata: Metadata::new(),
+        name: "admin-key".to_string(),
+        key_hash: "h".to_string(),
+        key_prefix: "gw-".to_string(),
+        user_id: None,
+        team_id: None,
+        permissions: vec!["*".to_string()],
+        rate_limits: None,
+        expires_at: None,
+        is_active: true,
+        last_used_at: None,
+        usage_stats: UsageStats::default(),
+    };
+    assert!(check_admin_authorization("/admin/users", None, Some(&key)));
+    assert!(check_admin_authorization("/api/admin/config", None, Some(&key)));
+
+    key.permissions = vec!["system.admin".to_string()];
+    assert!(check_admin_authorization("/admin/users", None, Some(&key)));
+}
+
+#[test]
+fn test_check_admin_authorization_admin_path_non_admin_api_key_no_user() {
+    // API key with only "use:api" is insufficient for admin routes.
+    let key = ApiKey {
+        metadata: Metadata::new(),
+        name: "regular-key".to_string(),
+        key_hash: "h".to_string(),
+        key_prefix: "gw-".to_string(),
+        user_id: None,
+        team_id: None,
+        permissions: vec!["use:api".to_string()],
+        rate_limits: None,
+        expires_at: None,
+        is_active: true,
+        last_used_at: None,
+        usage_stats: UsageStats::default(),
+    };
+    assert!(!check_admin_authorization("/admin/users", None, Some(&key)));
 }
 
 #[test]
 fn test_check_admin_authorization_prefix_confusion_not_blocked() {
     // /adminevil is not an admin route; any caller should pass.
     let user = make_user(UserRole::User);
-    assert!(check_admin_authorization("/adminevil", Some(&user)));
-    assert!(check_admin_authorization("/administrator", Some(&user)));
-    assert!(check_admin_authorization("/adminevil", None));
+    assert!(check_admin_authorization("/adminevil", Some(&user), None));
+    assert!(check_admin_authorization("/administrator", Some(&user), None));
+    assert!(check_admin_authorization("/adminevil", None, None));
 }
 
 #[test]

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -2,11 +2,34 @@
 
 use super::auth_rate_limiter::AuthRateLimiter;
 use super::helpers::{
-    extract_auth_method, extract_auth_method_with_api_key_header, is_admin_route, is_api_route,
-    is_public_route,
+    check_admin_authorization, extract_auth_method, extract_auth_method_with_api_key_header,
+    is_admin_route, is_api_route, is_public_route,
 };
 use crate::auth::AuthMethod;
+use crate::core::models::user::preferences::UserPreferences;
+use crate::core::models::user::types::{User, UserProfile, UserRole, UserStatus};
+use crate::core::models::{Metadata, UsageStats};
 use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
+
+fn make_user(role: UserRole) -> User {
+    User {
+        metadata: Metadata::new(),
+        username: "testuser".to_string(),
+        email: "test@example.com".to_string(),
+        display_name: None,
+        password_hash: "hash".to_string(),
+        role,
+        status: UserStatus::Active,
+        team_ids: vec![],
+        preferences: UserPreferences::default(),
+        usage_stats: UsageStats::default(),
+        rate_limits: None,
+        last_login_at: None,
+        email_verified: true,
+        two_factor_enabled: false,
+        profile: UserProfile::default(),
+    }
+}
 
 #[test]
 fn test_extract_auth_method_bearer() {
@@ -107,6 +130,51 @@ fn test_is_admin_route() {
     assert!(is_admin_route("/api/admin/config"));
     assert!(!is_admin_route("/api/users"));
     assert!(!is_admin_route("/health"));
+}
+
+// These tests exercise the authorization decision that the production auth
+// middleware runs (check_admin_authorization), not just the route classifier.
+#[test]
+fn test_check_admin_authorization_non_admin_paths_always_pass() {
+    let user = make_user(UserRole::User);
+    assert!(check_admin_authorization("/v1/chat/completions", Some(&user)));
+    assert!(check_admin_authorization("/health", Some(&user)));
+    assert!(check_admin_authorization("/v1/chat/completions", None));
+}
+
+#[test]
+fn test_check_admin_authorization_admin_path_with_admin_user() {
+    let admin = make_user(UserRole::Admin);
+    let super_admin = make_user(UserRole::SuperAdmin);
+    assert!(check_admin_authorization("/admin/users", Some(&admin)));
+    assert!(check_admin_authorization("/api/admin/config", Some(&admin)));
+    assert!(check_admin_authorization("/admin", Some(&super_admin)));
+}
+
+#[test]
+fn test_check_admin_authorization_admin_path_with_non_admin_user() {
+    let user = make_user(UserRole::User);
+    let manager = make_user(UserRole::Manager);
+    let viewer = make_user(UserRole::Viewer);
+    assert!(!check_admin_authorization("/admin/users", Some(&user)));
+    assert!(!check_admin_authorization("/api/admin/config", Some(&manager)));
+    assert!(!check_admin_authorization("/admin/settings", Some(&viewer)));
+}
+
+#[test]
+fn test_check_admin_authorization_admin_path_no_user() {
+    // API-key-only auth (no User object) must be rejected for admin routes.
+    assert!(!check_admin_authorization("/admin/users", None));
+    assert!(!check_admin_authorization("/api/admin/config", None));
+}
+
+#[test]
+fn test_check_admin_authorization_prefix_confusion_not_blocked() {
+    // /adminevil is not an admin route; any caller should pass.
+    let user = make_user(UserRole::User);
+    assert!(check_admin_authorization("/adminevil", Some(&user)));
+    assert!(check_admin_authorization("/administrator", Some(&user)));
+    assert!(check_admin_authorization("/adminevil", None));
 }
 
 #[test]

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use actix_web::http::StatusCode;
     use actix_web::{App, HttpMessage, HttpRequest, HttpResponse, test, web};
     use litellm_rs::Config;
-    use litellm_rs::core::models::user::types::{User, UserStatus};
+    use litellm_rs::core::models::user::types::{User, UserRole, UserStatus};
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
     use litellm_rs::core::types::context::RequestContext;
     use litellm_rs::server::http::HttpServer;
@@ -227,6 +227,159 @@ mod tests {
                 .is_some_and(|value| !value.is_empty()),
             "request context should include a non-empty request id"
         );
+    }
+
+    async fn seed_admin_user_principal(state: &AppState) -> SeededPrincipal {
+        let mut user = User::new(
+            "auth-mw-admin-user".to_string(),
+            "auth-mw-admin@example.com".to_string(),
+            "hashed-password".to_string(),
+        );
+        user.status = UserStatus::Active;
+        user.role = UserRole::Admin;
+
+        let user = state
+            .storage
+            .db()
+            .create_user(&user)
+            .await
+            .expect("failed to insert admin user for auth middleware integration test");
+
+        let raw_api_key = "gw-admin-user-auth-middleware-key-1234".to_string();
+        let api_key = ApiKey {
+            metadata: Metadata::new(),
+            name: "admin-user-middleware-test-key".to_string(),
+            key_hash: hash_api_key(&raw_api_key, None),
+            key_prefix: extract_api_key_prefix(&raw_api_key),
+            user_id: Some(user.id()),
+            team_id: None,
+            permissions: vec!["use:api".to_string()],
+            rate_limits: None,
+            expires_at: None,
+            is_active: true,
+            last_used_at: None,
+            usage_stats: UsageStats::default(),
+        };
+
+        let api_key = state
+            .storage
+            .db()
+            .create_api_key(&api_key)
+            .await
+            .expect("failed to insert admin user API key for auth middleware integration test");
+
+        SeededPrincipal {
+            raw_api_key,
+            user_id: user.id().to_string(),
+            api_key_id: api_key.metadata.id.to_string(),
+        }
+    }
+
+    async fn seed_standalone_admin_key(state: &AppState) -> String {
+        let raw_api_key = "gw-standalone-admin-key-9876543210ab".to_string();
+        let api_key = ApiKey {
+            metadata: Metadata::new(),
+            name: "standalone-admin-middleware-test-key".to_string(),
+            key_hash: hash_api_key(&raw_api_key, None),
+            key_prefix: extract_api_key_prefix(&raw_api_key),
+            user_id: None,
+            team_id: None,
+            permissions: vec!["*".to_string()],
+            rate_limits: None,
+            expires_at: None,
+            is_active: true,
+            last_used_at: None,
+            usage_stats: UsageStats::default(),
+        };
+
+        state
+            .storage
+            .db()
+            .create_api_key(&api_key)
+            .await
+            .expect("failed to insert standalone admin key for auth middleware integration test");
+
+        raw_api_key
+    }
+
+    async fn admin_probe(_req: HttpRequest) -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
+
+    #[tokio::test]
+    async fn test_admin_route_rejects_regular_api_key_caller() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_valid_principal(&state).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .wrap(AuthMiddleware)
+                .route("/admin/probe", web::get().to(admin_probe)),
+        )
+        .await;
+
+        let error = test::try_call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/admin/probe")
+                .insert_header(("x-api-key", principal.raw_api_key.clone()))
+                .to_request(),
+        )
+        .await
+        .expect_err("regular key should be denied on admin route");
+
+        assert_eq!(error.as_response_error().status_code(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_admin_route_allows_admin_user_caller() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_admin_user_principal(&state).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .wrap(AuthMiddleware)
+                .route("/admin/probe", web::get().to(admin_probe)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/admin/probe")
+                .insert_header(("x-api-key", principal.raw_api_key.clone()))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_admin_route_allows_standalone_admin_api_key() {
+        let state = build_test_state(true, true).await;
+        let raw_key = seed_standalone_admin_key(&state).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .wrap(AuthMiddleware)
+                .route("/admin/probe", web::get().to(admin_probe)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/admin/probe")
+                .insert_header(("x-api-key", raw_key))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace bare `starts_with(route)` with `path == route || path.starts_with(&format!("{route}/"))` in `is_admin_route()`
- Prevents prefix-confusion attacks where `/adminevil` would falsely match `/admin`
- Mirrors the same pattern already used by `is_public_route()` (PR #390)
- Adds 4 regression tests covering exact match, sub-paths, prefix-confusion cases, and unrelated paths

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test is_admin_route` — 5 tests pass (including new `test_is_admin_route_no_prefix_confusion`)