### PR TITLE
fix(pricing): validate negative costs and duration dispatch

### DIFF
--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -25,9 +25,9 @@ fn require_pricing_field(
             pricing_type, model, field
         ))
     })?;
-    if value < 0.0 {
+    if value < 0.0 || value.is_nan() {
         return Err(GatewayError::Config(format!(
-            "Negative {} for model {}: {} ({})",
+            "Invalid {} for model {}: {} ({})",
             pricing_type, model, field, value
         )));
     }
@@ -41,9 +41,9 @@ fn require_total_time_seconds(model: &str, total_time_seconds: Option<f64>) -> R
             model
         ))
     })?;
-    if total_time_seconds < 0.0 {
+    if total_time_seconds < 0.0 || total_time_seconds.is_nan() {
         return Err(GatewayError::validation(format!(
-            "Negative total_time_seconds ({}) for model {}",
+            "Invalid total_time_seconds ({}) for model {}",
             total_time_seconds, model
         )));
     }

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -19,12 +19,35 @@ fn require_pricing_field(
     pricing_type: &str,
     field: &str,
 ) -> Result<f64> {
-    value.ok_or_else(|| {
+    let value = value.ok_or_else(|| {
         GatewayError::Config(format!(
             "Missing {} for model {}: {}",
             pricing_type, model, field
         ))
-    })
+    })?;
+    if value < 0.0 {
+        return Err(GatewayError::Config(format!(
+            "Negative {} for model {}: {} ({})",
+            pricing_type, model, field, value
+        )));
+    }
+    Ok(value)
+}
+
+fn require_total_time_seconds(model: &str, total_time_seconds: Option<f64>) -> Result<f64> {
+    let total_time_seconds = total_time_seconds.ok_or_else(|| {
+        GatewayError::validation(format!(
+            "Missing total_time_seconds for time-based pricing model {}",
+            model
+        ))
+    })?;
+    if total_time_seconds < 0.0 {
+        return Err(GatewayError::validation(format!(
+            "Negative total_time_seconds ({}) for model {}",
+            total_time_seconds, model
+        )));
+    }
+    Ok(total_time_seconds)
 }
 
 /// Pricing service using LiteLLM data format
@@ -91,10 +114,12 @@ impl PricingService {
             .get_model_info(model)
             .ok_or_else(|| GatewayError::not_found(format!("Model not found: {}", model)))?;
 
-        let provider = model_info.litellm_provider.clone();
+        if model_info.cost_per_second.is_some() {
+            let total_time_seconds = require_total_time_seconds(model, total_time_seconds)?;
+            return self.calculate_time_based_cost(model, &model_info, total_time_seconds);
+        }
 
-        // Provider-specific cost calculation
-        match provider.as_str() {
+        match model_info.litellm_provider.as_str() {
             "openai" | "azure" => {
                 self.calculate_token_based_cost(model, &model_info, input_tokens, output_tokens)
             }
@@ -109,15 +134,6 @@ impl PricingService {
                 prompt,
                 completion,
             ),
-            "replicate" | "together_ai" | "baseten" => {
-                let total_time_seconds = total_time_seconds.ok_or_else(|| {
-                    GatewayError::validation(format!(
-                        "Missing total_time_seconds for time-based pricing model {}",
-                        model
-                    ))
-                })?;
-                self.calculate_time_based_cost(model, &model_info, total_time_seconds)
-            }
             "zhipuai" | "glm" => {
                 self.calculate_token_based_cost(model, &model_info, input_tokens, output_tokens)
             }

--- a/src/core/pricing_service/service_tests.rs
+++ b/src/core/pricing_service/service_tests.rs
@@ -330,7 +330,24 @@ fn pricing_review_rejects_negative_token_pricing_field() {
         Err(GatewayError::Config(message))
             if message.contains("gpt-negative-token")
                 && message.contains("input_cost_per_token")
-                && message.contains("Negative token pricing")
+                && message.contains("Invalid token pricing")
+    ));
+}
+
+#[test]
+fn pricing_review_rejects_nan_token_pricing_field() {
+    let service = PricingService::new(None);
+    let mut model_info = create_test_model_info("openai");
+    model_info.output_cost_per_token = Some(f64::NAN);
+
+    let result = service.calculate_token_based_cost("gpt-nan-token", &model_info, 1000, 500);
+
+    assert!(matches!(
+        result,
+        Err(GatewayError::Config(message))
+            if message.contains("gpt-nan-token")
+                && message.contains("output_cost_per_token")
+                && message.contains("Invalid token pricing")
     ));
 }
 
@@ -354,7 +371,7 @@ fn pricing_review_rejects_negative_character_pricing_field() {
         Err(GatewayError::Config(message))
             if message.contains("gemini-negative-char")
                 && message.contains("output_cost_per_character")
-                && message.contains("Negative character pricing")
+                && message.contains("Invalid character pricing")
     ));
 }
 
