### PR TITLE
docs(readme): align provider capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ litellm-rs = { version = "0.5", default-features = false, features = ["gateway"]
 
 Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLAUDE.md#provider-tiers) for the engineering definition).
 
-- **Tier 1 — catalog-only**: OpenAI-compatible endpoints declared as data in [`src/core/providers/registry/catalog.rs`](./src/core/providers/registry/catalog.rs). Routed through `OpenAILikeProvider`. Always available (no cargo feature required). Capabilities reflect what the upstream OpenAI-compatible surface offers; this crate forwards `/chat/completions`, `/completions`, `/embeddings`, etc., when the upstream exposes them.
+- **Tier 1 — catalog-only**: OpenAI-compatible endpoints declared as data in [`src/core/providers/registry/catalog.rs`](./src/core/providers/registry/catalog.rs). Routed through `OpenAILikeProvider`. Always available (no cargo feature required). Today this crate exposes chat completions and chat streaming for these providers; non-chat OpenAI-compatible endpoints need explicit provider methods before they are advertised.
 - **Tier 2 — code-based**: providers with custom request/response handling, auth signing, or streaming. Wired into the `Provider` enum and the factory. Some Tier 2 builders are feature-gated.
 
 > The matrix below is **hand-maintained** and reflects the runtime surface today. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 wiring lives in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Capability columns describe which endpoints this crate exposes for the provider — `passthrough` means the call is forwarded to the upstream OpenAI-compatible endpoint without per-provider transformation. A dynamically-generated matrix is tracked as a follow-up.
@@ -123,23 +123,23 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | OpenAI (`openai`) | always | ✅ | ✅ | ✅ | ✅ | ✅ | Reference implementation. |
 | Anthropic (`anthropic`) | always | ✅ | ✅ | – | – | – | Native Anthropic messages API. |
 | Mistral (`mistral`) | always | ✅ | ✅ | passthrough | – | – | Native client. |
-| Cloudflare Workers AI (`cloudflare`) | always | ✅ | ✅ | passthrough | – | – | Native client with account-id auth. |
-| Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | passthrough | passthrough | Dedicated module gated on `providers-extra`. |
-| Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
+| Cloudflare Workers AI (`cloudflare`) | always | ✅ | – | – | – | – | Native client with account-id auth; streaming and embeddings currently return `NotSupported`. |
+| Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extra`. |
+| Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extra`. |
 | AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |
-| Google Vertex AI (`vertex_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
-| Meta Llama API (`meta_llama`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
-| Vercel v0 (`v0`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extra`. |
+| Google Vertex AI (`vertex_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extra`. |
+| Meta Llama API (`meta_llama`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extra`. |
+| Vercel v0 (`v0`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extra`. |
 | Amazon Nova (`amazon_nova`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extended`. |
 | fal.ai (`fal_ai`) | wired via factory (`OpenAILike`) | passthrough | passthrough | – | passthrough | – | Dedicated module gated on `providers-extended`. |
 | Replicate (`replicate`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | passthrough | – | Dedicated module gated on `providers-extended`. |
-| GitHub Models (`github`) | wired via factory (`OpenAILike`) | ✅ | ✅ | passthrough | – | – | Dedicated module gated on `providers-extended`. |
+| GitHub Models (`github`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extended`. |
 | GitHub Copilot (`github_copilot`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Dedicated module gated on `providers-extended`. |
-| Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | passthrough | passthrough | passthrough | For self-hosted / unlisted endpoints. |
+| Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | – | – | – | For self-hosted / unlisted chat endpoints. |
 
 ### Tier 1 — catalog providers (OpenAI-compatible, always available)
 
-All entries below route through `OpenAILikeProvider`. Chat and streaming work for any endpoint that follows OpenAI's `/chat/completions` SSE protocol. Other endpoints (embeddings, images, audio) are forwarded only when the upstream exposes them; the crate does not add per-provider transformations.
+All entries below route through `OpenAILikeProvider`. Chat and streaming work for any endpoint that follows OpenAI's `/chat/completions` SSE protocol. Embeddings, images, audio, and other non-chat endpoints are not exposed for catalog providers until explicit methods are implemented.
 
 **Cloud (`Bearer` auth via env var):**
 
@@ -188,7 +188,7 @@ use litellm_rs::{completion, user_message};
 // Automatically routes to the right provider based on model name
 let openai = completion("gpt-4", vec![user_message("Hi")], None).await?;
 let anthropic = completion("anthropic/claude-3-opus", vec![user_message("Hi")], None).await?;
-let groq = completion("groq/llama-3.1-70b", vec![user_message("Hi")], None).await?;
+let groq = completion("groq/llama-3.1-8b-instant", vec![user_message("Hi")], None).await?;
 let bedrock = completion(
     "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     vec![user_message("Hi")],


### PR DESCRIPTION
Closes #635.

## Summary
- tighten Tier 1/OpenAILike docs to the chat + chat-streaming surface currently exposed by this crate
- correct Cloudflare stream/embed cells to match the current `NotSupported` implementation
- remove non-chat passthrough claims from OpenAILike-backed rows
- replace the Groq example with `groq/llama-3.1-8b-instant`, matching repo tests and current Groq docs

## Review threads addressed
- #582 `PRRT_kwDOPMtB5s6EXcx8`
- #582 `PRRT_kwDOPMtB5s6FE1wl`
- #582 `PRRT_kwDOPMtB5s6FE1wo`
- #582 `PRRT_kwDOPMtB5s6FE1wy`

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test --all-features -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -A warnings`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh` (PASS; script reported 0/0, manual `git diff --stat origin/main...HEAD` shows README.md only, 22 lines)
- `bash scripts/guards/check_pr_overlap.sh` (PASS, no file overlaps)