### PR TITLE
fix(storage): reject placeholder vector backends

### DIFF
--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -85,11 +85,21 @@ impl Validate for RedisConfig {
 
 impl Validate for VectorDbConfig {
     fn validate(&self) -> Result<(), String> {
-        let supported_types = ["qdrant", "weaviate", "pinecone"];
-        if !supported_types.contains(&self.db_type.as_str()) {
+        // Only Qdrant has a complete runtime implementation today. Weaviate
+        // and Pinecone modules are placeholders and should be rejected during
+        // config validation instead of failing later at runtime.
+        let implemented_types = ["qdrant"];
+        let planned_types = ["weaviate", "pinecone"];
+        if planned_types.contains(&self.db_type.as_str()) {
             return Err(format!(
-                "Unsupported vector DB type: {}. Supported types: {:?}",
-                self.db_type, supported_types
+                "Vector DB type '{}' is declared but not implemented yet. Implemented types: {:?}",
+                self.db_type, implemented_types
+            ));
+        }
+        if !implemented_types.contains(&self.db_type.as_str()) {
+            return Err(format!(
+                "Unsupported vector DB type: {}. Implemented types: {:?}",
+                self.db_type, implemented_types
             ));
         }
 
@@ -102,5 +112,34 @@ impl Validate for VectorDbConfig {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vector_config(db_type: &str) -> VectorDbConfig {
+        VectorDbConfig {
+            db_type: db_type.to_string(),
+            url: "http://localhost:6333".to_string(),
+            api_key: "test-key".to_string(),
+            index_name: "vectors".to_string(),
+        }
+    }
+
+    #[test]
+    fn vector_validation_accepts_qdrant() {
+        assert!(vector_config("qdrant").validate().is_ok());
+    }
+
+    #[test]
+    fn vector_validation_rejects_placeholder_backends() {
+        for db_type in ["pinecone", "weaviate"] {
+            let err = vector_config(db_type)
+                .validate()
+                .expect_err("placeholder vector backend must fail validation");
+            assert!(err.contains("not implemented yet"));
+        }
     }
 }

--- a/src/storage/vector/backend.rs
+++ b/src/storage/vector/backend.rs
@@ -27,12 +27,10 @@ impl VectorStoreBackend {
 
         match config.db_type.as_str() {
             "qdrant" => Ok(VectorStoreBackend::Qdrant(QdrantStore::new(config).await?)),
-            "weaviate" => Ok(VectorStoreBackend::Weaviate(
-                WeaviateStore::new(config).await?,
-            )),
-            "pinecone" => Ok(VectorStoreBackend::Pinecone(
-                PineconeStore::new(config).await?,
-            )),
+            "weaviate" | "pinecone" => Err(GatewayError::Config(format!(
+                "Vector DB type '{}' is declared but not implemented yet. Implemented types: [\"qdrant\"]",
+                config.db_type
+            ))),
             _ => Err(GatewayError::Config(format!(
                 "Unsupported vector DB type: {}",
                 config.db_type


### PR DESCRIPTION
## Summary

- Reject placeholder vector backends (`pinecone`, `weaviate`) during config validation.
- Keep Qdrant as the only implemented vector backend accepted by validation.
- Return a clear config error from `VectorStoreBackend::new()` for placeholder backends.
- Add validation tests for accepted and rejected vector backend types.

Closes #437.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test vector_validation --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
