### PR TITLE
fix(ai): hold deployment leases for streams

### DIFF
--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use super::context::get_request_context;
-use super::execution::execute_with_selected_deployment;
+use super::execution::{execute_stream_with_selected_deployment, execute_with_selected_deployment};
 use super::openai_errors;
 use super::provider_selection::select_provider_for_model;
 
@@ -100,8 +100,8 @@ async fn handle_streaming_chat_completion(
 
     let requested_model = core_request.model.clone();
     let context_for_execution = context.clone();
-    match execute_with_selected_deployment(
-        unified_router,
+    match execute_stream_with_selected_deployment(
+        state.unified_router.clone(),
         &requested_model,
         move |provider, selected_model| {
             let core_request = core_request.clone();
@@ -109,16 +109,15 @@ async fn handle_streaming_chat_completion(
             async move {
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = selected_model;
-                let stream = provider
+                provider
                     .chat_completion_stream(request_for_provider, context)
-                    .await?;
-                Ok((stream, 0))
+                    .await
             }
         },
     )
     .await
     {
-        Ok(mut stream) => {
+        Ok((mut stream, lease)) => {
             // Use a channel so that when the client disconnects and actix-web
             // drops the response stream, the receiver is dropped, which causes
             // the sender to fail. This breaks the upstream read loop and drops
@@ -128,6 +127,9 @@ async fn handle_streaming_chat_completion(
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
 
             tokio::spawn(async move {
+                let mut lease = Some(lease);
+                let mut tokens_used = 0_u64;
+
                 loop {
                     let chunk_result = if idle_timeout_secs == 0 {
                         stream.next().await
@@ -151,7 +153,14 @@ async fn handle_streaming_chat_completion(
                                 if tx.send(error_bytes).await.is_err() {
                                     info!("Client disconnected before timeout error could be sent");
                                 }
-                                break;
+                                if let Some(lease) = lease.take() {
+                                    let error = ProviderError::timeout(
+                                        "router",
+                                        format!("stream idle timeout after {}s", idle_timeout_secs),
+                                    );
+                                    lease.finish_failure(&error);
+                                }
+                                return;
                             }
                         }
                     };
@@ -162,6 +171,9 @@ async fn handle_streaming_chat_completion(
 
                     let bytes = match chunk_result {
                         Ok(chunk) => {
+                            if let Some(usage) = &chunk.usage {
+                                tokens_used = u64::from(usage.total_tokens);
+                            }
                             let chat_chunk = convert_core_chunk_to_streaming(chunk);
                             match serde_json::to_string(&chat_chunk) {
                                 Ok(json) => {
@@ -181,7 +193,14 @@ async fn handle_streaming_chat_completion(
                                             "Client disconnected before error event could be sent"
                                         );
                                     }
-                                    break;
+                                    if let Some(lease) = lease.take() {
+                                        let error = ProviderError::serialization(
+                                            "router",
+                                            format!("Serialization error: {}", e),
+                                        );
+                                        lease.finish_failure(&error);
+                                    }
+                                    return;
                                 }
                             }
                         }
@@ -193,7 +212,10 @@ async fn handle_streaming_chat_completion(
                             if tx.send(error_bytes).await.is_err() {
                                 info!("Client disconnected before error event could be sent");
                             }
-                            break;
+                            if let Some(lease) = lease.take() {
+                                lease.finish_failure(&e);
+                            }
+                            return;
                         }
                     };
 
@@ -202,7 +224,7 @@ async fn handle_streaming_chat_completion(
                     // stream to cancel the upstream request.
                     if tx.send(bytes).await.is_err() {
                         info!("Client disconnected during streaming, cancelling upstream");
-                        break;
+                        return;
                     }
                 }
 
@@ -210,6 +232,9 @@ async fn handle_streaming_chat_completion(
                 let done_event = Event::default().data("[DONE]");
                 if tx.send(done_event.to_bytes()).await.is_err() {
                     info!("Client disconnected before [DONE] event could be sent");
+                }
+                if let Some(lease) = lease.take() {
+                    lease.finish_success(tokens_used);
                 }
                 // `stream` (the provider stream) is dropped here, cancelling
                 // any remaining upstream work.

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -2,7 +2,59 @@
 
 use crate::core::providers::{Provider, ProviderError};
 use crate::core::router::UnifiedRouter;
+use crate::core::router::execution::{
+    calculate_retry_delay, infer_cooldown_reason, is_retryable_error,
+    router_error_to_provider_error,
+};
 use crate::utils::error::gateway_error::GatewayError;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Holds a selected deployment active for the lifetime of a streaming response.
+pub(super) struct StreamingDeploymentLease {
+    router: Arc<UnifiedRouter>,
+    deployment_id: String,
+    started_at: Instant,
+    finalized: bool,
+}
+
+impl StreamingDeploymentLease {
+    fn new(router: Arc<UnifiedRouter>, deployment_id: String, started_at: Instant) -> Self {
+        Self {
+            router,
+            deployment_id,
+            started_at,
+            finalized: false,
+        }
+    }
+
+    pub(super) fn finish_success(mut self, tokens_used: u64) {
+        let latency_us = self.started_at.elapsed().as_micros() as u64;
+        self.router
+            .record_success(&self.deployment_id, tokens_used, latency_us);
+        self.release();
+    }
+
+    pub(super) fn finish_failure(mut self, error: &ProviderError) {
+        let cooldown_reason = infer_cooldown_reason(error);
+        self.router
+            .record_failure_with_reason(&self.deployment_id, cooldown_reason);
+        self.release();
+    }
+
+    fn release(&mut self) {
+        if !self.finalized {
+            self.router.release_deployment(&self.deployment_id);
+            self.finalized = true;
+        }
+    }
+}
+
+impl Drop for StreamingDeploymentLease {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
 
 /// Execute an AI route operation against the deployment selected by `UnifiedRouter`.
 ///
@@ -38,14 +90,103 @@ where
     Ok(execution.0)
 }
 
+/// Start a streaming operation while keeping the selected deployment active.
+///
+/// The returned lease must live until the stream completes, errors, or is
+/// cancelled by client disconnect. Dropping it releases the deployment without
+/// recording success or failure; explicit finish methods record final outcome.
+pub(super) async fn execute_stream_with_selected_deployment<T, F, Fut>(
+    router: Arc<UnifiedRouter>,
+    requested_model: &str,
+    operation: F,
+) -> Result<(T, StreamingDeploymentLease), GatewayError>
+where
+    F: Fn(Provider, String) -> Fut + Clone,
+    Fut: std::future::Future<Output = Result<T, ProviderError>>,
+{
+    let max_attempts = router.config().num_retries + 1;
+    let mut last_error = None;
+
+    for attempt in 1..=max_attempts {
+        let started_at = Instant::now();
+
+        let deployment_id = match router.select_deployment(requested_model) {
+            Ok(id) => id,
+            Err(router_err) => {
+                let provider_err = router_error_to_provider_error(router_err);
+
+                if is_retryable_error(&provider_err) && attempt < max_attempts {
+                    let delay = calculate_retry_delay(router.config(), attempt);
+                    last_error = Some(provider_err);
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                return Err(GatewayError::Provider(provider_err));
+            }
+        };
+
+        let Some(deployment) = router.get_deployment(&deployment_id) else {
+            router.release_deployment(&deployment_id);
+            let err = ProviderError::other("router", "Selected deployment not found");
+            if is_retryable_error(&err) && attempt < max_attempts {
+                let delay = calculate_retry_delay(router.config(), attempt);
+                last_error = Some(err);
+                tokio::time::sleep(delay).await;
+                continue;
+            }
+            return Err(GatewayError::Provider(err));
+        };
+
+        let provider = deployment.provider.clone();
+        let selected_model = deployment.model.clone();
+        drop(deployment);
+
+        match operation.clone()(provider, selected_model).await {
+            Ok(stream) => {
+                let lease =
+                    StreamingDeploymentLease::new(router.clone(), deployment_id, started_at);
+                return Ok((stream, lease));
+            }
+            Err(err) => {
+                router.release_deployment(&deployment_id);
+
+                if is_retryable_error(&err) && attempt < max_attempts {
+                    router.record_failure_with_reason(
+                        &deployment_id,
+                        crate::core::router::CooldownReason::ConsecutiveFailures,
+                    );
+                    let delay = calculate_retry_delay(router.config(), attempt);
+                    last_error = Some(err);
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                let cooldown_reason = infer_cooldown_reason(&err);
+                router.record_failure_with_reason(&deployment_id, cooldown_reason);
+                return Err(GatewayError::Provider(err));
+            }
+        }
+    }
+
+    Err(GatewayError::Provider(last_error.unwrap_or_else(|| {
+        ProviderError::Other {
+            provider: "router",
+            message: "Unknown error during streaming retry".to_string(),
+        }
+    })))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::execute_with_selected_deployment;
+    use super::{execute_stream_with_selected_deployment, execute_with_selected_deployment};
     use crate::core::providers::Provider;
     use crate::core::providers::ProviderError;
     use crate::core::providers::openai::OpenAIProvider;
     use crate::core::router::{Deployment, UnifiedRouter};
     use crate::utils::error::gateway_error::GatewayError;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
     async fn build_test_router() -> UnifiedRouter {
         let router = UnifiedRouter::default();
@@ -92,5 +233,77 @@ mod tests {
             err,
             GatewayError::Provider(ProviderError::Timeout { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn test_execute_stream_holds_deployment_active_until_success() {
+        let router = Arc::new(build_test_router().await);
+
+        let (_stream, lease) = execute_stream_with_selected_deployment(
+            router.clone(),
+            "gpt-4",
+            |_provider, model| async move { Ok(model) },
+        )
+        .await
+        .expect("stream creation should succeed");
+
+        let deployment = router
+            .get_deployment("deployment-1")
+            .expect("deployment should exist");
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(deployment.state.success_requests.load(Ordering::Relaxed), 0);
+        drop(deployment);
+
+        lease.finish_success(42);
+
+        let deployment = router
+            .get_deployment("deployment-1")
+            .expect("deployment should exist");
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(deployment.state.success_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(deployment.state.tpm_current.load(Ordering::Relaxed), 42);
+    }
+
+    #[tokio::test]
+    async fn test_stream_lease_drop_releases_without_recording_outcome() {
+        let router = Arc::new(build_test_router().await);
+
+        let (_stream, lease) = execute_stream_with_selected_deployment(
+            router.clone(),
+            "gpt-4",
+            |_provider, model| async move { Ok(model) },
+        )
+        .await
+        .expect("stream creation should succeed");
+
+        drop(lease);
+
+        let deployment = router
+            .get_deployment("deployment-1")
+            .expect("deployment should exist");
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(deployment.state.total_requests.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_stream_records_stream_failure() {
+        let router = Arc::new(build_test_router().await);
+
+        let (_stream, lease) = execute_stream_with_selected_deployment(
+            router.clone(),
+            "gpt-4",
+            |_provider, model| async move { Ok(model) },
+        )
+        .await
+        .expect("stream creation should succeed");
+
+        let error = ProviderError::rate_limit("test", Some(1));
+        lease.finish_failure(&error);
+
+        let deployment = router
+            .get_deployment("deployment-1")
+            .expect("deployment should exist");
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(deployment.state.fail_requests.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -12,7 +12,7 @@ use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
 use crate::core::types::{context::RequestContext, model::ProviderCapability};
 use crate::server::routes::ai::chat::build_core_chat_request;
-use crate::server::routes::ai::execution::execute_with_selected_deployment;
+use crate::server::routes::ai::execution::execute_stream_with_selected_deployment;
 use crate::server::routes::ai::responses::{
     current_unix_ts, finish_reason_enum_to_status, uuid_v4_hex,
 };
@@ -75,8 +75,8 @@ pub(crate) async fn handle_streaming_response(
     let requested_model = core_request.model.clone();
     let context_clone = context.clone();
 
-    match execute_with_selected_deployment(
-        unified_router,
+    match execute_stream_with_selected_deployment(
+        state.unified_router.clone(),
         &requested_model,
         move |provider, selected_model| {
             let core_request = core_request.clone();
@@ -84,18 +84,19 @@ pub(crate) async fn handle_streaming_response(
             async move {
                 let mut req = core_request.clone();
                 req.model = selected_model;
-                let stream = provider.chat_completion_stream(req, ctx).await?;
-                Ok((stream, 0))
+                provider.chat_completion_stream(req, ctx).await
             }
         },
     )
     .await
     {
-        Ok(mut stream) => {
+        Ok((mut stream, lease)) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout = state.config.load().gateway.server.stream_idle_timeout;
 
             tokio::spawn(async move {
+                let mut lease = Some(lease);
+
                 // ── response.created ──────────────────────────────────────────
                 let shell = make_shell(&resp_id, created_at, &model_name, "in_progress", &original);
                 if emit(
@@ -142,6 +143,13 @@ pub(crate) async fn handle_streaming_response(
                                         "timeout",
                                     ))
                                     .await;
+                                if let Some(lease) = lease.take() {
+                                    let error = ProviderError::timeout(
+                                        "router",
+                                        format!("stream idle timeout after {idle_timeout}s"),
+                                    );
+                                    lease.finish_failure(&error);
+                                }
                                 return;
                             }
                         }
@@ -316,6 +324,9 @@ pub(crate) async fn handle_streaming_response(
                             error!("Responses API stream error: {e}");
                             let (et, ec) = classify(&e);
                             let _ = tx.send(sse_error(&e.to_string(), et, ec)).await;
+                            if let Some(lease) = lease.take() {
+                                lease.finish_failure(&e);
+                            }
                             return;
                         }
                     }
@@ -459,6 +470,9 @@ pub(crate) async fn handle_streaming_response(
 
                 // Final SSE terminator
                 let _ = tx.send(Event::default().data("[DONE]").to_bytes()).await;
+                if let Some(lease) = lease.take() {
+                    lease.finish_success(u64::from(in_tokens) + u64::from(out_tokens));
+                }
             });
 
             let body = tokio_stream::wrappers::ReceiverStream::new(rx)


### PR DESCRIPTION
## Summary
- add a streaming deployment lease that keeps router `active_requests` held for the stream lifetime
- finish leases on normal streaming completion with latency/token accounting
- record provider stream failures and idle timeouts as deployment failures; drop-only releases cover client disconnects

Closes #438

## Tests
- cargo fmt --check
- cargo test execute_stream --features gateway,storage
- cargo test stream_lease --features gateway,storage
- cargo test test_completions_streaming_response_sends_sse_and_done --features gateway,storage
- cargo clippy --features gateway,storage --all-targets -- -D warnings
- cargo test --features gateway,storage