### PR TITLE
Route SDK provider selection through core router

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -640,7 +640,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 
 ### Step E4 C15 team/user convergence
 
-- status: `in_progress`
+- status: `completed`
 - Expected changes:
   - `src/storage/database/migration/m20240301_000001_create_user_management_tables.rs`
   - `src/storage/database/migration/m20240301_000002_create_teams_table.rs`
@@ -659,7 +659,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 - Completion judgment:
   - A team/user created by any API is visible through the canonical repository.
 - Owner decision:
-  - Confirm no deployment depends on raw SQL against `um_*` names before drop migration.
+  - Drop migration remains intentionally deferred until the owner confirms no deployment depends on raw SQL against `um_*` names.
 
 ### Step E5 C16 AuthConfig default consistency
 
@@ -715,7 +715,7 @@ Goal: remove parallel systems after correctness/security work is stable.
 
 ### Step E8 H14 SDK delegates to UnifiedRouter
 
-- status: `pending`
+- status: `completed`
 - Expected changes:
   - `src/sdk/client/routing.rs`
   - SDK client tests
@@ -924,6 +924,29 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
 ## 9. Execution Log
 
 - 2026-05-02
+  - Step E8 SDK router convergence: `completed`
+    - Modified files:
+      - `src/core/router/selection.rs`
+      - `src/sdk/client/llm_client.rs`
+      - `src/sdk/client/routing.rs`
+      - `src/sdk/client/types.rs`
+      - `src/sdk/client/tests.rs`
+    - Main changes:
+      - Exposed `UnifiedRouter::select_from_routing_contexts` as the shared core router selection entry point for pre-built routing snapshots.
+      - Replaced the SDK-specific load-balancing implementation with an adapter that converts SDK provider candidates into core router `RoutingContext` snapshots.
+      - Mapped SDK `WeightedRandom`, `LeastLatency`, `HealthBased`, and `RoundRobin` strategies onto core router strategy functions.
+      - Routed explicit SDK model selection through the same core selection path across all enabled matching providers instead of returning the first matching provider.
+      - Routed stream fallback selection through the shared load-balancer path when no default provider is configured.
+      - Filtered SDK load-balanced candidates by chat/stream capability before core router selection to avoid routing to unsupported providers.
+      - Removed the now-dead first-enabled-provider helper.
+    - Execute tests:
+      - `cargo fmt --all -- --check` -> pass
+      - `cargo test sdk` -> pass (`233` tests)
+      - `cargo test router` -> pass (`365` lib-filtered tests, `6` integration-filtered tests)
+      - `cargo test --all-features sdk` -> pass (`233` tests)
+      - `cargo check --all-features` -> pass
+      - `git diff --check` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E4 user bridge: `in_progress`
     - Modified files:
       - `src/storage/database/seaorm_db/mod.rs`

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -6,10 +6,11 @@
 use super::config::RoutingStrategy;
 use super::deployment::{Deployment, DeploymentId};
 use super::error::RouterError;
-use super::strategy_impl;
+use super::strategy_impl::{self, RoutingContext};
 use super::unified::Router;
 use crate::core::types::model::ProviderCapability;
-use std::sync::atomic::Ordering::Relaxed;
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 impl Router {
     /// Select the best deployment for a given model (core routing method)
@@ -42,6 +43,41 @@ impl Router {
                 .iter()
                 .any(|cap| cap == capability)
         })
