### PR TITLE
fix(responses-stream): emit reasoning_summary_text events for delta.thinking

### DIFF
--- a/src/core/models/openai/responses_api.rs
+++ b/src/core/models/openai/responses_api.rs
@@ -489,6 +489,26 @@ pub enum ResponseStreamEvent {
         call_id: String,
         arguments: String,
     },
+    /// Incremental reasoning-summary delta (o-series / Anthropic
+    /// extended thinking / DeepSeek R1 / Gemini thinking).
+    ///
+    /// Maps each upstream `delta.thinking` chunk to the OpenAI Responses
+    /// API `response.reasoning_summary_text.delta` event so consumers
+    /// receive the model's reasoning trace in real time.
+    #[serde(rename = "response.reasoning_summary_text.delta")]
+    ResponseReasoningSummaryTextDelta {
+        output_index: u32,
+        summary_index: u32,
+        delta: String,
+    },
+    /// Reasoning-summary part finished — emitted once with the full
+    /// accumulated text after the upstream stream ends.
+    #[serde(rename = "response.reasoning_summary_text.done")]
+    ResponseReasoningSummaryTextDone {
+        output_index: u32,
+        summary_index: u32,
+        text: String,
+    },
     /// Catch-all for forward-compatible events
     #[serde(other)]
     Unknown,

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -115,6 +115,10 @@ pub(crate) async fn handle_streaming_response(
                 let mut tool_states: HashMap<u32, ToolCallAccum> = HashMap::new();
                 // Preserves insertion order for final iteration
                 let mut tool_order: Vec<u32> = Vec::new();
+                // Reasoning-summary state (o-series / extended thinking / DeepSeek R1 / Gemini)
+                let mut full_reasoning = String::new();
+                let mut reasoning_output_index: u32 = 0;
+                let mut reasoning_started = false;
 
                 // ── text and tool-call deltas ─────────────────────────────────
                 loop {
@@ -157,6 +161,32 @@ pub(crate) async fn handle_streaming_response(
                             for choice in &chunk.choices {
                                 if let Some(r) = &choice.finish_reason {
                                     final_status = finish_reason_enum_to_status(Some(r));
+                                }
+
+                                // ── reasoning summary delta ───────────────────
+                                if let Some(thinking) = &choice.delta.thinking
+                                    && let Some(reasoning_text) = thinking.content.as_deref()
+                                    && !reasoning_text.is_empty()
+                                {
+                                    if !reasoning_started {
+                                        reasoning_started = true;
+                                        reasoning_output_index = next_output_index;
+                                        next_output_index += 1;
+                                    }
+                                    full_reasoning.push_str(reasoning_text);
+                                    if emit(
+                                        &tx,
+                                        &ResponseStreamEvent::ResponseReasoningSummaryTextDelta {
+                                            output_index: reasoning_output_index,
+                                            summary_index: 0,
+                                            delta: reasoning_text.to_string(),
+                                        },
+                                    )
+                                    .await
+                                    .is_err()
+                                    {
+                                        return;
+                                    }
                                 }
 
                                 // ── text content ──────────────────────────────
@@ -325,6 +355,22 @@ pub(crate) async fn handle_streaming_response(
 
                 let item_status = final_status;
                 let mut all_output: Vec<(u32, ResponseOutputItem)> = Vec::new();
+
+                // ── reasoning done events ─────────────────────────────────────
+                if reasoning_started
+                    && emit(
+                        &tx,
+                        &ResponseStreamEvent::ResponseReasoningSummaryTextDone {
+                            output_index: reasoning_output_index,
+                            summary_index: 0,
+                            text: full_reasoning.clone(),
+                        },
+                    )
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
 
                 // ── text done events ──────────────────────────────────────────
                 if text_started {

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -115,7 +115,16 @@ pub(crate) async fn handle_streaming_response(
                 let mut tool_states: HashMap<u32, ToolCallAccum> = HashMap::new();
                 // Preserves insertion order for final iteration
                 let mut tool_order: Vec<u32> = Vec::new();
-                // Reasoning-summary state (o-series / extended thinking / DeepSeek R1 / Gemini)
+                // Reasoning-summary state (o-series / extended thinking / DeepSeek R1 / Gemini).
+                //
+                // Output-index ordering invariant: the OpenAI Responses API requires
+                // reasoning items to have a lower `output_index` than the text item.
+                // We rely on upstream providers to emit reasoning chunks before text
+                // chunks (OpenAI o-series, Anthropic extended thinking, DeepSeek R1,
+                // and Gemini thinking all conform to this protocol convention). The
+                // first-arrival assignment below preserves canonical order under that
+                // assumption. If a provider ever violates the convention, a `warn!`
+                // is emitted so operators can detect the inversion.
                 let mut full_reasoning = String::new();
                 let mut reasoning_output_index: u32 = 0;
                 let mut reasoning_started = false;
@@ -169,6 +178,19 @@ pub(crate) async fn handle_streaming_response(
                                     && !reasoning_text.is_empty()
                                 {
                                     if !reasoning_started {
+                                        if text_started {
+                                            // Protocol violation: reasoning arrived after
+                                            // text claimed an output_index. The Responses API
+                                            // contract (reasoning at lower output_index than
+                                            // text) is broken for this stream. Continue
+                                            // emitting in arrival order; flag for ops.
+                                            warn!(
+                                                "responses stream reasoning chunk arrived after text chunk; \
+                                                 output_index ordering will be reversed from canonical \
+                                                 (reasoning={}, text={})",
+                                                next_output_index, text_output_index
+                                            );
+                                        }
                                         reasoning_started = true;
                                         reasoning_output_index = next_output_index;
                                         next_output_index += 1;


### PR DESCRIPTION
Closes #512.

## Summary

The `/v1/responses?stream=true` surface read only `choice.delta.content` and never `delta.thinking`. Reasoning models (o-series, Anthropic extended thinking, DeepSeek R1, Gemini thinking) produced no reasoning trace on the Responses-API stream — even though the same model on `/v1/chat/completions?stream=true` did.

## Fix

Two new `ResponseStreamEvent` variants matching the OpenAI Responses API spec:

- `response.reasoning_summary_text.delta` — emitted per upstream `delta.thinking` chunk
- `response.reasoning_summary_text.done` — emitted once at stream end with the accumulated full reasoning text

Wired into `responses_stream.rs`:
- Reasoning gets its own `output_index` assigned on first delta
- `done` event fires before the existing `text_done` event so consumers see reasoning before the final answer

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib server::routes::ai` — 65/65 passing
- [x] `cargo fmt --all -- --check`
- [ ] Manual: send a `deepseek-reasoner` request to `/v1/responses?stream=true` and confirm `response.reasoning_summary_text.delta` events appear in the SSE stream