### PR TITLE
fix(health): reuse readiness aggregates

### DIFF
--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -264,7 +264,7 @@ struct DetailedHealthStatus {
 #[derive(Debug, Clone, serde::Serialize)]
 struct ProviderHealthStatus {
     /// Aggregate label across all configured providers. One of `healthy`,
-    /// `degraded`, `unknown`, `not_configured`.
+    /// `degraded`, `unknown`, `disabled`, `not_configured`.
     aggregate: Cow<'static, str>,
     healthy_providers: usize,
     total_providers: usize,
@@ -281,6 +281,46 @@ struct ProviderHealth {
     response_time_ms: Option<u64>,
     last_check: chrono::DateTime<chrono::Utc>,
     error_message: Option<String>,
+}
+
+impl ProviderHealthStatus {
+    fn from_details(provider_details: Vec<ProviderHealth>) -> Self {
+        let total = provider_details.len();
+        let enabled_count = provider_details
+            .iter()
+            .filter(|provider| provider.status != "disabled")
+            .count();
+        let healthy_count = provider_details
+            .iter()
+            .filter(|provider| provider.status == "healthy")
+            .count();
+        let aggregate = Self::aggregate_for_details(&provider_details, enabled_count);
+
+        Self {
+            aggregate,
+            healthy_providers: healthy_count,
+            total_providers: total,
+            enabled_providers: enabled_count,
+            provider_details,
+        }
+    }
+
+    fn aggregate_for_details(
+        provider_details: &[ProviderHealth],
+        enabled_count: usize,
+    ) -> Cow<'static, str> {
+        if provider_details.is_empty() {
+            Cow::Borrowed("not_configured")
+        } else if enabled_count == 0 {
+            Cow::Borrowed("disabled")
+        } else if provider_details.iter().any(|p| p.status == "unhealthy") {
+            Cow::Borrowed("degraded")
+        } else if provider_details.iter().any(|p| p.status == "unknown") {
+            Cow::Borrowed("unknown")
+        } else {
+            Cow::Borrowed("healthy")
+        }
+    }
 }
 
 /// System status information
@@ -329,26 +369,17 @@ struct ReadinessVerdict {
 async fn collect_component_health(
     state: &AppState,
 ) -> (crate::storage::StorageHealthStatus, ProviderHealthStatus) {
-    let cfg = state.config.load();
-
-    let storage_health = if cfg.storage().database.url.is_empty() {
-        crate::storage::StorageHealthStatus {
-            overall: false,
-            database: false,
-            redis: false,
-            files: false,
-            vector: false,
-        }
-    } else {
-        match state.storage.health_check().await {
-            Ok(status) => status,
-            Err(_) => crate::storage::StorageHealthStatus {
+    let storage_health = match state.storage.health_check().await {
+        Ok(status) => status,
+        Err(e) => {
+            error!("Storage health check failed: {}", e);
+            crate::storage::StorageHealthStatus {
                 overall: false,
                 database: false,
                 redis: false,
                 files: false,
                 vector: false,
-            },
+            }
         }
     };
 
@@ -395,34 +426,23 @@ fn aggregate_readiness(
         };
     }
 
-    // Among enabled providers, any non-healthy status (unhealthy OR unknown)
-    // blocks readiness. Disabled providers are filtered out upstream.
-    let mut has_unhealthy = false;
-    let mut has_unknown = false;
-    for p in &provider_health.provider_details {
-        match p.status.as_ref() {
-            "unhealthy" => has_unhealthy = true,
-            "unknown" => has_unknown = true,
-            _ => {}
-        }
-    }
-
-    if has_unhealthy {
-        return ReadinessVerdict {
+    match provider_health.aggregate.as_ref() {
+        "healthy" => ReadinessVerdict {
+            ready: true,
+            reason: Cow::Borrowed("ok"),
+        },
+        "degraded" => ReadinessVerdict {
             ready: false,
             reason: Cow::Borrowed("one or more providers unhealthy"),
-        };
-    }
-    if has_unknown {
-        return ReadinessVerdict {
+        },
+        "unknown" => ReadinessVerdict {
             ready: false,
             reason: Cow::Borrowed("one or more providers have unknown status"),
-        };
-    }
-
-    ReadinessVerdict {
-        ready: true,
-        reason: Cow::Borrowed("ok"),
+        },
+        _ => ReadinessVerdict {
+            ready: false,
+            reason: Cow::Borrowed("provider health unavailable"),
+        },
     }
 }
 
@@ -437,24 +457,17 @@ async fn check_provider_health(
 ) -> Result<ProviderHealthStatus, crate::utils::error::gateway_error::GatewayError> {
     let cfg = state.config.load();
     let mut provider_details = Vec::new();
-    let mut healthy_count = 0;
-    let mut enabled_count = 0;
 
     for provider_config in cfg.providers() {
         let (status, error_message): (Cow<'static, str>, Option<String>) =
             if !provider_config.enabled {
                 (Cow::Borrowed("disabled"), None)
             } else {
-                enabled_count += 1;
                 (
                     Cow::Borrowed("unknown"),
                     Some("Provider health check not implemented".to_string()),
                 )
             };
-
-        if status == "healthy" {
-            healthy_count += 1;
-        }
 
         provider_details.push(ProviderHealth {
             name: provider_config.name.clone(),
@@ -465,26 +478,7 @@ async fn check_provider_health(
         });
     }
 
-    let total = cfg.providers().len();
-    let aggregate = if total == 0 {
-        Cow::Borrowed("not_configured")
-    } else if enabled_count == 0 {
-        Cow::Borrowed("disabled")
-    } else if provider_details.iter().any(|p| p.status == "unhealthy") {
-        Cow::Borrowed("degraded")
-    } else if provider_details.iter().any(|p| p.status == "unknown") {
-        Cow::Borrowed("unknown")
-    } else {
-        Cow::Borrowed("healthy")
-    };
-
-    Ok(ProviderHealthStatus {
-        aggregate,
-        healthy_providers: healthy_count,
-        total_providers: total,
-        enabled_providers: enabled_count,
-        provider_details,
-    })
+    Ok(ProviderHealthStatus::from_details(provider_details))
 }
 
 /// Get system uptime in seconds

--- a/tests/integration/http_routes_tests.rs
+++ b/tests/integration/http_routes_tests.rs
@@ -8,12 +8,25 @@ mod tests {
     use actix_web::http::StatusCode;
     use actix_web::{App, test, web};
     use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use litellm_rs::server::middleware::AuthMiddleware;
     use litellm_rs::server::routes;
     use litellm_rs::server::state::AppState;
     use serde_json::Value;
     use std::sync::Arc;
+
+    async fn build_state_with_config(config: Config) -> AppState {
+        let server = match GatewayHttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(err) => panic!("failed to build HTTP server for integration test: {err}"),
+        };
+        let state = server.state().clone();
+        if let Err(err) = state.storage.migrate().await {
+            panic!("failed to run in-memory DB migrations: {err}");
+        }
+        state
+    }
 
     /// Build an AppState with auth enabled (both JWT and API key).
     async fn build_auth_enabled_state() -> AppState {
@@ -25,16 +38,7 @@ mod tests {
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
 
-        let server = GatewayHttpServer::new(&config)
-            .await
-            .expect("failed to build HTTP server for integration test");
-        let state = server.state().clone();
-        state
-            .storage
-            .migrate()
-            .await
-            .expect("failed to run in-memory DB migrations");
-        state
+        build_state_with_config(config).await
     }
 
     /// Build an AppState with auth disabled.
@@ -46,16 +50,7 @@ mod tests {
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
 
-        let server = GatewayHttpServer::new(&config)
-            .await
-            .expect("failed to build HTTP server for integration test");
-        let state = server.state().clone();
-        state
-            .storage
-            .migrate()
-            .await
-            .expect("failed to run in-memory DB migrations");
-        state
+        build_state_with_config(config).await
     }
 
     /// Construct an actix-web test app with AuthMiddleware and route
@@ -116,6 +111,78 @@ mod tests {
 
         let body: Value = test::read_body_json(resp).await;
         assert!(body["data"]["timestamp"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_readiness_reports_storage_failure_from_storage_layer() {
+        let tempdir = match tempfile::tempdir() {
+            Ok(tempdir) => tempdir,
+            Err(err) => panic!("failed to create temp dir: {err}"),
+        };
+        let storage_path = tempdir.path().join("files");
+
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.storage.files.local_path = Some(storage_path.to_string_lossy().into_owned());
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+
+        let state = build_state_with_config(config).await;
+        if let Err(err) = std::fs::remove_dir_all(&storage_path) {
+            panic!("failed to remove storage dir: {err}");
+        }
+        let app = test::init_service(build_test_app(state)).await;
+
+        let req = test::TestRequest::get().uri("/health/ready").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["success"], true);
+        assert_eq!(body["data"]["ready"], false);
+        assert_eq!(body["data"]["reason"], "storage unhealthy");
+        assert_eq!(body["data"]["storage"]["overall"], false);
+        assert_eq!(body["data"]["storage"]["files"], false);
+    }
+
+    #[tokio::test]
+    async fn test_readiness_reports_unknown_enabled_provider() {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.database.url.clear();
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.providers.push(ProviderConfig {
+            name: "openai".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            models: vec!["gpt-4".to_string()],
+            ..ProviderConfig::default()
+        });
+
+        let state = build_state_with_config(config).await;
+        let app = test::init_service(build_test_app(state)).await;
+
+        let req = test::TestRequest::get().uri("/health/ready").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["success"], true);
+        assert_eq!(body["data"]["ready"], false);
+        assert_eq!(
+            body["data"]["reason"],
+            "one or more providers have unknown status"
+        );
+        assert_eq!(body["data"]["storage"]["overall"], true);
+        assert_eq!(body["data"]["providers"]["aggregate"], "unknown");
+        assert_eq!(body["data"]["providers"]["enabled_providers"], 1);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Always collect readiness storage status from `StorageLayer::health_check()` instead of special-casing an empty database URL in the health route.
- Reuse the provider aggregate computed with provider details when deriving readiness.
- Add HTTP route regressions for storage failure and unknown-provider readiness.

## Validation
- `cargo check --features gateway,storage`
- `cargo test --features gateway,storage server::routes::health -- --nocapture`
- `cargo test --features gateway,storage --test lib integration::http_routes_tests -- --nocapture`
- `cargo test --features gateway,storage`

Closes #633