### PR TITLE
fix(openai): forward typed chat parameters

### DIFF
--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -268,8 +268,29 @@ impl OpenAIProvider {
             openai_request["stream_options"] = serde_json::to_value(stream_options)?;
         }
 
-        // Add extra parameters from config
-        // Skip extra_params as BaseConfig doesn't have it
+        macro_rules! insert_optional_param {
+            ($field:ident) => {
+                if let Some(value) = request.$field {
+                    openai_request[stringify!($field)] = serde_json::to_value(value)?;
+                }
+            };
+        }
+        insert_optional_param!(frequency_penalty);
+        insert_optional_param!(presence_penalty);
+        insert_optional_param!(logit_bias);
+        insert_optional_param!(logprobs);
+        insert_optional_param!(top_logprobs);
+        insert_optional_param!(reasoning_effort);
+        insert_optional_param!(store);
+        insert_optional_param!(metadata);
+        insert_optional_param!(service_tier);
+        insert_optional_param!(parallel_tool_calls);
+
+        if let Some(obj) = openai_request.as_object_mut() {
+            for (key, value) in request.extra_params {
+                obj.entry(key).or_insert(value);
+            }
+        }
 
         Ok(openai_request)
     }

--- a/src/core/providers/openai/client_tests.rs
+++ b/src/core/providers/openai/client_tests.rs
@@ -4,7 +4,9 @@
 
 use super::*;
 use crate::core::providers::base::GlobalPoolManager;
+use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::context::RequestContext;
 use crate::core::types::model::ProviderCapability;
 use crate::core::types::{
     chat::ChatMessage, chat::ChatRequest, message::MessageContent, message::MessageRole,
@@ -24,6 +26,53 @@ fn create_test_provider() -> OpenAIProvider {
         config: create_test_config(),
         model_registry: get_openai_registry(),
     }
+}
+
+fn chat_request_with_typed_params(extra_key: &str) -> ChatRequest {
+    ChatRequest {
+        model: "gpt-4".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Hello".to_string())),
+            ..Default::default()
+        }],
+        frequency_penalty: Some(0.2),
+        presence_penalty: Some(0.4),
+        logit_bias: Some(HashMap::from([("50256".to_string(), -1.5)])),
+        logprobs: Some(true),
+        top_logprobs: Some(3),
+        reasoning_effort: Some("medium".to_string()),
+        store: Some(true),
+        metadata: Some(HashMap::from([(
+            "trace_id".to_string(),
+            "trace-123".to_string(),
+        )])),
+        service_tier: Some("flex".to_string()),
+        parallel_tool_calls: Some(false),
+        extra_params: HashMap::from([
+            (extra_key.to_string(), serde_json::json!("kept")),
+            ("model".to_string(), serde_json::json!("wrong-model")),
+            ("messages".to_string(), serde_json::json!("wrong-messages")),
+            ("frequency_penalty".to_string(), serde_json::json!(1.9)),
+        ]),
+        ..Default::default()
+    }
+}
+
+fn assert_typed_params_forwarded(json: &serde_json::Value, extra_key: &str) {
+    assert_eq!(json["frequency_penalty"], serde_json::json!(0.2_f32));
+    assert_eq!(json["presence_penalty"], serde_json::json!(0.4_f32));
+    assert_eq!(json["logit_bias"], serde_json::json!({ "50256": -1.5_f32 }));
+    assert_eq!(json["logprobs"], true);
+    assert_eq!(json["top_logprobs"], 3);
+    assert_eq!(json["reasoning_effort"], "medium");
+    assert_eq!(json["store"], true);
+    assert_eq!(json["metadata"]["trace_id"], "trace-123");
+    assert_eq!(json["service_tier"], "flex");
+    assert_eq!(json["parallel_tool_calls"], false);
+    assert_eq!(json[extra_key], "kept");
+    assert_eq!(json["model"], "gpt-4");
+    assert!(json["messages"].is_array());
 }
 
 // ==================== Provider Creation Tests ====================
