### PR TITLE
fix(storage): honor configured file storage

### DIFF
--- a/src/config/models/file_storage.rs
+++ b/src/config/models/file_storage.rs
@@ -6,10 +6,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileStorageConfig {
     /// Storage type (local, s3, etc.)
+    #[serde(default = "default_file_storage_type")]
     pub storage_type: String,
     /// Local storage path
+    #[serde(default)]
     pub local_path: Option<String>,
     /// S3 configuration
+    #[serde(default)]
     pub s3: Option<S3Config>,
 }
 
@@ -20,6 +23,29 @@ impl Default for FileStorageConfig {
             local_path: None,
             s3: None,
         }
+    }
+}
+
+fn default_file_storage_type() -> String {
+    "local".to_string()
+}
+
+impl FileStorageConfig {
+    /// Merge file storage configurations.
+    pub fn merge(mut self, other: Self) -> Self {
+        let default = Self::default();
+
+        if !other.storage_type.is_empty() && other.storage_type != default.storage_type {
+            self.storage_type = other.storage_type;
+        }
+        if other.local_path.is_some() {
+            self.local_path = other.local_path;
+        }
+        if other.s3.is_some() {
+            self.s3 = other.s3;
+        }
+
+        self
     }
 }
 
@@ -194,10 +220,35 @@ mod tests {
     }
 
     #[test]
+    fn test_file_storage_config_deserializes_partial_local_config() {
+        let json = r#"{"local_path": "/configured/files"}"#;
+        let config: FileStorageConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.storage_type, "local");
+        assert_eq!(config.local_path, Some("/configured/files".to_string()));
+        assert!(config.s3.is_none());
+    }
+
+    #[test]
     fn test_file_storage_config_clone() {
         let config = FileStorageConfig::default();
         let cloned = config.clone();
         assert_eq!(config.storage_type, cloned.storage_type);
+    }
+
+    #[test]
+    fn test_file_storage_config_merge_local_path() {
+        let base = FileStorageConfig::default();
+        let other = FileStorageConfig {
+            storage_type: "local".to_string(),
+            local_path: Some("/configured/files".to_string()),
+            s3: None,
+        };
+
+        let merged = base.merge(other);
+
+        assert_eq!(merged.storage_type, "local");
+        assert_eq!(merged.local_path, Some("/configured/files".to_string()));
     }
 
     // ==================== S3Config Tests ====================

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -1,6 +1,6 @@
 //! Storage configuration
 
-use super::file_storage::VectorDbConfig;
+use super::file_storage::{FileStorageConfig, VectorDbConfig};
 use super::*;
 use super::{default_connection_timeout, default_redis_max_connections};
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,9 @@ pub struct StorageConfig {
     pub database: DatabaseConfig,
     /// Redis configuration
     pub redis: RedisConfig,
+    /// File storage configuration
+    #[serde(default, alias = "file_storage")]
+    pub files: FileStorageConfig,
     /// Vector database configuration (optional)
     #[serde(default)]
     pub vector_db: Option<VectorDbConfig>,
@@ -22,6 +25,7 @@ impl StorageConfig {
     pub fn merge(mut self, other: Self) -> Self {
         self.database = self.database.merge(other.database);
         self.redis = self.redis.merge(other.redis);
+        self.files = self.files.merge(other.files);
         if other.vector_db.is_some() {
             self.vector_db = other.vector_db;
         }
@@ -466,6 +470,7 @@ mod tests {
         let config = StorageConfig::default();
         assert_eq!(config.database.url, "postgresql://localhost/litellm");
         assert_eq!(config.redis.url, "redis://localhost:6379");
+        assert_eq!(config.files.storage_type, "local");
         assert!(config.vector_db.is_none());
     }
 
@@ -474,6 +479,7 @@ mod tests {
         let config = StorageConfig {
             database: DatabaseConfig::default(),
             redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
             vector_db: None,
         };
         assert!(config.vector_db.is_none());
@@ -485,6 +491,26 @@ mod tests {
         let json = serde_json::to_value(&config).unwrap();
         assert!(json["database"].is_object());
         assert!(json["redis"].is_object());
+        assert!(json["files"].is_object());
+    }
+
+    #[test]
+    fn test_storage_config_deserializes_file_storage_alias() {
+        let json = serde_json::json!({
+            "database": DatabaseConfig::default(),
+            "redis": RedisConfig::default(),
+            "file_storage": {
+                "local_path": "/configured/files"
+            }
+        });
+
+        let config: StorageConfig = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            config.files.local_path,
+            Some("/configured/files".to_string())
+        );
+        assert_eq!(config.files.storage_type, "local");
     }
 
     #[test]
@@ -500,10 +526,32 @@ mod tests {
                 fallback_to_sqlite: false,
             },
             redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
             vector_db: None,
         };
         let merged = base.merge(other);
         assert_eq!(merged.database.url, "postgresql://new/db");
+    }
+
+    #[test]
+    fn test_storage_config_merge_files() {
+        let base = StorageConfig::default();
+        let other = StorageConfig {
+            database: DatabaseConfig::default(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig {
+                storage_type: "local".to_string(),
+                local_path: Some("/var/lib/litellm/files".to_string()),
+                s3: None,
+            },
+            vector_db: None,
+        };
+
+        let merged = base.merge(other);
+        assert_eq!(
+            merged.files.local_path,
+            Some("/var/lib/litellm/files".to_string())
+        );
     }
 
     #[test]

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -4,7 +4,7 @@
 //! structures including StorageConfig, DatabaseConfig, RedisConfig, and VectorDbConfig.
 
 use super::trait_def::Validate;
-use crate::config::models::file_storage::VectorDbConfig;
+use crate::config::models::file_storage::{FileStorageConfig, VectorDbConfig};
 use crate::config::models::storage::{DatabaseConfig, RedisConfig, StorageConfig};
 use tracing::debug;
 
@@ -19,11 +19,49 @@ impl Validate for StorageConfig {
             self.redis.validate()?;
         }
 
+        self.files.validate()?;
+
         if let Some(vector_db) = &self.vector_db {
             vector_db.validate()?;
         }
 
         Ok(())
+    }
+}
+
+impl Validate for FileStorageConfig {
+    fn validate(&self) -> Result<(), String> {
+        match self.storage_type.as_str() {
+            "local" => {
+                if self
+                    .local_path
+                    .as_deref()
+                    .is_some_and(|path| path.trim().is_empty())
+                {
+                    return Err("File storage local_path cannot be empty".to_string());
+                }
+                Ok(())
+            }
+            "s3" => {
+                let s3 = self.s3.as_ref().ok_or_else(|| {
+                    "File storage s3 configuration is required when storage_type is s3".to_string()
+                })?;
+                if s3.bucket.trim().is_empty() {
+                    return Err("File storage S3 bucket cannot be empty".to_string());
+                }
+                if s3.region.trim().is_empty() {
+                    return Err("File storage S3 region cannot be empty".to_string());
+                }
+                if s3.access_key_id.trim().is_empty() {
+                    return Err("File storage S3 access_key_id cannot be empty".to_string());
+                }
+                if s3.secret_access_key.trim().is_empty() {
+                    return Err("File storage S3 secret_access_key cannot be empty".to_string());
+                }
+                Ok(())
+            }
+            other => Err(format!("Unsupported file storage type: {}", other)),
+        }
     }
 }
 
