### PR TITLE
fix(oauth): redact response bodies in error logs

### DIFF
--- a/src/auth/oauth/client.rs
+++ b/src/auth/oauth/client.rs
@@ -163,7 +163,11 @@ impl OAuthClient {
                 error!("OAuth token exchange error: {}", oauth_error);
                 return Err(GatewayError::Auth(oauth_error.to_string()));
             }
-            error!("Token exchange failed with status {}: {}", status, body);
+            error!(
+                "Token exchange failed with status {} (response body redacted, {} bytes)",
+                status,
+                body.len()
+            );
             return Err(GatewayError::Auth(format!(
                 "Token exchange failed: {}",
                 status
@@ -260,7 +264,11 @@ impl OAuthClient {
                 error!("OAuth token refresh error: {}", oauth_error);
                 return Err(GatewayError::Auth(oauth_error.to_string()));
             }
-            error!("Token refresh failed with status {}: {}", status, body);
+            error!(
+                "Token refresh failed with status {} (response body redacted, {} bytes)",
+                status,
+                body.len()
+            );
             return Err(GatewayError::Auth(format!(
                 "Token refresh failed: {}",
                 status
@@ -299,7 +307,10 @@ impl OAuthClient {
             .map_err(|e| GatewayError::Network(format!("Failed to read response body: {}", e)))?;
 
         if !status.is_success() {
-            error!("UserInfo request failed with status {}: {}", status, body);
+            let body_bytes = body.len();
+            error!(
+                "UserInfo request failed with status {status} (body redacted, {body_bytes} bytes)"
+            );
             return Err(GatewayError::Auth(format!(
                 "UserInfo request failed: {}",
                 status

--- a/src/auth/oauth/client.rs
+++ b/src/auth/oauth/client.rs
@@ -220,8 +220,8 @@ impl OAuthClient {
         }
 
         Err(GatewayError::Validation(format!(
-            "Failed to parse token response: {}",
-            body
+            "Failed to parse token response ({} bytes)",
+            body.len()
         )))
     }
 


### PR DESCRIPTION
Closes #503.

## Summary

- Three `error!` call sites in `OAuthClient` logged the full upstream HTTP body on non-2xx responses (token exchange, token refresh, userinfo). UserInfo bodies regularly contain PII; token endpoints can include token material when the upstream returns a non-RFC-6749 shape.
- Replace each with a redacted form that logs only `status` + `body.len()`. The structured `OAuthError` path (which already does its own logging) is unchanged.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: trigger an IdP 4xx that does not parse as OAuthError (e.g. malformed redirect_uri response) and confirm logs no longer contain body content