@@ -387,6 +436,34 @@ fn test_transform_chat_request_with_n() {
 
     let transformed = result.unwrap();
     assert_eq!(transformed["n"], 3);
+}
+
+#[test]
+fn test_transform_chat_request_forwards_typed_params_and_extras() {
+    let provider = create_test_provider();
+    let request = chat_request_with_typed_params("modalities");
+
+    let Ok(transformed) = provider.transform_chat_request(request) else {
+        panic!("transform_chat_request must succeed");
+    };
+    assert_typed_params_forwarded(&transformed, "modalities");
+}
+
+#[tokio::test]
+async fn test_openai_like_transform_request_forwards_typed_params_and_extras() {
+    let config = OpenAILikeConfig::new("http://localhost:8000/v1").with_skip_api_key(true);
+    let Ok(provider) = OpenAILikeProvider::new(config).await else {
+        panic!("provider creation must succeed");
+    };
+    let request = chat_request_with_typed_params("provider_flag");
+
+    let Ok(transformed) = provider
+        .transform_request(request, RequestContext::default())
+        .await
+    else {
+        panic!("transform_request must succeed");
+    };
+    assert_typed_params_forwarded(&transformed, "provider_flag");
 }
 
 // ==================== Map OpenAI Params Tests ====================

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -47,7 +47,6 @@ pub struct OpenAILikeProvider {
 impl OpenAILikeProvider {
     /// Create a new OpenAI-like provider
     pub async fn new(config: OpenAILikeConfig) -> Result<Self, OpenAILikeError> {
-        // Validate configuration
         config
             .validate()
             .map_err(|e| OpenAILikeError::configuration(PROVIDER_NAME, e))?;
@@ -86,27 +85,22 @@ impl OpenAILikeProvider {
     fn get_request_headers(&self) -> Vec<HeaderPair> {
         let mut headers = Vec::with_capacity(4 + self.config.custom_headers.len());
 
-        // Add Authorization header if API key is provided
         if let Some(api_key) = &self.config.base.api_key {
             headers.push(header("Authorization", format!("Bearer {}", api_key)));
         }
 
-        // Add organization header if present
         if let Some(org) = &self.config.base.organization {
             headers.push(header("OpenAI-Organization", org.clone()));
         }
 
-        // Add base headers
         for (key, value) in &self.config.base.headers {
             headers.push(header_owned(key.clone(), value.clone()));
         }
 
-        // Add custom headers
         for (key, value) in &self.config.custom_headers {
             headers.push(header_owned(key.clone(), value.clone()));
         }
 
-        // Add OpenRouter-specific headers when OR_SITE_URL / OR_APP_NAME are set
         if self.config.provider_name == "openrouter" {
             if let Ok(site_url) = std::env::var("OR_SITE_URL") {
                 headers.push(header_owned("HTTP-Referer".to_string(), site_url));
@@ -124,10 +118,8 @@ impl OpenAILikeProvider {
         &self,
         request: ChatRequest,
     ) -> Result<ChatResponse, OpenAILikeError> {
-        // Transform request to OpenAI format
         let openai_request = self.transform_chat_request(request)?;
 
-        // Execute HTTP request
         let url = format!("{}/chat/completions", self.config.get_api_base());
         let headers = self.get_request_headers();
         let body = Some(openai_request);
@@ -138,7 +130,6 @@ impl OpenAILikeProvider {
             .await
             .map_err(|e| OpenAILikeError::network(PROVIDER_NAME, e.to_string()))?;
 
-        // Check for error status codes
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
@@ -153,7 +144,6 @@ impl OpenAILikeProvider {
         let response_json: Value = serde_json::from_slice(&response_bytes)
             .map_err(|e| OpenAILikeError::response_parsing(PROVIDER_NAME, e.to_string()))?;
 
-        // Transform response back to standard format
         self.transform_chat_response(response_json)
     }
 
@@ -165,11 +155,9 @@ impl OpenAILikeProvider {
         Pin<Box<dyn Stream<Item = Result<ChatChunk, OpenAILikeError>> + Send>>,
         OpenAILikeError,
     > {
-        // Transform request with streaming enabled
         let mut openai_request = self.transform_chat_request(request)?;
         openai_request["stream"] = Value::Bool(true);
 
-        // Execute streaming request via pool_manager's client
         let url = format!("{}/chat/completions", self.config.get_api_base());
         let client = self.pool_manager.client();
         let headers = self.get_request_headers();
@@ -180,14 +168,12 @@ impl OpenAILikeProvider {
             .await
             .map_err(|e| OpenAILikeError::network(PROVIDER_NAME, e.to_string()))?;
 
-        // Check for error status codes
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(self.map_error_response(status.as_u16(), &body));
         }
 
-        // Create stream handler using unified SSE parser
         let stream = response.bytes_stream();
         Ok(Box::pin(super::streaming::create_openai_like_stream(
             stream,
@@ -196,7 +182,6 @@ impl OpenAILikeProvider {
 
     /// Transform ChatRequest to OpenAI API format
     fn transform_chat_request(&self, request: ChatRequest) -> Result<Value, OpenAILikeError> {
-        // Get effective model name (strip prefix if configured)
         let model = self.config.get_effective_model(&request.model);
 
         let mut openai_request = serde_json::json!({
@@ -204,7 +189,6 @@ impl OpenAILikeProvider {
             "messages": request.messages
         });
 
-        // Add optional parameters
         if let Some(temp) = request.temperature {
             openai_request["temperature"] = serde_json::json!(temp);
         }
@@ -276,28 +260,43 @@ impl OpenAILikeProvider {
             None
         };
 
-        // Forward extra_params (e.g. OpenRouter-specific params, frequency_penalty, etc.)
+        macro_rules! insert_optional_param {
+            ($field:ident) => {
+                if let Some(value) = request.$field {
+                    openai_request[stringify!($field)] =
+                        serde_json::to_value(value).map_err(|e| {
+                            OpenAILikeError::serialization(PROVIDER_NAME, e.to_string())
+                        })?;
+                }
+            };
+        }
+        insert_optional_param!(frequency_penalty);
+        insert_optional_param!(presence_penalty);
+        insert_optional_param!(logit_bias);
+        insert_optional_param!(logprobs);
+        insert_optional_param!(top_logprobs);
+        insert_optional_param!(reasoning_effort);
+        insert_optional_param!(store);
+        insert_optional_param!(metadata);
+        insert_optional_param!(service_tier);
+        insert_optional_param!(parallel_tool_calls);
+
         if let Some(obj) = openai_request.as_object_mut() {
             for (key, value) in request.extra_params {
-                obj.insert(key, value);
+                obj.entry(key).or_insert(value);
             }
-            // Merge OpenRouter reasoning params without overwriting user-supplied nested keys.
-            // If both extra_params and the thinking transform produced a "reasoning" object,
-            // merge their inner keys so that user-provided flags (e.g. "exclude") are preserved.
+
             if let Some(Value::Object(params)) = openrouter_thinking_params {
                 for (key, value) in params {
                     match obj.get_mut(&key) {
                         Some(Value::Object(existing)) if value.is_object() => {
-                            // Deep merge: add thinking-param keys not already set by the user.
                             if let Value::Object(incoming) = value {
                                 for (k, v) in incoming {
                                     existing.entry(k).or_insert(v);
                                 }
                             }
                         }
-                        Some(_) => {
-                            // User already set this top-level key via extra_params; keep it.
-                        }
+                        Some(_) => {}
                         None => {
                             obj.insert(key, value);
                         }


### PR DESCRIPTION
## Summary

Closes #590.

- forwards typed chat request fields that were silently dropped by the native OpenAI serializer
- forwards the same typed fields in OpenAI-like providers before merging provider-specific `extra_params`
- prevents `extra_params` collisions from overriding core/typed fields such as `model`, `messages`, and `frequency_penalty`
- adds regression coverage for native OpenAI and OpenAI-like outbound request JSON

Fields covered: `frequency_penalty`, `presence_penalty`, `logit_bias`, `logprobs`, `top_logprobs`, `reasoning_effort`, `store`, `metadata`, `service_tier`, `parallel_tool_calls`, plus provider-specific `extra_params`.

## Root-cause proof

The new native OpenAI regression test was run before the fix and failed on missing `frequency_penalty`, proving CR-1 locally. A review-thread finding then exposed that whole-request serialization let flattened `extra_params` collisions override typed fields; the implementation now inserts typed fields directly and merges extras only when the key is not already present.

## Verification

```bash
cargo test --all-features forwards_typed_params -- --nocapture
cargo fmt --all -- --check
cargo check --all-features
cargo test --all-features
bash scripts/guards/check_pr_scope.sh
```

Results:
- targeted tests: 2 passed, including collision coverage
- fmt check: passed
- cargo check all features: passed
- full cargo test all features: passed
- scope guard: passed, 3 files / 151 changed lines

Known gate status:
- `cargo clippy --all-targets --all-features -- -D warnings` fails on existing `origin/main` lint debt outside this PR: `src/core/providers/sagemaker/sigv4.rs:74` and `src/core/providers/vertex_ai/transformers.rs:81`.
- `bash scripts/guards/check_pr_overlap.sh` reports overlap with open PR #570 on `src/core/providers/openai/client_tests.rs`. PR #570 changes one model recommendation assertion; this PR adds request-serialization regression tests elsewhere. Merge order still needs coordination: re-run overlap guard and targeted tests after whichever PR lands first.
