### PR TITLE
Mirror canonical teams into legacy tables

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,29 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E4 canonical-to-legacy team mirror: `in_progress`
+    - Modified files:
+      - `src/storage/database/seaorm_db/team_repository.rs`
+      - `src/storage/database/seaorm_db/team_repository_tests.rs`
+    - Main changes:
+      - Mirrored canonical `TeamRepository::create` and `update` writes into `um_teams` so `/v1/teams` teams are visible to the legacy `user_management` facade.
+      - Mirrored canonical member add/update/remove operations into legacy `Team.members`.
+      - Updated legacy `um_users.data.teams` when canonical member add/remove sees a matching legacy user.
+      - Removed legacy `um_users.data.teams` references when a canonical team is deleted.
+      - Preserved legacy-only `TeamSettings` and `organization_id` fields when canonical updates mirror back into `um_teams`.
+      - Cleaned `um_users.data.teams` even when deleting a legacy-only team before read-through materializes canonical rows.
+      - Addressed PR review feedback: inactive legacy members stay out of canonical `team_members` so role-only authorization checks cannot restore revoked access.
+      - Addressed PR review feedback: canonical sync preserves an existing legacy `organization_id` when canonical metadata does not provide one.
+      - Preserved the E4 read-through conflict guards from the prior PR while adding reverse-direction parity.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test team_repository` -> pass (`14` tests)
+      - `cargo test user_management` -> pass (`72` tests)
+      - `cargo test --all-features team_repository` -> pass (`14` tests)
+      - `cargo test --all-features user_management` -> pass (`72` tests)
+      - `cargo check --all-features` -> pass
+      - `git diff --check` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E4 legacy team read-through convergence: `in_progress`
     - Modified files:
       - `src/storage/database/seaorm_db/team_repository.rs`

--- a/src/storage/database/seaorm_db/team_repository.rs
+++ b/src/storage/database/seaorm_db/team_repository.rs
@@ -10,6 +10,7 @@ use crate::core::models::{Metadata, UsageStats};
 use crate::core::teams::repository::TeamRepository;
 use crate::core::user_management::{
     Team as LegacyTeam, TeamMember as LegacyTeamMember, TeamRole as LegacyTeamRole,
+    TeamSettings as LegacyTeamSettings,
 };
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use async_trait::async_trait;
@@ -71,6 +72,44 @@ impl SeaOrmTeamRepository {
         }
     }
 
+    fn core_role_to_legacy(role: &TeamRole) -> LegacyTeamRole {
+        match role {
+            TeamRole::Owner => LegacyTeamRole::Owner,
+            TeamRole::Admin | TeamRole::Manager => LegacyTeamRole::Admin,
+            TeamRole::Member => LegacyTeamRole::Member,
+            TeamRole::Viewer => LegacyTeamRole::ReadOnly,
+        }
+    }
+
+    fn string_vec_metadata(team: &Team, key: &str) -> Vec<String> {
+        team.team_metadata
+            .get(key)
+            .and_then(|value| value.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn string_metadata(team: &Team, key: &str) -> Option<String> {
+        team.team_metadata
+            .get(key)
+            .or_else(|| team.metadata.extra.get(key))
+            .and_then(|value| value.as_str())
+            .map(str::to_owned)
+    }
+
+    fn legacy_budget_reset_at(team: &Team) -> Option<chrono::DateTime<chrono::Utc>> {
+        Self::string_metadata(team, "legacy_budget_reset_at").and_then(|value| {
+            chrono::DateTime::parse_from_rfc3339(&value)
+                .ok()
+                .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        })
+    }
+
     fn legacy_member_to_core(
         team_id: Uuid,
         member: &LegacyTeamMember,
@@ -103,6 +142,15 @@ impl SeaOrmTeamRepository {
             MemberStatus::Left
         };
         Ok(Some(core_member))
+    }
+
+    fn core_member_to_legacy(member: &TeamMember) -> LegacyTeamMember {
+        LegacyTeamMember {
+            user_id: member.user_id.to_string(),
+            role: Self::core_role_to_legacy(&member.role),
+            joined_at: member.joined_at,
+            is_active: member.is_active(),
+        }
     }
 
     fn legacy_team_to_core(legacy: &LegacyTeam) -> Result<(Team, Vec<TeamMember>)> {
@@ -184,6 +232,35 @@ impl SeaOrmTeamRepository {
             .collect();
 
         Ok((team, members))
+    }
+
+    fn core_team_to_legacy(team: &Team, members: Vec<TeamMember>) -> LegacyTeam {
+        let metadata = team
+            .team_metadata
+            .iter()
+            .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_owned())))
+            .collect();
+
+        LegacyTeam {
+            team_id: team.id().to_string(),
+            team_name: team.name.clone(),
+            description: team.description.clone(),
+            organization_id: Self::string_metadata(team, "legacy_organization_id"),
+            members: members.iter().map(Self::core_member_to_legacy).collect(),
+            permissions: Self::string_vec_metadata(team, "legacy_permissions"),
+            models: Self::string_vec_metadata(team, "legacy_models"),
+            max_budget: team
+                .team_metadata
+                .get("legacy_max_budget")
+                .and_then(|value| value.as_f64()),
+            spend: team.usage_stats.total_cost,
+            budget_duration: Self::string_metadata(team, "legacy_budget_duration"),
+            budget_reset_at: Self::legacy_budget_reset_at(team),
+            metadata,
+            is_active: team.is_active(),
+            created_at: team.metadata.created_at,
+            settings: LegacyTeamSettings::default(),
+        }
     }
 
     /// SQL predicate for filtering logically deleted teams from JSON payload.
@@ -508,12 +585,56 @@ impl SeaOrmTeamRepository {
         }
         Ok(())
     }
+
+    async fn sync_legacy_team_from_canonical(&self, team_id: Uuid) -> Result<()> {
+        let Some(team) = self.get_canonical(team_id).await? else {
+            return Ok(());
+        };
+
+        let members = self.list_canonical_members(team_id).await?;
+        let mut legacy = Self::core_team_to_legacy(&team, members);
+        if let Some(existing) = self.db.get_team(&legacy.team_id).await? {
+            if legacy.organization_id.is_none() {
+                legacy.organization_id = existing.organization_id;
+            }
+            legacy.settings = existing.settings;
+            self.db.update_team(&legacy).await
+        } else {
+            self.db.create_team(&legacy).await
+        }
+    }
+
+    async fn add_legacy_user_team(&self, user_id: Uuid, team_id: Uuid) -> Result<()> {
+        let user_id = user_id.to_string();
+        let team_id = team_id.to_string();
+        if let Some(mut user) = self.db.get_user(&user_id).await?
+            && !user.teams.contains(&team_id)
+        {
+            user.teams.push(team_id);
+            self.db.update_user(&user).await?;
+        }
+        Ok(())
+    }
+
+    async fn remove_legacy_user_team(&self, user_id: Uuid, team_id: Uuid) -> Result<()> {
+        let user_id = user_id.to_string();
+        let team_id = team_id.to_string();
+        if let Some(mut user) = self.db.get_user(&user_id).await? {
+            let original_len = user.teams.len();
+            user.teams.retain(|existing| existing != &team_id);
+            if user.teams.len() != original_len {
+                self.db.update_user(&user).await?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl TeamRepository for SeaOrmTeamRepository {
     async fn create(&self, team: Team) -> Result<Team> {
         self.insert_canonical_team(&team).await?;
+        self.sync_legacy_team_from_canonical(team.id()).await?;
         Ok(team)
     }
 
@@ -562,10 +683,31 @@ impl TeamRepository for SeaOrmTeamRepository {
             ],
         );
         self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        self.sync_legacy_team_from_canonical(team.id()).await?;
         Ok(team)
     }
 
     async fn delete(&self, id: Uuid) -> Result<()> {
+        let mut member_user_ids: HashSet<Uuid> = self
+            .list_canonical_members(id)
+            .await?
+            .into_iter()
+            .map(|member| member.user_id)
+            .collect();
+        if let Some(legacy) = self.get_legacy_um_team(id).await? {
+            for member in legacy.members {
+                match Uuid::parse_str(&member.user_id) {
+                    Ok(user_id) => {
+                        member_user_ids.insert(user_id);
+                    }
+                    Err(_) => warn!(
+                        legacy_user_id = %member.user_id,
+                        team_id = %id,
+                        "Skipping legacy user membership cleanup because user_id is not a UUID"
+                    ),
+                }
+            }
+        }
         let id_str = id.to_string();
         let txn = self.db.db.begin().await.map_err(GatewayError::from)?;
 
@@ -595,6 +737,11 @@ impl TeamRepository for SeaOrmTeamRepository {
         txn.execute(stmt).await.map_err(GatewayError::from)?;
 
         txn.commit().await.map_err(GatewayError::from)?;
+
+        for user_id in member_user_ids {
+            self.remove_legacy_user_team(user_id, id).await?;
+        }
+
         Ok(())
     }
 
@@ -666,6 +813,9 @@ impl TeamRepository for SeaOrmTeamRepository {
 
     async fn add_member(&self, member: TeamMember) -> Result<TeamMember> {
         self.insert_canonical_member(&member).await?;
+        self.sync_legacy_team_from_canonical(member.team_id).await?;
+        self.add_legacy_user_team(member.user_id, member.team_id)
+            .await?;
         Ok(member)
     }
 
@@ -730,24 +880,14 @@ impl TeamRepository for SeaOrmTeamRepository {
         txn.execute(stmt).await.map_err(GatewayError::from)?;
 
         txn.commit().await.map_err(GatewayError::from)?;
+        self.sync_legacy_team_from_canonical(team_id).await?;
         Ok(member)
     }
 
     async fn remove_member(&self, team_id: Uuid, user_id: Uuid) -> Result<()> {
-        let sql = format!(
-            "DELETE FROM team_members WHERE team_id = {} AND user_id = {}",
-            self.ph(1),
-            self.ph(2)
-        );
-        let stmt = Statement::from_sql_and_values(
-            self.backend(),
-            &sql,
-            [
-                Value::String(Some(Box::new(team_id.to_string()))),
-                Value::String(Some(Box::new(user_id.to_string()))),
-            ],
-        );
-        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        self.delete_canonical_member(team_id, user_id).await?;
+        self.sync_legacy_team_from_canonical(team_id).await?;
+        self.remove_legacy_user_team(user_id, team_id).await?;
         Ok(())
     }
 

--- a/src/storage/database/seaorm_db/team_repository_tests.rs
+++ b/src/storage/database/seaorm_db/team_repository_tests.rs
@@ -1,11 +1,12 @@
 use super::team_repository::SeaOrmTeamRepository;
 use super::types::SeaOrmDatabase;
 use crate::config::models::storage::DatabaseConfig;
-use crate::core::models::team::{Team, TeamStatus};
+use crate::core::models::team::{Team, TeamMember, TeamRole, TeamStatus};
 use crate::core::teams::repository::TeamRepository;
 use crate::core::user_management::{
     Team as LegacyTeam, TeamMember as LegacyTeamMember, TeamRole as LegacyTeamRole,
-    TeamSettings as LegacyTeamSettings,
+    TeamSettings as LegacyTeamSettings, User as LegacyUser,
+    UserPreferences as LegacyUserPreferences, UserRole as LegacyUserRole,
 };
 use chrono::Utc;
 use std::collections::HashMap;
@@ -52,6 +53,28 @@ fn legacy_team(name: &str, owner_id: Uuid) -> LegacyTeam {
         is_active: true,
         created_at: Utc::now(),
         settings: LegacyTeamSettings::default(),
+    }
+}
+
+fn legacy_user(user_id: Uuid, email: &str) -> LegacyUser {
+    LegacyUser {
+        user_id: user_id.to_string(),
+        email: email.to_string(),
+        display_name: Some(email.to_string()),
+        first_name: None,
+        last_name: None,
+        role: LegacyUserRole::User,
+        teams: vec![],
+        permissions: vec![],
+        metadata: HashMap::new(),
+        max_budget: None,
+        spend: 0.0,
+        budget_duration: None,
+        budget_reset_at: None,
+        is_active: true,
+        created_at: Utc::now(),
+        last_login_at: None,
+        preferences: LegacyUserPreferences::default(),
     }
 }
 
@@ -192,6 +215,36 @@ async fn test_legacy_member_removal_removes_backfilled_canonical_member() {
 }
 
 #[tokio::test]
+async fn test_inactive_legacy_members_are_not_backfilled_to_canonical_members() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let inactive_user_id = Uuid::new_v4();
+    let mut legacy = legacy_team("legacy-inactive-member", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+    legacy.members.push(LegacyTeamMember {
+        user_id: inactive_user_id.to_string(),
+        role: LegacyTeamRole::Admin,
+        joined_at: Utc::now(),
+        is_active: false,
+    });
+
+    db.create_team(&legacy).await.unwrap();
+
+    assert!(
+        repo.get_member(legacy_id, inactive_user_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        repo.get_user_teams(inactive_user_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn test_delete_does_not_resurrect_backfilled_legacy_team() {
     let (repo, db) = create_repository_with_db().await;
     let owner_id = Uuid::new_v4();
@@ -223,4 +276,158 @@ async fn test_legacy_name_conflict_does_not_return_wrong_team_for_id_lookup() {
     assert!(repo.get(legacy_id).await.unwrap().is_none());
     let by_name = repo.get_by_name("shared-name").await.unwrap().unwrap();
     assert_eq!(by_name.id(), canonical_id);
+}
+
+#[tokio::test]
+async fn test_canonical_team_create_is_visible_through_legacy_user_management_tables() {
+    let (repo, db) = create_repository_with_db().await;
+    let mut canonical = Team::new(
+        "canonical-visible".to_string(),
+        Some("Canonical".to_string()),
+    );
+    canonical.description = Some("created through canonical repository".to_string());
+    let canonical_id = canonical.id();
+
+    repo.create(canonical).await.unwrap();
+
+    let legacy = db
+        .get_team(&canonical_id.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(legacy.team_id, canonical_id.to_string());
+    assert_eq!(legacy.team_name, "canonical-visible");
+    assert_eq!(
+        legacy.description,
+        Some("created through canonical repository".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_canonical_update_preserves_legacy_settings_and_organization_id() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let mut legacy = legacy_team("legacy-update-preserve", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+    let organization_id = legacy.organization_id.clone();
+    legacy.settings.default_model = Some("claude-3-5-sonnet".to_string());
+    legacy.settings.auto_approve_members = false;
+    legacy.settings.require_approval_for_high_cost = true;
+    legacy.settings.high_cost_threshold = Some(25.0);
+    db.create_team(&legacy).await.unwrap();
+
+    let mut canonical = repo.get(legacy_id).await.unwrap().unwrap();
+    canonical.description = Some("updated through canonical repository".to_string());
+
+    repo.update(canonical).await.unwrap();
+
+    let updated = db.get_team(&legacy_id.to_string()).await.unwrap().unwrap();
+    assert_eq!(updated.organization_id, organization_id);
+    assert_eq!(
+        updated.description,
+        Some("updated through canonical repository".to_string())
+    );
+    assert_eq!(
+        updated.settings.default_model,
+        Some("claude-3-5-sonnet".to_string())
+    );
+    assert!(!updated.settings.auto_approve_members);
+    assert!(updated.settings.require_approval_for_high_cost);
+    assert_eq!(updated.settings.high_cost_threshold, Some(25.0));
+}
+
+#[tokio::test]
+async fn test_canonical_update_preserves_existing_legacy_organization_id() {
+    let (repo, db) = create_repository_with_db().await;
+    let mut canonical = Team::new("canonical-existing-org".to_string(), None);
+    let team_id = canonical.id();
+    repo.create(canonical.clone()).await.unwrap();
+
+    let mut legacy = db.get_team(&team_id.to_string()).await.unwrap().unwrap();
+    legacy.organization_id = Some("legacy-org-kept".to_string());
+    db.update_team(&legacy).await.unwrap();
+
+    canonical.description = Some("canonical update without legacy org metadata".to_string());
+    repo.update(canonical).await.unwrap();
+
+    let updated = db.get_team(&team_id.to_string()).await.unwrap().unwrap();
+    assert_eq!(updated.organization_id, Some("legacy-org-kept".to_string()));
+    assert_eq!(
+        updated.description,
+        Some("canonical update without legacy org metadata".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_canonical_member_changes_update_legacy_team_and_user_membership() {
+    let (repo, db) = create_repository_with_db().await;
+    let user_id = Uuid::new_v4();
+    db.um_create_user(&legacy_user(user_id, "member@example.com"))
+        .await
+        .unwrap();
+
+    let canonical = repo
+        .create(Team::new("canonical-members".to_string(), None))
+        .await
+        .unwrap();
+    let team_id = canonical.id();
+    let member = TeamMember::new(team_id, user_id, TeamRole::Member, None);
+
+    repo.add_member(member).await.unwrap();
+
+    let legacy = db.get_team(&team_id.to_string()).await.unwrap().unwrap();
+    assert_eq!(legacy.members.len(), 1);
+    assert_eq!(legacy.members[0].user_id, user_id.to_string());
+    let legacy_user = db.get_user(&user_id.to_string()).await.unwrap().unwrap();
+    assert_eq!(legacy_user.teams, vec![team_id.to_string()]);
+
+    repo.remove_member(team_id, user_id).await.unwrap();
+
+    let legacy = db.get_team(&team_id.to_string()).await.unwrap().unwrap();
+    assert!(legacy.members.is_empty());
+    let legacy_user = db.get_user(&user_id.to_string()).await.unwrap().unwrap();
+    assert!(legacy_user.teams.is_empty());
+}
+
+#[tokio::test]
+async fn test_delete_legacy_only_team_removes_legacy_user_membership_without_readthrough() {
+    let (repo, db) = create_repository_with_db().await;
+    let owner_id = Uuid::new_v4();
+    let legacy = legacy_team("legacy-delete-direct", owner_id);
+    let legacy_id = Uuid::parse_str(&legacy.team_id).unwrap();
+    let mut user = legacy_user(owner_id, "legacy-delete-direct@example.com");
+    user.teams.push(legacy_id.to_string());
+
+    db.um_create_user(&user).await.unwrap();
+    db.create_team(&legacy).await.unwrap();
+
+    repo.delete(legacy_id).await.unwrap();
+
+    assert!(db.get_team(&legacy_id.to_string()).await.unwrap().is_none());
+    let legacy_user = db.get_user(&owner_id.to_string()).await.unwrap().unwrap();
+    assert!(legacy_user.teams.is_empty());
+}
+
+#[tokio::test]
+async fn test_canonical_team_delete_removes_legacy_user_memberships() {
+    let (repo, db) = create_repository_with_db().await;
+    let user_id = Uuid::new_v4();
+    db.um_create_user(&legacy_user(user_id, "delete-member@example.com"))
+        .await
+        .unwrap();
+
+    let team = repo
+        .create(Team::new("canonical-delete-membership".to_string(), None))
+        .await
+        .unwrap();
+    let team_id = team.id();
+    repo.add_member(TeamMember::new(team_id, user_id, TeamRole::Member, None))
+        .await
+        .unwrap();
+
+    repo.delete(team_id).await.unwrap();
+
+    assert!(db.get_team(&team_id.to_string()).await.unwrap().is_none());
+    let legacy_user = db.get_user(&user_id.to_string()).await.unwrap().unwrap();
+    assert!(legacy_user.teams.is_empty());
 }


### PR DESCRIPTION
## Summary
- mirror canonical TeamRepository create/update/delete writes into legacy `um_teams`
- mirror canonical member add/update/remove into legacy team members and `um_users.data.teams`
- preserve legacy-only settings/organization metadata while keeping the prior read-through safeguards

## Verification
- `cargo fmt --all -- --check`
- `cargo test team_repository`
- `cargo test user_management`
- `cargo test --all-features team_repository`
- `cargo test --all-features user_management`
- `cargo check --all-features`
- `git diff --check`
- `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if`