### PR TITLE
Converge Anthropic and Gemini pricing models

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,30 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E3 Anthropic/Gemini pricing model convergence: `in_progress`
+    - Modified files:
+      - `src/core/cost/types.rs`
+      - `src/core/cost/calculator.rs`
+      - `src/core/cost/utils.rs`
+      - `src/core/providers/anthropic/models.rs`
+      - `src/core/providers/gemini/mod.rs`
+      - `src/core/providers/gemini/models.rs`
+    - Main changes:
+      - Extended the shared `core::cost::types::ModelPricing` shape with provider-needed batch/video/audio fields so Anthropic and Gemini no longer need provider-local pricing structs.
+      - Re-exported the shared model from the Anthropic and Gemini registry modules to preserve the existing public import paths.
+      - Kept per-million-token authoring helpers inside the registries, while storing normalized per-1K token costs in the shared model.
+      - Preserved Gemini's public `get_model_pricing()` return units by converting shared per-1K costs back to the previous per-million tuple.
+      - Confirmed provider-local `pub struct ModelPricing`, `impl ModelPricing`, and `to_core_model_pricing` adapters are gone from `src/core/providers`.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test --all-features core::providers::anthropic::models::tests::` -> pass (`5` tests)
+      - `cargo test --all-features core::providers::gemini::models::tests::` -> pass (`25` tests)
+      - `cargo test pricing` -> pass (`179` lib filtered tests, `1` integration filtered test)
+      - `cargo test cost` -> pass (`326` lib filtered tests)
+      - `cargo check --all-features` -> pass
+      - `git diff --check` -> pass
+      - `rg -n "pub struct ModelPricing|impl ModelPricing|to_core_model_pricing" src/core/providers -g '*.rs'` -> no matches
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E3 Bedrock pricing model convergence: `in_progress`
     - Modified files:
       - `src/core/providers/bedrock/utils/cost.rs`

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -193,8 +193,11 @@ fn litellm_to_cost_pricing(
         image_cost_per_token: extra_f64(info, "image_cost_per_token"),
         reasoning_cost_per_token: extra_f64(info, "output_cost_per_reasoning_token"),
         cost_per_second: info.cost_per_second,
+        video_cost_per_second: extra_f64(info, "video_cost_per_second"),
+        audio_cost_per_second: extra_f64(info, "audio_cost_per_second"),
         cost_per_image: None,
         tiered_pricing: None,
+        batch_discount: extra_f64(info, "batch_discount"),
         currency: "USD".to_string(),
         updated_at: Utc::now(),
     }

--- a/src/core/cost/types.rs
+++ b/src/core/cost/types.rs
@@ -86,10 +86,16 @@ pub struct ModelPricing {
     pub reasoning_cost_per_token: Option<f64>,
     /// Cost per second (for speech/TTS models)
     pub cost_per_second: Option<f64>,
+    /// Video processing cost per second
+    pub video_cost_per_second: Option<f64>,
+    /// Audio processing cost per second
+    pub audio_cost_per_second: Option<f64>,
     /// Cost per image (for image generation)
     pub cost_per_image: Option<HashMap<String, f64>>,
     /// Tiered pricing for high volume (above threshold pricing)
     pub tiered_pricing: Option<HashMap<String, f64>>,
+    /// Batch processing discount multiplier, when a provider exposes one
+    pub batch_discount: Option<f64>,
     /// Currency (usually "USD")
     pub currency: String,
     /// Last updated timestamp
@@ -109,8 +115,11 @@ impl Default for ModelPricing {
             image_cost_per_token: None,
             reasoning_cost_per_token: None,
             cost_per_second: None,
+            video_cost_per_second: None,
+            audio_cost_per_second: None,
             cost_per_image: None,
             tiered_pricing: None,
+            batch_discount: None,
             currency: "USD".to_string(),
             updated_at: Utc::now(),
         }

--- a/src/core/cost/utils.rs
+++ b/src/core/cost/utils.rs
@@ -16,6 +16,9 @@ pub fn get_cost_per_unit(pricing: &ModelPricing, cost_key: &str) -> f64 {
         "image_cost_per_token" => pricing.image_cost_per_token.unwrap_or(0.0),
         "reasoning_cost_per_token" => pricing.reasoning_cost_per_token.unwrap_or(0.0),
         "cost_per_second" => pricing.cost_per_second.unwrap_or(0.0),
+        "video_cost_per_second" => pricing.video_cost_per_second.unwrap_or(0.0),
+        "audio_cost_per_second" => pricing.audio_cost_per_second.unwrap_or(0.0),
+        "batch_discount" => pricing.batch_discount.unwrap_or(0.0),
         _ => 0.0,
     }
 }

--- a/src/core/providers/anthropic/models.rs
+++ b/src/core/providers/anthropic/models.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
+pub use crate::core::cost::types::ModelPricing;
 use crate::core::types::model::ModelInfo;
 
 /// Model
@@ -67,34 +68,22 @@ pub enum AnthropicModelFamily {
     ClaudeInstant,
 }
 
-/// Model pricing information
-#[derive(Debug, Clone)]
-pub struct ModelPricing {
-    /// Input token price (USD per million tokens)
-    pub input_price: f64,
-    /// Output token price (USD per million tokens)
-    pub output_price: f64,
-    /// Cache write price (optional)
-    pub cache_write_price: Option<f64>,
-    /// Cache read price (optional)
-    pub cache_read_price: Option<f64>,
-    /// Batch processing discount
-    pub batch_discount: Option<f64>,
-}
-
-impl ModelPricing {
-    /// Convert Anthropic's per-million-token registry pricing into the shared cost model.
-    pub fn to_core_model_pricing(&self, model_id: &str) -> crate::core::cost::types::ModelPricing {
-        crate::core::cost::types::ModelPricing {
-            model: model_id.to_string(),
-            input_cost_per_1k_tokens: self.input_price / 1000.0,
-            output_cost_per_1k_tokens: self.output_price / 1000.0,
-            cache_creation_input_token_cost: self.cache_write_price.map(|price| price / 1000.0),
-            cache_read_input_token_cost: self.cache_read_price.map(|price| price / 1000.0),
-            currency: "USD".to_string(),
-            updated_at: chrono::Utc::now(),
-            ..Default::default()
-        }
+fn pricing_per_million(
+    input_price: f64,
+    output_price: f64,
+    cache_write_price: Option<f64>,
+    cache_read_price: Option<f64>,
+    batch_discount: Option<f64>,
+) -> ModelPricing {
+    ModelPricing {
+        input_cost_per_1k_tokens: input_price / 1000.0,
+        output_cost_per_1k_tokens: output_price / 1000.0,
+        cache_creation_input_token_cost: cache_write_price.map(|price| price / 1000.0),
+        cache_read_input_token_cost: cache_read_price.map(|price| price / 1000.0),
+        batch_discount,
+        currency: "USD".to_string(),
+        updated_at: chrono::Utc::now(),
+        ..Default::default()
     }
 }
 
@@ -194,13 +183,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 5.0,
-                    output_price: 25.0,
-                    cache_write_price: Some(6.25),
-                    cache_read_price: Some(0.50),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(5.0, 25.0, Some(6.25), Some(0.50), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 128_000,
@@ -248,13 +231,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 5.0,
-                    output_price: 25.0,
-                    cache_write_price: Some(6.25),
-                    cache_read_price: Some(0.50),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(5.0, 25.0, Some(6.25), Some(0.50), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 128_000,
@@ -302,13 +279,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 5.0,              // $5/1M input (updated from OpenRouter)
-                    output_price: 25.0,            // $25/1M output (updated from OpenRouter)
-                    cache_write_price: Some(6.25), // 1.25x input
-                    cache_read_price: Some(0.50),  // 0.1x input
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(5.0, 25.0, Some(6.25), Some(0.50), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 64_000,
@@ -356,13 +327,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 3.0,
-                    output_price: 15.0,
-                    cache_write_price: Some(3.75),
-                    cache_read_price: Some(0.30),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(3.0, 15.0, Some(3.75), Some(0.30), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 64_000,
@@ -410,13 +375,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 3.0,
-                    output_price: 15.0,
-                    cache_write_price: Some(3.75),
-                    cache_read_price: Some(0.30),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(3.0, 15.0, Some(3.75), Some(0.30), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 64_000,
@@ -463,13 +422,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::BatchProcessing,
                     ModelFeature::ThinkingMode,
                 ],
-                pricing: ModelPricing {
-                    input_price: 1.0,
-                    output_price: 5.0,
-                    cache_write_price: Some(1.25),
-                    cache_read_price: Some(0.10),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(1.0, 5.0, Some(1.25), Some(0.10), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 64_000,
@@ -517,13 +470,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 3.0,
-                    output_price: 15.0,
-                    cache_write_price: Some(3.75),
-                    cache_read_price: Some(0.30),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(3.0, 15.0, Some(3.75), Some(0.30), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 16_000,
@@ -571,13 +518,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 15.0,
-                    output_price: 75.0,
-                    cache_write_price: Some(18.75),
-                    cache_read_price: Some(1.50),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(15.0, 75.0, Some(18.75), Some(1.50), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 32_000,
@@ -625,13 +566,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 15.0,
-                    output_price: 75.0,
-                    cache_write_price: Some(18.75),
-                    cache_read_price: Some(1.50),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(15.0, 75.0, Some(18.75), Some(1.50), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 32_000,
@@ -677,13 +612,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::SystemMessages,
                     ModelFeature::BatchProcessing,
                 ],
-                pricing: ModelPricing {
-                    input_price: 1.0,
-                    output_price: 5.0,
-                    cache_write_price: Some(1.25),
-                    cache_read_price: Some(0.10),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(1.0, 5.0, Some(1.25), Some(0.10), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 8_192,
@@ -731,13 +660,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::ThinkingMode,
                     ModelFeature::ComputerUse,
                 ],
-                pricing: ModelPricing {
-                    input_price: 3.0,
-                    output_price: 15.0,
-                    cache_write_price: Some(3.75),
-                    cache_read_price: Some(0.30),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(3.0, 15.0, Some(3.75), Some(0.30), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 8_192,
@@ -783,13 +706,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::SystemMessages,
                     ModelFeature::BatchProcessing,
                 ],
-                pricing: ModelPricing {
-                    input_price: 15.0,
-                    output_price: 75.0,
-                    cache_write_price: Some(18.75),
-                    cache_read_price: Some(1.50),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(15.0, 75.0, Some(18.75), Some(1.50), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 4_096,
@@ -835,13 +752,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::SystemMessages,
                     ModelFeature::BatchProcessing,
                 ],
-                pricing: ModelPricing {
-                    input_price: 3.0,
-                    output_price: 15.0,
-                    cache_write_price: Some(3.75),
-                    cache_read_price: Some(0.30),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(3.0, 15.0, Some(3.75), Some(0.30), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 4_096,
@@ -887,13 +798,7 @@ impl AnthropicModelRegistry {
                     ModelFeature::SystemMessages,
                     ModelFeature::BatchProcessing,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.25,
-                    output_price: 1.25,
-                    cache_write_price: Some(0.30),
-                    cache_read_price: Some(0.03),
-                    batch_discount: Some(0.5),
-                },
+                pricing: pricing_per_million(0.25, 1.25, Some(0.30), Some(0.03), Some(0.5)),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 4_096,
@@ -930,13 +835,7 @@ impl AnthropicModelRegistry {
                 },
                 family: AnthropicModelFamily::Claude21,
                 features: vec![ModelFeature::StreamingSupport, ModelFeature::SystemMessages],
-                pricing: ModelPricing {
-                    input_price: 8.0,
-                    output_price: 24.0,
-                    cache_write_price: None,
-                    cache_read_price: None,
-                    batch_discount: None,
-                },
+                pricing: pricing_per_million(8.0, 24.0, None, None, None),
                 limits: ModelLimits {
                     max_context_length: 200_000,
                     max_output_tokens: 4_096,
@@ -973,13 +872,7 @@ impl AnthropicModelRegistry {
                 },
                 family: AnthropicModelFamily::ClaudeInstant,
                 features: vec![ModelFeature::StreamingSupport, ModelFeature::SystemMessages],
-                pricing: ModelPricing {
-                    input_price: 0.80,
-                    output_price: 2.40,
-                    cache_write_price: None,
-                    cache_read_price: None,
-                    batch_discount: None,
-                },
+                pricing: pricing_per_million(0.80, 2.40, None, None, None),
                 limits: ModelLimits {
                     max_context_length: 100_000,
                     max_output_tokens: 4_096,
@@ -1014,7 +907,8 @@ impl AnthropicModelRegistry {
     }
 
     /// Register a model
-    fn register_model(&mut self, id: &str, spec: ModelSpec) {
+    fn register_model(&mut self, id: &str, mut spec: ModelSpec) {
+        spec.pricing.model = id.to_string();
         self.models.insert(id.to_string(), spec);
     }
 
@@ -1022,6 +916,7 @@ impl AnthropicModelRegistry {
         if let Some(spec) = self.models.get(target) {
             let mut alias_spec = spec.clone();
             alias_spec.model_info.id = alias.to_string();
+            alias_spec.pricing.model = alias.to_string();
             self.models.insert(alias.to_string(), alias_spec);
         }
     }
@@ -1054,12 +949,9 @@ impl AnthropicModelRegistry {
     }
 
     /// Get model pricing in the shared core cost model shape.
-    pub fn get_core_model_pricing(
-        &self,
-        model_id: &str,
-    ) -> Option<crate::core::cost::types::ModelPricing> {
+    pub fn get_core_model_pricing(&self, model_id: &str) -> Option<ModelPricing> {
         self.get_model_spec(model_id)
-            .map(|spec| spec.pricing.to_core_model_pricing(model_id))
+            .map(|spec| spec.pricing.clone())
     }
 
     /// Get model limits
@@ -1181,10 +1073,9 @@ impl CostCalculator {
     ) -> Option<f64> {
         let registry = get_anthropic_registry();
         let pricing = registry.get_core_model_pricing(model_id)?;
-        let legacy_pricing = registry.get_model_pricing(model_id)?;
 
         let batch_multiplier = if is_batch {
-            legacy_pricing.batch_discount.unwrap_or(1.0)
+            pricing.batch_discount.unwrap_or(1.0)
         } else {
             1.0
         };
@@ -1252,8 +1143,8 @@ mod tests {
         assert!(opus_spec.features.contains(&ModelFeature::ComputerUse));
 
         // Test pricing
-        assert_eq!(opus_spec.pricing.input_price, 5.0);
-        assert_eq!(opus_spec.pricing.output_price, 25.0);
+        assert_eq!(opus_spec.pricing.input_cost_per_1k_tokens, 0.005);
+        assert_eq!(opus_spec.pricing.output_cost_per_1k_tokens, 0.025);
     }
 
     #[test]
@@ -1268,6 +1159,7 @@ mod tests {
         assert_eq!(pricing.output_cost_per_1k_tokens, 0.025);
         assert_eq!(pricing.cache_creation_input_token_cost, Some(0.00625));
         assert_eq!(pricing.cache_read_input_token_cost, Some(0.0005));
+        assert_eq!(pricing.batch_discount, Some(0.5));
         assert_eq!(pricing.currency, "USD");
     }
 

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -59,7 +59,10 @@ pub fn is_model_supported(model_id: &str) -> bool {
 
 /// Get model pricing
 pub fn get_model_pricing(model_id: &str) -> Option<(f64, f64)> {
-    get_gemini_registry()
-        .get_model_pricing(model_id)
-        .map(|p| (p.input_price, p.output_price))
+    get_gemini_registry().get_model_pricing(model_id).map(|p| {
+        (
+            p.input_cost_per_1k_tokens * 1000.0,
+            p.output_cost_per_1k_tokens * 1000.0,
+        )
+    })
 }

--- a/src/core/providers/gemini/models.rs
+++ b/src/core/providers/gemini/models.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
+pub use crate::core::cost::types::ModelPricing;
 use crate::core::providers::shared::{
     GEMINI_15_PRO_CONTEXT_WINDOW, GEMINI_20_FLASH_CONTEXT_WINDOW,
     GEMINI_20_FLASH_THINKING_CONTEXT_WINDOW,
@@ -78,40 +79,28 @@ pub enum GeminiModelFamily {
     GeminiExperimental,
 }
 
-/// Model
-#[derive(Debug, Clone)]
-pub struct ModelPricing {
-    /// Input token price (USD per million tokens)
-    pub input_price: f64,
-    /// Output token price (USD per million tokens)
-    pub output_price: f64,
-    /// Cached input price (optional)
-    pub cached_input_price: Option<f64>,
-    /// Image price (per image)
-    pub image_price: Option<f64>,
-    /// Video price (per second)
-    pub video_price_per_second: Option<f64>,
-    /// Audio price (per second)
-    pub audio_price_per_second: Option<f64>,
-}
-
-impl ModelPricing {
-    /// Convert Gemini's per-million-token registry pricing into the shared cost model.
-    pub fn to_core_model_pricing(&self, model_id: &str) -> crate::core::cost::types::ModelPricing {
-        crate::core::cost::types::ModelPricing {
-            model: model_id.to_string(),
-            input_cost_per_1k_tokens: self.input_price / 1000.0,
-            output_cost_per_1k_tokens: self.output_price / 1000.0,
-            cache_read_input_token_cost: self.cached_input_price.map(|price| price / 1000.0),
-            cost_per_image: self.image_price.map(|price| {
-                let mut costs = HashMap::new();
-                costs.insert("default".to_string(), price);
-                costs
-            }),
-            currency: "USD".to_string(),
-            updated_at: chrono::Utc::now(),
-            ..Default::default()
-        }
+fn pricing_per_million(
+    input_price: f64,
+    output_price: f64,
+    cached_input_price: Option<f64>,
+    image_price: Option<f64>,
+    video_price_per_second: Option<f64>,
+    audio_price_per_second: Option<f64>,
+) -> ModelPricing {
+    ModelPricing {
+        input_cost_per_1k_tokens: input_price / 1000.0,
+        output_cost_per_1k_tokens: output_price / 1000.0,
+        cache_read_input_token_cost: cached_input_price.map(|price| price / 1000.0),
+        cost_per_image: image_price.map(|price| {
+            let mut costs = HashMap::new();
+            costs.insert("default".to_string(), price);
+            costs
+        }),
+        video_cost_per_second: video_price_per_second,
+        audio_cost_per_second: audio_price_per_second,
+        currency: "USD".to_string(),
+        updated_at: chrono::Utc::now(),
+        ..Default::default()
     }
 }
 
@@ -212,14 +201,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 2.0,
-                    output_price: 12.0,
-                    cached_input_price: Some(0.2),
-                    image_price: Some(0.005),
-                    video_price_per_second: Some(0.005),
-                    audio_price_per_second: Some(0.0005),
-                },
+                pricing: pricing_per_million(
+                    2.0,
+                    12.0,
+                    Some(0.2),
+                    Some(0.005),
+                    Some(0.005),
+                    Some(0.0005),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_048_576,
                     max_output_tokens: 65536,
@@ -272,14 +261,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.075,
-                    output_price: 0.30,
-                    cached_input_price: Some(0.01875),
-                    image_price: Some(0.0002),
-                    video_price_per_second: Some(0.0002),
-                    audio_price_per_second: Some(0.00002),
-                },
+                pricing: pricing_per_million(
+                    0.075,
+                    0.30,
+                    Some(0.01875),
+                    Some(0.0002),
+                    Some(0.0002),
+                    Some(0.00002),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_048_576,
                     max_output_tokens: 65536,
@@ -332,14 +321,7 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.25,
-                    output_price: 1.5,
-                    cached_input_price: Some(0.025),
-                    image_price: None,
-                    video_price_per_second: None,
-                    audio_price_per_second: None,
-                },
+                pricing: pricing_per_million(0.25, 1.5, Some(0.025), None, None, None),
                 limits: ModelLimits {
                     max_context_length: 1_048_576,
                     max_output_tokens: 65536,
@@ -394,14 +376,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 2.0,   // $2 per 1M tokens (<=200K)
-                    output_price: 12.0, // $12 per 1M tokens (<=200K)
-                    cached_input_price: Some(0.5),
-                    image_price: Some(0.005),
-                    video_price_per_second: Some(0.005),
-                    audio_price_per_second: Some(0.0005),
-                },
+                pricing: pricing_per_million(
+                    2.0,
+                    12.0,
+                    Some(0.5),
+                    Some(0.005),
+                    Some(0.005),
+                    Some(0.0005),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 65536,
@@ -453,14 +435,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 4.0,   // $4 per 1M tokens (deep think mode)
-                    output_price: 24.0, // $24 per 1M tokens (deep think mode)
-                    cached_input_price: Some(1.0),
-                    image_price: Some(0.01),
-                    video_price_per_second: Some(0.01),
-                    audio_price_per_second: Some(0.001),
-                },
+                pricing: pricing_per_million(
+                    4.0,
+                    24.0,
+                    Some(1.0),
+                    Some(0.01),
+                    Some(0.01),
+                    Some(0.001),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 65536,
@@ -513,14 +495,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.5,  // $0.50 per 1M tokens
-                    output_price: 3.0, // $3 per 1M tokens
-                    cached_input_price: Some(0.05),
-                    image_price: Some(0.002),
-                    video_price_per_second: Some(0.002),
-                    audio_price_per_second: Some(0.0002),
-                },
+                pricing: pricing_per_million(
+                    0.5,
+                    3.0,
+                    Some(0.05),
+                    Some(0.002),
+                    Some(0.002),
+                    Some(0.0002),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_048_576,
                     max_output_tokens: 65536,
@@ -565,14 +547,7 @@ impl GeminiModelRegistry {
                     ModelFeature::SystemInstructions,
                     ModelFeature::JsonMode,
                 ],
-                pricing: ModelPricing {
-                    input_price: 2.0,   // $2 per 1M tokens
-                    output_price: 12.0, // $12 per 1M tokens
-                    cached_input_price: Some(0.5),
-                    image_price: Some(0.04), // Image generation pricing
-                    video_price_per_second: None,
-                    audio_price_per_second: None,
-                },
+                pricing: pricing_per_million(2.0, 12.0, Some(0.5), Some(0.04), None, None),
                 limits: ModelLimits {
                     max_context_length: 65536,
                     max_output_tokens: 8192,
@@ -627,14 +602,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 1.25,  // $1.25 per 1M tokens (<=200K)
-                    output_price: 10.0, // $10 per 1M tokens (<=200K)
-                    cached_input_price: Some(0.3125),
-                    image_price: Some(0.005),
-                    video_price_per_second: Some(0.005),
-                    audio_price_per_second: Some(0.0005),
-                },
+                pricing: pricing_per_million(
+                    1.25,
+                    10.0,
+                    Some(0.3125),
+                    Some(0.005),
+                    Some(0.005),
+                    Some(0.0005),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 65536,
@@ -687,14 +662,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.30,  // $0.30 per 1M tokens
-                    output_price: 2.50, // $2.50 per 1M tokens
-                    cached_input_price: Some(0.075),
-                    image_price: Some(0.0002),
-                    video_price_per_second: Some(0.0002),
-                    audio_price_per_second: Some(0.0001),
-                },
+                pricing: pricing_per_million(
+                    0.30,
+                    2.50,
+                    Some(0.075),
+                    Some(0.0002),
+                    Some(0.0002),
+                    Some(0.0001),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 65536,
@@ -745,14 +720,7 @@ impl GeminiModelRegistry {
                     ModelFeature::CodeExecution,
                     ModelFeature::SearchGrounding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.10,  // $0.10 per 1M tokens
-                    output_price: 0.40, // $0.40 per 1M tokens
-                    cached_input_price: Some(0.025),
-                    image_price: Some(0.0001),
-                    video_price_per_second: None,
-                    audio_price_per_second: None,
-                },
+                pricing: pricing_per_million(0.10, 0.40, Some(0.025), Some(0.0001), None, None),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 65536,
@@ -807,14 +775,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.01,  // $0.01 per 1M tokens
-                    output_price: 0.04, // $0.04 per 1M tokens
-                    cached_input_price: Some(0.0025),
-                    image_price: Some(0.0001),
-                    video_price_per_second: Some(0.001),
-                    audio_price_per_second: Some(0.0001),
-                },
+                pricing: pricing_per_million(
+                    0.01,
+                    0.04,
+                    Some(0.0025),
+                    Some(0.0001),
+                    Some(0.001),
+                    Some(0.0001),
+                ),
                 limits: ModelLimits {
                     max_context_length: GEMINI_20_FLASH_CONTEXT_WINDOW,
                     max_output_tokens: 8192,
@@ -857,14 +825,7 @@ impl GeminiModelRegistry {
                     ModelFeature::StreamingSupport,
                     ModelFeature::SystemInstructions,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.01,
-                    output_price: 0.04,
-                    cached_input_price: None,
-                    image_price: Some(0.0001),
-                    video_price_per_second: None,
-                    audio_price_per_second: None,
-                },
+                pricing: pricing_per_million(0.01, 0.04, None, Some(0.0001), None, None),
                 limits: ModelLimits {
                     max_context_length: GEMINI_20_FLASH_THINKING_CONTEXT_WINDOW,
                     max_output_tokens: 8192,
@@ -917,14 +878,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 1.25, // $1.25 per 1M tokens (<=128K)
-                    output_price: 5.0, // $5.00 per 1M tokens (<=128K)
-                    cached_input_price: Some(0.3125),
-                    image_price: Some(0.002625),
-                    video_price_per_second: Some(0.002625),
-                    audio_price_per_second: Some(0.000125),
-                },
+                pricing: pricing_per_million(
+                    1.25,
+                    5.0,
+                    Some(0.3125),
+                    Some(0.002625),
+                    Some(0.002625),
+                    Some(0.000125),
+                ),
                 limits: ModelLimits {
                     max_context_length: GEMINI_15_PRO_CONTEXT_WINDOW,
                     max_output_tokens: 8192,
@@ -977,14 +938,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.075, // $0.075 per 1M tokens (<=128K)
-                    output_price: 0.30, // $0.30 per 1M tokens (<=128K)
-                    cached_input_price: Some(0.01875),
-                    image_price: Some(0.0002),
-                    video_price_per_second: Some(0.0002),
-                    audio_price_per_second: Some(0.0001),
-                },
+                pricing: pricing_per_million(
+                    0.075,
+                    0.30,
+                    Some(0.01875),
+                    Some(0.0002),
+                    Some(0.0002),
+                    Some(0.0001),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 8192,
@@ -1035,14 +996,14 @@ impl GeminiModelRegistry {
                     ModelFeature::VideoUnderstanding,
                     ModelFeature::AudioUnderstanding,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.0375, // $0.0375 per 1M tokens
-                    output_price: 0.15,  // $0.15 per 1M tokens
-                    cached_input_price: Some(0.01),
-                    image_price: Some(0.0001),
-                    video_price_per_second: Some(0.0001),
-                    audio_price_per_second: Some(0.00005),
-                },
+                pricing: pricing_per_million(
+                    0.0375,
+                    0.15,
+                    Some(0.01),
+                    Some(0.0001),
+                    Some(0.0001),
+                    Some(0.00005),
+                ),
                 limits: ModelLimits {
                     max_context_length: 1_000_000,
                     max_output_tokens: 8192,
@@ -1088,14 +1049,7 @@ impl GeminiModelRegistry {
                     ModelFeature::SystemInstructions,
                     ModelFeature::BatchProcessing,
                 ],
-                pricing: ModelPricing {
-                    input_price: 0.50,  // $0.50 per 1M tokens
-                    output_price: 1.50, // $1.50 per 1M tokens
-                    cached_input_price: None,
-                    image_price: None,
-                    video_price_per_second: None,
-                    audio_price_per_second: None,
-                },
+                pricing: pricing_per_million(0.50, 1.50, None, None, None, None),
                 limits: ModelLimits {
                     max_context_length: 32_000,
                     max_output_tokens: 8192,
@@ -1110,7 +1064,8 @@ impl GeminiModelRegistry {
     }
 
     /// Model
-    fn register_model(&mut self, id: &str, spec: ModelSpec) {
+    fn register_model(&mut self, id: &str, mut spec: ModelSpec) {
+        spec.pricing.model = id.to_string();
         self.models.insert(id.to_string(), spec);
     }
 
@@ -1142,12 +1097,9 @@ impl GeminiModelRegistry {
     }
 
     /// Get model pricing in the shared core cost model shape.
-    pub fn get_core_model_pricing(
-        &self,
-        model_id: &str,
-    ) -> Option<crate::core::cost::types::ModelPricing> {
+    pub fn get_core_model_pricing(&self, model_id: &str) -> Option<ModelPricing> {
         self.get_model_spec(model_id)
-            .map(|spec| spec.pricing.to_core_model_pricing(model_id))
+            .map(|spec| spec.pricing.clone())
     }
 
     /// Model
@@ -1268,7 +1220,6 @@ impl CostCalculator {
     ) -> Option<f64> {
         let registry = get_gemini_registry();
         let pricing = registry.get_core_model_pricing(model_id)?;
-        let legacy_pricing = registry.get_model_pricing(model_id)?;
 
         let mut total_cost = 0.0;
         let mut remaining_prompt_tokens = prompt_tokens;
@@ -1292,20 +1243,25 @@ impl CostCalculator {
         total_cost += output_cost;
 
         // Image cost
-        if let (Some(img_count), Some(img_price)) = (images, legacy_pricing.image_price) {
+        let image_price = pricing
+            .cost_per_image
+            .as_ref()
+            .and_then(|costs| costs.get("default"))
+            .copied();
+        if let (Some(img_count), Some(img_price)) = (images, image_price) {
             total_cost += img_count as f64 * img_price;
         }
 
         // Video cost
         if let (Some(video_secs), Some(video_price)) =
-            (video_seconds, legacy_pricing.video_price_per_second)
+            (video_seconds, pricing.video_cost_per_second)
         {
             total_cost += video_secs as f64 * video_price;
         }
 
         // Audio cost
         if let (Some(audio_secs), Some(audio_price)) =
-            (audio_seconds, legacy_pricing.audio_price_per_second)
+            (audio_seconds, pricing.audio_cost_per_second)
         {
             total_cost += audio_secs as f64 * audio_price;
         }
@@ -1343,8 +1299,8 @@ mod tests {
         );
 
         // Test pricing
-        assert_eq!(flash_spec.pricing.input_price, 0.01);
-        assert_eq!(flash_spec.pricing.output_price, 0.04);
+        assert_eq!(flash_spec.pricing.input_cost_per_1k_tokens, 0.00001);
+        assert_eq!(flash_spec.pricing.output_cost_per_1k_tokens, 0.00004);
     }
 
     #[test]
@@ -1429,9 +1385,9 @@ mod tests {
         let pricing = registry.get_model_pricing("gemini-1.5-flash");
         assert!(pricing.is_some());
         let pricing_value = pricing.unwrap();
-        assert_eq!(pricing_value.input_price, 0.075);
-        assert_eq!(pricing_value.output_price, 0.30);
-        assert!(pricing_value.cached_input_price.is_some());
+        assert_eq!(pricing_value.input_cost_per_1k_tokens, 0.000075);
+        assert_eq!(pricing_value.output_cost_per_1k_tokens, 0.0003);
+        assert!(pricing_value.cache_read_input_token_cost.is_some());
     }
 
     #[test]
@@ -1445,6 +1401,8 @@ mod tests {
         assert_eq!(pricing.input_cost_per_1k_tokens, 0.000075);
         assert_eq!(pricing.output_cost_per_1k_tokens, 0.0003);
         assert_eq!(pricing.cache_read_input_token_cost, Some(0.00001875));
+        assert_eq!(pricing.video_cost_per_second, Some(0.0002));
+        assert_eq!(pricing.audio_cost_per_second, Some(0.0001));
         assert_eq!(
             pricing
                 .cost_per_image


### PR DESCRIPTION
## Summary
- extend the shared core cost `ModelPricing` with batch/video/audio fields needed by Anthropic and Gemini
- migrate Anthropic and Gemini registries to store the shared pricing model directly while keeping their public re-export paths
- preserve Gemini `get_model_pricing()` per-million return units and record the E3 progress in the remediation plan

## Verification
- cargo fmt --all -- --check
- cargo test --all-features core::providers::anthropic::models::tests::
- cargo test --all-features core::providers::gemini::models::tests::
- cargo test pricing
- cargo test cost
- cargo check --all-features
- git diff --check
- rg -n "pub struct ModelPricing|impl ModelPricing|to_core_model_pricing" src/core/providers -g "*.rs"
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if

Note: clippy still prints the existing Bedrock collapsible_if warning because this command explicitly force-warns that lint, but exits 0.