### PR TITLE
fix(cache): include output-affecting fields in chat key, bump schema to v3

### DIFF
--- a/src/core/cache/key_generator.rs
+++ b/src/core/cache/key_generator.rs
@@ -48,6 +48,7 @@ pub fn generate_chat_key_with_user(
         "function_call": &request.function_call,
         "tools": &request.tools,
         "tool_choice": &request.tool_choice,
+        "parallel_tool_calls": request.parallel_tool_calls,
         "response_format": &request.response_format,
         "seed": request.seed,
         "logprobs": request.logprobs,
@@ -56,6 +57,10 @@ pub fn generate_chat_key_with_user(
         "audio": &request.audio,
         "reasoning_effort": &request.reasoning_effort,
         "service_tier": &request.service_tier,
+        "prediction": &request.prediction,
+        "safety_settings": &request.safety_settings,
+        "cache_control": &request.cache_control,
+        "extra_body": &request.extra_body,
         "user_id": user_id,
     });
 
@@ -234,7 +239,7 @@ mod tests {
         };
 
         let key = generate_chat_key(&request);
-        assert!(key.as_str().starts_with("chat:gpt-4:v2:"));
+        assert!(key.as_str().starts_with("chat:gpt-4:v3:"));
     }
 
     #[test]
@@ -328,6 +333,39 @@ mod tests {
         let key2 = generate_chat_key(&request2);
 
         assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn test_generate_chat_key_includes_output_affecting_extras() {
+        let base = ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![create_user_message("hi")],
+            ..Default::default()
+        };
+
+        let mut parallel = base.clone();
+        parallel.parallel_tool_calls = Some(false);
+        assert_ne!(generate_chat_key(&base), generate_chat_key(&parallel));
+
+        let mut prediction = base.clone();
+        prediction.prediction = Some(serde_json::json!({"type":"content","content":"42"}));
+        assert_ne!(generate_chat_key(&base), generate_chat_key(&prediction));
+
+        let mut safety = base.clone();
+        safety.safety_settings =
+            Some(serde_json::json!([{"category":"HARM","threshold":"BLOCK_NONE"}]));
+        assert_ne!(generate_chat_key(&base), generate_chat_key(&safety));
+
+        let mut cache_control = base.clone();
+        cache_control.cache_control = Some(serde_json::json!({"type":"ephemeral"}));
+        assert_ne!(generate_chat_key(&base), generate_chat_key(&cache_control));
+
+        let mut extra = base.clone();
+        extra.extra_body.insert(
+            "provider_specific".to_string(),
+            serde_json::json!({"k":"v"}),
+        );
+        assert_ne!(generate_chat_key(&base), generate_chat_key(&extra));
     }
 
     #[test]
@@ -427,7 +465,7 @@ mod tests {
         };
 
         let key = generate_embedding_key(&request);
-        assert!(key.as_str().starts_with("embed:text-embedding-ada-002:v2:"));
+        assert!(key.as_str().starts_with("embed:text-embedding-ada-002:v3:"));
     }
 
     #[test]

--- a/src/core/cache/key_policy.rs
+++ b/src/core/cache/key_policy.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 ///
 /// Bumping this value intentionally cold-starts older Redis/cache entries so
 /// responses produced under an older request identity policy are not reused.
-pub const CACHE_KEY_SCHEMA_VERSION: &str = "v2";
+pub const CACHE_KEY_SCHEMA_VERSION: &str = "v3";
 
 /// Generate a stable SHA-256 digest for any serializable value.
 pub fn stable_digest<T: Serialize>(value: &T) -> String {
@@ -113,8 +113,8 @@ mod tests {
     fn versioned_key_includes_schema_version() {
         assert_eq!(
             versioned_key("chat", Some("gpt-4"), "abc"),
-            "chat:gpt-4:v2:abc"
+            "chat:gpt-4:v3:abc"
         );
-        assert_eq!(versioned_key("raw", None, "abc"), "raw:v2:abc");
+        assert_eq!(versioned_key("raw", None, "abc"), "raw:v3:abc");
     }
 }


### PR DESCRIPTION
Closes #505.

## Summary

- The chat cache key payload omitted `parallel_tool_calls`, `prediction`, `safety_settings`, `cache_control`, and `extra_body` — all of which change the response shape or content. Cross-request collisions could serve the wrong response.
- Add the five fields to the payload.
- Bump `CACHE_KEY_SCHEMA_VERSION` from `v2` to `v3` so existing entries cold-start (intentional cache invalidation, per the constant's docstring) instead of serving stale collisions after deploy.
- Update the two `v2` literal assertions in tests and add a regression test asserting each new field changes the cache key.

## Test plan

- [x] `cargo test --all-features --lib core::cache` — 140/140 passing
- [x] New test `test_generate_chat_key_includes_output_affecting_extras` covers each new field
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`