@@ -141,5 +179,30 @@ mod tests {
                 .expect_err("placeholder vector backend must fail validation");
             assert!(err.contains("not implemented yet"));
         }
+    }
+
+    #[test]
+    fn file_storage_validation_accepts_configured_local_path() {
+        let config = FileStorageConfig {
+            storage_type: "local".to_string(),
+            local_path: Some("/var/lib/litellm/files".to_string()),
+            s3: None,
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn file_storage_validation_rejects_missing_s3_config() {
+        let config = FileStorageConfig {
+            storage_type: "s3".to_string(),
+            local_path: None,
+            s3: None,
+        };
+
+        let err = config
+            .validate()
+            .expect_err("s3 file storage should require s3 config");
+        assert!(err.contains("s3 configuration is required"));
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -60,10 +60,9 @@ impl StorageLayer {
             }
         };
 
-        // Initialize file storage (using default config for now)
+        // Initialize file storage
         debug!("Initializing file storage");
-        let default_file_config = crate::config::models::file_storage::FileStorageConfig::default();
-        let files = Arc::new(files::FileStorage::new(&default_file_config).await?);
+        let files = Arc::new(files::FileStorage::new(&config.files).await?);
 
         // Initialize vector database (optional)
         let vector = if let Some(ref vector_config) = config.vector_db {
@@ -366,7 +365,9 @@ pub struct StorageHealthStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::models::file_storage::FileStorageConfig;
     use crate::config::models::storage::{DatabaseConfig, RedisConfig};
+    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_storage_layer_creation() {
@@ -386,6 +387,7 @@ mod tests {
                 connection_timeout: 5,
                 cluster: false,
             },
+            files: FileStorageConfig::default(),
             vector_db: None,
         };
 
@@ -393,5 +395,38 @@ mod tests {
         // For now, we'll just test that the config is properly structured
         assert_eq!(config.database.url, "postgresql://localhost:5432/test");
         assert_eq!(config.redis.url, "redis://localhost:6379");
+    }
+
+    #[tokio::test]
+    async fn test_storage_layer_uses_configured_file_storage_path() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let configured_path = temp_dir.path().join("configured-files");
+        let config = StorageConfig {
+            database: DatabaseConfig::default(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig {
+                storage_type: "local".to_string(),
+                local_path: Some(configured_path.to_string_lossy().to_string()),
+                s3: None,
+            },
+            vector_db: None,
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("storage layer should initialize with configured local file storage");
+        let file_id = storage
+            .store_file("configured.txt", b"configured storage")
+            .await
+            .expect("file should be stored");
+
+        let expected_path = configured_path
+            .join(&file_id[..2.min(file_id.len())])
+            .join(&file_id);
+        assert!(
+            expected_path.exists(),
+            "stored file should use configured path: {}",
+            expected_path.display()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add file storage config to StorageConfig with default local behavior and file_storage alias
- pass configured file storage settings into StorageLayer instead of constructing defaults
- validate local/S3 file storage config and test configured local paths

Closes #436

## Tests
- cargo fmt --check
- cargo test file_storage_config --features gateway,storage
- cargo test storage_config --features gateway,storage
- cargo test test_storage_layer_uses_configured_file_storage_path --features gateway,storage
- cargo test --features gateway,storage
- cargo clippy --features gateway,storage --all-targets -- -D warnings