+    }
+
+    /// Select a deployment ID from pre-built routing contexts.
+    ///
+    /// This is the shared routing-policy entry point used by the full
+    /// `UnifiedRouter` and lightweight adapters such as the SDK client.
+    pub fn select_from_routing_contexts<'id>(
+        strategy: RoutingStrategy,
+        model_name: &str,
+        routing_contexts: &[RoutingContext<'id>],
+        round_robin_counters: &DashMap<String, AtomicUsize>,
+    ) -> Option<&'id DeploymentId> {
+        match strategy {
+            RoutingStrategy::SimpleShuffle => {
+                strategy_impl::weighted_random_from_context(routing_contexts)
+            }
+            RoutingStrategy::LeastBusy => strategy_impl::least_busy_from_context(routing_contexts),
+            RoutingStrategy::UsageBased => {
+                strategy_impl::lowest_usage_from_context(routing_contexts)
+            }
+            RoutingStrategy::LatencyBased => {
+                strategy_impl::lowest_latency_from_context(routing_contexts)
+            }
+            RoutingStrategy::PriorityBased => {
+                strategy_impl::lowest_priority_from_context(routing_contexts)
+            }
+            RoutingStrategy::RateLimitAware => {
+                strategy_impl::rate_limit_aware_from_context(routing_contexts)
+            }
+            RoutingStrategy::RoundRobin => strategy_impl::round_robin_from_context(
+                model_name,
+                routing_contexts,
+                round_robin_counters,
+            ),
+        }
     }
 
     fn select_deployment_matching<F>(
@@ -174,29 +210,12 @@ impl Router {
         }
 
         // 4. Select based on the immutable routing contexts.
-        let selected_id = match self.config.routing_strategy {
-            RoutingStrategy::SimpleShuffle => {
-                strategy_impl::weighted_random_from_context(&routing_contexts)
-            }
-            RoutingStrategy::LeastBusy => strategy_impl::least_busy_from_context(&routing_contexts),
-            RoutingStrategy::UsageBased => {
-                strategy_impl::lowest_usage_from_context(&routing_contexts)
-            }
-            RoutingStrategy::LatencyBased => {
-                strategy_impl::lowest_latency_from_context(&routing_contexts)
-            }
-            RoutingStrategy::PriorityBased => {
-                strategy_impl::lowest_priority_from_context(&routing_contexts)
-            }
-            RoutingStrategy::RateLimitAware => {
-                strategy_impl::rate_limit_aware_from_context(&routing_contexts)
-            }
-            RoutingStrategy::RoundRobin => strategy_impl::round_robin_from_context(
-                resolved_name,
-                &routing_contexts,
-                &self.round_robin_counters,
-            ),
-        }
+        let selected_id = Self::select_from_routing_contexts(
+            self.config.routing_strategy,
+            resolved_name,
+            &routing_contexts,
+            &self.round_robin_counters,
+        )
         .ok_or_else(|| RouterError::NoAvailableDeployment(model_name.to_string()))?
         .clone();
 

--- a/src/sdk/client/llm_client.rs
+++ b/src/sdk/client/llm_client.rs
@@ -111,15 +111,6 @@ impl LLMClient {
             .filter(|provider| provider.enabled)
     }
 
-    /// Return the first enabled provider in config order.
-    pub(crate) fn first_enabled_provider(&self) -> Result<&SdkProviderConfig> {
-        self.config
-            .providers
-            .iter()
-            .find(|provider| provider.enabled)
-            .ok_or(SDKError::NoDefaultProvider)
-    }
-
     /// Find the first enabled provider that explicitly supports `model`.
     pub(crate) fn provider_for_model(&self, model: &str) -> Result<&SdkProviderConfig> {
         self.config

--- a/src/sdk/client/routing.rs
+++ b/src/sdk/client/routing.rs
@@ -2,6 +2,11 @@
 
 use super::llm_client::LLMClient;
 use super::types::{LoadBalancingStrategy, ProviderStats};
+use crate::core::router::UnifiedRouter;
+use crate::core::router::UnifiedRoutingStrategy;
+use crate::core::router::deployment::DeploymentId;
+use crate::core::router::strategy_impl::RoutingContext;
+use crate::sdk::config::{ProviderType, SdkProviderConfig};
 use crate::sdk::errors::*;
 use crate::sdk::types::{Message, SdkChatRequest};
 use std::collections::HashMap;
@@ -15,7 +20,14 @@ impl LLMClient {
         request: &SdkChatRequest,
     ) -> Result<&crate::sdk::config::SdkProviderConfig> {
         if !request.model.is_empty() {
-            return self.provider_for_model(&request.model);
+            return self
+                .load_balancer
+                .select_chat_provider(
+                    &self.config.providers,
+                    &self.provider_stats,
+                    Some(&request.model),
+                )
+                .await;
         }
 
         if let Some(provider) = self.default_enabled_provider() {
@@ -23,7 +35,7 @@ impl LLMClient {
         }
 
         self.load_balancer
-            .select_provider(&self.config.providers, &self.provider_stats)
+            .select_chat_provider(&self.config.providers, &self.provider_stats, None)
             .await
     }
 
@@ -36,91 +48,160 @@ impl LLMClient {
             return Ok(provider);
         }
 
-        self.first_enabled_provider()
+        self.load_balancer
+            .select_stream_provider(&self.config.providers, &self.provider_stats)
+            .await
     }
 }
 
 // Load balancer implementation
-use std::sync::atomic::Ordering;
-
 use super::types::LoadBalancer;
 
 impl LoadBalancer {
-    /// Select provider using load balancing strategy
-    pub(crate) async fn select_provider<'a>(
+    /// Select a chat-capable provider using the configured load balancing strategy.
+    pub(crate) async fn select_chat_provider<'a>(
         &self,
-        providers: &'a [crate::sdk::config::SdkProviderConfig],
+        providers: &'a [SdkProviderConfig],
         stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
-    ) -> Result<&'a crate::sdk::config::SdkProviderConfig> {
-        let enabled_providers: Vec<&crate::sdk::config::SdkProviderConfig> =
-            providers.iter().filter(|p| p.enabled).collect();
+        model: Option<&str>,
+    ) -> Result<&'a SdkProviderConfig> {
+        self.select_provider_with_capability(providers, stats, model, supports_chat)
+            .await
+    }
+
+    /// Select a streaming-capable provider using the configured load balancing strategy.
+    pub(crate) async fn select_stream_provider<'a>(
+        &self,
+        providers: &'a [SdkProviderConfig],
+        stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
+    ) -> Result<&'a SdkProviderConfig> {
+        self.select_provider_with_capability(providers, stats, None, supports_stream)
+            .await
+    }
+
+    async fn select_provider_with_capability<'a>(
+        &self,
+        providers: &'a [SdkProviderConfig],
+        stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
+        model: Option<&str>,
+        supports_capability: impl Fn(&SdkProviderConfig) -> bool,
+    ) -> Result<&'a SdkProviderConfig> {
+        let enabled_providers: Vec<&SdkProviderConfig> = providers
+            .iter()
+            .filter(|provider| {
+                provider.enabled
+                    && supports_capability(provider)
+                    && model.is_none_or(|model| {
+                        provider.models.iter().any(|candidate| candidate == model)
+                    })
+            })
+            .collect();
 
         if enabled_providers.is_empty() {
-            return Err(SDKError::NoDefaultProvider);
+            return match model {
+                Some(model) => Err(SDKError::ModelNotFound(format!(
+                    "Model '{}' not supported by any provider",
+                    model
+                ))),
+                None => Err(SDKError::NoDefaultProvider),
+            };
         }
 
