### PR TITLE
fix(ai): return OpenAI error envelopes

### DIFF
--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -3,13 +3,13 @@
 use crate::core::audio::AudioService;
 use crate::core::audio::types::SpeechRequest;
 use crate::core::types::model::ProviderCapability;
-use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
-use actix_web::{HttpRequest, HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde::Deserialize;
 use tracing::{error, info};
 
 use crate::server::routes::ai::context::get_request_context;
+use crate::server::routes::ai::openai_errors;
 use crate::server::routes::ai::provider_selection::select_provider_for_model;
 
 /// Audio speech generation request
@@ -51,8 +51,7 @@ pub async fn audio_speech(
     let _context = match get_request_context(&req) {
         Ok(ctx) => ctx,
         Err(_) => {
-            return Ok(HttpResponse::Unauthorized()
-                .json(ApiResponse::<()>::error("Unauthorized".to_string())));
+            return Ok(openai_errors::unauthorized_error("Unauthorized"));
         }
     };
 
@@ -64,7 +63,7 @@ pub async fn audio_speech(
         ProviderCapability::TextToSpeech,
     ) {
         Ok(selection) => selection,
-        Err(e) => return Ok(e.error_response()),
+        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
     };
 
     let speech_request = SpeechRequest {
@@ -83,7 +82,7 @@ pub async fn audio_speech(
             .body(response.audio)),
         Err(e) => {
             error!("Speech generation error: {}", e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -3,14 +3,14 @@
 use crate::core::audio::AudioService;
 use crate::core::audio::types::TranscriptionRequest;
 use crate::core::types::model::ProviderCapability;
-use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
 use actix_multipart::Multipart;
-use actix_web::{HttpRequest, HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
 use crate::server::routes::ai::context::get_request_context;
+use crate::server::routes::ai::openai_errors;
 use crate::server::routes::ai::provider_selection::select_provider_for_model;
 
 /// Audio transcriptions endpoint
@@ -28,8 +28,7 @@ pub async fn audio_transcriptions(
     let _context = match get_request_context(&req) {
         Ok(ctx) => ctx,
         Err(_) => {
-            return Ok(HttpResponse::Unauthorized()
-                .json(ApiResponse::<()>::error("Unauthorized".to_string())));
+            return Ok(openai_errors::unauthorized_error("Unauthorized"));
         }
     };
 
@@ -47,12 +46,10 @@ pub async fn audio_transcriptions(
             Ok(f) => f,
             Err(e) => {
                 error!("Error reading multipart field: {}", e);
-                return Ok(
-                    HttpResponse::BadRequest().json(ApiResponse::<()>::error(format!(
-                        "Invalid multipart data: {}",
-                        e
-                    ))),
-                );
+                return Ok(openai_errors::validation_error(format!(
+                    "Invalid multipart data: {}",
+                    e
+                )));
             }
         };
 
@@ -77,8 +74,7 @@ pub async fn audio_transcriptions(
                         Ok(bytes) => data.extend_from_slice(&bytes),
                         Err(e) => {
                             error!("Error reading file chunk: {}", e);
-                            return Ok(HttpResponse::BadRequest()
-                                .json(ApiResponse::<()>::error("Error reading file".to_string())));
+                            return Ok(openai_errors::validation_error("Error reading file"));
                         }
                     }
                 }
@@ -122,9 +118,7 @@ pub async fn audio_transcriptions(
     let file = match file_data {
         Some(data) if !data.is_empty() => data,
         _ => {
-            return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(
-                "No audio file provided".to_string(),
-            )));
+            return Ok(openai_errors::validation_error("No audio file provided"));
         }
     };
 
@@ -136,7 +130,7 @@ pub async fn audio_transcriptions(
         ProviderCapability::AudioTranscription,
     ) {
         Ok(selection) => selection,
-        Err(e) => return Ok(e.error_response()),
+        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
     };
 
     // Create transcription request
@@ -158,7 +152,7 @@ pub async fn audio_transcriptions(
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(e) => {
             error!("Transcription error: {}", e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -3,14 +3,14 @@
 use crate::core::audio::AudioService;
 use crate::core::audio::types::TranslationRequest;
 use crate::core::types::model::ProviderCapability;
-use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
 use actix_multipart::Multipart;
-use actix_web::{HttpRequest, HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
 use crate::server::routes::ai::context::get_request_context;
+use crate::server::routes::ai::openai_errors;
 use crate::server::routes::ai::provider_selection::select_provider_for_model;
 
 /// Audio translations endpoint
@@ -28,8 +28,7 @@ pub async fn audio_translations(
     let _context = match get_request_context(&req) {
         Ok(ctx) => ctx,
         Err(_) => {
-            return Ok(HttpResponse::Unauthorized()
-                .json(ApiResponse::<()>::error("Unauthorized".to_string())));
+            return Ok(openai_errors::unauthorized_error("Unauthorized"));
         }
     };
 
@@ -46,12 +45,10 @@ pub async fn audio_translations(
             Ok(f) => f,
             Err(e) => {
                 error!("Error reading multipart field: {}", e);
-                return Ok(
-                    HttpResponse::BadRequest().json(ApiResponse::<()>::error(format!(
-                        "Invalid multipart data: {}",
-                        e
-                    ))),
-                );
+                return Ok(openai_errors::validation_error(format!(
+                    "Invalid multipart data: {}",
+                    e
+                )));
             }
         };
 
@@ -104,9 +101,7 @@ pub async fn audio_translations(
     let file = match file_data {
         Some(data) if !data.is_empty() => data,
         _ => {
-            return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(
-                "No audio file provided".to_string(),
-            )));
+            return Ok(openai_errors::validation_error("No audio file provided"));
         }
     };
 
@@ -118,7 +113,7 @@ pub async fn audio_translations(
         ProviderCapability::AudioTranslation,
     ) {
         Ok(selection) => selection,
-        Err(e) => return Ok(e.error_response()),
+        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
     };
 
     let translation_request = TranslationRequest {
@@ -136,7 +131,7 @@ pub async fn audio_translations(
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(e) => {
             error!("Translation error: {}", e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -4,25 +4,25 @@
 //! Business logic is not implemented yet, so handlers return explicit 501.
 
 use crate::utils::error::gateway_error::GatewayError;
-use actix_web::{HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpResponse, Result as ActixResult, web};
 use tracing::warn;
+
+use super::openai_errors;
 
 /// Create a batch request.
 pub async fn create_batch() -> ActixResult<HttpResponse> {
     warn!("Batch create endpoint is not implemented");
-    Ok(
-        GatewayError::not_implemented("Batch create endpoint is not implemented yet")
-            .error_response(),
-    )
+    Ok(openai_errors::gateway_error_response(
+        &GatewayError::not_implemented("Batch create endpoint is not implemented yet"),
+    ))
 }
 
 /// List batches.
 pub async fn list_batches() -> ActixResult<HttpResponse> {
     warn!("Batch list endpoint is not implemented");
-    Ok(
-        GatewayError::not_implemented("Batch list endpoint is not implemented yet")
-            .error_response(),
-    )
+    Ok(openai_errors::gateway_error_response(
+        &GatewayError::not_implemented("Batch list endpoint is not implemented yet"),
+    ))
 }
 
 /// Get a batch by ID.
@@ -31,10 +31,9 @@ pub async fn get_batch(batch_id: web::Path<String>) -> ActixResult<HttpResponse>
         batch_id = %batch_id.as_str(),
         "Batch retrieve endpoint is not implemented"
     );
-    Ok(
-        GatewayError::not_implemented("Batch retrieve endpoint is not implemented yet")
-            .error_response(),
-    )
+    Ok(openai_errors::gateway_error_response(
+        &GatewayError::not_implemented("Batch retrieve endpoint is not implemented yet"),
+    ))
 }
 
 /// Cancel a batch by ID.
@@ -43,8 +42,7 @@ pub async fn cancel_batch(batch_id: web::Path<String>) -> ActixResult<HttpRespon
         batch_id = %batch_id.as_str(),
         "Batch cancel endpoint is not implemented"
     );
-    Ok(
-        GatewayError::not_implemented("Batch cancel endpoint is not implemented yet")
-            .error_response(),
-    )
+    Ok(openai_errors::gateway_error_response(
+        &GatewayError::not_implemented("Batch cancel endpoint is not implemented yet"),
+    ))
 }

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -11,12 +11,11 @@ use crate::core::streaming::types::{
 use crate::core::types::{
     self, chat::ChatRequest as CoreChatRequest, context::RequestContext, model::ProviderCapability,
 };
-use crate::server::routes::errors;
 use crate::server::state::AppState;
 use crate::utils::data::validation::RequestValidator;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
-use actix_web::{HttpRequest, HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use bytes::Bytes;
 use futures::StreamExt;
 use serde_json::json;
@@ -26,6 +25,7 @@ use tracing::{error, info, warn};
 
 use super::context::get_request_context;
 use super::execution::execute_with_selected_deployment;
+use super::openai_errors;
 use super::provider_selection::select_provider_for_model;
 
 /// Chat completions endpoint
@@ -49,7 +49,7 @@ pub async fn chat_completions(
         request.temperature,
     ) {
         warn!("Invalid chat completion request: {}", e);
-        return Ok(errors::validation_error(&e.to_string()));
+        return Ok(openai_errors::validation_error(e.to_string()));
     }
 
     // Check if streaming is requested
@@ -64,7 +64,7 @@ pub async fn chat_completions(
             Ok(response) => Ok(HttpResponse::Ok().json(response)),
             Err(e) => {
                 error!("Chat completion error: {}", e);
-                Ok(e.error_response())
+                Ok(openai_errors::gateway_error_response(&e))
             }
         }
     }
@@ -89,13 +89,13 @@ async fn handle_streaming_chat_completion(
         &request.model,
         ProviderCapability::ChatCompletionStream,
     ) {
-        return Ok(e.error_response());
+        return Ok(openai_errors::gateway_error_response(&e));
     }
 
     let requested_model = request.model.clone();
     let core_request = match build_core_chat_request(request, requested_model, true) {
         Ok(req) => req,
-        Err(e) => return Ok(e.error_response()),
+        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
     };
 
     let requested_model = core_request.model.clone();
@@ -227,7 +227,7 @@ async fn handle_streaming_chat_completion(
         }
         Err(e) => {
             error!("Failed to create streaming response: {}", e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/context.rs
+++ b/src/server/routes/ai/context.rs
@@ -4,7 +4,7 @@ use crate::core::models::ApiKey;
 use crate::core::models::user::types::User;
 use crate::core::types::context::RequestContext;
 use crate::utils::error::gateway_error::GatewayError;
-use actix_web::{HttpMessage, HttpRequest, HttpResponse, ResponseError, Result as ActixResult};
+use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result as ActixResult};
 use serde::Serialize;
 use std::future::Future;
 use tracing::{debug, error};
@@ -123,7 +123,7 @@ pub async fn log_api_usage(context: &RequestContext, model: &str, tokens_used: u
 /// let context = get_request_context(&req)?;
 /// match handler(request.into_inner(), context).await {
 ///     Ok(r) => Ok(HttpResponse::Ok().json(r)),
-///     Err(e) => { error!("..."); Ok(e.error_response()) }
+///     Err(e) => { error!("..."); Ok(openai_errors::gateway_error_response(&e)) }
 /// }
 /// ```
 pub async fn handle_ai_request<Req, Resp, F, Fut>(
@@ -142,7 +142,7 @@ where
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(e) => {
             error!("{} error: {}", error_label, e);
-            Ok(e.error_response())
+            Ok(super::openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -11,6 +11,7 @@ mod embeddings;
 mod execution;
 mod images;
 mod models;
+mod openai_errors;
 mod provider_selection;
 mod responses;
 mod responses_stream;

--- a/src/server/routes/ai/models.rs
+++ b/src/server/routes/ai/models.rs
@@ -4,8 +4,10 @@ use crate::core::models::openai::{Model, ModelListResponse};
 use crate::core::router::UnifiedRouter;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
-use actix_web::{HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpResponse, Result as ActixResult, web};
 use tracing::{debug, error};
+
+use super::openai_errors;
 
 /// List available models
 ///
@@ -25,7 +27,7 @@ pub async fn list_models(state: web::Data<AppState>) -> ActixResult<HttpResponse
         }
         Err(e) => {
             error!("Failed to list models: {}", e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }
@@ -43,12 +45,12 @@ pub async fn get_model(
 
     match get_model_from_router(unified_router, &model_id).await {
         Ok(Some(model)) => Ok(HttpResponse::Ok().json(model)),
-        Ok(None) => {
-            Ok(GatewayError::not_found(format!("Model not found: {}", model_id)).error_response())
-        }
+        Ok(None) => Ok(openai_errors::gateway_error_response(
+            &GatewayError::not_found(format!("Model not found: {}", model_id)),
+        )),
         Err(e) => {
             error!("Failed to get model {}: {}", model_id, e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -1,0 +1,397 @@
+//! OpenAI-compatible error response helpers for `/v1/*` endpoints.
+
+use crate::core::providers::ProviderError;
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::http::StatusCode;
+use actix_web::{HttpResponse, http::header};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct OpenAiErrorResponse {
+    error: OpenAiErrorDetail,
+}
+
+#[derive(Serialize)]
+struct OpenAiErrorDetail {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    param: Option<String>,
+    code: Option<&'static str>,
+}
+
+struct OpenAiErrorSpec {
+    status: StatusCode,
+    message: String,
+    error_type: &'static str,
+    code: Option<&'static str>,
+}
+
+pub(crate) fn validation_error(message: impl Into<String>) -> HttpResponse {
+    build_response(OpenAiErrorSpec {
+        status: StatusCode::BAD_REQUEST,
+        message: message.into(),
+        error_type: "invalid_request_error",
+        code: Some("invalid_request"),
+    })
+}
+
+pub(crate) fn unauthorized_error(message: impl Into<String>) -> HttpResponse {
+    build_response(OpenAiErrorSpec {
+        status: StatusCode::UNAUTHORIZED,
+        message: message.into(),
+        error_type: "authentication_error",
+        code: Some("authentication_error"),
+    })
+}
+
+pub(crate) fn gateway_error_response(error: &GatewayError) -> HttpResponse {
+    let spec = gateway_error_spec(error);
+    let mut builder = HttpResponse::build(spec.status);
+
+    match error {
+        GatewayError::RateLimit {
+            retry_after,
+            rpm_limit,
+            tpm_limit,
+            ..
+        } => {
+            if let Some(secs) = retry_after {
+                builder.insert_header((header::RETRY_AFTER, secs.to_string()));
+            }
+            if let Some(rpm) = rpm_limit {
+                builder.insert_header(("X-RateLimit-Limit-Requests", rpm.to_string()));
+            }
+            if let Some(tpm) = tpm_limit {
+                builder.insert_header(("X-RateLimit-Limit-Tokens", tpm.to_string()));
+            }
+        }
+        GatewayError::Provider(ProviderError::RateLimit {
+            retry_after: Some(secs),
+            ..
+        }) => {
+            builder.insert_header((header::RETRY_AFTER, secs.to_string()));
+        }
+        _ => {}
+    }
+
+    builder.json(response_body(spec.message, spec.error_type, spec.code))
+}
+
+fn build_response(spec: OpenAiErrorSpec) -> HttpResponse {
+    HttpResponse::build(spec.status).json(response_body(spec.message, spec.error_type, spec.code))
+}
+
+fn response_body(
+    message: String,
+    error_type: &'static str,
+    code: Option<&'static str>,
+) -> OpenAiErrorResponse {
+    OpenAiErrorResponse {
+        error: OpenAiErrorDetail {
+            message,
+            error_type,
+            param: None,
+            code,
+        },
+    }
+}
+
+fn gateway_error_spec(error: &GatewayError) -> OpenAiErrorSpec {
+    match error {
+        GatewayError::Config(_) | GatewayError::Internal(_) | GatewayError::Io(_) => spec(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            error.to_string(),
+            "server_error",
+            "internal_error",
+        ),
+        GatewayError::Storage(_) => spec(
+            StatusCode::SERVICE_UNAVAILABLE,
+            error.to_string(),
+            "server_error",
+            "service_unavailable",
+        ),
+        GatewayError::HttpClient(_) | GatewayError::Network(_) => spec(
+            StatusCode::BAD_GATEWAY,
+            error.to_string(),
+            "server_error",
+            "network_error",
+        ),
+        GatewayError::Serialization(_)
+        | GatewayError::Validation(_)
+        | GatewayError::BadRequest(_) => spec(
+            StatusCode::BAD_REQUEST,
+            error.to_string(),
+            "invalid_request_error",
+            "invalid_request",
+        ),
+        GatewayError::Auth(_) => spec(
+            StatusCode::UNAUTHORIZED,
+            error.to_string(),
+            "authentication_error",
+            "authentication_error",
+        ),
+        GatewayError::Forbidden(_) => spec(
+            StatusCode::FORBIDDEN,
+            error.to_string(),
+            "permission_error",
+            "permission_denied",
+        ),
+        GatewayError::Provider(provider_error) => provider_error_spec(provider_error),
+        GatewayError::RateLimit { .. } => spec(
+            StatusCode::TOO_MANY_REQUESTS,
+            error.to_string(),
+            "rate_limit_error",
+            "rate_limit_exceeded",
+        ),
+        GatewayError::Timeout(_) => spec(
+            StatusCode::REQUEST_TIMEOUT,
+            error.to_string(),
+            "server_error",
+            "timeout",
+        ),
+        GatewayError::NotFound(_) => spec(
+            StatusCode::NOT_FOUND,
+            error.to_string(),
+            "invalid_request_error",
+            "not_found",
+        ),
+        GatewayError::Conflict(_) => spec(
+            StatusCode::CONFLICT,
+            error.to_string(),
+            "invalid_request_error",
+            "conflict",
+        ),
+        GatewayError::Unavailable(_) => spec(
+            StatusCode::SERVICE_UNAVAILABLE,
+            error.to_string(),
+            "server_error",
+            "service_unavailable",
+        ),
+        GatewayError::NotImplemented(_) => spec(
+            StatusCode::NOT_IMPLEMENTED,
+            error.to_string(),
+            "invalid_request_error",
+            "not_implemented",
+        ),
+    }
+}
+
+fn provider_error_spec(error: &ProviderError) -> OpenAiErrorSpec {
+    match error {
+        ProviderError::Authentication { .. } => spec(
+            StatusCode::UNAUTHORIZED,
+            error.to_string(),
+            "authentication_error",
+            "authentication_error",
+        ),
+        ProviderError::RateLimit { .. } => spec(
+            StatusCode::TOO_MANY_REQUESTS,
+            error.to_string(),
+            "rate_limit_error",
+            "rate_limit_exceeded",
+        ),
+        ProviderError::QuotaExceeded { .. } => spec(
+            StatusCode::PAYMENT_REQUIRED,
+            error.to_string(),
+            "insufficient_quota",
+            "insufficient_quota",
+        ),
+        ProviderError::ModelNotFound { .. } => spec(
+            StatusCode::NOT_FOUND,
+            error.to_string(),
+            "invalid_request_error",
+            "model_not_found",
+        ),
+        ProviderError::InvalidRequest { .. } => spec(
+            StatusCode::BAD_REQUEST,
+            error.to_string(),
+            "invalid_request_error",
+            "invalid_request",
+        ),
+        ProviderError::Network { .. } => spec(
+            StatusCode::BAD_GATEWAY,
+            error.to_string(),
+            "server_error",
+            "provider_network_error",
+        ),
+        ProviderError::ProviderUnavailable { .. } => spec(
+            StatusCode::SERVICE_UNAVAILABLE,
+            error.to_string(),
+            "server_error",
+            "provider_unavailable",
+        ),
+        ProviderError::NotSupported { .. }
+        | ProviderError::NotImplemented { .. }
+        | ProviderError::FeatureDisabled { .. } => spec(
+            StatusCode::NOT_IMPLEMENTED,
+            error.to_string(),
+            "invalid_request_error",
+            "not_supported",
+        ),
+        ProviderError::Configuration { .. }
+        | ProviderError::Serialization { .. }
+        | ProviderError::TransformationError { .. } => spec(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            error.to_string(),
+            "server_error",
+            "internal_error",
+        ),
+        ProviderError::Timeout { .. } => spec(
+            StatusCode::GATEWAY_TIMEOUT,
+            error.to_string(),
+            "server_error",
+            "timeout",
+        ),
+        ProviderError::ContextLengthExceeded { .. } => spec(
+            StatusCode::BAD_REQUEST,
+            error.to_string(),
+            "invalid_request_error",
+            "context_length_exceeded",
+        ),
+        ProviderError::ContentFiltered { .. } => spec(
+            StatusCode::BAD_REQUEST,
+            error.to_string(),
+            "invalid_request_error",
+            "content_filter",
+        ),
+        ProviderError::ApiError { status, .. } => api_error_spec(*status, error.to_string()),
+        ProviderError::TokenLimitExceeded { .. } => spec(
+            StatusCode::BAD_REQUEST,
+            error.to_string(),
+            "invalid_request_error",
+            "token_limit_exceeded",
+        ),
+        ProviderError::DeploymentError { .. } => spec(
+            StatusCode::NOT_FOUND,
+            error.to_string(),
+            "invalid_request_error",
+            "deployment_not_found",
+        ),
+        ProviderError::ResponseParsing { .. } | ProviderError::Streaming { .. } => spec(
+            StatusCode::BAD_GATEWAY,
+            error.to_string(),
+            "server_error",
+            "provider_response_error",
+        ),
+        ProviderError::RoutingError { .. } => spec(
+            StatusCode::SERVICE_UNAVAILABLE,
+            error.to_string(),
+            "server_error",
+            "provider_routing_error",
+        ),
+        ProviderError::Cancelled { .. } => spec(
+            StatusCode::BAD_REQUEST,
+            error.to_string(),
+            "server_error",
+            "cancelled",
+        ),
+        ProviderError::Other { .. } => spec(
+            StatusCode::BAD_GATEWAY,
+            error.to_string(),
+            "server_error",
+            "provider_error",
+        ),
+    }
+}
+
+fn api_error_spec(status: u16, message: String) -> OpenAiErrorSpec {
+    let status_code = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+    match status {
+        400 => spec(
+            status_code,
+            message,
+            "invalid_request_error",
+            "invalid_request",
+        ),
+        401 => spec(
+            status_code,
+            message,
+            "authentication_error",
+            "authentication_error",
+        ),
+        403 => spec(
+            status_code,
+            message,
+            "permission_error",
+            "permission_denied",
+        ),
+        404 => spec(status_code, message, "invalid_request_error", "not_found"),
+        408 => spec(status_code, message, "server_error", "timeout"),
+        409 => spec(status_code, message, "invalid_request_error", "conflict"),
+        429 => spec(
+            status_code,
+            message,
+            "rate_limit_error",
+            "rate_limit_exceeded",
+        ),
+        500..=599 => spec(status_code, message, "server_error", "provider_api_error"),
+        _ => spec(status_code, message, "server_error", "provider_api_error"),
+    }
+}
+
+fn spec(
+    status: StatusCode,
+    message: String,
+    error_type: &'static str,
+    code: &'static str,
+) -> OpenAiErrorSpec {
+    OpenAiErrorSpec {
+        status,
+        message,
+        error_type,
+        code: Some(code),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::body::to_bytes;
+    use serde_json::Value;
+
+    #[actix_web::test]
+    async fn validation_error_uses_openai_shape() {
+        let response = validation_error("model must not be empty");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_json(response).await;
+        assert_eq!(body["error"]["message"], "model must not be empty");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["param"], Value::Null);
+        assert_eq!(body["error"]["code"], "invalid_request");
+        assert!(body.get("success").is_none());
+    }
+
+    #[actix_web::test]
+    async fn provider_rate_limit_uses_openai_shape_and_retry_after() {
+        let error = GatewayError::Provider(ProviderError::RateLimit {
+            provider: "openai",
+            message: "Rate limit exceeded".to_string(),
+            retry_after: Some(2),
+            rpm_limit: None,
+            tpm_limit: None,
+            current_usage: None,
+        });
+
+        let response = gateway_error_response(&error);
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers().get(header::RETRY_AFTER).unwrap(), "2");
+        let body = to_json(response).await;
+        assert_eq!(body["error"]["type"], "rate_limit_error");
+        assert_eq!(body["error"]["code"], "rate_limit_exceeded");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("Rate limit exceeded")
+        );
+        assert!(body["error"]["retryable"].is_null());
+    }
+
+    async fn to_json(response: HttpResponse) -> Value {
+        let body = to_bytes(response.into_body()).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+}

--- a/src/server/routes/ai/responses.rs
+++ b/src/server/routes/ai/responses.rs
@@ -14,10 +14,11 @@ use crate::core::models::openai::responses_api::{
 };
 use crate::core::types::responses::FinishReason;
 use crate::server::routes::ai::chat::handle_chat_completion_with_state;
-use crate::server::routes::errors;
 use crate::server::state::AppState;
-use actix_web::{HttpRequest, HttpResponse, ResponseError, Result as ActixResult, web};
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use tracing::{error, info};
+
+use super::openai_errors;
 
 /// POST /v1/responses handler
 pub async fn create_response(
@@ -31,27 +32,31 @@ pub async fn create_response(
     let request = body.into_inner();
 
     if request.model.trim().is_empty() {
-        return Ok(errors::validation_error("model must not be empty"));
+        return Ok(openai_errors::validation_error("model must not be empty"));
     }
 
     match &request.input {
         ResponseInput::Text(t) if t.trim().is_empty() => {
-            return Ok(errors::validation_error("input text must not be empty"));
+            return Ok(openai_errors::validation_error(
+                "input text must not be empty",
+            ));
         }
         ResponseInput::Items(items) if items.is_empty() => {
-            return Ok(errors::validation_error("input array must not be empty"));
+            return Ok(openai_errors::validation_error(
+                "input array must not be empty",
+            ));
         }
         _ => {}
     }
 
     if request.background.unwrap_or(false) {
-        return Ok(errors::validation_error(
+        return Ok(openai_errors::validation_error(
             "background (async) execution is not supported; omit background or set it to false",
         ));
     }
 
     if request.previous_response_id.is_some() {
-        return Ok(errors::validation_error(
+        return Ok(openai_errors::validation_error(
             "previous_response_id (stateful chaining) is not supported; \
              omit previous_response_id to make a fresh request",
         ));
@@ -59,7 +64,7 @@ pub async fn create_response(
 
     let chat_request = match build_chat_request(&request) {
         Ok(r) => r,
-        Err(e) => return Ok(errors::validation_error(&e)),
+        Err(e) => return Ok(openai_errors::validation_error(e)),
     };
 
     if request.stream.unwrap_or(false) {
@@ -90,7 +95,7 @@ async fn handle_sync_response(
         }
         Err(e) => {
             error!("Responses API error: {}", e);
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -18,7 +18,7 @@ use crate::server::routes::ai::responses::{
 };
 use crate::server::state::AppState;
 use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
-use actix_web::{HttpResponse, ResponseError, Result as ActixResult};
+use actix_web::{HttpResponse, Result as ActixResult};
 use bytes::Bytes;
 use futures::StreamExt;
 use serde_json::json;
@@ -26,6 +26,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
+
+use super::openai_errors;
 
 /// Accumulated state for one in-progress tool call during streaming.
 struct ToolCallAccum {
@@ -55,7 +57,7 @@ pub(crate) async fn handle_streaming_response(
         &chat_request.model,
         ProviderCapability::ChatCompletionStream,
     ) {
-        return Ok(e.error_response());
+        return Ok(openai_errors::gateway_error_response(&e));
     }
 
     chat_request.stream = Some(true);
@@ -66,8 +68,7 @@ pub(crate) async fn handle_streaming_response(
     let core_request = match build_core_chat_request(chat_request, model_name.clone(), true) {
         Ok(r) => r,
         Err(e) => {
-            use actix_web::ResponseError;
-            return Ok(e.error_response());
+            return Ok(openai_errors::gateway_error_response(&e));
         }
     };
 
@@ -472,7 +473,7 @@ pub(crate) async fn handle_streaming_response(
         }
         Err(e) => {
             error!("Failed to start Responses API stream: {e}");
-            Ok(e.error_response())
+            Ok(openai_errors::gateway_error_response(&e))
         }
     }
 }

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -287,6 +287,21 @@ mod tests {
         assert_eq!(response.error, Some("test error".to_string()));
     }
 
+    #[actix_web::test]
+    async fn test_gateway_error_helpers_keep_api_response_envelope() {
+        let response = errors::validation_error("test validation error");
+
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["success"], false);
+        assert_eq!(json["error"], "test validation error");
+        assert!(json["data"].is_null());
+    }
+
     #[test]
     fn test_pagination_meta() {
         let meta = PaginationMeta::new(2, 10, 25);

--- a/tests/integration/completions_route_tests.rs
+++ b/tests/integration/completions_route_tests.rs
@@ -238,11 +238,14 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         let body: Value = test::read_body_json(resp).await;
-        assert_eq!(body["success"], false);
-        let error_message = body["error"]
+        assert!(body.get("success").is_none());
+        let error_message = body["error"]["message"]
             .as_str()
-            .expect("validation response should contain error string");
+            .expect("validation response should contain OpenAI error message");
         assert!(error_message.contains("Model name cannot be empty"));
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["param"], Value::Null);
+        assert_eq!(body["error"]["code"], "invalid_request");
 
         let requests = mock_server.requests();
         assert!(requests.is_empty());
@@ -271,11 +274,14 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
 
         let body: Value = test::read_body_json(resp).await;
-        assert_eq!(body["error"]["code"], "PROVIDER_RATE_LIMIT");
-        assert_eq!(body["error"]["retryable"], true);
+        assert!(body.get("success").is_none());
+        assert_eq!(body["error"]["type"], "rate_limit_error");
+        assert_eq!(body["error"]["param"], Value::Null);
+        assert_eq!(body["error"]["code"], "rate_limit_exceeded");
+        assert!(body["error"].get("retryable").is_none());
         let message = body["error"]["message"]
             .as_str()
-            .expect("provider error body should have message");
+            .expect("provider error body should have OpenAI error message");
         assert!(message.to_lowercase().contains("rate limit"));
 
         let requests = mock_server.requests();


### PR DESCRIPTION
## Summary
- add an OpenAI-compatible error envelope helper for `/v1/*` AI routes
- route chat, responses, embeddings/images via shared handling, models, batches, and audio errors through the OpenAI envelope
- keep gateway management error helpers on the existing `ApiResponse` envelope

Closes #439

## Tests
- cargo fmt --check
- cargo test openai_errors --features gateway,storage
- cargo test test_completions_bad_request_validation --features gateway,storage
- cargo test test_completions_provider_failure_maps_to_rate_limit --features gateway,storage
- cargo test test_gateway_error_helpers_keep_api_response_envelope --features gateway,storage
- cargo clippy --features gateway,storage --all-targets -- -D warnings
- cargo test --features gateway,storage