### PR TITLE
Route OpenAI cost through shared pricing

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,19 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-01
+  - Step E3 OpenAI cost convergence: `in_progress`
+    - Modified files:
+      - `src/core/providers/openai/client.rs`
+      - `src/core/providers/openai/client_tests.rs`
+    - Main changes:
+      - Routed `OpenAIProvider::calculate_cost` through shared `core::cost::calculator::generic_cost_per_token`.
+      - Kept the previous default-model-info fallback so unknown/custom OpenAI-compatible model names still return the compatibility cost instead of hard failing.
+      - Strengthened the provider cost test to prove `gpt-4o-mini` no longer prices as zero.
+    - Execute tests:
+      - `cargo test core::providers::openai::client_tests::test_calculate_cost` -> pass (`2` matching tests)
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test pricing` -> pass (`175` lib filtered tests, `1` integration filtered test)
+      - `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if` -> pass
   - Step E3 Gemini pricing convergence: `in_progress`
     - Modified files:
       - `src/core/providers/gemini/models.rs`

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -441,6 +441,13 @@ impl LLMProvider for OpenAIProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
+        let usage = crate::core::cost::types::UsageTokens::new(input_tokens, output_tokens);
+        if let Ok(breakdown) =
+            crate::core::cost::calculator::generic_cost_per_token(model, &usage, "openai")
+        {
+            return Ok(breakdown.total_cost);
+        }
+
         let model_info = self.get_model_info(model)?;
 
         let input_cost = model_info

--- a/src/core/providers/openai/client_tests.rs
+++ b/src/core/providers/openai/client_tests.rs
@@ -413,12 +413,11 @@ async fn test_map_openai_params_passthrough() {
 async fn test_calculate_cost() {
     let provider = create_test_provider();
 
-    let cost = provider.calculate_cost("gpt-4", 1000, 500).await;
+    let cost = provider.calculate_cost("gpt-4o-mini", 1000, 500).await;
     assert!(cost.is_ok());
 
-    // Cost should be 0 for unknown pricing (default model info has None for costs)
     let cost_value = cost.unwrap();
-    assert!(cost_value >= 0.0);
+    assert!((cost_value - 0.00045).abs() < f64::EPSILON);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- route OpenAIProvider calculate_cost through the shared core cost pricing path
- preserve the existing compatibility fallback for unknown/custom OpenAI-compatible models
- strengthen the provider cost test so gpt-4o-mini no longer silently prices as zero
- update the E3 execution log with validation evidence

## Validation
- cargo test core::providers::openai::client_tests::test_calculate_cost
- cargo fmt --all -- --check
- cargo test pricing
- git diff --check
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if