### PR TITLE
fix(router): execute with capability-aware deployments

### DIFF
--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -11,6 +11,7 @@ use super::execution::{
 use super::fallback::{ExecutionResult, FallbackType};
 use super::unified::Router;
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::model::ProviderCapability;
 
 impl Router {
     /// Execute a request for a single model with retry logic
@@ -87,6 +88,80 @@ impl Router {
             last_error.unwrap_or_else(|| ProviderError::Other {
                 provider: "router",
                 message: "Unknown error during retry".to_string(),
+            }),
+            max_attempts,
+        ))
+    }
+
+    /// Execute a request for a single model with retry logic, constrained to
+    /// deployments that support the requested provider capability.
+    pub async fn execute_with_capability_retry<T, F, Fut>(
+        &self,
+        model_name: &str,
+        capability: &ProviderCapability,
+        operation: F,
+    ) -> Result<(T, DeploymentId, u32, u64), (ProviderError, u32)>
+    where
+        F: Fn(DeploymentId) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        let max_attempts = self.config.num_retries + 1;
+        let mut last_error = None;
+
+        for attempt in 1..=max_attempts {
+            let start = std::time::Instant::now();
+
+            let deployment_id = match self.select_deployment_for_capability(model_name, capability)
+            {
+                Ok(id) => id,
+                Err(router_err) => {
+                    let provider_err = router_error_to_provider_error(router_err);
+
+                    if is_retryable_error(&provider_err) && attempt < max_attempts {
+                        let delay = calculate_retry_delay(&self.config, attempt);
+                        last_error = Some(provider_err);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    } else {
+                        return Err((provider_err, attempt));
+                    }
+                }
+            };
+
+            let result = operation(deployment_id.clone()).await;
+            let latency_us = start.elapsed().as_micros() as u64;
+
+            match result {
+                Ok((value, tokens_used)) => {
+                    self.release_deployment(&deployment_id);
+                    self.record_success(&deployment_id, tokens_used, latency_us);
+                    return Ok((value, deployment_id, attempt, latency_us));
+                }
+                Err(err) => {
+                    self.release_deployment(&deployment_id);
+
+                    if is_retryable_error(&err) && attempt < max_attempts {
+                        self.record_failure_with_reason(
+                            &deployment_id,
+                            CooldownReason::ConsecutiveFailures,
+                        );
+                        let delay = calculate_retry_delay(&self.config, attempt);
+                        last_error = Some(err);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    } else {
+                        let cooldown_reason = infer_cooldown_reason(&err);
+                        self.record_failure_with_reason(&deployment_id, cooldown_reason);
+                        return Err((err, attempt));
+                    }
+                }
+            }
+        }
+
+        Err((
+            last_error.unwrap_or_else(|| ProviderError::Other {
+                provider: "router",
+                message: "Unknown error during capability retry".to_string(),
             }),
             max_attempts,
         ))

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -4,10 +4,11 @@
 //! the best deployment for a given model.
 
 use super::config::RoutingStrategy;
-use super::deployment::DeploymentId;
+use super::deployment::{Deployment, DeploymentId};
 use super::error::RouterError;
 use super::strategy_impl;
 use super::unified::Router;
