### PR TITLE
docs(readme): align provider claims and version with actual feature surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # litellm-rs
 
-A high-performance Rust library and gateway for calling 100+ LLM APIs in an OpenAI-compatible format.
+A high-performance Rust library and gateway for calling LLM APIs in an OpenAI-compatible format. Ships with 50+ built-in OpenAI-compatible providers plus first-class adapters for OpenAI, Anthropic, Mistral, and Cloudflare.
 
 [![Crates.io](https://img.shields.io/crates/v/litellm-rs.svg)](https://crates.io/crates/litellm-rs)
 [![Documentation](https://docs.rs/litellm-rs/badge.svg)](https://docs.rs/litellm-rs)
@@ -8,7 +8,7 @@ A high-performance Rust library and gateway for calling 100+ LLM APIs in an Open
 
 ## Features
 
-- **100+ AI Providers** - OpenAI, Anthropic, Google, Azure, AWS Bedrock, and more
+- **60+ runtime-wired providers** - OpenAI, Anthropic, Mistral, Cloudflare, plus 50+ OpenAI-compatible providers via the Tier 1 catalog. See [Provider Support](#provider-support) for the full matrix.
 - **OpenAI-Compatible API** - Drop-in replacement for OpenAI SDK
 - **High Performance** - 10,000+ requests/second, <10ms routing overhead
 - **Intelligent Routing** - Load balancing, failover, cost optimization
@@ -20,7 +20,7 @@ Most users use this project as a unified API library, not as a gateway server. S
 
 ```toml
 [dependencies]
-litellm-rs = { version = "0.4", default-features = false, features = ["lite"] }
+litellm-rs = { version = "0.5", default-features = false, features = ["lite"] }
 ```
 
 For crate users, no `make` is required.
@@ -92,46 +92,70 @@ The gateway router config maps these fields into the runtime router:
 ```toml
 # Full gateway with SQLite + Redis (default)
 [dependencies]
-litellm-rs = "0.4"
+litellm-rs = "0.5"
 
 # API-only - lightweight, no actix-web/argon2/aes-gcm/clap
 [dependencies]
-litellm-rs = { version = "0.4", default-features = false }
+litellm-rs = { version = "0.5", default-features = false }
 
 # API-only with metrics
 [dependencies]
-litellm-rs = { version = "0.4", default-features = false, features = ["lite"] }
+litellm-rs = { version = "0.5", default-features = false, features = ["lite"] }
 
 # Gateway modules in library context (not standalone gateway binary runtime)
 [dependencies]
-litellm-rs = { version = "0.4", default-features = false, features = ["gateway"] }
+litellm-rs = { version = "0.5", default-features = false, features = ["gateway"] }
 ```
 
-## Supported Providers
+## Provider Support
 
-| Provider | Chat | Embeddings | Images | Audio |
-|----------|------|------------|--------|-------|
-| OpenAI | ✅ | ✅ | ✅ | ✅ |
-| Anthropic | ✅ | - | - | - |
-| Google (Gemini) | ✅ | ✅ | ✅ | - |
-| Azure OpenAI | ✅ | ✅ | ✅ | ✅ |
-| AWS Bedrock | ✅ | ✅ | - | - |
-| Google Vertex AI | ✅ | ✅ | ✅ | - |
-| Groq | ✅ | - | - | ✅ |
-| DeepSeek | ✅ | - | - | - |
-| Kimi (Moonshot AI) | ✅ | - | - | - |
-| GLM (Zhipu AI) | ✅ | - | - | - |
-| MiniMax | ✅ | - | - | - |
-| Mistral | ✅ | ✅ | - | - |
-| Cohere | ✅ | ✅ | - | - |
-| OpenRouter | ✅ | - | - | - |
-| Together AI | ✅ | ✅ | - | - |
-| Fireworks AI | ✅ | ✅ | - | - |
-| Perplexity | ✅ | - | - | - |
-| Replicate | ✅ | - | ✅ | - |
-| Hugging Face | ✅ | ✅ | - | - |
-| Ollama | ✅ | ✅ | - | - |
-| And 80+ more... | | | | |
+Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLAUDE.md#provider-tiers) for the engineering definition).
+
+- **Tier 1 — catalog-only**: OpenAI-compatible endpoints declared as data in [`src/core/providers/registry/catalog.rs`](./src/core/providers/registry/catalog.rs). Routed through `OpenAILikeProvider`. Always available (no cargo feature required). Capabilities reflect what the upstream OpenAI-compatible surface offers; this crate forwards `/chat/completions`, `/completions`, `/embeddings`, etc., when the upstream exposes them.
+- **Tier 2 — code-based**: providers with custom request/response handling, auth signing, or streaming. Wired into the `Provider` enum and the factory. Some Tier 2 builders are feature-gated.
+
+> The matrix below is **hand-maintained** and reflects the runtime surface today. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 wiring lives in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Capability columns describe which endpoints this crate exposes for the provider — `passthrough` means the call is forwarded to the upstream OpenAI-compatible endpoint without per-provider transformation. A dynamically-generated matrix is tracked as a follow-up.
+
+### Tier 2 — code-based providers
+
+| Provider | Cargo feature | Chat | Stream | Embed | Image | Audio | Notes |
+|----------|---------------|------|--------|-------|-------|-------|-------|
+| OpenAI (`openai`) | always | ✅ | ✅ | ✅ | ✅ | ✅ | Reference implementation. |
+| Anthropic (`anthropic`) | always | ✅ | ✅ | – | – | – | Native Anthropic messages API. |
+| Mistral (`mistral`) | always | ✅ | ✅ | passthrough | – | – | Native client. |
+| Cloudflare Workers AI (`cloudflare`) | always | ✅ | ✅ | passthrough | – | – | Native client with account-id auth. |
+| Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | passthrough | passthrough | Dedicated module gated on `providers-extra`. |
+| Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
+| AWS Bedrock (`bedrock`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Routed through Bedrock's OpenAI-compatible surface. SigV4-signed dedicated module gated on `providers-extra`; not yet wired as the runtime path. |
+| Google Vertex AI (`vertex_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
+| Meta Llama API (`meta_llama`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
+| Vercel v0 (`v0`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
+| Amazon Nova (`amazon_nova`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extended`. |
+| fal.ai (`fal_ai`) | wired via factory (`OpenAILike`) | passthrough | passthrough | – | passthrough | – | Dedicated module gated on `providers-extended`. |
+| Replicate (`replicate`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | passthrough | – | Dedicated module gated on `providers-extended`. |
+| GitHub Models (`github`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extended`. |
+| GitHub Copilot (`github_copilot`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extended`. |
+| Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | passthrough | passthrough | passthrough | For self-hosted / unlisted endpoints. |
+
+### Tier 1 — catalog providers (OpenAI-compatible, always available)
+
+All entries below route through `OpenAILikeProvider`. Chat and streaming work for any endpoint that follows OpenAI's `/chat/completions` SSE protocol. Other endpoints (embeddings, images, audio) are forwarded only when the upstream exposes them; the crate does not add per-provider transformations.
+
+**Cloud (`Bearer` auth via env var):**
+
+`groq`, `together`, `fireworks`, `perplexity`, `cerebras`, `openrouter`, `deepinfra`, `deepseek`, `novita`, `nvidia_nim`, `nebius`, `nscale`, `hyperbolic`, `featherless`, `galadriel`, `sambanova`, `heroku`, `friendliai`, `xai`, `moonshot`, `dashscope`, `qwen`, `baichuan`, `minimax`, `volcengine`, `xiaomi_mimo`, `zhipu`, `lemonade`, `linkup`, `poe`, `wandb`, `nanogpt`, `aiml_api`, `aleph_alpha`, `anyscale`, `bytez`, `comet_api`, `compactifai`, `maritalk`, `siliconflow`, `yi`, `lambda_ai`, `ovhcloud`
+
+**Local (no API key):**
+
+`vllm`, `hosted_vllm`, `lm_studio`, `llamafile`, `docker_model_runner`, `xinference`, `infinity`, `oobabooga`
+
+### Experimental / module-only
+
+The following modules exist under `src/core/providers/` (gated on `providers-extra` or `providers-extended`) but are **not wired into the unified `Provider` enum or the factory** today. They compile but cannot be selected through `create_provider`/`from_config_async`. Treat them as experimental scaffolding subject to change:
+
+`ai21`, `baseten`, `clarifai`, `codestral`, `cohere`, `custom_api`, `databricks`, `datarobot`, `deepgram`, `deepl`, `elevenlabs`, `empower`, `exa_ai`, `firecrawl`, `gemini`, `gigachat`, `google_pse`, `gradient_ai`, `huggingface`, `jina`, `langgraph`, `manus`, `milvus`, `morph`, `nlp_cloud`, `oci`, `ollama`, `petals`, `pg_vector`, `predibase`, `ragflow`, `recraft`, `runwayml`, `sagemaker`, `sap_ai`, `searxng`, `snowflake`, `spark`, `stability`, `tavily`, `topaz`, `triton`, `vercel_ai`, `voyage`, `watsonx`
+
+For self-hosted or unlisted OpenAI-compatible endpoints, prefer the generic `openai_compatible` provider type instead.
 
 ## Environment Variables
 
@@ -163,7 +187,7 @@ use litellm_rs::{completion, user_message};
 // Automatically routes to the right provider based on model name
 let openai = completion("gpt-4", vec![user_message("Hi")], None).await?;
 let anthropic = completion("anthropic/claude-3-opus", vec![user_message("Hi")], None).await?;
-let google = completion("gemini/gemini-pro", vec![user_message("Hi")], None).await?;
+let groq = completion("groq/llama-3.1-70b", vec![user_message("Hi")], None).await?;
 let bedrock = completion(
     "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     vec![user_message("Hi")],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # litellm-rs
 
-A high-performance Rust library and gateway for calling LLM APIs in an OpenAI-compatible format. Ships with 50+ built-in OpenAI-compatible providers plus first-class adapters for OpenAI, Anthropic, Mistral, and Cloudflare.
+A high-performance Rust library and gateway for calling LLM APIs in an OpenAI-compatible format. Ships with 50+ built-in OpenAI-compatible providers plus first-class adapters for OpenAI, Anthropic, AWS Bedrock, Mistral, and Cloudflare.
 
 [![Crates.io](https://img.shields.io/crates/v/litellm-rs.svg)](https://crates.io/crates/litellm-rs)
 [![Documentation](https://docs.rs/litellm-rs/badge.svg)](https://docs.rs/litellm-rs)
@@ -8,7 +8,7 @@ A high-performance Rust library and gateway for calling LLM APIs in an OpenAI-co
 
 ## Features
 
-- **60+ runtime-wired providers** - OpenAI, Anthropic, Mistral, Cloudflare, plus 50+ OpenAI-compatible providers via the Tier 1 catalog. See [Provider Support](#provider-support) for the full matrix.
+- **60+ runtime-wired providers** - OpenAI, Anthropic, AWS Bedrock, Mistral, Cloudflare, plus 50+ OpenAI-compatible providers via the Tier 1 catalog. See [Provider Support](#provider-support) for the full matrix.
 - **OpenAI-Compatible API** - Drop-in replacement for OpenAI SDK
 - **High Performance** - 10,000+ requests/second, <10ms routing overhead
 - **Intelligent Routing** - Load balancing, failover, cost optimization
@@ -126,7 +126,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Cloudflare Workers AI (`cloudflare`) | always | ✅ | ✅ | passthrough | – | – | Native client with account-id auth. |
 | Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | passthrough | passthrough | Dedicated module gated on `providers-extra`. |
 | Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
-| AWS Bedrock (`bedrock`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Routed through Bedrock's OpenAI-compatible surface. SigV4-signed dedicated module gated on `providers-extra`; not yet wired as the runtime path. |
+| AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |
 | Google Vertex AI (`vertex_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
 | Meta Llama API (`meta_llama`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
 | Vercel v0 (`v0`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |


### PR DESCRIPTION
## Summary
- Updates install snippets from 0.4 → 0.5 to match Cargo.toml.
- Replaces vague 100+ claim with an honest provider support matrix.
- Documents Tier 1 vs Tier 2 vs feature-gated providers per CLAUDE.md taxonomy.

## Test plan
- [ ] grep -n 'litellm-rs = "0.4"' returns 0 matches
- [ ] Matrix entries reflect actual `src/core/providers/registry/catalog.rs`

Closes #558