### PR TITLE
Fix cwd-independent default pricing source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = [
     "src/**/*",
     "config/*.example",
     "config/*.template",
+    "config/model_prices_extended.json",
     "migrations/**/*",
     "build.rs",
     "Cargo.toml",

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -139,8 +139,9 @@ cache:
   similarity_threshold: 0.95
 
 pricing:
-  # PricingService source path/URL (set to null to use service default behavior)
-  source: "config/model_prices_extended.json"
+  # PricingService source path/URL. The embedded default is cwd-independent;
+  # user-provided relative paths are resolved by the process working directory.
+  source: "embedded://model_prices_extended"
 
 rate_limit:
   enabled: true

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -40,7 +40,7 @@ const ENV_PRICING_SOURCE: &str = "LITELLM_PRICING_SOURCE";
 const ENV_CACHE_ENABLED: &str = "LITELLM_CACHE_ENABLED";
 const ENV_RATE_LIMIT_ENABLED: &str = "LITELLM_RATE_LIMIT_ENABLED";
 const ENV_ENTERPRISE_ENABLED: &str = "LITELLM_ENTERPRISE_ENABLED";
-const DEFAULT_PRICING_SOURCE: &str = "config/model_prices_extended.json";
+const DEFAULT_PRICING_SOURCE: &str = crate::core::pricing_service::DEFAULT_PRICING_SOURCE;
 
 fn env_var(key: &str) -> Option<String> {
     env::var(key)
@@ -239,7 +239,7 @@ impl Default for GatewayPricingConfig {
 
 fn default_pricing_source() -> Option<String> {
     // Keep the runtime default aligned with config/gateway.yaml.example.
-    // Relative paths are resolved by the process working directory.
+    // User-provided relative paths are still resolved by the process working directory.
     Some(DEFAULT_PRICING_SOURCE.to_string())
 }
 

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -59,11 +59,16 @@ fn create_valid_config() -> GatewayConfig {
 // ==================== GatewayConfig Default Tests ====================
 
 #[test]
-fn test_default_pricing_source_matches_example_path() {
+fn test_default_pricing_source_uses_embedded_source() {
     let config = GatewayPricingConfig::default();
 
     assert_eq!(config.source.as_deref(), Some(DEFAULT_PRICING_SOURCE));
-    assert!(!std::path::Path::new(config.source.as_deref().unwrap()).is_absolute());
+    assert!(
+        config
+            .source
+            .as_deref()
+            .is_some_and(|source| source.starts_with("embedded://"))
+    );
 }
 
 #[test]

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use tracing::warn;
 
-const DEFAULT_PRICING_SOURCE: &str = "config/model_prices_extended.json";
+const EMBEDDED_MODEL_PRICES: &str = include_str!("../../config/model_prices_extended.json");
 
 /// LiteLLM-compatible model pricing data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +49,8 @@ pub struct LiteLLMModelInfo {
 
 /// Compatibility alias for callers that still import provider-base pricing.
 pub type ModelPricing = LiteLLMModelInfo;
+
+pub(crate) type PricingModelMap = HashMap<String, ModelPricing>;
 
 /// Usage information for simple pricing database calculations.
 ///
@@ -117,22 +119,12 @@ impl PricingDatabase {
         Ok(Self { models })
     }
 
-    /// Load from the same local pricing source used by gateway configuration.
+    /// Load from the bundled default pricing source used by gateway configuration.
     pub fn from_default_source() -> Result<Self, String> {
-        let possible_paths = vec![
-            DEFAULT_PRICING_SOURCE,
-            "../config/model_prices_extended.json",
-            "../../config/model_prices_extended.json",
-            "../../../config/model_prices_extended.json",
-        ];
+        let models = embedded_default_pricing_models()
+            .map_err(|e| format!("Failed to parse embedded pricing JSON: {}", e))?;
 
-        for path in &possible_paths {
-            if Path::new(path).exists() {
-                return Self::from_json_file(path);
-            }
-        }
-
-        Ok(Self::default())
+        Ok(Self { models })
     }
 
     /// Load pricing data from the default source.
@@ -539,6 +531,10 @@ pub fn parse_litellm_pricing_json(
         .filter(|(key, _)| !is_litellm_pricing_metadata_key(key))
         .map(|(key, value)| serde_json::from_value(value).map(|pricing| (key, pricing)))
         .collect()
+}
+
+pub(crate) fn embedded_default_pricing_models() -> serde_json::Result<PricingModelMap> {
+    parse_litellm_pricing_json(EMBEDDED_MODEL_PRICES)
 }
 
 pub fn is_litellm_pricing_metadata_key(key: &str) -> bool {

--- a/src/core/pricing_service/cache.rs
+++ b/src/core/pricing_service/cache.rs
@@ -36,7 +36,9 @@ impl PricingService {
     pub async fn refresh_pricing_data(&self) -> Result<()> {
         info!("Refreshing pricing data from: {}", self.pricing_url);
 
-        let data = if self.pricing_url.starts_with("http") {
+        let data = if self.pricing_url == super::DEFAULT_PRICING_SOURCE {
+            self.load_from_embedded_default()?
+        } else if self.pricing_url.starts_with("http") {
             // Load from URL
             self.load_from_url().await?
         } else {

--- a/src/core/pricing_service/loader.rs
+++ b/src/core/pricing_service/loader.rs
@@ -2,13 +2,11 @@
 
 use super::service::PricingService;
 use super::types::LiteLLMModelInfo;
-use crate::core::pricing::parse_litellm_pricing_json;
+use crate::core::pricing::{embedded_default_pricing_models, parse_litellm_pricing_json};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::collections::HashMap;
 use std::time::Duration;
 use tracing::debug;
-
-const EMBEDDED_MODEL_PRICES: &str = include_str!("../../../config/model_prices_extended.json");
 
 impl PricingService {
     /// Initialize pricing data (load from URL or local file)
@@ -60,7 +58,7 @@ impl PricingService {
 
     /// Load bundled default pricing data.
     pub(super) fn load_from_embedded_default(&self) -> Result<HashMap<String, LiteLLMModelInfo>> {
-        let data = parse_litellm_pricing_json(EMBEDDED_MODEL_PRICES)
+        let data = embedded_default_pricing_models()
             .map_err(|e| GatewayError::parsing(format!("Failed to parse pricing JSON: {}", e)))?;
 
         debug!("Loaded {} models from embedded default pricing", data.len());

--- a/src/core/pricing_service/loader.rs
+++ b/src/core/pricing_service/loader.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tracing::debug;
 
+const EMBEDDED_MODEL_PRICES: &str = include_str!("../../../config/model_prices_extended.json");
+
 impl PricingService {
     /// Initialize pricing data (load from URL or local file)
     pub async fn initialize(&self) -> Result<()> {
@@ -54,5 +56,74 @@ impl PricingService {
 
         debug!("Loaded {} models from file", data.len());
         Ok(data)
+    }
+
+    /// Load bundled default pricing data.
+    pub(super) fn load_from_embedded_default(&self) -> Result<HashMap<String, LiteLLMModelInfo>> {
+        let data = parse_litellm_pricing_json(EMBEDDED_MODEL_PRICES)
+            .map_err(|e| GatewayError::parsing(format!("Failed to parse pricing JSON: {}", e)))?;
+
+        debug!("Loaded {} models from embedded default pricing", data.len());
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::pricing_service::DEFAULT_PRICING_SOURCE;
+    use std::fs;
+
+    fn pricing_json(model: &str, provider: &str) -> String {
+        format!(
+            r#"{{
+                "{model}": {{
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000002,
+                    "litellm_provider": "{provider}",
+                    "mode": "chat"
+                }}
+            }}"#
+        )
+    }
+
+    #[tokio::test]
+    async fn default_pricing_source_loads_embedded_data() -> Result<()> {
+        let service = PricingService::new(Some(DEFAULT_PRICING_SOURCE.to_string()));
+
+        service.initialize().await?;
+
+        assert!(service.get_model_info("gpt-4o").is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_relative_pricing_source_uses_filesystem_path() -> Result<()> {
+        let temp_dir = tempfile::tempdir_in(".").map_err(GatewayError::Io)?;
+        let file_path = temp_dir.path().join("custom-prices.json");
+        fs::write(&file_path, pricing_json("custom-priced-model", "custom"))
+            .map_err(GatewayError::Io)?;
+        let relative_path = if file_path.is_absolute() {
+            file_path
+                .strip_prefix(std::env::current_dir().map_err(GatewayError::Io)?)
+                .map_err(|error| GatewayError::Config(error.to_string()))?
+                .to_path_buf()
+        } else {
+            file_path
+        }
+        .to_string_lossy()
+        .to_string();
+        let service = PricingService::new(Some(relative_path));
+
+        service.initialize().await?;
+
+        assert_eq!(
+            service
+                .get_model_info("custom-priced-model")
+                .map(|info| info.litellm_provider),
+            Some("custom".to_string())
+        );
+        assert!(service.get_model_info("gpt-4o").is_none());
+        Ok(())
     }
 }

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -12,6 +12,12 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+/// Built-in local pricing source used by gateway defaults.
+///
+/// Relative user-configured paths remain filesystem paths. This value is an
+/// explicit embedded source so the default does not depend on process cwd.
+pub const DEFAULT_PRICING_SOURCE: &str = "embedded://model_prices_extended";
+
 // Re-export public types
 pub use service::PricingService;
 pub use types::{


### PR DESCRIPTION
## Summary
- change the gateway default pricing source to an embedded bundled JSON source
- keep explicit relative pricing paths on the filesystem path loader
- include the bundled pricing JSON in crate packaging and document the embedded default in the gateway example

## Validation
- cargo check
- cargo test

Closes #648