### PR TITLE
fix(router): prefer xai key for api base overrides

### DIFF
--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -144,12 +144,15 @@ fn resolve_dynamic_provider_api_key(
     route: &DynamicProviderRoute<'_>,
 ) -> Option<String> {
     options.api_key.clone().or_else(|| {
-        custom_api_base_api_key_fallback(
-            options,
-            route,
-            std::env::var("OPENAI_API_KEY").ok(),
-            dynamic_provider_api_key(route),
-        )
+        let provider_api_key = dynamic_provider_api_key(route);
+        provider_api_key.clone().or_else(|| {
+            custom_api_base_api_key_fallback(
+                options,
+                route,
+                std::env::var("OPENAI_API_KEY").ok(),
+                provider_api_key,
+            )
+        })
     })
 }
 

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -191,6 +191,10 @@ fn is_openai_compatible_api_key_fallback(route: &DynamicProviderRoute<'_>) -> bo
     )
 }
 
+fn uses_dynamic_openai_like_provider(route: &DynamicProviderRoute<'_>) -> bool {
+    matches!(route.provider_type, "xai" | "groq")
+}
+
 fn custom_api_base_api_key_fallback(
     options: &CompletionOptions,
     route: &DynamicProviderRoute<'_>,
@@ -252,7 +256,7 @@ impl DefaultRouter {
                 )
                 .await?
             }
-            "xai" => {
+            _ if uses_dynamic_openai_like_provider(&route) => {
                 self.create_dynamic_openai_like(&route, &api_key, chat_request, context, options)
                     .await?
             }
@@ -312,7 +316,7 @@ impl DefaultRouter {
                 )
                 .await?
             }
