### PR TITLE
Route pricing consumers through core pricing

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,30 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E3 core pricing consumer migration batch 1: `in_progress`
+    - Modified files:
+      - `src/core/providers/mod.rs`
+      - `src/core/providers/ai21/models.rs`
+      - `src/core/providers/ai21/provider.rs`
+      - `src/core/providers/amazon_nova/provider.rs`
+      - `src/core/providers/cohere/provider.rs`
+      - `src/core/providers/databricks/provider.rs`
+      - `src/core/providers/datarobot/provider.rs`
+      - `src/core/providers/exa_ai/provider.rs`
+      - `src/core/providers/firecrawl/provider.rs`
+      - `src/core/providers/openai/models/registry.rs`
+    - Main changes:
+      - Migrated the first direct consumers from `core::providers::base::pricing::Usage` / `base::get_pricing_db` to `core::pricing`.
+      - Kept provider-base compatibility exports in place while reducing real usage of the legacy path.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test core::providers::openai::models` -> pass (`6` tests)
+      - `cargo test core::providers::ai21` -> pass (`0` matching tests)
+      - `cargo test core::providers::cohere` -> pass (`0` matching tests)
+      - `cargo test pricing` -> pass (`178` lib filtered tests, `1` integration filtered test)
+      - `git diff --check` -> pass
+      - `cargo check --all-features` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E3 core pricing database ownership: `in_progress`
     - Modified files:
       - `src/core/pricing.rs`

--- a/src/core/providers/ai21/models.rs
+++ b/src/core/providers/ai21/models.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use crate::core::providers::base::get_pricing_db;
+use crate::core::pricing::get_pricing_db;
 use crate::core::types::model::ModelInfo;
 
 /// Model feature flags

--- a/src/core/providers/ai21/provider.rs
+++ b/src/core/providers/ai21/provider.rs
@@ -174,7 +174,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/amazon_nova/provider.rs
+++ b/src/core/providers/amazon_nova/provider.rs
@@ -185,7 +185,7 @@ crate::define_pooled_http_provider_with_hooks!(
             return Ok(input_cost + output_cost);
         }
 
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/cohere/provider.rs
+++ b/src/core/providers/cohere/provider.rs
@@ -554,7 +554,7 @@ impl LLMProvider for CohereProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/databricks/provider.rs
+++ b/src/core/providers/databricks/provider.rs
@@ -570,7 +570,7 @@ impl LLMProvider for DatabricksProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/datarobot/provider.rs
+++ b/src/core/providers/datarobot/provider.rs
@@ -129,7 +129,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/exa_ai/provider.rs
+++ b/src/core/providers/exa_ai/provider.rs
@@ -219,7 +219,7 @@ impl LLMProvider for ExaAiProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/firecrawl/provider.rs
+++ b/src/core/providers/firecrawl/provider.rs
@@ -138,7 +138,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -406,14 +406,14 @@ impl Provider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::providers::base::pricing::Usage {
+        let usage = crate::core::pricing::Usage {
             prompt_tokens: input_tokens,
             completion_tokens: output_tokens,
             total_tokens: input_tokens + output_tokens,
             reasoning_tokens: None,
         };
 
-        Ok(crate::core::providers::base::get_pricing_db().calculate(model, &usage))
+        Ok(crate::core::pricing::get_pricing_db().calculate(model, &usage))
     }
 
     /// Execute streaming chat completion

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use crate::core::providers::base::get_pricing_db;
+use crate::core::pricing::get_pricing_db;
 use crate::core::types::model::ModelInfo;
 
 use super::registry_types::{


### PR DESCRIPTION
## Summary
- move the first batch of provider pricing consumers from provider-base compatibility paths to core::pricing
- update central provider cost helper and OpenAI/AI21 model registries to use core pricing directly
- record this E3 consumer-migration batch in the audit remediation plan

## Verification
- cargo fmt --all -- --check
- cargo test core::providers::openai::models
- cargo test core::providers::ai21
- cargo test core::providers::cohere
- cargo test pricing
- git diff --check
- cargo check --all-features
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if

Note: local VibeGuard pre-commit was skipped with VIBEGUARD_SKIP_PRECOMMIT=1 because its internal cargo check times out after 10s. The explicit verification commands above passed.