### PR TITLE
fix(security): stop logging raw upstream response bodies

### DIFF
--- a/scripts/guards/check_log_pii.sh
+++ b/scripts/guards/check_log_pii.sh
@@ -1,25 +1,32 @@
 #!/usr/bin/env bash
 # Log PII guard.
 #
-# Baseline-aware during the audit remediation campaign: C9 will remove the
-# existing request/response body logs, then this threshold should be tightened.
+# Blocks raw request/response body logging in normal tracing/log macros.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-MAX_ALLOWED="${LITELLM_LOG_PII_BASELINE_MAX:-8}"
+MAX_ALLOWED="${LITELLM_LOG_PII_BASELINE_MAX:-0}"
 
 if ! command -v rg >/dev/null 2>&1; then
     echo "Log PII guard failed: 'rg' is required." >&2
     exit 1
 fi
 
-pattern='(debug!|info!|warn!|error!|tracing::debug!|tracing::info!|tracing::warn!|tracing::error!).*\b(body|body_str|error_body|response_text|request_body|response_body)\b'
+log_macro='(debug!|info!|warn!|error!|tracing::debug!|tracing::info!|tracing::warn!|tracing::error!)'
+raw_body_names='(body_str|error_body|error_text|response_text|request_body|response_body)'
+raw_body_value_names='(body|body_str|error_body|error_text|response_text|request_body|response_body)'
+raw_body_value_suffix='(\.(as_str|clone|to_string)\(\))?'
+raw_body_label='"[^"]*\b(request|response|error)?[ _-]?body\s*:\s*\{[^"]*"'
+raw_named_arg="&?\s*${raw_body_names}\b${raw_body_value_suffix}\s*(,|\))"
+raw_body_arg=",\s*&?\s*body\b${raw_body_value_suffix}\s*(,|\))"
+raw_body_field="\b(body|request_body|response_body|error_body|error_text)\s*=\s*[%?]?\s*&?\s*${raw_body_value_names}\b${raw_body_value_suffix}\s*(,|\))"
+pattern="(?s)${log_macro}\\s*\\([^;]{0,1200}(${raw_body_label}|${raw_named_arg}|${raw_body_arg}|${raw_body_field})[^;]{0,1200};"
 
 matches="$(
-    rg -n --no-heading --color never \
+    rg -n -U --no-heading --color never \
         -g '*.rs' \
         "$pattern" \
         src/ || true
@@ -30,7 +37,7 @@ count="$(printf '%s\n' "$matches" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
 echo "Log PII guard: $count suspicious body-log hits (baseline max: $MAX_ALLOWED)."
 
 if [[ "$count" -gt "$MAX_ALLOWED" ]]; then
-    echo "FAIL: suspicious body-log count increased above the audit baseline."
+    echo "FAIL: suspicious body-log count exceeds the allowed maximum."
     printf '%s\n' "$matches"
     echo
     echo "Avoid logging raw request/response bodies. Log request id, provider, model, status, size, or redacted snippets instead."
@@ -38,7 +45,7 @@ if [[ "$count" -gt "$MAX_ALLOWED" ]]; then
 fi
 
 if [[ "$count" -gt 0 ]]; then
-    echo "WARN: existing C9/M12 logging debt remains. This guard currently blocks regressions, not the baseline debt."
+    echo "WARN: suspicious body-log hits remain."
     printf '%s\n' "$matches"
 fi
 