@@ -371,7 +388,7 @@ fn pricing_review_rejects_negative_time_pricing_field() {
         Err(GatewayError::Config(message))
             if message.contains("replicate/negative-time")
                 && message.contains("cost_per_second")
-                && message.contains("Negative time pricing")
+                && message.contains("Invalid time pricing")
     ));
 }
 
@@ -392,7 +409,28 @@ async fn pricing_review_rejects_negative_total_time_seconds() {
         result,
         Err(GatewayError::Validation(message))
             if message.contains("replicate/negative-duration")
-                && message.contains("Negative total_time_seconds")
+                && message.contains("Invalid total_time_seconds")
+    ));
+}
+
+#[tokio::test]
+async fn pricing_review_rejects_nan_total_time_seconds() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "replicate/nan-duration".to_string(),
+        create_time_based_model_info("replicate"),
+    );
+    service.pricing_data.write().last_updated = SystemTime::now();
+
+    let result = service
+        .calculate_completion_cost("replicate/nan-duration", 0, 0, None, None, Some(f64::NAN))
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GatewayError::Validation(message))
+            if message.contains("replicate/nan-duration")
+                && message.contains("Invalid total_time_seconds")
     ));
 }
 

--- a/src/core/pricing_service/service_tests.rs
+++ b/src/core/pricing_service/service_tests.rs
@@ -42,6 +42,14 @@ fn create_character_based_model_info() -> LiteLLMModelInfo {
     }
 }
 
+fn create_time_based_model_info(provider: &str) -> LiteLLMModelInfo {
+    let mut model_info = create_test_model_info(provider);
+    model_info.input_cost_per_token = None;
+    model_info.output_cost_per_token = None;
+    model_info.cost_per_second = Some(0.001);
+    model_info
+}
+
 // ==================== Provider and Model Listing Tests ====================
 
 #[test]
