### PR TITLE
Fix AuthConfig default JWT state

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -663,7 +663,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 
 ### Step E5 C16 AuthConfig default consistency
 
-- status: `pending`
+- status: `completed`
 - Expected changes:
   - `src/config/models/auth.rs`
   - config builder/tests
@@ -924,6 +924,27 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E5 AuthConfig default consistency: `completed`
+    - Modified files:
+      - `src/config/models/auth.rs`
+      - `src/config/models/gateway_tests.rs`
+      - `src/config/validation/tests.rs`
+      - `tests/integration/config_validation_tests.rs`
+    - Main changes:
+      - Changed the model-level and serde default for `enable_jwt` to `false`, while preserving API key authentication as enabled by default.
+      - Kept explicit JWT configurations fail-closed: empty, short, placeholder, or weak secrets still fail whenever JWT is enabled.
+      - Added a regression test proving configs that omit `enable_jwt` and `jwt_secret` deserialize with JWT disabled and validate without a generated secret.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test auth_config_default` -> pass (`1` matching test)
+      - `cargo test config::models::auth` -> pass (`24` tests)
+      - `cargo test config::validation` -> pass (`158` tests)
+      - `cargo test config_validation_tests` -> pass (`31` integration tests)
+      - `cargo test test_gateway_config_validate_empty_jwt_secret` -> pass (`1` matching test)
+      - `cargo test test_gateway_config_empty_jwt_secret` -> pass (`1` integration matching test)
+      - `git diff --check` -> pass
+      - `cargo check --all-features` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E3 Bedrock pricing convergence: `in_progress`
     - Modified files:
       - `src/core/providers/bedrock/utils/cost.rs`

--- a/src/config/models/auth.rs
+++ b/src/config/models/auth.rs
@@ -8,12 +8,13 @@ use tracing::warn;
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AuthConfig {
     /// Enable JWT authentication
-    #[serde(default = "default_true")]
+    #[serde(default = "default_auth_enable_jwt")]
     pub enable_jwt: bool,
     /// Enable API key authentication
     #[serde(default = "default_true")]
     pub enable_api_key: bool,
     /// JWT secret
+    #[serde(default)]
     pub jwt_secret: String,
     /// JWT expiration in seconds
     #[serde(default = "default_jwt_expiration")]
@@ -51,7 +52,7 @@ impl std::fmt::Debug for AuthConfig {
 impl Default for AuthConfig {
     fn default() -> Self {
         Self {
-            enable_jwt: true,
+            enable_jwt: default_auth_enable_jwt(),
             enable_api_key: true,
             jwt_secret: String::new(),
             jwt_expiration: default_jwt_expiration(),
@@ -146,6 +147,10 @@ impl AuthConfig {
     pub fn is_production_ready(&self) -> bool {
         self.enable_jwt || self.enable_api_key
     }
+}
+
+fn default_auth_enable_jwt() -> bool {
+    false
 }
 
 fn is_forbidden_jwt_placeholder(secret: &str) -> bool {
@@ -310,17 +315,27 @@ mod tests {
     #[test]
     fn test_auth_config_default() {
         let config = AuthConfig::default();
-        assert!(config.enable_jwt);
+        assert!(!config.enable_jwt);
         assert!(config.enable_api_key);
         assert!(config.jwt_secret.is_empty());
         assert_eq!(config.jwt_expiration, 86400); // 24 hours
         assert_eq!(config.api_key_header, "Authorization");
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.contains("jwt_secret is empty"),
-            "Expected empty secret error, got: {}",
-            err
-        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_auth_config_deserialize_missing_enable_jwt_defaults_disabled() {
+        let json = r#"{
+            "enable_api_key": true,
+            "jwt_expiration": 3600,
+            "api_key_header": "Authorization"
+        }"#;
+        let config: AuthConfig = serde_json::from_str(json).unwrap();
+
+        assert!(!config.enable_jwt);
+        assert!(config.enable_api_key);
+        assert!(config.jwt_secret.is_empty());
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -300,6 +300,7 @@ fn test_gateway_config_validate_empty_database_url() {
 #[test]
 fn test_gateway_config_validate_empty_jwt_secret() {
     let mut config = create_valid_config();
+    config.auth.enable_jwt = true;
     config.auth.jwt_secret = "".to_string();
     let result = config.validate();
     assert!(result.is_err());

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -153,6 +153,7 @@ fn test_provider_config_empty_name() {
 #[test]
 fn test_auth_config_validation() {
     let mut config = AuthConfig {
+        enable_jwt: true,
         jwt_secret: "A-very-long-secret-key-for-testing-purposes123!".to_string(),
         ..Default::default()
     };
@@ -169,6 +170,7 @@ fn test_auth_config_validation() {
 fn test_auth_config_jwt_secret_min_length() {
     // Exactly minimum length with mixed characters (required by validation)
     let config = AuthConfig {
+        enable_jwt: true,
         jwt_secret: "aA1!".repeat(8), // 32 bytes with mixed case, numbers, and special chars
         ..Default::default()
     };
@@ -176,6 +178,7 @@ fn test_auth_config_jwt_secret_min_length() {
 
     // Just under minimum length
     let config = AuthConfig {
+        enable_jwt: true,
         jwt_secret: "aA1!".repeat(7) + "aA1", // 31 bytes
         ..Default::default()
     };

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -93,6 +93,7 @@ mod tests {
     #[test]
     fn test_gateway_config_empty_jwt_secret() {
         let mut config = create_valid_gateway_config();
+        config.auth.enable_jwt = true;
         config.auth.jwt_secret = String::new();
 
         let result = config.validate();


### PR DESCRIPTION
## Summary
- default AuthConfig no longer enables JWT with an empty secret
- add serde defaults so missing JWT fields deserialize as disabled JWT state
- keep explicit JWT configs fail-closed and update plan/test coverage

## Verification
- cargo fmt --all -- --check
- cargo test auth_config_default
- cargo test config::models::auth
- cargo test config::validation
- cargo test config_validation_tests
- cargo test test_gateway_config_validate_empty_jwt_secret
- cargo test test_gateway_config_empty_jwt_secret
- git diff --check
- cargo check --all-features
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if