--- a/src/core/fine_tuning/providers/openai.rs
+++ b/src/core/fine_tuning/providers/openai.rs
@@ -105,14 +105,20 @@ impl OpenAIFineTuningProvider {
                 .await
                 .map_err(|e| FineTuningError::other(format!("Failed to parse response: {}", e)))
         } else {
-            let error_body = response.text().await.unwrap_or_else(|e| {
+            let error_text = response.text().await.unwrap_or_else(|e| {
                 warn!(
-                    "Failed to read OpenAI fine-tuning error response body: {}",
+                    "Failed to read OpenAI fine-tuning error response payload: {}",
                     e
                 );
                 String::new()
             });
-            warn!("OpenAI API error: {} - {}", status, error_body);
+            let response_bytes = error_text.len();
+            let safe_error_message = extract_openai_error_message(&error_text);
+            warn!(
+                %status,
+                response_bytes,
+                "OpenAI fine-tuning API returned non-success status"
+            );
 
             match status.as_u16() {
                 401 => Err(FineTuningError::auth("Invalid API key")),
@@ -128,10 +134,27 @@ impl OpenAIFineTuningProvider {
                 }
                 _ => Err(FineTuningError::provider(format!(
                     "API error {}: {}",
-                    status, error_body
+                    status,
+                    safe_error_message.unwrap_or_else(|| format!(
+                        "upstream response omitted a safe error message (response_bytes={})",
+                        response_bytes
+                    ))
                 ))),
             }
         }
+    }
+}
+
+fn extract_openai_error_message(error_text: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(error_text).ok()?;
+    let error = value.get("error").unwrap_or(&value);
+    let message = error.get("message").and_then(|message| message.as_str())?;
+    let message = message.trim();
+
+    if message.is_empty() {
+        None
+    } else {
+        Some(message.to_string())
     }
 }
 
@@ -353,5 +376,21 @@ mod tests {
         let provider = OpenAIFineTuningProvider::new(ProviderFineTuningConfig::new());
         let result = provider.auth_header();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_openai_error_message_from_nested_error() {
+        let message = extract_openai_error_message(
+            r#"{"error":{"message":"Invalid training_file","type":"invalid_request_error"}}"#,
+        );
+
+        assert_eq!(message.as_deref(), Some("Invalid training_file"));
+    }
+
+    #[test]
+    fn test_extract_openai_error_message_rejects_non_json_body() {
+        let message = extract_openai_error_message("raw upstream failure with possible content");
+
+        assert_eq!(message, None);
     }
 }

