### PR TITLE
fix(storage): make startup migrations configurable

### DIFF
--- a/config/gateway.dev.yaml.example
+++ b/config/gateway.dev.yaml.example
@@ -54,6 +54,7 @@ storage:
     connection_timeout: 5
     ssl: false
     enabled: false
+    auto_migrate: false
   redis:
     url: "redis://localhost:6379"
     enabled: false

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -88,6 +88,9 @@ storage:
     connection_timeout: 5
     ssl: false
     enabled: false
+    # Keep false in production runtime. Run migrations before startup, or set
+    # true only when this process is allowed to execute database DDL.
+    auto_migrate: false
   redis:
     url: "redis://localhost:6379"
     # Enable only when Redis is deployed; otherwise the gateway uses local

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -24,6 +24,7 @@ const ENV_DATABASE_MAX_CONNECTIONS: &str = "LITELLM_DATABASE_MAX_CONNECTIONS";
 const ENV_DATABASE_CONNECTION_TIMEOUT: &str = "LITELLM_DATABASE_CONNECTION_TIMEOUT";
 const ENV_DATABASE_SSL: &str = "LITELLM_DATABASE_SSL";
 const ENV_DATABASE_ENABLED: &str = "LITELLM_DATABASE_ENABLED";
+const ENV_DATABASE_AUTO_MIGRATE: &str = "LITELLM_DATABASE_AUTO_MIGRATE";
 const ENV_REDIS_URL: &str = "LITELLM_REDIS_URL";
 const ENV_REDIS_ENABLED: &str = "LITELLM_REDIS_ENABLED";
 const ENV_REDIS_MAX_CONNECTIONS: &str = "LITELLM_REDIS_MAX_CONNECTIONS";
