### PR TITLE
fix(runtime): fail-fast on enabled-but-failed dependencies

### DIFF
--- a/src/config/models/file_storage.rs
+++ b/src/config/models/file_storage.rs
@@ -90,6 +90,14 @@ pub struct VectorDbConfig {
     pub api_key: String,
     /// Index name
     pub index_name: String,
+    /// When the vector DB section is configured and init fails, allow the gateway
+    /// to keep running without a vector backend instead of failing startup.
+    ///
+    /// Defaults to `false` so a configured-but-broken vector DB is surfaced at
+    /// startup. Set to `true` only when the vector DB is best-effort (e.g.
+    /// optional semantic cache) and silent degradation is acceptable.
+    #[serde(default)]
+    pub allow_degraded: bool,
 }
 
 impl std::fmt::Debug for VectorDbConfig {
@@ -99,6 +107,7 @@ impl std::fmt::Debug for VectorDbConfig {
             .field("url", &self.url)
             .field("api_key", &"***REDACTED***")
             .field("index_name", &self.index_name)
+            .field("allow_degraded", &self.allow_degraded)
             .finish()
     }
 }
@@ -110,6 +119,7 @@ impl Default for VectorDbConfig {
             url: String::new(),
             api_key: String::new(),
             index_name: "default".to_string(),
+            allow_degraded: false,
         }
     }
 }
@@ -330,6 +340,7 @@ mod tests {
             url: "http://weaviate:8080".to_string(),
             api_key: "weaviate-key".to_string(),
             index_name: "embeddings".to_string(),
+            allow_degraded: false,
         };
         assert_eq!(config.db_type, "weaviate");
         assert_eq!(config.index_name, "embeddings");
@@ -342,10 +353,20 @@ mod tests {
             url: "http://qdrant:6333".to_string(),
             api_key: "qdrant-key".to_string(),
             index_name: "vectors".to_string(),
+            allow_degraded: false,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["db_type"], "qdrant");
         assert_eq!(json["url"], "http://qdrant:6333");
+    }
+
+    #[test]
+    fn test_vector_db_config_allow_degraded_default_false() {
+        let config = VectorDbConfig::default();
+        assert!(
+            !config.allow_degraded,
+            "allow_degraded must default to false so explicit failures are surfaced"
+        );
     }
 
     #[test]

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -216,12 +216,22 @@ pub struct GatewayPricingConfig {
     /// Optional pricing source path/URL used by PricingService::new
     #[serde(default = "default_pricing_source")]
     pub source: Option<String>,
+    /// When the pricing source is configured and the initial load fails, allow
+    /// the gateway to keep running without pricing data instead of failing
+    /// startup.
+    ///
+    /// Defaults to `false` so a configured-but-broken pricing source is
+    /// surfaced at startup. A `true` value documents that the gateway may
+    /// serve traffic without cost accounting until pricing data is refreshed.
+    #[serde(default)]
+    pub allow_degraded: bool,
 }
 
 impl Default for GatewayPricingConfig {
     fn default() -> Self {
         Self {
             source: default_pricing_source(),
+            allow_degraded: false,
         }
     }
 }

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -58,6 +58,15 @@ pub struct DatabaseConfig {
     /// local database when the configured PostgreSQL backend is unavailable.
     #[serde(default)]
     pub fallback_to_sqlite: bool,
+    /// When `enabled` is true and budget-persistence snapshot loading fails,
+    /// allow the gateway to keep running with in-memory budget tracking
+    /// instead of failing startup.
+    ///
+    /// Defaults to `false` so a configured-but-broken budget persistence path
+    /// is surfaced at startup. A `true` value documents that operating with
+    /// in-memory budgets only is intentional.
+    #[serde(default)]
+    pub allow_degraded: bool,
 }
 
 impl Default for DatabaseConfig {
@@ -69,6 +78,7 @@ impl Default for DatabaseConfig {
             ssl: false,
             enabled: false,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         }
     }
 }
@@ -95,6 +105,9 @@ impl DatabaseConfig {
         if other.fallback_to_sqlite {
             self.fallback_to_sqlite = true;
         }
+        if other.allow_degraded {
+            self.allow_degraded = true;
+        }
         self
     }
 }
