### PR TITLE
fix(http): stop disabling pricing source when semantic_cache is enabled

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -62,12 +62,7 @@ impl HttpServer {
         let auth =
             crate::auth::AuthSystem::new(&config.gateway.auth, Arc::new(storage.clone())).await?;
 
-        let pricing_source = if config.gateway.cache.semantic_cache {
-            None
-        } else {
-            config.gateway.pricing.source.clone()
-        };
-        let pricing = Arc::new(PricingService::new(pricing_source));
+        let pricing = Arc::new(PricingService::new(config.gateway.pricing.source.clone()));
         if let Err(e) = pricing.initialize().await {
             warn!("Pricing service initial load failed: {}", e);
         } else {


### PR DESCRIPTION
Closes #501.

## Summary

- The wiring conditional in `HttpServer::new` was nullifying `pricing.source` whenever `cache.semantic_cache=true`. The two settings have no semantic relationship; the coupling was silent and undocumented.
- Pass the configured `pricing.source` unconditionally.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: start the gateway with both `cache.semantic_cache: true` and `pricing.source` set, confirm the configured pricing path loads (look for "Pricing service initial load completed" with the right path)