### PR TITLE
refactor(router): remove redundant dead-code zai/ prefix check

### DIFF
--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -92,20 +92,6 @@ fn resolve_dynamic_provider_route<'a>(
         }
     }
 
-    if model.starts_with("zai/") {
-        let actual_model = model.strip_prefix("zai/").unwrap_or(model);
-        let api_base = options
-            .api_base
-            .clone()
-            .unwrap_or_else(|| "https://open.bigmodel.cn/api/paas/v4".to_string());
-        return Some(DynamicProviderRoute {
-            provider_type: "zhipu",
-            provider_label: "Zhipu",
-            actual_model,
-            api_base,
-        });
-    }
-
     if model.starts_with("azure_ai/") || model.starts_with("azure-ai/") {
         let actual_model = model
             .strip_prefix("azure_ai/")


### PR DESCRIPTION
## Summary
- Remove unreachable `if model.starts_with("zai/")` block (lines 94-107) from `resolve_dynamic_provider_route()`
- The `zai/` prefix is already an entry in `DYNAMIC_PROVIDER_PREFIXES`, so the loop handles it before the dead-code branch is ever reached
- Reduces future maintenance risk of the prefix list and the post-loop block diverging

## Test plan
- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — 95 tests pass, including `test_resolve_dynamic_route_for_zai_alias` which verifies the loop-based path still works correctly