### PR TITLE
Complete audit remediation closeout

### DIFF
--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -360,6 +360,7 @@ fn bench_serialization(c: &mut Criterion) {
         function_call: None,
         tools: None,
         tool_choice: None,
+        parallel_tool_calls: None,
         response_format: None,
         seed: None,
         logprobs: None,
@@ -370,6 +371,10 @@ fn bench_serialization(c: &mut Criterion) {
         store: None,
         metadata: None,
         service_tier: None,
+        prediction: None,
+        safety_settings: None,
+        cache_control: None,
+        extra_body: Default::default(),
     };
 
     group.bench_function("serialize_request", |b| {

--- a/docs/audit-2026-05-01/closeout-2026-05-02.md
+++ b/docs/audit-2026-05-01/closeout-2026-05-02.md
@@ -1,0 +1,99 @@
+# Audit remediation closeout - 2026-05-02
+
+## Result
+
+The 2026-05-01 audit remediation program is closed.
+
+- Raw findings captured: 77 findings, 20 Critical, 27 High, 30 Medium.
+- Deduplicated execution tracker: 72 items, 20 Critical, 22 High, 30 Medium.
+- Execution plan steps: 41 completed, 0 pending, 0 in progress, 0 blocked.
+- Audit remediation PRs: #463 through #494 merged.
+- Open PR queue after closure check: 0 open PRs.
+
+The canonical execution record remains `docs/plan/audit-remediation-complete-plan.md`.
+The original evidence bundle remains under `docs/audit-2026-05-01/`.
+
+## Merged PR Trail
+
+| PR | Scope | Merge commit |
+|----|-------|--------------|
+| #463 | Foundation through pricing source cleanup | `04c0774afbb7d4dd9566127ec5926afdb30f3675` |
+| #464 | Continue pricing source convergence | `f1b4decf4afcb1f6b125fcb20dacbc9caf66a17c` |
+| #465 | Gemini basic cost through shared pricing | `f620b5b6ad3a0befb69c8c9b7b76f5e704c180d6` |
+| #466 | OpenAI cost through shared pricing | `10887a1a463112398bba1b10d5c40edf99dafbe0` |
+| #467 | Bedrock provider pricing shape | `717345eae57eed8fb1948ac389a06ab77f15f81b` |
+| #468 | Anthropic and Gemini pricing adapters | `8fea595d8194c404d010586a72b04c488ef89b04` |
+| #469 | Spark pricing adapter | `8eb06a3b1cc115d208448c7f6ecd2fb7472de0a2` |
+| #470 | AuthConfig default JWT state | `3f7425d271f7f1771b093a9d412ed7c1ed923a76` |
+| #471 | Provider support from registry | `20c33a93c51bf550f474fb6264cc502941b8dd66` |
+| #472 | Provider module lifecycle states | `582de546ba958c3126c6e6438f97b97bdbe7b7a1` |
+| #473 | Shared LiteLLM pricing JSON parsing | `dae89f2253c069449b6247f75d69560053478199` |
+| #474 | Core pricing database ownership | `753c385e1dcd3967ab17e17b3c14e406356383e7` |
+| #475 | Pricing consumers through core pricing | `5ffdfd2b22a0dec93898d6dffc26e603ad074e8c` |
+| #476 | Finish core pricing consumer migration | `694dff2e341602fa94d0c75af09028449a460ee8` |
+| #477 | Core pricing import guard | `a756933ee6d653e8305744c57c76c8fc04a28c5e` |
+| #478 | Spark pricing model | `e5d16eabb6b89894ea806a22ae75ee928d0343a4` |
+| #479 | Bedrock pricing model | `a2a42247fa0a801d2a970526c4a44e7409176ea7` |
+| #480 | Anthropic and Gemini pricing models | `121091bb59c05b2f4821f69e91d245e36cc7d77c` |
+| #481 | Core pricing service ownership | `8cd237e58c650425f2115ce338f38123c86840b2` |
+| #482 | Legacy teams read through canonical repository | `ebac7a225dfc15f79fbc36a9d7083dd6f609530e` |
+| #483 | Canonical teams mirrored into legacy tables | `7efff3106ed622314043e2319cbe8a3f1030a027` |
+| #484 | Canonical and legacy users bridged | `003cc519b448949fa765c288513e9bce20e6d0ed` |
+| #485 | SDK provider selection through core router | `97adfb37b36dc7c1803ba765a6e1c8c1c8fa7c3b` |
+| #486 | Strict gateway config parsing | `e2e36532070a959406bc27cdcd11dd5310824d60` |
+| #487 | Base SSE provider transformer split | `30d1a1b8e3a129ae3a2b0d647501214689d5fdb8` |
+| #488 | Anthropic model registry split | `b15f03b68040b694f7e2867157d8af90c782aa1f` |
+| #489 | Anthropic client test split | `0ac117e24e37e95c367e8b1696b6f721786742e5` |
+| #490 | Cost calculator module split | `6510dd4ccf8a4310d61c0e1a92d0db554e58db22` |
+| #491 | F1 stream/provider serialization sweep | `175d980d856744521370c1f7450546df6040d7d0` |
+| #492 | F2 security/privacy hygiene sweep | `e36c33e874c941563b7ed6416f42f6675352a369` |
+| #493 | F3 runtime/config hygiene sweep | `315c7693d8b2bee6a21e6d80549c7756e745d2c1` |
+| #494 | F4 provider/cost API cleanup sweep | `36f43f15b7ad724f66a5aeac06b750ca4930e269` |
+
+## Final Closure Fixes
+
+The final health pass found three small drifts after #494 had already merged:
+
+- `src/core/providers/bedrock/chat/converse.rs`: collapsed the last strict clippy failure in Bedrock Converse assistant tool-use handling without changing behavior.
+- `benches/performance_benchmarks.rs`: updated the benchmark request initializer for the new OpenAI-compatible request fields so `--all-targets` checks include benchmarks cleanly.
+- `scripts/guards/check_pr_scope.sh`: fixed the no-change path so it no longer prints `integer expected` while still exiting 0.
+
+## Final Verification
+
+These commands were run after the final closure fixes:
+
+```bash
+cargo fmt --all -- --check
+git diff --check
+cargo test --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+cargo check --no-default-features --features lite
+bash scripts/guards/check_pr_scope.sh
+bash scripts/guards/check_pr_overlap.sh
+```
+
+Observed results:
+
+- `cargo test --all-features`: passed.
+  - library tests: 10481 passed, 0 failed.
+  - binary tests: 4 passed, 0 failed.
+  - integration tests: 145 passed, 12 ignored, 0 failed.
+  - connection-pool integration tests: 3 passed, 0 failed.
+  - doctests: 96 passed, 36 ignored, 0 failed.
+- `cargo clippy --all-targets --all-features -- -D warnings`: passed with no warning allowances.
+- `cargo check --no-default-features --features lite`: passed.
+- `cargo fmt --all -- --check`: passed.
+- `git diff --check`: passed.
+- `check_pr_scope.sh`: passed; final PR scope is 3 non-doc files and 31 changed lines, and the no-change path no longer emits the integer warning.
+- `check_pr_overlap.sh`: passed with no open-PR overlap.
+
+## Residual Risk
+
+No audit-remediation tracker item remains pending.
+
+Intentional non-blockers after closure:
+
+- Ignored E2E tests still require external provider credentials and are not part of local deterministic closure.
+- MCP compatibility aliases for old public names remain hidden for source compatibility.
+- `ProviderError` still has a static fallback provider-name path; the leak is removed, but a fully owned provider-error model would be a separate API-shape cleanup.
+- Provider lifecycle documentation now declares which modules are active, wired, or legacy; deleting legacy provider code should happen in future narrow PRs only when compatibility policy allows it.

--- a/scripts/guards/check_pr_scope.sh
+++ b/scripts/guards/check_pr_scope.sh
@@ -83,7 +83,7 @@ for file in $(git diff --name-only "$BASE"...HEAD -- ':!Cargo.lock' ':!*.md' ':!
     esac
 done
 
-UNIQUE_DOMAINS=$(echo "$DOMAINS" | tr ' ' '\n' | sort -u | grep -v '^$' | wc -l | tr -d ' ' || echo "0")
+UNIQUE_DOMAINS=$(printf '%s\n' "$DOMAINS" | tr ' ' '\n' | awk 'NF' | sort -u | wc -l | tr -d ' ')
 if [ "$UNIQUE_DOMAINS" -gt 3 ]; then
     echo -e "${YELLOW}WARN: PR touches $UNIQUE_DOMAINS ownership domains${NC}"
     echo "  Domains: $(echo "$DOMAINS" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ', ')"

--- a/src/core/providers/bedrock/chat/converse.rs
+++ b/src/core/providers/bedrock/chat/converse.rs
@@ -276,20 +276,18 @@ fn transform_to_converse(request: &ChatRequest) -> Result<ConverseRequest, Provi
                     vec![]
                 };
 
-                if msg.role == MessageRole::Assistant {
-                    if let Some(tool_calls) = &msg.tool_calls {
-                        for tool_call in tool_calls {
-                            content.push(ContentBlock::ToolUse {
-                                tool_use: ToolUseBlock {
-                                    tool_use_id: tool_call.id.clone(),
-                                    name: tool_call.function.name.clone(),
-                                    input: serde_json::from_str::<Value>(
-                                        &tool_call.function.arguments,
-                                    )
+                if msg.role == MessageRole::Assistant
+                    && let Some(tool_calls) = &msg.tool_calls
+                {
+                    for tool_call in tool_calls {
+                        content.push(ContentBlock::ToolUse {
+                            tool_use: ToolUseBlock {
+                                tool_use_id: tool_call.id.clone(),
+                                name: tool_call.function.name.clone(),
+                                input: serde_json::from_str::<Value>(&tool_call.function.arguments)
                                     .unwrap_or(Value::Object(Default::default())),
-                                },
-                            });
-                        }
+                            },
+                        });
                     }
                 }
 


### PR DESCRIPTION
## Summary
- add the 2026-05-02 audit remediation closeout report covering the deduped tracker, merged PR trail, final verification, and residual non-blockers
- clean up the final strict health pass findings: Bedrock clippy nesting, benchmark request-field drift, and the PR scope guard no-change warning
- confirm the remediation queue is closed with no pending plan steps and no open PR overlap

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --no-default-features --features lite
- cargo check
- cargo test --all-features bedrock
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh

Note: the local pre-commit hook still times out its internal `cargo check` after 10s. A standalone `cargo check` passed in 27.95s, so the commit used the hook's documented `VIBEGUARD_SKIP_PRECOMMIT=1` path after verification.
