### PR TITLE
fix(s3): wire S3Config credentials and endpoint into the AWS client

### DIFF
--- a/src/storage/files/s3.rs
+++ b/src/storage/files/s3.rs
@@ -29,6 +29,16 @@ pub struct S3Storage {
 
 impl S3Storage {
     /// Create a new S3 storage instance
+    ///
+    /// Credential resolution order:
+    /// - If `access_key_id` and `secret_access_key` are both non-empty,
+    ///   use them as static credentials.
+    /// - Otherwise, fall back to the AWS default provider chain
+    ///   (env vars, shared config, IMDS, container credentials).
+    ///
+    /// `endpoint` may be set to point at S3-compatible services
+    /// (MinIO, Tigris, Cloudflare R2). When set, path-style addressing
+    /// is forced.
     pub async fn new(config: &S3Config) -> Result<Self> {
         info!(
             "S3 file storage initialized: bucket={}, region={}",
@@ -37,15 +47,42 @@ impl S3Storage {
 
         #[cfg(feature = "s3")]
         {
-            use aws_s3::config::Region;
+            use aws_s3::config::{Credentials, Region};
+
+            let use_static_creds =
+                !config.access_key_id.is_empty() && !config.secret_access_key.is_empty();
+            info!(
+                "S3 client config: endpoint={:?}, credentials={}",
+                config.endpoint,
+                if use_static_creds {
+                    "static"
+                } else {
+                    "default-chain"
+                }
+            );
 
             let region = Region::new(config.region.clone());
-            let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-                .region(region)
-                .load()
-                .await;
+            let mut loader =
+                aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region);
 
-            let client = aws_s3::Client::new(&aws_config);
+            if use_static_creds {
+                let creds = Credentials::new(
+                    &config.access_key_id,
+                    &config.secret_access_key,
+                    None,
+                    None,
+                    "litellm-rs-s3-config",
+                );
+                loader = loader.credentials_provider(creds);
+            }
+
+            let aws_config = loader.load().await;
+
+            let mut s3_builder = aws_s3::config::Builder::from(&aws_config);
+            if let Some(endpoint) = &config.endpoint {
+                s3_builder = s3_builder.endpoint_url(endpoint).force_path_style(true);
+            }
+            let client = aws_s3::Client::from_conf(s3_builder.build());
 
             Ok(Self {
                 bucket: config.bucket.clone(),


### PR DESCRIPTION
Closes #516.

## Summary

`S3Storage::new` was only consuming `region` and `bucket` from `S3Config`. The `access_key_id`, `secret_access_key`, and `endpoint` fields were redacted in Debug and silently dropped — operators got no signal that their YAML credentials were ignored, and S3-compatible services (MinIO, R2, Tigris) were unreachable because no endpoint override path existed.

## Behavior

- **Static credentials**: when `access_key_id` and `secret_access_key` are both non-empty, install `Credentials::new(...)` on the aws_config loader.
- **Default chain**: otherwise fall back to env vars / shared config / IMDS / container credentials (preserves the existing default behavior).
- **Endpoint override**: when `endpoint` is set, apply via `endpoint_url(...)` and `force_path_style(true)` on the S3 config builder.
- Log the credential source at startup so operators can verify which path was taken.

## Test plan

- [x] `cargo build --all-features` — clean
- [x] `cargo build --no-default-features --features "postgres redis tracing"` — clean (s3 feature off)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: configure `s3.access_key_id` / `s3.secret_access_key` in YAML and confirm `credentials=static` appears in startup log
- [ ] Manual: configure `s3.endpoint=http://localhost:9000` against MinIO, confirm puts/gets succeed