### PR TITLE
fix(release): keep binary publishing resilient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,18 +131,14 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release upload "${{ needs.create-release.outputs.version }}" \
-          ./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.tar.gz \
-          --clobber
+        gh release upload "${{ needs.create-release.outputs.version }}" "./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.tar.gz" --clobber
 
     - name: Upload Release Asset (Windows)
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release upload "${{ needs.create-release.outputs.version }}" \
-          ./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.zip \
-          --clobber
+        gh release upload "${{ needs.create-release.outputs.version }}" "./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.zip" --clobber
 
   # Build and push Docker image
   docker-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RELEASE_FEATURES: postgres,sqlite,redis,s3,metrics,tracing,websockets,analytics,providers-extra,providers-extended,mcp-validation
 
 permissions:
   contents: write
@@ -18,7 +19,6 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
     steps:
     - name: Checkout code
@@ -28,41 +28,54 @@ jobs:
       id: get_version
       run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Create or update Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ steps.get_version.outputs.version }}
-        body_path: CHANGELOG.md
-        draft: false
-        prerelease: false
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        version="${{ steps.get_version.outputs.version }}"
+        if gh release view "$version" >/dev/null 2>&1; then
+          gh release edit "$version" \
+            --title "Release $version" \
+            --notes-file CHANGELOG.md \
+            --draft=false \
+            --prerelease=false
+        else
+          gh release create "$version" \
+            --title "Release $version" \
+            --notes-file CHANGELOG.md \
+            --verify-tag
+        fi
 
   # Build and upload binaries
   build-release:
     name: Build Release
     needs: create-release
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             name: linux-x86_64
+            allow_failure: false
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             name: linux-x86_64-musl
+            allow_failure: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             name: windows-x86_64
+            allow_failure: false
           - os: macos-latest
             target: x86_64-apple-darwin
             name: macos-x86_64
+            allow_failure: false
           - os: macos-latest
             target: aarch64-apple-darwin
             name: macos-aarch64
+            allow_failure: false
 
     steps:
     - name: Checkout code
@@ -97,7 +110,7 @@ jobs:
         brew install postgresql openssl pkg-config
 
     - name: Build release binary
-      run: cargo build --release --target ${{ matrix.target }} --all-features
+      run: cargo build --release --target ${{ matrix.target }} --bin gateway --no-default-features --features "$RELEASE_FEATURES"
 
     - name: Create archive (Unix)
       if: matrix.os != 'windows-latest'
@@ -115,25 +128,21 @@ jobs:
 
     - name: Upload Release Asset (Unix)
       if: matrix.os != 'windows-latest'
-      uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: ./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.tar.gz
-        asset_name: rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.tar.gz
-        asset_content_type: application/gzip
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload "${{ needs.create-release.outputs.version }}" \
+          ./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.tar.gz \
+          --clobber
 
     - name: Upload Release Asset (Windows)
       if: matrix.os == 'windows-latest'
-      uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: ./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.zip
-        asset_name: rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload "${{ needs.create-release.outputs.version }}" \
+          ./rust-litellm-gateway-${{ needs.create-release.outputs.version }}-${{ matrix.name }}.zip \
+          --clobber
 
   # Build and push Docker image
   docker-release:
@@ -141,19 +150,36 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
+    - name: Check Docker credentials
+      id: docker_credentials
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Docker publish skipped::Set DOCKER_USERNAME and DOCKER_PASSWORD to publish Docker images during releases."
+        fi
+
     - name: Checkout code
+      if: steps.docker_credentials.outputs.available == 'true'
       uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
+      if: steps.docker_credentials.outputs.available == 'true'
       uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
+      if: steps.docker_credentials.outputs.available == 'true'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Login to GitHub Container Registry
+      if: steps.docker_credentials.outputs.available == 'true'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -161,6 +187,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract metadata
+      if: steps.docker_credentials.outputs.available == 'true'
       id: meta
       uses: docker/metadata-action@v5
       with:
@@ -174,6 +201,7 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Build and push Docker image
+      if: steps.docker_credentials.outputs.available == 'true'
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -190,13 +218,28 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
+    - name: Check crates.io token
+      id: crates_token
+      env:
+        CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      run: |
+        if [ -n "$CRATES_IO_TOKEN" ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::notice title=crates.io publish skipped::Set CRATES_IO_TOKEN to publish litellm-rs during releases."
+        fi
+
     - name: Checkout code
+      if: steps.crates_token.outputs.available == 'true'
       uses: actions/checkout@v4
 
     - name: Install Rust
+      if: steps.crates_token.outputs.available == 'true'
       uses: dtolnay/rust-toolchain@stable
 
     - name: Cache dependencies
+      if: steps.crates_token.outputs.available == 'true'
       uses: actions/cache@v4
       with:
         path: |
@@ -206,12 +249,16 @@ jobs:
         key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Install system dependencies
+      if: steps.crates_token.outputs.available == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y libpq-dev pkg-config libssl-dev
 
     - name: Publish to crates.io
-      run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+      if: steps.crates_token.outputs.available == 'true'
+      env:
+        CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      run: cargo publish --token "$CRATES_IO_TOKEN"
 
   # Update Homebrew formula from the published macOS release asset
   homebrew-release:


### PR DESCRIPTION
## Summary
- make tag releases idempotent when a GitHub Release already exists
- publish the gateway binary with an explicit release feature set and upload assets with `gh release upload --clobber`
- keep optional Docker/crates.io channels from failing releases when secrets are absent
- allow the optional musl target to fail without blocking macOS/Homebrew assets

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok release"'`\n- `git diff --check`\n- `cargo check --bin gateway --no-default-features --features postgres,sqlite,redis,s3,metrics,tracing,websockets,analytics,providers-extra,providers-extended,mcp-validation`