### PR TITLE
Bridge canonical and legacy users

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -924,6 +924,30 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E4 user bridge: `in_progress`
+    - Modified files:
+      - `src/storage/database/seaorm_db/mod.rs`
+      - `src/storage/database/seaorm_db/user_ops.rs`
+      - `src/storage/database/seaorm_db/user_management_ops.rs`
+      - `src/storage/database/seaorm_db/user_repository_tests.rs`
+    - Main changes:
+      - Mirrored canonical `create_user` writes into `um_users` without copying password hashes into legacy JSON.
+      - Added legacy `um_users` read-through for canonical `find_user_by_id`, `find_user_by_username`, and `find_user_by_email`.
+      - Added canonical user materialization when legacy `get_user` or `get_user_by_email` sees an existing canonical row.
+      - Generated an unguessable parseable password hash for materialized legacy users so auth failures stay on the normal invalid-credentials path.
+      - Looked up legacy users by `metadata.canonical_username` when canonical username rows are missing.
+      - Added conservative role/status/preference/budget field mapping while respecting the existing canonical `users` table column surface.
+      - Skipped legacy mirror writes on email conflict instead of returning a different legacy user for the canonical ID.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test user_repository` -> pass (`7` tests)
+      - `cargo test user_management` -> pass (`73` tests)
+      - `cargo test team_repository` -> pass (`14` tests)
+      - `cargo test --all-features user_repository` -> pass (`7` tests)
+      - `cargo test --all-features user_management` -> pass (`73` tests)
+      - `cargo check --all-features` -> pass
+      - `git diff --check` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E4 canonical-to-legacy team mirror: `in_progress`
     - Modified files:
       - `src/storage/database/seaorm_db/team_repository.rs`

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -11,6 +11,8 @@ mod token_ops;
 mod types;
 mod user_management_ops;
 mod user_ops;
+#[cfg(test)]
+mod user_repository_tests;
 mod virtual_key_ops;
 
 // Re-export public types

--- a/src/storage/database/seaorm_db/user_management_ops.rs
+++ b/src/storage/database/seaorm_db/user_management_ops.rs
@@ -49,7 +49,7 @@ impl SeaOrmDatabase {
 
 impl SeaOrmDatabase {
     /// Retrieve a user management user by their string ID.
-    pub async fn get_user(&self, user_id: &str) -> Result<Option<User>> {
+    pub(crate) async fn get_legacy_user_by_id(&self, user_id: &str) -> Result<Option<User>> {
         debug!("um: get_user {}", user_id);
         let sql = format!("SELECT data FROM um_users WHERE user_id = {}", self.ph(1));
         let stmt = Statement::from_sql_and_values(
@@ -67,7 +67,7 @@ impl SeaOrmDatabase {
     }
 
     /// Retrieve a user management user by their email address.
-    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<User>> {
+    pub(crate) async fn get_legacy_user_by_email(&self, email: &str) -> Result<Option<User>> {
         debug!("um: get_user_by_email {}", email);
         let sql = format!("SELECT data FROM um_users WHERE email = {}", self.ph(1));
         let stmt = Statement::from_sql_and_values(
@@ -82,6 +82,67 @@ impl SeaOrmDatabase {
                 Ok(Some(Self::deserialize(&data)?))
             }
         }
+    }
+
+    /// Retrieve a user management user by the canonical username preserved in
+    /// its JSON metadata.
+    pub(crate) async fn get_legacy_user_by_canonical_username(
+        &self,
+        username: &str,
+    ) -> Result<Option<User>> {
+        debug!("um: get_user_by_canonical_username {}", username);
+        let predicate = match self.backend_type {
+            DatabaseBackendType::PostgreSQL => {
+                format!(
+                    "data::jsonb -> 'metadata' ->> 'canonical_username' = {}",
+                    self.ph(1)
+                )
+            }
+            DatabaseBackendType::SQLite => {
+                format!(
+                    "json_extract(data, '$.metadata.canonical_username') = {}",
+                    self.ph(1)
+                )
+            }
+        };
+        let sql = format!("SELECT data FROM um_users WHERE {}", predicate);
+        let stmt = Statement::from_sql_and_values(
+            self.db_backend(),
+            &sql,
+            [Value::String(Some(Box::new(username.to_owned())))],
+        );
+        match self.db.query_one(stmt).await.map_err(GatewayError::from)? {
+            None => Ok(None),
+            Some(row) => {
+                let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
+                Ok(Some(Self::deserialize(&data)?))
+            }
+        }
+    }
+
+    /// Retrieve a user management user by their string ID.
+    pub async fn get_user(&self, user_id: &str) -> Result<Option<User>> {
+        if let Some(user) = self.get_legacy_user_by_id(user_id).await? {
+            return Ok(Some(user));
+        }
+
+        let Ok(user_uuid) = uuid::Uuid::parse_str(user_id) else {
+            return Ok(None);
+        };
+        self.sync_legacy_user_from_canonical(user_uuid).await?;
+        self.get_legacy_user_by_id(user_id).await
+    }
+
+    /// Retrieve a user management user by their email address.
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<User>> {
+        if let Some(user) = self.get_legacy_user_by_email(email).await? {
+            return Ok(Some(user));
+        }
+
+        if let Some(user) = self.find_canonical_user_by_email(email).await? {
+            self.sync_legacy_user_from_canonical(user.id()).await?;
+        }
+        self.get_legacy_user_by_email(email).await
     }
 
     /// Persist a new user management user to the database.
@@ -109,6 +170,7 @@ impl SeaOrmDatabase {
             ],
         );
         self.db.execute(stmt).await.map_err(GatewayError::from)?;
+        let _ = self.persist_legacy_user(user).await?;
         Ok(())
     }
 

--- a/src/storage/database/seaorm_db/user_ops.rs
+++ b/src/storage/database/seaorm_db/user_ops.rs
@@ -1,17 +1,179 @@
-use crate::core::models::user::types::User;
+use crate::core::models::user::preferences::UserPreferences;
+use crate::core::models::user::types::{User, UserProfile, UserRole as CoreUserRole, UserStatus};
+use crate::core::models::{Metadata, UsageStats};
+use crate::core::user_management::{
+    User as LegacyUser, UserPreferences as LegacyUserPreferences, UserRole as LegacyUserRole,
+};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use sea_orm::prelude::Expr;
 use sea_orm::*;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::super::entities::{self, user};
 use super::types::SeaOrmDatabase;
 
 impl SeaOrmDatabase {
-    /// Find user by ID
-    pub async fn find_user_by_id(&self, user_id: uuid::Uuid) -> Result<Option<User>> {
-        debug!("Finding user by ID: {}", user_id);
+    fn core_role_to_legacy(role: &CoreUserRole) -> LegacyUserRole {
+        match role {
+            CoreUserRole::SuperAdmin => LegacyUserRole::SuperAdmin,
+            CoreUserRole::Admin => LegacyUserRole::OrgAdmin,
+            CoreUserRole::Manager => LegacyUserRole::TeamAdmin,
+            CoreUserRole::User => LegacyUserRole::User,
+            CoreUserRole::Viewer => LegacyUserRole::ReadOnly,
+            CoreUserRole::ApiUser => LegacyUserRole::ServiceAccount,
+        }
+    }
 
+    fn legacy_role_to_core(role: &LegacyUserRole) -> CoreUserRole {
+        match role {
+            LegacyUserRole::SuperAdmin => CoreUserRole::SuperAdmin,
+            LegacyUserRole::OrgAdmin => CoreUserRole::Admin,
+            LegacyUserRole::TeamAdmin => CoreUserRole::Manager,
+            LegacyUserRole::User => CoreUserRole::User,
+            LegacyUserRole::ReadOnly => CoreUserRole::Viewer,
+            LegacyUserRole::ServiceAccount => CoreUserRole::ApiUser,
+        }
+    }
+
+    fn core_preferences_to_legacy(preferences: &UserPreferences) -> LegacyUserPreferences {
+        LegacyUserPreferences {
+            language: preferences.language.clone(),
+            timezone: preferences.timezone.clone(),
+            email_notifications: preferences.notifications.email_enabled,
+            slack_notifications: preferences.notifications.slack_enabled,
+            dashboard_config: std::collections::HashMap::new(),
+        }
+    }
+
+    fn legacy_preferences_to_core(preferences: &LegacyUserPreferences) -> UserPreferences {
+        let mut core = UserPreferences {
+            language: preferences.language.clone(),
+            timezone: preferences.timezone.clone(),
+            ..UserPreferences::default()
+        };
+        core.notifications.email_enabled = preferences.email_notifications;
+        core.notifications.slack_enabled = preferences.slack_notifications;
+        core
+    }
+
+    fn unavailable_legacy_password_hash() -> Result<String> {
+        let password = format!("legacy-password-unavailable:{}", uuid::Uuid::new_v4());
+        crate::utils::auth::crypto::password::hash_password(&password)
+    }
+
+    pub(crate) fn core_user_to_legacy(user: &User) -> LegacyUser {
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("canonical_username".to_string(), user.username.clone());
+
+        LegacyUser {
+            user_id: user.id().to_string(),
+            email: user.email.clone(),
+            display_name: user.display_name.clone(),
+            first_name: user.profile.first_name.clone(),
+            last_name: user.profile.last_name.clone(),
+            role: Self::core_role_to_legacy(&user.role),
+            teams: user.team_ids.iter().map(ToString::to_string).collect(),
+            permissions: Vec::new(),
+            metadata,
+            max_budget: user
+                .rate_limits
+                .as_ref()
+                .and_then(|limits| limits.monthly_budget),
+            spend: user.usage_stats.total_cost,
+            budget_duration: None,
+            budget_reset_at: None,
+            is_active: user.is_active(),
+            created_at: user.metadata.created_at,
+            last_login_at: user.last_login_at,
+            preferences: Self::core_preferences_to_legacy(&user.preferences),
+        }
+    }
+
+    pub(crate) fn legacy_user_to_core(legacy: &LegacyUser) -> Result<Option<User>> {
+        let user_id = match uuid::Uuid::parse_str(&legacy.user_id) {
+            Ok(id) => id,
+            Err(_) => {
+                warn!(
+                    legacy_user_id = %legacy.user_id,
+                    "Skipping legacy user sync because user_id is not a UUID"
+                );
+                return Ok(None);
+            }
+        };
+
+        let mut metadata = Metadata::new();
+        metadata.id = user_id;
+        metadata.created_at = legacy.created_at;
+        metadata.updated_at = legacy.created_at;
+        metadata
+            .extra
+            .insert("legacy_um_user".to_string(), serde_json::Value::Bool(true));
+
+        let team_ids = legacy
+            .teams
+            .iter()
+            .filter_map(|team_id| match uuid::Uuid::parse_str(team_id) {
+                Ok(id) => Some(id),
+                Err(_) => {
+                    warn!(
+                        legacy_team_id = %team_id,
+                        legacy_user_id = %legacy.user_id,
+                        "Skipping legacy user team reference because team_id is not a UUID"
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        Ok(Some(User {
+            metadata,
+            username: legacy
+                .metadata
+                .get("canonical_username")
+                .cloned()
+                .unwrap_or_else(|| legacy.email.clone()),
+            email: legacy.email.clone(),
+            display_name: legacy.display_name.clone(),
+            password_hash: Self::unavailable_legacy_password_hash()?,
+            role: Self::legacy_role_to_core(&legacy.role),
+            status: if legacy.is_active {
+                UserStatus::Active
+            } else {
+                UserStatus::Inactive
+            },
+            team_ids,
+            preferences: Self::legacy_preferences_to_core(&legacy.preferences),
+            usage_stats: UsageStats {
+                total_cost: legacy.spend,
+                cost_today: legacy.spend,
+                last_reset: legacy.created_at,
+                ..UsageStats::default()
+            },
+            rate_limits: legacy.max_budget.map(|monthly_budget| {
+                crate::core::models::user::types::UserRateLimits {
+                    rpm: None,
+                    tpm: None,
+                    rpd: None,
+                    tpd: None,
+                    concurrent: None,
+                    monthly_budget: Some(monthly_budget),
+                }
+            }),
+            last_login_at: legacy.last_login_at,
+            email_verified: false,
+            two_factor_enabled: false,
+            profile: UserProfile {
+                first_name: legacy.first_name.clone(),
+                last_name: legacy.last_name.clone(),
+                ..UserProfile::default()
+            },
+        }))
+    }
+
+    pub(crate) async fn find_canonical_user_by_id(
+        &self,
+        user_id: uuid::Uuid,
+    ) -> Result<Option<User>> {
         let user_model = entities::User::find_by_id(user_id)
             .one(&self.db)
             .await
@@ -20,10 +182,10 @@ impl SeaOrmDatabase {
         Ok(user_model.map(|model| model.to_domain_user()))
     }
 
-    /// Find user by username
-    pub async fn find_user_by_username(&self, username: &str) -> Result<Option<User>> {
-        debug!("Finding user by username: {}", username);
-
+    pub(crate) async fn find_canonical_user_by_username(
+        &self,
+        username: &str,
+    ) -> Result<Option<User>> {
         let user_model = entities::User::find()
             .filter(user::Column::Username.eq(username))
             .one(&self.db)
@@ -33,10 +195,7 @@ impl SeaOrmDatabase {
         Ok(user_model.map(|model| model.to_domain_user()))
     }
 
-    /// Find user by email
-    pub async fn find_user_by_email(&self, email: &str) -> Result<Option<User>> {
-        debug!("Finding user by email: {}", email);
-
+    pub(crate) async fn find_canonical_user_by_email(&self, email: &str) -> Result<Option<User>> {
         let user_model = entities::User::find()
             .filter(user::Column::Email.eq(email))
             .one(&self.db)
@@ -44,6 +203,126 @@ impl SeaOrmDatabase {
             .map_err(GatewayError::from)?;
 
         Ok(user_model.map(|model| model.to_domain_user()))
+    }
+
+    pub(crate) async fn persist_legacy_user(&self, legacy: &LegacyUser) -> Result<Option<User>> {
+        let Some(user) = Self::legacy_user_to_core(legacy)? else {
+            return Ok(None);
+        };
+
+        if let Some(existing) = self.find_canonical_user_by_id(user.id()).await? {
+            if existing.email != user.email {
+                warn!(
+                    legacy_user_id = %user.id(),
+                    legacy_email = %user.email,
+                    canonical_email = %existing.email,
+                    "Skipping legacy user sync because canonical user ID already exists with a different email"
+                );
+                return Ok(None);
+            }
+            return Ok(Some(existing));
+        }
+
+        if let Some(existing) = self.find_canonical_user_by_email(&user.email).await?
+            && existing.id() != user.id()
+        {
+            warn!(
+                legacy_user_id = %user.id(),
+                existing_user_id = %existing.id(),
+                email = %user.email,
+                "Skipping legacy user sync because canonical user email already exists"
+            );
+            return Ok(None);
+        }
+
+        if let Some(existing) = self.find_canonical_user_by_username(&user.username).await?
+            && existing.id() != user.id()
+        {
+            warn!(
+                legacy_user_id = %user.id(),
+                existing_user_id = %existing.id(),
+                username = %user.username,
+                "Skipping legacy user sync because canonical username already exists"
+            );
+            return Ok(None);
+        }
+
+        let active_model = user::Model::from_domain_user(&user);
+        entities::User::insert(active_model)
+            .exec(&self.db)
+            .await
+            .map_err(GatewayError::from)?;
+        Ok(Some(user))
+    }
+
+    pub(crate) async fn sync_legacy_user_from_canonical(&self, user_id: uuid::Uuid) -> Result<()> {
+        let Some(user) = self.find_canonical_user_by_id(user_id).await? else {
+            return Ok(());
+        };
+        self.upsert_legacy_user_from_core(&user).await
+    }
+
+    async fn upsert_legacy_user_from_core(&self, user: &User) -> Result<()> {
+        let legacy = Self::core_user_to_legacy(user);
+        if self.get_legacy_user_by_id(&legacy.user_id).await?.is_some() {
+            self.update_user(&legacy).await
+        } else if let Some(existing) = self.get_legacy_user_by_email(&legacy.email).await? {
+            warn!(
+                canonical_user_id = %legacy.user_id,
+                existing_legacy_user_id = %existing.user_id,
+                email = %legacy.email,
+                "Skipping canonical user sync because legacy user email already exists"
+            );
+            Ok(())
+        } else {
+            self.um_create_user(&legacy).await
+        }
+    }
+
+    /// Find user by ID
+    pub async fn find_user_by_id(&self, user_id: uuid::Uuid) -> Result<Option<User>> {
+        debug!("Finding user by ID: {}", user_id);
+
+        if let Some(user) = self.find_canonical_user_by_id(user_id).await? {
+            return Ok(Some(user));
+        }
+
+        match self.get_user(&user_id.to_string()).await? {
+            Some(legacy) => self.persist_legacy_user(&legacy).await,
+            None => Ok(None),
+        }
+    }
+
+    /// Find user by username
+    pub async fn find_user_by_username(&self, username: &str) -> Result<Option<User>> {
+        debug!("Finding user by username: {}", username);
+
+        if let Some(user) = self.find_canonical_user_by_username(username).await? {
+            return Ok(Some(user));
+        }
+
+        if let Some(legacy) = self.get_legacy_user_by_canonical_username(username).await? {
+            return self.persist_legacy_user(&legacy).await;
+        }
+
+        match self.get_user_by_email(username).await? {
+            Some(legacy) => self.persist_legacy_user(&legacy).await,
+            None => Ok(None),
+        }
+    }
+
+    /// Find user by email
+    pub async fn find_user_by_email(&self, email: &str) -> Result<Option<User>> {
+        debug!("Finding user by email: {}", email);
+
+        if let Some(user) = self.find_canonical_user_by_email(email).await? {
+            return Ok(Some(user));
+        }
+
+        match self.get_user_by_email(email).await? {
+            Some(legacy) => self.persist_legacy_user(&legacy).await,
+            None => Ok(None),
+        }
     }
 
     /// Create a new user
@@ -56,6 +335,8 @@ impl SeaOrmDatabase {
             .exec(&self.db)
             .await
             .map_err(GatewayError::from)?;
+
+        self.upsert_legacy_user_from_core(user).await?;
 
         // Return the created user
         Ok(user.clone())

--- a/src/storage/database/seaorm_db/user_repository_tests.rs
+++ b/src/storage/database/seaorm_db/user_repository_tests.rs
@@ -1,0 +1,229 @@
+use super::super::entities;
+use super::types::SeaOrmDatabase;
+use crate::config::models::storage::DatabaseConfig;
+use crate::core::models::user::types::{User, UserProfile, UserRateLimits, UserRole, UserStatus};
+use crate::core::user_management::{
+    User as LegacyUser, UserPreferences as LegacyUserPreferences, UserRole as LegacyUserRole,
+};
+use crate::utils::auth::crypto::password::verify_password;
+use chrono::Utc;
+use sea_orm::EntityTrait;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+async fn create_database() -> SeaOrmDatabase {
+    let db = SeaOrmDatabase::new(&DatabaseConfig {
+        enabled: false,
+        ..DatabaseConfig::default()
+    })
+    .await
+    .expect("failed to create in-memory database");
+    db.migrate().await.expect("failed to run migrations");
+    db
+}
+
+fn canonical_user(username: &str, email: &str) -> User {
+    let mut user = User::new(username.to_string(), email.to_string(), "hash".to_string());
+    user.status = UserStatus::Active;
+    user.display_name = Some("Canonical User".to_string());
+    user.profile = UserProfile {
+        first_name: Some("Canonical".to_string()),
+        last_name: Some("User".to_string()),
+        ..UserProfile::default()
+    };
+    user.role = UserRole::Manager;
+    user.team_ids = vec![Uuid::new_v4()];
+    user.usage_stats.total_cost = 17.5;
+    user.rate_limits = Some(UserRateLimits {
+        rpm: None,
+        tpm: None,
+        rpd: None,
+        tpd: None,
+        concurrent: None,
+        monthly_budget: Some(250.0),
+    });
+    user
+}
+
+fn legacy_user(user_id: Uuid, email: &str) -> LegacyUser {
+    LegacyUser {
+        user_id: user_id.to_string(),
+        email: email.to_string(),
+        display_name: Some("Legacy User".to_string()),
+        first_name: Some("Legacy".to_string()),
+        last_name: Some("User".to_string()),
+        role: LegacyUserRole::TeamAdmin,
+        teams: vec![Uuid::new_v4().to_string()],
+        permissions: vec!["keys.create".to_string()],
+        metadata: HashMap::new(),
+        max_budget: Some(100.0),
+        spend: 9.25,
+        budget_duration: Some("1m".to_string()),
+        budget_reset_at: Some(Utc::now()),
+        is_active: true,
+        created_at: Utc::now(),
+        last_login_at: Some(Utc::now()),
+        preferences: LegacyUserPreferences::default(),
+    }
+}
+
+#[tokio::test]
+async fn test_canonical_user_create_is_visible_through_legacy_user_management_tables() {
+    let db = create_database().await;
+    let user = canonical_user("canonical-user", "canonical@example.com");
+    let user_id = user.id();
+
+    db.create_user(&user).await.unwrap();
+
+    let legacy = db.get_user(&user_id.to_string()).await.unwrap().unwrap();
+    assert_eq!(legacy.user_id, user_id.to_string());
+    assert_eq!(legacy.email, "canonical@example.com");
+    assert_eq!(legacy.display_name, Some("Canonical User".to_string()));
+    assert_eq!(legacy.role, LegacyUserRole::TeamAdmin);
+    assert_eq!(
+        legacy.teams,
+        user.team_ids
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(legacy.max_budget, Some(250.0));
+    assert_eq!(legacy.spend, 17.5);
+    assert_eq!(
+        legacy.metadata.get("canonical_username"),
+        Some(&"canonical-user".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_user_create_is_visible_through_canonical_user_repository() {
+    let db = create_database().await;
+    let user_id = Uuid::new_v4();
+    let legacy = legacy_user(user_id, "legacy@example.com");
+
+    db.um_create_user(&legacy).await.unwrap();
+
+    let canonical = db.find_user_by_id(user_id).await.unwrap().unwrap();
+    assert_eq!(canonical.id(), user_id);
+    assert_eq!(canonical.username, "legacy@example.com");
+    assert_eq!(canonical.email, "legacy@example.com");
+    assert_eq!(canonical.display_name, Some("Legacy User".to_string()));
+    assert_eq!(canonical.role, UserRole::Manager);
+    assert!(canonical.is_active());
+    assert!(canonical.last_login_at.is_some());
+}
+
+#[tokio::test]
+async fn test_legacy_user_lookup_materializes_existing_canonical_user() {
+    let db = create_database().await;
+    let user = canonical_user("canonical-materialize", "materialize@example.com");
+    let user_id = user.id();
+
+    db.create_user(&user).await.unwrap();
+    db.delete_user(&user_id.to_string()).await.unwrap();
+    assert!(
+        db.get_legacy_user_by_id(&user_id.to_string())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let legacy = db
+        .get_user_by_email("materialize@example.com")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(legacy.user_id, user_id.to_string());
+    assert_eq!(legacy.email, "materialize@example.com");
+}
+
+#[tokio::test]
+async fn test_canonical_user_sync_skips_legacy_email_conflict() {
+    let db = create_database().await;
+    let canonical = canonical_user("canonical-conflict", "conflict@example.com");
+    let canonical_id = canonical.id();
+    db.create_user(&canonical).await.unwrap();
+    db.delete_user(&canonical_id.to_string()).await.unwrap();
+
+    let legacy_id = Uuid::new_v4();
+    db.um_create_user(&legacy_user(legacy_id, "conflict@example.com"))
+        .await
+        .unwrap();
+
+    assert!(db.find_user_by_id(canonical_id).await.unwrap().is_some());
+    assert!(
+        db.get_user(&canonical_id.to_string())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let legacy = db
+        .get_legacy_user_by_email("conflict@example.com")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(legacy.user_id, legacy_id.to_string());
+}
+
+#[tokio::test]
+async fn test_legacy_user_sync_skips_existing_canonical_id_email_conflict() {
+    let db = create_database().await;
+    let canonical = canonical_user("canonical-id-conflict", "canonical-id@example.com");
+    let canonical_id = canonical.id();
+    db.create_user(&canonical).await.unwrap();
+    db.delete_user(&canonical_id.to_string()).await.unwrap();
+
+    let legacy = legacy_user(canonical_id, "legacy-id@example.com");
+    db.um_create_user(&legacy).await.unwrap();
+
+    assert!(
+        db.find_user_by_email("legacy-id@example.com")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let canonical = db.find_user_by_id(canonical_id).await.unwrap().unwrap();
+    assert_eq!(canonical.email, "canonical-id@example.com");
+}
+
+#[tokio::test]
+async fn test_legacy_user_materialization_preserves_parseable_password_hash() {
+    let db = create_database().await;
+    let user_id = Uuid::new_v4();
+    let legacy = legacy_user(user_id, "legacy-password@example.com");
+
+    db.um_create_user(&legacy).await.unwrap();
+
+    let canonical = db.find_user_by_id(user_id).await.unwrap().unwrap();
+    assert!(canonical.password_hash.starts_with("$argon2"));
+    assert!(
+        !verify_password("legacy-password@example.com", &canonical.password_hash).unwrap(),
+        "legacy users must not become loginable with a predictable placeholder password"
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_user_lookup_by_canonical_username_metadata() {
+    let db = create_database().await;
+    let user_id = Uuid::new_v4();
+    let mut legacy = legacy_user(user_id, "legacy-handle@example.com");
+    legacy.metadata.insert(
+        "canonical_username".to_string(),
+        "legacy-handle".to_string(),
+    );
+
+    db.um_create_user(&legacy).await.unwrap();
+    entities::User::delete_by_id(user_id)
+        .exec(&db.db)
+        .await
+        .unwrap();
+
+    let canonical = db
+        .find_user_by_username("legacy-handle")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(canonical.id(), user_id);
+    assert_eq!(canonical.username, "legacy-handle");
+    assert_eq!(canonical.email, "legacy-handle@example.com");
+}


### PR DESCRIPTION
## Summary
- mirror canonical user creates into legacy `um_users` without copying password hashes
- add read-through bridging from legacy `um_users` into canonical user lookups by id, username/email
- materialize canonical users for legacy `get_user`/`get_user_by_email` callers and skip email conflicts to avoid wrong-id returns
- document the E4 user-bridge verification in the audit remediation plan

## Verification
- cargo fmt --all -- --check
- cargo test user_repository
- cargo test user_management
- cargo test team_repository
- cargo test --all-features user_repository
- cargo test --all-features user_management
- cargo check --all-features
- git diff --check
- cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if
