### PR TITLE
fix(openai_like): route Tier-1 responses through OpenAIResponseTransformer

### DIFF
--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -11,14 +11,14 @@ use std::sync::Arc;
 use crate::core::providers::base::{
     GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
 };
+use crate::core::providers::openai::{OpenAIResponseTransformer, models::OpenAIChatResponse};
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::{
     chat::ChatRequest,
     context::RequestContext,
     health::HealthStatus,
-    model::ModelInfo,
-    model::ProviderCapability,
+    model::{ModelInfo, ProviderCapability},
     responses::{ChatChunk, ChatResponse},
 };
 
@@ -309,10 +309,10 @@ impl OpenAILikeProvider {
         Ok(openai_request)
     }
 
-    /// Transform OpenAI response to standard format
     fn transform_chat_response(&self, response: Value) -> Result<ChatResponse, OpenAILikeError> {
-        // Directly deserialize to ChatResponse since it's OpenAI-compatible
-        serde_json::from_value(response)
+        let resp: OpenAIChatResponse = serde_json::from_value(response)
+            .map_err(|e| OpenAILikeError::response_parsing(PROVIDER_NAME, e.to_string()))?;
+        OpenAIResponseTransformer::transform(resp)
             .map_err(|e| OpenAILikeError::response_parsing(PROVIDER_NAME, e.to_string()))
     }
 


### PR DESCRIPTION
Closes #509.

## Summary

`OpenAILikeProvider::transform_chat_response` was deserializing upstream JSON directly into `core::types::responses::ChatResponse`. Serde silently drops fields not declared on the target type, so DeepSeek's `reasoning_content`, OpenRouter's `reasoning`, and OpenAI-style `refusal` strings were lost before reaching the client for every Tier-1 provider routed through `OpenAILikeProvider` (~53 of 66+ providers).

## Fix

Reuse `OpenAIResponseTransformer` (the same path the OpenAI direct provider uses) so reasoning_content / reasoning are extracted into core `ChatMessage.thinking`, and prompt-token cache details survive.

The change is purely behind the `transform_chat_response` boundary; streaming, request transform, and error mapping are unchanged.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib core::providers::openai_like` — 41/41 passing
- [x] `cargo fmt --all -- --check`
- [ ] Manual: send a `deepseek-reasoner` request through the gateway and confirm the response now contains `thinking` extracted from upstream `reasoning_content`