### PR TITLE
Unify Bedrock provider pricing shape

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -923,6 +923,25 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 
 ## 9. Execution Log
 
+- 2026-05-02
+  - Step E3 Bedrock pricing convergence: `in_progress`
+    - Modified files:
+      - `src/core/providers/bedrock/utils/cost.rs`
+      - `src/core/providers/bedrock/provider.rs`
+    - Main changes:
+      - Added a compatibility adapter from Bedrock's AWS-model static pricing entries into the shared `core::cost::types::ModelPricing` shape.
+      - Routed Bedrock provider model metadata through the shared cost model shape while preserving the existing Bedrock pricing table as the data source for AWS model IDs.
+      - Added a regression test proving the shared-shape adapter preserves model ID, input/output rates, and currency.
+    - Execute tests:
+      - `cargo test --features providers-extra core::providers::bedrock::utils::cost::tests::test_core_model_pricing_lookup -- --exact` -> pass (`1` test)
+      - `cargo test --features providers-extra core::providers::bedrock::utils::cost::tests::` -> pass (`50` tests)
+      - `cargo test --features providers-extra core::providers::bedrock::provider_tests::` -> pass (`48` tests)
+      - `cargo fmt --all -- --check` -> pass
+      - `git diff --check` -> pass
+      - `cargo test pricing` -> pass (`175` lib filtered tests, `1` integration filtered test)
+      - `cargo test cost` -> pass (`326` lib filtered tests)
+      - `cargo check --all-features` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
 - 2026-05-01
   - Step E3 OpenAI cost convergence: `in_progress`
     - Modified files:

--- a/src/core/providers/bedrock/provider.rs
+++ b/src/core/providers/bedrock/provider.rs
@@ -66,7 +66,7 @@ impl BedrockProvider {
         let available_models = CostCalculator::get_all_models();
 
         for model_id in available_models {
-            if let Some(pricing) = CostCalculator::get_model_pricing(model_id)
+            if let Some(pricing) = CostCalculator::get_core_model_pricing(model_id)
                 && let Ok(model_config) = get_model_config(model_id)
             {
                 models.push(ModelInfo {
@@ -81,9 +81,9 @@ impl BedrockProvider {
                     supports_streaming: model_config.supports_streaming,
                     supports_tools: model_config.supports_function_calling,
                     supports_multimodal: model_config.supports_multimodal,
-                    input_cost_per_1k_tokens: Some(pricing.input_cost_per_1k),
-                    output_cost_per_1k_tokens: Some(pricing.output_cost_per_1k),
-                    currency: pricing.currency.to_string(),
+                    input_cost_per_1k_tokens: Some(pricing.input_cost_per_1k_tokens),
+                    output_cost_per_1k_tokens: Some(pricing.output_cost_per_1k_tokens),
+                    currency: pricing.currency,
                     capabilities: vec![],
                     created_at: None,
                     updated_at: None,

--- a/src/core/providers/bedrock/utils/cost.rs
+++ b/src/core/providers/bedrock/utils/cost.rs
@@ -14,6 +14,20 @@ pub struct ModelPricing {
     pub currency: &'static str,
 }
 
+impl ModelPricing {
+    /// Convert Bedrock's static pricing entry into the shared cost model.
+    pub fn to_core_model_pricing(&self, model_id: &str) -> crate::core::cost::types::ModelPricing {
+        crate::core::cost::types::ModelPricing {
+            model: model_id.to_string(),
+            input_cost_per_1k_tokens: self.input_cost_per_1k,
+            output_cost_per_1k_tokens: self.output_cost_per_1k,
+            currency: self.currency.to_string(),
+            updated_at: chrono::Utc::now(),
+            ..Default::default()
+        }
+    }
+}
+
 /// Comprehensive pricing database for all Bedrock models
 static MODEL_PRICING: LazyLock<HashMap<&'static str, ModelPricing>> = LazyLock::new(|| {
     let mut pricing = HashMap::new();
@@ -603,6 +617,15 @@ impl CostCalculator {
         MODEL_PRICING.get(model_id)
     }
 
+    /// Get pricing information in the shared core cost model shape.
+    pub fn get_core_model_pricing(
+        model_id: &str,
+    ) -> Option<crate::core::cost::types::ModelPricing> {
+        MODEL_PRICING
+            .get(model_id)
+            .map(|pricing| pricing.to_core_model_pricing(model_id))
+    }
+
     /// Get all available models with pricing
     pub fn get_all_models() -> Vec<&'static str> {
         MODEL_PRICING.keys().copied().collect()
@@ -770,6 +793,16 @@ mod tests {
             CostCalculator::get_model_pricing("anthropic.claude-3-opus-20240229").unwrap();
         assert_eq!(pricing.input_cost_per_1k, 0.015);
         assert_eq!(pricing.output_cost_per_1k, 0.075);
+        assert_eq!(pricing.currency, "USD");
+    }
+
+    #[test]
+    fn test_core_model_pricing_lookup() {
+        let pricing =
+            CostCalculator::get_core_model_pricing("anthropic.claude-3-opus-20240229").unwrap();
+        assert_eq!(pricing.model, "anthropic.claude-3-opus-20240229");
+        assert_eq!(pricing.input_cost_per_1k_tokens, 0.015);
+        assert_eq!(pricing.output_cost_per_1k_tokens, 0.075);
         assert_eq!(pricing.currency, "USD");
     }
 


### PR DESCRIPTION
## Summary
- add a Bedrock pricing adapter that converts AWS model pricing entries into the shared core cost `ModelPricing` shape
- route Bedrock provider model metadata through the shared cost shape while preserving the existing Bedrock AWS pricing data source
- document the E3 execution slice in the audit remediation plan

## Tests
- cargo test --features providers-extra core::providers::bedrock::utils::cost::tests::test_core_model_pricing_lookup -- --exact
- cargo test --features providers-extra core::providers::bedrock::utils::cost::tests::
- cargo test --features providers-extra core::providers::bedrock::provider_tests::
- cargo fmt --all -- --check
- git diff --check
- cargo test pricing
- cargo test cost
- cargo check --all-features
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if