### PR TITLE
fix(config): reject unsupported sticky router fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Notes:
 - `gateway` requires the `storage` feature at build time.
 - Default features include `sqlite`, so default `cargo run`/`cargo install` satisfy this requirement.
 
+#### Router Configuration
+
+The gateway router config maps these fields into the runtime router:
+
+- `router.strategy` selects the deployment routing strategy.
+- `router.circuit_breaker.failure_threshold` controls consecutive failures before cooldown.
+- `router.circuit_breaker.recovery_timeout` controls cooldown duration in seconds.
+- `router.circuit_breaker.min_requests` sets the sample size required before cooldown.
+- `router.circuit_breaker.success_threshold` sets the successes required to recover from cooldown.
+- `router.load_balancer.health_check_enabled` enables pre-call deployment health checks.
+
+`router.load_balancer.sticky_sessions` and `router.load_balancer.session_timeout` are reserved for future session affinity. Non-default values fail config validation until runtime affinity is implemented.
+
 ## Installation
 
 ```toml

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -76,8 +76,10 @@ router:
     success_threshold: 3
   load_balancer:
     health_check_enabled: true
-    sticky_sessions: false
-    session_timeout: 3600
+    # Sticky sessions are not implemented yet. Leave these unset; non-default
+    # values are rejected during config validation until runtime affinity exists.
+    # sticky_sessions: false
+    # session_timeout: 3600
 
 storage:
   database:

--- a/src/config/validation/router_validators.rs
+++ b/src/config/validation/router_validators.rs
@@ -16,34 +16,6 @@ impl Validate for GatewayRouterConfig {
         self.circuit_breaker.validate()?;
         self.load_balancer.validate()?;
 
-        if self.circuit_breaker.min_requests != crate::config::models::default_min_requests() {
-            return Err(
-                "router.circuit_breaker.min_requests is not supported by runtime router yet"
-                    .to_string(),
-            );
-        }
-
-        if self.circuit_breaker.success_threshold != 3 {
-            return Err(
-                "router.circuit_breaker.success_threshold is not supported by runtime router yet"
-                    .to_string(),
-            );
-        }
-
-        if self.load_balancer.sticky_sessions {
-            return Err(
-                "router.load_balancer.sticky_sessions is not supported by runtime router yet"
-                    .to_string(),
-            );
-        }
-
-        if self.load_balancer.session_timeout != 3600 {
-            return Err(
-                "router.load_balancer.session_timeout is not supported by runtime router yet"
-                    .to_string(),
-            );
-        }
-
         Ok(())
     }
 }
@@ -71,8 +43,20 @@ impl Validate for CircuitBreakerConfig {
 
 impl Validate for LoadBalancerConfig {
     fn validate(&self) -> Result<(), String> {
-        // Basic validation for load balancer config
-        // Specific validation can be added based on strategy type
+        if self.sticky_sessions {
+            return Err(
+                "router.load_balancer.sticky_sessions is not implemented by runtime router yet"
+                    .to_string(),
+            );
+        }
+
+        if self.session_timeout != 3600 {
+            return Err(
+                "router.load_balancer.session_timeout is not implemented by runtime router yet"
+                    .to_string(),
+            );
+        }
+
         Ok(())
     }
 }
@@ -290,11 +274,44 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn test_router_config_accepts_runtime_mapped_circuit_breaker_fields() {
+        let mut config = GatewayRouterConfig::default();
+        config.circuit_breaker.min_requests = 25;
+        config.circuit_breaker.success_threshold = 4;
+
+        assert!(validate_config(&config).is_ok());
+    }
+
     // ==================== LoadBalancerConfig Validation Tests ====================
 
     #[test]
     fn test_load_balancer_config_valid() {
         let config = LoadBalancerConfig::default();
         assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_load_balancer_rejects_sticky_sessions() {
+        let config = LoadBalancerConfig {
+            sticky_sessions: true,
+            ..Default::default()
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("sticky_sessions"));
+    }
+
+    #[test]
+    fn test_load_balancer_rejects_session_timeout() {
+        let config = LoadBalancerConfig {
+            session_timeout: 900,
+            ..Default::default()
+        };
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("session_timeout"));
     }
 }

--- a/src/config/validation/router_validators.rs
+++ b/src/config/validation/router_validators.rs
@@ -50,7 +50,7 @@ impl Validate for LoadBalancerConfig {
             );
         }
 
-        if self.session_timeout != 3600 {
+        if self.session_timeout != LoadBalancerConfig::default().session_timeout {
             return Err(
                 "router.load_balancer.session_timeout is not implemented by runtime router yet"
                     .to_string(),

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -7,28 +7,18 @@ use super::config::RouterConfig;
 use super::deployment::{Deployment, DeploymentConfig};
 use super::error::RouterError;
 use super::unified::Router;
+use crate::config::Validate;
 use crate::config::models::provider::ProviderConfig;
 use crate::config::models::router::GatewayRouterConfig;
 use crate::core::providers::{Provider, create_provider};
-use tracing::warn;
 
 /// Build runtime router config from gateway YAML router config.
-///
-/// Note: `GatewayRouterConfig` fields `load_balancer.sticky_sessions` and
-/// `load_balancer.session_timeout` are currently not mapped because runtime
-/// `RouterConfig` has no corresponding fields yet.
-pub fn runtime_router_config_from_gateway(config: &GatewayRouterConfig) -> RouterConfig {
-    let has_unmapped_fields =
-        config.load_balancer.sticky_sessions || config.load_balancer.session_timeout != 3600;
-    if has_unmapped_fields {
-        warn!(
-            sticky_sessions = config.load_balancer.sticky_sessions,
-            session_timeout = config.load_balancer.session_timeout,
-            "Gateway router config contains load balancer fields not mapped to runtime RouterConfig yet; values are ignored"
-        );
-    }
+pub fn runtime_router_config_from_gateway(
+    config: &GatewayRouterConfig,
+) -> Result<RouterConfig, String> {
+    Validate::validate(config)?;
 
-    RouterConfig {
+    Ok(RouterConfig {
         routing_strategy: config.strategy,
         allowed_fails: config.circuit_breaker.failure_threshold,
         min_requests: config.circuit_breaker.min_requests,
@@ -36,7 +26,7 @@ pub fn runtime_router_config_from_gateway(config: &GatewayRouterConfig) -> Route
         success_threshold: config.circuit_breaker.success_threshold,
         enable_pre_call_checks: config.load_balancer.health_check_enabled,
         ..RouterConfig::default()
-    }
+    })
 }
 
 impl Router {
@@ -154,7 +144,7 @@ mod tests {
     #[test]
     fn test_runtime_router_config_from_gateway_round_robin() {
         let gateway = GatewayRouterConfig::default();
-        let runtime = runtime_router_config_from_gateway(&gateway);
+        let runtime = runtime_router_config_from_gateway(&gateway).unwrap();
         assert_eq!(
             runtime.routing_strategy,
             super::super::config::RoutingStrategy::RoundRobin
@@ -168,7 +158,7 @@ mod tests {
             circuit_breaker: CircuitBreakerConfig::default(),
             load_balancer: LoadBalancerConfig::default(),
         };
-        let runtime = runtime_router_config_from_gateway(&gateway);
+        let runtime = runtime_router_config_from_gateway(&gateway).unwrap();
         assert_eq!(
             runtime.routing_strategy,
             super::super::config::RoutingStrategy::LatencyBased
@@ -187,10 +177,40 @@ mod tests {
             },
             load_balancer: LoadBalancerConfig::default(),
         };
-        let runtime = runtime_router_config_from_gateway(&gateway);
+        let runtime = runtime_router_config_from_gateway(&gateway).unwrap();
         assert_eq!(runtime.allowed_fails, 8);
         assert_eq!(runtime.cooldown_time_secs, 45);
         assert_eq!(runtime.min_requests, 20);
         assert_eq!(runtime.success_threshold, 5);
+    }
+
+    #[test]
+    fn test_runtime_router_config_rejects_sticky_sessions() {
+        let gateway = GatewayRouterConfig {
+            strategy: RoutingStrategyConfig::RoundRobin,
+            circuit_breaker: CircuitBreakerConfig::default(),
+            load_balancer: LoadBalancerConfig {
+                sticky_sessions: true,
+                ..LoadBalancerConfig::default()
+            },
+        };
+
+        let err = runtime_router_config_from_gateway(&gateway).unwrap_err();
+        assert!(err.contains("sticky_sessions"));
+    }
+
+    #[test]
+    fn test_runtime_router_config_rejects_session_timeout() {
+        let gateway = GatewayRouterConfig {
+            strategy: RoutingStrategyConfig::RoundRobin,
+            circuit_breaker: CircuitBreakerConfig::default(),
+            load_balancer: LoadBalancerConfig {
+                session_timeout: 900,
+                ..LoadBalancerConfig::default()
+            },
+        };
+
+        let err = runtime_router_config_from_gateway(&gateway).unwrap_err();
+        assert!(err.contains("session_timeout"));
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -78,7 +78,8 @@ impl HttpServer {
         let runtime_router_config =
             crate::core::router::gateway_config::runtime_router_config_from_gateway(
                 &config.gateway.router,
-            );
+            )
+            .map_err(|e| GatewayError::Config(format!("Invalid router config: {}", e)))?;
 
         let unified_router = crate::core::router::UnifiedRouter::from_gateway_config(
             &config.gateway.providers,


### PR DESCRIPTION
## Summary
- reject unsupported router.load_balancer sticky/session values during validation and runtime router mapping
- keep runtime-mapped circuit breaker fields accepted by validation
- mark sticky session fields as not yet supported in the example config and README

Fixes #557

## Validation
- cargo fmt --all
- cargo test config::validation::router_validators::tests --lib
- cargo test core::router::gateway_config::tests --lib
- cargo check
- cargo test --lib