### PR TITLE
fix(cache): reject unwired gateway cache config

### DIFF
--- a/src/config/validation/cache_validators.rs
+++ b/src/config/validation/cache_validators.rs
@@ -9,22 +9,18 @@ use crate::config::models::rate_limit::RateLimitConfig;
 
 impl Validate for CacheConfig {
     fn validate(&self) -> Result<(), String> {
-        if !self.enabled {
-            return Ok(());
+        if self.enabled {
+            return Err(
+                "Gateway cache is not wired into runtime request handling; leave cache.enabled=false until support lands"
+                    .to_string(),
+            );
         }
 
-        if self.ttl == 0 {
-            return Err("Cache TTL must be greater than 0".to_string());
-        }
-
-        if self.max_size == 0 {
-            return Err("Cache max size must be greater than 0".to_string());
-        }
-
-        if self.semantic_cache
-            && (self.similarity_threshold <= 0.0 || self.similarity_threshold > 1.0)
-        {
-            return Err("Semantic cache similarity threshold must be between 0 and 1".to_string());
+        if self.semantic_cache {
+            return Err(
+                "Semantic cache is not wired into runtime request handling; leave cache.semantic_cache=false until support lands"
+                    .to_string(),
+            );
         }
 
         Ok(())

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -193,10 +193,32 @@ fn test_cache_validation_skips_when_disabled() {
         enabled: false,
         ttl: 0,
         max_size: 0,
-        semantic_cache: true,
+        semantic_cache: false,
         similarity_threshold: 2.0,
     };
     assert!(Validate::validate(&config).is_ok());
+}
+
+#[test]
+fn test_cache_validation_rejects_unwired_cache_enabled() {
+    let config = CacheConfig {
+        enabled: true,
+        ..Default::default()
+    };
+
+    let error = Validate::validate(&config).unwrap_err();
+    assert!(error.contains("not wired into runtime"));
+}
+
+#[test]
+fn test_cache_validation_rejects_unwired_semantic_cache() {
+    let config = CacheConfig {
+        semantic_cache: true,
+        ..Default::default()
+    };
+
+    let error = Validate::validate(&config).unwrap_err();
+    assert!(error.contains("not wired into runtime"));
 }
 
 #[test]

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -2,8 +2,8 @@
 //!
 //! This module provides the HttpServer struct and its core methods.
 
-use crate::config::Config;
 use crate::config::models::server::{CorsConfig, ServerConfig};
+use crate::config::{Config, Validate};
 use crate::core::budget::UnifiedBudgetLimits;
 use crate::core::pricing_service::PricingService;
 use crate::core::rate_limiter::{get_global_rate_limiter, init_global_rate_limiter_with_redis};
@@ -40,6 +40,8 @@ impl HttpServer {
         info!("Creating HTTP server");
 
         Self::validate_cors_config(&config.gateway.server.cors)?;
+        Validate::validate(&config.gateway.cache)
+            .map_err(|e| GatewayError::Config(format!("Invalid cache configuration: {}", e)))?;
         start_auth_rate_limiter_cleanup_task();
 
         let storage = crate::storage::StorageLayer::new(&config.gateway.storage).await?;
@@ -458,6 +460,28 @@ mod tests {
              got: {:?}",
             result.err()
         );
+    }
+
+    #[tokio::test]
+    async fn new_rejects_unwired_cache_config() {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+        config.gateway.cache.enabled = true;
+
+        let error = match HttpServer::new(&config).await {
+            Ok(_) => panic!("expected unwired cache configuration to fail startup"),
+            Err(error) => error,
+        };
+
+        match error {
+            GatewayError::Config(message) => {
+                assert!(message.contains("Invalid cache configuration"));
+                assert!(message.contains("not wired into runtime"));
+            }
+            other => panic!("expected config error, got: {other:?}"),
+        }
     }
 
     /// In-memory budget snapshots load succeeds (returns empty) on sqlite, so


### PR DESCRIPTION
Closes #593.

## Summary
- reject `cache.enabled=true` because gateway cache is not wired into runtime request handling
- reject `cache.semantic_cache=true` for the same reason
- validate cache config in `HttpServer::new` so direct startup paths cannot silently accept inert cache config

## Verification
- `cargo test --all-features rejects_unwired -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Known unrelated local lint baseline
- `cargo clippy --all-targets --all-features -- -D warnings` still fails on existing main-line lint findings in `src/core/providers/sagemaker/sigv4.rs:74` and `src/core/providers/vertex_ai/transformers.rs:81`; this PR does not touch those files.