@@ -328,6 +329,9 @@ impl GatewayConfig {
         }
         if let Some(enabled) = parse_env_bool(ENV_DATABASE_ENABLED)? {
             config.storage.database.enabled = enabled;
+        }
+        if let Some(auto_migrate) = parse_env_bool(ENV_DATABASE_AUTO_MIGRATE)? {
+            config.storage.database.auto_migrate = auto_migrate;
         }
 
         if let Some(redis_url) = env_var(ENV_REDIS_URL) {

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -4,12 +4,14 @@ use std::sync::Mutex;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-const TEST_ENV_KEYS: [&str; 21] = [
+const TEST_ENV_KEYS: [&str; 23] = [
     ENV_HOST,
     ENV_PORT,
     ENV_WORKERS,
     ENV_TIMEOUT,
     ENV_DATABASE_URL,
+    ENV_DATABASE_ENABLED,
+    ENV_DATABASE_AUTO_MIGRATE,
     ENV_ENABLE_JWT,
     ENV_ENABLE_API_KEY,
     ENV_JWT_SECRET,
@@ -82,6 +84,8 @@ fn test_gateway_config_from_env() {
             ENV_DATABASE_URL,
             "postgresql://env-user:env-pass@localhost/env-db",
         );
+        env::set_var(ENV_DATABASE_ENABLED, "true");
+        env::set_var(ENV_DATABASE_AUTO_MIGRATE, "true");
         env::set_var(ENV_ENABLE_JWT, "true");
         env::set_var(ENV_JWT_SECRET, "StrongJwtSecretWithMixedCaseAndNumbers1234");
         env::set_var(ENV_PROVIDERS, "openai");
@@ -107,6 +111,8 @@ fn test_gateway_config_from_env() {
         config.storage.database.url,
         "postgresql://env-user:env-pass@localhost/env-db"
     );
+    assert!(config.storage.database.enabled);
+    assert!(config.storage.database.auto_migrate);
     assert_eq!(config.providers.len(), 1);
     assert_eq!(config.providers[0].name, "openai");
     assert_eq!(config.providers[0].provider_type, "openai");

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -110,9 +110,7 @@ impl DatabaseConfig {
         if other.enabled {
             self.enabled = true;
         }
-        if other.auto_migrate {
-            self.auto_migrate = true;
-        }
+        self.auto_migrate = other.auto_migrate;
         if other.fallback_to_sqlite {
             self.fallback_to_sqlite = true;
         }
@@ -306,13 +304,13 @@ mod tests {
     }
 
     #[test]
-    fn test_database_config_merge_preserves_auto_migrate_on_default_overlay() {
+    fn test_database_config_merge_auto_migrate_false_overrides_base() {
         let base = DatabaseConfig {
             auto_migrate: true,
             ..DatabaseConfig::default()
         };
         let merged = base.merge(DatabaseConfig::default());
-        assert!(merged.auto_migrate);
+        assert!(!merged.auto_migrate);
     }
 
     #[test]

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -52,6 +52,13 @@ pub struct DatabaseConfig {
     /// Enable database (if false, use in-memory storage)
     #[serde(default)]
     pub enabled: bool,
+    /// Run database migrations automatically during storage startup.
+    ///
+    /// Disabled by default for configured databases so production runtime
+    /// users do not need DDL privileges. The storage layer still migrates the
+    /// non-persistent in-memory SQLite fallback used when `enabled=false`.
+    #[serde(default)]
+    pub auto_migrate: bool,
     /// Allow PostgreSQL connection failures to fall back to local SQLite.
     ///
     /// Disabled by default to avoid silently writing production data to a
@@ -77,6 +84,7 @@ impl Default for DatabaseConfig {
             connection_timeout: default_connection_timeout(),
             ssl: false,
             enabled: false,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         }
@@ -101,6 +109,9 @@ impl DatabaseConfig {
         }
         if other.enabled {
             self.enabled = true;
+        }
+        if other.auto_migrate {
+            self.auto_migrate = true;
         }
         if other.fallback_to_sqlite {
             self.fallback_to_sqlite = true;
@@ -198,6 +209,7 @@ mod tests {
         assert_eq!(config.connection_timeout, 5);
         assert!(!config.ssl);
         assert!(!config.enabled);
+        assert!(!config.auto_migrate);
         assert!(!config.fallback_to_sqlite);
     }
 
@@ -209,11 +221,13 @@ mod tests {
             connection_timeout: 60,
             ssl: true,
             enabled: true,
+            auto_migrate: true,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
         assert!(config.ssl);
         assert!(config.enabled);
+        assert!(config.auto_migrate);
         assert_eq!(config.max_connections, 20);
     }
 
@@ -225,6 +239,7 @@ mod tests {
             connection_timeout: 45,
             ssl: true,
             enabled: true,
+            auto_migrate: true,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -232,6 +247,7 @@ mod tests {
         assert_eq!(json["url"], "postgresql://test");
         assert_eq!(json["max_connections"], 15);
         assert_eq!(json["ssl"], true);
+        assert_eq!(json["auto_migrate"], true);
     }
 
     #[test]
@@ -240,6 +256,7 @@ mod tests {
         let config: DatabaseConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.url, "postgresql://prod/app");
         assert!(config.ssl);
+        assert!(!config.auto_migrate);
     }
 
     #[test]
@@ -275,6 +292,27 @@ mod tests {
         };
         let merged = base.merge(other);
         assert!(merged.enabled);
+    }
+
+    #[test]
+    fn test_database_config_merge_auto_migrate_true() {
+        let base = DatabaseConfig::default();
+        let other = DatabaseConfig {
+            auto_migrate: true,
+            ..DatabaseConfig::default()
+        };
+        let merged = base.merge(other);
+        assert!(merged.auto_migrate);
+    }
+
+    #[test]
+    fn test_database_config_merge_preserves_auto_migrate_on_default_overlay() {
+        let base = DatabaseConfig {
+            auto_migrate: true,
+            ..DatabaseConfig::default()
+        };
+        let merged = base.merge(DatabaseConfig::default());
+        assert!(merged.auto_migrate);
     }
 
     #[test]
@@ -581,6 +619,15 @@ mod tests {
         assert!(
             !config.allow_degraded,
             "allow_degraded must default to false so explicit failures are surfaced"
+        );
+    }
+
+    #[test]
+    fn test_database_config_auto_migrate_default_false() {
+        let config = DatabaseConfig::default();
+        assert!(
+            !config.auto_migrate,
+            "auto_migrate must default to false for configured databases"
         );
     }
 

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -240,6 +240,7 @@ fn test_database_validation_skips_when_disabled() {
         max_connections: 0,
         connection_timeout: 0,
         ssl: false,
+        auto_migrate: false,
         fallback_to_sqlite: false,
         allow_degraded: false,
     };

--- a/src/storage/database/seaorm_db/connection.rs
+++ b/src/storage/database/seaorm_db/connection.rs
@@ -1,7 +1,8 @@
 use crate::config::models::storage::DatabaseConfig;
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use sea_orm::*;
-use sea_orm_migration::MigratorTrait;
+use sea_orm_migration::{MigratorTrait, seaql_migrations};
+use std::collections::HashSet;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -127,6 +128,40 @@ impl SeaOrmDatabase {
         })?;
         info!("Database migrations completed successfully");
         Ok(())
+    }
+
+    /// Verify all repository migrations have already been applied without
+    /// creating or modifying migration metadata.
+    pub async fn verify_migrations_applied(&self) -> Result<()> {
+        let applied_migrations = seaql_migrations::Entity::find()
+            .all(&self.db)
+            .await
+            .map_err(|e| {
+                GatewayError::Storage(format!(
+                    "Database migration metadata is missing or unreadable: {}",
+                    e
+                ))
+            })?;
+        let applied_versions: HashSet<String> = applied_migrations
+            .into_iter()
+            .map(|migration| migration.version)
+            .collect();
+        let pending_migrations: Vec<String> = Migrator::get_migration_files()
+            .into_iter()
+            .filter_map(|migration| {
+                let name = migration.name().to_string();
+                (!applied_versions.contains(&name)).then_some(name)
+            })
+            .collect();
+
+        if pending_migrations.is_empty() {
+            return Ok(());
+        }
+
+        Err(GatewayError::Storage(format!(
+            "Database schema has pending migrations: {}",
+            pending_migrations.join(", ")
+        )))
     }
 
     /// Get the underlying database connection

--- a/src/storage/database/seaorm_db/connection.rs
+++ b/src/storage/database/seaorm_db/connection.rs
@@ -155,8 +155,8 @@ impl SeaOrmDatabase {
         let pending_migrations: Vec<String> = Migrator::get_migration_files()
             .into_iter()
             .filter_map(|migration| {
-                let name = migration.name().to_string();
-                (!applied_versions.contains(&name)).then_some(name)
+                let name = migration.name();
+                (!applied_versions.contains(name)).then_some(name.to_string())
             })
             .collect();
 

--- a/src/storage/database/seaorm_db/connection.rs
+++ b/src/storage/database/seaorm_db/connection.rs
@@ -139,6 +139,15 @@ impl SeaOrmDatabase {
     /// Verify all repository migrations have already been applied without
     /// creating or modifying migration metadata.
     pub async fn verify_migrations_applied(&self) -> Result<()> {
+        self.verify_migrations_applied_except(&[]).await
+    }
+
+    /// Verify migrations while allowing explicitly degraded feature migrations
+    /// to remain pending.
+    pub async fn verify_migrations_applied_except(
+        &self,
+        allowed_pending_migrations: &[&str],
+    ) -> Result<()> {
         let applied_migrations = seaql_migrations::Entity::find()
             .all(&self.db)
             .await
@@ -156,7 +165,8 @@ impl SeaOrmDatabase {
             .into_iter()
             .filter_map(|migration| {
                 let name = migration.name();
-                (!applied_versions.contains(name)).then_some(name.to_string())
+                (!applied_versions.contains(name) && !allowed_pending_migrations.contains(&name))
+                    .then_some(name.to_string())
             })
             .collect();
 

--- a/src/storage/database/seaorm_db/connection.rs
+++ b/src/storage/database/seaorm_db/connection.rs
@@ -27,7 +27,11 @@ impl SeaOrmDatabase {
                     DatabaseBackendType::PostgreSQL
                 };
                 info!("Database connection established ({:?})", backend_type);
-                Ok(Self { db, backend_type })
+                Ok(Self {
+                    db,
+                    backend_type,
+                    sqlite_fallback: false,
+                })
             }
             Err(e) => {
                 if config.fallback_to_sqlite
@@ -60,6 +64,7 @@ impl SeaOrmDatabase {
         Ok(Self {
             db,
             backend_type: DatabaseBackendType::SQLite,
+            sqlite_fallback: false,
         })
     }
 
@@ -106,6 +111,7 @@ impl SeaOrmDatabase {
         Ok(Self {
             db,
             backend_type: DatabaseBackendType::SQLite,
+            sqlite_fallback: true,
         })
     }
 
@@ -116,7 +122,7 @@ impl SeaOrmDatabase {
 
     /// Check if using SQLite fallback
     pub fn is_sqlite_fallback(&self) -> bool {
-        self.backend_type == DatabaseBackendType::SQLite
+        self.sqlite_fallback
     }
 
     /// Run database migrations

--- a/src/storage/database/seaorm_db/types.rs
+++ b/src/storage/database/seaorm_db/types.rs
@@ -6,6 +6,8 @@ pub struct SeaOrmDatabase {
     pub(super) db: DatabaseConnection,
     /// Backend type indicator
     pub(super) backend_type: DatabaseBackendType,
+    /// True when a failed PostgreSQL connection fell back to local SQLite.
+    pub(super) sqlite_fallback: bool,
 }
 
 /// Database backend type indicator

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -15,7 +15,7 @@ pub mod vector;
 
 pub use dependency_status::DependencyStatus;
 
-use crate::config::models::storage::StorageConfig;
+use crate::config::models::storage::{DatabaseConfig, StorageConfig};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -77,7 +77,7 @@ impl StorageLayer {
         // Initialize database
         debug!("Connecting to database");
         let database = Arc::new(database::Database::new(&config.database).await?);
-        database.migrate().await?;
+        Self::initialize_database_schema(&database, &config.database).await?;
 
         // Initialize Redis (fail-fast unless allow_degraded is set)
         debug!("Creating Redis connection pool");
@@ -169,6 +169,39 @@ impl StorageLayer {
             redis_status,
             vector_status,
         })
+    }
+
+    async fn initialize_database_schema(
+        database: &database::Database,
+        config: &DatabaseConfig,
+    ) -> Result<()> {
+        if Self::should_run_startup_migrations(config) {
+            info!("Running database migrations during storage startup");
+            database.migrate().await?;
+            return Ok(());
+        }
+
+        info!(
+            "Database startup migrations disabled; verifying configured schema is already present"
+        );
+        database.verify_migrations_applied().await.map_err(|e| {
+            GatewayError::Storage(format!(
+                "Database schema check failed while storage.database.auto_migrate=false. \
+                 Run migrations before startup or set storage.database.auto_migrate=true: {}",
+                e
+            ))
+        })?;
+        database.health_check().await.map_err(|e| {
+            GatewayError::Storage(format!(
+                "Database health check failed while storage.database.auto_migrate=false: {}",
+                e
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn should_run_startup_migrations(config: &DatabaseConfig) -> bool {
+        !config.enabled || config.auto_migrate
     }
 
     /// Run database migrations
@@ -457,6 +490,7 @@ mod tests {
                 connection_timeout: 5,
                 ssl: false,
                 enabled: true,
+                auto_migrate: false,
                 fallback_to_sqlite: false,
                 allow_degraded: false,
             },
@@ -533,6 +567,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn configured_database_without_auto_migrate_requires_existing_schema() {
+        let config = StorageConfig {
+            database: DatabaseConfig {
+                url: "sqlite::memory:".to_string(),
+                max_connections: 1,
+                connection_timeout: 1,
+                ssl: false,
+                enabled: true,
+                auto_migrate: false,
+                fallback_to_sqlite: false,
+                allow_degraded: false,
+            },
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let err = match StorageLayer::new(&config).await {
+            Ok(_) => panic!("configured database without schema must fail when auto_migrate=false"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("auto_migrate=false"),
+            "error should explain how to enable or run migrations, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_database_with_auto_migrate_runs_startup_migrations() {
+        let config = StorageConfig {
+            database: sqlite_db_config(),
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        };
+
+        let storage = match StorageLayer::new(&config).await {
+            Ok(storage) => storage,
+            Err(err) => panic!("auto_migrate=true should initialize SQLite schema: {}", err),
+        };
+        let snapshots = match storage.database.load_budget_limit_snapshots().await {
+            Ok(snapshots) => snapshots,
+            Err(err) => panic!("startup migration should create budget tables: {}", err),
+        };
+
+        assert!(snapshots.is_empty());
+    }
+
+    #[tokio::test]
     async fn storage_layer_migrate_is_idempotent_after_startup_migration() {
         let config = StorageConfig {
             database: DatabaseConfig::default(),
@@ -571,6 +655,7 @@ mod tests {
             connection_timeout: 1,
             ssl: false,
             enabled: true,
+            auto_migrate: true,
             fallback_to_sqlite: false,
             allow_degraded: false,
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,6 +21,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
+const BUDGET_LIMIT_SNAPSHOT_MIGRATION: &str = "m20240501_000001_create_budget_limit_snapshots";
+
 /// Returns the default base directory for local gateway state.
 ///
 /// Resolution order:
@@ -184,13 +186,21 @@ impl StorageLayer {
         info!(
             "Database startup migrations disabled; verifying configured schema is already present"
         );
-        database.verify_migrations_applied().await.map_err(|e| {
-            GatewayError::Storage(format!(
-                "Database schema check failed while storage.database.auto_migrate=false. \
+        let allowed_pending = if config.allow_degraded {
+            &[BUDGET_LIMIT_SNAPSHOT_MIGRATION][..]
+        } else {
+            &[][..]
+        };
+        database
+            .verify_migrations_applied_except(allowed_pending)
+            .await
+            .map_err(|e| {
+                GatewayError::Storage(format!(
+                    "Database schema check failed while storage.database.auto_migrate=false. \
                  Run migrations before startup or set storage.database.auto_migrate=true: {}",
-                e
-            ))
-        })?;
+                    e
+                ))
+            })?;
         database.health_check().await.map_err(|e| {
             GatewayError::Storage(format!(
                 "Database health check failed while storage.database.auto_migrate=false: {}",

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -175,7 +175,7 @@ impl StorageLayer {
         database: &database::Database,
         config: &DatabaseConfig,
     ) -> Result<()> {
-        if Self::should_run_startup_migrations(config) {
+        if Self::should_run_startup_migrations(database, config) {
             info!("Running database migrations during storage startup");
             database.migrate().await?;
             return Ok(());
@@ -200,8 +200,11 @@ impl StorageLayer {
         Ok(())
     }
 
-    fn should_run_startup_migrations(config: &DatabaseConfig) -> bool {
-        !config.enabled || config.auto_migrate
+    fn should_run_startup_migrations(
+        database: &database::Database,
+        config: &DatabaseConfig,
+    ) -> bool {
+        !config.enabled || config.auto_migrate || database.is_sqlite_fallback()
     }
 
     /// Run database migrations

--- a/tests/common/database.rs
+++ b/tests/common/database.rs
@@ -25,6 +25,7 @@ impl TestDatabase {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -76,6 +77,7 @@ pub fn test_db_config() -> DatabaseConfig {
         connection_timeout: 5,
         ssl: false,
         enabled: true,
+        auto_migrate: false,
         fallback_to_sqlite: false,
         allow_degraded: false,
     }

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -228,6 +228,74 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_storage_layer_allow_degraded_accepts_budget_only_schema_gap() {
+        let temp_dir = match TempDir::new() {
+            Ok(temp_dir) => temp_dir,
+            Err(err) => panic!("temp dir should be created: {}", err),
+        };
+        let migration_config = sqlite_file_db_config(&temp_dir, false);
+        let db = match Database::new(&migration_config).await {
+            Ok(db) => db,
+            Err(err) => panic!("SQLite file database should connect: {}", err),
+        };
+        let migrations = Migrator::migrations();
+        let budget_migration = migrations
+            .last()
+            .expect("budget migration should be last")
+            .name()
+            .to_string();
+        assert_eq!(
+            budget_migration, "m20240501_000001_create_budget_limit_snapshots",
+            "test setup depends on budget snapshots being the only pending migration"
+        );
+        let migrations_before_budget = match migrations.len().checked_sub(1) {
+            Some(count) => count,
+            None => panic!("migration list should not be empty"),
+        };
+        drop(migrations);
+        if let Err(err) = Migrator::up(db.connection(), Some(migrations_before_budget as u32)).await
+        {
+            panic!(
+                "core migrations should apply before budget migration: {}",
+                err
+            );
+        }
+        if let Err(err) = db.close().await {
+            panic!(
+                "database should close cleanly before startup check: {}",
+                err
+            );
+        }
+
+        let err = match StorageLayer::new(&storage_config(sqlite_file_db_config(&temp_dir, false)))
+            .await
+        {
+            Ok(_) => panic!("budget-only schema gap must fail when allow_degraded=false"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains(&budget_migration),
+            "error should identify the pending budget migration, got: {}",
+            err
+        );
+
+        let mut allow_degraded_config = sqlite_file_db_config(&temp_dir, false);
+        allow_degraded_config.allow_degraded = true;
+        let storage = match StorageLayer::new(&storage_config(allow_degraded_config)).await {
+            Ok(storage) => storage,
+            Err(err) => panic!(
+                "allow_degraded=true should allow startup when only budget migration is pending: {}",
+                err
+            ),
+        };
+        let budget_load = storage.database.load_budget_limit_snapshots().await;
+        assert!(
+            budget_load.is_err(),
+            "budget snapshots should remain unavailable for Server::new to degrade"
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_storage_layer_sqlite_fallback_runs_startup_migrations() {
         let _guard = ENV_LOCK.lock().await;

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -5,12 +5,42 @@
 
 #[cfg(test)]
 mod tests {
+    use litellm_rs::config::models::file_storage::FileStorageConfig;
     use litellm_rs::config::models::storage::DatabaseConfig;
+    use litellm_rs::config::models::storage::{RedisConfig, StorageConfig};
     use litellm_rs::core::models::user::types::User;
     use litellm_rs::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
-    use litellm_rs::storage::database::{Database, DatabaseBackendType};
+    use litellm_rs::storage::StorageLayer;
+    use litellm_rs::storage::database::{Database, DatabaseBackendType, migration::Migrator};
     use sea_orm::{ConnectionTrait, DatabaseBackend, Statement, Value};
+    use sea_orm_migration::MigratorTrait;
+    use tempfile::TempDir;
     use uuid::Uuid;
+
+    fn sqlite_file_db_config(temp_dir: &TempDir, auto_migrate: bool) -> DatabaseConfig {
+        DatabaseConfig {
+            url: format!(
+                "sqlite://{}?mode=rwc",
+                temp_dir.path().join("gateway.db").display()
+            ),
+            max_connections: 1,
+            connection_timeout: 1,
+            ssl: false,
+            enabled: true,
+            auto_migrate,
+            fallback_to_sqlite: false,
+            allow_degraded: false,
+        }
+    }
+
+    fn storage_config(database: DatabaseConfig) -> StorageConfig {
+        StorageConfig {
+            database,
+            redis: RedisConfig::default(),
+            files: FileStorageConfig::default(),
+            vector_db: None,
+        }
+    }
 
     /// Test basic database connection and health check
     #[tokio::test]
@@ -21,6 +51,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -51,6 +82,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -70,6 +102,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -97,6 +130,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_storage_layer_auto_migrate_false_accepts_pre_migrated_schema() {
+        let temp_dir = match TempDir::new() {
+            Ok(temp_dir) => temp_dir,
+            Err(err) => panic!("temp dir should be created: {}", err),
+        };
+        let migration_config = sqlite_file_db_config(&temp_dir, false);
+        let db = match Database::new(&migration_config).await {
+            Ok(db) => db,
+            Err(err) => panic!("SQLite file database should connect: {}", err),
+        };
+        if let Err(err) = db.migrate().await {
+            panic!("manual migration should prepare schema: {}", err);
+        }
+        if let Err(err) = db.close().await {
+            panic!(
+                "database should close cleanly before startup check: {}",
+                err
+            );
+        }
+
+        let storage =
+            match StorageLayer::new(&storage_config(sqlite_file_db_config(&temp_dir, false))).await
+            {
+                Ok(storage) => storage,
+                Err(err) => panic!(
+                    "pre-migrated configured database should start with auto_migrate=false: {}",
+                    err
+                ),
+            };
+        let health = match storage.health_check().await {
+            Ok(health) => health,
+            Err(err) => panic!("pre-migrated database should pass health check: {}", err),
+        };
+
+        assert!(health.database);
+    }
+
+    #[tokio::test]
+    async fn test_storage_layer_auto_migrate_false_rejects_partial_schema() {
+        let temp_dir = match TempDir::new() {
+            Ok(temp_dir) => temp_dir,
+            Err(err) => panic!("temp dir should be created: {}", err),
+        };
+        let migration_config = sqlite_file_db_config(&temp_dir, false);
+        let db = match Database::new(&migration_config).await {
+            Ok(db) => db,
+            Err(err) => panic!("SQLite file database should connect: {}", err),
+        };
+        if let Err(err) = Migrator::up(db.connection(), Some(1)).await {
+            panic!("partial migration should apply first migration: {}", err);
+        }
+        if let Err(err) = db.close().await {
+            panic!(
+                "database should close cleanly before startup check: {}",
+                err
+            );
+        }
+
+        let err = match StorageLayer::new(&storage_config(sqlite_file_db_config(&temp_dir, false)))
+            .await
+        {
+            Ok(_) => panic!("partial schema must fail when auto_migrate=false"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("pending migrations"),
+            "error should identify pending migrations, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
     async fn test_database_disabled_uses_in_memory_sqlite() {
         let config = DatabaseConfig {
             url: "postgresql://unreachable-host:5432/unreachable-db".to_string(),
@@ -104,6 +210,7 @@ mod tests {
             connection_timeout: 1,
             ssl: false,
             enabled: false,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -128,6 +235,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -152,6 +260,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -176,6 +285,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -197,6 +307,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -346,6 +457,7 @@ mod tests {
             connection_timeout: 5,
             ssl: false,
             enabled: true,
+            auto_migrate: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -15,7 +15,33 @@ mod tests {
     use sea_orm::{ConnectionTrait, DatabaseBackend, Statement, Value};
     use sea_orm_migration::MigratorTrait;
     use tempfile::TempDir;
+    use tokio::sync::Mutex;
     use uuid::Uuid;
+
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    struct EnvRestore {
+        sqlite_path: Option<String>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                sqlite_path: std::env::var("LITELLM_SQLITE_PATH").ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.sqlite_path {
+                    Some(value) => std::env::set_var("LITELLM_SQLITE_PATH", value),
+                    None => std::env::remove_var("LITELLM_SQLITE_PATH"),
+                }
+            }
+        }
+    }
 
     fn sqlite_file_db_config(temp_dir: &TempDir, auto_migrate: bool) -> DatabaseConfig {
         DatabaseConfig {
@@ -199,6 +225,54 @@ mod tests {
             err.to_string().contains("pending migrations"),
             "error should identify pending migrations, got: {}",
             err
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_storage_layer_sqlite_fallback_runs_startup_migrations() {
+        let _guard = ENV_LOCK.lock().await;
+        let _restore = EnvRestore::capture();
+        let temp_dir = match TempDir::new() {
+            Ok(temp_dir) => temp_dir,
+            Err(err) => panic!("temp dir should be created: {}", err),
+        };
+        let sqlite_path = temp_dir.path().join("fallback.db");
+        unsafe {
+            std::env::set_var("LITELLM_SQLITE_PATH", &sqlite_path);
+        }
+
+        let config = storage_config(DatabaseConfig {
+            url: "postgresql://127.0.0.1:1/unreachable".to_string(),
+            max_connections: 1,
+            connection_timeout: 1,
+            ssl: false,
+            enabled: true,
+            auto_migrate: false,
+            fallback_to_sqlite: true,
+            allow_degraded: false,
+        });
+
+        let storage = match StorageLayer::new(&config).await {
+            Ok(storage) => storage,
+            Err(err) => panic!(
+                "SQLite fallback should start and migrate even when auto_migrate=false: {}",
+                err
+            ),
+        };
+        let snapshots = match storage.database.load_budget_limit_snapshots().await {
+            Ok(snapshots) => snapshots,
+            Err(err) => panic!(
+                "SQLite fallback should have migrated budget tables: {}",
+                err
+            ),
+        };
+
+        assert!(storage.database.is_sqlite_fallback());
+        assert_eq!(storage.database.backend_type(), DatabaseBackendType::SQLite);
+        assert!(snapshots.is_empty());
+        assert!(
+            sqlite_path.exists(),
+            "SQLite fallback should use configured test path"
         );
     }
 


### PR DESCRIPTION
## Summary
- add `storage.database.auto_migrate` with a production-safe default of `false`
- keep automatic migrations for the disabled database in-memory SQLite fallback so default startup remains usable
- when a configured database has `auto_migrate=false`, verify migration metadata and database health without running DDL
- document the new setting in gateway config examples

## Tests
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test --all-features test_storage_layer_auto_migrate_false -- --nocapture`
- `cargo test --all-features configured_database_ -- --nocapture`
- `FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo clippy --lib --tests --bins --features "$FEATURES" -- -D warnings --force-warn clippy::collapsible-if`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Note
`cargo clippy --all-targets --all-features -- -D warnings` currently fails on `origin/main` in untouched provider files (`sagemaker/sigv4.rs`, `vertex_ai/transformers.rs`). This PR leaves that unrelated baseline issue out of scope and verifies the CI lint command instead.

Fixes #611
