### PR TITLE
style(cache): use validate method syntax

### DIFF
--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -206,7 +206,7 @@ fn test_cache_validation_rejects_unwired_cache_enabled() {
         ..Default::default()
     };
 
-    let error = Validate::validate(&config).unwrap_err();
+    let error = config.validate().unwrap_err();
     assert!(error.contains("not wired into runtime"));
 }
 
@@ -217,7 +217,7 @@ fn test_cache_validation_rejects_unwired_semantic_cache() {
         ..Default::default()
     };
 
-    let error = Validate::validate(&config).unwrap_err();
+    let error = config.validate().unwrap_err();
     assert!(error.contains("not wired into runtime"));
 }
 

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -40,7 +40,10 @@ impl HttpServer {
         info!("Creating HTTP server");
 
         Self::validate_cors_config(&config.gateway.server.cors)?;
-        Validate::validate(&config.gateway.cache)
+        config
+            .gateway
+            .cache
+            .validate()
             .map_err(|e| GatewayError::Config(format!("Invalid cache configuration: {}", e)))?;
         start_auth_rate_limiter_cleanup_task();
 


### PR DESCRIPTION
Closes #612.

This addresses the unresolved review feedback from merged PR #598 by using idiomatic method-call syntax for the cache validation call sites.

Changes:
- Replace the HTTP server startup cache validation call with method-call syntax.
- Replace the two reviewed cache validation test calls with method-call syntax.

Validation:
- cargo fmt --all -- --check passed
- cargo test --all-features cache_validation -- --nocapture passed
- cargo check --all-features passed
- cargo test --all-features passed
- cargo clippy --all-targets --all-features -- -A warnings passed
- bash scripts/guards/check_pr_scope.sh passed
- bash scripts/guards/check_pr_overlap.sh passed

Note:
- Local strict cargo clippy --all-targets --all-features -- -D warnings still fails on pre-existing warnings in src/core/providers/sagemaker/sigv4.rs and src/core/providers/vertex_ai/transformers.rs; this PR does not touch those files.