-            "xai" => {
+            _ if uses_dynamic_openai_like_provider(&route) => {
                 self.create_dynamic_openai_like_stream(
                     &route,
                     &api_key,

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -143,17 +143,26 @@ fn resolve_dynamic_provider_api_key(
     options: &CompletionOptions,
     route: &DynamicProviderRoute<'_>,
 ) -> Option<String> {
-    if let Some(api_key) = &options.api_key {
-        return Some(api_key.clone());
+    resolve_dynamic_provider_api_key_from_sources(
+        options,
+        route,
+        dynamic_provider_api_key(route),
+        std::env::var("OPENAI_API_KEY").ok(),
+    )
+}
+
+fn resolve_dynamic_provider_api_key_from_sources(
+    options: &CompletionOptions,
+    route: &DynamicProviderRoute<'_>,
+    provider_api_key: Option<String>,
+    openai_api_key: Option<String>,
+) -> Option<String> {
+    if let Some(api_key) = options.api_key.clone() {
+        return Some(api_key);
     }
 
     options.api_base.as_ref()?;
-    custom_api_base_api_key_fallback(
-        options,
-        route,
-        std::env::var("OPENAI_API_KEY").ok(),
-        dynamic_provider_api_key(route),
-    )
+    custom_api_base_api_key_fallback(options, route, openai_api_key, provider_api_key)
 }
 
 fn dynamic_provider_api_key(route: &DynamicProviderRoute<'_>) -> Option<String> {

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -143,17 +143,17 @@ fn resolve_dynamic_provider_api_key(
     options: &CompletionOptions,
     route: &DynamicProviderRoute<'_>,
 ) -> Option<String> {
-    options.api_key.clone().or_else(|| {
-        let provider_api_key = dynamic_provider_api_key(route);
-        provider_api_key.clone().or_else(|| {
-            custom_api_base_api_key_fallback(
-                options,
-                route,
-                std::env::var("OPENAI_API_KEY").ok(),
-                provider_api_key,
-            )
-        })
-    })
+    if let Some(api_key) = &options.api_key {
+        return Some(api_key.clone());
+    }
+
+    options.api_base.as_ref()?;
+    custom_api_base_api_key_fallback(
+        options,
+        route,
+        std::env::var("OPENAI_API_KEY").ok(),
+        dynamic_provider_api_key(route),
+    )
 }
 
 fn dynamic_provider_api_key(route: &DynamicProviderRoute<'_>) -> Option<String> {

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -192,7 +192,7 @@ fn is_openai_compatible_api_key_fallback(route: &DynamicProviderRoute<'_>) -> bo
 }
 
 fn uses_dynamic_openai_like_provider(route: &DynamicProviderRoute<'_>) -> bool {
-    matches!(route.provider_type, "xai" | "groq")
+    matches!(route.provider_type, "openrouter" | "xai" | "groq")
 }
 
 fn custom_api_base_api_key_fallback(

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -138,19 +138,36 @@ fn resolve_dynamic_provider_api_key(
     route: &DynamicProviderRoute<'_>,
 ) -> Option<String> {
     options.api_key.clone().or_else(|| {
-        custom_api_base_api_key_fallback(options, route, std::env::var("OPENAI_API_KEY").ok())
+        custom_api_base_api_key_fallback(
+            options,
+            route,
+            std::env::var("OPENAI_API_KEY").ok(),
+            dynamic_provider_api_key(route),
+        )
     })
+}
+
+fn dynamic_provider_api_key(route: &DynamicProviderRoute<'_>) -> Option<String> {
+    match route.provider_type {
+        "xai" => std::env::var("XAI_API_KEY").ok(),
+        _ => None,
+    }
 }
 
 fn custom_api_base_api_key_fallback(
     options: &CompletionOptions,
     route: &DynamicProviderRoute<'_>,
     openai_api_key: Option<String>,
+    provider_api_key: Option<String>,
 ) -> Option<String> {
     if options.api_base.is_some()
         && (route.provider_type == "openai-compatible" || route.provider_type == "xai")
     {
-        Some(openai_api_key.unwrap_or_else(|| "dummy-key-for-local".to_string()))
+        Some(
+            provider_api_key
+                .or(openai_api_key)
+                .unwrap_or_else(|| "dummy-key-for-local".to_string()),
+        )
     } else {
         None
     }

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -72,6 +72,12 @@ const DYNAMIC_PROVIDER_PREFIXES: &[DynamicProviderPrefix] = &[
         default_api_base: "https://api.x.ai/v1",
     },
     DynamicProviderPrefix {
+        prefix: "groq/",
+        provider_type: "groq",
+        provider_label: "Groq",
+        default_api_base: "https://api.groq.com/openai/v1",
+    },
+    DynamicProviderPrefix {
         prefix: "openai/",
         provider_type: "openai",
         provider_label: "OpenAI",
@@ -148,10 +154,38 @@ fn resolve_dynamic_provider_api_key(
 }
 
 fn dynamic_provider_api_key(route: &DynamicProviderRoute<'_>) -> Option<String> {
+    dynamic_provider_api_key_env_var(route).and_then(|env_var| std::env::var(env_var).ok())
+}
+
+fn dynamic_provider_api_key_env_var(route: &DynamicProviderRoute<'_>) -> Option<&'static str> {
     match route.provider_type {
-        "xai" => std::env::var("XAI_API_KEY").ok(),
+        "openai" => Some("OPENAI_API_KEY"),
+        "openrouter" => Some("OPENROUTER_API_KEY"),
+        "anthropic" => Some("ANTHROPIC_API_KEY"),
+        "deepseek" => Some("DEEPSEEK_API_KEY"),
+        "moonshot" => Some("MOONSHOT_API_KEY"),
+        "minimax" => Some("MINIMAX_API_KEY"),
+        "zhipu" => Some("ZHIPU_API_KEY"),
+        "xai" => Some("XAI_API_KEY"),
+        "groq" => Some("GROQ_API_KEY"),
+        "azure_ai" => Some("AZURE_AI_API_KEY"),
         _ => None,
     }
+}
+
+fn is_openai_compatible_api_key_fallback(route: &DynamicProviderRoute<'_>) -> bool {
+    matches!(
+        route.provider_type,
+        "openai-compatible"
+            | "openai"
+            | "openrouter"
+            | "deepseek"
+            | "moonshot"
+            | "minimax"
+            | "zhipu"
+            | "xai"
+            | "groq"
+    )
 }
 
 fn custom_api_base_api_key_fallback(
@@ -160,17 +194,14 @@ fn custom_api_base_api_key_fallback(
     openai_api_key: Option<String>,
     provider_api_key: Option<String>,
 ) -> Option<String> {
-    if options.api_base.is_some()
-        && (route.provider_type == "openai-compatible" || route.provider_type == "xai")
-    {
-        Some(
-            provider_api_key
-                .or(openai_api_key)
-                .unwrap_or_else(|| "dummy-key-for-local".to_string()),
-        )
-    } else {
-        None
+    if options.api_base.is_none() {
+        return None;
     }
+
+    provider_api_key.or_else(|| {
+        is_openai_compatible_api_key_fallback(route)
+            .then(|| openai_api_key.unwrap_or_else(|| "dummy-key-for-local".to_string()))
+    })
 }
 
 impl DefaultRouter {

--- a/src/core/completion/default_router/dynamic_providers.rs
+++ b/src/core/completion/default_router/dynamic_providers.rs
@@ -194,9 +194,7 @@ fn custom_api_base_api_key_fallback(
     openai_api_key: Option<String>,
     provider_api_key: Option<String>,
 ) -> Option<String> {
-    if options.api_base.is_none() {
-        return None;
-    }
+    options.api_base.as_ref()?;
 
     provider_api_key.or_else(|| {
         is_openai_compatible_api_key_fallback(route)

--- a/src/core/completion/default_router/dynamic_providers/tests.rs
+++ b/src/core/completion/default_router/dynamic_providers/tests.rs
@@ -414,6 +414,24 @@ fn test_api_key_fallback_does_not_apply_to_prefixed_routes() {
 }
 
 #[test]
+fn test_provider_env_key_without_api_base_does_not_enable_dynamic_route() {
+    let options = CompletionOptions::default();
+    let Some(route) = resolve_dynamic_provider_route("xai/grok-4.3", &options) else {
+        panic!("prefixed route should resolve");
+    };
+    let original = std::env::var("XAI_API_KEY").ok();
+
+    unsafe { std::env::set_var("XAI_API_KEY", "sk-xai-env") };
+    let api_key = resolve_dynamic_provider_api_key(&options, &route);
+    match original {
+        Some(value) => unsafe { std::env::set_var("XAI_API_KEY", value) },
+        None => unsafe { std::env::remove_var("XAI_API_KEY") },
+    }
+
+    assert!(api_key.is_none());
+}
+
+#[test]
 fn test_resolve_dynamic_route_without_prefix_or_api_base() {
     let options = CompletionOptions::default();
     let route = resolve_dynamic_provider_route("my-custom-model", &options);

--- a/src/core/completion/default_router/dynamic_providers/tests.rs
+++ b/src/core/completion/default_router/dynamic_providers/tests.rs
@@ -58,6 +58,20 @@ fn test_resolve_dynamic_route_for_xai() {
 }
 
 #[test]
+fn test_resolve_dynamic_route_for_groq() {
+    let options = CompletionOptions::default();
+    let Some(route) = resolve_dynamic_provider_route("groq/llama-3.3-70b-versatile", &options)
+    else {
+        panic!("Groq route should resolve");
+    };
+
+    assert_eq!(route.provider_type, "groq");
+    assert_eq!(route.provider_label, "Groq");
+    assert_eq!(route.actual_model, "llama-3.3-70b-versatile");
+    assert_eq!(route.api_base, "https://api.groq.com/openai/v1");
+}
+
+#[test]
 fn test_resolve_dynamic_route_with_custom_api_base() {
     let options = CompletionOptions {
         api_base: Some("http://localhost:5567/v1".to_string()),
@@ -100,6 +114,121 @@ fn test_custom_api_base_api_key_fallback_uses_dummy_without_env_key() {
     let api_key = custom_api_base_api_key_fallback(&options, &route, None, None);
 
     assert_eq!(api_key.as_deref(), Some("dummy-key-for-local"));
+}
+
+#[test]
+fn test_dynamic_provider_api_key_env_var_maps_named_routes() {
+    let options = CompletionOptions {
+        api_base: Some("http://localhost:5567/v1".to_string()),
+        ..CompletionOptions::default()
+    };
+    let cases = [
+        ("openai/gpt-4.1", "openai", "OPENAI_API_KEY"),
+        (
+            "openrouter/anthropic/claude-sonnet-4",
+            "openrouter",
+            "OPENROUTER_API_KEY",
+        ),
+        (
+            "anthropic/claude-sonnet-4",
+            "anthropic",
+            "ANTHROPIC_API_KEY",
+        ),
+        ("deepseek/deepseek-chat", "deepseek", "DEEPSEEK_API_KEY"),
+        ("moonshot/kimi-k2.5", "moonshot", "MOONSHOT_API_KEY"),
+        (
+            "minimax/MiniMax-M2.5-lightning",
+            "minimax",
+            "MINIMAX_API_KEY",
+        ),
+        ("zhipu/glm-5", "zhipu", "ZHIPU_API_KEY"),
+        ("xai/grok-4.3", "xai", "XAI_API_KEY"),
+        ("groq/llama-3.3-70b-versatile", "groq", "GROQ_API_KEY"),
+        ("azure_ai/gpt-4.1", "azure_ai", "AZURE_AI_API_KEY"),
+    ];
+
+    for (model, provider_type, env_var) in cases {
+        let Some(route) = resolve_dynamic_provider_route(model, &options) else {
+            panic!("{model} route should resolve");
+        };
+
+        assert_eq!(route.provider_type, provider_type);
+        assert_eq!(dynamic_provider_api_key_env_var(&route), Some(env_var));
+    }
+}
+
+#[test]
+fn test_custom_api_base_fallback_supports_openai_compatible_named_routes() {
+    let options = CompletionOptions {
+        api_base: Some("http://localhost:5567/v1".to_string()),
+        ..CompletionOptions::default()
+    };
+    let models = [
+        "openai/gpt-4.1",
+        "openrouter/anthropic/claude-sonnet-4",
+        "deepseek/deepseek-chat",
+        "moonshot/kimi-k2.5",
+        "minimax/MiniMax-M2.5-lightning",
+        "zhipu/glm-5",
+        "xai/grok-4.3",
+        "groq/llama-3.3-70b-versatile",
+    ];
+
+    for model in models {
+        let Some(route) = resolve_dynamic_provider_route(model, &options) else {
+            panic!("{model} route should resolve");
+        };
+
+        let provider_key = custom_api_base_api_key_fallback(
+            &options,
+            &route,
+            Some("sk-openai-env".to_string()),
+            Some("sk-provider-env".to_string()),
+        );
+        assert_eq!(provider_key.as_deref(), Some("sk-provider-env"));
+
+        let openai_key = custom_api_base_api_key_fallback(
+            &options,
+            &route,
+            Some("sk-openai-env".to_string()),
+            None,
+        );
+        assert_eq!(openai_key.as_deref(), Some("sk-openai-env"));
+
+        let dummy_key = custom_api_base_api_key_fallback(&options, &route, None, None);
+        assert_eq!(dummy_key.as_deref(), Some("dummy-key-for-local"));
+    }
+}
+
+#[test]
+fn test_custom_api_base_fallback_requires_provider_key_for_non_openai_compatible_routes() {
+    let options = CompletionOptions {
+        api_base: Some("http://localhost:5567/v1".to_string()),
+        ..CompletionOptions::default()
+    };
+    let models = ["anthropic/claude-sonnet-4", "azure_ai/gpt-4.1"];
+
+    for model in models {
+        let Some(route) = resolve_dynamic_provider_route(model, &options) else {
+            panic!("{model} route should resolve");
+        };
+
+        let openai_key = custom_api_base_api_key_fallback(
+            &options,
+            &route,
+            Some("sk-openai-env".to_string()),
+            None,
+        );
+        assert!(openai_key.is_none());
+
+        let provider_key = custom_api_base_api_key_fallback(
+            &options,
+            &route,
+            Some("sk-openai-env".to_string()),
+            Some("sk-provider-env".to_string()),
+        );
+        assert_eq!(provider_key.as_deref(), Some("sk-provider-env"));
+    }
 }
 
 #[test]

--- a/src/core/completion/default_router/dynamic_providers/tests.rs
+++ b/src/core/completion/default_router/dynamic_providers/tests.rs
@@ -82,7 +82,7 @@ fn test_custom_api_base_api_key_fallback_uses_env_key() {
     };
 
     let api_key =
-        custom_api_base_api_key_fallback(&options, &route, Some("sk-from-env".to_string()));
+        custom_api_base_api_key_fallback(&options, &route, Some("sk-from-env".to_string()), None);
 
     assert_eq!(api_key.as_deref(), Some("sk-from-env"));
 }
@@ -97,7 +97,7 @@ fn test_custom_api_base_api_key_fallback_uses_dummy_without_env_key() {
         panic!("custom api_base route should resolve");
     };
 
-    let api_key = custom_api_base_api_key_fallback(&options, &route, None);
+    let api_key = custom_api_base_api_key_fallback(&options, &route, None, None);
 
     assert_eq!(api_key.as_deref(), Some("dummy-key-for-local"));
 }
@@ -176,8 +176,28 @@ fn test_xai_api_base_override_stays_named_dynamic_route() {
     assert_eq!(route.actual_model, "grok-4.3");
     assert_eq!(route.api_base, "http://localhost:5567/v1");
 
-    let api_key = custom_api_base_api_key_fallback(&options, &route, None);
+    let api_key = custom_api_base_api_key_fallback(&options, &route, None, None);
     assert_eq!(api_key.as_deref(), Some("dummy-key-for-local"));
+}
+
+#[test]
+fn test_xai_api_base_override_prefers_xai_env_key() {
+    let options = CompletionOptions {
+        api_base: Some("http://localhost:5567/v1".to_string()),
+        ..CompletionOptions::default()
+    };
+    let Some(route) = resolve_dynamic_provider_route("xai/grok-4.3", &options) else {
+        panic!("xAI route should resolve before generic custom api_base");
+    };
+
+    let api_key = custom_api_base_api_key_fallback(
+        &options,
+        &route,
+        Some("sk-openai-env".to_string()),
+        Some("sk-xai-env".to_string()),
+    );
+
+    assert_eq!(api_key.as_deref(), Some("sk-xai-env"));
 }
 
 #[test]
@@ -188,7 +208,7 @@ fn test_api_key_fallback_does_not_apply_to_prefixed_routes() {
     };
 
     let api_key =
-        custom_api_base_api_key_fallback(&options, &route, Some("sk-from-env".to_string()));
+        custom_api_base_api_key_fallback(&options, &route, Some("sk-from-env".to_string()), None);
 
     assert!(api_key.is_none());
 }

--- a/src/core/completion/default_router/dynamic_providers/tests.rs
+++ b/src/core/completion/default_router/dynamic_providers/tests.rs
@@ -327,6 +327,39 @@ fn test_dynamic_groq_uses_openai_like_config() {
 }
 
 #[test]
+fn test_dynamic_openrouter_uses_openai_like_config() {
+    let mut headers = std::collections::HashMap::new();
+    headers.insert("x-proxy-route".to_string(), "tenant-a".to_string());
+    let options = CompletionOptions {
+        headers: Some(headers),
+        organization: Some("org-openrouter-test".to_string()),
+        timeout: Some(31),
+        ..CompletionOptions::default()
+    };
+    let Some(route) =
+        resolve_dynamic_provider_route("openrouter/anthropic/claude-sonnet-4", &options)
+    else {
+        panic!("OpenRouter route should resolve");
+    };
+
+    assert!(uses_dynamic_openai_like_provider(&route));
+
+    let config = dynamic_openai_like_config("sk-test", &route.api_base, &route, &options);
+
+    assert_eq!(config.provider_name, "openrouter");
+    assert_eq!(config.base.api_key.as_deref(), Some("sk-test"));
+    assert_eq!(config.base.timeout, 31);
+    assert_eq!(
+        config.base.headers.get("x-proxy-route").map(String::as_str),
+        Some("tenant-a")
+    );
+    assert_eq!(
+        config.base.organization.as_deref(),
+        Some("org-openrouter-test")
+    );
+}
+
+#[test]
 fn test_xai_api_base_override_stays_named_dynamic_route() {
     let options = CompletionOptions {
         api_base: Some("http://localhost:5567/v1".to_string()),

--- a/src/core/completion/default_router/dynamic_providers/tests.rs
+++ b/src/core/completion/default_router/dynamic_providers/tests.rs
@@ -414,21 +414,60 @@ fn test_api_key_fallback_does_not_apply_to_prefixed_routes() {
 }
 
 #[test]
-fn test_provider_env_key_without_api_base_does_not_enable_dynamic_route() {
+fn test_provider_env_key_does_not_activate_default_named_route() {
     let options = CompletionOptions::default();
     let Some(route) = resolve_dynamic_provider_route("xai/grok-4.3", &options) else {
         panic!("prefixed route should resolve");
     };
-    let original = std::env::var("XAI_API_KEY").ok();
 
-    unsafe { std::env::set_var("XAI_API_KEY", "sk-xai-env") };
-    let api_key = resolve_dynamic_provider_api_key(&options, &route);
-    match original {
-        Some(value) => unsafe { std::env::set_var("XAI_API_KEY", value) },
-        None => unsafe { std::env::remove_var("XAI_API_KEY") },
-    }
+    let api_key = resolve_dynamic_provider_api_key_from_sources(
+        &options,
+        &route,
+        Some("sk-xai-env".to_string()),
+        Some("sk-openai-env".to_string()),
+    );
 
     assert!(api_key.is_none());
+}
+
+#[test]
+fn test_explicit_api_key_activates_default_named_route() {
+    let options = CompletionOptions {
+        api_key: Some("sk-request".to_string()),
+        ..CompletionOptions::default()
+    };
+    let Some(route) = resolve_dynamic_provider_route("xai/grok-4.3", &options) else {
+        panic!("prefixed route should resolve");
+    };
+
+    let api_key = resolve_dynamic_provider_api_key_from_sources(
+        &options,
+        &route,
+        Some("sk-xai-env".to_string()),
+        Some("sk-openai-env".to_string()),
+    );
+
+    assert_eq!(api_key.as_deref(), Some("sk-request"));
+}
+
+#[test]
+fn test_provider_env_key_still_activates_api_base_override() {
+    let options = CompletionOptions {
+        api_base: Some("http://localhost:5567/v1".to_string()),
+        ..CompletionOptions::default()
+    };
+    let Some(route) = resolve_dynamic_provider_route("xai/grok-4.3", &options) else {
+        panic!("prefixed route should resolve");
+    };
+
+    let api_key = resolve_dynamic_provider_api_key_from_sources(
+        &options,
+        &route,
+        Some("sk-xai-env".to_string()),
+        Some("sk-openai-env".to_string()),
+    );
+
+    assert_eq!(api_key.as_deref(), Some("sk-xai-env"));
 }
 
 #[test]

--- a/src/core/completion/default_router/dynamic_providers/tests.rs
+++ b/src/core/completion/default_router/dynamic_providers/tests.rs
@@ -289,6 +289,44 @@ fn test_dynamic_xai_uses_openai_like_config() {
 }
 
 #[test]
+fn test_dynamic_groq_uses_openai_like_config() {
+    let mut headers = std::collections::HashMap::new();
+    headers.insert("x-proxy-route".to_string(), "tenant-a".to_string());
+    headers.insert("x-request-source".to_string(), "stream-test".to_string());
+    let options = CompletionOptions {
+        headers: Some(headers),
+        organization: Some("org-groq-test".to_string()),
+        timeout: Some(29),
+        ..CompletionOptions::default()
+    };
+    let Some(route) = resolve_dynamic_provider_route("groq/llama-3.3-70b-versatile", &options)
+    else {
+        panic!("Groq route should resolve");
+    };
+
+    assert!(uses_dynamic_openai_like_provider(&route));
+
+    let config = dynamic_openai_like_config("sk-test", &route.api_base, &route, &options);
+
+    assert_eq!(config.provider_name, "groq");
+    assert_eq!(config.base.api_key.as_deref(), Some("sk-test"));
+    assert_eq!(config.base.timeout, 29);
+    assert_eq!(
+        config.base.headers.get("x-proxy-route").map(String::as_str),
+        Some("tenant-a")
+    );
+    assert_eq!(
+        config
+            .base
+            .headers
+            .get("x-request-source")
+            .map(String::as_str),
+        Some("stream-test")
+    );
+    assert_eq!(config.base.organization.as_deref(), Some("org-groq-test"));
+}
+
+#[test]
 fn test_xai_api_base_override_stays_named_dynamic_route() {
     let options = CompletionOptions {
         api_base: Some("http://localhost:5567/v1".to_string()),


### PR DESCRIPTION
## Summary
Prefer `XAI_API_KEY` when an `xai/*` dynamic provider route uses an `api_base` override without a per-request API key.

Fixes #617

## Changes
- Read the xAI provider env key for xAI dynamic `api_base` overrides before falling back to OpenAI/dummy credentials.
- Keep generic OpenAI-compatible dynamic provider fallback behavior unchanged.
- Add a regression test for xAI override credential precedence.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test --all-features test_xai_api_base_override -- --nocapture`
- `cargo check --all-features`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -A warnings`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

Note: strict `cargo clippy --all-targets --all-features -- -D warnings` still fails on existing main-branch warnings in `src/core/providers/sagemaker/sigv4.rs:74` and `src/core/providers/vertex_ai/transformers.rs:81`; this PR does not touch those files.