### PR TITLE
Derive provider support from registry

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -678,7 +678,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 
 ### Step E6 C17/C18 provider source-of-truth convergence
 
-- status: `pending`
+- status: `completed`
 - Expected changes:
   - `src/core/providers/provider_type.rs`
   - `src/core/providers/factory/registry.rs`
@@ -694,7 +694,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 - Completion judgment:
   - Parseable provider types cannot be silently unreachable.
 - Owner decision:
-  - Confirm enum dispatch versus trait-object direction.
+  - Resolved for E6: keep enum dispatch; registry convergence removes list drift without a trait-object refactor.
 
 ### Step E7 H13/H17 orphan provider decisions
 
@@ -924,6 +924,24 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E6 provider source-of-truth convergence: `completed`
+    - Modified files:
+      - `src/core/providers/provider_type.rs`
+      - `src/core/providers/registry/types.rs`
+      - `src/core/providers/registry/mod.rs`
+      - `src/core/providers/mod.rs`
+    - Main changes:
+      - Routed `ProviderType::from`, strict `FromStr`, and `Display` through the canonical provider registry entry matrix.
+      - Replaced the hand-maintained `factory_supported_provider_types` list with the registry-derived dispatchable provider slice.
+      - Kept enum dispatch while making unsupported enum variants explicit via `ProviderDispatchKind::UnsupportedEnum`.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test provider_type` -> pass (`60` matching tests)
+      - `cargo test core::providers::factory::` -> pass (`28` tests)
+      - `cargo test core::providers::registry::types` -> pass (`6` tests)
+      - `git diff --check` -> pass
+      - `cargo check --all-features` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E5 AuthConfig default consistency: `completed`
     - Modified files:
       - `src/config/models/auth.rs`

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -363,42 +363,7 @@ impl Provider {
 
     /// Single source of truth for factory branches currently wired in `from_config_async`.
     pub fn factory_supported_provider_types() -> &'static [ProviderType] {
-        static SUPPORTED: &[ProviderType] = &[
-            ProviderType::OpenAI,
-            ProviderType::Anthropic,
-            ProviderType::Mistral,
-            ProviderType::Cloudflare,
-            ProviderType::OpenAICompatible,
-            // Tier 2: providers with explicit OpenAI-compatible factory branches
-            ProviderType::MetaLlama,
-            ProviderType::V0,
-            ProviderType::AzureAI,
-            ProviderType::AmazonNova,
-            ProviderType::FalAI,
-            ProviderType::Azure,
-            ProviderType::Bedrock,
-            ProviderType::VertexAI,
-            ProviderType::Replicate,
-            ProviderType::GitHub,
-            ProviderType::GitHubCopilot,
-            // Catalog-covered provider types (Tier 1)
-            ProviderType::Groq,
-            ProviderType::OpenRouter,
-            ProviderType::DeepSeek,
-            ProviderType::DeepInfra,
-            ProviderType::Moonshot,
-            ProviderType::Minimax,
-            ProviderType::Dashscope,
-            ProviderType::XAI,
-            ProviderType::Perplexity,
-            ProviderType::Hyperbolic,
-            ProviderType::Infinity,
-            ProviderType::Novita,
-            ProviderType::Volcengine,
-            ProviderType::Nebius,
-            ProviderType::Nscale,
-        ];
-        SUPPORTED
+        registry::dispatchable_provider_types_slice()
     }
 
     /// Check if provider supports a specific model

--- a/src/core/providers/provider_type.rs
+++ b/src/core/providers/provider_type.rs
@@ -40,43 +40,9 @@ pub enum ProviderType {
 
 impl From<&str> for ProviderType {
     fn from(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "openai" => ProviderType::OpenAI,
-            "anthropic" => ProviderType::Anthropic,
-            "bedrock" | "aws-bedrock" => ProviderType::Bedrock,
-            "openrouter" => ProviderType::OpenRouter,
-            "vertex_ai" | "vertexai" | "vertex-ai" => ProviderType::VertexAI,
-            "azure" | "azure-openai" => ProviderType::Azure,
-            "azure_ai" | "azureai" | "azure-ai" => ProviderType::AzureAI,
-            "deepseek" | "deep-seek" => ProviderType::DeepSeek,
-            "deepinfra" | "deep-infra" => ProviderType::DeepInfra,
-            "v0" => ProviderType::V0,
-            "meta_llama" | "llama" | "meta-llama" => ProviderType::MetaLlama,
-            "mistral" | "mistralai" => ProviderType::Mistral,
-            "moonshot" | "moonshot-ai" => ProviderType::Moonshot,
-            "minimax" | "minimax-ai" => ProviderType::Minimax,
-            "dashscope" | "alibaba" | "qwen" | "tongyi" => ProviderType::Dashscope,
-            "groq" => ProviderType::Groq,
-            "xai" => ProviderType::XAI,
-            "cloudflare" | "cf" | "workers-ai" => ProviderType::Cloudflare,
-            "perplexity" | "perplexity-ai" | "pplx" => ProviderType::Perplexity,
-            "replicate" | "replicate-ai" => ProviderType::Replicate,
-            "fal_ai" | "fal-ai" | "fal" => ProviderType::FalAI,
-            "amazon_nova" | "amazon-nova" | "nova" => ProviderType::AmazonNova,
-            "github" | "github-models" => ProviderType::GitHub,
-            "github_copilot" | "github-copilot" | "copilot" => ProviderType::GitHubCopilot,
-            "hyperbolic" | "hyperbolic-ai" => ProviderType::Hyperbolic,
-            "infinity" | "infinity-embedding" => ProviderType::Infinity,
-            "novita" | "novita-ai" => ProviderType::Novita,
-            "volcengine" | "volc" | "doubao" | "bytedance" => ProviderType::Volcengine,
-            "nebius" | "nebius-ai" => ProviderType::Nebius,
-            "nscale" | "nscale-ai" => ProviderType::Nscale,
-            "pydantic_ai" | "pydantic-ai" | "pydantic" => ProviderType::PydanticAI,
-            "openai_compatible" | "openai-compatible" | "openai_like" | "openai-like" => {
-                ProviderType::OpenAICompatible
-            }
-            _ => ProviderType::Custom(s.to_string()),
-        }
+        crate::core::providers::registry::entry_for_name(s)
+            .map(|entry| entry.provider_type.clone())
+            .unwrap_or_else(|| ProviderType::Custom(s.to_string()))
     }
 }
 
@@ -94,89 +60,29 @@ impl std::str::FromStr for ProviderType {
     type Err = crate::core::types::errors::ConfigError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "openai" => Ok(ProviderType::OpenAI),
-            "anthropic" => Ok(ProviderType::Anthropic),
-            "bedrock" | "aws-bedrock" => Ok(ProviderType::Bedrock),
-            "openrouter" => Ok(ProviderType::OpenRouter),
-            "vertex_ai" | "vertexai" | "vertex-ai" => Ok(ProviderType::VertexAI),
-            "azure" | "azure-openai" => Ok(ProviderType::Azure),
-            "azure_ai" | "azureai" | "azure-ai" => Ok(ProviderType::AzureAI),
-            "deepseek" | "deep-seek" => Ok(ProviderType::DeepSeek),
-            "deepinfra" | "deep-infra" => Ok(ProviderType::DeepInfra),
-            "v0" => Ok(ProviderType::V0),
-            "meta_llama" | "llama" | "meta-llama" => Ok(ProviderType::MetaLlama),
-            "mistral" | "mistralai" => Ok(ProviderType::Mistral),
-            "moonshot" | "moonshot-ai" => Ok(ProviderType::Moonshot),
-            "minimax" | "minimax-ai" => Ok(ProviderType::Minimax),
-            "dashscope" | "alibaba" | "qwen" | "tongyi" => Ok(ProviderType::Dashscope),
-            "groq" => Ok(ProviderType::Groq),
-            "xai" => Ok(ProviderType::XAI),
-            "cloudflare" | "cf" | "workers-ai" => Ok(ProviderType::Cloudflare),
-            "perplexity" | "perplexity-ai" | "pplx" => Ok(ProviderType::Perplexity),
-            "replicate" | "replicate-ai" => Ok(ProviderType::Replicate),
-            "fal_ai" | "fal-ai" | "fal" => Ok(ProviderType::FalAI),
-            "amazon_nova" | "amazon-nova" | "nova" => Ok(ProviderType::AmazonNova),
-            "github" | "github-models" => Ok(ProviderType::GitHub),
-            "github_copilot" | "github-copilot" | "copilot" => Ok(ProviderType::GitHubCopilot),
-            "hyperbolic" | "hyperbolic-ai" => Ok(ProviderType::Hyperbolic),
-            "infinity" | "infinity-embedding" => Ok(ProviderType::Infinity),
-            "novita" | "novita-ai" => Ok(ProviderType::Novita),
-            "volcengine" | "volc" | "doubao" | "bytedance" => Ok(ProviderType::Volcengine),
-            "nebius" | "nebius-ai" => Ok(ProviderType::Nebius),
-            "nscale" | "nscale-ai" => Ok(ProviderType::Nscale),
-            "pydantic_ai" | "pydantic-ai" | "pydantic" => Ok(ProviderType::PydanticAI),
-            "openai_compatible" | "openai-compatible" | "openai_like" | "openai-like" => {
-                Ok(ProviderType::OpenAICompatible)
-            }
-            _ => Err(crate::core::types::errors::ConfigError::InvalidValue {
+        crate::core::providers::registry::entry_for_name(s)
+            .map(|entry| entry.provider_type.clone())
+            .ok_or_else(|| crate::core::types::errors::ConfigError::InvalidValue {
                 field: "provider_type".to_string(),
                 value: format!(
                     "unknown provider type '{}'; use a recognised provider name or construct \
                      ProviderType::Custom explicitly",
                     s
                 ),
-            }),
-        }
+            })
     }
 }
 
 impl std::fmt::Display for ProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProviderType::OpenAI => write!(f, "openai"),
-            ProviderType::Anthropic => write!(f, "anthropic"),
-            ProviderType::Bedrock => write!(f, "bedrock"),
-            ProviderType::OpenRouter => write!(f, "openrouter"),
-            ProviderType::VertexAI => write!(f, "vertex_ai"),
-            ProviderType::Azure => write!(f, "azure"),
-            ProviderType::AzureAI => write!(f, "azure_ai"),
-            ProviderType::DeepSeek => write!(f, "deepseek"),
-            ProviderType::DeepInfra => write!(f, "deepinfra"),
-            ProviderType::V0 => write!(f, "v0"),
-            ProviderType::MetaLlama => write!(f, "meta_llama"),
-            ProviderType::Mistral => write!(f, "mistral"),
-            ProviderType::Moonshot => write!(f, "moonshot"),
-            ProviderType::Minimax => write!(f, "minimax"),
-            ProviderType::Dashscope => write!(f, "dashscope"),
-            ProviderType::Groq => write!(f, "groq"),
-            ProviderType::XAI => write!(f, "xai"),
-            ProviderType::Cloudflare => write!(f, "cloudflare"),
-            ProviderType::Perplexity => write!(f, "perplexity"),
-            ProviderType::Replicate => write!(f, "replicate"),
-            ProviderType::FalAI => write!(f, "fal_ai"),
-            ProviderType::AmazonNova => write!(f, "amazon_nova"),
-            ProviderType::GitHub => write!(f, "github"),
-            ProviderType::GitHubCopilot => write!(f, "github_copilot"),
-            ProviderType::Hyperbolic => write!(f, "hyperbolic"),
-            ProviderType::Infinity => write!(f, "infinity"),
-            ProviderType::Novita => write!(f, "novita"),
-            ProviderType::Volcengine => write!(f, "volcengine"),
-            ProviderType::Nebius => write!(f, "nebius"),
-            ProviderType::Nscale => write!(f, "nscale"),
-            ProviderType::PydanticAI => write!(f, "pydantic_ai"),
-            ProviderType::OpenAICompatible => write!(f, "openai_compatible"),
             ProviderType::Custom(name) => write!(f, "{}", name),
+            provider_type => {
+                match crate::core::providers::registry::entry_for_type(provider_type) {
+                    Some(entry) => write!(f, "{}", entry.canonical_name),
+                    None => write!(f, "{:?}", provider_type),
+                }
+            }
         }
     }
 }

--- a/src/core/providers/registry/mod.rs
+++ b/src/core/providers/registry/mod.rs
@@ -14,5 +14,6 @@ pub use catalog::{PROVIDER_CATALOG, get_definition, is_tier1_provider};
 pub use definition::{AuthType, ProviderDefinition};
 pub use types::{
     PROVIDER_TYPE_REGISTRY, ProviderDispatchKind, ProviderRegistryEntry,
-    dispatchable_provider_types, entry_for_name, entry_for_type, provider_type_registry,
+    dispatchable_provider_types, dispatchable_provider_types_slice, entry_for_name, entry_for_type,
+    provider_type_registry,
 };

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -1,9 +1,11 @@
 //! Canonical provider registry matrix.
 //!
-//! This module is intentionally observational for now: it records provider
-//! identity, aliases, and dispatch class without replacing factory routing yet.
+//! This module is the canonical provider identity matrix for enum variants:
+//! aliases, display names, dispatchability, and factory support are derived
+//! from these entries.
 
 use crate::core::providers::provider_type::ProviderType;
+use std::sync::LazyLock;
 
 /// How a provider selector is currently dispatched.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -277,6 +279,14 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
     ),
 ];
 
+static DISPATCHABLE_PROVIDER_TYPES: LazyLock<Vec<ProviderType>> = LazyLock::new(|| {
+    PROVIDER_TYPE_REGISTRY
+        .iter()
+        .filter(|entry| entry.is_dispatchable())
+        .map(|entry| entry.provider_type.clone())
+        .collect()
+});
+
 pub fn provider_type_registry() -> &'static [ProviderRegistryEntry] {
     PROVIDER_TYPE_REGISTRY
 }
@@ -294,11 +304,11 @@ pub fn entry_for_name(name: &str) -> Option<&'static ProviderRegistryEntry> {
 }
 
 pub fn dispatchable_provider_types() -> Vec<ProviderType> {
-    PROVIDER_TYPE_REGISTRY
-        .iter()
-        .filter(|entry| entry.is_dispatchable())
-        .map(|entry| entry.provider_type.clone())
-        .collect()
+    dispatchable_provider_types_slice().to_vec()
+}
+
+pub fn dispatchable_provider_types_slice() -> &'static [ProviderType] {
+    DISPATCHABLE_PROVIDER_TYPES.as_slice()
 }
 
 const fn entry(


### PR DESCRIPTION
## Summary
- route ProviderType parsing and display through the canonical provider registry entries
- derive factory-supported provider types from registry dispatchability instead of a hand-maintained list
- record E6 completion and the enum-dispatch decision in the audit remediation plan

## Verification
- cargo fmt --all -- --check
- cargo test provider_type
- cargo test core::providers::factory::
- cargo test core::providers::registry::types
- git diff --check
- cargo check --all-features
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if
