### PR TITLE
Complete F2 security privacy sweep

### DIFF
--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -789,7 +789,7 @@ Goal: close remaining medium issues after the main architecture is stable.
 
 ### Step F2 Security/privacy hygiene sweep
 
-- status: `pending`
+- status: `completed`
 - Covers: M8, M9, M10, M11, M12
 - Expected changes:
   - `src/core/mcp/server.rs`
@@ -1023,6 +1023,38 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
       - `cargo fmt --all -- --check` -> pass
       - `git diff --check` -> pass
       - `rg "streaming::providers|OpenAIStreaming|AnthropicStreaming|GenericStreaming" src tests` -> pass (no references)
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
+  - Step F2 security/privacy hygiene sweep: `completed`
+    - Modified files:
+      - `src/core/mcp/error.rs`
+      - `src/core/mcp/protocol.rs`
+      - `src/core/mcp/server.rs`
+      - `src/core/providers/openai_like/provider.rs`
+      - `src/core/secret_managers/file.rs`
+      - `src/server/routes/auth/password.rs`
+      - `src/utils/error/canonical.rs`
+      - `src/utils/error/gateway_error/conversions.rs`
+    - Main changes:
+      - Added stable MCP tool definition hash baselines so changed tool descriptions or schemas are rejected after cache refresh instead of silently replacing trusted tool metadata.
+      - Reused existing audit redaction coverage for common Bearer/JWT/AWS/Anthropic/gateway key shapes and reconfirmed it through the audit test filter.
+      - Added minimum forgot-password response timing on both success and hidden-not-found paths while preserving the same public OK response.
+      - Validated file secret names before path existence checks so traversal attempts are denied consistently for existing and non-existing targets.
+      - Stopped forwarding raw non-JSON OpenAI-compatible upstream error bodies into provider errors.
+    - Execute tests:
+      - `cargo test mcp` -> pass (`138` lib-filtered tests)
+      - `cargo test audit` -> pass (`55` lib-filtered tests)
+      - `cargo test auth` -> pass (`820` lib-filtered tests, `8` integration-filtered tests)
+      - `cargo test secret_managers` -> pass (`30` lib-filtered tests)
+      - `cargo test openai_like` -> pass (`48` lib-filtered tests)
+      - `cargo test --all-features mcp` -> pass (`141` lib-filtered tests)
+      - `cargo test --all-features audit` -> pass (`55` lib-filtered tests)
+      - `cargo test --all-features auth` -> pass (`820` lib-filtered tests, `8` integration-filtered tests)
+      - `cargo test --all-features secret_managers` -> pass (`35` lib-filtered tests)
+      - `cargo test --all-features openai_like` -> pass (`48` lib-filtered tests)
+      - `cargo test server::routes::auth::password::tests::password_reset_padding_equalizes_fast_paths` -> pass
+      - `cargo check --all-features` -> pass
+      - `cargo fmt --all -- --check` -> pass
+      - `git diff --check` -> pass
       - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
   - Step E8 SDK router convergence: `completed`
     - Modified files:

--- a/src/core/mcp/error.rs
+++ b/src/core/mcp/error.rs
@@ -83,6 +83,13 @@ pub enum McpError {
         tool_name: String,
         errors: Vec<String>,
     },
+
+    /// Tool definitions changed after the initial trust baseline
+    ToolDefinitionChanged {
+        server_name: String,
+        expected_hash: String,
+        actual_hash: String,
+    },
 }
 
 impl fmt::Display for McpError {
@@ -205,6 +212,17 @@ impl fmt::Display for McpError {
                     tool_name,
                     server_name,
                     errors.join("; ")
+                )
+            }
+            McpError::ToolDefinitionChanged {
+                server_name,
+                expected_hash,
+                actual_hash,
+            } => {
+                write!(
+                    f,
+                    "MCP tool definitions changed for server '{}': expected hash {}, got {}",
+                    server_name, expected_hash, actual_hash
                 )
             }
         }

--- a/src/core/mcp/protocol.rs
+++ b/src/core/mcp/protocol.rs
@@ -186,6 +186,7 @@ impl JsonRpcError {
             McpError::ConfigurationError { .. } => -32602,
             McpError::ToolExecutionError { .. } | McpError::SerializationError { .. } => -32603,
             McpError::ServerAlreadyExists { .. } => -32009,
+            McpError::ToolDefinitionChanged { .. } => -32009,
             McpError::ValidationError { .. } => -32602,
         };
 