--- a/src/core/guardrails/openai_moderation.rs
+++ b/src/core/guardrails/openai_moderation.rs
@@ -64,7 +64,7 @@ impl OpenAIModerationGuardrail {
             let status = response.status();
             let body = response.text().await.unwrap_or_else(|e| {
                 warn!(
-                    "Failed to read OpenAI moderation error response body: {}",
+                    "Failed to read OpenAI moderation error response payload: {}",
                     e
                 );
                 String::new()

--- a/src/core/integrations/observability/arize.rs
+++ b/src/core/integrations/observability/arize.rs
@@ -314,8 +314,12 @@ impl ArizeIntegration {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            warn!("Arize API returned {}: {}", status, body);
+            let response_bytes = response.bytes().await.map(|bytes| bytes.len()).unwrap_or(0);
+            warn!(
+                %status,
+                response_bytes,
+                "Arize API returned non-success status"
+            );
         }
 
         Ok(())

--- a/src/core/integrations/observability/datadog.rs
+++ b/src/core/integrations/observability/datadog.rs
@@ -390,8 +390,12 @@ impl DataDogIntegration {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            warn!("DataDog metrics API returned {}: {}", status, body);
+            let response_bytes = response.bytes().await.map(|bytes| bytes.len()).unwrap_or(0);
+            warn!(
+                %status,
+                response_bytes,
+                "DataDog metrics API returned non-success status"
+            );
         }
 
         Ok(())
@@ -415,8 +419,12 @@ impl DataDogIntegration {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            warn!("DataDog logs API returned {}: {}", status, body);
+            let response_bytes = response.bytes().await.map(|bytes| bytes.len()).unwrap_or(0);
+            warn!(
+                %status,
+                response_bytes,
+                "DataDog logs API returned non-success status"
+            );
         }
 
         Ok(())

--- a/src/core/integrations/observability/helicone.rs
+++ b/src/core/integrations/observability/helicone.rs
@@ -273,8 +273,12 @@ impl HeliconeIntegration {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            warn!("Helicone API returned {}: {}", status, body);
+            let response_bytes = response.bytes().await.map(|bytes| bytes.len()).unwrap_or(0);
+            warn!(
+                %status,
+                response_bytes,
+                "Helicone API returned non-success status"
+            );
         }
 
         Ok(())

--- a/src/core/providers/gemini/client.rs
+++ b/src/core/providers/gemini/client.rs
@@ -100,10 +100,13 @@ impl GeminiClient {
         let headers = self.get_request_headers();
 
         if self.config.debug {
-            tracing::debug!("Gemini request URL: {}", url);
+            let request_bytes = serde_json::to_vec(&body)
+                .map(|bytes| bytes.len())
+                .unwrap_or(0);
             tracing::debug!(
-                "Gemini request body: {}",
-                serde_json::to_string_pretty(&body).unwrap_or_default()
+                %url,
+                request_bytes,
+                "Gemini request prepared"
             );
         }
 
@@ -129,10 +132,13 @@ impl GeminiClient {
         let headers = self.get_request_headers();
 
         if self.config.debug {
-            tracing::debug!("Gemini stream request URL: {}", url);
+            let request_bytes = serde_json::to_vec(&body)
+                .map(|bytes| bytes.len())
+                .unwrap_or(0);
             tracing::debug!(
-                "Gemini stream request body: {}",
-                serde_json::to_string_pretty(&body).unwrap_or_default()
+                %url,
+                request_bytes,
+                "Gemini stream request prepared"
             );
         }
 
@@ -189,8 +195,9 @@ impl GeminiClient {
             .map_err(|e| gemini_network_error(format!("Failed to read response: {}", e)))?;
 
         if self.config.debug {
+            let response_bytes = response_text.len();
             tracing::debug!("Gemini response status: {}", status);
-            tracing::debug!("Gemini response body: {}", response_text);
+            tracing::debug!(%status, response_bytes, "Gemini response received");
         }
 
         if !status.is_success() {

--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -298,7 +298,11 @@ impl LLMClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            error!("Anthropic stream API error: {} - {}", status, error_text);
+            error!(
+                %status,
+                response_bytes = error_text.len(),
+                "Anthropic stream API error"
+            );
             return Err(SDKError::ApiError(format!(
                 "HTTP {}: {}",
                 status, error_text

--- a/src/server/routes/ai/responses.rs
+++ b/src/server/routes/ai/responses.rs
@@ -24,12 +24,12 @@ use super::openai_errors;
 pub async fn create_response(
     state: web::Data<AppState>,
     req: HttpRequest,
-    body: web::Json<ResponsesApiRequest>,
+    payload: web::Json<ResponsesApiRequest>,
 ) -> ActixResult<HttpResponse> {
-    info!("Responses API request for model: {}", body.model);
+    info!("Responses API request for model: {}", payload.model);
 
     let context = super::context::get_request_context(&req)?;
-    let request = body.into_inner();
+    let request = payload.into_inner();
 
     if request.model.trim().is_empty() {
         return Ok(openai_errors::validation_error("model must not be empty"));

--- a/src/server/routes/teams.rs
+++ b/src/server/routes/teams.rs
@@ -227,9 +227,9 @@ fn resolve_invited_by(req: &HttpRequest) -> Option<Uuid> {
 pub async fn create_team(
     req: HttpRequest,
     state: web::Data<AppState>,
-    body: web::Json<CreateTeamBody>,
+    payload: web::Json<CreateTeamBody>,
 ) -> ActixResult<HttpResponse> {
-    info!("Creating team: {}", body.name);
+    info!("Creating team: {}", payload.name);
 
     if is_auth_enabled(&state) {
         match get_request_caller(&req) {
@@ -246,9 +246,9 @@ pub async fn create_team(
     let manager = get_team_manager(&state);
 
     let request = CreateTeamRequest {
-        name: body.name.clone(),
-        display_name: body.display_name.clone(),
-        description: body.description.clone(),
+        name: payload.name.clone(),
+        display_name: payload.display_name.clone(),
+        description: payload.description.clone(),
         settings: None,
     };
 


### PR DESCRIPTION
Closes #549.

## Summary
- remove raw upstream/vendor response bodies from warning/debug logs
- log safe metadata instead: HTTP status and response byte length
- rename two route payload parameters that were false-positive guard hits
- tighten `check_log_pii.sh` default baseline from 8 to 0

## Verification
- `scripts/guards/check_log_pii.sh`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -q`