### PR TITLE
Complete F4 provider cost API cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ futures = "0.3"
 async-trait = "0.1"
 async-stream = "0.3"
 pin-project-lite = "0.2"
-paste = { package = "pastey", version = "0.2.2" }
+pastey = "0.2.2"
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls", "multipart"], default-features = false }

--- a/docs/plan/audit-remediation-complete-plan.md
+++ b/docs/plan/audit-remediation-complete-plan.md
@@ -821,7 +821,7 @@ Goal: close remaining medium issues after the main architecture is stable.
 
 ### Step F4 Provider/cost API cleanup sweep
 
-- status: `pending`
+- status: `completed`
 - Covers: M16, M17, M18, M19, M23, M24, M25, M29
 - Expected changes:
   - `src/core/providers/mod.rs`
@@ -1088,6 +1088,35 @@ No parallel agents are launched by this plan. If the owner chooses to paralleliz
       - `cargo fmt --all -- --check` -> pass
       - `git diff --check` -> pass
       - `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if` -> pass (`collapsible_if` remains warning by command design)
+  - Step F4 provider/cost API cleanup sweep: `completed`
+    - Modified files:
+      - `Cargo.toml`
+      - `src/core/mcp/config.rs`
+      - `src/core/mcp/mod.rs`
+      - `src/core/mcp/permissions.rs`
+      - `src/core/pricing.rs`
+      - `src/core/providers/mod.rs`
+      - `src/core/providers/openai_like/provider.rs`
+      - `src/core/providers/unified_provider.rs`
+      - `src/core/providers/macros/MACROS.md`
+      - `src/core/providers/macros/mod.rs`
+      - `src/core/traits/provider/llm_provider/trait_definition.rs`
+      - `src/lib.rs`
+    - Main changes:
+      - Removed the OpenAI-like provider-name leak by changing `LLMProvider::name()` to borrow from `self`; default error constructors use a separate static `error_provider_name()` until `ProviderError` can be made fully owned.
+      - Added provider-aware `PricingDatabase::calculate_for_provider()` and routed `Provider::calculate_cost()` through it so a model on one provider does not borrow another provider's rate.
+      - Renamed MCP public concepts to `McpAuthType` and `McpPermissionLevel`, keeping hidden compatibility aliases for the old unprefixed names.
+      - Dropped the `paste = { package = "pastey" }` rename and switched macro code to `::pastey::paste!`.
+      - Added a curated crate `prelude` and hid broad lower-level root re-exports from generated docs without removing compatibility.
+      - Documented provider macro status in `src/core/providers/macros/MACROS.md`; active hook macros are kept, compatibility-only exports are documented as legacy.
+      - Verified M16/M29 were already closed by earlier steps: the stale `providers::ModelPricing` struct is gone, and cache keys are SHA-256/versioned via the C20 key policy.
+    - Execute tests:
+      - `cargo test providers` -> pass (`901` lib-filtered tests, `9` integration-filtered tests)
+      - `cargo test mcp` -> pass (`138` lib-filtered tests)
+      - `cargo test cache` -> pass (`299` lib-filtered tests)
+      - `cargo test calculate_for_provider` -> pass (`1` lib-filtered test)
+      - `cargo check --all-features` -> pass
+      - `cargo fmt --all -- --check` -> pass
   - Step E8 SDK router convergence: `completed`
     - Modified files:
       - `src/core/router/selection.rs`

