### PR TITLE
fix(config): preserve auto migrate overlay intent

### DIFF
--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -332,6 +332,7 @@ impl GatewayConfig {
         }
         if let Some(auto_migrate) = parse_env_bool(ENV_DATABASE_AUTO_MIGRATE)? {
             config.storage.database.auto_migrate = auto_migrate;
+            config.storage.database.auto_migrate_configured = true;
         }
 
         if let Some(redis_url) = env_var(ENV_REDIS_URL) {

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -113,6 +113,7 @@ fn test_gateway_config_from_env() {
     );
     assert!(config.storage.database.enabled);
     assert!(config.storage.database.auto_migrate);
+    assert!(config.storage.database.auto_migrate_configured);
     assert_eq!(config.providers.len(), 1);
     assert_eq!(config.providers[0].name, "openai");
     assert_eq!(config.providers[0].provider_type, "openai");

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -85,6 +85,7 @@ pub struct DatabaseConfig {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct DatabaseConfigFields {
+    #[serde(default = "default_database_url")]
     pub url: String,
     #[serde(default = "default_max_connections")]
     pub max_connections: u32,
@@ -94,7 +95,7 @@ struct DatabaseConfigFields {
     pub ssl: bool,
     #[serde(default)]
     pub enabled: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_auto_migrate")]
     pub auto_migrate: Option<bool>,
     #[serde(default)]
     pub fallback_to_sqlite: bool,
@@ -124,10 +125,21 @@ impl<'de> Deserialize<'de> for DatabaseConfig {
     }
 }
 
+fn default_database_url() -> String {
+    "postgresql://localhost/litellm".to_string()
+}
+
+fn deserialize_auto_migrate<'de, D>(deserializer: D) -> std::result::Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    bool::deserialize(deserializer).map(Some)
+}
+
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            url: "postgresql://localhost/litellm".to_string(),
+            url: default_database_url(),
             max_connections: default_max_connections(),
             connection_timeout: default_connection_timeout(),
             ssl: false,
@@ -313,6 +325,22 @@ mod tests {
     }
 
     #[test]
+    fn test_database_config_deserialization_defaults_omitted_url() {
+        let config: DatabaseConfig = match serde_yml::from_str("enabled: true\n") {
+            Ok(config) => config,
+            Err(error) => panic!("omitted database URL config should parse: {}", error),
+        };
+        assert_eq!(config.url, "postgresql://localhost/litellm");
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn test_database_config_deserialization_rejects_null_auto_migrate() {
+        let result = serde_yml::from_str::<DatabaseConfig>("auto_migrate:\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_database_config_merge_url() {
         let base = DatabaseConfig::default();
         let other = DatabaseConfig {
@@ -362,13 +390,13 @@ mod tests {
     #[test]
     fn test_database_config_merge_auto_migrate_false_overrides_base() {
         let base = DatabaseConfig {
+            url: "postgresql://custom-host/mydb".to_string(),
             auto_migrate: true,
             auto_migrate_configured: false,
             ..DatabaseConfig::default()
         };
         let other: DatabaseConfig = match serde_yml::from_str(
-            r#"url: "postgresql://localhost/litellm"
-auto_migrate: false
+            r#"auto_migrate: false
 "#,
         ) {
             Ok(config) => config,
@@ -377,24 +405,26 @@ auto_migrate: false
         assert!(other.auto_migrate_configured);
 
         let merged = base.merge(other);
+        assert_eq!(merged.url, "postgresql://custom-host/mydb");
         assert!(!merged.auto_migrate);
     }
 
     #[test]
     fn test_database_config_merge_preserves_auto_migrate_when_overlay_omits_field() {
         let base = DatabaseConfig {
+            url: "postgresql://custom-host/mydb".to_string(),
             auto_migrate: true,
             auto_migrate_configured: false,
             ..DatabaseConfig::default()
         };
-        let other: DatabaseConfig =
-            match serde_yml::from_str(r#"url: "postgresql://localhost/litellm""#) {
-                Ok(config) => config,
-                Err(error) => panic!("omitted auto_migrate config should parse: {}", error),
-            };
+        let other: DatabaseConfig = match serde_yml::from_str("enabled: true\n") {
+            Ok(config) => config,
+            Err(error) => panic!("omitted auto_migrate config should parse: {}", error),
+        };
         assert!(!other.auto_migrate_configured);
 
         let merged = base.merge(other);
+        assert_eq!(merged.url, "postgresql://custom-host/mydb");
         assert!(merged.auto_migrate);
     }
 

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -35,8 +35,7 @@ impl StorageConfig {
 }
 
 /// Database configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DatabaseConfig {
     /// Database URL
     pub url: String,
@@ -59,6 +58,13 @@ pub struct DatabaseConfig {
     /// non-persistent in-memory SQLite fallback used when `enabled=false`.
     #[serde(default)]
     pub auto_migrate: bool,
+    /// Tracks whether `auto_migrate` was present in deserialized config.
+    ///
+    /// This preserves merge semantics for layered config: an omitted field
+    /// should not be treated as an explicit `false` override.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub auto_migrate_configured: bool,
     /// Allow PostgreSQL connection failures to fall back to local SQLite.
     ///
     /// Disabled by default to avoid silently writing production data to a
@@ -76,6 +82,48 @@ pub struct DatabaseConfig {
     pub allow_degraded: bool,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DatabaseConfigFields {
+    pub url: String,
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout: u64,
+    #[serde(default)]
+    pub ssl: bool,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub auto_migrate: Option<bool>,
+    #[serde(default)]
+    pub fallback_to_sqlite: bool,
+    #[serde(default)]
+    pub allow_degraded: bool,
+}
+
+impl<'de> Deserialize<'de> for DatabaseConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let fields = DatabaseConfigFields::deserialize(deserializer)?;
+        let auto_migrate_configured = fields.auto_migrate.is_some();
+
+        Ok(Self {
+            url: fields.url,
+            max_connections: fields.max_connections,
+            connection_timeout: fields.connection_timeout,
+            ssl: fields.ssl,
+            enabled: fields.enabled,
+            auto_migrate: fields.auto_migrate.unwrap_or(false),
+            auto_migrate_configured,
+            fallback_to_sqlite: fields.fallback_to_sqlite,
+            allow_degraded: fields.allow_degraded,
+        })
+    }
+}
+
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
@@ -85,6 +133,7 @@ impl Default for DatabaseConfig {
             ssl: false,
             enabled: false,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         }
@@ -110,7 +159,10 @@ impl DatabaseConfig {
         if other.enabled {
             self.enabled = true;
         }
-        self.auto_migrate = other.auto_migrate;
+        if other.auto_migrate_configured || other.auto_migrate {
+            self.auto_migrate = other.auto_migrate;
+            self.auto_migrate_configured = other.auto_migrate_configured;
+        }
         if other.fallback_to_sqlite {
             self.fallback_to_sqlite = true;
         }
@@ -220,6 +272,7 @@ mod tests {
             ssl: true,
             enabled: true,
             auto_migrate: true,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -238,6 +291,7 @@ mod tests {
             ssl: true,
             enabled: true,
             auto_migrate: true,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -255,6 +309,7 @@ mod tests {
         assert_eq!(config.url, "postgresql://prod/app");
         assert!(config.ssl);
         assert!(!config.auto_migrate);
+        assert!(!config.auto_migrate_configured);
     }
 
     #[test]
@@ -297,6 +352,7 @@ mod tests {
         let base = DatabaseConfig::default();
         let other = DatabaseConfig {
             auto_migrate: true,
+            auto_migrate_configured: false,
             ..DatabaseConfig::default()
         };
         let merged = base.merge(other);
@@ -307,10 +363,39 @@ mod tests {
     fn test_database_config_merge_auto_migrate_false_overrides_base() {
         let base = DatabaseConfig {
             auto_migrate: true,
+            auto_migrate_configured: false,
             ..DatabaseConfig::default()
         };
-        let merged = base.merge(DatabaseConfig::default());
+        let other: DatabaseConfig = match serde_yml::from_str(
+            r#"url: "postgresql://localhost/litellm"
+auto_migrate: false
+"#,
+        ) {
+            Ok(config) => config,
+            Err(error) => panic!("explicit auto_migrate=false config should parse: {}", error),
+        };
+        assert!(other.auto_migrate_configured);
+
+        let merged = base.merge(other);
         assert!(!merged.auto_migrate);
+    }
+
+    #[test]
+    fn test_database_config_merge_preserves_auto_migrate_when_overlay_omits_field() {
+        let base = DatabaseConfig {
+            auto_migrate: true,
+            auto_migrate_configured: false,
+            ..DatabaseConfig::default()
+        };
+        let other: DatabaseConfig =
+            match serde_yml::from_str(r#"url: "postgresql://localhost/litellm""#) {
+                Ok(config) => config,
+                Err(error) => panic!("omitted auto_migrate config should parse: {}", error),
+            };
+        assert!(!other.auto_migrate_configured);
+
+        let merged = base.merge(other);
+        assert!(merged.auto_migrate);
     }
 
     #[test]

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -241,6 +241,7 @@ fn test_database_validation_skips_when_disabled() {
         connection_timeout: 0,
         ssl: false,
         auto_migrate: false,
+        auto_migrate_configured: false,
         fallback_to_sqlite: false,
         allow_degraded: false,
     };

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -504,6 +504,7 @@ mod tests {
                 ssl: false,
                 enabled: true,
                 auto_migrate: false,
+                auto_migrate_configured: false,
                 fallback_to_sqlite: false,
                 allow_degraded: false,
             },
@@ -589,6 +590,7 @@ mod tests {
                 ssl: false,
                 enabled: true,
                 auto_migrate: false,
+                auto_migrate_configured: false,
                 fallback_to_sqlite: false,
                 allow_degraded: false,
             },
@@ -669,6 +671,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: true,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         }

--- a/tests/common/database.rs
+++ b/tests/common/database.rs
@@ -26,6 +26,7 @@ impl TestDatabase {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -78,6 +79,7 @@ pub fn test_db_config() -> DatabaseConfig {
         ssl: false,
         enabled: true,
         auto_migrate: false,
+        auto_migrate_configured: false,
         fallback_to_sqlite: false,
         allow_degraded: false,
     }

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -54,6 +54,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         }
@@ -78,6 +79,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -109,6 +111,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -129,6 +132,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -316,6 +320,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: true,
             allow_degraded: false,
         });
@@ -353,6 +358,7 @@ mod tests {
             ssl: false,
             enabled: false,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -378,6 +384,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -403,6 +410,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -428,6 +436,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -450,6 +459,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };
@@ -600,6 +610,7 @@ mod tests {
             ssl: false,
             enabled: true,
             auto_migrate: false,
+            auto_migrate_configured: false,
             fallback_to_sqlite: false,
             allow_degraded: false,
         };


### PR DESCRIPTION
## Summary
Preserve `storage.database.auto_migrate` across layered config merges when an overlay omits the field, while still allowing explicit `false` from config/env to disable migrations.

Fixes #616

## Changes
- Track whether `auto_migrate` was present during `DatabaseConfig` deserialization.
- Apply `auto_migrate` during merge only when it was explicitly configured or programmatically set to `true`.
- Mark `LITELLM_DATABASE_AUTO_MIGRATE` as explicit in `GatewayConfig::from_env()`.
- Add regression coverage for omitted overlays, explicit `false`, and env configuration.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test --all-features auto_migrate -- --nocapture`
- `cargo test --all-features test_gateway_config_from_env -- --nocapture`
- `cargo check --all-features`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -A warnings`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

Note: strict `cargo clippy --all-targets --all-features -- -D warnings` still fails on existing main-branch warnings in `src/core/providers/sagemaker/sigv4.rs:74` and `src/core/providers/vertex_ai/transformers.rs:81`; this PR does not touch those files.