### PR TITLE
refactor(providers/base): extract shared ProviderModelEntry struct

### DIFF
--- a/src/core/providers/base/mod.rs
+++ b/src/core/providers/base/mod.rs
@@ -5,6 +5,7 @@
 pub mod config;
 pub mod connection_pool;
 pub mod http;
+pub mod model_entry;
 pub mod pricing;
 pub mod sse;
 
@@ -18,6 +19,7 @@ pub use http::{
     BaseHttpClient, HttpErrorMapper, OpenAIRequestTransformer, UrlBuilder, create_http_client,
     validate_chat_request_common,
 };
+pub use model_entry::ProviderModelEntry;
 pub use sse::{
     AnthropicTransformer, CohereTransformer, DatabricksTransformer, GeminiTransformer,
     OpenAICompatibleTransformer, SSEEvent, SSEEventType, SSETransformer, UnifiedSSEParser,

--- a/src/core/providers/base/model_entry.rs
+++ b/src/core/providers/base/model_entry.rs
@@ -1,0 +1,33 @@
+//! Shared static catalog entry for provider-local model lists.
+//!
+//! Several providers maintain a small `LazyLock<HashMap<&str, ModelInfo>>`
+//! catalog of supported models with the same field shape:
+//! `{model_id, display_name, max_context_length, max_output_length,
+//!   supports_tools, supports_multimodal, input_cost_per_million,
+//!   output_cost_per_million}`. The struct used to be copy-pasted into each
+//! provider's `model_info.rs` (manus, morph, nlp_cloud, petals, predibase,
+//! ragflow). This module is the shared definition.
+
+/// Static catalog entry describing one model supported by a provider.
+///
+/// Field semantics match the per-provider copies that previously lived in
+/// each provider's `model_info.rs` module.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderModelEntry {
+    /// Model ID as used in the provider API.
+    pub model_id: &'static str,
+    /// Human-readable display name.
+    pub display_name: &'static str,
+    /// Maximum context length in tokens.
+    pub max_context_length: u32,
+    /// Maximum output length in tokens.
+    pub max_output_length: u32,
+    /// Whether the model supports tools / function calling.
+    pub supports_tools: bool,
+    /// Whether the model supports multimodal (vision / audio) input.
+    pub supports_multimodal: bool,
+    /// Input cost per million tokens, in USD.
+    pub input_cost_per_million: f64,
+    /// Output cost per million tokens, in USD.
+    pub output_cost_per_million: f64,
+}

--- a/src/core/providers/manus/model_info.rs
+++ b/src/core/providers/manus/model_info.rs
@@ -10,18 +10,7 @@ pub enum ManusModel {
     Manus_1,
 }
 
-#[derive(Debug, Clone)]
-pub struct ModelInfo {
-    pub model_id: &'static str,
-    pub display_name: &'static str,
-    pub max_context_length: u32,
-    pub max_output_length: u32,
-    pub supports_tools: bool,
-    pub supports_multimodal: bool,
-    pub input_cost_per_million: f64,
-    pub output_cost_per_million: f64,
-}
-
+pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
 static MODEL_CONFIGS: LazyLock<HashMap<&'static str, ModelInfo>> = LazyLock::new(|| {
     let mut configs = HashMap::new();
 

--- a/src/core/providers/morph/model_info.rs
+++ b/src/core/providers/morph/model_info.rs
@@ -10,18 +10,7 @@ pub enum MorphModel {
     Morph_1,
 }
 
-#[derive(Debug, Clone)]
-pub struct ModelInfo {
-    pub model_id: &'static str,
-    pub display_name: &'static str,
-    pub max_context_length: u32,
-    pub max_output_length: u32,
-    pub supports_tools: bool,
-    pub supports_multimodal: bool,
-    pub input_cost_per_million: f64,
-    pub output_cost_per_million: f64,
-}
-
+pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
 static MODEL_CONFIGS: LazyLock<HashMap<&'static str, ModelInfo>> = LazyLock::new(|| {
     let mut configs = HashMap::new();
 

--- a/src/core/providers/nlp_cloud/model_info.rs
+++ b/src/core/providers/nlp_cloud/model_info.rs
@@ -3,18 +3,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-#[derive(Debug, Clone)]
-pub struct ModelInfo {
-    pub model_id: &'static str,
-    pub display_name: &'static str,
-    pub max_context_length: u32,
-    pub max_output_length: u32,
-    pub supports_tools: bool,
-    pub supports_multimodal: bool,
-    pub input_cost_per_million: f64,
-    pub output_cost_per_million: f64,
-}
-
+pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
 static MODEL_CONFIGS: LazyLock<HashMap<&'static str, ModelInfo>> = LazyLock::new(|| {
     let mut configs = HashMap::new();
 

