### PR TITLE
Fix SDK Anthropic Haiku 4.5 preset aliases

### DIFF
--- a/src/sdk/client/tests.rs
+++ b/src/sdk/client/tests.rs
@@ -68,7 +68,11 @@ async fn test_provider_selection_accepts_anthropic_haiku_preset_aliases() {
         .build();
     let client = LLMClient::new(config).unwrap();
 
-    for model in ["claude-haiku-4-5", "claude-haiku-4-5-20251001"] {
+    for model in [
+        "claude-3-5-haiku-20241022",
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+    ] {
         let provider = client
             .select_provider(&SdkChatRequest {
                 model: model.to_string(),

--- a/src/sdk/client/tests.rs
+++ b/src/sdk/client/tests.rs
@@ -62,6 +62,27 @@ async fn test_provider_selection() {
 }
 
 #[tokio::test]
+async fn test_provider_selection_accepts_anthropic_haiku_preset_aliases() {
+    let config = ConfigBuilder::new()
+        .add_anthropic("anthropic", "test-key")
+        .build();
+    let client = LLMClient::new(config).unwrap();
+
+    for model in ["claude-haiku-4-5", "claude-haiku-4-5-20251001"] {
+        let provider = client
+            .select_provider(&SdkChatRequest {
+                model: model.to_string(),
+                messages: vec![],
+                options: ChatOptions::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(provider.id, "anthropic");
+    }
+}
+
+#[tokio::test]
 async fn test_stream_provider_selection_prefers_default_provider() {
     let config = ConfigBuilder::new()
         .default_provider("openai")

--- a/src/sdk/config.rs
+++ b/src/sdk/config.rs
@@ -185,7 +185,8 @@ impl SdkConfigBuilder {
             models: vec![
                 "claude-opus-4-6".to_string(),
                 "claude-sonnet-4-5".to_string(),
-                "claude-3-5-haiku-20241022".to_string(),
+                "claude-haiku-4-5".to_string(),
+                "claude-haiku-4-5-20251001".to_string(),
             ],
             enabled: true,
             weight: 1.0,
@@ -601,7 +602,13 @@ mod tests {
             config.providers[0]
                 .models
                 .iter()
-                .any(|m| m.contains("claude"))
+                .any(|m| m == "claude-haiku-4-5")
+        );
+        assert!(
+            config.providers[0]
+                .models
+                .iter()
+                .any(|m| m == "claude-haiku-4-5-20251001")
         );
     }
 

--- a/src/sdk/config.rs
+++ b/src/sdk/config.rs
@@ -185,6 +185,7 @@ impl SdkConfigBuilder {
             models: vec![
                 "claude-opus-4-6".to_string(),
                 "claude-sonnet-4-5".to_string(),
+                "claude-3-5-haiku-20241022".to_string(),
                 "claude-haiku-4-5".to_string(),
                 "claude-haiku-4-5-20251001".to_string(),
             ],
@@ -598,6 +599,12 @@ mod tests {
             config.providers[0].provider_type,
             ProviderType::Anthropic
         ));
+        assert!(
+            config.providers[0]
+                .models
+                .iter()
+                .any(|m| m == "claude-3-5-haiku-20241022")
+        );
         assert!(
             config.providers[0]
                 .models


### PR DESCRIPTION
## Summary
- update the SDK Anthropic preset to advertise both `claude-haiku-4-5` and `claude-haiku-4-5-20251001`
- add regression coverage proving preset-built SDK clients accept both Haiku 4.5 identifiers

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test