--- a/src/core/mcp/config.rs
+++ b/src/core/mcp/config.rs
@@ -173,7 +173,7 @@ impl McpServerConfig {
 pub struct AuthConfig {
     /// Authentication type
     #[serde(rename = "type")]
-    pub auth_type: AuthType,
+    pub auth_type: McpAuthType,
 
     /// Authentication value (API key, token, etc.)
     /// Can use environment variable syntax: ${ENV_VAR}
@@ -209,7 +209,7 @@ impl AuthConfig {
     /// Create API key authentication
     pub fn api_key(value: impl Into<String>) -> Self {
         Self {
-            auth_type: AuthType::ApiKey,
+            auth_type: McpAuthType::ApiKey,
             value: Some(value.into()),
             client_id: None,
             client_secret: None,
@@ -223,7 +223,7 @@ impl AuthConfig {
     /// Create Bearer token authentication
     pub fn bearer(token: impl Into<String>) -> Self {
         Self {
-            auth_type: AuthType::BearerToken,
+            auth_type: McpAuthType::BearerToken,
             value: Some(token.into()),
             client_id: None,
             client_secret: None,
@@ -240,7 +240,7 @@ impl AuthConfig {
         let credentials = format!("{}:{}", username.into(), password.into());
         let encoded = STANDARD.encode(credentials.as_bytes());
         Self {
-            auth_type: AuthType::Basic,
+            auth_type: McpAuthType::Basic,
             value: Some(encoded),
             client_id: None,
             client_secret: None,
@@ -258,7 +258,7 @@ impl AuthConfig {
         token_url: impl Into<String>,
     ) -> Self {
         Self {
-            auth_type: AuthType::OAuth2,
+            auth_type: McpAuthType::OAuth2,
             value: None,
             client_id: Some(client_id.into()),
             client_secret: Some(client_secret.into()),
@@ -284,7 +284,7 @@ impl AuthConfig {
     /// Validate the authentication configuration
     pub fn validate(&self) -> Result<(), String> {
         match self.auth_type {
-            AuthType::ApiKey | AuthType::BearerToken => {
+            McpAuthType::ApiKey | McpAuthType::BearerToken => {
                 if self.value.is_none() {
                     return Err(format!(
                         "{:?} authentication requires a value",
@@ -292,12 +292,12 @@ impl AuthConfig {
                     ));
                 }
             }
-            AuthType::Basic => {
+            McpAuthType::Basic => {
                 if self.value.is_none() {
                     return Err("Basic authentication requires credentials".to_string());
                 }
             }
-            AuthType::OAuth2 => {
+            McpAuthType::OAuth2 => {
                 if self.client_id.is_none() {
                     return Err("OAuth2 authentication requires client_id".to_string());
                 }
@@ -308,7 +308,7 @@ impl AuthConfig {
                     return Err("OAuth2 authentication requires token_url".to_string());
                 }
             }
-            AuthType::None => {}
+            McpAuthType::None => {}
         }
         Ok(())
     }
@@ -316,17 +316,17 @@ impl AuthConfig {
     /// Get the authorization header value
     pub fn get_header_value(&self) -> Option<String> {
         match self.auth_type {
-            AuthType::None => None,
-            AuthType::ApiKey => self.value.as_ref().map(|v| {
+            McpAuthType::None => None,
+            McpAuthType::ApiKey => self.value.as_ref().map(|v| {
                 if let Some(prefix) = &self.header_prefix {
                     format!("{} {}", prefix, v)
                 } else {
                     v.clone()
                 }
             }),
-            AuthType::BearerToken => self.value.as_ref().map(|v| format!("Bearer {}", v)),
-            AuthType::Basic => self.value.as_ref().map(|v| format!("Basic {}", v)),
-            AuthType::OAuth2 => {
+            McpAuthType::BearerToken => self.value.as_ref().map(|v| format!("Bearer {}", v)),
+            McpAuthType::Basic => self.value.as_ref().map(|v| format!("Basic {}", v)),
+            McpAuthType::OAuth2 => {
                 // OAuth2 tokens are obtained separately
                 None
             }
@@ -342,7 +342,7 @@ impl AuthConfig {
 /// Authentication type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum AuthType {
+pub enum McpAuthType {
     /// No authentication
     #[default]
     None,
@@ -355,6 +355,10 @@ pub enum AuthType {
     /// OAuth 2.0 client credentials
     OAuth2,
 }
+
+/// Backward-compatible alias for the prefixed MCP authentication type.
+#[doc(hidden)]
+pub type AuthType = McpAuthType;
 
 /// MCP gateway configuration (collection of servers)
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -531,7 +535,7 @@ mod tests {
     #[test]
     fn test_auth_config_api_key() {
         let auth = AuthConfig::api_key("my-api-key");
-        assert_eq!(auth.auth_type, AuthType::ApiKey);
+        assert_eq!(auth.auth_type, McpAuthType::ApiKey);
         assert_eq!(auth.value.as_deref(), Some("my-api-key"));
         assert!(auth.validate().is_ok());
     }
@@ -539,14 +543,14 @@ mod tests {
     #[test]
     fn test_auth_config_bearer() {
         let auth = AuthConfig::bearer("my-token");
-        assert_eq!(auth.auth_type, AuthType::BearerToken);
+        assert_eq!(auth.auth_type, McpAuthType::BearerToken);
         assert_eq!(auth.get_header_value(), Some("Bearer my-token".to_string()));
     }
 
     #[test]
     fn test_auth_config_basic() {
         let auth = AuthConfig::basic("user", "pass");
-        assert_eq!(auth.auth_type, AuthType::Basic);
+        assert_eq!(auth.auth_type, McpAuthType::Basic);
         let header = auth.get_header_value().unwrap();
         assert!(header.starts_with("Basic "));
     }
@@ -559,7 +563,7 @@ mod tests {
             "https://auth.example.com/token",
         )
         .with_scopes(vec!["read".to_string(), "write".to_string()]);
-        assert_eq!(auth.auth_type, AuthType::OAuth2);
+        assert_eq!(auth.auth_type, McpAuthType::OAuth2);
         assert_eq!(auth.client_id.as_deref(), Some("client-id"));
         assert_eq!(auth.scopes.len(), 2);
         assert!(auth.validate().is_ok());
@@ -568,7 +572,7 @@ mod tests {
     #[test]
     fn test_auth_config_oauth2_missing_client_id() {
         let auth = AuthConfig {
-            auth_type: AuthType::OAuth2,
+            auth_type: McpAuthType::OAuth2,
             value: None,
             client_id: None,
             client_secret: Some("secret".to_string()),
@@ -606,8 +610,8 @@ mod tests {
 
     #[test]
     fn test_auth_type_default() {
-        let auth_type = AuthType::default();
-        assert_eq!(auth_type, AuthType::None);
+        let auth_type = McpAuthType::default();
+        assert_eq!(auth_type, McpAuthType::None);
     }
 
     #[test]

--- a/src/core/mcp/mod.rs
+++ b/src/core/mcp/mod.rs
@@ -70,10 +70,14 @@ pub mod transport;
 pub mod validation;
 
 // Re-export commonly used types
-pub use config::{AuthConfig, AuthType, McpServerConfig};
+#[doc(hidden)]
+pub use config::AuthType;
+pub use config::{AuthConfig, McpAuthType, McpServerConfig};
 pub use error::{McpError, McpResult};
 pub use gateway::McpGateway;
-pub use permissions::{PermissionLevel, PermissionManager, PermissionPolicy, PermissionRule};
+#[doc(hidden)]
+pub use permissions::PermissionLevel;
+pub use permissions::{McpPermissionLevel, PermissionManager, PermissionPolicy, PermissionRule};
 pub use protocol::{JsonRpcRequest, JsonRpcResponse, McpMessage};
 pub use server::McpServer;
 pub use tools::{Tool, ToolCall, ToolResult};
@@ -87,6 +91,6 @@ mod tests {
     fn test_module_exports() {
         // Verify all public types are accessible
         let _ = Transport::Http;
-        let _ = AuthType::ApiKey;
+        let _ = McpAuthType::ApiKey;
     }
 }

--- a/src/core/mcp/permissions.rs
+++ b/src/core/mcp/permissions.rs
@@ -10,7 +10,7 @@ use super::error::{McpError, McpResult};
 /// Permission level for MCP access
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum PermissionLevel {
+pub enum McpPermissionLevel {
     /// No access
     Deny,
     /// Read-only access (list tools, view info)
@@ -22,22 +22,29 @@ pub enum PermissionLevel {
     Admin,
 }
 
-impl PermissionLevel {
+impl McpPermissionLevel {
     /// Check if this level allows reading
     pub fn can_read(&self) -> bool {
-        !matches!(self, PermissionLevel::Deny)
+        !matches!(self, McpPermissionLevel::Deny)
     }
 
     /// Check if this level allows execution
     pub fn can_execute(&self) -> bool {
-        matches!(self, PermissionLevel::Execute | PermissionLevel::Admin)
+        matches!(
+            self,
+            McpPermissionLevel::Execute | McpPermissionLevel::Admin
+        )
     }
 
     /// Check if this level allows admin operations
     pub fn is_admin(&self) -> bool {
-        matches!(self, PermissionLevel::Admin)
+        matches!(self, McpPermissionLevel::Admin)
     }
 }
+
+/// Backward-compatible alias for the prefixed MCP permission level.
+#[doc(hidden)]
+pub type PermissionLevel = McpPermissionLevel;
 
 /// Permission rule for a specific server or tool
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,12 +57,12 @@ pub struct PermissionRule {
     pub tool_pattern: Option<String>,
 
     /// Permission level
-    pub level: PermissionLevel,
+    pub level: McpPermissionLevel,
 }
 
 impl PermissionRule {
     /// Create a new permission rule
-    pub fn new(server: impl Into<String>, level: PermissionLevel) -> Self {
+    pub fn new(server: impl Into<String>, level: McpPermissionLevel) -> Self {
         Self {
             server_pattern: server.into(),
             tool_pattern: None,
@@ -115,7 +122,7 @@ pub struct PermissionPolicy {
 
     /// Default permission level for unspecified servers
     #[serde(default)]
-    pub default_level: PermissionLevel,
+    pub default_level: McpPermissionLevel,
 
     /// Specific permission rules (evaluated in order)
     #[serde(default)]
@@ -147,7 +154,7 @@ impl PermissionPolicy {
     pub fn allow_all(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            default_level: PermissionLevel::Execute,
+            default_level: McpPermissionLevel::Execute,
             ..Default::default()
         }
     }
@@ -156,7 +163,7 @@ impl PermissionPolicy {
     pub fn deny_all(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            default_level: PermissionLevel::Deny,
+            default_level: McpPermissionLevel::Deny,
             ..Default::default()
         }
     }
@@ -180,15 +187,15 @@ impl PermissionPolicy {
     }
 
     /// Check permission for a server access
-    pub fn check_server_access(&self, server: &str) -> PermissionLevel {
+    pub fn check_server_access(&self, server: &str) -> McpPermissionLevel {
         // Check deny list first
         if self.denied_servers.contains(server) {
-            return PermissionLevel::Deny;
+            return McpPermissionLevel::Deny;
         }
 
         // Check allow list if not empty
         if !self.allowed_servers.is_empty() && !self.allowed_servers.contains(server) {
-            return PermissionLevel::Deny;
+            return McpPermissionLevel::Deny;
         }
 
         // Check rules in order
@@ -203,11 +210,11 @@ impl PermissionPolicy {
     }
 
     /// Check permission for a tool access
-    pub fn check_tool_access(&self, server: &str, tool: &str) -> PermissionLevel {
+    pub fn check_tool_access(&self, server: &str, tool: &str) -> McpPermissionLevel {
         // First check server-level access
         let server_level = self.check_server_access(server);
-        if server_level == PermissionLevel::Deny {
-            return PermissionLevel::Deny;
+        if server_level == McpPermissionLevel::Deny {
+            return McpPermissionLevel::Deny;
         }
 
         // Check tool-specific rules
@@ -311,11 +318,11 @@ impl PermissionManager {
         api_key: Option<&str>,
         team_id: Option<&str>,
         org_id: Option<&str>,
-    ) -> McpResult<PermissionLevel> {
+    ) -> McpResult<McpPermissionLevel> {
         let policy = self.get_effective_policy(api_key, team_id, org_id);
         let level = policy.check_server_access(server);
 
-        if level == PermissionLevel::Deny {
+        if level == McpPermissionLevel::Deny {
             return Err(McpError::AuthorizationError {
                 server_name: server.to_string(),
                 tool_name: None,
@@ -334,11 +341,11 @@ impl PermissionManager {
         api_key: Option<&str>,
         team_id: Option<&str>,
         org_id: Option<&str>,
-    ) -> McpResult<PermissionLevel> {
+    ) -> McpResult<McpPermissionLevel> {
         let policy = self.get_effective_policy(api_key, team_id, org_id);
         let level = policy.check_tool_access(server, tool);
 
-        if level == PermissionLevel::Deny {
+        if level == McpPermissionLevel::Deny {
             return Err(McpError::AuthorizationError {
                 server_name: server.to_string(),
                 tool_name: Some(tool.to_string()),
@@ -364,18 +371,18 @@ mod tests {
 
     #[test]
     fn test_permission_level_hierarchy() {
-        assert!(!PermissionLevel::Deny.can_read());
-        assert!(PermissionLevel::Read.can_read());
-        assert!(PermissionLevel::Execute.can_read());
-        assert!(PermissionLevel::Admin.can_read());
+        assert!(!McpPermissionLevel::Deny.can_read());
+        assert!(McpPermissionLevel::Read.can_read());
+        assert!(McpPermissionLevel::Execute.can_read());
+        assert!(McpPermissionLevel::Admin.can_read());
 
-        assert!(!PermissionLevel::Deny.can_execute());
-        assert!(!PermissionLevel::Read.can_execute());
-        assert!(PermissionLevel::Execute.can_execute());
-        assert!(PermissionLevel::Admin.can_execute());
+        assert!(!McpPermissionLevel::Deny.can_execute());
+        assert!(!McpPermissionLevel::Read.can_execute());
+        assert!(McpPermissionLevel::Execute.can_execute());
+        assert!(McpPermissionLevel::Admin.can_execute());
 
-        assert!(!PermissionLevel::Execute.is_admin());
-        assert!(PermissionLevel::Admin.is_admin());
+        assert!(!McpPermissionLevel::Execute.is_admin());
+        assert!(McpPermissionLevel::Admin.is_admin());
     }
 
     #[test]
@@ -394,12 +401,12 @@ mod tests {
 
     #[test]
     fn test_permission_rule_matching() {
-        let rule = PermissionRule::new("github", PermissionLevel::Execute);
+        let rule = PermissionRule::new("github", McpPermissionLevel::Execute);
         assert!(rule.matches("github", None));
         assert!(!rule.matches("gitlab", None));
 
         let rule_with_tool =
-            PermissionRule::new("github", PermissionLevel::Execute).for_tool("get_repo");
+            PermissionRule::new("github", McpPermissionLevel::Execute).for_tool("get_repo");
         assert!(rule_with_tool.matches("github", Some("get_repo")));
         assert!(!rule_with_tool.matches("github", Some("delete_repo")));
         assert!(!rule_with_tool.matches("github", None));
@@ -411,11 +418,11 @@ mod tests {
 
         assert_eq!(
             policy.check_server_access("github"),
-            PermissionLevel::Execute
+            McpPermissionLevel::Execute
         );
         assert_eq!(
             policy.check_server_access("dangerous_server"),
-            PermissionLevel::Deny
+            McpPermissionLevel::Deny
         );
     }
 
@@ -423,25 +430,28 @@ mod tests {
     fn test_policy_allow_list() {
         let policy = PermissionPolicy::deny_all("test")
             .allow_server("github")
-            .with_rule(PermissionRule::new("github", PermissionLevel::Execute));
+            .with_rule(PermissionRule::new("github", McpPermissionLevel::Execute));
 
         assert_eq!(
             policy.check_server_access("github"),
-            PermissionLevel::Execute
+            McpPermissionLevel::Execute
         );
-        assert_eq!(policy.check_server_access("gitlab"), PermissionLevel::Deny);
+        assert_eq!(
+            policy.check_server_access("gitlab"),
+            McpPermissionLevel::Deny
+        );
     }
 
     #[test]
     fn test_policy_rules_order() {
         let policy = PermissionPolicy::new("test")
-            .with_rule(PermissionRule::new("*", PermissionLevel::Read))
-            .with_rule(PermissionRule::new("github", PermissionLevel::Execute));
+            .with_rule(PermissionRule::new("*", McpPermissionLevel::Read))
+            .with_rule(PermissionRule::new("github", McpPermissionLevel::Execute));
 
         // First matching rule wins
         assert_eq!(
             policy.check_server_access("github"),
-            PermissionLevel::Read // "*" matches first
+            McpPermissionLevel::Read // "*" matches first
         );
     }
 
@@ -449,16 +459,18 @@ mod tests {
     fn test_policy_tool_access() {
         // Tool-specific rules should come before general rules
         let policy = PermissionPolicy::new("test")
-            .with_rule(PermissionRule::new("github", PermissionLevel::Deny).for_tool("delete_repo"))
-            .with_rule(PermissionRule::new("github", PermissionLevel::Execute));
+            .with_rule(
+                PermissionRule::new("github", McpPermissionLevel::Deny).for_tool("delete_repo"),
+            )
+            .with_rule(PermissionRule::new("github", McpPermissionLevel::Execute));
 
         assert_eq!(
             policy.check_tool_access("github", "get_repo"),
-            PermissionLevel::Execute
+            McpPermissionLevel::Execute
         );
         assert_eq!(
             policy.check_tool_access("github", "delete_repo"),
-            PermissionLevel::Deny
+            McpPermissionLevel::Deny
         );
     }
 
@@ -469,7 +481,7 @@ mod tests {
 
         let level = manager.check_server_access("github", Some("sk-test123"), None, None);
         assert!(level.is_ok());
-        assert_eq!(level.unwrap(), PermissionLevel::Execute);
+        assert_eq!(level.unwrap(), McpPermissionLevel::Execute);
     }
 
     #[test]
@@ -487,14 +499,15 @@ mod tests {
         // Set org policy (lowest priority)
         manager.set_org_policy(
             "org1",
-            PermissionPolicy::new("org").with_rule(PermissionRule::new("*", PermissionLevel::Read)),
+            PermissionPolicy::new("org")
+                .with_rule(PermissionRule::new("*", McpPermissionLevel::Read)),
         );
 
         // Set key policy (highest priority)
         manager.set_key_policy(
             "sk-admin",
             PermissionPolicy::new("admin")
-                .with_rule(PermissionRule::new("*", PermissionLevel::Admin)),
+                .with_rule(PermissionRule::new("*", McpPermissionLevel::Admin)),
         );
 
         // Key policy takes precedence
@@ -512,7 +525,7 @@ mod tests {
         manager.set_key_policy(
             "sk-reader",
             PermissionPolicy::new("reader")
-                .with_rule(PermissionRule::new("*", PermissionLevel::Read)),
+                .with_rule(PermissionRule::new("*", McpPermissionLevel::Read)),
         );
 
         // Read-only should not allow tool execution
@@ -524,7 +537,7 @@ mod tests {
     #[test]
     fn test_permission_policy_serialization() {
         let policy = PermissionPolicy::new("test")
-            .with_rule(PermissionRule::new("github", PermissionLevel::Execute));
+            .with_rule(PermissionRule::new("github", McpPermissionLevel::Execute));
 
         let json = serde_json::to_string(&policy).unwrap();
         let deserialized: PermissionPolicy = serde_json::from_str(&json).unwrap();

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -117,6 +117,26 @@ impl PricingDatabase {
         0.0
     }
 
+    /// Calculate cost for a provider/model pair and token usage.
+    ///
+    /// Provider dispatch should use this method instead of `calculate` so a
+    /// same-named model on another provider does not accidentally supply prices.
+    pub fn calculate_for_provider(&self, provider: &str, model: &str, usage: &Usage) -> f64 {
+        if let Some(pricing) = self.models.get(model)
+            && pricing_matches_provider(model, pricing, provider)
+        {
+            return self.calculate_with_pricing(pricing, usage);
+        }
+
+        for (key, pricing) in &self.models {
+            if pricing_matches_provider(key, pricing, provider) && model_matches_key(model, key) {
+                return self.calculate_with_pricing(pricing, usage);
+            }
+        }
+
+        0.0
+    }
+
     fn calculate_with_pricing(&self, pricing: &ModelPricing, usage: &Usage) -> f64 {
         let mut cost = 0.0;
 
@@ -201,6 +221,18 @@ impl PricingDatabase {
             })
             .unwrap_or(false)
     }
+}
+
+fn pricing_matches_provider(model_key: &str, pricing: &ModelPricing, provider: &str) -> bool {
+    let provider = provider.to_ascii_lowercase();
+    let pricing_provider = pricing.litellm_provider.to_ascii_lowercase();
+    let model_key = model_key.to_ascii_lowercase();
+
+    pricing_provider == provider || model_key.starts_with(&format!("{provider}/"))
+}
+
+fn model_matches_key(model: &str, key: &str) -> bool {
+    model == key || model.contains(key) || key.contains(model)
 }
 
 fn extra_f64(pricing: &ModelPricing, key: &str) -> f64 {
@@ -393,6 +425,27 @@ mod tests {
 
         let cost = db.calculate("claude-3-opus", &usage);
         assert!(cost > 0.0);
+    }
+
+    #[test]
+    fn calculate_for_provider_uses_matching_provider_rates() {
+        let db = PricingDatabase::default();
+        let usage = Usage {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 1500,
+            reasoning_tokens: None,
+        };
+
+        assert_eq!(
+            db.calculate_for_provider("openai", "gpt-4", &usage),
+            1000.0 * 0.00003 + 500.0 * 0.00006
+        );
+        assert_eq!(db.calculate_for_provider("anthropic", "gpt-4", &usage), 0.0);
+        assert_eq!(
+            db.calculate_for_provider("openai", "claude-3-opus", &usage),
+            0.0
+        );
     }
 
     #[test]

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -116,6 +116,10 @@ impl LLMProvider for AnthropicProvider {
         "anthropic"
     }
 
+    fn error_provider_name(&self) -> &'static str {
+        "anthropic"
+    }
+
     fn capabilities(&self) -> &'static [ProviderCapability] {
         &[
             ProviderCapability::ChatCompletion,

--- a/src/core/providers/cloudflare/provider.rs
+++ b/src/core/providers/cloudflare/provider.rs
@@ -196,6 +196,10 @@ impl LLMProvider for CloudflareProvider {
         "cloudflare"
     }
 
+    fn error_provider_name(&self) -> &'static str {
+        "cloudflare"
+    }
+
     fn capabilities(&self) -> &'static [ProviderCapability] {
         CLOUDFLARE_CAPABILITIES
     }

--- a/src/core/providers/macros/MACROS.md
+++ b/src/core/providers/macros/MACROS.md
@@ -1,0 +1,38 @@
+# Provider Macro Status
+
+This directory still contains crate-root `#[macro_export]` helpers. F4 keeps
+the legacy exports for compatibility, but the recommended implementation path is
+provider registry/catalog wiring plus normal Rust modules.
+
+## Active In-Tree Macros
+
+- `define_http_provider_with_hooks!`
+  - Used by `custom_api` and `deepl`.
+  - Keep until those providers are converted to explicit modules.
+- `define_pooled_http_provider_with_hooks!`
+  - Used by `ai21`, `amazon_nova`, `datarobot`, `empower`, and `firecrawl`.
+  - Keep until those providers are converted to explicit modules.
+
+## Compatibility-Only Macros
+
+These exports have no non-macro in-tree call sites as of F4. They remain
+compiled so downstream users are not broken by this cleanup sweep:
+
+- `impl_provider_basics!`
+- `impl_error_conversion!`
+- `provider_config!`
+- `impl_health_check!`
+- `build_request!`
+- `not_implemented!`
+- `model_list!`
+- `impl_streaming!`
+- `validate_response!`
+- `with_retry!`
+- `extract_usage!`
+- `require_config!`
+- `standard_provider!`
+- `define_openai_compatible_provider!`
+
+New provider code should not introduce additional call sites for compatibility
+macros; use a concrete provider module or the active hook macros only when the
+existing hook shape already fits.

--- a/src/core/providers/macros/mod.rs
+++ b/src/core/providers/macros/mod.rs
@@ -7,6 +7,9 @@
 //! - `openai_compatible`: `define_openai_compatible_provider!` macro
 //! - `http_hooks`: `define_http_provider_with_hooks!` macro
 //! - `pooled_hooks`: `define_pooled_http_provider_with_hooks!` macro
+//!
+//! See `MACROS.md` in this directory for the current in-tree usage audit and
+//! compatibility status of each exported provider macro.
 mod config_helpers;
 
 // All macro modules contain #[macro_export] macros, which are hoisted to crate root.

--- a/src/core/providers/mistral/mod.rs
+++ b/src/core/providers/mistral/mod.rs
@@ -467,6 +467,10 @@ impl LLMProvider for MistralProvider {
         "mistral"
     }
 
+    fn error_provider_name(&self) -> &'static str {
+        "mistral"
+    }
+
     fn capabilities(&self) -> &'static [ProviderCapability] {
         MISTRAL_CAPABILITIES
     }

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -337,7 +337,7 @@ pub enum Provider {
 
 impl Provider {
     /// Get provider name
-    pub fn name(&self) -> &'static str {
+    pub fn name(&self) -> &str {
         match self {
             Provider::OpenAI(_) => "openai",
             Provider::Anthropic(_) => "anthropic",
@@ -413,7 +413,13 @@ impl Provider {
             reasoning_tokens: None,
         };
 
-        Ok(crate::core::pricing::get_pricing_db().calculate(model, &usage))
+        Ok(
+            crate::core::pricing::get_pricing_db().calculate_for_provider(
+                self.name(),
+                model,
+                &usage,
+            ),
+        )
     }
 
     /// Execute streaming chat completion

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -340,6 +340,10 @@ impl LLMProvider for OpenAIProvider {
         "openai"
     }
 
+    fn error_provider_name(&self) -> &'static str {
+        "openai"
+    }
+
     fn capabilities(&self) -> &'static [ProviderCapability] {
         static CAPABILITIES: &[ProviderCapability] = &[
             ProviderCapability::ChatCompletion,

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -40,20 +40,8 @@ pub struct OpenAILikeProvider {
     config: OpenAILikeConfig,
     /// Model registry
     model_registry: &'static OpenAILikeModelRegistry,
-    /// Interned provider name for `&'static str` return in `name()`
-    provider_name: &'static str,
-}
-
-/// Intern a provider name as `&'static str`.
-///
-/// Returns the pre-existing constant for the default name to avoid allocation,
-/// and leaks the string for custom names. Providers are long-lived singletons,
-/// so the small allocation is acceptable.
-fn intern_provider_name(name: &str) -> &'static str {
-    if name == PROVIDER_NAME {
-        return PROVIDER_NAME;
-    }
-    Box::leak(name.to_string().into_boxed_str())
+    /// Provider name returned by the LLM provider trait.
+    provider_name: String,
 }
 
 impl OpenAILikeProvider {
@@ -69,7 +57,7 @@ impl OpenAILikeProvider {
                 .map_err(|e| OpenAILikeError::network(PROVIDER_NAME, e.to_string()))?,
         );
         let model_registry = get_openai_like_registry();
-        let provider_name = intern_provider_name(&config.provider_name);
+        let provider_name = config.provider_name.clone();
 
         Ok(Self {
             pool_manager,
@@ -438,8 +426,12 @@ where
 }
 
 impl LLMProvider for OpenAILikeProvider {
-    fn name(&self) -> &'static str {
-        self.provider_name
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn error_provider_name(&self) -> &'static str {
+        PROVIDER_NAME
     }
 
     fn capabilities(&self) -> &'static [ProviderCapability] {
@@ -740,18 +732,6 @@ mod tests {
             .with_skip_api_key(true);
         let provider = OpenAILikeProvider::new(config).await.unwrap();
         assert_eq!(provider.name(), "deepseek");
-    }
-
-    #[test]
-    fn test_intern_provider_name_default() {
-        let name = intern_provider_name("openai_like");
-        assert_eq!(name, PROVIDER_NAME);
-    }
-
-    #[test]
-    fn test_intern_provider_name_custom() {
-        let name = intern_provider_name("xai");
-        assert_eq!(name, "xai");
     }
 
     /// OR_SITE_URL → HTTP-Referer and OR_APP_NAME → X-Title are injected via

--- a/src/core/providers/unified_provider.rs
+++ b/src/core/providers/unified_provider.rs
@@ -751,7 +751,7 @@ impl ProviderError {
 #[macro_export]
 macro_rules! define_provider_error_helpers {
     ($provider:expr, $prefix:ident) => {
-        ::paste::paste! {
+        ::pastey::paste! {
             /// Create configuration error
             pub fn [<$prefix _config_error>](msg: impl Into<String>) -> $crate::core::providers::unified_provider::ProviderError {
                 $crate::core::providers::unified_provider::ProviderError::configuration($provider, msg.into())
@@ -817,7 +817,7 @@ macro_rules! define_provider_error_helpers {
 #[macro_export]
 macro_rules! impl_provider_error_helpers {
     ($provider:expr, $prefix:ident) => {
-        ::paste::paste! {
+        ::pastey::paste! {
             impl $crate::core::providers::unified_provider::ProviderError {
                 /// Create authentication error
                 pub fn [<$prefix _authentication>](message: impl Into<String>) -> Self {
@@ -934,7 +934,7 @@ pub fn parse_error_message_from_body(response_body: &str) -> Option<String> {
 #[macro_export]
 macro_rules! define_standard_error_mapper {
     ($provider:expr, $name:ident) => {
-        ::paste::paste! {
+        ::pastey::paste! {
             /// Error mapper for the provider, using the standard HTTP status code mapping.
             #[derive(Debug)]
             pub struct [<$name ErrorMapper>];
@@ -988,7 +988,7 @@ pub fn extended_http_error_mapper(
 #[macro_export]
 macro_rules! define_extended_error_mapper {
     ($provider:expr, $name:ident) => {
-        ::paste::paste! {
+        ::pastey::paste! {
             /// Error mapper for the provider, using the extended HTTP status code mapping.
             #[derive(Debug)]
             pub struct [<$name ErrorMapper>];

--- a/src/core/traits/provider/llm_provider/trait_definition.rs
+++ b/src/core/traits/provider/llm_provider/trait_definition.rs
@@ -46,11 +46,20 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// Get provider name
     ///
     /// # Returns
-    /// Static string identifier for the provider, such as "openai", "anthropic", "v0", etc.
+    /// String identifier for the provider, such as "openai", "anthropic", "v0", etc.
     ///
     /// # Note
-    /// This name is used for routing and logging, must be unique across the entire system
-    fn name(&self) -> &'static str;
+    /// This name is used for routing and logging, must be unique across the entire system.
+    /// Implementations may return either a static literal or a value borrowed from `self`.
+    fn name(&self) -> &str;
+
+    /// Static provider name used by legacy `ProviderError` constructors.
+    ///
+    /// Providers with dynamic names should return a stable family name here and
+    /// keep the specific provider identity in `name()`.
+    fn error_provider_name(&self) -> &'static str {
+        "provider"
+    }
 
     /// Get provider capabilities
     ///
@@ -293,7 +302,10 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
         _context: RequestContext,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<ChatChunk, ProviderError>> + Send>>, ProviderError>
     {
-        Err(ProviderError::not_supported(self.name(), "streaming"))
+        Err(ProviderError::not_supported(
+            self.error_provider_name(),
+            "streaming",
+        ))
     }
 
     // ==================== Optional Features ====================
@@ -322,7 +334,10 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
         _request: EmbeddingRequest,
         _context: RequestContext,
     ) -> Result<EmbeddingResponse, ProviderError> {
-        Err(ProviderError::not_supported(self.name(), "embeddings"))
+        Err(ProviderError::not_supported(
+            self.error_provider_name(),
+            "embeddings",
+        ))
     }
 
     /// Generate images
@@ -349,7 +364,7 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
         _context: RequestContext,
     ) -> Result<ImageGenerationResponse, ProviderError> {
         Err(ProviderError::not_supported(
-            self.name(),
+            self.error_provider_name(),
             "image_generation",
         ))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,21 @@ pub use config::Config;
 pub use utils::error::gateway_error::{GatewayError, Result};
 pub use version::{BuildInfo, GIT_HASH, VERSION, build_info, full_version};
 
+/// Curated imports for applications using the stable high-level LiteLLM-RS API.
+pub mod prelude {
+    pub use crate::config::Config;
+    pub use crate::core::completion::{
+        CompletionOptions, CompletionResponse, LiteLLMError, Message, Router, Usage, acompletion,
+        assistant_message, completion, completion_stream, system_message, user_message,
+    };
+    pub use crate::core::embedding::{
+        EmbeddingInput, EmbeddingOptions, EmbeddingResponse, aembedding, embed_text, embed_texts,
+        embed_texts_with_options, embedding,
+    };
+    pub use crate::utils::error::gateway_error::{GatewayError, Result};
+    pub use crate::version::{BuildInfo, GIT_HASH, VERSION, build_info, full_version};
+}
+
 // Export core completion functionality (Python LiteLLM compatible)
 pub use core::completion::{
     Choice, CompletionOptions, CompletionResponse, ContentPart, LiteLLMError, Message, Router,
@@ -115,6 +130,7 @@ pub use core::types::message::{MessageContent, MessageRole};
 
 // Export core functionality
 pub use core::models::RequestContext;
+#[doc(hidden)]
 pub use core::models::openai::{
     AudioContent, AudioDelta, AudioParams, CacheControl, ChatChoice, ChatChoiceDelta,
     ChatCompletionChoice, ChatCompletionRequest, ChatCompletionResponse, ChatMessage,
@@ -125,9 +141,11 @@ pub use core::models::openai::{
     StreamOptions, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolChoiceFunction,
     ToolChoiceFunctionSpec, TopLogprob,
 };
+#[doc(hidden)]
 pub use core::providers::{Provider, ProviderError, ProviderRegistry, ProviderType};
 
 // Export unified router
+#[doc(hidden)]
 pub use core::router::{
     CooldownReason, Deployment, DeploymentConfig, FallbackConfig, FallbackType, RouterConfig,
     RouterError, UnifiedRouter, UnifiedRoutingStrategy as RoutingStrategy,


### PR DESCRIPTION
## Summary
- Remove the OpenAI-like provider-name leak by letting `LLMProvider::name()` borrow from the provider instance while keeping a static `error_provider_name()` for existing `ProviderError` constructors.
- Make `Provider::calculate_cost()` provider-aware via `PricingDatabase::calculate_for_provider()` so provider-specific rates do not bleed across same/similar model names.
- Prefix MCP auth/permission public types, drop the `paste` dependency rename, add a curated crate prelude, and document provider macro compatibility status.

## Verification
- `cargo test providers`
- `cargo test mcp`
- `cargo test cache`
- `cargo test calculate_for_provider`
- `cargo check --all-features`
- `cargo check --no-default-features --features lite`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --lib --tests --bins --all-features -- -D warnings --force-warn clippy::collapsible-if`