### PR TITLE
fix(storage): simplify Redis init status

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -94,15 +94,11 @@ impl StorageLayer {
             match redis::RedisPool::new(&config.redis).await {
                 Ok(pool) => {
                     if pool.is_noop() {
-                        // RedisPool::new returns a no-op pool when enabled=false,
-                        // but we already handled that branch above. Treat any
-                        // other no-op as healthy to be safe.
                         info!("Redis pool initialized in no-op mode");
-                        (Arc::new(pool), DependencyStatus::Healthy)
                     } else {
                         info!("Redis connection established");
-                        (Arc::new(pool), DependencyStatus::Healthy)
                     }
+                    (Arc::new(pool), DependencyStatus::Healthy)
                 }
                 Err(e) => {
                     if config.redis.allow_degraded {


### PR DESCRIPTION
## Summary
- Simplify the successful Redis initialization branch so `DependencyStatus::Healthy` is selected once after logging.
- Keep separate log messages for no-op and real Redis pools.

## Review thread
Follow-up for #586 review thread: https://github.com/majiayu000/litellm-rs/pull/586#discussion_r3295882040

Fixes #632

## Validation
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- `cargo test --all-features storage::tests::redis -- --nocapture`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh`
- `cargo test --all-features`