--- a/src/core/mcp/server.rs
+++ b/src/core/mcp/server.rs
@@ -15,6 +15,8 @@ use super::protocol::{
 use super::tools::{Tool, ToolCall, ToolList, ToolResult};
 use super::transport::Transport;
 use crate::utils::net::http::get_client_with_timeout;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 /// MCP Server connection state
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +50,9 @@ pub struct McpServer {
 
     /// Cached tools list
     tools_cache: RwLock<Option<Vec<Tool>>>,
+
+    /// Stable hash of the first trusted tool definition set
+    tools_baseline_hash: RwLock<Option<String>>,
 
     /// Server capabilities (from initialize response)
     capabilities: RwLock<Option<McpCapabilities>>,
@@ -97,6 +102,7 @@ impl McpServer {
             http_client,
             custom_headers: headers,
             tools_cache: RwLock::new(None),
+            tools_baseline_hash: RwLock::new(None),
             capabilities: RwLock::new(None),
             request_id: std::sync::atomic::AtomicU64::new(1),
         })
@@ -198,8 +204,7 @@ impl McpServer {
         if let Some(result) = response.result {
             let list: ToolList = serde_json::from_value(result)?;
 
-            // Cache the tools
-            *self.tools_cache.write().await = Some(list.tools.clone());
+            self.cache_tools_with_baseline(&list).await?;
 
             Ok(list)
         } else if let Some(error) = response.error {
@@ -354,6 +359,26 @@ impl McpServer {
         *self.tools_cache.write().await = None;
     }
 
+    async fn cache_tools_with_baseline(&self, list: &ToolList) -> McpResult<()> {
+        let hash = stable_tools_hash(&list.tools)?;
+        let mut baseline = self.tools_baseline_hash.write().await;
+
+        if let Some(expected_hash) = baseline.as_ref() {
+            if expected_hash != &hash {
+                return Err(McpError::ToolDefinitionChanged {
+                    server_name: self.config.name.clone(),
+                    expected_hash: expected_hash.clone(),
+                    actual_hash: hash,
+                });
+            }
+        } else {
+            *baseline = Some(hash);
+        }
+
+        *self.tools_cache.write().await = Some(list.tools.clone());
+        Ok(())
+    }
+
     /// Get server capabilities
     pub async fn capabilities(&self) -> Option<McpCapabilities> {
         self.capabilities.read().await.clone()
@@ -362,6 +387,58 @@ impl McpServer {
 
 /// Thread-safe MCP Server handle
 pub type McpServerHandle = Arc<McpServer>;
+
+fn stable_tools_hash(tools: &[Tool]) -> McpResult<String> {
+    let mut values = tools
+        .iter()
+        .map(|tool| {
+            serde_json::to_value(tool).map_err(|e| McpError::SerializationError {
+                message: e.to_string(),
+            })
+        })
+        .collect::<McpResult<Vec<_>>>()?;
+
+    for value in &mut values {
+        canonicalize_json(value);
+    }
+    values.sort_by(|left, right| {
+        tool_sort_key(left)
+            .cmp(&tool_sort_key(right))
+            .then_with(|| left.to_string().cmp(&right.to_string()))
+    });
+
+    let canonical = serde_json::to_string(&values).map_err(|e| McpError::SerializationError {
+        message: e.to_string(),
+    })?;
+    Ok(hex::encode(Sha256::digest(canonical.as_bytes())))
+}
+
+fn tool_sort_key(value: &Value) -> String {
+    value
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn canonicalize_json(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            let mut entries = std::mem::take(map).into_iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            for (key, mut child) in entries {
+                canonicalize_json(&mut child);
+                map.insert(key, child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                canonicalize_json(item);
+            }
+        }
+        _ => {}
+    }
+}
 
 /// MCP Server registry
 #[derive(Debug, Default)]
@@ -413,6 +490,7 @@ impl McpServerRegistry {
 mod tests {
     use super::*;
     use crate::core::mcp::config::AuthConfig;
+    use crate::core::mcp::tools::ToolInputSchema;
 
     #[test]
     fn test_server_state_variants() {
@@ -498,6 +576,69 @@ mod tests {
         let server = McpServer::new(config).unwrap();
 
         assert_eq!(server.state().await, ServerState::Disconnected);
+    }
+
+    #[test]
+    fn test_tools_hash_is_stable_across_ordering() {
+        let schema_a = ToolInputSchema::object()
+            .with_property("city", super::super::tools::PropertySchema::string(), true)
+            .with_property(
+                "units",
+                super::super::tools::PropertySchema::string(),
+                false,
+            );
+        let schema_b = ToolInputSchema::object()
+            .with_property(
+                "units",
+                super::super::tools::PropertySchema::string(),
+                false,
+            )
+            .with_property("city", super::super::tools::PropertySchema::string(), true);
+
+        let tools_a = vec![
+            Tool::new("search").with_description("Search docs"),
+            Tool::new("weather")
+                .with_description("Get weather")
+                .with_schema(schema_a),
+        ];
+        let tools_b = vec![
+            Tool::new("weather")
+                .with_description("Get weather")
+                .with_schema(schema_b),
+            Tool::new("search").with_description("Search docs"),
+        ];
+
+        assert_eq!(
+            stable_tools_hash(&tools_a).unwrap(),
+            stable_tools_hash(&tools_b).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tools_baseline_rejects_definition_change() {
+        let config = McpServerConfig::new("test", "https://example.com/mcp");
+        let server = McpServer::new(config).unwrap();
+        let initial = ToolList {
+            tools: vec![Tool::new("search").with_description("Search docs")],
+            next_cursor: None,
+        };
+        let changed = ToolList {
+            tools: vec![Tool::new("search").with_description("Read private files")],
+            next_cursor: None,
+        };
+
+        server.cache_tools_with_baseline(&initial).await.unwrap();
+        server.invalidate_cache().await;
+
+        let result = server.cache_tools_with_baseline(&changed).await;
+        assert!(matches!(
+            result,
+            Err(McpError::ToolDefinitionChanged {
+                server_name,
+                expected_hash: _,
+                actual_hash: _
+            }) if server_name == "test"
+        ));
     }
 
     #[test]

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -370,7 +370,7 @@ impl OpenAILikeProvider {
             500..=599 => {
                 OpenAILikeError::openai_like_unavailable(format!("Server error: {}", status))
             }
-            _ => OpenAILikeError::openai_like_api_error(status, body.to_string()),
+            _ => OpenAILikeError::openai_like_api_error(status, sanitized_upstream_error(status)),
         }
     }
 
@@ -383,6 +383,13 @@ impl OpenAILikeProvider {
     pub fn config(&self) -> &OpenAILikeConfig {
         &self.config
     }
+}
+
+fn sanitized_upstream_error(status: u16) -> String {
+    format!(
+        "Upstream OpenAI-compatible provider returned HTTP {}",
+        status
+    )
 }
 
 /// Error mapper for OpenAI-like provider
@@ -403,7 +410,7 @@ where
             401 => E::authentication_failed("Authentication failed"),
             429 => E::rate_limited(None),
             404 => E::not_supported("Resource not found"),
-            _ => E::network_error(&format!("HTTP error {}: {}", status_code, response_body)),
+            _ => E::network_error(&sanitized_upstream_error(status_code)),
         }
     }
 
@@ -662,6 +669,51 @@ mod tests {
         let err = OpenAILikeError::openai_like_rate_limit(Some(60));
         assert!(err.is_retryable());
         assert_eq!(err.retry_delay(), Some(60));
+    }
+
+    #[tokio::test]
+    async fn test_non_json_upstream_error_body_is_not_forwarded() {
+        let provider = OpenAILikeProvider::with_api_base("http://localhost:8000/v1")
+            .await
+            .unwrap();
+        let err = provider.map_error_response(
+            418,
+            "trace_id=abc secret=sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+        );
+
+        match err {
+            ProviderError::ApiError {
+                status, message, ..
+            } => {
+                assert_eq!(status, 418);
+                assert_eq!(
+                    message,
+                    "Upstream OpenAI-compatible provider returned HTTP 418"
+                );
+                assert!(!message.contains("sk-ant"));
+            }
+            other => panic!("expected api error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_error_mapper_non_json_body_is_not_forwarded() {
+        let mapper = OpenAILikeErrorMapper;
+        let err: ProviderError = mapper.map_http_error(
+            502,
+            "upstream panic included Authorization: Bearer eyJsecret.token.value",
+        );
+
+        match err {
+            ProviderError::Network { message, .. } => {
+                assert_eq!(
+                    message,
+                    "Upstream OpenAI-compatible provider returned HTTP 502"
+                );
+                assert!(!message.contains("Bearer"));
+            }
+            other => panic!("expected network error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/core/secret_managers/file.rs
+++ b/src/core/secret_managers/file.rs
@@ -3,7 +3,7 @@
 //! Reads secrets from files on disk. Useful for development and Kubernetes secrets.
 
 use async_trait::async_trait;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tokio::fs;
 use tracing::debug;
 
@@ -63,6 +63,24 @@ impl FileSecretManager {
         self.base_path.join(filename)
     }
 
+    fn validate_secret_name(&self, name: &str) -> SecretResult<()> {
+        let path = Path::new(name);
+        if name.is_empty()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    Component::CurDir
+                        | Component::ParentDir
+                        | Component::RootDir
+                        | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(SecretError::access_denied(name));
+        }
+        Ok(())
+    }
+
     /// Validate that a path is within the base directory (prevent path traversal)
     fn validate_path(&self, path: &Path) -> SecretResult<()> {
         let canonical_base = self
@@ -114,15 +132,19 @@ impl SecretManager for FileSecretManager {
     }
 
     async fn read_secret(&self, name: &str) -> SecretResult<Option<String>> {
+        self.validate_secret_name(name)?;
         let path = self.get_secret_path(name);
 
-        // Check if file exists first
-        if !path.exists() {
-            debug!("Secret file not found: {}", path.display());
+        if !self.base_path.exists() {
             return Ok(None);
         }
 
         self.validate_path(&path)?;
+
+        if !path.exists() {
+            debug!("Secret file not found: {}", path.display());
+            return Ok(None);
+        }
 
         match fs::read_to_string(&path).await {
             Ok(content) => {
@@ -142,6 +164,7 @@ impl SecretManager for FileSecretManager {
     }
 
     async fn write_secret(&self, name: &str, value: &str) -> SecretResult<()> {
+        self.validate_secret_name(name)?;
         let path = self.get_secret_path(name);
 
         // Ensure base directory exists
@@ -166,13 +189,18 @@ impl SecretManager for FileSecretManager {
     }
 
     async fn delete_secret(&self, name: &str) -> SecretResult<()> {
+        self.validate_secret_name(name)?;
         let path = self.get_secret_path(name);
 
-        if !path.exists() {
+        if !self.base_path.exists() {
             return Ok(());
         }
 
         self.validate_path(&path)?;
+
+        if !path.exists() {
+            return Ok(());
+        }
 
         fs::remove_file(&path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::PermissionDenied {
@@ -402,9 +430,26 @@ mod tests {
         let (_temp_dir, manager) = setup().await;
 
         let result = manager.read_secret("../../../etc/passwd").await;
-        // Should either return None (file not found) or error (path traversal)
-        // The exact behavior depends on whether the path exists
-        assert!(result.is_ok() || result.is_err());
+        assert!(matches!(result, Err(SecretError::AccessDenied { .. })));
+
+        let result = manager
+            .read_secret("../../../definitely-not-a-secret")
+            .await;
+        assert!(matches!(result, Err(SecretError::AccessDenied { .. })));
+
+        let result = manager.read_secret(".").await;
+        assert!(matches!(result, Err(SecretError::AccessDenied { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_missing_base_path_returns_none_after_name_validation() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing_base = temp_dir.path().join("missing");
+        let manager = FileSecretManager::new(missing_base);
+
+        assert_eq!(manager.read_secret("nonexistent").await.unwrap(), None);
+        let traversal = manager.read_secret("../outside").await;
+        assert!(matches!(traversal, Err(SecretError::AccessDenied { .. })));
     }
 
     #[tokio::test]

--- a/src/server/routes/auth/password.rs
+++ b/src/server/routes/auth/password.rs
@@ -7,6 +7,7 @@ use crate::utils::data::validation::DataValidator;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 use tracing::{info, warn};
 
 use super::models::{ChangePasswordRequest, ForgotPasswordRequest, ResetPasswordRequest};
@@ -59,6 +60,21 @@ fn extract_client_ip(req: &HttpRequest, trusted_proxies: &[String]) -> String {
 
 /// Counter for probabilistic cleanup of rate limiter entries
 static PASSWORD_RESET_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+const PASSWORD_RESET_MIN_RESPONSE_TIME: Duration = Duration::from_millis(250);
+
+fn password_reset_padding(elapsed: Duration) -> Option<Duration> {
+    if elapsed < PASSWORD_RESET_MIN_RESPONSE_TIME {
+        Some(PASSWORD_RESET_MIN_RESPONSE_TIME - elapsed)
+    } else {
+        None
+    }
+}
+
+async fn enforce_password_reset_min_response_time(started_at: Instant) {
+    if let Some(delay) = password_reset_padding(started_at.elapsed()) {
+        tokio::time::sleep(delay).await;
+    }
+}
 
 /// Forgot password endpoint
 pub async fn forgot_password(
@@ -66,6 +82,7 @@ pub async fn forgot_password(
     state: web::Data<AppState>,
     request: web::Json<ForgotPasswordRequest>,
 ) -> ActixResult<HttpResponse> {
+    let started_at = Instant::now();
     let cfg = state.config.load();
     let client_ip = extract_client_ip(&req, &cfg.gateway.server.trusted_proxies);
 
@@ -100,12 +117,14 @@ pub async fn forgot_password(
             // Record as failure to count against the rate limit regardless of outcome,
             // preventing enumeration attacks
             limiter.record_failure(&client_ip);
+            enforce_password_reset_min_response_time(started_at).await;
             Ok(HttpResponse::Ok().json(ApiResponse::success(())))
         }
         Err(e) => {
             // Don't reveal if email exists or not
             warn!("Password reset request failed: {}", e);
             limiter.record_failure(&client_ip);
+            enforce_password_reset_min_response_time(started_at).await;
             Ok(HttpResponse::Ok().json(ApiResponse::success(())))
         }
     }
@@ -204,5 +223,20 @@ pub async fn change_password(
             warn!("Password change failed: {}", e);
             Ok(HttpResponse::Ok().json(ApiResponse::<()>::error_for_type(e.to_string())))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn password_reset_padding_equalizes_fast_paths() {
+        assert_eq!(
+            password_reset_padding(Duration::from_millis(10)),
+            Some(Duration::from_millis(240))
+        );
+        assert_eq!(password_reset_padding(Duration::from_millis(250)), None);
+        assert_eq!(password_reset_padding(Duration::from_millis(500)), None);
     }
 }

--- a/src/utils/error/canonical.rs
+++ b/src/utils/error/canonical.rs
@@ -191,7 +191,9 @@ impl CanonicalError for McpError {
             McpError::Timeout { .. } => ErrorCode::Timeout,
             McpError::ConfigurationError { .. } => ErrorCode::Configuration,
             McpError::SerializationError { .. } => ErrorCode::Parsing,
-            McpError::ServerAlreadyExists { .. } => ErrorCode::Conflict,
+            McpError::ServerAlreadyExists { .. } | McpError::ToolDefinitionChanged { .. } => {
+                ErrorCode::Conflict
+            }
             McpError::RateLimitExceeded { .. } => ErrorCode::RateLimited,
             McpError::ValidationError { .. } => ErrorCode::InvalidRequest,
         }

--- a/src/utils/error/gateway_error/conversions.rs
+++ b/src/utils/error/gateway_error/conversions.rs
@@ -196,6 +196,14 @@ impl From<McpError> for GatewayError {
             McpError::ServerAlreadyExists { server_name } => {
                 GatewayError::Conflict(format!("MCP server already registered: {}", server_name))
             }
+            McpError::ToolDefinitionChanged {
+                server_name,
+                expected_hash,
+                actual_hash,
+            } => GatewayError::Conflict(format!(
+                "MCP tool definitions changed for server '{}': expected hash {}, got {}",
+                server_name, expected_hash, actual_hash
+            )),
             McpError::InvalidUrl { url, message } => {
                 GatewayError::BadRequest(format!("Invalid MCP server URL '{}': {}", url, message))
             }


### PR DESCRIPTION
## Summary
- Add stable MCP tool definition hash baselines so changed tool descriptions/schemas are rejected after cache refresh
- Equalize forgot-password timing and validate file-secret names before path existence checks
- Stop forwarding raw non-JSON OpenAI-compatible upstream error bodies and mark F2 complete

## Verification
- `cargo test mcp`
- `cargo test audit`
- `cargo test auth`
- `cargo test secret_managers`
- `cargo test openai_like`
- `cargo test --all-features mcp`
- `cargo test --all-features audit`
- `cargo test --all-features auth`
- `cargo test --all-features secret_managers`
- `cargo test --all-features openai_like`
- `cargo test server::routes::auth::password::tests::password_reset_padding_equalizes_fast_paths`
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if`