+        let stats_guard = stats.read().await;
+        let deployment_ids: Vec<DeploymentId> = enabled_providers
+            .iter()
+            .map(|provider| provider.id.clone())
+            .collect();
+        let contexts: Vec<RoutingContext<'_>> = enabled_providers
+            .iter()
+            .zip(deployment_ids.iter())
+            .map(|(provider, deployment_id)| {
+                let provider_stats = stats_guard.get(&provider.id);
+                RoutingContext {
+                    deployment_id,
+                    weight: sdk_weight_to_router_weight(provider.weight),
+                    priority: health_score_to_priority(
+                        provider_stats
+                            .map(|stats| stats.health_score)
+                            .unwrap_or(1.0),
+                    ),
+                    active_requests: 0,
+                    tpm_current: 0,
+                    tpm_limit: provider.rate_limit_tpm.map(u64::from),
+                    rpm_current: 0,
+                    rpm_limit: provider.rate_limit_rpm.map(u64::from),
+                    avg_latency_us: provider_stats
+                        .map(|stats| latency_ms_to_us(stats.avg_latency_ms))
+                        .unwrap_or(0),
+                }
+            })
+            .collect();
+
+        let route_key = model.unwrap_or("__sdk_default__");
+        let selected_id = UnifiedRouter::select_from_routing_contexts(
+            self.core_strategy(),
+            route_key,
+            &contexts,
+            &self.round_robin_counters,
+        )
+        .ok_or_else(|| match model {
+            Some(model) => {
+                SDKError::ModelNotFound(format!("Model '{}' not supported by any provider", model))
+            }
+            None => SDKError::NoDefaultProvider,
+        })?;
+
+        enabled_providers
+            .into_iter()
+            .find(|provider| provider.id == *selected_id)
+            .ok_or_else(|| SDKError::ProviderNotFound(selected_id.clone()))
+    }
+
+    fn core_strategy(&self) -> UnifiedRoutingStrategy {
         match self.strategy {
-            LoadBalancingStrategy::RoundRobin => {
-                let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed)
-                    % enabled_providers.len();
-                Ok(enabled_providers[idx])
-            }
-            LoadBalancingStrategy::WeightedRandom => {
-                // Weighted random selection
-                use rand::Rng;
-                let total_weight: f32 = enabled_providers.iter().map(|p| p.weight).sum();
-                let mut rng = rand::rng();
-                let mut random_weight = rng.random::<f32>() * total_weight;
-
-                for provider in &enabled_providers {
-                    random_weight -= provider.weight;
-                    if random_weight <= 0.0 {
-                        return Ok(provider);
-                    }
-                }
-
-                Ok(enabled_providers[0])
-            }
-            LoadBalancingStrategy::HealthBased => {
-                // Health-based selection
-                let stats_guard = stats.read().await;
-                let mut best_provider = enabled_providers[0];
-                let mut best_score = 0.0f64;
-
-                for provider in enabled_providers {
-                    let health_score = stats_guard
-                        .get(&provider.id)
-                        .map(|s| s.health_score)
-                        .unwrap_or(1.0);
-
-                    if health_score > best_score {
-                        best_score = health_score;
-                        best_provider = provider;
-                    }
-                }
-
-                Ok(best_provider)
-            }
-            LoadBalancingStrategy::LeastLatency => {
-                // Latency-based selection
-                let stats_guard = stats.read().await;
-                let mut best_provider = enabled_providers[0];
-                let mut best_latency = f64::INFINITY;
-
-                for provider in enabled_providers {
-                    let latency = stats_guard
-                        .get(&provider.id)
-                        .map(|s| s.avg_latency_ms)
-                        .unwrap_or(0.0);
-
-                    if latency < best_latency {
-                        best_latency = latency;
-                        best_provider = provider;
-                    }
-                }
-
-                Ok(best_provider)
-            }
+            LoadBalancingStrategy::RoundRobin => UnifiedRoutingStrategy::RoundRobin,
+            LoadBalancingStrategy::LeastLatency => UnifiedRoutingStrategy::LatencyBased,
+            LoadBalancingStrategy::WeightedRandom => UnifiedRoutingStrategy::SimpleShuffle,
+            LoadBalancingStrategy::HealthBased => UnifiedRoutingStrategy::PriorityBased,
         }
     }