@@ -294,10 +302,7 @@ async fn test_calculate_completion_cost_propagates_missing_token_pricing() {
 #[tokio::test]
 async fn test_calculate_completion_cost_requires_time_for_time_based_pricing() {
     let service = PricingService::new(None);
-    let mut model_info = create_test_model_info("replicate");
-    model_info.input_cost_per_token = None;
-    model_info.output_cost_per_token = None;
-    model_info.cost_per_second = Some(0.001);
+    let model_info = create_time_based_model_info("replicate");
     service.add_custom_model("replicate/timed".to_string(), model_info);
     service.pricing_data.write().last_updated = SystemTime::now();
 
@@ -310,6 +315,131 @@ async fn test_calculate_completion_cost_requires_time_for_time_based_pricing() {
         Err(GatewayError::Validation(message))
             if message.contains("replicate/timed") && message.contains("total_time_seconds")
     ));
+}
+
+#[test]
+fn pricing_review_rejects_negative_token_pricing_field() {
+    let service = PricingService::new(None);
+    let mut model_info = create_test_model_info("openai");
+    model_info.input_cost_per_token = Some(-0.00001);
+
+    let result = service.calculate_token_based_cost("gpt-negative-token", &model_info, 1000, 500);
+
+    assert!(matches!(
+        result,
+        Err(GatewayError::Config(message))
+            if message.contains("gpt-negative-token")
+                && message.contains("input_cost_per_token")
+                && message.contains("Negative token pricing")
+    ));
+}
+
+#[test]
+fn pricing_review_rejects_negative_character_pricing_field() {
+    let service = PricingService::new(None);
+    let mut model_info = create_character_based_model_info();
+    model_info.output_cost_per_character = Some(-0.000002);
+
+    let result = service.calculate_google_cost(
+        "gemini-negative-char",
+        &model_info,
+        10,
+        5,
+        Some("p"),
+        Some("c"),
+    );
+
+    assert!(matches!(
+        result,
+        Err(GatewayError::Config(message))
+            if message.contains("gemini-negative-char")
+                && message.contains("output_cost_per_character")
+                && message.contains("Negative character pricing")
+    ));
+}
+
+#[test]
+fn pricing_review_rejects_negative_time_pricing_field() {
+    let service = PricingService::new(None);
+    let mut model_info = create_time_based_model_info("replicate");
+    model_info.cost_per_second = Some(-0.001);
+
+    let result = service.calculate_time_based_cost("replicate/negative-time", &model_info, 10.0);
+
+    assert!(matches!(
+        result,
+        Err(GatewayError::Config(message))
+            if message.contains("replicate/negative-time")
+                && message.contains("cost_per_second")
+                && message.contains("Negative time pricing")
+    ));
+}
+
+#[tokio::test]
+async fn pricing_review_rejects_negative_total_time_seconds() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "replicate/negative-duration".to_string(),
+        create_time_based_model_info("replicate"),
+    );
+    service.pricing_data.write().last_updated = SystemTime::now();
+
+    let result = service
+        .calculate_completion_cost("replicate/negative-duration", 0, 0, None, None, Some(-1.0))
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(GatewayError::Validation(message))
+            if message.contains("replicate/negative-duration")
+                && message.contains("Negative total_time_seconds")
+    ));
+}
+
+#[tokio::test]
+async fn pricing_review_uses_token_pricing_for_token_priced_together_ai_model() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "together/token-priced".to_string(),
+        create_test_model_info("together_ai"),
+    );
+    service.pricing_data.write().last_updated = SystemTime::now();
+
+    let result = service
+        .calculate_completion_cost("together/token-priced", 1000, 500, None, None, None)
+        .await;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(error) => panic!("expected token pricing success, got {error:?}"),
+    };
+
+    assert_eq!(result.cost_type, CostType::TokenBased);
+    assert_eq!(result.input_cost, 1000.0 * 0.00001);
+    assert_eq!(result.output_cost, 500.0 * 0.00003);
+}
+
+#[tokio::test]
+async fn pricing_review_uses_token_pricing_for_token_priced_baseten_model() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "baseten/token-priced".to_string(),
+        create_test_model_info("baseten"),
+    );
+    service.pricing_data.write().last_updated = SystemTime::now();
+
+    let result = service
+        .calculate_completion_cost("baseten/token-priced", 2000, 750, None, None, None)
+        .await;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(error) => panic!("expected token pricing success, got {error:?}"),
+    };
+
+    assert_eq!(result.cost_type, CostType::TokenBased);
+    assert_eq!(result.input_cost, 2000.0 * 0.00001);
+    assert_eq!(result.output_cost, 750.0 * 0.00003);
 }
 
 // ==================== Clone Tests ====================


### PR DESCRIPTION
## What

- Reject negative or NaN token, character, and time pricing fields before calculating cost.
- Reject negative or NaN `total_time_seconds` for duration-priced models.
- Route duration pricing from `cost_per_second` availability instead of hard-coded provider names, so token-priced `together_ai` and `baseten` models use token pricing without requiring duration.
- Add regression tests for the review findings from #597 and the follow-up NaN review on this PR.

## Why

Follow-up to #597 review feedback. The previous implementation still allowed invalid cost calculations and forced all `together_ai` / `baseten` models through duration pricing even when the model data only had token prices.

Closes #608.

## Test Plan

- [x] `cargo test --all-features pricing_review_ -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-features`
- [x] `cargo test --all-features`
- [x] `bash scripts/guards/check_pr_scope.sh`
- [x] `bash scripts/guards/check_pr_overlap.sh`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` fails locally on existing unrelated lints outside this PR: `src/core/providers/sagemaker/sigv4.rs:74` and `src/core/providers/vertex_ai/transformers.rs:81`
- [ ] Tested manually: not applicable; covered by unit/regression tests
