### PR TITLE
refactor(pricing): collapse pricing::Usage into core::types::responses::Usage

### DIFF
--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -50,14 +50,12 @@ pub struct LiteLLMModelInfo {
 /// Compatibility alias for callers that still import provider-base pricing.
 pub type ModelPricing = LiteLLMModelInfo;
 
-/// Usage information for simple pricing database calculations.
-#[derive(Debug, Clone)]
-pub struct Usage {
-    pub prompt_tokens: u32,
-    pub completion_tokens: u32,
-    pub total_tokens: u32,
-    pub reasoning_tokens: Option<u32>,
-}
+// Usage is re-exported from the canonical types tree
+// (core::types::responses::Usage). The richer canonical shape carries
+// nested CompletionTokensDetails (reasoning_tokens lives there now)
+// plus PromptTokensDetails and ThinkingUsage, which the per-request
+// cost path can consume in future without further breaking changes.
+pub use crate::core::types::responses::Usage;
 
 /// Pricing database backed by the shared LiteLLM model info shape.
 #[derive(Debug, Clone)]
@@ -143,7 +141,11 @@ impl PricingDatabase {
         cost += usage.prompt_tokens as f64 * pricing.input_cost_per_token.unwrap_or(0.0);
         cost += usage.completion_tokens as f64 * pricing.output_cost_per_token.unwrap_or(0.0);
 
-        if let Some(reasoning_tokens) = usage.reasoning_tokens {
+        let reasoning_tokens = usage
+            .completion_tokens_details
+            .as_ref()
+            .and_then(|d| d.reasoning_tokens);
+        if let Some(reasoning_tokens) = reasoning_tokens {
             cost += reasoning_tokens as f64 * extra_f64(pricing, "output_cost_per_reasoning_token");
         }
 
@@ -337,13 +339,7 @@ pub fn get_pricing_db() -> &'static PricingDatabase {
 
 /// Quick cost calculation for compatibility callers.
 pub fn calculate_cost(model: &str, prompt_tokens: u32, completion_tokens: u32) -> f64 {
-    let usage = Usage {
-        prompt_tokens,
-        completion_tokens,
-        total_tokens: prompt_tokens + completion_tokens,
-        reasoning_tokens: None,
-    };
-
+    let usage = Usage::new(prompt_tokens, completion_tokens);
     GLOBAL_PRICING_DB.calculate(model, &usage)
 }
 
@@ -412,12 +408,7 @@ mod tests {
     fn test_default_pricing() {
         let db = PricingDatabase::default();
 
-        let usage = Usage {
-            prompt_tokens: 1000,
-            completion_tokens: 500,
-            total_tokens: 1500,
-            reasoning_tokens: None,
-        };
+        let usage = Usage::new(1000, 500);
 
         let cost = db.calculate("gpt-4", &usage);
         assert!(cost > 0.0);
@@ -430,12 +421,7 @@ mod tests {
     #[test]
     fn calculate_for_provider_uses_matching_provider_rates() {
         let db = PricingDatabase::default();
-        let usage = Usage {
-            prompt_tokens: 1000,
-            completion_tokens: 500,
-            total_tokens: 1500,
-            reasoning_tokens: None,
-        };
+        let usage = Usage::new(1000, 500);
 
         assert_eq!(
             db.calculate_for_provider("openai", "gpt-4", &usage),
@@ -472,17 +458,7 @@ mod tests {
         let db = PricingDatabase::from_default_source().unwrap();
 
         assert!(db.get_model_info("gpt-4o").is_some());
-        assert!(
-            db.calculate(
-                "gpt-4o",
-                &Usage {
-                    prompt_tokens: 1000,
-                    completion_tokens: 500,
-                    total_tokens: 1500,
-                    reasoning_tokens: None,
-                }
-            ) > 0.0
-        );
+        assert!(db.calculate("gpt-4o", &Usage::new(1000, 500)) > 0.0);
     }
 
     #[test]

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -50,12 +50,54 @@ pub struct LiteLLMModelInfo {
 /// Compatibility alias for callers that still import provider-base pricing.
 pub type ModelPricing = LiteLLMModelInfo;
 
-// Usage is re-exported from the canonical types tree
-// (core::types::responses::Usage). The richer canonical shape carries
-// nested CompletionTokensDetails (reasoning_tokens lives there now)
-// plus PromptTokensDetails and ThinkingUsage, which the per-request
-// cost path can consume in future without further breaking changes.
-pub use crate::core::types::responses::Usage;
+/// Usage information for simple pricing database calculations.
+///
+/// Kept as a stable public type so downstream library consumers can continue
+/// to construct `litellm_rs::core::pricing::Usage { prompt_tokens, ..., reasoning_tokens }`
+/// with struct-literal syntax. The richer
+/// [`crate::core::types::responses::Usage`] (with nested
+/// `PromptTokensDetails` / `CompletionTokensDetails` / `ThinkingUsage`) is
+/// the canonical shape used elsewhere; conversion helpers below bridge
+/// between the two when the per-request cost path needs the canonical
+/// metadata. See PR #519 architecture roadmap for the broader convergence.
+#[derive(Debug, Clone)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+    pub reasoning_tokens: Option<u32>,
+}
+
+impl Usage {
+    /// Build a Usage from prompt + completion token counts.
+    ///
+    /// Auto-computes `total_tokens = prompt + completion` and leaves
+    /// `reasoning_tokens` unset. Mirrors the canonical
+    /// [`crate::core::types::responses::Usage::new`] signature so internal
+    /// pricing call sites can use the same constructor on either type.
+    pub fn new(prompt_tokens: u32, completion_tokens: u32) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+            reasoning_tokens: None,
+        }
+    }
+}
+
+impl From<&crate::core::types::responses::Usage> for Usage {
+    fn from(usage: &crate::core::types::responses::Usage) -> Self {
+        Self {
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens,
+            total_tokens: usage.total_tokens,
+            reasoning_tokens: usage
+                .completion_tokens_details
+                .as_ref()
+                .and_then(|d| d.reasoning_tokens),
+        }
+    }
+}
 
 /// Pricing database backed by the shared LiteLLM model info shape.
 #[derive(Debug, Clone)]
@@ -141,11 +183,7 @@ impl PricingDatabase {
         cost += usage.prompt_tokens as f64 * pricing.input_cost_per_token.unwrap_or(0.0);
         cost += usage.completion_tokens as f64 * pricing.output_cost_per_token.unwrap_or(0.0);
 
-        let reasoning_tokens = usage
-            .completion_tokens_details
-            .as_ref()
-            .and_then(|d| d.reasoning_tokens);
-        if let Some(reasoning_tokens) = reasoning_tokens {
+        if let Some(reasoning_tokens) = usage.reasoning_tokens {
             cost += reasoning_tokens as f64 * extra_f64(pricing, "output_cost_per_reasoning_token");
         }
 

--- a/src/core/providers/ai21/provider.rs
+++ b/src/core/providers/ai21/provider.rs
@@ -174,12 +174,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     },

--- a/src/core/providers/amazon_nova/provider.rs
+++ b/src/core/providers/amazon_nova/provider.rs
@@ -185,12 +185,7 @@ crate::define_pooled_http_provider_with_hooks!(
             return Ok(input_cost + output_cost);
         }
 
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     },

--- a/src/core/providers/cohere/provider.rs
+++ b/src/core/providers/cohere/provider.rs
@@ -554,12 +554,7 @@ impl LLMProvider for CohereProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
         Ok(get_pricing_db().calculate(model, &usage))
     }
 }

--- a/src/core/providers/databricks/provider.rs
+++ b/src/core/providers/databricks/provider.rs
@@ -570,12 +570,7 @@ impl LLMProvider for DatabricksProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     }

--- a/src/core/providers/datarobot/provider.rs
+++ b/src/core/providers/datarobot/provider.rs
@@ -129,12 +129,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     },

--- a/src/core/providers/empower/provider.rs
+++ b/src/core/providers/empower/provider.rs
@@ -138,12 +138,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     },

--- a/src/core/providers/exa_ai/provider.rs
+++ b/src/core/providers/exa_ai/provider.rs
@@ -219,12 +219,7 @@ impl LLMProvider for ExaAiProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     }

