### PR TITLE
fix(oauth): redact generic OIDC error bodies

### DIFF
--- a/scripts/guards/check_log_pii.sh
+++ b/scripts/guards/check_log_pii.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-MAX_ALLOWED="${LITELLM_LOG_PII_BASELINE_MAX:-14}"
+MAX_ALLOWED="${LITELLM_LOG_PII_BASELINE_MAX:-8}"
 
 if ! command -v rg >/dev/null 2>&1; then
     echo "Log PII guard failed: 'rg' is required." >&2

--- a/src/auth/oauth/providers/generic_oidc.rs
+++ b/src/auth/oauth/providers/generic_oidc.rs
@@ -408,7 +408,11 @@ impl OidcProvider {
             .map_err(|e| GatewayError::Network(format!("Failed to read response: {}", e)))?;
 
         if !status.is_success() {
-            error!("Token exchange failed: {} - {}", status, body);
+            error!(
+                "Token exchange failed with status {} (response body redacted, {} bytes)",
+                status,
+                body.len()
+            );
             return Err(GatewayError::Auth(format!(
                 "Token exchange failed: {}",
                 status
@@ -448,7 +452,11 @@ impl OidcProvider {
             .map_err(|e| GatewayError::Network(format!("Failed to read response: {}", e)))?;
 
         if !status.is_success() {
-            error!("UserInfo request failed: {} - {}", status, body);
+            error!(
+                "UserInfo request failed with status {} (response body redacted, {} bytes)",
+                status,
+                body.len()
+            );
             return Err(GatewayError::Auth(format!(
                 "UserInfo request failed: {}",
                 status
@@ -556,7 +564,11 @@ impl OidcProvider {
             .map_err(|e| GatewayError::Network(format!("Failed to read response: {}", e)))?;
 
         if !status.is_success() {
-            error!("Token refresh failed: {} - {}", status, body);
+            error!(
+                "Token refresh failed with status {} (response body redacted, {} bytes)",
+                status,
+                body.len()
+            );
             return Err(GatewayError::Auth(format!(
                 "Token refresh failed: {}",
                 status


### PR DESCRIPTION
## Summary
- redact Generic OIDC token exchange, userinfo, and refresh failure logs
- log HTTP status and response body length instead of raw OAuth response bodies
- tighten the log PII guard baseline from 14 to 8 after removing the three OIDC hits

Fixes #539.

## Verification
- `bash scripts/guards/check_log_pii.sh`
- `cargo test -q oauth`
- `cargo check`
- `cargo test -q`
