### PR TITLE
Fix gateway quickstart config without secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```bash
 git clone https://github.com/majiayu000/litellm-rs.git
 cd litellm-rs
-cp config/gateway.yaml.example config/gateway.yaml
+cp config/gateway.dev.yaml.example config/gateway.yaml
 cargo run --bin gateway
 ```
 
@@ -64,7 +64,7 @@ cargo run --bin gateway
 ```bash
 cargo install litellm-rs --bin gateway
 mkdir -p config
-curl -L https://raw.githubusercontent.com/majiayu000/litellm-rs/main/config/gateway.yaml.example -o config/gateway.yaml
+curl -L https://raw.githubusercontent.com/majiayu000/litellm-rs/main/config/gateway.dev.yaml.example -o config/gateway.yaml
 gateway
 ```
 
@@ -72,6 +72,7 @@ Notes:
 
 - `gateway` requires the `storage` feature at build time.
 - Default features include `sqlite`, so default `cargo run`/`cargo install` satisfy this requirement.
+- The development config starts without provider credentials or auth secrets and uses the local `vllm` catalog provider. Use `config/gateway.yaml.example` for production-style deployments with real provider keys and auth enabled.
 
 ## Installation
 
@@ -217,7 +218,8 @@ while let Some(chunk) = stream.next().await {
 
 - [API Documentation](https://docs.rs/litellm-rs)
 - [Documentation Index](./docs/README.md)
-- [Configuration Guide](./config/gateway.yaml.example)
+- [Development Gateway Config](./config/gateway.dev.yaml.example)
+- [Production Gateway Config](./config/gateway.yaml.example)
 - [Examples](./examples/README.md)
 
 ## Contributing

--- a/config/gateway.dev.yaml.example
+++ b/config/gateway.dev.yaml.example
@@ -6,7 +6,9 @@ schema_version: "1.0"
 
 server:
   host: "127.0.0.1"
-  port: 8000
+  # Keep the gateway off port 8000 so the local vLLM provider can use its
+  # conventional OpenAI-compatible endpoint at http://127.0.0.1:8000/v1.
+  port: 8080
   dev_mode: true
   cors:
     enabled: true

--- a/config/gateway.dev.yaml.example
+++ b/config/gateway.dev.yaml.example
@@ -96,7 +96,7 @@ cache:
   similarity_threshold: 0.95
 
 pricing:
-  source: "config/model_prices_extended.json"
+  source: null
 
 rate_limit:
   enabled: false

--- a/config/gateway.dev.yaml.example
+++ b/config/gateway.dev.yaml.example
@@ -1,0 +1,115 @@
+# LiteLLM-RS Gateway Development Configuration Example
+# Local smoke-test config: no provider credentials and no auth secrets required.
+# Use config/gateway.yaml.example for production-style deployments.
+
+schema_version: "1.0"
+
+server:
+  host: "127.0.0.1"
+  port: 8000
+  dev_mode: true
+  cors:
+    enabled: true
+    allowed_origins:
+      - "http://localhost:3000"
+      - "http://127.0.0.1:3000"
+    allowed_methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    allowed_headers: ["authorization", "content-type", "x-requested-with"]
+    max_age: 3600
+    allow_credentials: false
+
+providers:
+  - name: "local-vllm"
+    provider_type: "vllm"
+    api_key: ""
+    weight: 1.0
+    rpm: 1000
+    tpm: 100000
+    max_concurrent_requests: 32
+    timeout: 30
+    max_retries: 1
+    models:
+      - "local-model"
+    tags: ["local", "development"]
+    enabled: true
+
+router:
+  strategy: "round_robin"
+  circuit_breaker:
+    failure_threshold: 5
+    recovery_timeout: 60
+    min_requests: 10
+    success_threshold: 3
+  load_balancer:
+    health_check_enabled: false
+    sticky_sessions: false
+    session_timeout: 3600
+
+storage:
+  database:
+    url: "postgresql://localhost/litellm"
+    max_connections: 10
+    connection_timeout: 5
+    ssl: false
+    enabled: false
+  redis:
+    url: "redis://localhost:6379"
+    enabled: false
+    max_connections: 20
+    connection_timeout: 5
+    cluster: false
+  vector_db: null
+
+auth:
+  enable_jwt: false
+  enable_api_key: false
+  jwt_secret: ""
+  jwt_expiration: 86400
+  api_key_header: "Authorization"
+  rbac:
+    enabled: false
+    default_role: "user"
+    admin_roles: ["admin", "superuser"]
+
+monitoring:
+  metrics:
+    enabled: false
+    port: 9090
+    path: "/metrics"
+    interval_seconds: 15
+  tracing:
+    enabled: false
+    endpoint: null
+    service_name: "litellm-rs-dev"
+    sampling_rate: 0.1
+    jaeger: null
+  health:
+    path: "/health"
+    detailed: true
+  logging: null
+
+cache:
+  enabled: false
+  ttl: 3600
+  max_size: 1000
+  semantic_cache: false
+  similarity_threshold: 0.95
+
+pricing:
+  source: "config/model_prices_extended.json"
+
+rate_limit:
+  enabled: false
+  strategy: token_bucket
+  default_rpm: 1000
+  default_tpm: 100000
+  requests_per_second: null
+  requests_per_minute: null
+  tokens_per_minute: null
+  burst_size: null
+
+enterprise:
+  enabled: false
+  sso: null
+  audit_logging: false
+  advanced_analytics: false

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -27,7 +27,9 @@ mod tests {
     #[tokio::test]
     async fn test_gateway_dev_example_validates_without_secrets() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("config/gateway.dev.yaml.example");
-        let content = std::fs::read_to_string(&path).expect("dev gateway example should exist");
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .expect("dev gateway example should exist");
 
         assert!(
             !content.contains("${"),
@@ -40,6 +42,7 @@ mod tests {
 
         assert!(!config.auth().enable_jwt);
         assert!(!config.auth().enable_api_key);
+        assert!(config.gateway.pricing.source.is_none());
         assert_eq!(config.providers()[0].provider_type, "vllm");
     }
 

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -43,7 +43,9 @@ mod tests {
         assert!(!config.auth().enable_jwt);
         assert!(!config.auth().enable_api_key);
         assert!(config.gateway.pricing.source.is_none());
+        assert_eq!(config.server().port, 8080);
         assert_eq!(config.providers()[0].provider_type, "vllm");
+        assert!(config.providers()[0].base_url.is_none());
     }
 
     /// Test that server port 0 fails validation

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -6,11 +6,13 @@
 
 #[cfg(test)]
 mod tests {
+    use litellm_rs::Config;
     use litellm_rs::config::models::gateway::GatewayConfig;
     use litellm_rs::config::models::provider::{
         ProviderConfig, ProviderHealthCheckConfig, RetryConfig,
     };
     use litellm_rs::config::models::server::{CorsConfig, ServerConfig, TlsConfig};
+    use std::path::Path;
 
     // ==================== GatewayConfig Validation ====================
 
@@ -19,6 +21,26 @@ mod tests {
     fn test_valid_gateway_config() {
         let config = create_valid_gateway_config();
         assert!(config.validate().is_ok());
+    }
+
+    /// Test that the README gateway quickstart config validates without secrets.
+    #[tokio::test]
+    async fn test_gateway_dev_example_validates_without_secrets() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("config/gateway.dev.yaml.example");
+        let content = std::fs::read_to_string(&path).expect("dev gateway example should exist");
+
+        assert!(
+            !content.contains("${"),
+            "dev gateway example must not require environment placeholders"
+        );
+
+        let config = Config::from_file(&path)
+            .await
+            .expect("dev gateway example should validate");
+
+        assert!(!config.auth().enable_jwt);
+        assert!(!config.auth().enable_api_key);
+        assert_eq!(config.providers()[0].provider_type, "vllm");
     }
 
     /// Test that server port 0 fails validation


### PR DESCRIPTION
## Summary
- add `config/gateway.dev.yaml.example` for local gateway smoke tests without provider credentials or auth secrets
- update README quickstart and config links to use the no-secret dev config
- add a regression test that loads the documented dev config through `Config::from_file`

Closes #559.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run --bin gateway -- validate-config --config config/gateway.dev.yaml.example`
- `cargo check`
- `cargo test --test lib integration::config_validation_tests::tests::test_gateway_dev_example_validates_without_secrets`