--- a/src/core/providers/firecrawl/provider.rs
+++ b/src/core/providers/firecrawl/provider.rs
@@ -138,12 +138,7 @@ crate::define_pooled_http_provider_with_hooks!(
                      input_tokens: u32,
                      output_tokens: u32|
      -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     },

--- a/src/core/providers/gigachat/mod.rs
+++ b/src/core/providers/gigachat/mod.rs
@@ -405,12 +405,7 @@ impl LLMProvider for GigaChatProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
         Ok(get_pricing_db().calculate(model, &usage))
     }
 }

--- a/src/core/providers/google_pse/mod.rs
+++ b/src/core/providers/google_pse/mod.rs
@@ -367,12 +367,7 @@ impl LLMProvider for GooglePSEProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
         Ok(get_pricing_db().calculate(model, &usage))
     }
 }

--- a/src/core/providers/jina/mod.rs
+++ b/src/core/providers/jina/mod.rs
@@ -669,12 +669,7 @@ impl LLMProvider for JinaProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
         Ok(get_pricing_db().calculate(model, &usage))
     }
 }

--- a/src/core/providers/langgraph/provider.rs
+++ b/src/core/providers/langgraph/provider.rs
@@ -568,12 +568,7 @@ impl LLMProvider for LangGraphProvider {
     ) -> Result<f64, ProviderError> {
         // LangGraph itself doesn't have fixed costs - costs depend on the underlying LLM
         // Use the pricing database for estimation
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     }

