### PR TITLE
Bridge legacy teams into canonical repository

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -620,7 +620,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 
 ### Step E3 C11 pricing system unification
 
-- status: `in_progress`
+- status: `completed`
 - Expected changes:
   - `src/core/cost/`
   - `src/core/providers/base/pricing.rs`
@@ -640,7 +640,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 
 ### Step E4 C15 team/user convergence
 
-- status: `pending`
+- status: `in_progress`
 - Expected changes:
   - `src/storage/database/migration/m20240301_000001_create_user_management_tables.rs`
   - `src/storage/database/migration/m20240301_000002_create_teams_table.rs`
@@ -924,6 +924,27 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E4 legacy team read-through convergence: `in_progress`
+    - Modified files:
+      - `src/storage/database/seaorm_db/team_repository.rs`
+      - `src/storage/database/seaorm_db/team_repository_tests.rs`
+      - `docs/plan/audit-remediation-complete-plan.md`
+    - Main changes:
+      - Marked Step E3 complete after the pricing model/service consolidation PRs landed.
+      - Added a conservative `um_teams` read-through bridge in `SeaOrmTeamRepository` so legacy `user_management::Team` rows are converted into canonical `core::models::team::Team` and copied into `teams`.
+      - Copies legacy team members into `team_members` when user IDs are UUID-compatible, preserving owner/admin/member/viewer role intent.
+      - Deletes the matching `um_teams` row when canonical delete runs so a backfilled legacy team cannot be resurrected by later list/count calls.
+      - Addressed PR review feedback: legacy name conflicts now skip sync for ID lookups instead of returning a different canonical team.
+      - Addressed PR review feedback: legacy member removals now remove stale canonical `team_members`, and backfill inserts tolerate concurrent readers that win the race first.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test team_repository` -> pass (`7` tests)
+      - `cargo test user_management` -> pass (`71` tests)
+      - `cargo test --all-features team_repository` -> pass (`7` tests)
+      - `cargo test --all-features user_management` -> pass (`71` tests)
+      - `cargo check --all-features` -> pass
+      - `git diff --check` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E3 core pricing service ownership: `in_progress`
     - Modified files:
       - `src/core/mod.rs`

--- a/src/storage/database/seaorm_db/team_repository.rs
+++ b/src/storage/database/seaorm_db/team_repository.rs
@@ -5,12 +5,18 @@
 //! `m20240301_000002_create_teams_table`.  Works with both SQLite and
 //! PostgreSQL backends via the live `SeaOrmDatabase` connection.
 
-use crate::core::models::team::{Team, TeamMember, TeamRole};
+use crate::core::models::team::{MemberStatus, Team, TeamMember, TeamRole, TeamStatus};
+use crate::core::models::{Metadata, UsageStats};
 use crate::core::teams::repository::TeamRepository;
+use crate::core::user_management::{
+    Team as LegacyTeam, TeamMember as LegacyTeamMember, TeamRole as LegacyTeamRole,
+};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use async_trait::async_trait;
 use sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait, Value};
+use std::collections::HashSet;
 use std::sync::Arc;
+use tracing::warn;
 use uuid::Uuid;
 
 use super::types::{DatabaseBackendType, SeaOrmDatabase};
@@ -49,6 +55,137 @@ impl SeaOrmTeamRepository {
         serde_json::from_str(s).map_err(|e| GatewayError::Internal(e.to_string()))
     }
 
+    fn invalid_legacy_uuid(kind: &str, value: &str) -> GatewayError {
+        GatewayError::Internal(format!(
+            "legacy user_management {} '{}' is not a valid UUID",
+            kind, value
+        ))
+    }
+
+    fn legacy_role_to_core(role: &LegacyTeamRole) -> TeamRole {
+        match role {
+            LegacyTeamRole::Owner => TeamRole::Owner,
+            LegacyTeamRole::Admin => TeamRole::Admin,
+            LegacyTeamRole::Member => TeamRole::Member,
+            LegacyTeamRole::ReadOnly => TeamRole::Viewer,
+        }
+    }
+
+    fn legacy_member_to_core(
+        team_id: Uuid,
+        member: &LegacyTeamMember,
+    ) -> Result<Option<TeamMember>> {
+        if !member.is_active {
+            return Ok(None);
+        }
+
+        let user_id = match Uuid::parse_str(&member.user_id) {
+            Ok(id) => id,
+            Err(_) => {
+                warn!(
+                    legacy_user_id = %member.user_id,
+                    "Skipping legacy team member because user_id is not a UUID"
+                );
+                return Ok(None);
+            }
+        };
+
+        let mut core_member = TeamMember::new(
+            team_id,
+            user_id,
+            Self::legacy_role_to_core(&member.role),
+            None,
+        );
+        core_member.joined_at = member.joined_at;
+        core_member.status = if member.is_active {
+            MemberStatus::Active
+        } else {
+            MemberStatus::Left
+        };
+        Ok(Some(core_member))
+    }
+
+    fn legacy_team_to_core(legacy: &LegacyTeam) -> Result<(Team, Vec<TeamMember>)> {
+        let team_id = Uuid::parse_str(&legacy.team_id)
+            .map_err(|_| Self::invalid_legacy_uuid("team_id", &legacy.team_id))?;
+
+        let mut metadata = Metadata::new();
+        metadata.id = team_id;
+        metadata.created_at = legacy.created_at;
+        metadata.updated_at = legacy.created_at;
+        metadata
+            .extra
+            .insert("legacy_um_team".to_string(), serde_json::Value::Bool(true));
+        if let Some(organization_id) = &legacy.organization_id {
+            metadata.extra.insert(
+                "legacy_organization_id".to_string(),
+                serde_json::Value::String(organization_id.clone()),
+            );
+        }
+
+        let mut team = Team::new(legacy.team_name.clone(), Some(legacy.team_name.clone()));
+        team.metadata = metadata;
+        team.description = legacy.description.clone();
+        team.status = if legacy.is_active {
+            TeamStatus::Active
+        } else {
+            TeamStatus::Inactive
+        };
+        team.usage_stats = UsageStats {
+            total_cost: legacy.spend,
+            cost_today: legacy.spend,
+            last_reset: legacy.created_at,
+            ..UsageStats::default()
+        };
+        team.team_metadata = legacy
+            .metadata
+            .iter()
+            .map(|(key, value)| (key.clone(), serde_json::Value::String(value.clone())))
+            .collect();
+        team.team_metadata.insert(
+            "legacy_permissions".to_string(),
+            serde_json::json!(legacy.permissions),
+        );
+        team.team_metadata.insert(
+            "legacy_models".to_string(),
+            serde_json::json!(legacy.models),
+        );
+        if let Some(max_budget) = legacy.max_budget {
+            team.team_metadata.insert(
+                "legacy_max_budget".to_string(),
+                serde_json::json!(max_budget),
+            );
+        }
+        if let Some(duration) = &legacy.budget_duration {
+            team.team_metadata.insert(
+                "legacy_budget_duration".to_string(),
+                serde_json::Value::String(duration.clone()),
+            );
+        }
+        if let Some(reset_at) = legacy.budget_reset_at {
+            team.team_metadata.insert(
+                "legacy_budget_reset_at".to_string(),
+                serde_json::Value::String(reset_at.to_rfc3339()),
+            );
+        }
+
+        let members = legacy
+            .members
+            .iter()
+            .filter_map(
+                |member| match Self::legacy_member_to_core(team_id, member) {
+                    Ok(member) => member,
+                    Err(err) => {
+                        warn!(error = %err, "Skipping invalid legacy team member");
+                        None
+                    }
+                },
+            )
+            .collect();
+
+        Ok((team, members))
+    }
+
     /// SQL predicate for filtering logically deleted teams from JSON payload.
     fn non_deleted_team_predicate(&self) -> &'static str {
         match self.db.backend_type {
@@ -60,14 +197,11 @@ impl SeaOrmTeamRepository {
             }
         }
     }
-}
 
-#[async_trait]
-impl TeamRepository for SeaOrmTeamRepository {
-    async fn create(&self, team: Team) -> Result<Team> {
+    async fn insert_canonical_team(&self, team: &Team) -> Result<()> {
         let id = team.id().to_string();
         let name = team.name.clone();
-        let data = Self::to_json(&team)?;
+        let data = Self::to_json(team)?;
         let sql = format!(
             "INSERT INTO teams (id, name, data) VALUES ({}, {}, {})",
             self.ph(1),
@@ -84,10 +218,33 @@ impl TeamRepository for SeaOrmTeamRepository {
             ],
         );
         self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
-        Ok(team)
+        Ok(())
     }
 
-    async fn get(&self, id: Uuid) -> Result<Option<Team>> {
+    async fn insert_canonical_member(&self, member: &TeamMember) -> Result<()> {
+        let team_id = member.team_id.to_string();
+        let user_id = member.user_id.to_string();
+        let data = Self::to_json(member)?;
+        let sql = format!(
+            "INSERT INTO team_members (team_id, user_id, data) VALUES ({}, {}, {})",
+            self.ph(1),
+            self.ph(2),
+            self.ph(3)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team_id))),
+                Value::String(Some(Box::new(user_id))),
+                Value::String(Some(Box::new(data))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
+    }
+
+    async fn get_canonical(&self, id: Uuid) -> Result<Option<Team>> {
         let sql = format!("SELECT data FROM teams WHERE id = {}", self.ph(1));
         let stmt = Statement::from_sql_and_values(
             self.backend(),
@@ -109,7 +266,7 @@ impl TeamRepository for SeaOrmTeamRepository {
         }
     }
 
-    async fn get_by_name(&self, name: &str) -> Result<Option<Team>> {
+    async fn get_canonical_by_name(&self, name: &str) -> Result<Option<Team>> {
         let sql = format!("SELECT data FROM teams WHERE name = {}", self.ph(1));
         let stmt = Statement::from_sql_and_values(
             self.backend(),
@@ -129,6 +286,259 @@ impl TeamRepository for SeaOrmTeamRepository {
                 Ok(Some(Self::from_json(&data)?))
             }
         }
+    }
+
+    async fn get_canonical_member(
+        &self,
+        team_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<TeamMember>> {
+        let sql = format!(
+            "SELECT data FROM team_members WHERE team_id = {} AND user_id = {}",
+            self.ph(1),
+            self.ph(2)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team_id.to_string()))),
+                Value::String(Some(Box::new(user_id.to_string()))),
+            ],
+        );
+        match self
+            .db
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(GatewayError::from)?
+        {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::from_json(&data)?))
+            }
+        }
+    }
+
+    async fn list_canonical_members(&self, team_id: Uuid) -> Result<Vec<TeamMember>> {
+        let sql = format!(
+            "SELECT data FROM team_members WHERE team_id = {}",
+            self.ph(1)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(team_id.to_string())))],
+        );
+        let rows = self
+            .db
+            .db
+            .query_all(stmt)
+            .await
+            .map_err(GatewayError::from)?;
+        rows.into_iter()
+            .map(|row| {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Self::from_json(&data)
+            })
+            .collect()
+    }
+
+    async fn delete_canonical_member(&self, team_id: Uuid, user_id: Uuid) -> Result<()> {
+        let sql = format!(
+            "DELETE FROM team_members WHERE team_id = {} AND user_id = {}",
+            self.ph(1),
+            self.ph(2)
+        );
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [
+                Value::String(Some(Box::new(team_id.to_string()))),
+                Value::String(Some(Box::new(user_id.to_string()))),
+            ],
+        );
+        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        Ok(())
+    }
+
+    async fn get_legacy_um_team(&self, id: Uuid) -> Result<Option<LegacyTeam>> {
+        let sql = format!("SELECT data FROM um_teams WHERE team_id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(id.to_string())))],
+        );
+        match self
+            .db
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(GatewayError::from)?
+        {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::from_json(&data)?))
+            }
+        }
+    }
+
+    async fn list_legacy_um_teams(&self) -> Result<Vec<LegacyTeam>> {
+        let sql = "SELECT data FROM um_teams ORDER BY created_at ASC";
+        let stmt = Statement::from_string(self.backend(), sql);
+        let rows = self
+            .db
+            .db
+            .query_all(stmt)
+            .await
+            .map_err(GatewayError::from)?;
+
+        let mut teams = Vec::with_capacity(rows.len());
+        for row in rows {
+            let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+            match Self::from_json::<LegacyTeam>(&data) {
+                Ok(team) => teams.push(team),
+                Err(err) => warn!(error = %err, "Skipping invalid legacy um_teams row"),
+            }
+        }
+        Ok(teams)
+    }
+
+    async fn ensure_legacy_team_inserted(&self, team: &Team) -> Result<bool> {
+        if self.get_canonical(team.id()).await?.is_some() {
+            return Ok(true);
+        }
+
+        if let Some(existing) = self.get_canonical_by_name(&team.name).await? {
+            warn!(
+                legacy_team_id = %team.id(),
+                existing_team_id = %existing.id(),
+                team_name = %team.name,
+                "Skipping legacy team sync because canonical team name already exists"
+            );
+            return Ok(false);
+        }
+
+        match self.insert_canonical_team(team).await {
+            Ok(()) => Ok(true),
+            Err(err) => {
+                if self.get_canonical(team.id()).await?.is_some() {
+                    return Ok(true);
+                }
+
+                if let Some(existing) = self.get_canonical_by_name(&team.name).await? {
+                    warn!(
+                        legacy_team_id = %team.id(),
+                        existing_team_id = %existing.id(),
+                        team_name = %team.name,
+                        "Skipping legacy team sync after concurrent canonical name insert"
+                    );
+                    return Ok(false);
+                }
+
+                Err(err)
+            }
+        }
+    }
+
+    async fn ensure_legacy_member_inserted(&self, member: &TeamMember) -> Result<()> {
+        if self
+            .get_canonical_member(member.team_id, member.user_id)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        match self.insert_canonical_member(member).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if self
+                    .get_canonical_member(member.team_id, member.user_id)
+                    .await?
+                    .is_some()
+                {
+                    Ok(())
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    async fn sync_legacy_members(&self, team_id: Uuid, members: Vec<TeamMember>) -> Result<()> {
+        let legacy_user_ids: HashSet<Uuid> = members.iter().map(|member| member.user_id).collect();
+
+        for member in &members {
+            self.ensure_legacy_member_inserted(member).await?;
+        }
+
+        for existing in self.list_canonical_members(team_id).await? {
+            if !legacy_user_ids.contains(&existing.user_id) {
+                self.delete_canonical_member(team_id, existing.user_id)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn persist_legacy_team(&self, legacy: &LegacyTeam) -> Result<Option<Team>> {
+        let (team, members) = match Self::legacy_team_to_core(legacy) {
+            Ok(converted) => converted,
+            Err(err) => {
+                warn!(error = %err, legacy_team_id = %legacy.team_id, "Skipping legacy team sync");
+                return Ok(None);
+            }
+        };
+
+        if !self.ensure_legacy_team_inserted(&team).await? {
+            return Ok(None);
+        }
+
+        self.sync_legacy_members(team.id(), members).await?;
+        Ok(Some(team))
+    }
+
+    async fn sync_legacy_um_teams(&self) -> Result<()> {
+        for legacy in self.list_legacy_um_teams().await? {
+            let _ = self.persist_legacy_team(&legacy).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TeamRepository for SeaOrmTeamRepository {
+    async fn create(&self, team: Team) -> Result<Team> {
+        self.insert_canonical_team(&team).await?;
+        Ok(team)
+    }
+
+    async fn get(&self, id: Uuid) -> Result<Option<Team>> {
+        if let Some(team) = self.get_canonical(id).await? {
+            return Ok(Some(team));
+        }
+
+        match self.get_legacy_um_team(id).await? {
+            Some(legacy) => self.persist_legacy_team(&legacy).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn get_by_name(&self, name: &str) -> Result<Option<Team>> {
+        if let Some(team) = self.get_canonical_by_name(name).await? {
+            return Ok(Some(team));
+        }
+
+        for legacy in self.list_legacy_um_teams().await? {
+            if legacy.team_name == name {
+                return self.persist_legacy_team(&legacy).await;
+            }
+        }
+        Ok(None)
     }
 
     async fn update(&self, mut team: Team) -> Result<Team> {
@@ -176,11 +586,21 @@ impl TeamRepository for SeaOrmTeamRepository {
         );
         txn.execute(stmt).await.map_err(GatewayError::from)?;
 
+        let sql = format!("DELETE FROM um_teams WHERE team_id = {}", self.ph(1));
+        let stmt = Statement::from_sql_and_values(
+            self.backend(),
+            &sql,
+            [Value::String(Some(Box::new(id.to_string())))],
+        );
+        txn.execute(stmt).await.map_err(GatewayError::from)?;
+
         txn.commit().await.map_err(GatewayError::from)?;
         Ok(())
     }
 
     async fn list(&self, offset: u32, limit: u32) -> Result<(Vec<Team>, u64)> {
+        self.sync_legacy_um_teams().await?;
+
         let sql = format!(
             "SELECT data FROM teams WHERE {} ORDER BY created_at ASC LIMIT {} OFFSET {}",
             self.non_deleted_team_predicate(),
@@ -227,6 +647,8 @@ impl TeamRepository for SeaOrmTeamRepository {
     }
 
     async fn count(&self) -> Result<u64> {
+        self.sync_legacy_um_teams().await?;
+
         let sql = format!(
             "SELECT COUNT(*) as cnt FROM teams WHERE {}",
             self.non_deleted_team_predicate()
@@ -243,55 +665,16 @@ impl TeamRepository for SeaOrmTeamRepository {
     }
 
     async fn add_member(&self, member: TeamMember) -> Result<TeamMember> {
-        let team_id = member.team_id.to_string();
-        let user_id = member.user_id.to_string();
-        let data = Self::to_json(&member)?;
-        let sql = format!(
-            "INSERT INTO team_members (team_id, user_id, data) VALUES ({}, {}, {})",
-            self.ph(1),
-            self.ph(2),
-            self.ph(3)
-        );
-        let stmt = Statement::from_sql_and_values(
-            self.backend(),
-            &sql,
-            [
-                Value::String(Some(Box::new(team_id))),
-                Value::String(Some(Box::new(user_id))),
-                Value::String(Some(Box::new(data))),
-            ],
-        );
-        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        self.insert_canonical_member(&member).await?;
         Ok(member)
     }
 
     async fn get_member(&self, team_id: Uuid, user_id: Uuid) -> Result<Option<TeamMember>> {
-        let sql = format!(
-            "SELECT data FROM team_members WHERE team_id = {} AND user_id = {}",
-            self.ph(1),
-            self.ph(2)
-        );
-        let stmt = Statement::from_sql_and_values(
-            self.backend(),
-            &sql,
-            [
-                Value::String(Some(Box::new(team_id.to_string()))),
-                Value::String(Some(Box::new(user_id.to_string()))),
-            ],
-        );
-        match self
-            .db
-            .db
-            .query_one(stmt)
-            .await
-            .map_err(GatewayError::from)?
-        {
-            None => Ok(None),
-            Some(row) => {
-                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
-                Ok(Some(Self::from_json(&data)?))
-            }
+        if let Some(legacy) = self.get_legacy_um_team(team_id).await? {
+            let _ = self.persist_legacy_team(&legacy).await?;
         }
+
+        self.get_canonical_member(team_id, user_id).await
     }
 
     async fn update_member_role(
@@ -369,30 +752,16 @@ impl TeamRepository for SeaOrmTeamRepository {
     }
 
     async fn list_members(&self, team_id: Uuid) -> Result<Vec<TeamMember>> {
-        let sql = format!(
-            "SELECT data FROM team_members WHERE team_id = {}",
-            self.ph(1)
-        );
-        let stmt = Statement::from_sql_and_values(
-            self.backend(),
-            &sql,
-            [Value::String(Some(Box::new(team_id.to_string())))],
-        );
-        let rows = self
-            .db
-            .db
-            .query_all(stmt)
-            .await
-            .map_err(GatewayError::from)?;
-        rows.into_iter()
-            .map(|row| {
-                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
-                Self::from_json(&data)
-            })
-            .collect()
+        if let Some(legacy) = self.get_legacy_um_team(team_id).await? {
+            let _ = self.persist_legacy_team(&legacy).await?;
+        }
+
+        self.list_canonical_members(team_id).await
     }
 
     async fn get_user_teams(&self, user_id: Uuid) -> Result<Vec<Team>> {
+        self.sync_legacy_um_teams().await?;
+
         let sql = format!(
             "SELECT team_id FROM team_members WHERE user_id = {}",
             self.ph(1)

--- a/src/storage/database/seaorm_db/team_repository_tests.rs
+++ b/src/storage/database/seaorm_db/team_repository_tests.rs
@@ -3,9 +3,16 @@ use super::types::SeaOrmDatabase;
 use crate::config::models::storage::DatabaseConfig;
 use crate::core::models::team::{Team, TeamStatus};
 use crate::core::teams::repository::TeamRepository;
+use crate::core::user_management::{
+    Team as LegacyTeam, TeamMember as LegacyTeamMember, TeamRole as LegacyTeamRole,
+    TeamSettings as LegacyTeamSettings,
+};
+use chrono::Utc;
+use std::collections::HashMap;
 use std::sync::Arc;
+use uuid::Uuid;
 
-async fn create_repository() -> SeaOrmTeamRepository {
+async fn create_repository_with_db() -> (SeaOrmTeamRepository, Arc<SeaOrmDatabase>) {
     let db = Arc::new(
         SeaOrmDatabase::new(&DatabaseConfig {
             enabled: false,
@@ -15,7 +22,37 @@ async fn create_repository() -> SeaOrmTeamRepository {
         .expect("failed to create in-memory database"),
     );
     db.migrate().await.expect("failed to run migrations");
-    SeaOrmTeamRepository::new(db)
+    (SeaOrmTeamRepository::new(Arc::clone(&db)), db)
+}
+
+async fn create_repository() -> SeaOrmTeamRepository {
+    let (repo, _) = create_repository_with_db().await;
+    repo
+}
+
+fn legacy_team(name: &str, owner_id: Uuid) -> LegacyTeam {
+    LegacyTeam {
+        team_id: Uuid::new_v4().to_string(),
+        team_name: name.to_string(),
+        description: Some(format!("legacy {}", name)),
+        organization_id: Some(Uuid::new_v4().to_string()),
+        members: vec![LegacyTeamMember {
+            user_id: owner_id.to_string(),
+            role: LegacyTeamRole::Owner,
+            joined_at: Utc::now(),
+            is_active: true,
+        }],
+        permissions: vec!["api.chat".to_string()],
+        models: vec!["gpt-4".to_string()],
+        max_budget: Some(1000.0),
+        spend: 42.0,
+        budget_duration: Some("1m".to_string()),
+        budget_reset_at: Some(Utc::now()),
+        metadata: HashMap::from([("source".to_string(), "legacy-test".to_string())]),
+        is_active: true,
+        created_at: Utc::now(),
+        settings: LegacyTeamSettings::default(),
+    }
 }
 
 #[tokio::test]
@@ -73,4 +110,117 @@ async fn test_pagination_applies_after_deleted_filtering() {
     assert_eq!(teams.len(), 2);
     assert_eq!(teams[0].name, "team-c");
     assert_eq!(teams[1].name, "team-d");
+}
+
+#[tokio::test]
+async fn test_legacy_user_management_team_is_visible_through_canonical_repository() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let legacy = legacy_team("legacy-visible", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+
+    db.create_team(&legacy).await.unwrap();
+
+    let fetched = repo.get(legacy_id).await.unwrap().unwrap();
+    assert_eq!(fetched.id(), legacy_id);
+    assert_eq!(fetched.name, "legacy-visible");
+    assert_eq!(fetched.description, legacy.description);
+    assert!(fetched.metadata.extra.contains_key("legacy_um_team"));
+    assert_eq!(fetched.usage_stats.total_cost, 42.0);
+
+    let by_name = repo.get_by_name("legacy-visible").await.unwrap().unwrap();
+    assert_eq!(by_name.id(), legacy_id);
+
+    let (teams, total) = repo.list(0, 10).await.unwrap();
+    assert_eq!(total, 1);
+    assert_eq!(teams.len(), 1);
+    assert_eq!(teams[0].id(), legacy_id);
+}
+
+#[tokio::test]
+async fn test_legacy_user_management_team_members_are_copied_to_canonical_members() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let legacy = legacy_team("legacy-members", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+
+    db.create_team(&legacy).await.unwrap();
+
+    let user_teams = repo.get_user_teams(owner_id).await.unwrap();
+    assert_eq!(user_teams.len(), 1);
+    assert_eq!(user_teams[0].id(), legacy_id);
+
+    let member = repo.get_member(legacy_id, owner_id).await.unwrap().unwrap();
+    assert_eq!(member.team_id, legacy_id);
+    assert_eq!(member.user_id, owner_id);
+}
+
+#[tokio::test]
+async fn test_legacy_member_removal_removes_backfilled_canonical_member() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let removed_user_id = Uuid::new_v4();
+    let mut legacy = legacy_team("legacy-member-removal", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+    legacy.members.push(LegacyTeamMember {
+        user_id: removed_user_id.to_string(),
+        role: LegacyTeamRole::Member,
+        joined_at: Utc::now(),
+        is_active: true,
+    });
+
+    db.create_team(&legacy).await.unwrap();
+    assert_eq!(repo.get_user_teams(removed_user_id).await.unwrap().len(), 1);
+
+    legacy
+        .members
+        .retain(|member| member.user_id != removed_user_id.to_string());
+    db.update_team(&legacy).await.unwrap();
+
+    assert!(
+        repo.get_user_teams(removed_user_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        repo.get_member(legacy_id, removed_user_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn test_delete_does_not_resurrect_backfilled_legacy_team() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let legacy = legacy_team("legacy-delete", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+
+    db.create_team(&legacy).await.unwrap();
+    assert!(repo.get(legacy_id).await.unwrap().is_some());
+
+    repo.delete(legacy_id).await.unwrap();
+
+    assert!(repo.get(legacy_id).await.unwrap().is_none());
+    let (teams, total) = repo.list(0, 10).await.unwrap();
+    assert_eq!(total, 0);
+    assert!(teams.is_empty());
+}
+
+#[tokio::test]
+async fn test_legacy_name_conflict_does_not_return_wrong_team_for_id_lookup() {
+    let (repo, db) = create_repository_with_db().await;
+    let canonical = Team::new("shared-name".to_string(), None);
+    let canonical_id = canonical.id();
+    repo.create(canonical).await.unwrap();
+
+    let legacy = legacy_team("shared-name", Uuid::new_v4());
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+    db.create_team(&legacy).await.unwrap();
+
+    assert!(repo.get(legacy_id).await.unwrap().is_none());
+    let by_name = repo.get_by_name("shared-name").await.unwrap().unwrap();
+    assert_eq!(by_name.id(), canonical_id);
 }


### PR DESCRIPTION
## Summary
- mark E3 pricing convergence complete and start E4 tracking in the audit remediation plan
- add `um_teams` read-through/backfill in `SeaOrmTeamRepository` so legacy `user_management::Team` rows become visible through canonical `teams`/`team_members`
- copy UUID-compatible legacy team members into canonical member rows and delete matching legacy rows on canonical delete to avoid resurrection

## Verification
- `cargo fmt --all -- --check`
- `cargo test team_repository`
- `cargo test user_management`
- `cargo test --all-features team_repository`
- `cargo test --all-features user_management`
- `cargo check --all-features`
- `git diff --check`
- `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if`
