### PR TITLE
fix(openai): preserve streaming audio metadata and reasoning deltas

### DIFF
--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -387,6 +387,9 @@ pub struct OpenAIDelta {
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    /// Reasoning content delta from OpenAI-compatible reasoning models.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audio: Option<OpenAIMessageAudio>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/providers/openai/transformer/response.rs
+++ b/src/core/providers/openai/transformer/response.rs
@@ -9,7 +9,7 @@ use crate::core::types::responses::{
     AudioDelta, ChatChoice, ChatChunk, ChatDelta, ChatResponse, ChatStreamChoice, FinishReason,
     FunctionCallDelta, LogProbs, TokenLogProb, ToolCallDelta, TopLogProb, Usage,
 };
-use crate::core::types::thinking::ThinkingContent;
+use crate::core::types::thinking::{ThinkingContent, ThinkingDelta};
 
 use super::super::error::OpenAIError;
 use super::super::models::*;
@@ -93,10 +93,13 @@ impl OpenAIResponseTransformer {
             arguments: f.arguments,
         });
         let audio = delta.audio.map(|a| AudioDelta {
+            id: a.id,
+            expires_at: a.expires_at,
             data: a.data,
             transcript: a.transcript,
             format: a.format,
         });
+        let thinking = delta.reasoning_content.map(ThinkingDelta::new);
 
         Ok(ChatDelta {
             role: delta.role.map(|r| match r.as_str() {
@@ -108,7 +111,7 @@ impl OpenAIResponseTransformer {
                 _ => MessageRole::Assistant,
             }),
             content: delta.content,
-            thinking: None,
+            thinking,
             tool_calls,
             function_call,
             audio,

--- a/src/core/providers/openai/transformer/response_tests.rs
+++ b/src/core/providers/openai/transformer/response_tests.rs
@@ -518,6 +518,7 @@ fn test_transform_stream_chunk() {
             delta: OpenAIDelta {
                 role: Some("assistant".to_string()),
                 content: Some("Hello".to_string()),
+                reasoning_content: None,
                 audio: None,
                 tool_calls: None,
                 function_call: None,
@@ -550,6 +551,7 @@ fn test_transform_stream_chunk_with_finish() {
             delta: OpenAIDelta {
                 role: None,
                 content: None,
+                reasoning_content: None,
                 audio: None,
                 tool_calls: None,
                 function_call: None,
@@ -583,6 +585,7 @@ fn test_transform_delta_roles() {
         let delta = OpenAIDelta {
             role: Some(role.to_string()),
             content: None,
+            reasoning_content: None,
             audio: None,
             tool_calls: None,
             function_call: None,
@@ -598,6 +601,7 @@ fn test_transform_delta_propagates_tool_and_function_calls() {
     let delta = OpenAIDelta {
         role: None,
         content: None,
+        reasoning_content: None,
         audio: None,
         tool_calls: Some(vec![OpenAIToolCallDelta {
             index: 0,

--- a/src/core/types/responses/delta.rs
+++ b/src/core/types/responses/delta.rs
@@ -8,6 +8,14 @@ use super::super::thinking::ThinkingDelta;
 /// Streaming audio delta content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AudioDelta {
+    /// Provider audio response identifier, when included in stream metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Provider audio expiration timestamp, when included in stream metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+
     /// Base64 encoded audio delta.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,

--- a/src/server/routes/ai/chat_tests.rs
+++ b/src/server/routes/ai/chat_tests.rs
@@ -159,6 +159,8 @@ fn test_convert_core_chunk_preserves_audio_delta() {
                 tool_calls: None,
                 function_call: None,
                 audio: Some(types::responses::AudioDelta {
+                    id: Some("audio-response-123".to_string()),
+                    expires_at: Some(456),
                     data: Some("base64-audio-delta".to_string()),
                     transcript: Some("hello from audio".to_string()),
                     format: Some("wav".to_string()),
@@ -175,6 +177,8 @@ fn test_convert_core_chunk_preserves_audio_delta() {
     let Some(audio) = converted.choices[0].delta.audio.as_ref() else {
         panic!("audio delta should be preserved");
     };
+    assert_eq!(audio.id.as_deref(), Some("audio-response-123"));
+    assert_eq!(audio.expires_at, Some(456));
     assert_eq!(audio.data.as_deref(), Some("base64-audio-delta"));
     assert_eq!(audio.transcript.as_deref(), Some("hello from audio"));
     assert_eq!(audio.format.as_deref(), Some("wav"));

--- a/tests/integration/openai_streaming_audio_tests.rs
+++ b/tests/integration/openai_streaming_audio_tests.rs
@@ -1,7 +1,7 @@
 use litellm_rs::core::providers::openai::{OpenAIResponseTransformer, models::OpenAIStreamChunk};
 
 #[test]
-fn openai_streaming_audio_delta_is_preserved() {
+fn openai_streaming_audio_delta_is_preserved() -> Result<(), Box<dyn std::error::Error>> {
     let chunk: OpenAIStreamChunk = serde_json::from_value(serde_json::json!({
         "id": "chatcmpl-audio",
         "object": "chat.completion.chunk",
@@ -12,6 +12,8 @@ fn openai_streaming_audio_delta_is_preserved() {
                 "index": 0,
                 "delta": {
                     "audio": {
+                        "id": "audio-response-123",
+                        "expires_at": 1677655888,
                         "data": "base64-audio-delta",
                         "transcript": "hello from audio",
                         "format": "wav"
@@ -20,13 +22,42 @@ fn openai_streaming_audio_delta_is_preserved() {
                 "finish_reason": null
             }
         ]
-    }))
-    .unwrap();
+    }))?;
 
-    let result = OpenAIResponseTransformer::transform_stream_chunk(chunk).unwrap();
-    let delta_json = serde_json::to_value(&result.choices[0].delta).unwrap();
+    let result = OpenAIResponseTransformer::transform_stream_chunk(chunk)?;
+    let delta_json = serde_json::to_value(&result.choices[0].delta)?;
 
+    assert_eq!(delta_json["audio"]["id"], "audio-response-123");
+    assert_eq!(delta_json["audio"]["expires_at"], 1677655888);
     assert_eq!(delta_json["audio"]["data"], "base64-audio-delta");
     assert_eq!(delta_json["audio"]["transcript"], "hello from audio");
     assert_eq!(delta_json["audio"]["format"], "wav");
+    Ok(())
+}
+
+#[test]
+fn openai_streaming_reasoning_content_maps_to_thinking() -> Result<(), Box<dyn std::error::Error>> {
+    let chunk: OpenAIStreamChunk = serde_json::from_value(serde_json::json!({
+        "id": "chatcmpl-reasoning",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "deepseek-r1",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "reasoning_content": "thinking through the answer"
+                },
+                "finish_reason": null
+            }
+        ]
+    }))?;
+
+    let result = OpenAIResponseTransformer::transform_stream_chunk(chunk)?;
+
+    assert_eq!(
+        result.choices[0].delta.thinking_content(),
+        Some("thinking through the answer")
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Preserve OpenAI streaming audio `id` and `expires_at` in unified `AudioDelta`.
- Parse OpenAI-compatible stream `reasoning_content` and map it to `ChatDelta.thinking`.
- Add regression coverage for audio metadata and reasoning deltas, plus server stream conversion coverage for audio metadata.

## Review threads addressed

- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293171606
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185651
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185657
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185659
- https://github.com/majiayu000/litellm-rs/pull/568#discussion_r3293185660

## Validation

- `cargo test openai_streaming` (failed before fix: audio id was null, reasoning thinking was none)
- `cargo test openai_streaming` (passed after fix)
- `cargo check`
- `cargo test`
- `cargo fmt --check`
- `git diff --check`
- `cargo check --all-features`

Closes #626