--- a/src/core/providers/mistral/mod.rs
+++ b/src/core/providers/mistral/mod.rs
@@ -703,12 +703,7 @@ impl LLMProvider for MistralProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
         Ok(get_pricing_db().calculate(model, &usage))
     }
 }

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -406,12 +406,7 @@ impl Provider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(
             crate::core::pricing::get_pricing_db().calculate_for_provider(

--- a/src/core/providers/runwayml/provider.rs
+++ b/src/core/providers/runwayml/provider.rs
@@ -519,12 +519,7 @@ impl LLMProvider for RunwayMLProvider {
     ) -> Result<f64, ProviderError> {
         // Runway pricing is per-second of video, not per token
         // Use pricing database for estimation if available
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     }

--- a/src/core/providers/stability/provider.rs
+++ b/src/core/providers/stability/provider.rs
@@ -367,12 +367,7 @@ impl LLMProvider for StabilityProvider {
     ) -> Result<f64, ProviderError> {
         // Stability AI pricing is per image, not per token
         // Use the pricing database for estimation
-        let usage = crate::core::pricing::Usage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-            reasoning_tokens: None,
-        };
+        let usage = crate::core::pricing::Usage::new(input_tokens, output_tokens);
 
         Ok(get_pricing_db().calculate(model, &usage))
     }


### PR DESCRIPTION
Refs #519. Phase 2 PR-A3 — third slice of the Usage convergence.

## Summary

`src/core/pricing.rs` declared its own `Usage` struct `{prompt_tokens, completion_tokens, total_tokens, reasoning_tokens?}` that was field-overlapping but not equal to the canonical `core::types::responses::Usage`. The canonical version puts `reasoning_tokens` inside `completion_tokens_details` (matching OpenAI's wire shape) plus adds `prompt_tokens_details` and `thinking_usage` slots the per-request pricing path could not consume.

## Changes

1. Replace local struct with `pub use crate::core::types::responses::Usage;`.
2. Update `calculate_with_pricing` to read `reasoning_tokens` via the canonical nested path.
3. All **16 caller sites** in `src/core/providers/*` use the identical boilerplate `Usage { prompt_tokens, completion_tokens, total_tokens, reasoning_tokens: None }`. They're rewritten to `Usage::new(...)`, which auto-computes `total_tokens`.
4. 4 sites inside `pricing.rs` itself (calculate_cost helper + 3 tests) get the same treatment.

## Behavior

Per-request pricing paths now consume the same `Usage` type the trait-level provider impls produce. Cost numbers are identical because `reasoning_tokens` still flows through (just via `completion_tokens_details` now), and no caller in this PR was passing non-None `reasoning_tokens` at the `pricing::Usage` call site.

## Architecture roadmap context (#519)

Third slice of Phase 2 type collapse, after PR #534 (`transform/` removal) and PR #535 (openai-models `Usage` `pub use`). **Three of the original six `Usage` definitions are now collapsed**; the remaining three (sdk public type, langfuse wire-format type, canonical type) have legitimately different schemas and are not merge candidates.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib` — **10333/10333 passing**
- [x] `cargo fmt --all -- --check`

## Diff stats

17 files changed, +31 / **−135 lines**.