### PR TITLE
fix(bedrock): reject invalid tool call arguments

### DIFF
--- a/src/core/providers/bedrock/chat/converse.rs
+++ b/src/core/providers/bedrock/chat/converse.rs
@@ -337,8 +337,18 @@ pub(in crate::core::providers::bedrock) fn transform_to_converse(
                             tool_use: ToolUseBlock {
                                 tool_use_id: tool_call.id.clone(),
                                 name: tool_call.function.name.clone(),
-                                input: serde_json::from_str::<Value>(&tool_call.function.arguments)
-                                    .unwrap_or(Value::Object(Default::default())),
+                                input: serde_json::from_str::<Value>(
+                                    &tool_call.function.arguments,
+                                )
+                                .map_err(|err| {
+                                    ProviderError::invalid_request(
+                                        "bedrock",
+                                        format!(
+                                            "Invalid Bedrock assistant tool-call arguments JSON while building Converse ToolUse block for tool_call_id='{}', function='{}': {}",
+                                            tool_call.id, tool_call.function.name, err
+                                        ),
+                                    )
+                                })?,
                             },
                         });
                     }
@@ -671,6 +681,10 @@ fn tool_result_contents_from_value(value: &Value) -> Result<Vec<ToolResultConten
 #[cfg(test)]
 #[path = "converse_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "converse_tool_call_tests.rs"]
+mod tool_call_tests;
 
 #[cfg(test)]
 #[path = "converse_parameter_policy_tests.rs"]

--- a/src/core/providers/bedrock/chat/converse_tool_call_tests.rs
+++ b/src/core/providers/bedrock/chat/converse_tool_call_tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+use crate::core::types::{chat::ChatMessage, message::MessageRole};
+
+#[test]
+fn assistant_tool_call_preserves_valid_arguments_json() {
+    let request = ChatRequest {
+        model: "anthropic.claude-3-sonnet".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::Assistant,
+            content: None,
+            tool_calls: Some(vec![crate::core::types::tools::ToolCall {
+                id: "tool-123".to_string(),
+                tool_type: "function".to_string(),
+                function: crate::core::types::tools::FunctionCall {
+                    name: "get_weather".to_string(),
+                    arguments: r#"{"city":"Paris","units":["metric"]}"#.to_string(),
+                },
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let Ok(converse) = transform_to_converse(&request) else {
+        panic!("valid tool-call arguments JSON should transform");
+    };
+    let Ok(json) = serde_json::to_value(&converse) else {
+        panic!("Converse request should serialize");
+    };
+    let input = &json["messages"][0]["content"][0]["toolUse"]["input"];
+
+    assert_eq!(input["city"], "Paris");
+    assert_eq!(input["units"][0], "metric");
+}
+
+#[test]
+fn assistant_tool_call_rejects_invalid_arguments_json() {
+    let request = ChatRequest {
+        model: "anthropic.claude-3-sonnet".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::Assistant,
+            content: None,
+            tool_calls: Some(vec![crate::core::types::tools::ToolCall {
+                id: "tool-123".to_string(),
+                tool_type: "function".to_string(),
+                function: crate::core::types::tools::FunctionCall {
+                    name: "get_weather".to_string(),
+                    arguments: "{city:Paris}".to_string(),
+                },
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let err = match transform_to_converse(&request) {
+        Ok(_) => panic!("invalid tool-call arguments JSON should be rejected"),
+        Err(err) => err,
+    };
+    let message = format!("{err}");
+
+    assert!(message.contains("Invalid Bedrock assistant tool-call arguments JSON"));
+    assert!(message.contains("tool-123"));
+    assert!(message.contains("get_weather"));
+}


### PR DESCRIPTION
## Summary
- reject invalid assistant tool-call argument JSON when building Bedrock Converse ToolUse blocks
- include tool call id and function name in the Bedrock invalid_request error
- add focused tests for valid and invalid assistant tool-call argument JSON

## Validation
- cargo check
- cargo test

Closes #644