### PR TITLE
fix(config): preserve pricing source on merge

### DIFF
--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -211,11 +211,9 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
 }
 
 /// Pricing source configuration
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GatewayPricingConfig {
     /// Optional pricing source path/URL used by PricingService::new
-    #[serde(default = "default_pricing_source")]
     pub source: Option<String>,
     /// When the pricing source is configured and the initial load fails, allow
     /// the gateway to keep running without pricing data instead of failing
@@ -224,8 +222,85 @@ pub struct GatewayPricingConfig {
     /// Defaults to `false` so a configured-but-broken pricing source is
     /// surfaced at startup. A `true` value documents that the gateway may
     /// serve traffic without cost accounting until pricing data is refreshed.
-    #[serde(default)]
     pub allow_degraded: bool,
+    #[serde(skip)]
+    merge_fields: GatewayPricingMergeFields,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct GatewayPricingMergeFields {
+    source: bool,
+    allow_degraded: bool,
+}
+
+enum ConfigField<T> {
+    Missing,
+    Present(T),
+}
+
+impl<T> Default for ConfigField<T> {
+    fn default() -> Self {
+        Self::Missing
+    }
+}
+
+impl<'de, T> Deserialize<'de> for ConfigField<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GatewayPricingConfigWire {
+    #[serde(default)]
+    source: ConfigField<Option<String>>,
+    #[serde(default)]
+    allow_degraded: ConfigField<bool>,
+}
+
+impl<'de> Deserialize<'de> for GatewayPricingConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = GatewayPricingConfigWire::deserialize(deserializer)?;
+        let mut merge_fields = GatewayPricingMergeFields::default();
+
+        let source = match wire.source {
+            ConfigField::Present(source) => {
+                merge_fields.source = true;
+                source
+            }
+            ConfigField::Missing => default_pricing_source(),
+        };
+
+        let allow_degraded = match wire.allow_degraded {
+            ConfigField::Present(allow_degraded) => {
+                merge_fields.allow_degraded = true;
+                allow_degraded
+            }
+            ConfigField::Missing => false,
+        };
+
+        Ok(Self {
+            source,
+            allow_degraded,
+            merge_fields,
+        })
+    }
+}
+
+impl PartialEq for GatewayPricingConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.source == other.source && self.allow_degraded == other.allow_degraded
+    }
 }
 
 impl Default for GatewayPricingConfig {
@@ -233,20 +308,32 @@ impl Default for GatewayPricingConfig {
         Self {
             source: default_pricing_source(),
             allow_degraded: false,
+            merge_fields: GatewayPricingMergeFields::default(),
         }
     }
 }
 
 impl GatewayPricingConfig {
-    /// Merge pricing configurations, with non-default overlay values taking precedence.
+    /// Merge pricing configurations, with explicit overlay values taking precedence.
     pub fn merge(mut self, other: Self) -> Self {
-        if other.source != default_pricing_source() {
+        let source_overridden =
+            other.merge_fields.source || other.source != default_pricing_source();
+        if source_overridden {
             self.source = other.source;
         }
-        if other.allow_degraded {
-            self.allow_degraded = true;
+
+        let allow_degraded_overridden = other.merge_fields.allow_degraded || other.allow_degraded;
+        if allow_degraded_overridden {
+            self.allow_degraded = other.allow_degraded;
         }
+
+        self.merge_fields.source |= source_overridden;
+        self.merge_fields.allow_degraded |= allow_degraded_overridden;
         self
+    }
+
+    fn mark_source_explicit_for_merge(&mut self) {
+        self.merge_fields.source = true;
     }
 }
 
@@ -390,6 +477,7 @@ impl GatewayConfig {
 
         if let Some(pricing_source) = env_var(ENV_PRICING_SOURCE) {
             config.pricing.source = Some(pricing_source);
+            config.pricing.mark_source_explicit_for_merge();
         }
 
         if let Some(enabled) = parse_env_bool(ENV_CACHE_ENABLED)? {

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -233,15 +233,11 @@ struct GatewayPricingMergeFields {
     allow_degraded: bool,
 }
 
+#[derive(Default)]
 enum ConfigField<T> {
+    #[default]
     Missing,
     Present(T),
-}
-
-impl<T> Default for ConfigField<T> {
-    fn default() -> Self {
-        Self::Missing
-    }
 }
 
 impl<'de, T> Deserialize<'de> for ConfigField<T>

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -237,6 +237,19 @@ impl Default for GatewayPricingConfig {
     }
 }
 
+impl GatewayPricingConfig {
+    /// Merge pricing configurations, with non-default overlay values taking precedence.
+    pub fn merge(mut self, other: Self) -> Self {
+        if other.source != default_pricing_source() {
+            self.source = other.source;
+        }
+        if other.allow_degraded {
+            self.allow_degraded = true;
+        }
+        self
+    }
+}
+
 fn default_pricing_source() -> Option<String> {
     // Keep the runtime default aligned with config/gateway.yaml.example.
     // Relative paths are resolved by the process working directory.
@@ -417,7 +430,7 @@ impl GatewayConfig {
         self.cache = self.cache.merge(other.cache);
         self.rate_limit = self.rate_limit.merge(other.rate_limit);
         self.enterprise = self.enterprise.merge(other.enterprise);
-        self.pricing = other.pricing;
+        self.pricing = self.pricing.merge(other.pricing);
 
         self
     }

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -534,6 +534,35 @@ fn test_gateway_config_merge_provider_override() {
     assert_eq!(merged.providers[0].api_key, "new-api-key");
 }
 
+#[test]
+fn test_gateway_config_merge_pricing_preserves_base_source_for_default_overlay() {
+    let mut base = create_valid_config();
+    base.pricing.source = Some("config/custom-prices.json".to_string());
+
+    let merged = base.merge(GatewayConfig::default());
+
+    assert_eq!(
+        merged.pricing.source.as_deref(),
+        Some("config/custom-prices.json")
+    );
+}
+
+#[test]
+fn test_gateway_config_merge_pricing_uses_explicit_overlay_source() {
+    let mut base = create_valid_config();
+    base.pricing.source = Some("config/base-prices.json".to_string());
+
+    let mut other = GatewayConfig::default();
+    other.pricing.source = Some("config/overlay-prices.json".to_string());
+
+    let merged = base.merge(other);
+
+    assert_eq!(
+        merged.pricing.source.as_deref(),
+        Some("config/overlay-prices.json")
+    );
+}
+
 // ==================== GatewayConfig Serialization Tests ====================
 
 #[test]

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -576,8 +576,10 @@ fn test_gateway_config_merge_pricing_uses_explicit_default_overlay_source() {
     let mut base = create_valid_config();
     base.pricing.source = None;
 
-    let mut other = GatewayConfig::default();
-    other.pricing = pricing_from_yaml(&format!("source: \"{}\"", DEFAULT_PRICING_SOURCE));
+    let other = GatewayConfig {
+        pricing: pricing_from_yaml(&format!("source: \"{}\"", DEFAULT_PRICING_SOURCE)),
+        ..Default::default()
+    };
 
     let merged = base.merge(other);
 
@@ -629,8 +631,10 @@ fn test_gateway_config_merge_pricing_uses_explicit_allow_degraded_false() {
     let mut base = create_valid_config();
     base.pricing.allow_degraded = true;
 
-    let mut other = GatewayConfig::default();
-    other.pricing = pricing_from_yaml("allow_degraded: false");
+    let other = GatewayConfig {
+        pricing: pricing_from_yaml("allow_degraded: false"),
+        ..Default::default()
+    };
 
     let merged = base.merge(other);
 

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-const TEST_ENV_KEYS: [&str; 23] = [
+const TEST_ENV_KEYS: [&str; 24] = [
     ENV_HOST,
     ENV_PORT,
     ENV_WORKERS,
@@ -28,6 +28,7 @@ const TEST_ENV_KEYS: [&str; 23] = [
     "LITELLM_PROVIDER_OPENAI_MODELS",
     "LITELLM_PROVIDER_OPENAI_TAGS",
     "LITELLM_PROVIDER_OPENAI_MAX_RETRIES",
+    "LITELLM_PROVIDER_VLLM_TYPE",
 ];
 
 fn clear_test_env() {
@@ -54,6 +55,13 @@ fn create_valid_config() -> GatewayConfig {
     config.storage.database.url = "postgres://localhost/test".to_string();
     config.auth.jwt_secret = "StrongJwtSecretWithMixedCaseAndNumbers1234!".to_string();
     config
+}
+
+fn pricing_from_yaml(yaml: &str) -> GatewayPricingConfig {
+    match serde_yml::from_str(yaml) {
+        Ok(pricing) => pricing,
+        Err(error) => panic!("expected pricing yaml to parse: {}", error),
+    }
 }
 
 // ==================== GatewayConfig Default Tests ====================
@@ -564,6 +572,49 @@ fn test_gateway_config_merge_pricing_uses_explicit_overlay_source() {
 }
 
 #[test]
+fn test_gateway_config_merge_pricing_uses_explicit_default_overlay_source() {
+    let mut base = create_valid_config();
+    base.pricing.source = None;
+
+    let mut other = GatewayConfig::default();
+    other.pricing = pricing_from_yaml(&format!("source: \"{}\"", DEFAULT_PRICING_SOURCE));
+
+    let merged = base.merge(other);
+
+    assert_eq!(
+        merged.pricing.source.as_deref(),
+        Some(DEFAULT_PRICING_SOURCE)
+    );
+}
+
+#[test]
+fn test_gateway_config_merge_pricing_uses_env_default_overlay_source() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_test_env();
+    unsafe {
+        env::set_var(ENV_ENABLE_JWT, "false");
+        env::set_var(ENV_PROVIDERS, "vllm");
+        env::set_var("LITELLM_PROVIDER_VLLM_TYPE", "vllm");
+        env::set_var(ENV_PRICING_SOURCE, DEFAULT_PRICING_SOURCE);
+    }
+
+    let mut base = create_valid_config();
+    base.pricing.source = None;
+    let other = match GatewayConfig::from_env() {
+        Ok(config) => config,
+        Err(error) => panic!("expected GatewayConfig::from_env() to succeed: {}", error),
+    };
+
+    let merged = base.merge(other);
+
+    assert_eq!(
+        merged.pricing.source.as_deref(),
+        Some(DEFAULT_PRICING_SOURCE)
+    );
+    clear_test_env();
+}
+
+#[test]
 fn test_gateway_config_merge_pricing_preserves_allow_degraded_for_default_overlay() {
     let mut base = create_valid_config();
     base.pricing.allow_degraded = true;
@@ -571,6 +622,19 @@ fn test_gateway_config_merge_pricing_preserves_allow_degraded_for_default_overla
     let merged = base.merge(GatewayConfig::default());
 
     assert!(merged.pricing.allow_degraded);
+}
+
+#[test]
+fn test_gateway_config_merge_pricing_uses_explicit_allow_degraded_false() {
+    let mut base = create_valid_config();
+    base.pricing.allow_degraded = true;
+
+    let mut other = GatewayConfig::default();
+    other.pricing = pricing_from_yaml("allow_degraded: false");
+
+    let merged = base.merge(other);
+
+    assert!(!merged.pricing.allow_degraded);
 }
 
 // ==================== GatewayConfig Serialization Tests ====================

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -563,6 +563,16 @@ fn test_gateway_config_merge_pricing_uses_explicit_overlay_source() {
     );
 }
 
+#[test]
+fn test_gateway_config_merge_pricing_preserves_allow_degraded_for_default_overlay() {
+    let mut base = create_valid_config();
+    base.pricing.allow_degraded = true;
+
+    let merged = base.merge(GatewayConfig::default());
+
+    assert!(merged.pricing.allow_degraded);
+}
+
 // ==================== GatewayConfig Serialization Tests ====================
 
 #[test]


### PR DESCRIPTION
## Summary
- add `GatewayPricingConfig::merge` so default overlay pricing config does not replace a custom base pricing source
- keep explicit overlay pricing sources taking precedence
- add regression coverage for both merge behaviors

## Validation
- `cargo test test_gateway_config_merge_pricing`
- `cargo check`
- `cargo fmt --check`
- `git diff --check`
- `cargo test`

Closes #629