### PR TITLE
Complete F3 runtime config hygiene

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ providers-extra = []
 providers-extended = []
 
 # Storage backends (implies gateway since auth/server/monitoring require it)
-storage = ["dep:sea-orm", "dep:sea-orm-migration", "gateway"]
+storage = ["dep:sea-orm", "dep:sea-orm-migration", "gateway", "redis"]
 postgres = ["storage", "sea-orm/sqlx-postgres", "sea-orm/runtime-tokio-rustls"]
 sqlite = ["storage", "sea-orm/sqlx-sqlite", "sea-orm/runtime-tokio-rustls"]
 redis = ["dep:redis"]
@@ -192,9 +192,9 @@ tracing = ["dep:tracing-subscriber"]
 mcp-validation = ["dep:jsonschema"]
 
 # Advanced features
-vector-db = []
+vector-db = ["storage"]
 websockets = []
-analytics = ["metrics"]
+analytics = []
 enterprise = ["analytics", "vector-db"]
 
 # Full feature set

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -88,7 +88,9 @@ storage:
     enabled: false
   redis:
     url: "redis://localhost:6379"
-    enabled: true
+    # Enable only when Redis is deployed; otherwise the gateway uses local
+    # in-process/no-op fallbacks for Redis-backed features.
+    enabled: false
     max_connections: 20
     connection_timeout: 5
     cluster: false

--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -804,7 +804,7 @@ Goal: close remaining medium issues after the main architecture is stable.
 
 ### Step F3 Runtime/config hygiene sweep
 
-- status: `pending`
+- status: `completed`
 - Covers: M13, M14, M15, M20, M21, M22
 - Expected changes:
   - `src/storage/database/mod.rs`
@@ -1053,6 +1053,38 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
       - `cargo test --all-features openai_like` -> pass (`48` lib-filtered tests)
       - `cargo test server::routes::auth::password::tests::password_reset_padding_equalizes_fast_paths` -> pass
       - `cargo check --all-features` -> pass
+      - `cargo fmt --all -- --check` -> pass
+      - `git diff --check` -> pass
+      - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
+  - Step F3 runtime/config hygiene sweep: `completed`
+    - Modified files:
+      - `Cargo.toml`
+      - `config/gateway.yaml.example`
+      - `src/server/state.rs`
+      - `src/storage/mod.rs`
+      - `src/storage/database/mod.rs`
+      - `src/storage/files/mod.rs`
+      - `src/storage/files/tests.rs`
+    - Main changes:
+      - Introduced a shared local state directory resolver from `LITELLM_DATA_DIR`; SQLite fallback now uses `$LITELLM_DATA_DIR/gateway.db` unless `LITELLM_SQLITE_PATH` explicitly overrides it, and local file storage defaults to `$LITELLM_DATA_DIR/data`.
+      - Removed implicit hot-reload claims from `AppState` comments; `AtomicValue` now documents explicit config swaps only.
+      - Changed `config/gateway.yaml.example` so Redis is disabled unless explicitly deployed, with a fallback comment.
+      - Decoupled `analytics` from `metrics` and `sysinfo`; `analytics` no longer pulls system metrics.
+      - Made `vector-db` a real feature by depending on storage, and made storage declare its current Redis dependency so `sqlite`, `postgres`, and `vector-db` compile independently of defaults.
+      - Verified M20/M15 prior fixes: lite feature compiles in the local and CI matrix; rate limiter and budget persistence already use Redis/DB-backed paths when configured.
+    - Execute tests:
+      - `cargo test storage` -> pass (`188` lib-filtered tests)
+      - `cargo test config` -> pass (`1097` lib-filtered tests, `2` main-filtered tests, `45` integration-filtered tests, `2` connection-pool-filtered tests)
+      - `cargo test gateway_yaml_example` -> pass (`1` lib-filtered test)
+      - `cargo test --all-features storage` -> pass (`189` lib-filtered tests)
+      - `cargo test --all-features config` -> pass (`1551` lib-filtered tests, `2` main-filtered tests, `45` integration-filtered tests, `2` connection-pool-filtered tests)
+      - `cargo check --no-default-features --features lite` -> pass
+      - `cargo check --no-default-features --features analytics` -> pass
+      - `cargo check --no-default-features --features vector-db` -> pass
+      - `cargo check --no-default-features --features sqlite` -> pass
+      - `cargo check --no-default-features --features postgres` -> pass
+      - `cargo check --all-features` -> pass
+      - `cargo tree -e features --no-default-features --features analytics | rg sysinfo` -> pass (no `sysinfo`)
       - `cargo fmt --all -- --check` -> pass
       - `git diff --check` -> pass
       - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -17,12 +17,12 @@ use std::sync::Arc;
 /// multiple request handlers. All fields are wrapped in Arc for efficient
 /// sharing across threads.
 ///
