### PR TITLE
fix(storage): migrate database during startup

### DIFF
--- a/src/storage/database/seaorm_db/connection.rs
+++ b/src/storage/database/seaorm_db/connection.rs
@@ -13,7 +13,7 @@ impl SeaOrmDatabase {
     /// Create a new database connection with automatic SQLite fallback
     pub async fn new(config: &DatabaseConfig) -> Result<Self> {
         if !config.enabled {
-            info!("Database disabled in config. Using in-memory SQLite backend");
+            warn!("Database disabled in config; using non-persistent in-memory SQLite backend");
             return Self::in_memory_sqlite(config.connection_timeout).await;
         }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -77,6 +77,7 @@ impl StorageLayer {
         // Initialize database
         debug!("Connecting to database");
         let database = Arc::new(database::Database::new(&config.database).await?);
+        database.migrate().await?;
 
         // Initialize Redis (fail-fast unless allow_degraded is set)
         debug!("Creating Redis connection pool");
@@ -508,6 +509,46 @@ mod tests {
             "stored file should use configured path: {}",
             expected_path.display()
         );
+    }
+
+    #[tokio::test]
+    async fn default_storage_layer_runs_in_memory_sqlite_migrations() {
+        let config = StorageConfig {
+            database: DatabaseConfig::default(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("default storage layer should initialize");
+        let snapshots = storage
+            .database
+            .load_budget_limit_snapshots()
+            .await
+            .expect("default in-memory SQLite should have migrated budget tables");
+
+        assert!(snapshots.is_empty());
+    }
+
+    #[tokio::test]
+    async fn storage_layer_migrate_is_idempotent_after_startup_migration() {
+        let config = StorageConfig {
+            database: DatabaseConfig::default(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("default storage layer should initialize");
+
+        storage
+            .migrate()
+            .await
+            .expect("explicit migration after startup migration should be idempotent");
     }
 
     fn unreachable_redis_config(allow_degraded: bool) -> RedisConfig {


### PR DESCRIPTION
## Summary

Closes #591.

- runs database migrations as part of `StorageLayer::new` so startup gets usable DB tables
- raises disabled database fallback from info to warn because it uses non-persistent in-memory SQLite
- adds regression coverage proving default storage init creates migrated budget tables before first query
- adds idempotency coverage for explicitly calling `StorageLayer::migrate()` after startup migrations

## Root-cause proof

The new regression test failed before the fix with:

```text
no such table: budget_limit_snapshots
```

That reproduces the default in-memory SQLite path having a connection but no migrated schema.

## Verification

```bash
cargo test --all-features default_storage_layer_runs_in_memory_sqlite_migrations -- --nocapture
cargo test --all-features storage::tests -- --nocapture
cargo test --all-features storage_layer_ -- --nocapture
cargo fmt --all -- --check
cargo check --all-features
cargo test --all-features
bash scripts/guards/check_pr_scope.sh
bash scripts/guards/check_pr_overlap.sh
```

Results:
- regression test: passed after fix
- storage test module: 68 passed
- focused startup/idempotency tests: 4 passed
- fmt check: passed
- cargo check all features: passed
- full cargo test all features: passed
- scope guard: passed, 2 files / 43 changed lines
- overlap guard: passed, no file overlaps with open PRs
