### PR TITLE
fix(openai): preserve streaming audio metadata and reasoning deltas

### DIFF
--- a/src/core/providers/base/sse.rs
+++ b/src/core/providers/base/sse.rs
@@ -424,6 +424,77 @@ mod tests {
     }
 
     #[test]
+    fn test_openai_transformer_reasoning_to_thinking() {
+        let transformer = OpenAICompatibleTransformer::new("test");
+
+        let json_data = r#"{
+            "id": "test-id-reasoning",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "openai-reasoning",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "content": "Answer",
+                    "reasoning": "openai chain-of-thought"
+                },
+                "finish_reason": null
+            }]
+        }"#;
+
+        let result = match transformer.transform_chunk(json_data) {
+            Ok(Some(result)) => result,
+            Ok(None) => panic!("SSE chunk should produce a result"),
+            Err(error) => panic!("SSE chunk transformation should succeed: {error}"),
+        };
+        assert_eq!(
+            result.choices[0]
+                .delta
+                .thinking
+                .as_ref()
+                .and_then(|t| t.content.as_ref())
+                .map(String::as_str),
+            Some("openai chain-of-thought")
+        );
+    }
+
+    #[test]
+    fn test_openai_transformer_empty_reasoning_content_falls_back_to_reasoning() {
+        let transformer = OpenAICompatibleTransformer::new("test");
+
+        let json_data = r#"{
+            "id": "test-id-reasoning",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "openai-reasoning",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "content": "Answer",
+                    "reasoning_content": "",
+                    "reasoning": "fallback chain-of-thought"
+                },
+                "finish_reason": null
+            }]
+        }"#;
+
+        let result = match transformer.transform_chunk(json_data) {
+            Ok(Some(result)) => result,
+            Ok(None) => panic!("SSE chunk should produce a result"),
+            Err(error) => panic!("SSE chunk transformation should succeed: {error}"),
+        };
+        assert_eq!(
+            result.choices[0]
+                .delta
+                .thinking
+                .as_ref()
+                .and_then(|t| t.content.as_ref())
+                .map(String::as_str),
+            Some("fallback chain-of-thought")
+        );
+    }
+
+    #[test]
     fn test_anthropic_stream_tool_use_deltas() {
         let transformer = AnthropicTransformer::new("claude-test");
 

--- a/src/core/providers/base/sse/openai.rs
+++ b/src/core/providers/base/sse/openai.rs
@@ -73,9 +73,19 @@ impl SSETransformer for OpenAICompatibleTransformer {
                     format!("Failed to parse delta: {}", e),
                 )
             })?;
-            if let Some(Value::String(reasoning_content)) = delta.get("reasoning_content") {
+            let reasoning = delta
+                .get("reasoning_content")
+                .and_then(Value::as_str)
+                .filter(|reasoning| !reasoning.is_empty())
+                .or_else(|| {
+                    delta
+                        .get("reasoning")
+                        .and_then(Value::as_str)
+                        .filter(|reasoning| !reasoning.is_empty())
+                });
+            if let Some(reasoning) = reasoning {
                 delta_obj.thinking = Some(ThinkingDelta {
-                    content: Some(reasoning_content.clone()),
+                    content: Some(reasoning.to_string()),
                     ..Default::default()
                 });
             }

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -388,6 +388,8 @@ pub struct OpenAIDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio: Option<OpenAIMessageAudio>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<OpenAIToolCallDelta>>,

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -388,6 +388,8 @@ pub struct OpenAIDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audio: Option<OpenAIMessageAudio>,

--- a/src/core/providers/openai/transformer/response.rs
+++ b/src/core/providers/openai/transformer/response.rs
@@ -94,6 +94,7 @@ impl OpenAIResponseTransformer {
         });
         let thinking = delta
             .reasoning_content
