### PR TITLE
fix(cli): add gateway release entrypoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,33 +4,221 @@
 
 #![allow(missing_docs)]
 
+use clap::{Parser, Subcommand};
 use litellm_rs::server;
+use litellm_rs::storage::database::Database;
+use litellm_rs::{Config, VERSION};
+use std::path::PathBuf;
 use std::process::ExitCode;
-#[cfg(feature = "tracing")]
+#[cfg(any(feature = "tracing", test))]
 use tracing::Level;
 
-fn init_logging() {
+#[derive(Debug, Parser)]
+#[command(
+    name = "gateway",
+    version = VERSION,
+    about = "Run and manage the LiteLLM-RS gateway"
+)]
+struct Cli {
+    /// Path to the gateway configuration file.
+    #[arg(
+        short,
+        long,
+        global = true,
+        default_value = "config/gateway.yaml",
+        value_name = "FILE"
+    )]
+    config: PathBuf,
+
+    /// Override the configured bind host.
+    #[arg(long, global = true, value_name = "HOST")]
+    host: Option<String>,
+
+    /// Override the configured bind port.
+    #[arg(long, global = true, value_name = "PORT")]
+    port: Option<u16>,
+
+    /// Set gateway log verbosity.
+    #[arg(long, global = true, value_name = "LEVEL")]
+    log_level: Option<String>,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Start the gateway server.
+    Serve,
+    /// Validate the gateway configuration file.
+    ValidateConfig,
+    /// Manage gateway database state.
+    Database {
+        #[command(subcommand)]
+        command: DatabaseCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum DatabaseCommands {
+    /// Run database migrations.
+    Migrate,
+}
+
+#[cfg(any(feature = "tracing", test))]
+fn parse_log_level(level: Option<&str>) -> Level {
+    match level.unwrap_or("info").to_ascii_lowercase().as_str() {
+        "trace" => Level::TRACE,
+        "debug" => Level::DEBUG,
+        "warn" | "warning" => Level::WARN,
+        "error" => Level::ERROR,
+        _ => Level::INFO,
+    }
+}
+
+fn init_logging(log_level: Option<&str>) {
     #[cfg(feature = "tracing")]
     {
         tracing_subscriber::fmt()
-            .with_max_level(Level::INFO)
+            .with_max_level(parse_log_level(log_level))
             .with_target(false)
             .with_thread_ids(false)
             .init();
     }
+    #[cfg(not(feature = "tracing"))]
+    let _ = log_level;
+}
+
+async fn load_config(config_path: &PathBuf) -> litellm_rs::Result<Config> {
+    load_config_with_overrides(config_path, None, None).await
+}
+
+async fn load_config_with_overrides(
+    config_path: &PathBuf,
+    host: Option<&str>,
+    port: Option<u16>,
+) -> litellm_rs::Result<Config> {
+    let mut config = Config::from_file(config_path).await?;
+    if let Some(host) = host {
+        config.gateway.server.host = host.to_string();
+    }
+    if let Some(port) = port {
+        config.gateway.server.port = port;
+    }
+    config.validate()?;
+    Ok(config)
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    init_logging();
+    let cli = Cli::parse();
+    init_logging(cli.log_level.as_deref());
 
-    // Start server (auto-loads config/gateway.yaml)
-    match server::builder::run_server().await {
+    let command = cli.command.unwrap_or(Commands::Serve);
+    let result = match command {
+        Commands::Serve => {
+            server::builder::run_server_with_config_overrides(
+                &cli.config,
+                cli.host.as_deref(),
+                cli.port,
+            )
+            .await
+        }
+        Commands::ValidateConfig => {
+            match load_config_with_overrides(&cli.config, cli.host.as_deref(), cli.port).await {
+                Ok(_) => {
+                    println!("Configuration is valid: {}", cli.config.display());
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+        Commands::Database {
+            command: DatabaseCommands::Migrate,
+        } => match load_config(&cli.config).await {
+            Ok(config) => match Database::new(&config.storage().database).await {
+                Ok(database) => {
+                    let result = database.migrate().await;
+                    if result.is_ok() {
+                        println!("Database migrations completed");
+                    }
+                    result
+                }
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        },
+    };
+
+    match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             // Print error using Display (not Debug) to preserve newlines
             eprintln!("Error: {}", e);
             ExitCode::FAILURE
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_trailing_global_config_for_migration() {
+        let cli = Cli::try_parse_from([
+            "gateway",
+            "database",
+            "migrate",
+            "--config",
+            "/tmp/gateway.yaml",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.config, PathBuf::from("/tmp/gateway.yaml"));
+        match cli.command {
+            Some(Commands::Database {
+                command: DatabaseCommands::Migrate,
+            }) => {}
+            _ => panic!("expected database migrate command"),
+        }
+    }
+
+    #[test]
+    fn defaults_to_config_file_when_omitted() {
+        let cli = Cli::try_parse_from(["gateway", "validate-config"]).unwrap();
+        assert_eq!(cli.config, PathBuf::from("config/gateway.yaml"));
+        assert!(matches!(cli.command, Some(Commands::ValidateConfig)));
+    }
+
+    #[test]
+    fn accepts_legacy_startup_overrides() {
+        let cli = Cli::try_parse_from([
+            "gateway",
+            "--config",
+            "/tmp/gateway.yaml",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8080",
+            "--log-level",
+            "debug",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.config, PathBuf::from("/tmp/gateway.yaml"));
+        assert_eq!(cli.host.as_deref(), Some("0.0.0.0"));
+        assert_eq!(cli.port, Some(8080));
+        assert_eq!(cli.log_level.as_deref(), Some("debug"));
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn parses_log_levels() {
+        assert_eq!(parse_log_level(Some("trace")), Level::TRACE);
+        assert_eq!(parse_log_level(Some("debug")), Level::DEBUG);
+        assert_eq!(parse_log_level(Some("warn")), Level::WARN);
+        assert_eq!(parse_log_level(Some("error")), Level::ERROR);
+        assert_eq!(parse_log_level(Some("unknown")), Level::INFO);
     }
 }

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -6,6 +6,7 @@
 use crate::config::Config;
 use crate::server::HttpServer;
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::path::Path;
 use tracing::info;
 
 /// Server builder for easier configuration
@@ -43,13 +44,33 @@ impl Default for ServerBuilder {
 
 /// Run the server with automatic configuration loading
 pub async fn run_server() -> Result<()> {
+    run_server_with_config_path("config/gateway.yaml").await
+}
+
+/// Run the server with an explicit configuration path.
+pub async fn run_server_with_config_path<P>(config_path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    run_server_with_config_overrides(config_path, None, None).await
+}
+
+/// Run the server with an explicit configuration path and CLI overrides.
+pub async fn run_server_with_config_overrides<P>(
+    config_path: P,
+    host: Option<&str>,
+    port: Option<u16>,
+) -> Result<()>
+where
+    P: AsRef<Path>,
+{
     info!("🚀 Starting Rust LiteLLM Gateway");
 
     // Auto-load configuration file
-    let config_path = "config/gateway.yaml";
-    info!("📄 Loading configuration file: {}", config_path);
+    let config_path = config_path.as_ref();
+    info!("📄 Loading configuration file: {}", config_path.display());
 
-    let config = match Config::from_file(config_path).await {
+    let mut config = match Config::from_file(config_path).await {
         Ok(config) => {
             info!("✅ Configuration file loaded successfully");
             config
@@ -57,7 +78,8 @@ pub async fn run_server() -> Result<()> {
         Err(file_error) => {
             info!(
                 "⚠️  Failed to load {}: {}. Trying environment variables.",
-                config_path, file_error
+                config_path.display(),
+                file_error
             );
             match Config::from_env() {
                 Ok(config) => {
@@ -73,6 +95,13 @@ pub async fn run_server() -> Result<()> {
             }
         }
     };
+
+    if let Some(host) = host {
+        config.gateway.server.host = host.to_string();
+    }
+    if let Some(port) = port {
+        config.gateway.server.port = port;
+    }
 
     // Ensure configuration is valid (including defaults)
     config.validate()?;


### PR DESCRIPTION
## Summary
- add a real `gateway` CLI with `--help`, `--version`, `--config`, `serve`, `validate-config`, and `database migrate`
- route `serve` through the selected config path while preserving the default `config/gateway.yaml` behavior
- add parser tests for the deployment/Homebrew-style `gateway database migrate --config <file>` command shape

## Why
Release/Homebrew users need the downloaded `gateway` binary to respond to basic CLI commands without requiring a full runtime config. This also restores the command forms already documented in deployment scripts.

Refs #427

## Validation
- `cargo fmt --check`
- `cargo test --bin gateway --features gateway,storage`
- `cargo run --bin gateway -- --version`
- `cargo run --bin gateway -- --help`
- `cargo clippy --bin gateway --features gateway,storage -- -D warnings`
- `cargo test --features gateway,storage`
- `git diff --check`