### PR TITLE
fix(bedrock): enforce model parameter policy

### DIFF
--- a/src/core/providers/bedrock/chat/converse.rs
+++ b/src/core/providers/bedrock/chat/converse.rs
@@ -3,6 +3,9 @@
 //! Modern unified API for chat completions in Bedrock
 
 use crate::core::providers::bedrock::model_id::is_prompt_management_model_id;
+use crate::core::providers::bedrock::parameter_policy::{
+    has_bedrock_model_parameter_overrides, serialize_bedrock_chat_parameters,
+};
 use crate::core::providers::bedrock::parse_bedrock_model_id;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::chat::ChatRequest;
@@ -252,6 +255,11 @@ pub(in crate::core::providers::bedrock) fn transform_to_converse(
     let mut messages = Vec::new();
     let mut system_messages = Vec::new();
     let prompt_management = is_prompt_management_model_id(&request.model);
+    let parameter_fields = if prompt_management {
+        None
+    } else {
+        Some(serialize_bedrock_chat_parameters(request)?)
+    };
 
     for msg in &request.messages {
         match msg.role {
@@ -355,19 +363,26 @@ pub(in crate::core::providers::bedrock) fn transform_to_converse(
             || request.temperature.is_some()
             || request.top_p.is_some()
             || request.stop.is_some()
+            || has_bedrock_model_parameter_overrides(request)
         {
             return Err(ProviderError::invalid_request(
                 "bedrock",
-                "Prompt-management ARNs do not support request-level inferenceConfig",
+                "Prompt-management ARNs do not support request-level inferenceConfig or additionalModelRequestFields",
             ));
         }
         None
     } else {
+        let Some(parameter_fields) = parameter_fields.as_ref() else {
+            return Err(ProviderError::configuration(
+                "bedrock",
+                "Bedrock parameter fields were not serialized for a Converse request",
+            ));
+        };
         Some(InferenceConfig {
-            max_tokens: request.max_completion_tokens.or(request.max_tokens),
-            temperature: request.temperature.map(|t| t as f64),
-            top_p: request.top_p.map(|t| t as f64),
-            stop_sequences: request.stop.clone(),
+            max_tokens: parameter_fields.max_tokens,
+            temperature: parameter_fields.temperature,
+            top_p: parameter_fields.top_p,
+            stop_sequences: parameter_fields.stop_sequences.clone(),
         })
     };
 
@@ -426,7 +441,9 @@ pub(in crate::core::providers::bedrock) fn transform_to_converse(
         prompt_variables,
         tool_config,
         guardrail_config: None, // NOTE: guardrail support not yet implemented
-        additional_model_request_fields: None,
+        additional_model_request_fields: parameter_fields
+            .as_ref()
+            .and_then(|fields| fields.additional_model_request_fields()),
     })
 }
 
@@ -654,3 +671,7 @@ fn tool_result_contents_from_value(value: &Value) -> Result<Vec<ToolResultConten
 #[cfg(test)]
 #[path = "converse_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "converse_parameter_policy_tests.rs"]
+mod parameter_policy_tests;

--- a/src/core/providers/bedrock/chat/converse_parameter_policy_tests.rs
+++ b/src/core/providers/bedrock/chat/converse_parameter_policy_tests.rs
@@ -1,0 +1,98 @@
+use super::*;
+use crate::core::types::thinking::{ThinkingConfig, ThinkingEffort};
+use crate::core::types::{chat::ChatMessage, message::MessageContent, message::MessageRole};
+
+#[test]
+fn bedrock_parameter_policy_rejects_opus_47_temperature() {
+    let request = ChatRequest {
+        model: "anthropic.claude-opus-4-7".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Hello".to_string())),
+            ..Default::default()
+        }],
+        temperature: Some(0.7),
+        ..Default::default()
+    };
+
+    let error = transform_to_converse(&request)
+        .expect_err("Claude Opus 4.7 should reject non-default temperature locally");
+    let message = error.to_string();
+    assert!(message.contains("claude-opus-4-7"));
+    assert!(message.contains("temperature"));
+}
+
+#[test]
+fn bedrock_parameter_policy_serializes_top_k_as_additional_model_field() {
+    let mut request = ChatRequest {
+        model: "anthropic.claude-3-sonnet".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Hello".to_string())),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    request
+        .extra_params
+        .insert("top_k".to_string(), serde_json::json!(128));
+
+    let converse = transform_to_converse(&request)
+        .unwrap_or_else(|err| panic!("top_k should transform: {err}"));
+    let fields = converse
+        .additional_model_request_fields
+        .unwrap_or_else(|| panic!("top_k should be emitted as additionalModelRequestFields"));
+
+    assert_eq!(fields["top_k"], 128);
+}
+
+#[test]
+fn bedrock_parameter_policy_serializes_opus_47_adaptive_thinking() {
+    let request = ChatRequest::new("anthropic.claude-opus-4-7")
+        .add_user_message("Think carefully")
+        .with_thinking(
+            ThinkingConfig::new()
+                .enabled()
+                .with_effort(ThinkingEffort::Low),
+        );
+
+    let converse = transform_to_converse(&request)
+        .unwrap_or_else(|err| panic!("adaptive thinking should transform: {err}"));
+    let fields = converse
+        .additional_model_request_fields
+        .unwrap_or_else(|| panic!("thinking should be emitted as additionalModelRequestFields"));
+
+    assert_eq!(
+        fields["thinking"],
+        serde_json::json!({
+            "type": "adaptive",
+            "effort": "low"
+        })
+    );
+}
+
+#[test]
+fn bedrock_parameter_policy_rejects_opus_47_budget_tokens() {
+    let request = ChatRequest::new("anthropic.claude-opus-4-7")
+        .add_user_message("Think carefully")
+        .with_thinking(ThinkingConfig::new().enabled().with_budget(32_000));
+
+    let error = transform_to_converse(&request)
+        .expect_err("Claude Opus 4.7 should reject fixed thinking budgets locally");
+    let message = error.to_string();
+    assert!(message.contains("claude-opus-4-7"));
+    assert!(message.contains("budget_tokens"));
+}
+
+#[test]
+fn bedrock_parameter_policy_rejects_raw_extra_params_thinking() {
+    let mut request = ChatRequest::new("anthropic.claude-opus-4-7").add_user_message("Hello");
+    request.extra_params.insert(
+        "thinking".to_string(),
+        serde_json::json!({"type": "adaptive"}),
+    );
+
+    let error = transform_to_converse(&request)
+        .expect_err("raw Bedrock thinking should use ChatRequest.thinking");
+    assert!(error.to_string().contains("extra_params.thinking"));
+}

--- a/src/core/providers/bedrock/chat/converse_parameter_policy_tests.rs
+++ b/src/core/providers/bedrock/chat/converse_parameter_policy_tests.rs
@@ -47,6 +47,63 @@ fn bedrock_parameter_policy_serializes_top_k_as_additional_model_field() {
 }
 
 #[test]
+fn bedrock_parameter_policy_preserves_custom_additional_model_fields() {
+    let mut request = ChatRequest::new("anthropic.claude-3-sonnet").add_user_message("Hello");
+    request.extra_params.insert(
+        "additionalModelRequestFields".to_string(),
+        serde_json::json!({
+            "topK": 96,
+            "vendorField": {
+                "mode": "passthrough"
+            }
+        }),
+    );
+
+    let converse = transform_to_converse(&request).unwrap_or_else(|err| {
+        panic!("custom additionalModelRequestFields should transform: {err}")
+    });
+    let fields = converse
+        .additional_model_request_fields
+        .unwrap_or_else(|| panic!("additionalModelRequestFields should be emitted"));
+
+    assert_eq!(fields["top_k"], 96);
+    assert_eq!(
+        fields["vendorField"],
+        serde_json::json!({
+            "mode": "passthrough"
+        })
+    );
+    assert!(fields.get("topK").is_none());
+}
+
+#[test]
+fn bedrock_parameter_policy_allows_opus_47_custom_additional_model_fields() {
+    let mut request = ChatRequest::new("anthropic.claude-opus-4-7").add_user_message("Hello");
+    request.extra_params.insert(
+        "additionalModelRequestFields".to_string(),
+        serde_json::json!({
+            "vendorField": {
+                "mode": "passthrough"
+            }
+        }),
+    );
+
+    let converse = transform_to_converse(&request).unwrap_or_else(|err| {
+        panic!("custom additionalModelRequestFields should transform: {err}")
+    });
+    let fields = converse
+        .additional_model_request_fields
+        .unwrap_or_else(|| panic!("additionalModelRequestFields should be emitted"));
+
+    assert_eq!(
+        fields["vendorField"],
+        serde_json::json!({
+            "mode": "passthrough"
+        })
+    );
+}
+
+#[test]
 fn bedrock_parameter_policy_serializes_opus_47_adaptive_thinking() {
     let request = ChatRequest::new("anthropic.claude-opus-4-7")
         .add_user_message("Think carefully")

--- a/src/core/providers/bedrock/chat/transformations/anthropic.rs
+++ b/src/core/providers/bedrock/chat/transformations/anthropic.rs
@@ -1,6 +1,7 @@
 //! Anthropic Claude Model Transformations
 
 use crate::core::providers::bedrock::model_config::ModelConfig;
+use crate::core::providers::bedrock::parameter_policy::serialize_bedrock_chat_parameters;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::chat::ChatRequest;
 use serde_json::{Value, json};
@@ -10,23 +11,33 @@ pub fn transform_request(
     request: &ChatRequest,
     _model_config: &ModelConfig,
 ) -> Result<Value, ProviderError> {
+    let parameter_fields = serialize_bedrock_chat_parameters(request)?;
+
     // Claude models on Bedrock use anthropic messages format
     let mut body = json!({
         "messages": request.messages,
-        "max_tokens": request.max_tokens.unwrap_or(4096),
-        "anthropic_version": "bedrock-2023-05-20"
+        "max_tokens": parameter_fields.max_tokens.unwrap_or(4096),
+        "anthropic_version": "bedrock-2023-05-31"
     });
 
-    if let Some(temp) = request.temperature {
+    if let Some(temp) = parameter_fields.temperature {
         body["temperature"] = json!(temp);
     }
 
-    if let Some(top_p) = request.top_p {
+    if let Some(top_p) = parameter_fields.top_p {
         body["top_p"] = json!(top_p);
     }
 
-    if let Some(stop) = &request.stop {
+    if let Some(stop) = parameter_fields.stop_sequences {
         body["stop_sequences"] = json!(stop);
+    }
+
+    if let Some(top_k) = parameter_fields.top_k {
+        body["top_k"] = top_k;
+    }
+
+    if let Some(thinking) = parameter_fields.thinking {
+        body["thinking"] = thinking;
     }
 
     if let Some(system) = extract_system_message(request) {
@@ -65,7 +76,12 @@ fn extract_system_message(request: &ChatRequest) -> Option<String> {
 mod tests {
     use super::*;
     use crate::core::providers::bedrock::model_config::{BedrockApiType, BedrockModelFamily};
-    use crate::core::types::{chat::ChatMessage, message::MessageContent, message::MessageRole};
+    use crate::core::types::{
+        chat::ChatMessage,
+        message::MessageContent,
+        message::MessageRole,
+        thinking::{ThinkingConfig, ThinkingEffort},
+    };
 
     fn create_test_request() -> ChatRequest {
         ChatRequest {
@@ -108,7 +124,7 @@ mod tests {
         let value = result.unwrap();
         assert!(value["messages"].is_array());
         assert_eq!(value["max_tokens"], 4096);
-        assert_eq!(value["anthropic_version"], "bedrock-2023-05-20");
+        assert_eq!(value["anthropic_version"], "bedrock-2023-05-31");
     }
 
     #[test]
@@ -133,6 +149,57 @@ mod tests {
         assert!(result.is_ok());
         let value = result.unwrap();
         assert_eq!(value["top_p"], 0.5);
+    }
+
+    #[test]
+    fn bedrock_parameter_policy_serializes_top_k() {
+        let mut request = create_test_request();
+        request
+            .extra_params
+            .insert("top_k".to_string(), serde_json::json!(64));
+        let model_config = create_test_model_config();
+
+        let result = transform_request(&request, &model_config);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert_eq!(value["top_k"], 64);
+    }
+
+    #[test]
+    fn bedrock_parameter_policy_rejects_opus_47_top_p() {
+        let mut request = create_test_request();
+        request.model = "anthropic.claude-opus-4-7".to_string();
+        request.top_p = Some(0.5);
+        let model_config = create_test_model_config();
+
+        let error = transform_request(&request, &model_config)
+            .expect_err("Claude Opus 4.7 should reject non-default top_p locally");
+        let message = error.to_string();
+        assert!(message.contains("claude-opus-4-7"));
+        assert!(message.contains("top_p"));
+    }
+
+    #[test]
+    fn bedrock_parameter_policy_serializes_opus_47_adaptive_thinking() {
+        let mut request = create_test_request();
+        request.model = "anthropic.claude-opus-4-7".to_string();
+        request.thinking = Some(
+            ThinkingConfig::new()
+                .enabled()
+                .with_effort(ThinkingEffort::High),
+        );
+        let model_config = create_test_model_config();
+
+        let result = transform_request(&request, &model_config);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert_eq!(
+            value["thinking"],
+            serde_json::json!({
+                "type": "adaptive",
+                "effort": "high"
+            })
+        );
     }
 
     #[test]

--- a/src/core/providers/bedrock/mod.rs
+++ b/src/core/providers/bedrock/mod.rs
@@ -10,6 +10,7 @@ mod config;
 mod error;
 mod model_config;
 mod model_id;
+mod parameter_policy;
 mod provider;
 mod sigv4;
 mod transformation;

--- a/src/core/providers/bedrock/model_id.rs
+++ b/src/core/providers/bedrock/model_id.rs
@@ -101,6 +101,10 @@ pub fn get_model_config_for_model_id(
         }
     }
 
+    if is_claude_opus_47_model_id(&parsed) {
+        return Ok(claude_opus_47_config());
+    }
+
     if let Some(fallback) = parsed.runtime_config_fallback {
         return Ok(match fallback {
             RuntimeConfigFallback::Converse => runtime_resolved_converse_config(),
@@ -154,6 +158,18 @@ static RUNTIME_RESOLVED_PROMPT_CONFIG: super::model_config::ModelConfig =
         output_cost_per_1k: 0.0,
     };
 
+static CLAUDE_OPUS_47_CONFIG: super::model_config::ModelConfig = super::model_config::ModelConfig {
+    family: super::model_config::BedrockModelFamily::Claude,
+    api_type: super::model_config::BedrockApiType::Converse,
+    supports_streaming: true,
+    supports_function_calling: true,
+    supports_multimodal: true,
+    max_context_length: 1_000_000,
+    max_output_length: Some(128_000),
+    input_cost_per_1k: 0.005,
+    output_cost_per_1k: 0.025,
+};
+
 fn runtime_resolved_converse_config() -> &'static super::model_config::ModelConfig {
     &RUNTIME_RESOLVED_CONVERSE_CONFIG
 }
@@ -164,6 +180,17 @@ fn runtime_resolved_invoke_config() -> &'static super::model_config::ModelConfig
 
 fn runtime_resolved_prompt_config() -> &'static super::model_config::ModelConfig {
     &RUNTIME_RESOLVED_PROMPT_CONFIG
+}
+
+fn claude_opus_47_config() -> &'static super::model_config::ModelConfig {
+    &CLAUDE_OPUS_47_CONFIG
+}
+
+fn is_claude_opus_47_model_id(parsed: &ParsedBedrockModelId) -> bool {
+    parsed
+        .metadata_lookup_ids
+        .iter()
+        .any(|id| id == "anthropic.claude-opus-4-7")
 }
 
 fn canonical_metadata_id(model_id: &str) -> Option<String> {
@@ -628,6 +655,16 @@ mod tests {
         assert_eq!(
             config.api_type,
             crate::core::providers::bedrock::BedrockApiType::InvokeStream
+        );
+    }
+
+    #[test]
+    fn claude_opus_47_has_converse_runtime_config() {
+        let config = config_for("anthropic.claude-opus-4-7");
+
+        assert_eq!(
+            config.api_type,
+            crate::core::providers::bedrock::BedrockApiType::Converse
         );
     }
 

--- a/src/core/providers/bedrock/parameter_policy.rs
+++ b/src/core/providers/bedrock/parameter_policy.rs
@@ -40,18 +40,19 @@ pub(in crate::core::providers::bedrock) struct BedrockChatParameterFields {
     pub stop_sequences: Option<Vec<String>>,
     pub top_k: Option<Value>,
     pub thinking: Option<Value>,
+    pub extra_additional_fields: Option<Map<String, Value>>,
 }
 
 impl BedrockChatParameterFields {
     pub fn additional_model_request_fields(&self) -> Option<Value> {
-        let mut fields = Map::new();
+        let mut fields = self.extra_additional_fields.clone().unwrap_or_default();
         if let Some(top_k) = &self.top_k {
             fields.insert("top_k".to_string(), top_k.clone());
         }
         if let Some(thinking) = &self.thinking {
             fields.insert("thinking".to_string(), thinking.clone());
         }
-        (!fields.is_empty()).then(|| Value::Object(fields))
+        (!fields.is_empty()).then_some(Value::Object(fields))
     }
 }
 
@@ -94,6 +95,7 @@ pub(in crate::core::providers::bedrock) fn serialize_bedrock_chat_parameters(
     let policy = bedrock_parameter_policy(&request.model);
     validate_sampling_policy(request, policy)?;
 
+    let extra_additional_fields = passthrough_additional_model_fields(request)?;
     let top_k = serialize_top_k(request, policy)?;
     let thinking = serialize_thinking(request, policy)?;
 
@@ -104,6 +106,7 @@ pub(in crate::core::providers::bedrock) fn serialize_bedrock_chat_parameters(
         stop_sequences: request.stop.clone(),
         top_k,
         thinking,
+        extra_additional_fields,
     })
 }
 
@@ -335,6 +338,27 @@ fn additional_model_field<'a>(
     request: &'a ChatRequest,
     field_name: &str,
 ) -> Result<Option<&'a Value>, ProviderError> {
+    Ok(additional_model_fields(request)?.and_then(|fields| fields.get(field_name)))
+}
+
+fn passthrough_additional_model_fields(
+    request: &ChatRequest,
+) -> Result<Option<Map<String, Value>>, ProviderError> {
+    let Some(fields) = additional_model_fields(request)? else {
+        return Ok(None);
+    };
+
+    let mut passthrough = fields.clone();
+    passthrough.remove("top_k");
+    passthrough.remove("topK");
+    passthrough.remove("thinking");
+
+    Ok((!passthrough.is_empty()).then_some(passthrough))
+}
+
+fn additional_model_fields(
+    request: &ChatRequest,
+) -> Result<Option<&Map<String, Value>>, ProviderError> {
     let Some(fields) = get_extra_param(
         request,
         "additionalModelRequestFields",
@@ -343,27 +367,9 @@ fn additional_model_field<'a>(
         return Ok(None);
     };
 
-    let object = fields.as_object().ok_or_else(|| {
+    fields.as_object().map(Some).ok_or_else(|| {
         ProviderError::invalid_request("bedrock", "additionalModelRequestFields must be an object")
-    })?;
-
-    validate_additional_model_fields(object)?;
-    Ok(object.get(field_name))
-}
-
-fn validate_additional_model_fields(fields: &Map<String, Value>) -> Result<(), ProviderError> {
-    for key in fields.keys() {
-        match key.as_str() {
-            "top_k" | "topK" | "thinking" => {}
-            other => {
-                return Err(ProviderError::invalid_request(
-                    "bedrock",
-                    format!("Unsupported Bedrock additionalModelRequestFields field: {other}"),
-                ));
-            }
-        }
-    }
-    Ok(())
+    })
 }
 
 fn get_extra_param<'a>(request: &'a ChatRequest, snake: &str, camel: &str) -> Option<&'a Value> {

--- a/src/core/providers/bedrock/parameter_policy.rs
+++ b/src/core/providers/bedrock/parameter_policy.rs
@@ -1,0 +1,400 @@
+//! Bedrock model-specific request parameter policy.
+//!
+//! The policy layer fails before transport when a Bedrock model cannot accept a
+//! requested parameter. This prevents silently dropping unsupported settings.
+
+use crate::core::providers::bedrock::parse_bedrock_model_id;
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::chat::ChatRequest;
+use crate::core::types::thinking::{ThinkingConfig, ThinkingEffort};
+use serde_json::{Map, Value, json};
+
+const DEFAULT_TEMPERATURE: f32 = 1.0;
+const DEFAULT_TOP_P: f32 = 0.999;
+const FLOAT_EPSILON: f32 = 0.000_001;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SamplingPolicy {
+    Allow,
+    ForbidNonDefault,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThinkingPolicy {
+    Unsupported,
+    AnthropicAdaptive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::core::providers::bedrock) struct BedrockParameterPolicy {
+    model_label: &'static str,
+    sampling: SamplingPolicy,
+    thinking: ThinkingPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::core::providers::bedrock) struct BedrockChatParameterFields {
+    pub max_tokens: Option<u32>,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub top_k: Option<Value>,
+    pub thinking: Option<Value>,
+}
+
+impl BedrockChatParameterFields {
+    pub fn additional_model_request_fields(&self) -> Option<Value> {
+        let mut fields = Map::new();
+        if let Some(top_k) = &self.top_k {
+            fields.insert("top_k".to_string(), top_k.clone());
+        }
+        if let Some(thinking) = &self.thinking {
+            fields.insert("thinking".to_string(), thinking.clone());
+        }
+        (!fields.is_empty()).then(|| Value::Object(fields))
+    }
+}
+
+pub(in crate::core::providers::bedrock) fn bedrock_parameter_policy(
+    model_id: &str,
+) -> BedrockParameterPolicy {
+    if is_claude_opus_47_model_id(model_id) {
+        BedrockParameterPolicy {
+            model_label: "anthropic.claude-opus-4-7",
+            sampling: SamplingPolicy::ForbidNonDefault,
+            thinking: ThinkingPolicy::AnthropicAdaptive,
+        }
+    } else {
+        BedrockParameterPolicy {
+            model_label: "default Bedrock model",
+            sampling: SamplingPolicy::Allow,
+            thinking: ThinkingPolicy::Unsupported,
+        }
+    }
+}
+
+pub(in crate::core::providers::bedrock) fn has_bedrock_model_parameter_overrides(
+    request: &ChatRequest,
+) -> bool {
+    request.thinking.is_some()
+        || request.reasoning_effort.is_some()
+        || request.extra_params.contains_key("thinking")
+        || get_extra_param(request, "top_k", "topK").is_some()
+        || get_extra_param(
+            request,
+            "additionalModelRequestFields",
+            "additional_model_request_fields",
+        )
+        .is_some()
+}
+
+pub(in crate::core::providers::bedrock) fn serialize_bedrock_chat_parameters(
+    request: &ChatRequest,
+) -> Result<BedrockChatParameterFields, ProviderError> {
+    let policy = bedrock_parameter_policy(&request.model);
+    validate_sampling_policy(request, policy)?;
+
+    let top_k = serialize_top_k(request, policy)?;
+    let thinking = serialize_thinking(request, policy)?;
+
+    Ok(BedrockChatParameterFields {
+        max_tokens: request.max_completion_tokens.or(request.max_tokens),
+        temperature: request.temperature.map(f64::from),
+        top_p: request.top_p.map(f64::from),
+        stop_sequences: request.stop.clone(),
+        top_k,
+        thinking,
+    })
+}
+
+fn validate_sampling_policy(
+    request: &ChatRequest,
+    policy: BedrockParameterPolicy,
+) -> Result<(), ProviderError> {
+    if policy.sampling != SamplingPolicy::ForbidNonDefault {
+        return Ok(());
+    }
+
+    if let Some(temperature) = request.temperature
+        && !float_matches_default(temperature, DEFAULT_TEMPERATURE)
+    {
+        return Err(forbidden_parameter(
+            policy,
+            "temperature",
+            "Claude Opus 4.7 on Bedrock only accepts the default temperature; omit temperature or set it to 1.0",
+        ));
+    }
+
+    if let Some(top_p) = request.top_p
+        && !float_matches_default(top_p, DEFAULT_TOP_P)
+    {
+        return Err(forbidden_parameter(
+            policy,
+            "top_p",
+            "Claude Opus 4.7 on Bedrock only accepts the default top_p; omit top_p or set it to 0.999",
+        ));
+    }
+
+    if get_extra_param(request, "top_k", "topK").is_some()
+        || additional_model_field(request, "top_k")?.is_some()
+        || additional_model_field(request, "topK")?.is_some()
+    {
+        return Err(forbidden_parameter(
+            policy,
+            "top_k",
+            "Claude Opus 4.7 on Bedrock does not accept top_k; omit the field",
+        ));
+    }
+
+    Ok(())
+}
+
+fn serialize_top_k(
+    request: &ChatRequest,
+    policy: BedrockParameterPolicy,
+) -> Result<Option<Value>, ProviderError> {
+    let top_k = get_extra_param(request, "top_k", "topK")
+        .map(|value| normalize_top_k(value, "top_k"))
+        .transpose()?;
+    let additional_top_k = additional_model_field(request, "top_k")?
+        .or(additional_model_field(request, "topK")?)
+        .map(|value| normalize_top_k(value, "additionalModelRequestFields.top_k"))
+        .transpose()?;
+
+    match (top_k, additional_top_k) {
+        (Some(_), Some(_)) => Err(ProviderError::invalid_request(
+            "bedrock",
+            "Duplicate Bedrock top_k parameter in extra_params and additionalModelRequestFields",
+        )),
+        (Some(value), None) | (None, Some(value)) => {
+            if policy.sampling == SamplingPolicy::ForbidNonDefault {
+                return Err(forbidden_parameter(
+                    policy,
+                    "top_k",
+                    "Claude Opus 4.7 on Bedrock does not accept top_k; omit the field",
+                ));
+            }
+            Ok(Some(value))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+fn serialize_thinking(
+    request: &ChatRequest,
+    policy: BedrockParameterPolicy,
+) -> Result<Option<Value>, ProviderError> {
+    if request.extra_params.contains_key("thinking") {
+        return Err(ProviderError::invalid_request(
+            "bedrock",
+            "Use ChatRequest.thinking for Bedrock thinking settings; raw extra_params.thinking is not accepted",
+        ));
+    }
+
+    if additional_model_field(request, "thinking")?.is_some() {
+        return Err(ProviderError::invalid_request(
+            "bedrock",
+            "Use ChatRequest.thinking for Bedrock thinking settings; raw additionalModelRequestFields.thinking is not accepted",
+        ));
+    }
+
+    let Some(thinking) = &request.thinking else {
+        if request.reasoning_effort.is_some() {
+            return Err(ProviderError::invalid_request(
+                "bedrock",
+                "Bedrock reasoning_effort requires ChatRequest.thinking.enabled=true",
+            ));
+        }
+        return Ok(None);
+    };
+
+    if !thinking.enabled {
+        if thinking.budget_tokens.is_some()
+            || thinking.effort.is_some()
+            || request.reasoning_effort.is_some()
+            || !thinking.extra_params.is_empty()
+            || !thinking.include_thinking
+        {
+            return Err(ProviderError::invalid_request(
+                "bedrock",
+                "Bedrock thinking settings must be enabled before setting effort, budget_tokens, include_thinking, or extra_params",
+            ));
+        }
+        return Ok(None);
+    }
+
+    match policy.thinking {
+        ThinkingPolicy::Unsupported => Err(ProviderError::invalid_request(
+            "bedrock",
+            format!(
+                "Bedrock model {} does not support local thinking serialization yet",
+                request.model
+            ),
+        )),
+        ThinkingPolicy::AnthropicAdaptive => {
+            serialize_anthropic_adaptive_thinking(request, thinking)
+        }
+    }
+}
+
+fn serialize_anthropic_adaptive_thinking(
+    request: &ChatRequest,
+    thinking: &ThinkingConfig,
+) -> Result<Option<Value>, ProviderError> {
+    if thinking.budget_tokens.is_some() {
+        return Err(ProviderError::invalid_request(
+            "bedrock",
+            format!(
+                "Bedrock model {} uses adaptive thinking and does not support budget_tokens",
+                request.model
+            ),
+        ));
+    }
+    if !thinking.include_thinking {
+        return Err(ProviderError::invalid_request(
+            "bedrock",
+            format!(
+                "Bedrock model {} cannot represent include_thinking=false for adaptive thinking",
+                request.model
+            ),
+        ));
+    }
+    if !thinking.extra_params.is_empty() {
+        return Err(ProviderError::invalid_request(
+            "bedrock",
+            format!(
+                "Bedrock model {} does not support raw thinking extra_params",
+                request.model
+            ),
+        ));
+    }
+
+    let effort = merge_thinking_effort(thinking.effort, request.reasoning_effort.as_deref())?;
+    let mut value = Map::new();
+    value.insert("type".to_string(), json!("adaptive"));
+    if let Some(effort) = effort {
+        value.insert("effort".to_string(), json!(effort));
+    }
+    Ok(Some(Value::Object(value)))
+}
+
+fn merge_thinking_effort(
+    config_effort: Option<ThinkingEffort>,
+    request_effort: Option<&str>,
+) -> Result<Option<&'static str>, ProviderError> {
+    let config_value = config_effort.map(|effort| effort.as_str());
+    let request_value = request_effort.map(validate_reasoning_effort).transpose()?;
+
+    match (config_value, request_value) {
+        (Some(config_value), Some(request_value)) if config_value != request_value => {
+            Err(ProviderError::invalid_request(
+                "bedrock",
+                format!(
+                    "Conflicting Bedrock thinking effort values: thinking.effort={config_value}, reasoning_effort={request_value}"
+                ),
+            ))
+        }
+        (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn validate_reasoning_effort(effort: &str) -> Result<&'static str, ProviderError> {
+    match effort {
+        "low" => Ok("low"),
+        "medium" => Ok("medium"),
+        "high" => Ok("high"),
+        other => Err(ProviderError::invalid_request(
+            "bedrock",
+            format!(
+                "Unsupported Bedrock reasoning_effort '{other}'; expected low, medium, or high"
+            ),
+        )),
+    }
+}
+
+fn normalize_top_k(value: &Value, field_name: &str) -> Result<Value, ProviderError> {
+    let top_k = value.as_u64().ok_or_else(|| {
+        ProviderError::invalid_request(
+            "bedrock",
+            format!("Bedrock {field_name} must be an unsigned integer"),
+        )
+    })?;
+
+    if top_k > 500 {
+        return Err(ProviderError::invalid_request(
+            "bedrock",
+            format!("Bedrock {field_name} must be less than or equal to 500"),
+        ));
+    }
+
+    Ok(json!(top_k))
+}
+
+fn additional_model_field<'a>(
+    request: &'a ChatRequest,
+    field_name: &str,
+) -> Result<Option<&'a Value>, ProviderError> {
+    let Some(fields) = get_extra_param(
+        request,
+        "additionalModelRequestFields",
+        "additional_model_request_fields",
+    ) else {
+        return Ok(None);
+    };
+
+    let object = fields.as_object().ok_or_else(|| {
+        ProviderError::invalid_request("bedrock", "additionalModelRequestFields must be an object")
+    })?;
+
+    validate_additional_model_fields(object)?;
+    Ok(object.get(field_name))
+}
+
+fn validate_additional_model_fields(fields: &Map<String, Value>) -> Result<(), ProviderError> {
+    for key in fields.keys() {
+        match key.as_str() {
+            "top_k" | "topK" | "thinking" => {}
+            other => {
+                return Err(ProviderError::invalid_request(
+                    "bedrock",
+                    format!("Unsupported Bedrock additionalModelRequestFields field: {other}"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn get_extra_param<'a>(request: &'a ChatRequest, snake: &str, camel: &str) -> Option<&'a Value> {
+    request
+        .extra_params
+        .get(snake)
+        .or_else(|| request.extra_params.get(camel))
+}
+
+fn forbidden_parameter(
+    policy: BedrockParameterPolicy,
+    parameter: &str,
+    detail: &str,
+) -> ProviderError {
+    ProviderError::invalid_request(
+        "bedrock",
+        format!(
+            "{} parameter policy forbids non-default {parameter}: {detail}",
+            policy.model_label
+        ),
+    )
+}
+
+fn float_matches_default(actual: f32, expected: f32) -> bool {
+    (actual - expected).abs() <= FLOAT_EPSILON
+}
+
+fn is_claude_opus_47_model_id(model_id: &str) -> bool {
+    let parsed = parse_bedrock_model_id(model_id);
+    parsed
+        .metadata_lookup_ids
+        .iter()
+        .any(|id| id == "anthropic.claude-opus-4-7")
+}

--- a/src/core/types/thinking.rs
+++ b/src/core/types/thinking.rs
@@ -99,7 +99,7 @@ fn default_include_thinking() -> bool {
 /// - Anthropic: maps to `thinking.enabled` and `thinking.budget_tokens`
 /// - DeepSeek: maps to `reasoning_effort`
 /// - Gemini: maps to thinking parameters
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThinkingConfig {
     /// Enable thinking mode
     #[serde(default)]
@@ -133,6 +133,18 @@ pub struct ThinkingConfig {
     /// Provider-specific extra parameters
     #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
     pub extra_params: HashMap<String, serde_json::Value>,
+}
+
+impl Default for ThinkingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            budget_tokens: None,
+            effort: None,
+            include_thinking: default_include_thinking(),
+            extra_params: HashMap::new(),
+        }
+    }
 }
 
 impl ThinkingConfig {


### PR DESCRIPTION
## Summary
- add a Bedrock parameter policy layer for model-specific sampling and thinking settings
- wire Converse additionalModelRequestFields and Anthropic Messages serialization for top_k and adaptive thinking
- reject unsupported Bedrock thinking/sampling settings locally before transport, and add Opus 4.7 runtime config fallback
- align ThinkingConfig::default with its documented include_thinking=true behavior

Fixes #577

## Validation
- cargo test bedrock_parameter_policy --lib
- cargo test claude_opus_47_has_converse_runtime_config --lib
- cargo test bedrock --lib
- cargo test anthropic --lib
- cargo check
- cargo test