+            .or(delta.reasoning)
             .filter(|reasoning| !reasoning.is_empty())
             .map(ThinkingDelta::new);
         let audio = delta.audio.map(|a| AudioDelta {

--- a/src/core/providers/openai/transformer/response.rs
+++ b/src/core/providers/openai/transformer/response.rs
@@ -94,6 +94,7 @@ impl OpenAIResponseTransformer {
         });
         let thinking = delta
             .reasoning_content
+            .filter(|reasoning| !reasoning.is_empty())
             .or(delta.reasoning)
             .filter(|reasoning| !reasoning.is_empty())
             .map(ThinkingDelta::new);

--- a/src/core/providers/openai/transformer/response.rs
+++ b/src/core/providers/openai/transformer/response.rs
@@ -9,7 +9,7 @@ use crate::core::types::responses::{
     AudioDelta, ChatChoice, ChatChunk, ChatDelta, ChatResponse, ChatStreamChoice, FinishReason,
     FunctionCallDelta, LogProbs, TokenLogProb, ToolCallDelta, TopLogProb, Usage,
 };
-use crate::core::types::thinking::ThinkingContent;
+use crate::core::types::thinking::{ThinkingContent, ThinkingDelta};
 
 use super::super::error::OpenAIError;
 use super::super::models::*;
@@ -92,7 +92,13 @@ impl OpenAIResponseTransformer {
             name: f.name,
             arguments: f.arguments,
         });