+use crate::core::types::model::ProviderCapability;
 use std::sync::atomic::Ordering::Relaxed;
 
 impl Router {
@@ -21,6 +22,36 @@ impl Router {
     /// 4. Select based on routing strategy
     /// 5. Increment active_requests counter
     pub fn select_deployment(&self, model_name: &str) -> Result<DeploymentId, RouterError> {
+        self.select_deployment_matching(model_name, |_| true)
+    }
+
+    /// Select the best deployment for a model that supports `capability`.
+    ///
+    /// This uses the same health, cooldown, concurrency, rate-limit, and
+    /// strategy filters as `select_deployment`, then reserves the selected
+    /// deployment by incrementing its active request count.
+    pub fn select_deployment_for_capability(
+        &self,
+        model_name: &str,
+        capability: &ProviderCapability,
+    ) -> Result<DeploymentId, RouterError> {
+        self.select_deployment_matching(model_name, |deployment| {
+            deployment
+                .provider
+                .capabilities()
+                .iter()
+                .any(|cap| cap == capability)
+        })
+    }
+
+    fn select_deployment_matching<F>(
+        &self,
+        model_name: &str,
+        is_candidate: F,
+    ) -> Result<DeploymentId, RouterError>
+    where
+        F: Fn(&Deployment) -> bool,
+    {
         // 1. Resolve model name with a borrowed fast path so the hot routing
         // path only allocates when we finally return the selected deployment ID.
         let alias_guard = self.maybe_model_alias(model_name);
@@ -48,6 +79,16 @@ impl Router {
             let Some(deployment) = self.deployments.get(id.as_str()) else {
                 continue;
             };
+
+            if !is_candidate(&deployment) {
+                tracing::trace!(
+                    deployment_id = id.as_str(),
+                    model = %resolved_name,
+                    reason = "capability_mismatch",
+                    "deployment excluded from routing candidates"
+                );
+                continue;
+            }
 
             // Check cooldown first: is_in_cooldown() resets health
             // from Cooldown to Degraded when the cooldown period expires.

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -298,6 +298,31 @@ impl Router {
                 continue;
             };
 
+            if deployment.is_in_cooldown() || !deployment.is_healthy() {
+                continue;
+            }
+
+            let active_requests = deployment.state.active_requests.load(Relaxed);
+            if let Some(limit) = deployment.config.max_parallel_requests
+                && active_requests >= limit
+            {
+                continue;
+            }
+
+            let rpm_current = deployment.state.rpm_current.load(Relaxed);
+            if let Some(limit) = deployment.config.rpm_limit
+                && rpm_current >= limit
+            {
+                continue;
+            }
+
+            let tpm_current = deployment.state.tpm_current.load(Relaxed);
+            if let Some(limit) = deployment.config.tpm_limit
+                && tpm_current >= limit
+            {
+                continue;
+            }
+
             if deployment
                 .provider
                 .capabilities()

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -26,7 +26,6 @@ use tracing::{error, info, warn};
 use super::context::get_request_context;
 use super::execution::{execute_stream_with_selected_deployment, execute_with_selected_deployment};
 use super::openai_errors;
-use super::provider_selection::select_provider_for_model;
 
 /// Chat completions endpoint
 ///
@@ -81,17 +80,6 @@ async fn handle_streaming_chat_completion(
         request.model
     );
 
-    let unified_router = &state.unified_router;
-
-    // Keep provider selection for capability validation before execution.
-    if let Err(e) = select_provider_for_model(
-        unified_router,
-        &request.model,
-        ProviderCapability::ChatCompletionStream,
-    ) {
-        return Ok(openai_errors::gateway_error_response(&e));
-    }
-
     let requested_model = request.model.clone();
     let core_request = match build_core_chat_request(request, requested_model, true) {
         Ok(req) => req,
@@ -103,6 +91,7 @@ async fn handle_streaming_chat_completion(
     match execute_stream_with_selected_deployment(
         state.unified_router.clone(),
         &requested_model,
+        ProviderCapability::ChatCompletionStream,
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
@@ -272,13 +261,6 @@ async fn handle_chat_completion_internal(
     request: ChatCompletionRequest,
     context: RequestContext,
 ) -> Result<ChatCompletionResponse, GatewayError> {
-    // Keep provider selection for capability validation before execution.
-    select_provider_for_model(
-        unified_router,
-        &request.model,
-        ProviderCapability::ChatCompletion,
-    )?;
-
     let requested_model = request.model.clone();
     let core_request = build_core_chat_request(request, requested_model, false)?;
     let requested_model = core_request.model.clone();
@@ -287,6 +269,7 @@ async fn handle_chat_completion_internal(
     let core_response = execute_with_selected_deployment(
         unified_router,
         &requested_model,
+        ProviderCapability::ChatCompletion,
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -12,7 +12,6 @@ use tracing::info;
 
 use super::context::handle_ai_request;
 use super::execution::execute_with_selected_deployment;
-use super::provider_selection::select_provider_for_model;
 
 fn parse_embedding_input(input: &serde_json::Value) -> Result<EmbeddingInput, GatewayError> {
     match input {
@@ -85,12 +84,9 @@ async fn handle_embedding_internal(
     // Convert OpenAI format request to core format.
     let input = parse_embedding_input(&request.input)?;
 
-    // Keep provider selection for capability validation before execution.
-    select_provider_for_model(
-        unified_router,
-        &request.model,
-        ProviderCapability::Embeddings,
-    )?;
+    if request.model.trim().is_empty() {
+        return Err(GatewayError::validation("Model is required"));
+    }
 
     let requested_model = request.model.clone();
     let core_request = CoreEmbeddingRequest {
@@ -107,6 +103,7 @@ async fn handle_embedding_internal(
     let core_response = execute_with_selected_deployment(
         unified_router,
         &requested_model,
+        ProviderCapability::Embeddings,
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -6,6 +6,7 @@ use crate::core::router::execution::{
     calculate_retry_delay, infer_cooldown_reason, is_retryable_error,
     router_error_to_provider_error,
 };
+use crate::core::types::model::ProviderCapability;
 use crate::utils::error::gateway_error::GatewayError;
 use std::sync::Arc;
 use std::time::Instant;
@@ -63,6 +64,7 @@ impl Drop for StreamingDeploymentLease {
 pub(super) async fn execute_with_selected_deployment<T, F, Fut>(
     router: &UnifiedRouter,
     requested_model: &str,
+    capability: ProviderCapability,
     operation: F,
 ) -> Result<T, GatewayError>
 where
@@ -70,7 +72,7 @@ where
     Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
 {
     let execution = router
-        .execute_with_retry(requested_model, move |deployment_id| {
+        .execute_with_capability_retry(requested_model, &capability, move |deployment_id| {
             let operation = operation.clone();
             async move {
                 let deployment = router.get_deployment(&deployment_id).ok_or_else(|| {
@@ -98,6 +100,7 @@ where
 pub(super) async fn execute_stream_with_selected_deployment<T, F, Fut>(
     router: Arc<UnifiedRouter>,
     requested_model: &str,
+    capability: ProviderCapability,
     operation: F,
 ) -> Result<(T, StreamingDeploymentLease), GatewayError>
 where
@@ -110,21 +113,22 @@ where
     for attempt in 1..=max_attempts {
         let started_at = Instant::now();
 
-        let deployment_id = match router.select_deployment(requested_model) {
-            Ok(id) => id,
-            Err(router_err) => {
-                let provider_err = router_error_to_provider_error(router_err);
+        let deployment_id =
+            match router.select_deployment_for_capability(requested_model, &capability) {
+                Ok(id) => id,
+                Err(router_err) => {
+                    let provider_err = router_error_to_provider_error(router_err);
 
-                if is_retryable_error(&provider_err) && attempt < max_attempts {
-                    let delay = calculate_retry_delay(router.config(), attempt);
-                    last_error = Some(provider_err);
-                    tokio::time::sleep(delay).await;
-                    continue;
+                    if is_retryable_error(&provider_err) && attempt < max_attempts {
+                        let delay = calculate_retry_delay(router.config(), attempt);
+                        last_error = Some(provider_err);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+
+                    return Err(GatewayError::Provider(provider_err));
                 }
-
-                return Err(GatewayError::Provider(provider_err));
-            }
-        };
+            };
 
         let Some(deployment) = router.get_deployment(&deployment_id) else {
             router.release_deployment(&deployment_id);
@@ -182,8 +186,13 @@ mod tests {
     use super::{execute_stream_with_selected_deployment, execute_with_selected_deployment};
     use crate::core::providers::Provider;
     use crate::core::providers::ProviderError;
+    use crate::core::providers::anthropic::{AnthropicConfig, AnthropicProvider};
     use crate::core::providers::openai::OpenAIProvider;
-    use crate::core::router::{Deployment, UnifiedRouter};
+    use crate::core::router::RouterConfig;
+    use crate::core::router::{
+        Deployment, DeploymentConfig, HealthStatus, UnifiedRouter, UnifiedRoutingStrategy,
+    };
+    use crate::core::types::model::ProviderCapability;
     use crate::utils::error::gateway_error::GatewayError;
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
@@ -206,13 +215,60 @@ mod tests {
         router
     }
 
+    async fn build_mixed_capability_router() -> UnifiedRouter {
+        let router = UnifiedRouter::new(RouterConfig {
+            routing_strategy: UnifiedRoutingStrategy::PriorityBased,
+            ..Default::default()
+        });
+
+        let chat_only_provider = Provider::Anthropic(
+            AnthropicProvider::new(AnthropicConfig::new("sk-test-key"))
+                .expect("test provider should build"),
+        );
+        let embedding_provider = Provider::OpenAI(
+            OpenAIProvider::with_api_key("sk-test-key")
+                .await
+                .expect("test provider should build"),
+        );
+
+        router.add_deployment(
+            Deployment::new(
+                "chat-only".to_string(),
+                chat_only_provider,
+                "claude-3-haiku".to_string(),
+                "shared-model".to_string(),
+            )
+            .with_config(DeploymentConfig {
+                priority: 0,
+                ..Default::default()
+            }),
+        );
+        router.add_deployment(
+            Deployment::new(
+                "embedding-capable".to_string(),
+                embedding_provider,
+                "text-embedding-3-small".to_string(),
+                "shared-model".to_string(),
+            )
+            .with_config(DeploymentConfig {
+                priority: 10,
+                ..Default::default()
+            }),
+        );
+
+        router
+    }
+
     #[tokio::test]
     async fn test_execute_with_selected_deployment_uses_actual_deployment_model() {
         let router = build_test_router().await;
 
-        let model = execute_with_selected_deployment(&router, "gpt-4", |_provider, model| async {
-            Ok((model, 0))
-        })
+        let model = execute_with_selected_deployment(
+            &router,
+            "gpt-4",
+            ProviderCapability::ChatCompletion,
+            |_provider, model| async { Ok((model, 0)) },
+        )
         .await
         .expect("execution should succeed");
 
@@ -220,12 +276,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_execute_with_selected_deployment_uses_capability_selected_deployment() {
+        let router = build_mixed_capability_router().await;
+
+        let (provider, model) = execute_with_selected_deployment(
+            &router,
+            "shared-model",
+            ProviderCapability::Embeddings,
+            |provider, model| async move { Ok(((provider.name().to_string(), model), 0)) },
+        )
+        .await
+        .expect("execution should use an embeddings-capable deployment");
+
+        assert_eq!(provider, "openai");
+        assert_eq!(model, "text-embedding-3-small");
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_selected_deployment_rejects_unavailable_capability() {
+        let router = build_mixed_capability_router().await;
+        let deployment = router
+            .get_deployment("embedding-capable")
+            .expect("deployment should exist");
+        deployment
+            .state
+            .health
+            .store(HealthStatus::Unhealthy as u8, Ordering::Relaxed);
+        drop(deployment);
+
+        let err = execute_with_selected_deployment(
+            &router,
+            "shared-model",
+            ProviderCapability::Embeddings,
+            |_provider, _model| async { Ok::<_, ProviderError>(("should not run", 0)) },
+        )
+        .await
+        .expect_err("unavailable capability should fail before execution");
+
+        assert!(matches!(
+            err,
+            GatewayError::Provider(ProviderError::ProviderUnavailable { .. })
+        ));
+    }
+
+    #[tokio::test]
     async fn test_execute_with_selected_deployment_maps_provider_error() {
         let router = build_test_router().await;
 
-        let err = execute_with_selected_deployment(&router, "gpt-4", |_provider, _model| async {
-            Err::<(String, u64), _>(ProviderError::timeout("test", "timed out"))
-        })
+        let err = execute_with_selected_deployment(
+            &router,
+            "gpt-4",
+            ProviderCapability::ChatCompletion,
+            |_provider, _model| async {
+                Err::<(String, u64), _>(ProviderError::timeout("test", "timed out"))
+            },
+        )
         .await
         .expect_err("provider error should be mapped");
 
@@ -242,6 +347,7 @@ mod tests {
         let (_stream, lease) = execute_stream_with_selected_deployment(
             router.clone(),
             "gpt-4",
+            ProviderCapability::ChatCompletionStream,
             |_provider, model| async move { Ok(model) },
         )
         .await
@@ -271,6 +377,7 @@ mod tests {
         let (_stream, lease) = execute_stream_with_selected_deployment(
             router.clone(),
             "gpt-4",
+            ProviderCapability::ChatCompletionStream,
             |_provider, model| async move { Ok(model) },
         )
         .await
@@ -292,6 +399,7 @@ mod tests {
         let (_stream, lease) = execute_stream_with_selected_deployment(
             router.clone(),
             "gpt-4",
+            ProviderCapability::ChatCompletionStream,
             |_provider, model| async move { Ok(model) },
         )
         .await

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -11,7 +11,6 @@ use tracing::info;
 
 use super::context::handle_ai_request;
 use super::execution::execute_with_selected_deployment;
-use super::provider_selection::select_provider_for_optional_model;
 
 /// Image generation endpoint
 ///
@@ -47,15 +46,17 @@ async fn handle_image_generation_internal(
     request: ImageGenerationRequest,
     context: RequestContext,
 ) -> Result<ImageGenerationResponse, GatewayError> {
-    let selected_model = select_provider_for_optional_model(
-        unified_router,
-        request.model.as_deref(),
-        ProviderCapability::ImageGeneration,
-    )?;
+    let requested_model = request
+        .model
+        .clone()
+        .ok_or_else(|| GatewayError::validation("Model is required"))?;
+    if requested_model.trim().is_empty() {
+        return Err(GatewayError::validation("Model is required"));
+    }
 
     let core_request = CoreImageRequest {
         prompt: request.prompt,
-        model: Some(selected_model.clone()),
+        model: Some(requested_model.clone()),
         n: request.n,
         size: request.size,
         response_format: request.response_format,
@@ -67,7 +68,8 @@ async fn handle_image_generation_internal(
     let context_for_execution = context.clone();
     let core_response = execute_with_selected_deployment(
         unified_router,
-        &selected_model,
+        &requested_model,
+        ProviderCapability::ImageGeneration,
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();

--- a/src/server/routes/ai/provider_selection.rs
+++ b/src/server/routes/ai/provider_selection.rs
@@ -13,11 +13,32 @@ pub fn select_provider_for_model(
         return Err(GatewayError::validation("Model is required"));
     }
 
+    let deployments = router.get_deployments_for_model(model);
+    let supports_capability = deployments.iter().any(|deployment_id| {
+        router
+            .get_deployment(deployment_id)
+            .map(|deployment| {
+                deployment
+                    .provider
+                    .capabilities()
+                    .iter()
+                    .any(|cap| cap == &capability)
+            })
+            .unwrap_or(false)
+    });
+
+    if !supports_capability {
+        return Err(GatewayError::validation(format!(
+            "Model '{}' does not support {:?}",
+            model, capability
+        )));
+    }
+
     let deployment = router
         .select_capability_deployment(model, &capability)
         .ok_or_else(|| {
-            GatewayError::validation(format!(
-                "Model '{}' does not support {:?}",
+            GatewayError::service_unavailable(format!(
+                "No available deployment for model '{}' with capability {:?}",
                 model, capability
             ))
         })?;
@@ -25,11 +46,59 @@ pub fn select_provider_for_model(
     Ok(deployment.model)
 }
 
-pub fn select_provider_for_optional_model(
-    router: &UnifiedRouter,
-    model: Option<&str>,
-    capability: ProviderCapability,
-) -> Result<String, GatewayError> {
-    let model = model.ok_or_else(|| GatewayError::validation("Model is required"))?;
-    select_provider_for_model(router, model, capability)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::providers::Provider;
+    use crate::core::providers::openai::OpenAIProvider;
+    use crate::core::router::{Deployment, HealthStatus, UnifiedRouter};
+    use std::sync::atomic::Ordering;
+
+    async fn build_embeddings_router() -> UnifiedRouter {
+        let router = UnifiedRouter::default();
+        let provider = Provider::OpenAI(
+            OpenAIProvider::with_api_key("sk-test-key")
+                .await
+                .expect("test provider should build"),
+        );
+
+        router.add_deployment(Deployment::new(
+            "embeddings-1".to_string(),
+            provider,
+            "text-embedding-3-small".to_string(),
+            "embedding-model".to_string(),
+        ));
+
+        router
+    }
+
+    #[tokio::test]
+    async fn select_provider_for_model_reports_unavailable_for_unroutable_capability() {
+        let router = build_embeddings_router().await;
+        let deployment = router
+            .get_deployment("embeddings-1")
+            .expect("deployment should exist");
+        deployment
+            .state
+            .health
+            .store(HealthStatus::Unhealthy as u8, Ordering::Relaxed);
+        drop(deployment);
+
+        let err =
+            select_provider_for_model(&router, "embedding-model", ProviderCapability::Embeddings)
+                .expect_err("unavailable capable deployment should not look unsupported");
+
+        assert!(matches!(err, GatewayError::Unavailable(_)));
+    }
+
+    #[tokio::test]
+    async fn select_provider_for_model_reports_validation_for_unsupported_capability() {
+        let router = build_embeddings_router().await;
+
+        let err =
+            select_provider_for_model(&router, "embedding-model", ProviderCapability::TextToSpeech)
+                .expect_err("unsupported capability should be a validation failure");
+
+        assert!(matches!(err, GatewayError::Validation(_)));
+    }
 }

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -50,16 +50,6 @@ pub(crate) async fn handle_streaming_response(
         chat_request.model
     );
 
-    let unified_router = &state.unified_router;
-
-    if let Err(e) = super::provider_selection::select_provider_for_model(
-        unified_router,
-        &chat_request.model,
-        ProviderCapability::ChatCompletionStream,
-    ) {
-        return Ok(openai_errors::gateway_error_response(&e));
-    }
-
     chat_request.stream = Some(true);
     let model_name = chat_request.model.clone();
     let resp_id = format!("resp_{}", uuid_v4_hex());
@@ -78,6 +68,7 @@ pub(crate) async fn handle_streaming_response(
     match execute_stream_with_selected_deployment(
         state.unified_router.clone(),
         &requested_model,
+        ProviderCapability::ChatCompletionStream,
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let ctx = context_clone.clone();


### PR DESCRIPTION
## Summary
- add capability-aware router selection that uses the same health, cooldown, concurrency, and rate-limit filters as normal routing
- route chat, streaming chat, embeddings, image generation, and responses streaming through capability-constrained execution instead of a separate precheck
- keep capability validation helpers aligned with routable deployments and add regressions for mixed-capability deployments and unavailable capability deployments

Fixes #410
Fixes #400

## Tests
- cargo fmt --check
- cargo test server::routes::ai::execution::tests --features gateway,storage
- cargo test integration::http_routes_tests --features gateway,storage
- cargo clippy --features gateway,storage --all-targets -- -D warnings
- cargo test --features gateway,storage