-/// `config` uses [`AtomicValue`] so the entire configuration can be swapped
-/// atomically at runtime (hot reload) while readers obtain lock-free
-/// `Arc<Config>` snapshots.
+/// `config` uses [`AtomicValue`] so callers can explicitly swap the entire
+/// configuration at runtime while readers obtain lock-free `Arc<Config>`
+/// snapshots. This type does not start a file watcher by itself.
 #[derive(Clone)]
 pub struct AppState {
-    /// Gateway configuration (atomically swappable for hot reload)
+    /// Gateway configuration (atomically swappable by explicit callers)
     pub config: AtomicValue<Config>,
     /// Authentication system
     pub auth: Arc<crate::auth::AuthSystem>,
@@ -71,7 +71,7 @@ impl AppState {
     /// Load a snapshot of the current gateway configuration.
     ///
     /// Returns an `Arc<Config>` that is valid for the lifetime of the
-    /// caller — subsequent hot-reload swaps will not affect already-loaded
+    /// caller — subsequent explicit swaps will not affect already-loaded
     /// snapshots.
     pub fn config(&self) -> Arc<Config> {
         self.config.load()

--- a/src/storage/database/mod.rs
+++ b/src/storage/database/mod.rs
@@ -17,17 +17,77 @@ pub use seaorm_db::{DatabaseBackendType, DatabaseStats, SeaOrmTeamRepository};
 /// Returns the default absolute path for the SQLite fallback database.
 ///
 /// Resolution order:
-/// 1. `LITELLM_SQLITE_PATH` environment variable (if set and non-empty)
-/// 2. `<data_local_dir>/litellm-rs/gateway.db` (platform-specific)
-/// 3. `/tmp/litellm-rs/gateway.db` (ultimate fallback)
+/// 1. `LITELLM_SQLITE_PATH` explicit file override (if set and non-empty)
+/// 2. `LITELLM_DATA_DIR/gateway.db` (if `LITELLM_DATA_DIR` is set and non-empty)
+/// 3. `<data_local_dir>/litellm-rs/gateway.db` (platform-specific)
+/// 4. `/tmp/litellm-rs/gateway.db` (ultimate fallback)
 pub fn default_sqlite_path() -> std::path::PathBuf {
     if let Ok(p) = std::env::var("LITELLM_SQLITE_PATH")
         && !p.is_empty()
     {
         return std::path::PathBuf::from(p);
     }
-    dirs::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join("litellm-rs")
-        .join("gateway.db")
+    super::default_data_dir().join("gateway.db")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_sqlite_path;
+    use std::path::PathBuf;
+
+    struct EnvRestore {
+        sqlite_path: Option<String>,
+        data_dir: Option<String>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                sqlite_path: std::env::var("LITELLM_SQLITE_PATH").ok(),
+                data_dir: std::env::var("LITELLM_DATA_DIR").ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.sqlite_path {
+                    Some(value) => std::env::set_var("LITELLM_SQLITE_PATH", value),
+                    None => std::env::remove_var("LITELLM_SQLITE_PATH"),
+                }
+                match &self.data_dir {
+                    Some(value) => std::env::set_var("LITELLM_DATA_DIR", value),
+                    None => std::env::remove_var("LITELLM_DATA_DIR"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn default_sqlite_path_uses_shared_data_dir() {
+        let _guard = crate::storage::ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore::capture();
+        unsafe {
+            std::env::remove_var("LITELLM_SQLITE_PATH");
+            std::env::set_var("LITELLM_DATA_DIR", "/custom/litellm-state");
+        }
+
+        assert_eq!(
+            default_sqlite_path(),
+            PathBuf::from("/custom/litellm-state/gateway.db")
+        );
+    }
+
+    #[test]
+    fn default_sqlite_path_explicit_override_wins() {
+        let _guard = crate::storage::ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore::capture();
+        unsafe {
+            std::env::set_var("LITELLM_SQLITE_PATH", "/explicit/gateway.db");
+            std::env::set_var("LITELLM_DATA_DIR", "/custom/litellm-state");
+        }
+
+        assert_eq!(default_sqlite_path(), PathBuf::from("/explicit/gateway.db"));
+    }
 }

--- a/src/storage/files/mod.rs
+++ b/src/storage/files/mod.rs
@@ -17,17 +17,9 @@ pub use types::{FileMetadata, FileStorage};
 /// Returns the default absolute path for local file storage.
 ///
 /// Resolution order:
-/// 1. `LITELLM_DATA_DIR` environment variable (if set and non-empty)
+/// 1. `LITELLM_DATA_DIR/data` (if `LITELLM_DATA_DIR` is set and non-empty)
 /// 2. `<data_local_dir>/litellm-rs/data` (platform-specific)
 /// 3. `/tmp/litellm-rs/data` (ultimate fallback)
 pub fn default_data_path() -> std::path::PathBuf {
-    if let Ok(p) = std::env::var("LITELLM_DATA_DIR")
-        && !p.is_empty()
-    {
-        return std::path::PathBuf::from(p);
-    }
-    dirs::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join("litellm-rs")
-        .join("data")
+    super::default_data_dir().join("data")
 }

--- a/src/storage/files/tests.rs
+++ b/src/storage/files/tests.rs
@@ -2,7 +2,27 @@
 
 use super::default_data_path;
 use super::local::LocalStorage;
+use std::path::PathBuf;
 use tempfile::TempDir;
+
+struct DataDirEnvRestore(Option<String>);
+
+impl DataDirEnvRestore {
+    fn capture() -> Self {
+        Self(std::env::var("LITELLM_DATA_DIR").ok())
+    }
+}
+
+impl Drop for DataDirEnvRestore {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.0 {
+                Some(value) => std::env::set_var("LITELLM_DATA_DIR", value),
+                None => std::env::remove_var("LITELLM_DATA_DIR"),
+            }
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_local_storage() {
@@ -35,6 +55,12 @@ async fn test_local_storage() {
 
 #[test]
 fn test_default_data_path_is_absolute() {
+    let _guard = crate::storage::ENV_LOCK.lock().unwrap();
+    let _restore = DataDirEnvRestore::capture();
+    unsafe {
+        std::env::remove_var("LITELLM_DATA_DIR");
+    }
+
     // Ensure the default path is absolute, not relative like the old "./data"
     let path = default_data_path();
     assert!(
@@ -46,6 +72,12 @@ fn test_default_data_path_is_absolute() {
 
 #[test]
 fn test_default_data_path_ends_with_data() {
+    let _guard = crate::storage::ENV_LOCK.lock().unwrap();
+    let _restore = DataDirEnvRestore::capture();
+    unsafe {
+        std::env::remove_var("LITELLM_DATA_DIR");
+    }
+
     let path = default_data_path();
     assert!(
         path.ends_with("litellm-rs/data"),
@@ -56,26 +88,20 @@ fn test_default_data_path_ends_with_data() {
 
 #[test]
 fn test_default_data_path_env_override() {
-    let original = std::env::var("LITELLM_DATA_DIR").ok();
-    // SAFETY: This test is not run in parallel with other tests that read
-    // LITELLM_DATA_DIR. set_var/remove_var are unsafe because they are not
-    // thread-safe, but #[test] functions run serially by default.
+    let _guard = crate::storage::ENV_LOCK.lock().unwrap();
+    let _restore = DataDirEnvRestore::capture();
+    // SAFETY: ENV_LOCK serializes tests in this crate that mutate
+    // LITELLM_DATA_DIR. set_var/remove_var are unsafe because environment
+    // mutation is process-global.
     unsafe {
         std::env::set_var("LITELLM_DATA_DIR", "/custom/storage/path");
     }
     let path = default_data_path();
     assert_eq!(
         path,
-        std::path::PathBuf::from("/custom/storage/path"),
-        "LITELLM_DATA_DIR should override the default path"
+        PathBuf::from("/custom/storage/path/data"),
+        "LITELLM_DATA_DIR should define the shared state directory"
     );
-    // Restore original env
-    unsafe {
-        match original {
-            Some(val) => std::env::set_var("LITELLM_DATA_DIR", val),
-            None => std::env::remove_var("LITELLM_DATA_DIR"),
-        }
-    }
 }
 
 #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13,8 +13,29 @@ pub mod vector;
 
 use crate::config::models::storage::StorageConfig;
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
+
+/// Returns the default base directory for local gateway state.
+///
+/// Resolution order:
+/// 1. `LITELLM_DATA_DIR` environment variable (if set and non-empty)
+/// 2. `<data_local_dir>/litellm-rs` (platform-specific)
+/// 3. `/tmp/litellm-rs` (ultimate fallback)
+pub fn default_data_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("LITELLM_DATA_DIR")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("litellm-rs")
+}
+
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Main storage layer that orchestrates all storage backends
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Resolve local state path drift by deriving SQLite fallback and local file storage defaults from a shared `LITELLM_DATA_DIR` base while preserving `LITELLM_SQLITE_PATH` as the explicit SQLite override.
- Clarify `AppState` config swapping docs and make Redis disabled by default in the example unless Redis is actually deployed.
- Clean up the feature graph: decouple `analytics` from `metrics`/`sysinfo`, make `vector-db` non-empty, and make `storage` declare its current Redis dependency.

## Verification
- `cargo test storage`
- `cargo test config`
- `cargo test gateway_yaml_example`
- `cargo test --all-features storage`
- `cargo test --all-features config`
- `cargo check --no-default-features --features lite`
- `cargo check --no-default-features --features analytics`
- `cargo check --no-default-features --features vector-db`
- `cargo check --no-default-features --features sqlite`
- `cargo check --no-default-features --features postgres`
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if`