+        let thinking = delta
+            .reasoning_content
+            .filter(|reasoning| !reasoning.is_empty())
+            .map(ThinkingDelta::new);
         let audio = delta.audio.map(|a| AudioDelta {
+            id: a.id,
+            expires_at: a.expires_at,
             data: a.data,
             transcript: a.transcript,
             format: a.format,
@@ -108,7 +114,7 @@ impl OpenAIResponseTransformer {
                 _ => MessageRole::Assistant,
             }),
             content: delta.content,
-            thinking: None,
+            thinking,
             tool_calls,
             function_call,
             audio,

--- a/src/core/providers/openai/transformer/response_tests.rs
+++ b/src/core/providers/openai/transformer/response_tests.rs
@@ -518,6 +518,7 @@ fn test_transform_stream_chunk() {
             delta: OpenAIDelta {
                 role: Some("assistant".to_string()),
                 content: Some("Hello".to_string()),
+                reasoning: None,
                 reasoning_content: None,
                 audio: None,
                 tool_calls: None,
@@ -551,6 +552,7 @@ fn test_transform_stream_chunk_with_finish() {
             delta: OpenAIDelta {
                 role: None,
                 content: None,
+                reasoning: None,
                 reasoning_content: None,
                 audio: None,
                 tool_calls: None,
@@ -585,6 +587,7 @@ fn test_transform_delta_roles() {
         let delta = OpenAIDelta {
             role: Some(role.to_string()),
             content: None,
+            reasoning: None,
             reasoning_content: None,
             audio: None,
             tool_calls: None,
@@ -601,6 +604,7 @@ fn test_transform_delta_propagates_tool_and_function_calls() {
     let delta = OpenAIDelta {
         role: None,
         content: None,
+        reasoning: None,
         reasoning_content: None,
         audio: None,
         tool_calls: Some(vec![OpenAIToolCallDelta {
@@ -636,6 +640,7 @@ fn test_transform_delta_preserves_audio_metadata_and_reasoning_content() {
     let delta = OpenAIDelta {
         role: None,
         content: None,
+        reasoning: None,
         reasoning_content: Some("reasoning delta".to_string()),
         audio: Some(OpenAIMessageAudio {
             id: Some("audio-123".to_string()),
@@ -661,4 +666,23 @@ fn test_transform_delta_preserves_audio_metadata_and_reasoning_content() {
     assert_eq!(audio.data.as_deref(), Some("base64-audio"));
     assert_eq!(audio.transcript.as_deref(), Some("hello"));
     assert_eq!(audio.format.as_deref(), Some("wav"));
+}
+
+#[test]
+fn test_transform_delta_preserves_openai_reasoning() {
+    let delta = OpenAIDelta {
+        role: None,
+        content: None,
+        reasoning: Some("openai reasoning delta".to_string()),
+        reasoning_content: None,
+        audio: None,
+        tool_calls: None,
+        function_call: None,
+    };
+
+    let out = match OpenAIResponseTransformer::transform_delta(delta) {
+        Ok(out) => out,
+        Err(error) => panic!("delta transformation should succeed: {error}"),
+    };
+    assert_eq!(out.thinking_content(), Some("openai reasoning delta"));
 }

--- a/src/core/providers/openai/transformer/response_tests.rs
+++ b/src/core/providers/openai/transformer/response_tests.rs
@@ -518,6 +518,7 @@ fn test_transform_stream_chunk() {
             delta: OpenAIDelta {
                 role: Some("assistant".to_string()),
                 content: Some("Hello".to_string()),
+                reasoning_content: None,
                 audio: None,
                 tool_calls: None,
                 function_call: None,
@@ -550,6 +551,7 @@ fn test_transform_stream_chunk_with_finish() {
             delta: OpenAIDelta {
                 role: None,
                 content: None,
+                reasoning_content: None,
                 audio: None,
                 tool_calls: None,
                 function_call: None,
@@ -583,6 +585,7 @@ fn test_transform_delta_roles() {
         let delta = OpenAIDelta {
             role: Some(role.to_string()),
             content: None,
+            reasoning_content: None,
             audio: None,
             tool_calls: None,
             function_call: None,
@@ -598,6 +601,7 @@ fn test_transform_delta_propagates_tool_and_function_calls() {
     let delta = OpenAIDelta {
         role: None,
         content: None,
+        reasoning_content: None,
         audio: None,
         tool_calls: Some(vec![OpenAIToolCallDelta {
             index: 0,
@@ -625,4 +629,36 @@ fn test_transform_delta_propagates_tool_and_function_calls() {
         out.function_call.as_ref().unwrap().name.as_deref(),
         Some("legacy_fn")
     );
+}
+
+#[test]
+fn test_transform_delta_preserves_audio_metadata_and_reasoning_content() {
+    let delta = OpenAIDelta {
+        role: None,
+        content: None,
+        reasoning_content: Some("reasoning delta".to_string()),
+        audio: Some(OpenAIMessageAudio {
+            id: Some("audio-123".to_string()),
+            expires_at: Some(1_717_171_717),
+            data: Some("base64-audio".to_string()),
+            transcript: Some("hello".to_string()),
+            format: Some("wav".to_string()),
+        }),
+        tool_calls: None,
+        function_call: None,
+    };
+
+    let out = match OpenAIResponseTransformer::transform_delta(delta) {
+        Ok(out) => out,
+        Err(error) => panic!("delta transformation should succeed: {error}"),
+    };
+    assert_eq!(out.thinking_content(), Some("reasoning delta"));
+    let Some(audio) = out.audio.as_ref() else {
+        panic!("audio delta should be present");
+    };
+    assert_eq!(audio.id.as_deref(), Some("audio-123"));
+    assert_eq!(audio.expires_at, Some(1_717_171_717));
+    assert_eq!(audio.data.as_deref(), Some("base64-audio"));
+    assert_eq!(audio.transcript.as_deref(), Some("hello"));
+    assert_eq!(audio.format.as_deref(), Some("wav"));
 }

--- a/src/core/providers/openai/transformer/response_tests.rs
+++ b/src/core/providers/openai/transformer/response_tests.rs
@@ -686,3 +686,41 @@ fn test_transform_delta_preserves_openai_reasoning() {
     };
     assert_eq!(out.thinking_content(), Some("openai reasoning delta"));
 }
+
+#[test]
+fn test_transform_delta_skips_empty_reasoning_content() {
+    let delta = OpenAIDelta {
+        role: None,
+        content: None,
+        reasoning: None,
+        reasoning_content: Some(String::new()),
+        audio: None,
+        tool_calls: None,
+        function_call: None,
+    };
+
+    let out = match OpenAIResponseTransformer::transform_delta(delta) {
+        Ok(out) => out,
+        Err(error) => panic!("delta transformation should succeed: {error}"),
+    };
+    assert!(out.thinking.is_none());
+}
+
+#[test]
+fn test_transform_delta_falls_back_to_openai_reasoning_when_reasoning_content_empty() {
+    let delta = OpenAIDelta {
+        role: None,
+        content: None,
+        reasoning: Some("openai fallback reasoning".to_string()),
+        reasoning_content: Some(String::new()),
+        audio: None,
+        tool_calls: None,
+        function_call: None,
+    };
+
+    let out = match OpenAIResponseTransformer::transform_delta(delta) {
+        Ok(out) => out,
+        Err(error) => panic!("delta transformation should succeed: {error}"),
+    };
+    assert_eq!(out.thinking_content(), Some("openai fallback reasoning"));
+}

--- a/src/core/types/responses/delta.rs
+++ b/src/core/types/responses/delta.rs
@@ -6,7 +6,7 @@ use super::super::message::MessageRole;
 use super::super::thinking::ThinkingDelta;
 
 /// Streaming audio delta content.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AudioDelta {
     /// Provider audio object identifier, when provided by the upstream stream.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/types/responses/delta.rs
+++ b/src/core/types/responses/delta.rs
@@ -8,6 +8,14 @@ use super::super::thinking::ThinkingDelta;
 /// Streaming audio delta content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AudioDelta {
+    /// Provider audio object identifier, when provided by the upstream stream.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Provider audio object expiration timestamp, when provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+
     /// Base64 encoded audio delta.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,

--- a/src/server/routes/ai/chat_tests.rs
+++ b/src/server/routes/ai/chat_tests.rs
@@ -159,6 +159,8 @@ fn test_convert_core_chunk_preserves_audio_delta() {
                 tool_calls: None,
                 function_call: None,
                 audio: Some(types::responses::AudioDelta {
+                    id: Some("audio-123".to_string()),
+                    expires_at: Some(1_717_171_717),
                     data: Some("base64-audio-delta".to_string()),
                     transcript: Some("hello from audio".to_string()),
                     format: Some("wav".to_string()),
@@ -175,6 +177,8 @@ fn test_convert_core_chunk_preserves_audio_delta() {
     let Some(audio) = converted.choices[0].delta.audio.as_ref() else {
         panic!("audio delta should be preserved");
     };
+    assert_eq!(audio.id.as_deref(), Some("audio-123"));
+    assert_eq!(audio.expires_at, Some(1_717_171_717));
     assert_eq!(audio.data.as_deref(), Some("base64-audio-delta"));
     assert_eq!(audio.transcript.as_deref(), Some("hello from audio"));
     assert_eq!(audio.format.as_deref(), Some("wav"));


### PR DESCRIPTION
## Summary
- Preserve OpenAI streaming audio `id` and `expires_at` metadata in the unified `AudioDelta`.
- Parse OpenAI stream `reasoning_content` and map it into `ChatDelta.thinking`.
- Add regression coverage for OpenAI transformer output and server stream conversion.

Closes #626

## Review Threads Covered
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293171606
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185651
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185657
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185659
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185660

## Validation
- cargo fmt --all -- --check
- cargo test --all-features preserves_audio -- --nocapture
- cargo check --all-features
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -A warnings
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh
- git diff --check

## Known Baseline
- `cargo clippy --all-targets --all-features -- -D warnings` still fails on existing main baseline lints outside this PR:
  - `src/core/providers/sagemaker/sigv4.rs:74` (`clippy::unnecessary_sort_by`)
  - `src/core/providers/vertex_ai/transformers.rs:81` (`clippy::manual_map`)
