### PR TITLE
fix(release): allow tag workflow to publish assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   # Create GitHub release
   create-release:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -120,7 +120,7 @@ jobs:
         if: steps.version.outputs.current_version != steps.version.outputs.new_version
         run: |
           git add Cargo.toml Cargo.lock CHANGELOG.md
-          git commit -m "chore(release): bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
+          git commit -m "chore(release): bump version to ${{ steps.version.outputs.new_version }}"
           git push
 
       - name: Create Release Tag


### PR DESCRIPTION
## Summary
- grant the release workflow `contents: write` so it can create GitHub Releases and upload assets
- grant `packages: write` for the GHCR release path
- stop version-bump from creating release commits with `[skip ci]`, because that suppresses the tag-triggered release workflow

## Why
The v0.5.0 release run failed at `actions/create-release` with `Resource not accessible by integration`, and the first v0.5.0 tag push was skipped because the target commit contained `[skip ci]`.

Refs #427
Refs #428

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release.yml .github/workflows/version-bump.yml`\n- `git diff --check`