### PR TITLE
fix(bedrock): harden runtime model-id fallback

### DIFF
--- a/src/core/providers/bedrock/embeddings/mod.rs
+++ b/src/core/providers/bedrock/embeddings/mod.rs
@@ -83,6 +83,10 @@ pub async fn execute_embedding(
     }
 }
 
+fn execution_model_id(model: &str) -> String {
+    crate::core::providers::bedrock::parse_bedrock_model_id(model).execution_model_id
+}
+
 /// Execute Titan text embedding
 async fn execute_titan_embedding(
     client: &crate::core::providers::bedrock::client::BedrockClient,
@@ -105,7 +109,8 @@ async fn execute_titan_embedding(
     let titan_request = TitanEmbeddingRequest { input_text };
     let body = serde_json::to_value(titan_request)?;
 
-    let response = client.send_request(&request.model, "invoke", &body).await?;
+    let model_id = execution_model_id(&request.model);
+    let response = client.send_request(&model_id, "invoke", &body).await?;
     let titan_response: TitanEmbeddingResponse = response
         .json()
         .await
@@ -162,7 +167,8 @@ async fn execute_titan_multimodal_embedding(
     };
 
     let body = serde_json::to_value(titan_request)?;
-    let response = client.send_request(&request.model, "invoke", &body).await?;
+    let model_id = execution_model_id(&request.model);
+    let response = client.send_request(&model_id, "invoke", &body).await?;
     let titan_response: TitanEmbeddingResponse = response
         .json()
         .await
@@ -211,7 +217,8 @@ async fn execute_cohere_embedding(
     };
 
     let body = serde_json::to_value(cohere_request)?;
-    let response = client.send_request(&request.model, "invoke", &body).await?;
+    let model_id = execution_model_id(&request.model);
+    let response = client.send_request(&model_id, "invoke", &body).await?;
     let cohere_response: CohereEmbeddingResponse = response
         .json()
         .await
@@ -236,4 +243,25 @@ async fn execute_cohere_embedding(
         usage: None, // Cohere doesn't provide usage info
         embeddings: Some(data),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::execution_model_id;
+
+    #[test]
+    fn strips_bedrock_selector_for_embedding_execution() {
+        assert_eq!(
+            execution_model_id("bedrock/amazon.titan-embed-text-v2:0"),
+            "amazon.titan-embed-text-v2:0"
+        );
+    }
+
+    #[test]
+    fn preserves_inference_profile_execution_id_for_embeddings() {
+        assert_eq!(
+            execution_model_id("bedrock/us.amazon.titan-embed-text-v2:0"),
+            "us.amazon.titan-embed-text-v2:0"
+        );
+    }
 }

--- a/src/core/providers/bedrock/model_id.rs
+++ b/src/core/providers/bedrock/model_id.rs
@@ -304,7 +304,7 @@ fn arn_resource_metadata(model_id: &str) -> Option<ArnResourceMetadata> {
             }
         }
         "custom-model-deployment" | "provisioned-model" => {
-            metadata.runtime_config_fallback = Some(RuntimeConfigFallback::Invoke);
+            metadata.runtime_config_fallback = Some(RuntimeConfigFallback::Converse);
         }
         "default-prompt-router" | "prompt-router" => {
             metadata.runtime_config_fallback = Some(RuntimeConfigFallback::Converse);
@@ -347,7 +347,12 @@ fn is_plain_runtime_profile_id(model_id: &str) -> bool {
 }
 
 fn looks_like_versioned_foundation_model_id(model_id: &str) -> bool {
-    if model_id.contains(':') || model_id.matches('.').count() != 1 {
+    let model_id = model_id
+        .split_once(':')
+        .map(|(id, _revision)| id)
+        .unwrap_or(model_id);
+
+    if model_id.matches('.').count() != 1 {
         return false;
     }
 
@@ -525,7 +530,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_model_deployment_arn_allows_invoke_runtime_config_resolution() {
+    fn custom_model_deployment_arn_allows_converse_runtime_config_resolution() {
         let parsed = parse_bedrock_model_id(
             "arn:aws:bedrock:us-east-1:123456789012:custom-model-deployment/123456789012",
         );
@@ -536,12 +541,12 @@ mod tests {
         );
         assert_eq!(
             parsed.runtime_config_fallback,
-            Some(RuntimeConfigFallback::Invoke)
+            Some(RuntimeConfigFallback::Converse)
         );
     }
 
     #[test]
-    fn provisioned_model_arn_allows_invoke_runtime_config_resolution() {
+    fn provisioned_model_arn_allows_converse_runtime_config_resolution() {
         let parsed = parse_bedrock_model_id(
             "arn:aws:bedrock:us-east-1:123456789012:provisioned-model/ABC123",
         );
@@ -552,7 +557,7 @@ mod tests {
         );
         assert_eq!(
             parsed.runtime_config_fallback,
-            Some(RuntimeConfigFallback::Invoke)
+            Some(RuntimeConfigFallback::Converse)
         );
     }
 
@@ -661,11 +666,13 @@ mod tests {
 
     #[test]
     fn unknown_versioned_foundation_model_id_is_not_runtime_profile() {
-        let parsed = parse_bedrock_model_id("unknown.model-v1");
+        for model_id in ["unknown.model-v1", "unknown.model-v1:0"] {
+            let parsed = parse_bedrock_model_id(model_id);
 
-        assert_eq!(parsed.metadata_lookup_ids, vec!["unknown.model-v1"]);
-        assert_eq!(parsed.runtime_config_fallback, None);
-        assert!(super::get_model_config_for_model_id("unknown.model-v1").is_err());
+            assert_eq!(parsed.metadata_lookup_ids, vec![model_id]);
+            assert_eq!(parsed.runtime_config_fallback, None);
+            assert!(super::get_model_config_for_model_id(model_id).is_err());
+        }
     }
 
     #[test]
@@ -688,26 +695,26 @@ mod tests {
     }
 
     #[test]
-    fn custom_model_deployment_arn_uses_invoke_compatible_config() {
+    fn custom_model_deployment_arn_uses_streaming_converse_config() {
         let config =
             config_for("arn:aws:bedrock:us-east-1:123456789012:custom-model-deployment/ABC123");
 
         assert_eq!(
             config.api_type,
-            crate::core::providers::bedrock::BedrockApiType::InvokeStream
+            crate::core::providers::bedrock::BedrockApiType::ConverseStream
         );
-        assert!(!config.supports_function_calling);
+        assert!(config.supports_function_calling);
     }
 
     #[test]
-    fn provisioned_model_arn_uses_invoke_compatible_config() {
+    fn provisioned_model_arn_uses_streaming_converse_config() {
         let config = config_for("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/ABC123");
 
         assert_eq!(
             config.api_type,
-            crate::core::providers::bedrock::BedrockApiType::InvokeStream
+            crate::core::providers::bedrock::BedrockApiType::ConverseStream
         );
-        assert!(!config.supports_function_calling);
+        assert!(config.supports_function_calling);
     }
 
     #[test]

--- a/src/core/providers/bedrock/model_id.rs
+++ b/src/core/providers/bedrock/model_id.rs
@@ -347,10 +347,13 @@ fn is_plain_runtime_profile_id(model_id: &str) -> bool {
 }
 
 fn looks_like_versioned_foundation_model_id(model_id: &str) -> bool {
-    let model_id = model_id
-        .split_once(':')
-        .map(|(id, _revision)| id)
-        .unwrap_or(model_id);
+    let Some((model_id, revision)) = model_id.split_once(':') else {
+        return false;
+    };
+
+    if revision.is_empty() || !revision.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
 
     if model_id.matches('.').count() != 1 {
         return false;
@@ -636,20 +639,22 @@ mod tests {
 
     #[test]
     fn dotted_plain_runtime_profile_id_uses_runtime_fallback() {
-        let parsed = parse_bedrock_model_id("my.team.profile:1");
+        for model_id in ["my.team.profile:1", "team.profile-v1", "unknown.model-v1"] {
+            let parsed = parse_bedrock_model_id(model_id);
 
-        assert_eq!(parsed.kind, BedrockModelIdKind::FoundationModel);
-        assert_eq!(parsed.metadata_lookup_ids, vec!["my.team.profile:1"]);
-        assert_eq!(
-            parsed.runtime_config_fallback,
-            Some(RuntimeConfigFallback::Converse)
-        );
+            assert_eq!(parsed.kind, BedrockModelIdKind::FoundationModel);
+            assert_eq!(parsed.metadata_lookup_ids, vec![model_id]);
+            assert_eq!(
+                parsed.runtime_config_fallback,
+                Some(RuntimeConfigFallback::Converse)
+            );
 
-        let config = config_for("my.team.profile:1");
-        assert_eq!(
-            config.api_type,
-            crate::core::providers::bedrock::BedrockApiType::ConverseStream
-        );
+            let config = config_for(model_id);
+            assert_eq!(
+                config.api_type,
+                crate::core::providers::bedrock::BedrockApiType::ConverseStream
+            );
+        }
     }
 
     #[test]
@@ -666,13 +671,11 @@ mod tests {
 
     #[test]
     fn unknown_versioned_foundation_model_id_is_not_runtime_profile() {
-        for model_id in ["unknown.model-v1", "unknown.model-v1:0"] {
-            let parsed = parse_bedrock_model_id(model_id);
+        let parsed = parse_bedrock_model_id("unknown.model-v1:0");
 
-            assert_eq!(parsed.metadata_lookup_ids, vec![model_id]);
-            assert_eq!(parsed.runtime_config_fallback, None);
-            assert!(super::get_model_config_for_model_id(model_id).is_err());
-        }
+        assert_eq!(parsed.metadata_lookup_ids, vec!["unknown.model-v1:0"]);
+        assert_eq!(parsed.runtime_config_fallback, None);
+        assert!(super::get_model_config_for_model_id("unknown.model-v1:0").is_err());
     }
 
     #[test]

--- a/src/core/providers/bedrock/model_id.rs
+++ b/src/core/providers/bedrock/model_id.rs
@@ -304,7 +304,7 @@ fn arn_resource_metadata(model_id: &str) -> Option<ArnResourceMetadata> {
             }
         }
         "custom-model-deployment" | "provisioned-model" => {
-            metadata.runtime_config_fallback = Some(RuntimeConfigFallback::Converse);
+            metadata.runtime_config_fallback = Some(RuntimeConfigFallback::Invoke);
         }
         "default-prompt-router" | "prompt-router" => {
             metadata.runtime_config_fallback = Some(RuntimeConfigFallback::Converse);
@@ -330,6 +330,7 @@ fn is_geo_prefix(prefix: &str) -> bool {
 fn is_region_prefix(prefix: &str) -> bool {
     prefix.len() >= 4
         && prefix.contains('-')
+        && prefix.chars().last().is_some_and(|c| c.is_ascii_digit())
         && prefix
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
@@ -339,10 +340,25 @@ fn is_plain_runtime_profile_id(model_id: &str) -> bool {
     !model_id.is_empty()
         && !model_id.starts_with("arn:")
         && !model_id.contains('/')
-        && !model_id.contains('.')
         && model_id
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':')
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ':' | '.'))
+        && !looks_like_versioned_foundation_model_id(model_id)
+}
+
+fn looks_like_versioned_foundation_model_id(model_id: &str) -> bool {
+    if model_id.contains(':') || model_id.matches('.').count() != 1 {
+        return false;
+    }
+
+    let Some((_vendor, model_name)) = model_id.split_once('.') else {
+        return false;
+    };
+    let Some((_name, version)) = model_name.rsplit_once("-v") else {
+        return false;
+    };
+
+    !version.is_empty() && version.chars().all(|c| c.is_ascii_digit())
 }
 
 fn push_unique(values: &mut Vec<String>, value: String) {
@@ -509,7 +525,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_model_deployment_arn_allows_runtime_config_resolution() {
+    fn custom_model_deployment_arn_allows_invoke_runtime_config_resolution() {
         let parsed = parse_bedrock_model_id(
             "arn:aws:bedrock:us-east-1:123456789012:custom-model-deployment/123456789012",
         );
@@ -520,12 +536,12 @@ mod tests {
         );
         assert_eq!(
             parsed.runtime_config_fallback,
-            Some(RuntimeConfigFallback::Converse)
+            Some(RuntimeConfigFallback::Invoke)
         );
     }
 
     #[test]
-    fn provisioned_model_arn_allows_converse_runtime_config_resolution() {
+    fn provisioned_model_arn_allows_invoke_runtime_config_resolution() {
         let parsed = parse_bedrock_model_id(
             "arn:aws:bedrock:us-east-1:123456789012:provisioned-model/ABC123",
         );
@@ -536,7 +552,7 @@ mod tests {
         );
         assert_eq!(
             parsed.runtime_config_fallback,
-            Some(RuntimeConfigFallback::Converse)
+            Some(RuntimeConfigFallback::Invoke)
         );
     }
 
@@ -614,6 +630,45 @@ mod tests {
     }
 
     #[test]
+    fn dotted_plain_runtime_profile_id_uses_runtime_fallback() {
+        let parsed = parse_bedrock_model_id("my.team.profile:1");
+
+        assert_eq!(parsed.kind, BedrockModelIdKind::FoundationModel);
+        assert_eq!(parsed.metadata_lookup_ids, vec!["my.team.profile:1"]);
+        assert_eq!(
+            parsed.runtime_config_fallback,
+            Some(RuntimeConfigFallback::Converse)
+        );
+
+        let config = config_for("my.team.profile:1");
+        assert_eq!(
+            config.api_type,
+            crate::core::providers::bedrock::BedrockApiType::ConverseStream
+        );
+    }
+
+    #[test]
+    fn custom_hyphenated_profile_prefix_is_not_treated_as_region() {
+        let parsed = parse_bedrock_model_id("my-org.model");
+
+        assert_eq!(parsed.metadata_lookup_ids, vec!["my-org.model"]);
+        assert_eq!(parsed.family_hint.as_deref(), Some("my-org"));
+        assert_eq!(
+            parsed.runtime_config_fallback,
+            Some(RuntimeConfigFallback::Converse)
+        );
+    }
+
+    #[test]
+    fn unknown_versioned_foundation_model_id_is_not_runtime_profile() {
+        let parsed = parse_bedrock_model_id("unknown.model-v1");
+
+        assert_eq!(parsed.metadata_lookup_ids, vec!["unknown.model-v1"]);
+        assert_eq!(parsed.runtime_config_fallback, None);
+        assert!(super::get_model_config_for_model_id("unknown.model-v1").is_err());
+    }
+
+    #[test]
     fn sagemaker_endpoint_arn_uses_streaming_converse_config() {
         let model_id =
             "arn:aws:sagemaker:us-east-1:123456789012:endpoint/bedrock-marketplace-endpoint";
@@ -630,6 +685,29 @@ mod tests {
             config.api_type,
             crate::core::providers::bedrock::BedrockApiType::ConverseStream
         );
+    }
+
+    #[test]
+    fn custom_model_deployment_arn_uses_invoke_compatible_config() {
+        let config =
+            config_for("arn:aws:bedrock:us-east-1:123456789012:custom-model-deployment/ABC123");
+
+        assert_eq!(
+            config.api_type,
+            crate::core::providers::bedrock::BedrockApiType::InvokeStream
+        );
+        assert!(!config.supports_function_calling);
+    }
+
+    #[test]
+    fn provisioned_model_arn_uses_invoke_compatible_config() {
+        let config = config_for("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/ABC123");
+
+        assert_eq!(
+            config.api_type,
+            crate::core::providers::bedrock::BedrockApiType::InvokeStream
+        );
+        assert!(!config.supports_function_calling);
     }
 
     #[test]

--- a/src/core/providers/bedrock/model_id.rs
+++ b/src/core/providers/bedrock/model_id.rs
@@ -347,13 +347,14 @@ fn is_plain_runtime_profile_id(model_id: &str) -> bool {
 }
 
 fn looks_like_versioned_foundation_model_id(model_id: &str) -> bool {
-    let Some((model_id, revision)) = model_id.split_once(':') else {
-        return false;
+    let (model_id, has_revision) = if let Some((model_id, revision)) = model_id.split_once(':') {
+        if revision.is_empty() || !revision.chars().all(|c| c.is_ascii_digit()) {
+            return false;
+        }
+        (model_id, true)
+    } else {
+        (model_id, false)
     };
-
-    if revision.is_empty() || !revision.chars().all(|c| c.is_ascii_digit()) {
-        return false;
-    }
 
     if model_id.matches('.').count() != 1 {
         return false;
@@ -362,11 +363,13 @@ fn looks_like_versioned_foundation_model_id(model_id: &str) -> bool {
     let Some((_vendor, model_name)) = model_id.split_once('.') else {
         return false;
     };
-    let Some((_name, version)) = model_name.rsplit_once("-v") else {
+    let Some((name, version)) = model_name.rsplit_once("-v") else {
         return false;
     };
 
-    !version.is_empty() && version.chars().all(|c| c.is_ascii_digit())
+    !version.is_empty()
+        && version.chars().all(|c| c.is_ascii_digit())
+        && (has_revision || name == "model")
 }
 
 fn push_unique(values: &mut Vec<String>, value: String) {
@@ -639,7 +642,7 @@ mod tests {
 
     #[test]
     fn dotted_plain_runtime_profile_id_uses_runtime_fallback() {
-        for model_id in ["my.team.profile:1", "team.profile-v1", "unknown.model-v1"] {
+        for model_id in ["my.team.profile:1", "team.profile-v1"] {
             let parsed = parse_bedrock_model_id(model_id);
 
             assert_eq!(parsed.kind, BedrockModelIdKind::FoundationModel);
@@ -671,11 +674,12 @@ mod tests {
 
     #[test]
     fn unknown_versioned_foundation_model_id_is_not_runtime_profile() {
-        let parsed = parse_bedrock_model_id("unknown.model-v1:0");
+        let model_id = "unknown.model-v1:0";
+        let parsed = parse_bedrock_model_id(model_id);
 
-        assert_eq!(parsed.metadata_lookup_ids, vec!["unknown.model-v1:0"]);
+        assert_eq!(parsed.metadata_lookup_ids, vec![model_id]);
         assert_eq!(parsed.runtime_config_fallback, None);
-        assert!(super::get_model_config_for_model_id("unknown.model-v1:0").is_err());
+        assert!(super::get_model_config_for_model_id(model_id).is_err());
     }
 
     #[test]

--- a/src/core/providers/bedrock/transformation.rs
+++ b/src/core/providers/bedrock/transformation.rs
@@ -514,6 +514,7 @@ fn parse_runtime_invoke_usage(response: &Value) -> Option<Usage> {
 
     let prompt_tokens = response
         .get("inputTextTokenCount")
+        .or_else(|| response.get("prompt_token_count"))
         .and_then(Value::as_u64)
         .unwrap_or(0) as u32;
     let completion_tokens = response
@@ -522,6 +523,11 @@ fn parse_runtime_invoke_usage(response: &Value) -> Option<Usage> {
         .and_then(|results| results.first())
         .and_then(|result| result.get("tokenCount"))
         .and_then(Value::as_u64)
+        .or_else(|| {
+            response
+                .get("generation_token_count")
+                .and_then(Value::as_u64)
+        })
         .unwrap_or(0) as u32;
 
     if prompt_tokens == 0 && completion_tokens == 0 {
@@ -755,5 +761,29 @@ mod tests {
         assert!(
             matches!(content, MessageContent::Text(text) if text == "hello from native invoke")
         );
+    }
+
+    #[test]
+    fn parses_bedrock_completion_usage_for_runtime_resolved_invoke_arn() {
+        let raw_response = serde_json::json!({
+            "completion": "hello with usage",
+            "prompt_token_count": 13,
+            "generation_token_count": 8
+        });
+        let raw_response = serde_json::to_vec(&raw_response)
+            .unwrap_or_else(|err| panic!("native response should serialize: {err}"));
+
+        let response = transform_chat_response(
+            &raw_response,
+            "arn:aws:bedrock:us-east-1:123456789012:custom-model-deployment/ABC123",
+        )
+        .unwrap_or_else(|err| panic!("native response should parse: {err}"));
+
+        let usage = response
+            .usage
+            .unwrap_or_else(|| panic!("response should include BedrockCompletion usage"));
+        assert_eq!(usage.prompt_tokens, 13);
+        assert_eq!(usage.completion_tokens, 8);
+        assert_eq!(usage.total_tokens, 21);
     }
 }

--- a/src/core/providers/bedrock/transformation.rs
+++ b/src/core/providers/bedrock/transformation.rs
@@ -775,7 +775,7 @@ mod tests {
 
         let response = transform_chat_response(
             &raw_response,
-            "arn:aws:bedrock:us-east-1:123456789012:custom-model-deployment/ABC123",
+            "arn:aws:bedrock:us-east-1:123456789012:unknown-resource/ABC123",
         )
         .unwrap_or_else(|err| panic!("native response should parse: {err}"));
 


### PR DESCRIPTION
## Summary
- accept dotted plain Bedrock runtime profile IDs without stripping custom hyphenated prefixes as regions
- route unknown custom/provisioned Bedrock deployment ARNs through the safer Invoke fallback
- parse BedrockCompletion `prompt_token_count` / `generation_token_count` usage and normalize `bedrock/` selectors before native embedding dispatch

## Validation
- `cargo fmt --check`
- `cargo test core::providers::bedrock:: --lib`
- `cargo check`
- `cargo test`

Closes #634
