### PR TITLE
refactor(types): collapse FunctionCallDelta / ToolCallDelta to canonical

### DIFF
--- a/src/core/models/openai/tools.rs
+++ b/src/core/models/openai/tools.rs
@@ -116,25 +116,8 @@ impl From<crate::core::types::tools::ToolCall> for ToolCall {
     }
 }
 
-/// Function call delta (legacy)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FunctionCallDelta {
-    /// Function name
-    pub name: Option<String>,
-    /// Function arguments delta
-    pub arguments: Option<String>,
-}
-
-/// Tool call delta
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolCallDelta {
-    /// Tool call index
-    pub index: u32,
-    /// Tool call ID
-    pub id: Option<String>,
-    /// Tool type
-    #[serde(rename = "type")]
-    pub tool_type: Option<String>,
-    /// Function call delta
-    pub function: Option<FunctionCallDelta>,
-}
+// FunctionCallDelta and ToolCallDelta are re-exported from the canonical
+// types tree (core::types::responses::*). The duplicates that lived here
+// had field-compatible layouts and were a downstream of the
+// parallel-type-tree schism (#519, audit A-2/A-5).
+pub use crate::core::types::responses::{FunctionCallDelta, ToolCallDelta};

--- a/src/core/streaming/types.rs
+++ b/src/core/streaming/types.rs
@@ -111,32 +111,10 @@ pub struct ChatCompletionDelta {
     pub function_call: Option<FunctionCallDelta>,
 }
 
-/// Tool call delta for streaming function calls
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ToolCallDelta {
-    /// Index of the tool call
-    pub index: u32,
-    /// Tool call ID (only in first chunk)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// Type of tool call (only in first chunk)
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub tool_type: Option<String>,
-    /// Function call details
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub function: Option<FunctionCallDelta>,
-}
-
-/// Function call delta for streaming
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct FunctionCallDelta {
-    /// Function name (only in first chunk)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// Incremental function arguments
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arguments: Option<String>,
-}
+// ToolCallDelta and FunctionCallDelta are re-exported from the canonical
+// types tree (core::types::responses::*). Duplicates eliminated as part
+// of the parallel-type-tree collapse tracked in #519.
+pub use crate::core::types::responses::{FunctionCallDelta, ToolCallDelta};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Refs #519. Phase 2 PR-C (delta slice).

## Summary

`src/core/streaming/types.rs` and `src/core/models/openai/tools.rs` both declared their own `ToolCallDelta` and `FunctionCallDelta` with field shapes compatible with the canonical `core::types::responses::delta::*`. Six total definitions for two struct concepts.

Replace each duplicate set with `pub use` of the canonical types:

\`\`\`rust
pub use crate::core::types::responses::{FunctionCallDelta, ToolCallDelta};
\`\`\`

Existing callers, including the 5 sites in `server/routes/ai/chat.rs` that construct `streaming::types::FunctionCallDelta` / `ToolCallDelta`, continue to compile unchanged because the type identity now resolves to the same canonical struct. `responses.rs` and `openai/mod.rs` re-exports likewise resolve transparently.

## Out of scope

The non-Delta variants `FunctionCall` and `ToolCall` are intentionally **not** part of this PR; they have explicit `From` impls between the local and canonical types and require careful per-caller migration. They'll fold in a future PR after the delta layer is canonical-only.

## Architecture roadmap context (#519)

Phase 2 PR-C (delta slice). `ToolCallDelta` definitions go from **3 → 1** (canonical only); same for `FunctionCallDelta`.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib` — **10333/10333 passing**
- [x] `cargo fmt --all -- --check`