### PR TITLE
Continue pricing source convergence

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,19 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-01
+  - Step E3 provider pricing convergence: `in_progress`
+    - Modified files:
+      - `src/core/providers/openai/client.rs`
+      - `src/core/providers/openai/client_tests.rs`
+    - Main changes:
+      - Routed `OpenAIProvider::get_model_pricing` through the shared `core::cost::calculator::get_model_pricing` source before using OpenAI's static registry as a compatibility fallback.
+      - Fixed the provider-level pricing helper that previously returned `None` because `get_model_info` intentionally emits default model metadata with no pricing fields.
+      - Added a regression test proving `gpt-4o-mini` provider pricing now uses the shared cost source.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test core::providers::openai::client_tests::test_model_pricing` -> pass (`2` matching tests)
+      - `cargo test core::providers::openai::client_tests::test_model_pricing_prefers_shared_cost_source` -> pass (`1` test)
+      - `cargo test pricing` -> pass (`175` lib filtered tests, `1` integration filtered test)
   - Step E3 utility convergence: `in_progress`
     - Modified files:
       - `src/utils/ai/models/pricing.rs`

--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -928,14 +928,18 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
     - Modified files:
       - `src/core/providers/openai/client.rs`
       - `src/core/providers/openai/client_tests.rs`
+      - `src/core/providers/anthropic/models.rs`
+      - `src/core/providers/anthropic/mod.rs`
     - Main changes:
       - Routed `OpenAIProvider::get_model_pricing` through the shared `core::cost::calculator::get_model_pricing` source before using OpenAI's static registry as a compatibility fallback.
       - Fixed the provider-level pricing helper that previously returned `None` because `get_model_info` intentionally emits default model metadata with no pricing fields.
       - Added a regression test proving `gpt-4o-mini` provider pricing now uses the shared cost source.
+      - Routed Anthropic's basic `CostCalculator::calculate_cost` through shared `core::cost::calculator::generic_cost_per_token`, keeping the provider registry fallback for compatibility.
     - Execute tests:
       - `cargo fmt --all -- --check` -> pass
       - `cargo test core::providers::openai::client_tests::test_model_pricing` -> pass (`2` matching tests)
       - `cargo test core::providers::openai::client_tests::test_model_pricing_prefers_shared_cost_source` -> pass (`1` test)
+      - `cargo test core::providers::anthropic::tests::test_cost_estimation` -> pass (`1` test)
       - `cargo test pricing` -> pass (`175` lib filtered tests, `1` integration filtered test)
   - Step E3 utility convergence: `in_progress`
     - Modified files:

--- a/src/core/providers/anthropic/mod.rs
+++ b/src/core/providers/anthropic/mod.rs
@@ -234,8 +234,8 @@ mod tests {
     #[test]
     fn test_cost_estimation() {
         let cost = estimate_cost("claude-opus-4-7", 1000, 500);
-        assert!(cost.is_some());
-        assert!(cost.unwrap() > 0.0);
+        let cost = cost.expect("claude-opus-4-7 should have Anthropic pricing");
+        assert!((cost - 0.0175).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/core/providers/anthropic/models.rs
+++ b/src/core/providers/anthropic/models.rs
@@ -1129,6 +1129,13 @@ impl CostCalculator {
         prompt_tokens: u32,
         completion_tokens: u32,
     ) -> Option<f64> {
+        let usage = crate::core::cost::types::UsageTokens::new(prompt_tokens, completion_tokens);
+        if let Ok(breakdown) =
+            crate::core::cost::calculator::generic_cost_per_token(model_id, &usage, "anthropic")
+        {
+            return Some(breakdown.total_cost);
+        }
+
         let registry = get_anthropic_registry();
         let pricing = registry.get_model_pricing(model_id)?;
 

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -598,7 +598,17 @@ impl OpenAIProvider {
 
     /// Get model pricing information
     pub fn get_model_pricing(&self, model_id: &str) -> Option<(f64, f64)> {
-        if let Ok(model_info) = self.get_model_info(model_id)
+        if let Ok(pricing) = crate::core::cost::calculator::get_model_pricing(model_id, "openai") {
+            return Some((
+                pricing.input_cost_per_1k_tokens,
+                pricing.output_cost_per_1k_tokens,
+            ));
+        }
+
+        if let Some(model_info) = self
+            .model_registry
+            .get_model_spec(model_id)
+            .map(|spec| &spec.model_info)
             && let (Some(input_cost), Some(output_cost)) = (
                 model_info.input_cost_per_1k_tokens,
                 model_info.output_cost_per_1k_tokens,

--- a/src/core/providers/openai/client_tests.rs
+++ b/src/core/providers/openai/client_tests.rs
@@ -634,10 +634,21 @@ fn test_feature_support() {
 fn test_model_pricing() {
     let provider = create_test_provider();
 
-    if let Some((input_cost, output_cost)) = provider.get_model_pricing("gpt-4") {
-        assert!(input_cost > 0.0);
-        assert!(output_cost > input_cost); // Output usually costs more
-    }
+    let (input_cost, output_cost) = provider
+        .get_model_pricing("gpt-4")
+        .expect("gpt-4 should have OpenAI pricing");
+    assert!(input_cost > 0.0);
+    assert!(output_cost > input_cost); // Output usually costs more
+}
+
+#[test]
+fn test_model_pricing_prefers_shared_cost_source() {
+    let provider = create_test_provider();
+
+    assert_eq!(
+        provider.get_model_pricing("gpt-4o-mini"),
+        Some((0.00015, 0.0006))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- route OpenAIProvider pricing lookup through the shared core cost pricing source
- keep the OpenAI static registry as a compatibility fallback
- route Anthropic basic cost estimation through shared core cost pricing while preserving the provider registry fallback
- add regression coverage for gpt-4o-mini shared pricing and update the remediation execution log

## Validation
- cargo fmt --all -- --check
- cargo test core::providers::openai::client_tests::test_model_pricing
- cargo test core::providers::openai::client_tests::test_model_pricing_prefers_shared_cost_source
- cargo test core::providers::anthropic::tests::test_cost_estimation
- cargo test pricing
- git diff --check
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if