### PR TITLE
Converge Spark pricing adapter

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -959,6 +959,21 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
       - `cargo test cost` -> pass (`326` lib filtered tests)
       - `cargo check --all-features` -> pass
       - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
+  - Step E3 Spark registry convergence: `in_progress`
+    - Modified files:
+      - `src/core/providers/spark/model_info.rs`
+    - Main changes:
+      - Added an adapter from Spark per-million-token registry pricing into the shared `core::cost::types::ModelPricing` shape.
+      - Routed Spark fallback cost calculation through the shared cost model shape.
+      - Added a regression test for Spark unit conversion and currency preservation.
+    - Execute tests:
+      - `cargo test --features providers-extended core::providers::spark::model_info::tests::` -> pass (`6` tests)
+      - `cargo fmt --all -- --check` -> pass
+      - `git diff --check` -> pass
+      - `cargo test pricing` -> pass (`176` lib filtered tests, `1` integration filtered test)
+      - `cargo test cost` -> pass (`326` lib filtered tests)
+      - `cargo check --all-features` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
 - 2026-05-01
   - Step E3 OpenAI cost convergence: `in_progress`
     - Modified files:

--- a/src/core/providers/spark/model_info.rs
+++ b/src/core/providers/spark/model_info.rs
@@ -31,6 +31,20 @@ pub struct ModelPricing {
     pub output_price: f64,
 }
 
+impl ModelPricing {
+    /// Convert Spark's per-million-token registry pricing into the shared cost model.
+    pub fn to_core_model_pricing(&self, model_id: &str) -> crate::core::cost::types::ModelPricing {
+        crate::core::cost::types::ModelPricing {
+            model: model_id.to_string(),
+            input_cost_per_1k_tokens: self.input_price / 1000.0,
+            output_cost_per_1k_tokens: self.output_price / 1000.0,
+            currency: "USD".to_string(),
+            updated_at: chrono::Utc::now(),
+            ..Default::default()
+        }
+    }
+}
+
 /// Model limits
 #[derive(Debug, Clone)]
 pub struct ModelLimits {
@@ -240,6 +254,15 @@ impl SparkModelRegistry {
         self.models.get(model_id)
     }
 
+    /// Get model pricing in the shared core cost model shape.
+    pub fn get_core_model_pricing(
+        &self,
+        model_id: &str,
+    ) -> Option<crate::core::cost::types::ModelPricing> {
+        self.get_model_spec(model_id)
+            .map(|spec| spec.pricing.to_core_model_pricing(model_id))
+    }
+
     /// List all models
     pub fn list_models(&self) -> Vec<&ModelSpec> {
         self.models.values().collect()
@@ -272,10 +295,10 @@ impl CostCalculator {
     /// Calculate cost for a request
     pub fn calculate_cost(model_id: &str, input_tokens: u32, output_tokens: u32) -> Option<f64> {
         let registry = get_spark_registry();
-        let spec = registry.get_model_spec(model_id)?;
+        let pricing = registry.get_core_model_pricing(model_id)?;
 
-        let input_cost = (input_tokens as f64 / 1_000_000.0) * spec.pricing.input_price;
-        let output_cost = (output_tokens as f64 / 1_000_000.0) * spec.pricing.output_price;
+        let input_cost = (input_tokens as f64 / 1000.0) * pricing.input_cost_per_1k_tokens;
+        let output_cost = (output_tokens as f64 / 1000.0) * pricing.output_cost_per_1k_tokens;
 
         Some(input_cost + output_cost)
     }
@@ -321,6 +344,19 @@ mod tests {
         let v2_spec = registry.get_model_spec("spark-desk-v2").unwrap();
         assert_eq!(v2_spec.limits.max_context_length, 4096);
         assert_eq!(v2_spec.limits.max_output_tokens, 2048);
+    }
+
+    #[test]
+    fn test_core_model_pricing_conversion() {
+        let registry = get_spark_registry();
+        let pricing = registry
+            .get_core_model_pricing("spark-desk-v3.5")
+            .expect("registry pricing should convert to core pricing");
+
+        assert_eq!(pricing.model, "spark-desk-v3.5");
+        assert_eq!(pricing.input_cost_per_1k_tokens, 0.003);
+        assert_eq!(pricing.output_cost_per_1k_tokens, 0.006);
+        assert_eq!(pricing.currency, "USD");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a shared core cost `ModelPricing` adapter for Spark registry pricing
- route Spark fallback cost calculation through the shared cost shape
- record the E3 execution evidence in the audit remediation plan

## Tests
- cargo test --features providers-extended core::providers::spark::model_info::tests::
- cargo fmt --all -- --check
- git diff --check
- cargo test pricing
- cargo test cost
- cargo check --all-features
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if