--- a/src/core/providers/petals/model_info.rs
+++ b/src/core/providers/petals/model_info.rs
@@ -11,18 +11,7 @@ pub enum PetalsModel {
     Llama2_70B,
 }
 
-#[derive(Debug, Clone)]
-pub struct ModelInfo {
-    pub model_id: &'static str,
-    pub display_name: &'static str,
-    pub max_context_length: u32,
-    pub max_output_length: u32,
-    pub supports_tools: bool,
-    pub supports_multimodal: bool,
-    pub input_cost_per_million: f64,
-    pub output_cost_per_million: f64,
-}
-
+pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
 static MODEL_CONFIGS: LazyLock<HashMap<&'static str, ModelInfo>> = LazyLock::new(|| {
     let mut configs = HashMap::new();
 

--- a/src/core/providers/predibase/model_info.rs
+++ b/src/core/providers/predibase/model_info.rs
@@ -3,18 +3,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-#[derive(Debug, Clone)]
-pub struct ModelInfo {
-    pub model_id: &'static str,
-    pub display_name: &'static str,
-    pub max_context_length: u32,
-    pub max_output_length: u32,
-    pub supports_tools: bool,
-    pub supports_multimodal: bool,
-    pub input_cost_per_million: f64,
-    pub output_cost_per_million: f64,
-}
-
+pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
 static MODEL_CONFIGS: LazyLock<HashMap<&'static str, ModelInfo>> = LazyLock::new(|| {
     let mut configs = HashMap::new();
 

--- a/src/core/providers/ragflow/model_info.rs
+++ b/src/core/providers/ragflow/model_info.rs
@@ -10,18 +10,7 @@ pub enum RagflowModel {
     Ragflow_Default,
 }
 
-#[derive(Debug, Clone)]
-pub struct ModelInfo {
-    pub model_id: &'static str,
-    pub display_name: &'static str,
-    pub max_context_length: u32,
-    pub max_output_length: u32,
-    pub supports_tools: bool,
-    pub supports_multimodal: bool,
-    pub input_cost_per_million: f64,
-    pub output_cost_per_million: f64,
-}
-
+pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
 static MODEL_CONFIGS: LazyLock<HashMap<&'static str, ModelInfo>> = LazyLock::new(|| {
     let mut configs = HashMap::new();
 


### PR DESCRIPTION
Refs #519. Phase 2 PR-B — first slice of ModelInfo collapse.

## Summary

Six provider modules (`manus`, `morph`, `nlp_cloud`, `petals`, `predibase`, `ragflow`) declared **byte-identical** `ModelInfo` structs:

\`\`\`rust
pub struct ModelInfo {
    pub model_id: &'static str,
    pub display_name: &'static str,
    pub max_context_length: u32,
    pub max_output_length: u32,
    pub supports_tools: bool,
    pub supports_multimodal: bool,
    pub input_cost_per_million: f64,
    pub output_cost_per_million: f64,
}
\`\`\`

Each was an internal copy with **zero external callers** (verified via workspace grep). The duplication is RS-12 (two systems for one responsibility) on a 6× scale.

## Fix

Extract one shared `ProviderModelEntry` in `src/core/providers/base/model_entry.rs` (re-exported from `providers/base`) and replace each provider's local struct with:

\`\`\`rust
pub use crate::core::providers::base::ProviderModelEntry as ModelInfo;
\`\`\`

Each provider keeps its `ModelInfo` import path so the static `MODEL_CONFIGS` HashMaps and helper functions don't need rewriting. The struct identity now resolves to one type, eliminating the copy-paste maintenance hazard that would let provider catalogs drift if anyone added a field on one but not the others.

## Out of scope

Two sibling provider catalogs are intentionally **not** part of this PR:
- `cloudflare/model_info.rs` — extra `supports_streaming: bool` field plus full doc comments
- `codestral/model_info.rs` — different shape (`supports_fim` instead of `supports_tools`, no multimodal flag)

Absorbing them would either drop fields (cloudflare) or change semantics (codestral). They can fold into the shared type later if/when they grow toward parity.

## Architecture roadmap context (#519)

`ModelInfo` definitions go from **10 → 4**. The remaining 4 (`core::types::model::ModelInfo`, `core::models::ModelInfo`, `cloudflare`, `codestral` locals) are now the only further candidates; the audit's A-5 "two competing canonical types" schism between `core::types` and `core::models` is the bigger refactor that follows.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib` — **10333/10333 passing**
- [x] `cargo fmt --all -- --check`