### PR TITLE
Route Gemini basic cost through shared pricing

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,19 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-01
+  - Step E3 Gemini pricing convergence: `in_progress`
+    - Modified files:
+      - `src/core/providers/gemini/models.rs`
+    - Main changes:
+      - Routed Gemini's basic `CostCalculator::calculate_cost` through shared `core::cost::calculator::generic_cost_per_token` using the `vertex_ai` pricing source.
+      - Kept the Gemini registry fallback so provider-only model aliases such as `gemini-1.0-pro` remain priced even when the shared catalog does not have an exact entry.
+    - Execute tests:
+      - `cargo test --features providers-extended core::providers::gemini::models::tests::test_cost_calculation` -> pass (`3` matching tests)
+      - `cargo test --features providers-extended core::providers::gemini::models::tests::test_cost_calculation_keeps_registry_fallback` -> pass (`covered by the same filtered run`)
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test pricing` -> pass (`175` lib filtered tests, `1` integration filtered test)
+      - `cargo check --all-features` -> pass
+      - `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extended" -- -D warnings --force-warn clippy::collapsible-if` -> pass
   - Step E3 provider pricing convergence: `in_progress`
     - Modified files:
       - `src/core/providers/openai/client.rs`

--- a/src/core/providers/gemini/models.rs
+++ b/src/core/providers/gemini/models.rs
@@ -1211,6 +1211,13 @@ impl CostCalculator {
         prompt_tokens: u32,
         completion_tokens: u32,
     ) -> Option<f64> {
+        let usage = crate::core::cost::types::UsageTokens::new(prompt_tokens, completion_tokens);
+        if let Ok(breakdown) =
+            crate::core::cost::calculator::generic_cost_per_token(model_id, &usage, "vertex_ai")
+        {
+            return Some(breakdown.total_cost);
+        }
+
         let registry = get_gemini_registry();
         let pricing = registry.get_model_pricing(model_id)?;
 
@@ -1335,6 +1342,14 @@ mod tests {
         let cost_value = cost.unwrap();
         // Expected: (1000/1M * $0.075) + (500/1M * $0.30) = $0.000075 + $0.00015 = $0.000225
         assert!((cost_value - 0.000225).abs() < 0.000001);
+    }
+
+    #[test]
+    fn test_cost_calculation_keeps_registry_fallback() {
+        let cost = CostCalculator::calculate_cost("gemini-1.0-pro", 1000, 500)
+            .expect("Gemini registry fallback should price gemini-1.0-pro");
+
+        assert!((cost - 0.00125).abs() < 0.000001);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route Gemini basic cost calculation through shared core cost pricing with the vertex_ai source
- preserve Gemini registry fallback for provider-only aliases such as gemini-1.0-pro
- update the E3 execution log with validation evidence

## Validation
- cargo test --features providers-extended core::providers::gemini::models::tests::test_cost_calculation
- cargo fmt --all -- --check
- cargo test pricing
- git diff --check
- cargo check --all-features
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extended" -- -D warnings --force-warn clippy::collapsible-if