### PR TITLE
fix(release): build windows assets with release features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,19 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         version="${{ steps.get_version.outputs.version }}"
+        target="$(git rev-list -n 1 "$version")"
         if gh release view "$version" >/dev/null 2>&1; then
           gh release edit "$version" \
             --title "Release $version" \
             --notes-file CHANGELOG.md \
+            --target "$target" \
             --draft=false \
             --prerelease=false
         else
           gh release create "$version" \
             --title "Release $version" \
             --notes-file CHANGELOG.md \
+            --target "$target" \
             --verify-tag
         fi
 
@@ -110,6 +113,7 @@ jobs:
         brew install postgresql openssl pkg-config
 
     - name: Build release binary
+      shell: bash
       run: cargo build --release --target ${{ matrix.target }} --bin gateway --no-default-features --features "$RELEASE_FEATURES"
 
     - name: Create archive (Unix)


### PR DESCRIPTION
## Summary
- run the release binary build step under bash so `$RELEASE_FEATURES` expands consistently on Windows
- update existing GitHub Releases to point at the tag commit when a tag is re-pushed

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok release"'`\n- `git diff --check`\n- `cargo check --bin gateway --no-default-features --features postgres,sqlite,redis,s3,metrics,tracing,websockets,analytics,providers-extra,providers-extended,mcp-validation`\n\n## Release evidence\nThe previous v0.5.0 release run failed only on the Windows matrix leg because PowerShell did not expand `"$RELEASE_FEATURES"`, so cargo built without the required `storage` feature.