+}
+
+fn supports_chat(provider: &SdkProviderConfig) -> bool {
+    matches!(
+        provider.provider_type,
+        ProviderType::Anthropic | ProviderType::OpenAI | ProviderType::Google
+    )
+}
+
+fn supports_stream(provider: &SdkProviderConfig) -> bool {
+    matches!(
+        provider.provider_type,
+        ProviderType::Anthropic | ProviderType::OpenAI | ProviderType::Ollama
+    )
+}
+
+fn sdk_weight_to_router_weight(weight: f32) -> u32 {
+    if !weight.is_finite() || weight <= 0.0 {
+        return 0;
+    }
+
+    (weight * 1_000.0).round().clamp(1.0, u32::MAX as f32) as u32
+}
+
+fn health_score_to_priority(score: f64) -> u32 {
+    let normalized = if score.is_finite() {
+        score.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    ((1.0 - normalized) * 100_000.0).round() as u32
+}
+
+fn latency_ms_to_us(latency_ms: f64) -> u64 {
+    if !latency_ms.is_finite() || latency_ms <= 0.0 {
+        return 0;
+    }
+
+    (latency_ms * 1_000.0).round().clamp(0.0, u64::MAX as f64) as u64
 }

--- a/src/sdk/client/tests.rs
+++ b/src/sdk/client/tests.rs
@@ -2,12 +2,15 @@
 
 #[cfg(test)]
 use super::llm_client::LLMClient;
+use super::types::{LoadBalancer, LoadBalancingStrategy, ProviderStats};
 use crate::sdk::config::{ConfigBuilder, ProviderType, SdkProviderConfig};
 use crate::sdk::errors::SDKError;
 use crate::sdk::types::{
     ChatOptions, Content, ContentPart, ImageUrl, Message, Role, SdkChatRequest,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 fn test_provider_config(id: &str, provider_type: ProviderType, model: &str) -> SdkProviderConfig {
     SdkProviderConfig {
@@ -106,6 +109,131 @@ async fn test_stream_provider_selection_prefers_default_provider() {
     let provider = client.select_provider_for_stream(&[]).await.unwrap();
 
     assert_eq!(provider.id, "openai");
+}
+
+#[tokio::test]
+async fn test_sdk_load_balancer_uses_core_round_robin_strategy_for_model() {
+    let providers = vec![
+        test_provider_config("openai-a", ProviderType::OpenAI, "gpt-shared"),
+        test_provider_config("openai-b", ProviderType::OpenAI, "gpt-shared"),
+    ];
+    let stats = Arc::new(RwLock::new(HashMap::<String, ProviderStats>::new()));
+    let load_balancer = LoadBalancer::new(LoadBalancingStrategy::RoundRobin);
+
+    let first = load_balancer
+        .select_chat_provider(&providers, &stats, Some("gpt-shared"))
+        .await
+        .unwrap();
+    let second = load_balancer
+        .select_chat_provider(&providers, &stats, Some("gpt-shared"))
+        .await
+        .unwrap();
+    let other_model = load_balancer
+        .select_chat_provider(&providers, &stats, Some("missing"))
+        .await
+        .unwrap_err();
+
+    assert_eq!(first.id, "openai-a");
+    assert_eq!(second.id, "openai-b");
+    assert!(matches!(other_model, SDKError::ModelNotFound(_)));
+}
+
+#[tokio::test]
+async fn test_sdk_load_balancer_maps_health_to_core_priority_strategy() {
+    let providers = vec![
+        test_provider_config("slow-errors", ProviderType::OpenAI, "gpt-shared"),
+        test_provider_config("healthy", ProviderType::OpenAI, "gpt-shared"),
+    ];
+    let stats = Arc::new(RwLock::new(HashMap::from([
+        (
+            "slow-errors".to_string(),
+            ProviderStats {
+                health_score: 0.25,
+                ..ProviderStats::default()
+            },
+        ),
+        (
+            "healthy".to_string(),
+            ProviderStats {
+                health_score: 0.98,
+                ..ProviderStats::default()
+            },
+        ),
+    ])));
+    let load_balancer = LoadBalancer::new(LoadBalancingStrategy::HealthBased);
+
+    let selected = load_balancer
+        .select_chat_provider(&providers, &stats, Some("gpt-shared"))
+        .await
+        .unwrap();
+
+    assert_eq!(selected.id, "healthy");
+}
+
+#[tokio::test]
+async fn test_sdk_load_balancer_maps_latency_to_core_latency_strategy() {
+    let providers = vec![
+        test_provider_config("slow", ProviderType::OpenAI, "gpt-shared"),
+        test_provider_config("fast", ProviderType::OpenAI, "gpt-shared"),
+    ];
+    let stats = Arc::new(RwLock::new(HashMap::from([
+        (
+            "slow".to_string(),
+            ProviderStats {
+                avg_latency_ms: 250.0,
+                ..ProviderStats::default()
+            },
+        ),
+        (
+            "fast".to_string(),
+            ProviderStats {
+                avg_latency_ms: 25.0,
+                ..ProviderStats::default()
+            },
+        ),
+    ])));
+    let load_balancer = LoadBalancer::new(LoadBalancingStrategy::LeastLatency);
+
+    let selected = load_balancer
+        .select_chat_provider(&providers, &stats, Some("gpt-shared"))
+        .await
+        .unwrap();
+
+    assert_eq!(selected.id, "fast");
+}
+
+#[tokio::test]
+async fn test_sdk_chat_routing_skips_non_chat_provider_with_matching_model() {
+    let providers = vec![
+        test_provider_config("azure", ProviderType::Azure, "gpt-shared"),
+        test_provider_config("openai", ProviderType::OpenAI, "gpt-shared"),
+    ];
+    let stats = Arc::new(RwLock::new(HashMap::<String, ProviderStats>::new()));
+    let load_balancer = LoadBalancer::new(LoadBalancingStrategy::RoundRobin);
+
+    let selected = load_balancer
+        .select_chat_provider(&providers, &stats, Some("gpt-shared"))
+        .await
+        .unwrap();
+
+    assert_eq!(selected.id, "openai");
+}
+
+#[tokio::test]
+async fn test_sdk_stream_routing_skips_non_stream_provider() {
+    let providers = vec![
+        test_provider_config("google", ProviderType::Google, "gemini-pro"),
+        test_provider_config("openai", ProviderType::OpenAI, "gpt-4o-mini"),
+    ];
+    let stats = Arc::new(RwLock::new(HashMap::<String, ProviderStats>::new()));
+    let load_balancer = LoadBalancer::new(LoadBalancingStrategy::RoundRobin);
+
+    let selected = load_balancer
+        .select_stream_provider(&providers, &stats)
+        .await
+        .unwrap();
+
+    assert_eq!(selected.id, "openai");
 }
 
 #[tokio::test]

--- a/src/sdk/client/types.rs
+++ b/src/sdk/client/types.rs
@@ -1,5 +1,6 @@
 //! Type definitions for the LLM client
 
+use dashmap::DashMap;
 use std::sync::atomic::AtomicUsize;
 use std::time::SystemTime;
 
@@ -19,7 +20,7 @@ pub struct ProviderStats {
 #[derive(Debug)]
 pub struct LoadBalancer {
     pub(crate) strategy: LoadBalancingStrategy,
-    pub(crate) round_robin_counter: AtomicUsize,
+    pub(crate) round_robin_counters: DashMap<String, AtomicUsize>,
 }
 
 /// Load balancing strategy
@@ -35,7 +36,7 @@ impl LoadBalancer {
     pub(crate) fn new(strategy: LoadBalancingStrategy) -> Self {
         Self {
             strategy,
-            round_robin_counter: AtomicUsize::new(0),
+            round_robin_counters: DashMap::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose a shared `UnifiedRouter::select_from_routing_contexts` entry point for pre-built routing snapshots
- route SDK provider selection through core router `RoutingContext` conversion instead of a parallel load-balancer implementation
- load-balance explicit SDK model requests across all enabled matching providers, while preserving default-provider precedence for model-less chat/stream requests
- filter load-balanced SDK candidates by chat/stream capability before core router selection
- add SDK coverage for round-robin, health/priority, latency, chat capability, and stream capability mapping

## Verification
- `cargo fmt --all -- --check`
- `cargo test sdk` (233 tests)
- `cargo test router` (365 lib-filtered tests, 6 integration-filtered tests)
- `cargo test --all-features sdk` (233 tests)
- `cargo check --all-features`
- `git diff --check`
- `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` (passes; existing Bedrock collapsible-if remains a forced warning)