### PR TITLE
fix(provider): enforce dispatch classification contract

### DIFF
--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -187,9 +187,71 @@ impl Provider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use provider_registry::{ProviderDispatchKind, provider_type_registry};
 
     fn supported_factory_provider_types() -> Vec<ProviderType> {
         Provider::factory_supported_provider_types().to_vec()
+    }
+
+    fn minimal_dispatch_config() -> serde_json::Value {
+        serde_json::json!({
+            "api_key": "sk-test-key",
+            "api_base": "https://example.test/v1",
+            "base_url": "https://example.test/v1",
+            "endpoint": "https://example.test/v1",
+            "provider_name": "test-openai-compatible",
+            "organization": "test-account",
+            "account_id": "test-account",
+            "aws_access_key_id": "AKIA_TEST",
+            "aws_secret_access_key": "secret-test",
+            "aws_region": "us-east-1",
+            "skip_api_key": false
+        })
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_kind_matches_runtime_variant() {
+        for entry in provider_type_registry() {
+            if !entry.is_dispatchable() {
+                continue;
+            }
+
+            let provider =
+                Provider::from_config_async(entry.provider_type.clone(), minimal_dispatch_config())
+                    .await
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "{:?} should be creatable for dispatch-kind guard: {}",
+                            entry.provider_type, err
+                        )
+                    });
+
+            match entry.dispatch_kind {
+                ProviderDispatchKind::Native => match (&entry.provider_type, &provider) {
+                    (ProviderType::OpenAI, Provider::OpenAI(_))
+                    | (ProviderType::Anthropic, Provider::Anthropic(_))
+                    | (ProviderType::Bedrock, Provider::Bedrock(_))
+                    | (ProviderType::Mistral, Provider::Mistral(_))
+                    | (ProviderType::Cloudflare, Provider::Cloudflare(_)) => {}
+                    _ => panic!(
+                        "{:?} is classified Native but created runtime provider {:?}",
+                        entry.provider_type,
+                        provider.provider_type()
+                    ),
+                },
+                ProviderDispatchKind::ExplicitOpenAiLike
+                | ProviderDispatchKind::CatalogOpenAiLike => assert!(
+                    matches!(provider, Provider::OpenAILike(_)),
+                    "{:?} is classified OpenAI-like but created {:?}",
+                    entry.provider_type,
+                    provider.provider_type()
+                ),
+                ProviderDispatchKind::UnsupportedEnum => unreachable!(
+                    "{:?} is not dispatchable and should have been skipped",
+                    entry.provider_type
+                ),
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -9,7 +9,7 @@
 /// Lifecycle decision for a provider module directory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderModuleLifecycle {
-    /// The provider is reachable from the runtime factory or a supported runtime path.
+    /// The provider module is reachable through a native runtime `Provider` enum branch.
     Wire,
     /// The provider should be represented by catalog metadata instead of a code module.
     CatalogOnly,
@@ -34,18 +34,18 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "ai21",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    wire(
+    stub(
         "amazon_nova",
-        "ProviderType::AmazonNova has an explicit OpenAI-compatible factory branch",
+        "native module retained; ProviderType::AmazonNova currently uses a generic OpenAI-compatible adapter",
     ),
     wire("anthropic", "native Provider enum variant"),
-    wire(
+    stub(
         "azure",
-        "ProviderType::Azure has an explicit OpenAI-compatible factory branch",
+        "native Azure module retained; ProviderType::Azure currently uses a generic OpenAI-compatible adapter",
     ),
-    wire(
+    stub(
         "azure_ai",
-        "ProviderType::AzureAI has an explicit OpenAI-compatible factory branch",
+        "native Azure AI module retained; ProviderType::AzureAI currently uses a generic OpenAI-compatible adapter",
     ),
     internal("base", "shared provider infrastructure"),
     stub(
@@ -99,9 +99,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "specialized provider module; not wired through the LLM factory yet",
     ),
     internal("factory", "provider construction infrastructure"),
-    wire(
+    stub(
         "fal_ai",
-        "ProviderType::FalAI has an explicit OpenAI-compatible factory branch",
+        "native Fal AI module retained; ProviderType::FalAI currently uses a generic OpenAI-compatible adapter",
     ),
     stub(
         "firecrawl",
@@ -111,13 +111,13 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "gemini",
         "specialized provider module used for model metadata but not wired through the LLM factory",
     ),
-    wire(
+    stub(
         "github",
-        "ProviderType::GitHub has an explicit OpenAI-compatible factory branch",
+        "native GitHub module retained; ProviderType::GitHub currently uses a generic OpenAI-compatible adapter",
     ),
-    wire(
+    stub(
         "github_copilot",
-        "ProviderType::GitHubCopilot has an explicit OpenAI-compatible factory branch",
+        "native GitHub Copilot module retained; ProviderType::GitHubCopilot currently uses a generic OpenAI-compatible adapter",
     ),
     stub(
         "gigachat",
@@ -148,9 +148,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "manus",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    wire(
+    stub(
         "meta_llama",
-        "ProviderType::MetaLlama has an explicit OpenAI-compatible factory branch",
+        "native Meta Llama module retained; ProviderType::MetaLlama currently uses a generic OpenAI-compatible adapter",
     ),
     internal(
         "milvus",
@@ -196,9 +196,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "specialized provider module; not wired through the LLM factory yet",
     ),
     internal("registry", "provider catalog and lifecycle infrastructure"),
-    wire(
+    stub(
         "replicate",
-        "ProviderType::Replicate has an explicit OpenAI-compatible factory branch",
+        "native Replicate module retained; ProviderType::Replicate currently uses a generic OpenAI-compatible adapter",
     ),
     stub(
         "runwayml",
@@ -241,17 +241,17 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "triton",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    wire(
+    stub(
         "v0",
-        "ProviderType::V0 has an explicit OpenAI-compatible factory branch",
+        "native V0 module retained; ProviderType::V0 currently uses a generic OpenAI-compatible adapter",
     ),
     stub(
         "vercel_ai",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    wire(
+    stub(
         "vertex_ai",
-        "ProviderType::VertexAI has an explicit OpenAI-compatible factory branch",
+        "native Vertex AI module retained; ProviderType::VertexAI currently uses a generic OpenAI-compatible adapter",
     ),
     stub(
         "voyage",
@@ -303,6 +303,45 @@ mod tests {
             .iter()
             .map(|entry| entry.module_name)
             .collect()
+    }
+
+    fn lifecycle_for(module_name: &str) -> ProviderModuleLifecycle {
+        PROVIDER_MODULE_LIFECYCLE
+            .iter()
+            .find(|entry| entry.module_name == module_name)
+            .unwrap_or_else(|| panic!("missing lifecycle entry for {module_name}"))
+            .lifecycle
+    }
+
+    #[test]
+    fn lifecycle_classifies_phase0_key_provider_modules() {
+        assert_eq!(lifecycle_for("bedrock"), ProviderModuleLifecycle::Wire);
+        assert_eq!(lifecycle_for("vertex_ai"), ProviderModuleLifecycle::Stub);
+        assert_eq!(lifecycle_for("azure"), ProviderModuleLifecycle::Stub);
+        assert_eq!(lifecycle_for("azure_ai"), ProviderModuleLifecycle::Stub);
+        assert_eq!(lifecycle_for("cohere"), ProviderModuleLifecycle::Stub);
+        assert_eq!(lifecycle_for("gemini"), ProviderModuleLifecycle::Stub);
+    }
+
+    #[test]
+    fn lifecycle_wire_entries_are_native_runtime_modules() {
+        let actual = PROVIDER_MODULE_LIFECYCLE
+            .iter()
+            .filter(|entry| entry.lifecycle == ProviderModuleLifecycle::Wire)
+            .map(|entry| entry.module_name)
+            .collect::<BTreeSet<_>>();
+        let expected = [
+            "anthropic",
+            "bedrock",
+            "cloudflare",
+            "mistral",
+            "openai",
+            "openai_like",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -274,7 +274,7 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::OpenAICompatible,
         "openai_compatible",
         &["openai-compatible", "openai_like", "openai-like"],
-        ProviderDispatchKind::Native,
+        ProviderDispatchKind::ExplicitOpenAiLike,
         false,
     ),
 ];
@@ -343,6 +343,13 @@ mod tests {
         values
     }
 
+    fn dispatch_kind_for(provider_type: &ProviderType) -> ProviderDispatchKind {
+        match entry_for_type(provider_type) {
+            Some(entry) => entry.dispatch_kind,
+            None => panic!("missing provider registry entry for {:?}", provider_type),
+        }
+    }
+
     #[test]
     fn provider_registry_contains_all_non_custom_provider_types() {
         assert_eq!(
@@ -374,6 +381,54 @@ mod tests {
         for entry in PROVIDER_TYPE_REGISTRY {
             assert_eq!(entry.provider_type.to_string(), entry.canonical_name);
         }
+    }
+
+    #[test]
+    fn provider_registry_native_entries_match_provider_enum_variants() {
+        let native_types = PROVIDER_TYPE_REGISTRY
+            .iter()
+            .filter(|entry| entry.dispatch_kind == ProviderDispatchKind::Native)
+            .map(|entry| entry.provider_type.clone())
+            .collect::<HashSet<_>>();
+        let expected = [
+            ProviderType::OpenAI,
+            ProviderType::Anthropic,
+            ProviderType::Bedrock,
+            ProviderType::Mistral,
+            ProviderType::Cloudflare,
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+
+        assert_eq!(native_types, expected);
+    }
+
+    #[test]
+    fn provider_registry_phase0_key_provider_classifications() {
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::Bedrock),
+            ProviderDispatchKind::Native
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::VertexAI),
+            ProviderDispatchKind::ExplicitOpenAiLike
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::Azure),
+            ProviderDispatchKind::ExplicitOpenAiLike
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::AzureAI),
+            ProviderDispatchKind::ExplicitOpenAiLike
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::OpenAICompatible),
+            ProviderDispatchKind::ExplicitOpenAiLike
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::PydanticAI),
+            ProviderDispatchKind::UnsupportedEnum
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #594.

## Summary
- classify `ProviderType::OpenAICompatible` as explicit OpenAI-like dispatch instead of native dispatch
- narrow provider module `Wire` lifecycle to native runtime `Provider` enum branches only
- mark retained native modules that are currently bypassed by generic OpenAI-like factory paths as `Stub`
- add dispatch/lifecycle guard tests so registry declarations must match actual runtime variants

## Follow-up issues created
- #599 Azure/AzureAI native dispatch
- #600 Vertex AI native dispatch
- #601 Gemini native dispatch contract
- #602 Cohere native dispatch contract
- #603 Replicate native dispatch
- #604 FalAI dispatch contract
- #605 GitHub Copilot native auth dispatch
- #606 catalogify explicit OpenAI-like adapter providers

## Verification
- `cargo test --all-features test_dispatch_kind_matches_runtime_variant -- --nocapture`
- `cargo test --all-features lifecycle_ -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test --all-features provider_registry_ -- --nocapture`
- `cargo check --all-features`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Known unrelated local lint baseline
- Local `cargo clippy --all-targets --all-features -- -D warnings` on rustc 1.95 fails in untouched files: `src/core/providers/sagemaker/sigv4.rs:74` (`unnecessary_sort_by`) and `src/core/providers/vertex_ai/transformers.rs:81` (`manual_map`). This PR does not touch those files.