@@ -117,6 +130,14 @@ pub struct RedisConfig {
     /// Enable cluster mode
     #[serde(default)]
     pub cluster: bool,
+    /// When `enabled` is true and Redis init fails, allow the gateway to keep
+    /// running with an in-process/no-op fallback instead of failing startup.
+    ///
+    /// Defaults to `false` so an explicitly enabled-but-unreachable Redis is
+    /// surfaced at startup. Set to `true` only when running in environments
+    /// where caching is best-effort and silent degradation is acceptable.
+    #[serde(default)]
+    pub allow_degraded: bool,
 }
 
 impl Default for RedisConfig {
@@ -127,6 +148,7 @@ impl Default for RedisConfig {
             max_connections: default_redis_max_connections(),
             connection_timeout: default_connection_timeout(),
             cluster: false,
+            allow_degraded: false,
         }
     }
 }
@@ -150,6 +172,9 @@ impl RedisConfig {
         // Redis defaults to enabled=false; propagate if other differs from default
         if other.enabled != default_redis_enabled() {
             self.enabled = other.enabled;
+        }
+        if other.allow_degraded {
+            self.allow_degraded = true;
         }
         self
     }
@@ -185,6 +210,7 @@ mod tests {
             ssl: true,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
         assert!(config.ssl);
         assert!(config.enabled);
@@ -200,6 +226,7 @@ mod tests {
             ssl: true,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["url"], "postgresql://test");
@@ -220,11 +247,8 @@ mod tests {
         let base = DatabaseConfig::default();
         let other = DatabaseConfig {
             url: "postgresql://new-host/new-db".to_string(),
-            max_connections: 10,
             connection_timeout: 30,
-            ssl: false,
-            enabled: false,
-            fallback_to_sqlite: false,
+            ..DatabaseConfig::default()
         };
         let merged = base.merge(other);
         assert_eq!(merged.url, "postgresql://new-host/new-db");
@@ -234,12 +258,9 @@ mod tests {
     fn test_database_config_merge_ssl() {
         let base = DatabaseConfig::default();
         let other = DatabaseConfig {
-            url: "postgresql://localhost/litellm".to_string(),
-            max_connections: 10,
             connection_timeout: 30,
             ssl: true,
-            enabled: false,
-            fallback_to_sqlite: false,
+            ..DatabaseConfig::default()
         };
         let merged = base.merge(other);
         assert!(merged.ssl);
@@ -249,12 +270,8 @@ mod tests {
     fn test_database_config_merge_enabled_true() {
         let base = DatabaseConfig::default();
         let other = DatabaseConfig {
-            url: "postgresql://localhost/litellm".to_string(),
-            max_connections: default_max_connections(),
-            connection_timeout: default_connection_timeout(),
-            ssl: false,
             enabled: true,
-            fallback_to_sqlite: false,
+            ..DatabaseConfig::default()
         };
         let merged = base.merge(other);
         assert!(merged.enabled);
@@ -349,6 +366,7 @@ mod tests {
             max_connections: 200,
             connection_timeout: 60,
             cluster: true,
+            allow_degraded: false,
         };
         assert!(config.cluster);
         assert_eq!(config.max_connections, 200);
@@ -362,6 +380,7 @@ mod tests {
             max_connections: 50,
             connection_timeout: 15,
             cluster: false,
+            allow_degraded: false,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["url"], "redis://cache:6379");
@@ -385,6 +404,7 @@ mod tests {
             max_connections: 100,
             connection_timeout: 30,
             cluster: false,
+            allow_degraded: false,
         };
         let merged = base.merge(other);
         assert_eq!(merged.url, "redis://new-redis:6379");
@@ -399,6 +419,7 @@ mod tests {
             max_connections: 100,
             connection_timeout: 30,
             cluster: true,
+            allow_degraded: false,
         };
         let merged = base.merge(other);
         assert!(merged.cluster);
@@ -413,6 +434,7 @@ mod tests {
             max_connections: default_redis_max_connections(),
             connection_timeout: default_connection_timeout(),
             cluster: false,
+            allow_degraded: false,
         };
         let merged = base.merge(other);
         assert!(merged.enabled);
@@ -522,11 +544,8 @@ mod tests {
         let other = StorageConfig {
             database: DatabaseConfig {
                 url: "postgresql://new/db".to_string(),
-                max_connections: 10,
                 connection_timeout: 30,
-                ssl: false,
-                enabled: false,
-                fallback_to_sqlite: false,
+                ..DatabaseConfig::default()
             },
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
@@ -534,6 +553,46 @@ mod tests {
         };
         let merged = base.merge(other);
         assert_eq!(merged.database.url, "postgresql://new/db");
+    }
+
+    #[test]
+    fn test_redis_config_allow_degraded_default_false() {
+        let config = RedisConfig::default();
+        assert!(
+            !config.allow_degraded,
+            "allow_degraded must default to false so explicit failures are surfaced"
+        );
+    }
+
+    #[test]
+    fn test_redis_config_merge_allow_degraded() {
+        let base = RedisConfig::default();
+        let other = RedisConfig {
+            allow_degraded: true,
+            ..RedisConfig::default()
+        };
+        let merged = base.merge(other);
+        assert!(merged.allow_degraded);
+    }
+
+    #[test]
+    fn test_database_config_allow_degraded_default_false() {
+        let config = DatabaseConfig::default();
+        assert!(
+            !config.allow_degraded,
+            "allow_degraded must default to false so explicit failures are surfaced"
+        );
+    }
+
+    #[test]
+    fn test_database_config_merge_allow_degraded() {
+        let base = DatabaseConfig::default();
+        let other = DatabaseConfig {
+            allow_degraded: true,
+            ..DatabaseConfig::default()
+        };
+        let merged = base.merge(other);
+        assert!(merged.allow_degraded);
     }
 
     #[test]

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -163,6 +163,7 @@ mod tests {
             url: "http://localhost:6333".to_string(),
             api_key: "test-key".to_string(),
             index_name: "vectors".to_string(),
+            allow_degraded: false,
         }
     }
 

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -219,6 +219,7 @@ fn test_database_validation_skips_when_disabled() {
         connection_timeout: 0,
         ssl: false,
         fallback_to_sqlite: false,
+        allow_degraded: false,
     };
     assert!(Validate::validate(&config).is_ok());
 }
@@ -231,6 +232,7 @@ fn test_redis_validation_skips_when_disabled() {
         max_connections: 0,
         connection_timeout: 0,
         cluster: false,
+        allow_degraded: false,
     };
     assert!(Validate::validate(&config).is_ok());
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -22,7 +22,7 @@ use actix_web::{
 };
 use std::sync::Arc;
 use tokio::task::JoinHandle;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 /// HTTP server
 pub struct HttpServer {
@@ -44,6 +44,10 @@ impl HttpServer {
 
         let storage = crate::storage::StorageLayer::new(&config.gateway.storage).await?;
         let mut budget_persistence_task = None;
+        // Budget persistence is co-located with the database backend. We treat
+        // a missing/disabled database as "budget persistence disabled" (no
+        // error), and a failed snapshot load on a configured database as a
+        // hard startup failure unless storage.database.allow_degraded=true.
         let budget_limits = match storage.database.load_budget_limit_snapshots().await {
             Ok(snapshots) => {
                 let count = snapshots.len();
@@ -57,11 +61,27 @@ impl HttpServer {
                 ))
             }
             Err(e) => {
-                warn!(
-                    "Budget limit persistence is unavailable; using in-memory budgets only: {}",
-                    e
-                );
-                Arc::new(UnifiedBudgetLimits::new())
+                if config.gateway.storage.database.allow_degraded
+                    || !config.gateway.storage.database.enabled
+                {
+                    error!(
+                        "Budget limit persistence is unavailable; using in-memory budgets \
+                         only (allow_degraded={}, db_enabled={}). Error: {}",
+                        config.gateway.storage.database.allow_degraded,
+                        config.gateway.storage.database.enabled,
+                        e
+                    );
+                    Arc::new(UnifiedBudgetLimits::new())
+                } else {
+                    error!(
+                        "Budget limit persistence load failed and \
+                         storage.database.allow_degraded=false; failing startup. Set \
+                         storage.database.allow_degraded=true to keep running with \
+                         in-memory budgets only. Error: {}",
+                        e
+                    );
+                    return Err(e);
+                }
             }
         };
         let auth =
@@ -69,7 +89,26 @@ impl HttpServer {
 
         let pricing = Arc::new(PricingService::new(config.gateway.pricing.source.clone()));
         if let Err(e) = pricing.initialize().await {
-            warn!("Pricing service initial load failed: {}", e);
+            // A `None` pricing source is "pricing disabled" and is not
+            // expected to fail; any other failure is a configured-but-broken
+            // pricing source. Honor allow_degraded the same way as other
+            // dependencies.
+            let is_configured = config.gateway.pricing.source.is_some();
+            if !is_configured || config.gateway.pricing.allow_degraded {
+                error!(
+                    "Pricing service initial load failed; gateway will serve traffic \
+                     without pricing data (configured={}, allow_degraded={}). Error: {}",
+                    is_configured, config.gateway.pricing.allow_degraded, e
+                );
+            } else {
+                error!(
+                    "Pricing service initial load failed and pricing.allow_degraded=false; \
+                     failing startup. Set pricing.allow_degraded=true to keep running \
+                     without pricing data. Error: {}",
+                    e
+                );
+                return Err(e);
+            }
         } else {
             info!("Pricing service initial load completed");
         }
@@ -383,5 +422,62 @@ mod tests {
             }
             other => panic!("expected config error, got: {other:?}"),
         }
+    }
+
+    /// Build a config whose only optional dependency that is *configured* is
+    /// the pricing source, which points at a non-existent file so the initial
+    /// load fails deterministically.
+    fn config_with_broken_pricing(allow_degraded: bool) -> Config {
+        let mut config = Config::default();
+        // Disable enterprise/storage subsystems that would require real I/O.
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source =
+            Some("/nonexistent/path/that/cannot/be/loaded.json".to_string());
+        config.gateway.pricing.allow_degraded = allow_degraded;
+        config
+    }
+
+    #[tokio::test]
+    async fn new_fails_when_pricing_source_broken_and_not_allowed_to_degrade() {
+        let config = config_with_broken_pricing(false);
+        let result = HttpServer::new(&config).await;
+        assert!(
+            result.is_err(),
+            "pricing source load failure with allow_degraded=false must fail startup"
+        );
+    }
+
+    #[tokio::test]
+    async fn new_succeeds_when_pricing_source_broken_but_allowed_to_degrade() {
+        let config = config_with_broken_pricing(true);
+        let result = HttpServer::new(&config).await;
+        assert!(
+            result.is_ok(),
+            "pricing source load failure with allow_degraded=true must keep startup running, \
+             got: {:?}",
+            result.err()
+        );
+    }
+
+    /// In-memory budget snapshots load succeeds (returns empty) on sqlite, so
+    /// we can't trigger a real "load failed" path from `Config::default()`
+    /// alone without a mock. The disabled-DB branch is covered here: when the
+    /// database is disabled we use the in-memory sqlite backend which always
+    /// returns an empty snapshot set, exercising the "Ok(snapshots)" arm.
+    #[tokio::test]
+    async fn new_succeeds_with_in_memory_budgets_when_db_disabled() {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        // Disable pricing so we don't conflate with the broken-pricing tests.
+        config.gateway.pricing.source = None;
+
+        let result = HttpServer::new(&config).await;
+        assert!(
+            result.is_ok(),
+            "disabled DB must keep startup running with in-memory budgets, got: {:?}",
+            result.err()
+        );
     }
 }

--- a/src/storage/dependency_status.rs
+++ b/src/storage/dependency_status.rs
@@ -1,0 +1,88 @@
+//! Runtime status tracking for optional storage / runtime dependencies.
+//!
+//! Captures whether a configured dependency (database, redis, vector DB,
+//! pricing service, budget persistence) is healthy, degraded, or unavailable.
+//! Used to make the runtime state explicit so callers (and future readiness
+//! reporting) can distinguish "intentionally off" from "configured but broken".
+
+use serde::Serialize;
+
+/// Status of a runtime-managed dependency.
+///
+/// Tracked per-dependency at startup so the gateway can report whether a
+/// configured component is actually serving traffic, intentionally disabled,
+/// or running in a degraded fallback mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyStatus {
+    /// Dependency is not configured / explicitly disabled. No fallback in
+    /// effect; absence of the feature is intentional.
+    Disabled,
+    /// Dependency was configured but initialization has not been attempted
+    /// yet (or no result is available). Reserved for future async health
+    /// rechecks.
+    Configured,
+    /// Dependency initialized successfully and is in use.
+    Healthy,
+    /// Dependency was configured and failed to initialize, but the operator
+    /// opted into `allow_degraded` so the gateway is running on an in-process
+    /// / no-op fallback. Surfaced to make the trade-off visible.
+    Degraded,
+    /// Dependency was configured and failed to initialize. Not expected to
+    /// be observed in normal operation because fail-fast is the default; this
+    /// variant exists for completeness when reporting historical state.
+    Unavailable,
+}
+
+impl DependencyStatus {
+    /// Returns true when the dependency is actively serving traffic
+    /// (regardless of whether through a real backend or a no-op fallback).
+    pub fn is_available(self) -> bool {
+        matches!(self, Self::Healthy | Self::Degraded)
+    }
+
+    /// Returns true when the dependency reported a configured-but-broken
+    /// state and the gateway accepted a fallback.
+    pub fn is_degraded(self) -> bool {
+        matches!(self, Self::Degraded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_is_not_available() {
+        assert!(!DependencyStatus::Disabled.is_available());
+        assert!(!DependencyStatus::Disabled.is_degraded());
+    }
+
+    #[test]
+    fn healthy_is_available_not_degraded() {
+        assert!(DependencyStatus::Healthy.is_available());
+        assert!(!DependencyStatus::Healthy.is_degraded());
+    }
+
+    #[test]
+    fn degraded_is_available_and_degraded() {
+        assert!(DependencyStatus::Degraded.is_available());
+        assert!(DependencyStatus::Degraded.is_degraded());
+    }
+
+    #[test]
+    fn unavailable_is_neither() {
+        assert!(!DependencyStatus::Unavailable.is_available());
+        assert!(!DependencyStatus::Unavailable.is_degraded());
+    }
+
+    #[test]
+    fn serializes_to_snake_case() {
+        let json = serde_json::to_string(&DependencyStatus::Healthy).unwrap();
+        assert_eq!(json, "\"healthy\"");
+        let json = serde_json::to_string(&DependencyStatus::Degraded).unwrap();
+        assert_eq!(json, "\"degraded\"");
+        let json = serde_json::to_string(&DependencyStatus::Disabled).unwrap();
+        assert_eq!(json, "\"disabled\"");
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,8 @@
 
 /// Database storage module
 pub mod database;
+/// Per-dependency runtime status (Healthy / Degraded / Disabled / ...)
+pub mod dependency_status;
 /// File storage module
 pub mod files;
 /// Redis cache module
@@ -11,11 +13,13 @@ pub mod redis;
 /// Vector storage module
 pub mod vector;
 
+pub use dependency_status::DependencyStatus;
+
 use crate::config::models::storage::StorageConfig;
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Returns the default base directory for local gateway state.
 ///
@@ -49,10 +53,24 @@ pub struct StorageLayer {
     /// Vector database client (optional)
     /// Note: Using concrete type instead of trait object for now
     pub vector: Option<Arc<vector::VectorStoreBackend>>,
+    /// Status of the Redis dependency after init.
+    pub redis_status: DependencyStatus,
+    /// Status of the vector DB dependency after init.
+    pub vector_status: DependencyStatus,
 }
 
 impl StorageLayer {
-    /// Create a new storage layer
+    /// Create a new storage layer.
+    ///
+    /// For each optional dependency:
+    /// * if `enabled` is `false` (or the section is absent), the dependency is
+    ///   treated as `Disabled` and a no-op fallback is used,
+    /// * if `enabled` is `true` and init succeeds, status is `Healthy`,
+    /// * if `enabled` is `true`, init fails, and `allow_degraded` is `false`,
+    ///   the call returns `Err` so startup fails loudly,
+    /// * if `enabled` is `true`, init fails, and `allow_degraded` is `true`,
+    ///   the error is logged at `error!` level and the dependency status is
+    ///   set to `Degraded` while the gateway keeps running.
     pub async fn new(config: &StorageConfig) -> Result<Self> {
         info!("Initializing storage layer");
 
@@ -60,24 +78,50 @@ impl StorageLayer {
         debug!("Connecting to database");
         let database = Arc::new(database::Database::new(&config.database).await?);
 
-        // Initialize Redis (optional with graceful degradation)
+        // Initialize Redis (fail-fast unless allow_degraded is set)
         debug!("Creating Redis connection pool");
-        let redis = match redis::RedisPool::new(&config.redis).await {
-            Ok(pool) => {
-                if pool.is_noop() {
-                    info!("Redis caching is disabled (no-op mode)");
-                } else {
-                    info!("Redis connection established");
+        let (redis, redis_status) = if !config.redis.enabled {
+            // Explicitly disabled — no fallback, no error.
+            info!("Redis disabled in config; using no-op pool");
+            (
+                Arc::new(redis::RedisPool::create_noop()),
+                DependencyStatus::Disabled,
+            )
+        } else {
+            match redis::RedisPool::new(&config.redis).await {
+                Ok(pool) => {
+                    if pool.is_noop() {
+                        // RedisPool::new returns a no-op pool when enabled=false,
+                        // but we already handled that branch above. Treat any
+                        // other no-op as healthy to be safe.
+                        info!("Redis pool initialized in no-op mode");
+                        (Arc::new(pool), DependencyStatus::Healthy)
+                    } else {
+                        info!("Redis connection established");
+                        (Arc::new(pool), DependencyStatus::Healthy)
+                    }
                 }
-                Arc::new(pool)
-            }
-            Err(e) => {
-                warn!(
-                    "Redis connection failed: {}. Gateway will operate without caching.",
-                    e
-                );
-                // Create a no-op Redis pool wrapper
-                Arc::new(redis::RedisPool::create_noop())
+                Err(e) => {
+                    if config.redis.allow_degraded {
+                        error!(
+                            "Redis init failed but allow_degraded=true; continuing without \
+                             cache. Error: {}",
+                            e
+                        );
+                        (
+                            Arc::new(redis::RedisPool::create_noop()),
+                            DependencyStatus::Degraded,
+                        )
+                    } else {
+                        error!(
+                            "Redis init failed and allow_degraded=false; failing startup. \
+                             Set storage.redis.allow_degraded=true to keep running in no-op \
+                             cache mode. Error: {}",
+                            e
+                        );
+                        return Err(e);
+                    }
+                }
             }
         };
 
@@ -85,22 +129,33 @@ impl StorageLayer {
         debug!("Initializing file storage");
         let files = Arc::new(files::FileStorage::new(&config.files).await?);
 
-        // Initialize vector database (optional)
-        let vector = if let Some(ref vector_config) = config.vector_db {
+        // Initialize vector database (fail-fast unless allow_degraded is set)
+        let (vector, vector_status) = if let Some(ref vector_config) = config.vector_db {
             debug!("Initializing vector database");
             match vector::VectorStoreBackend::new(vector_config).await {
-                Ok(v) => Some(Arc::new(v)),
+                Ok(v) => (Some(Arc::new(v)), DependencyStatus::Healthy),
                 Err(e) => {
-                    warn!(
-                        "Vector database initialization failed: {}, continuing without vector DB",
-                        e
-                    );
-                    None
+                    if vector_config.allow_degraded {
+                        error!(
+                            "Vector DB init failed but allow_degraded=true; continuing \
+                             without vector backend. Error: {}",
+                            e
+                        );
+                        (None, DependencyStatus::Degraded)
+                    } else {
+                        error!(
+                            "Vector DB init failed and allow_degraded=false; failing \
+                             startup. Set storage.vector_db.allow_degraded=true to keep \
+                             running without a vector backend. Error: {}",
+                            e
+                        );
+                        return Err(e);
+                    }
                 }
             }
         } else {
             debug!("Vector database not configured, skipping");
-            None
+            (None, DependencyStatus::Disabled)
         };
 
         info!("Storage layer initialized successfully");
@@ -110,6 +165,8 @@ impl StorageLayer {
             redis,
             files,
             vector,
+            redis_status,
+            vector_status,
         })
     }
 
@@ -400,6 +457,7 @@ mod tests {
                 ssl: false,
                 enabled: true,
                 fallback_to_sqlite: false,
+                allow_degraded: false,
             },
             redis: RedisConfig {
                 url: "redis://localhost:6379".to_string(),
@@ -407,6 +465,7 @@ mod tests {
                 max_connections: 10,
                 connection_timeout: 5,
                 cluster: false,
+                allow_degraded: false,
             },
             files: FileStorageConfig::default(),
             vector_db: None,
@@ -449,5 +508,146 @@ mod tests {
             "stored file should use configured path: {}",
             expected_path.display()
         );
+    }
+
+    fn unreachable_redis_config(allow_degraded: bool) -> RedisConfig {
+        RedisConfig {
+            // Port 1 reserved/unreachable; connection_timeout=1 keeps the
+            // test fast.
+            url: "redis://127.0.0.1:1".to_string(),
+            enabled: true,
+            max_connections: 1,
+            connection_timeout: 1,
+            cluster: false,
+            allow_degraded,
+        }
+    }
+
+    fn sqlite_db_config() -> DatabaseConfig {
+        DatabaseConfig {
+            url: "sqlite::memory:".to_string(),
+            max_connections: 1,
+            connection_timeout: 1,
+            ssl: false,
+            enabled: true,
+            fallback_to_sqlite: false,
+            allow_degraded: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn redis_enabled_failing_without_allow_degraded_fails_startup() {
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis: unreachable_redis_config(false),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let result = StorageLayer::new(&config).await;
+        assert!(
+            result.is_err(),
+            "enabled redis that cannot connect must fail startup when allow_degraded=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn redis_enabled_failing_with_allow_degraded_continues_with_noop() {
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis: unreachable_redis_config(true),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("allow_degraded=true should allow startup with no-op redis pool");
+        assert!(
+            storage.redis.is_noop(),
+            "degraded redis must fall back to a no-op pool"
+        );
+        assert_eq!(storage.redis_status, DependencyStatus::Degraded);
+    }
+
+    #[tokio::test]
+    async fn redis_disabled_uses_noop_without_error() {
+        let redis = RedisConfig {
+            enabled: false,
+            ..RedisConfig::default()
+        };
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis,
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("disabled redis must always succeed");
+        assert!(storage.redis.is_noop());
+        assert_eq!(storage.redis_status, DependencyStatus::Disabled);
+    }
+
+    fn unreachable_vector_config(
+        allow_degraded: bool,
+    ) -> crate::config::models::file_storage::VectorDbConfig {
+        crate::config::models::file_storage::VectorDbConfig {
+            // Unsupported db_type forces VectorStoreBackend::new to return Err
+            // synchronously, which keeps the test fast and offline-friendly.
+            db_type: "weaviate".to_string(),
+            url: "http://127.0.0.1:1".to_string(),
+            api_key: "test".to_string(),
+            index_name: "test".to_string(),
+            allow_degraded,
+        }
+    }
+
+    #[tokio::test]
+    async fn vector_db_failing_without_allow_degraded_fails_startup() {
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: Some(unreachable_vector_config(false)),
+        };
+
+        let result = StorageLayer::new(&config).await;
+        assert!(
+            result.is_err(),
+            "configured vector DB that cannot init must fail startup when allow_degraded=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn vector_db_failing_with_allow_degraded_continues_without_vector() {
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: Some(unreachable_vector_config(true)),
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("allow_degraded=true must allow startup without a vector backend");
+        assert!(storage.vector.is_none());
+        assert_eq!(storage.vector_status, DependencyStatus::Degraded);
+    }
+
+    #[tokio::test]
+    async fn vector_db_disabled_is_status_disabled() {
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("storage layer must init without vector DB");
+        assert_eq!(storage.vector_status, DependencyStatus::Disabled);
     }
 }

--- a/src/storage/redis/pool.rs
+++ b/src/storage/redis/pool.rs
@@ -90,6 +90,7 @@ impl RedisPool {
                 max_connections: 0,
                 connection_timeout: 0,
                 cluster: false,
+                allow_degraded: false,
             },
             noop_mode: true,
             semaphore: Arc::new(Semaphore::new(1)),

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -229,6 +229,7 @@ mod tests {
             max_connections: 10,
             connection_timeout: 1,
             cluster: false,
+            allow_degraded: false,
         };
 
         match RedisPool::new(&config).await {

--- a/src/storage/redis/tests.rs
+++ b/src/storage/redis/tests.rs
@@ -51,6 +51,7 @@ async fn test_redis_pool_creation_returns_error_for_unreachable_endpoint() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
+        allow_degraded: false,
     };
 
     let result = RedisPool::new(&config).await;
@@ -65,6 +66,7 @@ async fn test_redis_pool_disabled_is_noop() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
+        allow_degraded: false,
     };
 
     let pool = RedisPool::new(&config)
@@ -81,6 +83,7 @@ async fn live_redis_pool() -> Option<RedisPool> {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
+        allow_degraded: false,
     };
 
     match RedisPool::new(&config).await {

--- a/tests/common/database.rs
+++ b/tests/common/database.rs
@@ -26,6 +26,7 @@ impl TestDatabase {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -76,6 +77,7 @@ pub fn test_db_config() -> DatabaseConfig {
         ssl: false,
         enabled: true,
         fallback_to_sqlite: false,
+        allow_degraded: false,
     }
 }
 

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -22,6 +22,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config).await;
@@ -51,6 +52,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -69,6 +71,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -102,6 +105,7 @@ mod tests {
             ssl: false,
             enabled: false,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config).await.expect(
@@ -125,6 +129,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -148,6 +153,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -171,6 +177,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -191,6 +198,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)
@@ -339,6 +347,7 @@ mod tests {
             ssl: false,
             enabled: true,
             fallback_to_sqlite: false,
+            allow_degraded: false,
         };
 
         let db = Database::new(&config)


### PR DESCRIPTION
## Summary

Closes #556 (RUNTIME-01: enabled dependencies silently degrade).

Adds an `allow_degraded` flag (default `false`) to four optional runtime dependencies — Redis, vector DB, budget persistence (via `DatabaseConfig`), and pricing service. When `enabled: true` and the dependency init fails:

- `allow_degraded=false` (default) -> startup **fails fast** with an `error!` log explaining how to opt into degraded mode.
- `allow_degraded=true` -> the failure is logged at `error!` level and the gateway continues on an in-process/no-op fallback. The trade-off becomes explicit instead of being silently swallowed at `warn!` level.

Also introduces a `DependencyStatus` enum (`Disabled` / `Configured` / `Healthy` / `Degraded` / `Unavailable`) that `StorageLayer` now tracks for Redis and vector DB after init. Future readiness reporting (#555 / PR #583) can consume this without colliding with the active `/health` endpoint work.

## What changed

| File | Reason |
|---|---|
| `src/config/models/storage.rs` | Add `allow_degraded` to `DatabaseConfig` and `RedisConfig` (defaults to `false`), wire merge + tests |
| `src/config/models/file_storage.rs` | Add `allow_degraded` to `VectorDbConfig`, update tests |
| `src/config/models/gateway.rs` | Add `allow_degraded` to `GatewayPricingConfig` |
| `src/config/validation/{storage_validators,tests}.rs` | Update validator + config-validation test fixtures for new fields |
| `src/storage/dependency_status.rs` (new) | `DependencyStatus` enum + unit tests |
| `src/storage/mod.rs` | Wire fail-fast / allow-degraded for Redis + vector DB, track `redis_status` and `vector_status`, add `error!` logs + new tests |
| `src/server/http.rs` | Wire fail-fast / allow-degraded for budget snapshot load and pricing service initial load, add tests |
| `src/storage/redis/{pool,rate_limit,tests}.rs` | Update existing fixtures to include `allow_degraded` |
| `tests/common/database.rs`, `tests/integration/database_tests.rs` | Update existing fixtures to include `allow_degraded` |

## Test plan

- [x] Disabled dep -> unchanged behavior (`redis_disabled_uses_noop_without_error`, `vector_db_disabled_is_status_disabled`, `new_succeeds_with_in_memory_budgets_when_db_disabled`)
- [x] Enabled + failing + `allow_degraded=false` -> startup fails (`redis_enabled_failing_without_allow_degraded_fails_startup`, `vector_db_failing_without_allow_degraded_fails_startup`, `new_fails_when_pricing_source_broken_and_not_allowed_to_degrade`)
- [x] Enabled + failing + `allow_degraded=true` -> logs `error!`, continues (`redis_enabled_failing_with_allow_degraded_continues_with_noop`, `vector_db_failing_with_allow_degraded_continues_without_vector`, `new_succeeds_when_pricing_source_broken_but_allowed_to_degrade`)
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --all-features` clean
- [x] `cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing" -- -D warnings` clean
- [x] `cargo test --features "postgres sqlite redis s3 metrics tracing" --lib storage` -> 210 passed
- [x] `cargo test ... --lib server::http` -> 6 passed (3 new)
- [x] `cargo test ... --lib pricing` / `budget` / `config` / `file_storage` / `dependency_status` -> all green

## Notes for reviewers

- **PR size**: 13 files / 595 lines. Slightly above the per-issue guideline because the fix legitimately spans four independent dependencies (Redis / vector DB / budget persistence / pricing). Each one follows the same pattern, so the per-dep diff is small.
- `DependencyStatus` is intentionally not wired into the `/health` route here -- that surface belongs to PR #583 (issue #555). Avoiding the conflict keeps both PRs independently mergeable.
- `cargo clippy --all-features` surfaces three pre-existing `E0063` errors in `src/core/providers/ollama/streaming.rs` (missing `audio` field) that are unrelated to this change; they were present before this branch.