### PR TITLE
fix(rate-limit): enforce limiter on auth rejections

### DIFF
--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -82,6 +82,24 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
+    pub(super) fn token_bucket_reservation_window(&self) -> Duration {
+        if self.config.default_rpm == 0 {
+            return Duration::ZERO;
+        }
+
+        Duration::from_secs((60.0 / self.config.default_rpm as f64).ceil() as u64)
+            .max(Duration::from_secs(1))
+    }
+
+    fn local_reservation_reset_after_secs(&self, result: &RateLimitResult) -> u64 {
+        match self.config.strategy {
+            RateLimitStrategy::TokenBucket => self.token_bucket_reservation_window().as_secs(),
+            RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                result.reset_after_secs
+            }
+        }
+    }
+
     fn disabled_result(&self) -> RateLimitResult {
         RateLimitResult {
             allowed: true,
@@ -216,11 +234,9 @@ impl RateLimiter {
         }
 
         let result = self.check_and_record_local(key, recorded_at).await;
-        let reservation = RateLimitReservation::new(
-            RateLimitRecordSource::Local,
-            recorded_at,
-            result.reset_after_secs,
-        );
+        let reset_after_secs = self.local_reservation_reset_after_secs(&result);
+        let reservation =
+            RateLimitReservation::new(RateLimitRecordSource::Local, recorded_at, reset_after_secs);
         (result, reservation)
     }
 
@@ -263,7 +279,13 @@ impl RateLimiter {
 
         match reservation.source {
             RateLimitRecordSource::Disabled => {}
-            RateLimitRecordSource::Local => self.release_local(key, Some(reservation.recorded_at)),
+            RateLimitRecordSource::Local => {
+                if reservation.remaining_window_secs() == 0 {
+                    return;
+                }
+
+                self.release_local(key, Some(reservation.recorded_at));
+            }
             RateLimitRecordSource::Distributed => {
                 let remaining_window_secs = reservation.remaining_window_secs();
                 if remaining_window_secs == 0 {
@@ -300,7 +322,28 @@ impl RateLimiter {
                     }
                 }
                 RateLimitStrategy::TokenBucket => {
-                    entry.tokens = (entry.tokens + 1.0).min(limit);
+                    let should_refund = if let Some(recorded_at) = recorded_at {
+                        let now = Instant::now();
+                        let reservation_window = self.token_bucket_reservation_window();
+                        entry
+                            .timestamps
+                            .retain(|&ts| now.saturating_duration_since(ts) < reservation_window);
+
+                        if let Some(position) =
+                            entry.timestamps.iter().position(|&ts| ts == recorded_at)
+                        {
+                            entry.timestamps.remove(position);
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        true
+                    };
+
+                    if should_refund {
+                        entry.tokens = (entry.tokens + 1.0).min(limit);
+                    }
                 }
             }
 

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -136,6 +136,43 @@ impl RateLimiter {
         }
     }
 
+    /// Release one request previously reserved by `check_and_record`.
+    pub async fn release(&self, key: &str) {
+        if !self.config.enabled {
+            return;
+        }
+
+        #[cfg(feature = "gateway")]
+        if let Some(redis) = &self.redis {
+            if let Err(err) = redis.rate_limit_release(key).await {
+                warn!("Redis rate-limit release failed for key {}: {}", key, err);
+            }
+            return;
+        }
+
+        let limit = self.config.default_rpm as f64;
+        let should_remove = {
+            let Some(mut entry) = self.entries.get_mut(key) else {
+                return;
+            };
+
+            match self.config.strategy {
+                RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                    entry.timestamps.pop();
+                }
+                RateLimitStrategy::TokenBucket => {
+                    entry.tokens = (entry.tokens + 1.0).min(limit);
+                }
+            }
+
+            entry.timestamps.is_empty() && entry.tokens >= limit
+        };
+
+        if should_remove {
+            self.entries.remove(key);
+        }
+    }
+
     /// Record a request (increments counter)
     ///
     /// WARNING: This is a separate operation from check() and has a race condition.

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -4,7 +4,7 @@ use super::types::{RateLimitEntry, RateLimitResult};
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
 use dashmap::DashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(feature = "gateway")]
 use tracing::warn;
 
@@ -14,6 +14,58 @@ pub(crate) enum RateLimitRecordSource {
     Disabled,
     Local,
     Distributed,
+}
+
+/// A concrete rate-limit record that may later be released.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RateLimitReservation {
+    source: RateLimitRecordSource,
+    recorded_at: Instant,
+    expires_at: Option<Instant>,
+}
+
+impl RateLimitReservation {
+    fn new(source: RateLimitRecordSource, recorded_at: Instant, reset_after_secs: u64) -> Self {
+        let expires_at = match source {
+            RateLimitRecordSource::Disabled => None,
+            RateLimitRecordSource::Local | RateLimitRecordSource::Distributed => {
+                Some(recorded_at + Duration::from_secs(reset_after_secs.max(1)))
+            }
+        };
+
+        Self {
+            source,
+            recorded_at,
+            expires_at,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        source: RateLimitRecordSource,
+        recorded_at: Instant,
+        reset_after_secs: u64,
+    ) -> Self {
+        Self::new(source, recorded_at, reset_after_secs)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source(&self) -> RateLimitRecordSource {
+        self.source
+    }
+
+    fn remaining_window_secs(&self) -> u64 {
+        let Some(expires_at) = self.expires_at else {
+            return 0;
+        };
+
+        let remaining = expires_at.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            0
+        } else {
+            remaining.as_secs().max(1)
+        }
+    }
 }
 
 /// Rate limiter implementation
@@ -103,9 +155,18 @@ impl RateLimiter {
         }
 
         match self.config.strategy {
-            RateLimitStrategy::SlidingWindow => self.check_sliding_window_impl(key, false).await,
-            RateLimitStrategy::TokenBucket => self.check_token_bucket_impl(key, false).await,
-            RateLimitStrategy::FixedWindow => self.check_fixed_window_impl(key, false).await,
+            RateLimitStrategy::SlidingWindow => {
+                self.check_sliding_window_impl(key, false, Instant::now())
+                    .await
+            }
+            RateLimitStrategy::TokenBucket => {
+                self.check_token_bucket_impl(key, false, Instant::now())
+                    .await
+            }
+            RateLimitStrategy::FixedWindow => {
+                self.check_fixed_window_impl(key, false, Instant::now())
+                    .await
+            }
         }
     }
 
@@ -121,9 +182,14 @@ impl RateLimiter {
     pub(crate) async fn check_and_record_with_source(
         &self,
         key: &str,
-    ) -> (RateLimitResult, RateLimitRecordSource) {
+    ) -> (RateLimitResult, RateLimitReservation) {
+        let recorded_at = Instant::now();
+
         if !self.config.enabled {
-            return (self.disabled_result(), RateLimitRecordSource::Disabled);
+            return (
+                self.disabled_result(),
+                RateLimitReservation::new(RateLimitRecordSource::Disabled, recorded_at, 0),
+            );
         }
 
         #[cfg(feature = "gateway")]
@@ -132,7 +198,14 @@ impl RateLimiter {
                 .rate_limit_check_and_record(key, self.config.default_rpm, self.window.as_secs())
                 .await
             {
-                Ok(result) => return (result, RateLimitRecordSource::Distributed),
+                Ok(result) => {
+                    let reservation = RateLimitReservation::new(
+                        RateLimitRecordSource::Distributed,
+                        recorded_at,
+                        result.reset_after_secs,
+                    );
+                    return (result, reservation);
+                }
                 Err(err) => {
                     warn!(
                         "Redis rate-limit check failed for key {}; falling back to in-process limiter: {}",
@@ -142,17 +215,26 @@ impl RateLimiter {
             }
         }
 
-        (
-            self.check_and_record_local(key).await,
+        let result = self.check_and_record_local(key, recorded_at).await;
+        let reservation = RateLimitReservation::new(
             RateLimitRecordSource::Local,
-        )
+            recorded_at,
+            result.reset_after_secs,
+        );
+        (result, reservation)
     }
 
-    async fn check_and_record_local(&self, key: &str) -> RateLimitResult {
+    async fn check_and_record_local(&self, key: &str, recorded_at: Instant) -> RateLimitResult {
         match self.config.strategy {
-            RateLimitStrategy::SlidingWindow => self.check_sliding_window_impl(key, true).await,
-            RateLimitStrategy::TokenBucket => self.check_token_bucket_impl(key, true).await,
-            RateLimitStrategy::FixedWindow => self.check_fixed_window_impl(key, true).await,
+            RateLimitStrategy::SlidingWindow => {
+                self.check_sliding_window_impl(key, true, recorded_at).await
+            }
+            RateLimitStrategy::TokenBucket => {
+                self.check_token_bucket_impl(key, true, recorded_at).await
+            }
+            RateLimitStrategy::FixedWindow => {
+                self.check_fixed_window_impl(key, true, recorded_at).await
+            }
         }
     }
 
@@ -160,28 +242,37 @@ impl RateLimiter {
     pub async fn release(&self, key: &str) {
         #[cfg(feature = "gateway")]
         if self.redis.is_some() {
-            self.release_recorded(key, RateLimitRecordSource::Distributed)
-                .await;
+            if let Some(redis) = &self.redis
+                && let Err(err) = redis
+                    .rate_limit_release(key, self.window.as_secs().max(1))
+                    .await
+            {
+                warn!("Redis rate-limit release failed for key {}: {}", key, err);
+            }
             return;
         }
 
-        self.release_recorded(key, RateLimitRecordSource::Local)
-            .await;
+        self.release_local(key, None);
     }
 
     /// Release one request previously reserved by the given backend.
-    pub(crate) async fn release_recorded(&self, key: &str, source: RateLimitRecordSource) {
+    pub(crate) async fn release_recorded(&self, key: &str, reservation: RateLimitReservation) {
         if !self.config.enabled {
             return;
         }
 
-        match source {
+        match reservation.source {
             RateLimitRecordSource::Disabled => {}
-            RateLimitRecordSource::Local => self.release_local(key),
+            RateLimitRecordSource::Local => self.release_local(key, Some(reservation.recorded_at)),
             RateLimitRecordSource::Distributed => {
+                let remaining_window_secs = reservation.remaining_window_secs();
+                if remaining_window_secs == 0 {
+                    return;
+                }
+
                 #[cfg(feature = "gateway")]
                 if let Some(redis) = &self.redis
-                    && let Err(err) = redis.rate_limit_release(key).await
+                    && let Err(err) = redis.rate_limit_release(key, remaining_window_secs).await
                 {
                     warn!("Redis rate-limit release failed for key {}: {}", key, err);
                 }
@@ -189,7 +280,7 @@ impl RateLimiter {
         }
     }
 
-    fn release_local(&self, key: &str) {
+    fn release_local(&self, key: &str, recorded_at: Option<Instant>) {
         let limit = self.config.default_rpm as f64;
         let should_remove = {
             let Some(mut entry) = self.entries.get_mut(key) else {
@@ -198,14 +289,29 @@ impl RateLimiter {
 
             match self.config.strategy {
                 RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
-                    entry.timestamps.pop();
+                    if let Some(recorded_at) = recorded_at {
+                        if let Some(position) =
+                            entry.timestamps.iter().position(|&ts| ts == recorded_at)
+                        {
+                            entry.timestamps.remove(position);
+                        }
+                    } else {
+                        entry.timestamps.pop();
+                    }
                 }
                 RateLimitStrategy::TokenBucket => {
                     entry.tokens = (entry.tokens + 1.0).min(limit);
                 }
             }
 
-            entry.timestamps.is_empty() && entry.tokens >= limit
+            match self.config.strategy {
+                RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                    entry.timestamps.is_empty()
+                }
+                RateLimitStrategy::TokenBucket => {
+                    entry.timestamps.is_empty() && entry.tokens >= limit
+                }
+            }
         };
 
         if should_remove {

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -8,6 +8,14 @@ use std::time::Duration;
 #[cfg(feature = "gateway")]
 use tracing::warn;
 
+/// Backend that recorded a rate-limit reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitRecordSource {
+    Disabled,
+    Local,
+    Distributed,
+}
+
 /// Rate limiter implementation
 pub struct RateLimiter {
     /// Rate limit configuration
@@ -22,6 +30,17 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
+    fn disabled_result(&self) -> RateLimitResult {
+        RateLimitResult {
+            allowed: true,
+            current_count: 0,
+            limit: self.config.default_rpm,
+            remaining: self.config.default_rpm,
+            reset_after_secs: 0,
+            retry_after_secs: None,
+        }
+    }
+
     /// Create a new rate limiter
     pub fn new(config: RateLimitConfig) -> Self {
         Self {
@@ -64,14 +83,7 @@ impl RateLimiter {
     /// Use check_and_record() for atomic check-then-record operations.
     pub async fn check(&self, key: &str) -> RateLimitResult {
         if !self.config.enabled {
-            return RateLimitResult {
-                allowed: true,
-                current_count: 0,
-                limit: self.config.default_rpm,
-                remaining: self.config.default_rpm,
-                reset_after_secs: 0,
-                retry_after_secs: None,
-            };
+            return self.disabled_result();
         }
 
         #[cfg(feature = "gateway")]
@@ -102,15 +114,16 @@ impl RateLimiter {
     /// This is the preferred method for rate limiting as it performs both
     /// the check and record operations in a single lock acquisition.
     pub async fn check_and_record(&self, key: &str) -> RateLimitResult {
+        self.check_and_record_with_source(key).await.0
+    }
+
+    /// Atomically check and record a request, returning the backend used.
+    pub(crate) async fn check_and_record_with_source(
+        &self,
+        key: &str,
+    ) -> (RateLimitResult, RateLimitRecordSource) {
         if !self.config.enabled {
-            return RateLimitResult {
-                allowed: true,
-                current_count: 0,
-                limit: self.config.default_rpm,
-                remaining: self.config.default_rpm,
-                reset_after_secs: 0,
-                retry_after_secs: None,
-            };
+            return (self.disabled_result(), RateLimitRecordSource::Disabled);
         }
 
         #[cfg(feature = "gateway")]
@@ -119,7 +132,7 @@ impl RateLimiter {
                 .rate_limit_check_and_record(key, self.config.default_rpm, self.window.as_secs())
                 .await
             {
-                Ok(result) => return result,
+                Ok(result) => return (result, RateLimitRecordSource::Distributed),
                 Err(err) => {
                     warn!(
                         "Redis rate-limit check failed for key {}; falling back to in-process limiter: {}",
@@ -129,6 +142,13 @@ impl RateLimiter {
             }
         }
 
+        (
+            self.check_and_record_local(key).await,
+            RateLimitRecordSource::Local,
+        )
+    }
+
+    async fn check_and_record_local(&self, key: &str) -> RateLimitResult {
         match self.config.strategy {
             RateLimitStrategy::SlidingWindow => self.check_sliding_window_impl(key, true).await,
             RateLimitStrategy::TokenBucket => self.check_token_bucket_impl(key, true).await,
@@ -138,18 +158,38 @@ impl RateLimiter {
 
     /// Release one request previously reserved by `check_and_record`.
     pub async fn release(&self, key: &str) {
+        #[cfg(feature = "gateway")]
+        if self.redis.is_some() {
+            self.release_recorded(key, RateLimitRecordSource::Distributed)
+                .await;
+            return;
+        }
+
+        self.release_recorded(key, RateLimitRecordSource::Local)
+            .await;
+    }
+
+    /// Release one request previously reserved by the given backend.
+    pub(crate) async fn release_recorded(&self, key: &str, source: RateLimitRecordSource) {
         if !self.config.enabled {
             return;
         }
 
-        #[cfg(feature = "gateway")]
-        if let Some(redis) = &self.redis {
-            if let Err(err) = redis.rate_limit_release(key).await {
-                warn!("Redis rate-limit release failed for key {}: {}", key, err);
+        match source {
+            RateLimitRecordSource::Disabled => {}
+            RateLimitRecordSource::Local => self.release_local(key),
+            RateLimitRecordSource::Distributed => {
+                #[cfg(feature = "gateway")]
+                if let Some(redis) = &self.redis
+                    && let Err(err) = redis.rate_limit_release(key).await
+                {
+                    warn!("Redis rate-limit release failed for key {}: {}", key, err);
+                }
             }
-            return;
         }
+    }
 
+    fn release_local(&self, key: &str) {
         let limit = self.config.default_rpm as f64;
         let should_remove = {
             let Some(mut entry) = self.entries.get_mut(key) else {

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -94,9 +94,8 @@ impl RateLimiter {
     fn local_reservation_reset_after_secs(&self, result: &RateLimitResult) -> u64 {
         match self.config.strategy {
             RateLimitStrategy::TokenBucket => self.token_bucket_reservation_window().as_secs(),
-            RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
-                result.reset_after_secs
-            }
+            RateLimitStrategy::SlidingWindow => self.window.as_secs(),
+            RateLimitStrategy::FixedWindow => result.reset_after_secs,
         }
     }
 
@@ -304,12 +303,11 @@ impl RateLimiter {
 
     fn release_local(&self, key: &str, recorded_at: Option<Instant>) {
         let limit = self.config.default_rpm as f64;
-        let should_remove = {
-            let Some(mut entry) = self.entries.get_mut(key) else {
-                return;
-            };
+        let strategy = self.config.strategy.clone();
+        let reservation_window = self.token_bucket_reservation_window();
 
-            match self.config.strategy {
+        let _removed_entry = self.entries.remove_if_mut(key, |_, entry| {
+            match &strategy {
                 RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
                     if let Some(recorded_at) = recorded_at {
                         if let Some(position) =
@@ -324,7 +322,6 @@ impl RateLimiter {
                 RateLimitStrategy::TokenBucket => {
                     let should_refund = if let Some(recorded_at) = recorded_at {
                         let now = Instant::now();
-                        let reservation_window = self.token_bucket_reservation_window();
                         entry
                             .timestamps
                             .retain(|&ts| now.saturating_duration_since(ts) < reservation_window);
@@ -347,7 +344,7 @@ impl RateLimiter {
                 }
             }
 
-            match self.config.strategy {
+            match &strategy {
                 RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
                     entry.timestamps.is_empty()
                 }
@@ -355,11 +352,7 @@ impl RateLimiter {
                     entry.timestamps.is_empty() && entry.tokens >= limit
                 }
             }
-        };
-
-        if should_remove {
-            self.entries.remove(key);
-        }
+        });
     }
 
     /// Record a request (increments counter)

--- a/src/core/rate_limiter/mod.rs
+++ b/src/core/rate_limiter/mod.rs
@@ -11,6 +11,7 @@ mod utils;
 mod tests;
 
 // Re-export public types
+pub(crate) use limiter::RateLimitRecordSource;
 pub use limiter::RateLimiter;
 pub use types::RateLimitResult;
 

--- a/src/core/rate_limiter/mod.rs
+++ b/src/core/rate_limiter/mod.rs
@@ -11,7 +11,9 @@ mod utils;
 mod tests;
 
 // Re-export public types
+#[cfg(test)]
 pub(crate) use limiter::RateLimitRecordSource;
+pub(crate) use limiter::RateLimitReservation;
 pub use limiter::RateLimiter;
 pub use types::RateLimitResult;
 

--- a/src/core/rate_limiter/strategies.rs
+++ b/src/core/rate_limiter/strategies.rs
@@ -86,6 +86,11 @@ impl RateLimiter {
                 timestamps: Vec::new(),
             });
 
+        let reservation_window = self.token_bucket_reservation_window();
+        entry
+            .timestamps
+            .retain(|&ts| now.saturating_duration_since(ts) < reservation_window);
+
         // Refill tokens based on elapsed time
         let elapsed = now.duration_since(entry.last_refill);
         let new_tokens = elapsed.as_secs_f64() * tokens_per_second;
@@ -109,6 +114,7 @@ impl RateLimiter {
             // Atomically consume token if allowed and record flag is set
             if record {
                 entry.tokens -= 1.0;
+                entry.timestamps.push(now);
             }
             None
         };

--- a/src/core/rate_limiter/strategies.rs
+++ b/src/core/rate_limiter/strategies.rs
@@ -12,8 +12,8 @@ impl RateLimiter {
         &self,
         key: &str,
         record: bool,
+        now: Instant,
     ) -> RateLimitResult {
-        let now = Instant::now();
         let window_start = now - self.window;
         let limit = self.config.default_rpm;
 
@@ -68,8 +68,12 @@ impl RateLimiter {
 
     /// Token bucket rate limiting implementation
     /// If `record` is true, atomically consumes a token if allowed
-    pub(super) async fn check_token_bucket_impl(&self, key: &str, record: bool) -> RateLimitResult {
-        let now = Instant::now();
+    pub(super) async fn check_token_bucket_impl(
+        &self,
+        key: &str,
+        record: bool,
+        now: Instant,
+    ) -> RateLimitResult {
         let limit = self.config.default_rpm;
         let tokens_per_second = limit as f64 / 60.0;
 
@@ -126,8 +130,12 @@ impl RateLimiter {
 
     /// Fixed window rate limiting implementation
     /// If `record` is true, atomically records the request if allowed
-    pub(super) async fn check_fixed_window_impl(&self, key: &str, record: bool) -> RateLimitResult {
-        let now = Instant::now();
+    pub(super) async fn check_fixed_window_impl(
+        &self,
+        key: &str,
+        record: bool,
+        now: Instant,
+    ) -> RateLimitResult {
         let limit = self.config.default_rpm;
 
         let mut entry = self.entries.entry(key.to_string()).or_default();

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -1,17 +1,25 @@
 //! Tests for rate limiter
 
-use super::RateLimitRecordSource;
 #[cfg(test)]
 use super::limiter::RateLimiter;
+use super::{RateLimitRecordSource, RateLimitReservation};
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn test_config(enabled: bool, rpm: u32) -> RateLimitConfig {
+    test_config_with_strategy(enabled, rpm, RateLimitStrategy::SlidingWindow)
+}
+
+fn test_config_with_strategy(
+    enabled: bool,
+    rpm: u32,
+    strategy: RateLimitStrategy,
+) -> RateLimitConfig {
     RateLimitConfig {
         enabled,
         default_rpm: rpm,
         default_tpm: 100000,
-        strategy: RateLimitStrategy::SlidingWindow,
+        strategy,
         ..Default::default()
     }
 }
@@ -153,17 +161,35 @@ async fn test_atomic_check_and_record() {
 async fn test_release_recorded_local_source_restores_capacity() {
     let limiter = RateLimiter::new(test_config(true, 1));
 
-    let (result, source) = limiter.check_and_record_with_source("auth-ip").await;
+    let (result, reservation) = limiter.check_and_record_with_source("auth-ip").await;
     assert!(result.allowed);
-    assert_eq!(source, RateLimitRecordSource::Local);
+    assert_eq!(reservation.source(), RateLimitRecordSource::Local);
 
     let blocked = limiter.check_and_record("auth-ip").await;
     assert!(!blocked.allowed);
 
-    limiter.release_recorded("auth-ip", source).await;
+    limiter.release_recorded("auth-ip", reservation).await;
 
     let allowed_again = limiter.check_and_record("auth-ip").await;
     assert!(allowed_again.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_sliding_and_fixed_windows_remove_empty_entry() {
+    for strategy in [
+        RateLimitStrategy::SlidingWindow,
+        RateLimitStrategy::FixedWindow,
+    ] {
+        let limiter = RateLimiter::new(test_config_with_strategy(true, 1, strategy));
+
+        let (result, reservation) = limiter.check_and_record_with_source("auth-ip").await;
+        assert!(result.allowed);
+        assert!(limiter.entries.contains_key("auth-ip"));
+
+        limiter.release_recorded("auth-ip", reservation).await;
+
+        assert!(!limiter.entries.contains_key("auth-ip"));
+    }
 }
 
 #[tokio::test]
@@ -174,7 +200,10 @@ async fn test_release_recorded_distributed_source_keeps_local_capacity() {
     assert!(result.allowed);
 
     limiter
-        .release_recorded("auth-ip", RateLimitRecordSource::Distributed)
+        .release_recorded(
+            "auth-ip",
+            RateLimitReservation::for_test(RateLimitRecordSource::Distributed, Instant::now(), 60),
+        )
         .await;
 
     let blocked = limiter.check_and_record("auth-ip").await;

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 use super::limiter::RateLimiter;
+use super::types::RateLimitEntry;
 use super::{RateLimitRecordSource, RateLimitReservation};
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
 use std::time::{Duration, Instant};
@@ -190,6 +191,60 @@ async fn test_release_recorded_sliding_and_fixed_windows_remove_empty_entry() {
 
         assert!(!limiter.entries.contains_key("auth-ip"));
     }
+}
+
+#[tokio::test]
+async fn test_release_recorded_token_bucket_restores_fresh_reservation() {
+    let limiter = RateLimiter::new(test_config_with_strategy(
+        true,
+        1,
+        RateLimitStrategy::TokenBucket,
+    ));
+
+    let (result, reservation) = limiter.check_and_record_with_source("auth-ip").await;
+    assert!(result.allowed);
+
+    let blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!blocked.allowed);
+
+    limiter.release_recorded("auth-ip", reservation).await;
+
+    let allowed_again = limiter.check_and_record("auth-ip").await;
+    assert!(allowed_again.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_token_bucket_skips_expired_reservation() {
+    let limiter = RateLimiter::new(test_config_with_strategy(
+        true,
+        60,
+        RateLimitStrategy::TokenBucket,
+    ));
+    let key = "auth-ip";
+    let original_success = Instant::now() - Duration::from_secs(2);
+    let later_rejected_auth = Instant::now();
+
+    limiter.entries.insert(
+        key.to_string(),
+        RateLimitEntry {
+            timestamps: vec![original_success, later_rejected_auth],
+            tokens: 0.0,
+            last_refill: later_rejected_auth,
+        },
+    );
+
+    limiter
+        .release_recorded(
+            key,
+            RateLimitReservation::for_test(RateLimitRecordSource::Local, original_success, 1),
+        )
+        .await;
+
+    let blocked = limiter.check_and_record(key).await;
+    assert!(
+        !blocked.allowed,
+        "expired success release must not refund a later rejected-auth token"
+    );
 }
 
 #[tokio::test]

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -194,6 +194,39 @@ async fn test_release_recorded_sliding_and_fixed_windows_remove_empty_entry() {
 }
 
 #[tokio::test]
+async fn test_release_recorded_sliding_window_uses_recorded_timestamp_lifetime() {
+    let limiter = RateLimiter::with_window(
+        test_config_with_strategy(true, 2, RateLimitStrategy::SlidingWindow),
+        Duration::from_secs(2),
+    );
+    let key = "auth-ip";
+    let now = Instant::now();
+    limiter.entries.insert(
+        key.to_string(),
+        RateLimitEntry {
+            timestamps: vec![now - Duration::from_millis(1500)],
+            tokens: 0.0,
+            last_refill: now,
+        },
+    );
+
+    let (result, reservation) = limiter.check_and_record_with_source(key).await;
+    assert!(result.allowed);
+
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    limiter.release_recorded(key, reservation).await;
+
+    let first_after_release = limiter.check_and_record(key).await;
+    let second_after_release = limiter.check_and_record(key).await;
+
+    assert!(first_after_release.allowed);
+    assert!(
+        second_after_release.allowed,
+        "release must remove the successful auth reservation for its full sliding window lifetime"
+    );
+}
+
+#[tokio::test]
 async fn test_release_recorded_token_bucket_restores_fresh_reservation() {
     let limiter = RateLimiter::new(test_config_with_strategy(
         true,

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for rate limiter
 
+use super::RateLimitRecordSource;
 #[cfg(test)]
 use super::limiter::RateLimiter;
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
@@ -146,6 +147,38 @@ async fn test_atomic_check_and_record() {
     // 4th request should be blocked
     let r4 = limiter.check_and_record("atomic-key").await;
     assert!(!r4.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_local_source_restores_capacity() {
+    let limiter = RateLimiter::new(test_config(true, 1));
+
+    let (result, source) = limiter.check_and_record_with_source("auth-ip").await;
+    assert!(result.allowed);
+    assert_eq!(source, RateLimitRecordSource::Local);
+
+    let blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!blocked.allowed);
+
+    limiter.release_recorded("auth-ip", source).await;
+
+    let allowed_again = limiter.check_and_record("auth-ip").await;
+    assert!(allowed_again.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_distributed_source_keeps_local_capacity() {
+    let limiter = RateLimiter::new(test_config(true, 1));
+
+    let result = limiter.check_and_record("auth-ip").await;
+    assert!(result.allowed);
+
+    limiter
+        .release_recorded("auth-ip", RateLimitRecordSource::Distributed)
+        .await;
+
+    let blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!blocked.allowed);
 }
 
 #[tokio::test]

--- a/src/core/rate_limiter/utils.rs
+++ b/src/core/rate_limiter/utils.rs
@@ -2,6 +2,7 @@
 
 use super::limiter::RateLimiter;
 use super::types::RateLimitResult;
+use crate::config::models::rate_limit::RateLimitStrategy;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -14,9 +15,16 @@ impl RateLimiter {
         let limit = self.config.default_rpm as f64;
         self.entries.retain(|_, entry| {
             entry.timestamps.retain(|&t| t > window_start);
-            // Keep entry if it has recent timestamps OR has consumed tokens (not full bucket).
-            // A full bucket (tokens == limit) with no timestamps means the key is idle.
-            !entry.timestamps.is_empty() || entry.tokens < limit
+            match self.config.strategy {
+                RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                    !entry.timestamps.is_empty()
+                }
+                RateLimitStrategy::TokenBucket => {
+                    // Keep entry if it has recent timestamps OR has consumed tokens (not full bucket).
+                    // A full bucket (tokens == limit) with no timestamps means the key is idle.
+                    !entry.timestamps.is_empty() || entry.tokens < limit
+                }
+            }
         });
     }
 

--- a/src/core/rate_limiter/utils.rs
+++ b/src/core/rate_limiter/utils.rs
@@ -14,12 +14,16 @@ impl RateLimiter {
 
         let limit = self.config.default_rpm as f64;
         self.entries.retain(|_, entry| {
-            entry.timestamps.retain(|&t| t > window_start);
             match self.config.strategy {
                 RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                    entry.timestamps.retain(|&t| t > window_start);
                     !entry.timestamps.is_empty()
                 }
                 RateLimitStrategy::TokenBucket => {
+                    let reservation_window = self.token_bucket_reservation_window();
+                    entry
+                        .timestamps
+                        .retain(|&t| now.saturating_duration_since(t) < reservation_window);
                     // Keep entry if it has recent timestamps OR has consumed tokens (not full bucket).
                     // A full bucket (tokens == limit) with no timestamps means the key is idle.
                     !entry.timestamps.is_empty() || entry.tokens < limit

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -7,6 +7,7 @@ use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
 use crate::server::middleware::helpers::{
     extract_auth_method_with_api_key_header, is_public_route,
 };
+use crate::server::middleware::rate_limit::enforce_rate_limit_for_rejected_auth;
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{HttpMessage, HttpRequest, web};
@@ -77,6 +78,9 @@ where
             let enable_jwt = cfg.auth().enable_jwt;
             let enable_api_key = cfg.auth().enable_api_key;
             let api_key_header = cfg.auth().api_key_header.clone();
+            let rate_limit_enabled = cfg.gateway.rate_limit.enabled;
+            let rate_limit_rpm = cfg.gateway.rate_limit.default_rpm;
+            let trusted_proxies = cfg.server().trusted_proxies.clone();
 
             let context = build_request_context(&mut req);
             let auth_method =
@@ -96,6 +100,13 @@ where
             }
 
             if let Err(wait_seconds) = rate_limiter.check_allowed(&client_id) {
+                enforce_gateway_rate_limit_for_auth_rejection(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
+                )
+                .await?;
                 return Err(actix_web::error::ErrorTooManyRequests(format!(
                     "Too many failed attempts. Try again in {} seconds",
                     wait_seconds
@@ -105,12 +116,26 @@ where
             let auth_method = match auth_method {
                 AuthMethod::Jwt(_) if !enable_jwt => {
                     rate_limiter.record_failure(&client_id);
+                    enforce_gateway_rate_limit_for_auth_rejection(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?;
                     return Err(actix_web::error::ErrorUnauthorized(
                         "JWT authentication disabled",
                     ));
                 }
                 AuthMethod::ApiKey(_) if !enable_api_key => {
                     rate_limiter.record_failure(&client_id);
+                    enforce_gateway_rate_limit_for_auth_rejection(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?;
                     return Err(actix_web::error::ErrorUnauthorized(
                         "API key authentication disabled",
                     ));
@@ -120,6 +145,13 @@ where
 
             if matches!(auth_method, AuthMethod::None) {
                 rate_limiter.record_failure(&client_id);
+                enforce_gateway_rate_limit_for_auth_rejection(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
+                )
+                .await?;
                 return Err(actix_web::error::ErrorUnauthorized(
                     "Missing authentication",
                 ));
@@ -149,6 +181,13 @@ where
                             .clone()
                             .unwrap_or_else(|| "unauthorized".to_string())
                     );
+                    enforce_gateway_rate_limit_for_auth_rejection(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?;
                     Err(actix_web::error::ErrorUnauthorized(
                         result.error.unwrap_or_else(|| "Unauthorized".to_string()),
                     ))
@@ -163,6 +202,19 @@ where
             }
         })
     }
+}
+
+async fn enforce_gateway_rate_limit_for_auth_rejection(
+    req: &ServiceRequest,
+    enabled: bool,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    if !enabled {
+        return Ok(());
+    }
+
+    enforce_rate_limit_for_rejected_auth(req, requests_per_minute, trusted_proxies).await
 }
 
 /// Extract request context from request

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -8,7 +8,8 @@ use crate::server::middleware::helpers::{
     extract_auth_method_with_api_key_header, is_public_route,
 };
 use crate::server::middleware::rate_limit::{
-    enforce_rate_limit_for_rejected_auth, reject_if_rate_limited_for_auth_attempt,
+    AuthRateLimitReservation, enforce_rate_limit_for_rejected_auth,
+    reserve_rate_limit_for_auth_attempt,
 };
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
@@ -159,18 +160,25 @@ where
                 ));
             }
 
-            if requires_auth_verification(&auth_method) {
-                reject_if_gateway_rate_limited_before_auth(
-                    &req,
-                    rate_limit_enabled,
-                    rate_limit_rpm,
-                    &trusted_proxies,
+            let mut auth_rate_limit_reservation = if requires_auth_verification(&auth_method) {
+                Some(
+                    reserve_gateway_rate_limit_before_auth(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?,
                 )
-                .await?;
-            }
+            } else {
+                None
+            };
 
             match app_state.auth.authenticate(auth_method, context).await {
                 Ok(result) if result.success => {
+                    if let Some(reservation) = auth_rate_limit_reservation.take() {
+                        reservation.release().await;
+                    }
                     rate_limiter.record_success(&client_id);
                     debug!("Authentication succeeded");
 
@@ -193,18 +201,23 @@ where
                             .clone()
                             .unwrap_or_else(|| "unauthorized".to_string())
                     );
-                    enforce_gateway_rate_limit_for_auth_rejection(
-                        &req,
-                        rate_limit_enabled,
-                        rate_limit_rpm,
-                        &trusted_proxies,
-                    )
-                    .await?;
+                    if auth_rate_limit_reservation.is_none() {
+                        enforce_gateway_rate_limit_for_auth_rejection(
+                            &req,
+                            rate_limit_enabled,
+                            rate_limit_rpm,
+                            &trusted_proxies,
+                        )
+                        .await?;
+                    }
                     Err(actix_web::error::ErrorUnauthorized(
                         result.error.unwrap_or_else(|| "Unauthorized".to_string()),
                     ))
                 }
                 Err(err) => {
+                    if let Some(reservation) = auth_rate_limit_reservation.take() {
+                        reservation.release().await;
+                    }
                     rate_limiter.record_failure(&client_id);
                     Err(actix_web::error::ErrorInternalServerError(format!(
                         "Authentication error: {}",
@@ -229,17 +242,17 @@ async fn enforce_gateway_rate_limit_for_auth_rejection(
     enforce_rate_limit_for_rejected_auth(req, requests_per_minute, trusted_proxies).await
 }
 
-async fn reject_if_gateway_rate_limited_before_auth(
+async fn reserve_gateway_rate_limit_before_auth(
     req: &ServiceRequest,
     enabled: bool,
     requests_per_minute: u32,
     trusted_proxies: &[String],
-) -> Result<(), actix_web::Error> {
+) -> Result<AuthRateLimitReservation, actix_web::Error> {
     if !enabled {
-        return Ok(());
+        return Ok(AuthRateLimitReservation::noop());
     }
 
-    reject_if_rate_limited_for_auth_attempt(req, requests_per_minute, trusted_proxies).await
+    reserve_rate_limit_for_auth_attempt(req, requests_per_minute, trusted_proxies).await
 }
 
 fn requires_auth_verification(auth_method: &AuthMethod) -> bool {

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -7,7 +7,9 @@ use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
 use crate::server::middleware::helpers::{
     extract_auth_method_with_api_key_header, is_public_route,
 };
-use crate::server::middleware::rate_limit::enforce_rate_limit_for_rejected_auth;
+use crate::server::middleware::rate_limit::{
+    enforce_rate_limit_for_rejected_auth, reject_if_rate_limited_for_auth_attempt,
+};
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{HttpMessage, HttpRequest, web};
@@ -157,6 +159,16 @@ where
                 ));
             }
 
+            if requires_auth_verification(&auth_method) {
+                reject_if_gateway_rate_limited_before_auth(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
+                )
+                .await?;
+            }
+
             match app_state.auth.authenticate(auth_method, context).await {
                 Ok(result) if result.success => {
                     rate_limiter.record_success(&client_id);
@@ -215,6 +227,26 @@ async fn enforce_gateway_rate_limit_for_auth_rejection(
     }
 
     enforce_rate_limit_for_rejected_auth(req, requests_per_minute, trusted_proxies).await
+}
+
+async fn reject_if_gateway_rate_limited_before_auth(
+    req: &ServiceRequest,
+    enabled: bool,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    if !enabled {
+        return Ok(());
+    }
+
+    reject_if_rate_limited_for_auth_attempt(req, requests_per_minute, trusted_proxies).await
+}
+
+fn requires_auth_verification(auth_method: &AuthMethod) -> bool {
+    matches!(
+        auth_method,
+        AuthMethod::Jwt(_) | AuthMethod::ApiKey(_) | AuthMethod::Session(_)
+    )
 }
 
 /// Extract request context from request
@@ -382,5 +414,19 @@ mod tests {
             get_client_identifier(&req_b, &auth_b)
         );
         assert_eq!(get_client_identifier(&req_a, &auth_a), "ip:203.0.113.80");
+    }
+
+    #[test]
+    fn auth_verification_precheck_only_applies_to_present_credentials() {
+        assert!(requires_auth_verification(&AuthMethod::Jwt(
+            "jwt-token".to_string()
+        )));
+        assert!(requires_auth_verification(&AuthMethod::ApiKey(
+            "api-key".to_string()
+        )));
+        assert!(requires_auth_verification(&AuthMethod::Session(
+            "session-id".to_string()
+        )));
+        assert!(!requires_auth_verification(&AuthMethod::None));
     }
 }

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -127,18 +127,10 @@ impl AuthRateLimitReservation {
                 }
             }
             RateLimitReservationSource::Fallback { store, recorded_at } => {
-                let should_remove = {
-                    let Some(mut tracker) = store.get_mut(&self.key) else {
-                        return;
-                    };
-
+                let _removed_entry = store.remove_if_mut(&self.key, |_, tracker| {
                     tracker.release(recorded_at);
                     tracker.timestamps.is_empty()
-                };
-
-                if should_remove {
-                    store.remove(&self.key);
-                }
+                });
             }
             RateLimitReservationSource::Noop => {}
         }

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -14,6 +14,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
@@ -25,6 +26,11 @@ use tracing::{debug, info, warn};
 /// attacker rotates source addresses. The value matches `AuthRateLimiter`'s
 /// `DEFAULT_MAX_ENTRIES`.
 const MAX_FALLBACK_ENTRIES: usize = 10_000;
+
+static AUTH_REJECTION_FALLBACK_STORE: OnceLock<Arc<DashMap<String, KeyTracker>>> = OnceLock::new();
+
+const GLOBAL_LIMITER_SOURCE: &str = "global";
+const FALLBACK_LIMITER_SOURCE: &str = "fallback";
 
 /// Fallback per-key tracker for sliding window when global rate limiter is unavailable
 struct KeyTracker {
@@ -64,6 +70,18 @@ impl KeyTracker {
     }
 }
 
+struct RateLimitPass {
+    source: &'static str,
+    limit: u32,
+    remaining: u32,
+}
+
+struct RateLimitRejection {
+    source: &'static str,
+    retry_after: u64,
+    limit: u32,
+}
+
 /// Evict trackers when the fallback store exceeds the cap.
 ///
 /// Two-pass strategy: first drop trackers whose latest timestamp is already
@@ -92,6 +110,101 @@ fn enforce_fallback_capacity(store: &DashMap<String, KeyTracker>, window: Durati
     candidates.sort_by_key(|(ts, _)| *ts);
     for (_, key) in candidates.into_iter().take(overflow) {
         store.remove(&key);
+    }
+}
+
+async fn check_rate_limit_key(
+    key: &str,
+    requests_per_minute: u32,
+    fallback_store: &DashMap<String, KeyTracker>,
+) -> Result<RateLimitPass, RateLimitRejection> {
+    if let Some(global_limiter) = get_global_rate_limiter() {
+        let limit = global_limiter.limit();
+        let result = global_limiter.check_and_record(key).await;
+
+        if !result.allowed {
+            return Err(RateLimitRejection {
+                source: GLOBAL_LIMITER_SOURCE,
+                retry_after: result.retry_after_secs.unwrap_or(60),
+                limit,
+            });
+        }
+
+        return Ok(RateLimitPass {
+            source: GLOBAL_LIMITER_SOURCE,
+            limit,
+            remaining: result.remaining,
+        });
+    }
+
+    let window = Duration::from_secs(60);
+    let (allowed, retry_after) = {
+        let mut tracker = fallback_store
+            .entry(key.to_string())
+            .or_insert_with(KeyTracker::new);
+        tracker.check_and_record(requests_per_minute, window)
+    };
+    if fallback_store.len() > MAX_FALLBACK_ENTRIES {
+        enforce_fallback_capacity(fallback_store, window);
+    }
+
+    if !allowed {
+        return Err(RateLimitRejection {
+            source: FALLBACK_LIMITER_SOURCE,
+            retry_after,
+            limit: requests_per_minute,
+        });
+    }
+
+    let remaining = fallback_store
+        .get(key)
+        .map(|tracker| requests_per_minute.saturating_sub(tracker.timestamps.len() as u32))
+        .unwrap_or(requests_per_minute);
+
+    Ok(RateLimitPass {
+        source: FALLBACK_LIMITER_SOURCE,
+        limit: requests_per_minute,
+        remaining,
+    })
+}
+
+fn auth_rejection_fallback_store() -> Arc<DashMap<String, KeyTracker>> {
+    AUTH_REJECTION_FALLBACK_STORE
+        .get_or_init(|| Arc::new(DashMap::new()))
+        .clone()
+}
+
+pub(super) async fn enforce_rate_limit_for_rejected_auth(
+    req: &ServiceRequest,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    let key = extract_client_key(req, trusted_proxies);
+    let fallback_store = auth_rejection_fallback_store();
+
+    match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await {
+        Ok(pass) => {
+            debug!(
+                client = %key,
+                limit = pass.limit,
+                remaining = pass.remaining,
+                "Rate limit check passed for rejected auth path ({} limiter)",
+                pass.source
+            );
+            Ok(())
+        }
+        Err(rejection) => {
+            warn!(
+                client = %key,
+                "Rate limit exceeded for rejected auth path ({} limiter): retry after {}s",
+                rejection.source,
+                rejection.retry_after
+            );
+            Err(actix_web::Error::from(RateLimitError {
+                retry_after: rejection.retry_after,
+                limit: rejection.limit,
+            }))
+        }
     }
 }
 
@@ -259,84 +372,39 @@ where
 
         let client_key = extract_client_key(&req, &trusted_proxies);
 
-        // --- Try global rate limiter first ---
-        if let Some(global_limiter) = get_global_rate_limiter() {
-            let limit = global_limiter.limit();
-            // service.call() returns a lazy future; it only executes on .await.
-            // We must call it here because it consumes `req`, but we will NOT
-            // await it if the rate check fails — so no downstream work is wasted.
-            let fut = self.service.call(req);
-            let key = client_key.clone();
-
-            return Box::pin(async move {
-                let result = global_limiter.check_and_record(&key).await;
-
-                if !result.allowed {
-                    let retry_after = result.retry_after_secs.unwrap_or(60);
-                    warn!(
-                        client = %key,
-                        path = %path,
-                        "Rate limit exceeded (global limiter): retry after {}s",
-                        retry_after
-                    );
-                    let err = RateLimitError { retry_after, limit };
-                    return Err(actix_web::Error::from(err));
-                }
-
-                debug!(
-                    client = %key,
-                    remaining = result.remaining,
-                    "Rate limit check passed (global limiter)"
-                );
-
-                let res = fut.await?;
-                let duration = start_time.elapsed();
-                info!(
-                    "{} {} completed in {:?} with status {}",
-                    method,
-                    path,
-                    duration,
-                    res.status()
-                );
-                Ok(res)
-            });
-        }
-
-        // --- Fallback: in-process sliding window using middleware's requests_per_minute ---
         let fallback_store = self.fallback_store.clone();
+        // service.call() returns a lazy future; it only executes on .await.
+        // We must call it here because it consumes `req`, but we will NOT
+        // await it if the rate check fails, so no downstream work is wasted.
         let fut = self.service.call(req);
         let key = client_key.clone();
 
         Box::pin(async move {
-            let window = Duration::from_secs(60);
-            let (allowed, retry_after) = {
-                let mut tracker = fallback_store
-                    .entry(key.clone())
-                    .or_insert_with(KeyTracker::new);
-                tracker.check_and_record(requests_per_minute, window)
+            let pass = match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await
+            {
+                Ok(pass) => pass,
+                Err(rejection) => {
+                    warn!(
+                        client = %key,
+                        path = %path,
+                        "Rate limit exceeded ({} limiter): retry after {}s",
+                        rejection.source,
+                        rejection.retry_after
+                    );
+                    let err = RateLimitError {
+                        retry_after: rejection.retry_after,
+                        limit: rejection.limit,
+                    };
+                    return Err(actix_web::Error::from(err));
+                }
             };
-            if fallback_store.len() > MAX_FALLBACK_ENTRIES {
-                enforce_fallback_capacity(&fallback_store, window);
-            }
-
-            if !allowed {
-                warn!(
-                    client = %key,
-                    path = %path,
-                    "Rate limit exceeded (fallback limiter): retry after {}s",
-                    retry_after
-                );
-                let err = RateLimitError {
-                    retry_after,
-                    limit: requests_per_minute,
-                };
-                return Err(actix_web::Error::from(err));
-            }
 
             debug!(
                 client = %key,
-                limit = requests_per_minute,
-                "Rate limit check passed (fallback limiter)"
+                limit = pass.limit,
+                remaining = pass.remaining,
+                "Rate limit check passed ({} limiter)",
+                pass.source
             );
 
             let res = fut.await?;

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -44,16 +44,13 @@ impl KeyTracker {
         }
     }
 
-    /// Check-and-record atomically: returns (allowed, retry_after_secs)
-    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
+    fn check(&mut self, limit: u32, window: Duration) -> (bool, u64) {
         let now = Instant::now();
-        // Evict timestamps outside the window
         self.timestamps
             .retain(|&ts| now.duration_since(ts) < window);
 
         let count = self.timestamps.len() as u32;
         if count >= limit {
-            // Estimate when the oldest entry expires
             let retry_after = self
                 .timestamps
                 .first()
@@ -62,11 +59,20 @@ impl KeyTracker {
                     window.saturating_sub(age).as_secs().max(1)
                 })
                 .unwrap_or(window.as_secs());
-            (false, retry_after)
-        } else {
-            self.timestamps.push(now);
-            (true, 0)
+            return (false, retry_after);
         }
+
+        (true, 0)
+    }
+
+    /// Check-and-record atomically: returns (allowed, retry_after_secs)
+    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
+        let (allowed, retry_after) = self.check(limit, window);
+        if allowed {
+            self.timestamps.push(Instant::now());
+        }
+
+        (allowed, retry_after)
     }
 }
 
@@ -168,10 +174,93 @@ async fn check_rate_limit_key(
     })
 }
 
+async fn check_rate_limit_key_status(
+    key: &str,
+    requests_per_minute: u32,
+    fallback_store: &DashMap<String, KeyTracker>,
+) -> Result<RateLimitPass, RateLimitRejection> {
+    if let Some(global_limiter) = get_global_rate_limiter() {
+        let limit = global_limiter.limit();
+        let result = global_limiter.check(key).await;
+
+        if !result.allowed {
+            return Err(RateLimitRejection {
+                source: GLOBAL_LIMITER_SOURCE,
+                retry_after: result.retry_after_secs.unwrap_or(60),
+                limit,
+            });
+        }
+
+        return Ok(RateLimitPass {
+            source: GLOBAL_LIMITER_SOURCE,
+            limit,
+            remaining: result.remaining,
+        });
+    }
+
+    let window = Duration::from_secs(60);
+    let Some(mut tracker) = fallback_store.get_mut(key) else {
+        return Ok(RateLimitPass {
+            source: FALLBACK_LIMITER_SOURCE,
+            limit: requests_per_minute,
+            remaining: requests_per_minute,
+        });
+    };
+
+    let (allowed, retry_after) = tracker.check(requests_per_minute, window);
+    if !allowed {
+        return Err(RateLimitRejection {
+            source: FALLBACK_LIMITER_SOURCE,
+            retry_after,
+            limit: requests_per_minute,
+        });
+    }
+
+    Ok(RateLimitPass {
+        source: FALLBACK_LIMITER_SOURCE,
+        limit: requests_per_minute,
+        remaining: requests_per_minute.saturating_sub(tracker.timestamps.len() as u32),
+    })
+}
+
 fn auth_rejection_fallback_store() -> Arc<DashMap<String, KeyTracker>> {
     AUTH_REJECTION_FALLBACK_STORE
         .get_or_init(|| Arc::new(DashMap::new()))
         .clone()
+}
+
+pub(super) async fn reject_if_rate_limited_for_auth_attempt(
+    req: &ServiceRequest,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    let key = extract_client_key(req, trusted_proxies);
+    let fallback_store = auth_rejection_fallback_store();
+
+    match check_rate_limit_key_status(&key, requests_per_minute, &fallback_store).await {
+        Ok(pass) => {
+            debug!(
+                client = %key,
+                limit = pass.limit,
+                remaining = pass.remaining,
+                "Rate limit pre-check passed for auth attempt ({} limiter)",
+                pass.source
+            );
+            Ok(())
+        }
+        Err(rejection) => {
+            warn!(
+                client = %key,
+                "Rate limit exceeded before auth verification ({} limiter): retry after {}s",
+                rejection.source,
+                rejection.retry_after
+            );
+            Err(actix_web::Error::from(RateLimitError {
+                retry_after: rejection.retry_after,
+                limit: rejection.limit,
+            }))
+        }
+    }
 }
 
 pub(super) async fn enforce_rate_limit_for_rejected_auth(
@@ -538,6 +627,33 @@ mod tests {
         let key = extract_client_key(&req, &[]);
 
         assert_eq!(key, "user:user-123");
+    }
+
+    #[test]
+    fn test_key_tracker_status_check_does_not_record() {
+        let mut tracker = KeyTracker::new();
+        let window = Duration::from_secs(60);
+
+        let (allowed, retry_after) = tracker.check(1, window);
+
+        assert!(allowed);
+        assert_eq!(retry_after, 0);
+        assert!(tracker.timestamps.is_empty());
+    }
+
+    #[test]
+    fn test_key_tracker_status_check_rejects_full_bucket_without_recording() {
+        let mut tracker = KeyTracker::new();
+        let window = Duration::from_secs(60);
+        let (allowed, _) = tracker.check_and_record(1, window);
+        assert!(allowed);
+        let recorded = tracker.timestamps.len();
+
+        let (allowed, retry_after) = tracker.check(1, window);
+
+        assert!(!allowed);
+        assert!(retry_after > 0);
+        assert_eq!(tracker.timestamps.len(), recorded);
     }
 
     #[test]

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -1,6 +1,6 @@
 //! Rate limiting middleware
 
-use crate::core::rate_limiter::get_global_rate_limiter;
+use crate::core::rate_limiter::{RateLimitRecordSource, get_global_rate_limiter};
 use crate::core::types::context::RequestContext;
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
@@ -76,6 +76,7 @@ struct RateLimitPass {
     source: &'static str,
     limit: u32,
     remaining: u32,
+    record_source: Option<RateLimitRecordSource>,
 }
 
 struct RateLimitRejection {
@@ -85,7 +86,7 @@ struct RateLimitRejection {
 }
 
 enum RateLimitReservationSource {
-    Global,
+    Global(RateLimitRecordSource),
     Fallback(Arc<DashMap<String, KeyTracker>>),
     Noop,
 }
@@ -105,9 +106,11 @@ impl AuthRateLimitReservation {
 
     pub(super) async fn release(self) {
         match self.source {
-            RateLimitReservationSource::Global => {
+            RateLimitReservationSource::Global(record_source) => {
                 if let Some(global_limiter) = get_global_rate_limiter() {
-                    global_limiter.release(&self.key).await;
+                    global_limiter
+                        .release_recorded(&self.key, record_source)
+                        .await;
                 }
             }
             RateLimitReservationSource::Fallback(store) => {
@@ -158,7 +161,7 @@ async fn check_rate_limit_key(
 ) -> Result<RateLimitPass, RateLimitRejection> {
     if let Some(global_limiter) = get_global_rate_limiter() {
         let limit = global_limiter.limit();
-        let result = global_limiter.check_and_record(key).await;
+        let (result, record_source) = global_limiter.check_and_record_with_source(key).await;
 
         if !result.allowed {
             return Err(RateLimitRejection {
@@ -172,6 +175,7 @@ async fn check_rate_limit_key(
             source: GLOBAL_LIMITER_SOURCE,
             limit,
             remaining: result.remaining,
+            record_source: Some(record_source),
         });
     }
 
@@ -203,6 +207,7 @@ async fn check_rate_limit_key(
         source: FALLBACK_LIMITER_SOURCE,
         limit: requests_per_minute,
         remaining,
+        record_source: None,
     })
 }
 
@@ -229,11 +234,10 @@ pub(super) async fn reserve_rate_limit_for_auth_attempt(
                 "Rate limit reservation passed for auth attempt ({} limiter)",
                 pass.source
             );
-            let source = if pass.source == GLOBAL_LIMITER_SOURCE {
-                RateLimitReservationSource::Global
-            } else {
-                RateLimitReservationSource::Fallback(fallback_store)
-            };
+            let source = pass
+                .record_source
+                .map(RateLimitReservationSource::Global)
+                .unwrap_or_else(|| RateLimitReservationSource::Fallback(fallback_store));
             Ok(AuthRateLimitReservation { key, source })
         }
         Err(rejection) => {

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, warn};
 /// `DEFAULT_MAX_ENTRIES`.
 const MAX_FALLBACK_ENTRIES: usize = 10_000;
 
-static AUTH_REJECTION_FALLBACK_STORE: OnceLock<Arc<DashMap<String, KeyTracker>>> = OnceLock::new();
+static GATEWAY_FALLBACK_STORE: OnceLock<Arc<DashMap<String, KeyTracker>>> = OnceLock::new();
 
 const GLOBAL_LIMITER_SOURCE: &str = "global";
 const FALLBACK_LIMITER_SOURCE: &str = "fallback";
@@ -44,7 +44,12 @@ impl KeyTracker {
         }
     }
 
-    fn check(&mut self, limit: u32, window: Duration) -> (bool, u64) {
+    fn release(&mut self) {
+        self.timestamps.pop();
+    }
+
+    /// Check-and-record atomically: returns (allowed, retry_after_secs)
+    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
         let now = Instant::now();
         self.timestamps
             .retain(|&ts| now.duration_since(ts) < window);
@@ -62,17 +67,8 @@ impl KeyTracker {
             return (false, retry_after);
         }
 
+        self.timestamps.push(now);
         (true, 0)
-    }
-
-    /// Check-and-record atomically: returns (allowed, retry_after_secs)
-    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
-        let (allowed, retry_after) = self.check(limit, window);
-        if allowed {
-            self.timestamps.push(Instant::now());
-        }
-
-        (allowed, retry_after)
     }
 }
 
@@ -86,6 +82,42 @@ struct RateLimitRejection {
     source: &'static str,
     retry_after: u64,
     limit: u32,
+}
+
+enum RateLimitReservationSource {
+    Global,
+    Fallback(Arc<DashMap<String, KeyTracker>>),
+    Noop,
+}
+
+pub(super) struct AuthRateLimitReservation {
+    key: String,
+    source: RateLimitReservationSource,
+}
+
+impl AuthRateLimitReservation {
+    pub(super) fn noop() -> Self {
+        Self {
+            key: String::new(),
+            source: RateLimitReservationSource::Noop,
+        }
+    }
+
+    pub(super) async fn release(self) {
+        match self.source {
+            RateLimitReservationSource::Global => {
+                if let Some(global_limiter) = get_global_rate_limiter() {
+                    global_limiter.release(&self.key).await;
+                }
+            }
+            RateLimitReservationSource::Fallback(store) => {
+                if let Some(mut tracker) = store.get_mut(&self.key) {
+                    tracker.release();
+                }
+            }
+            RateLimitReservationSource::Noop => {}
+        }
+    }
 }
 
 /// Evict trackers when the fallback store exceeds the cap.
@@ -174,79 +206,35 @@ async fn check_rate_limit_key(
     })
 }
 
-async fn check_rate_limit_key_status(
-    key: &str,
-    requests_per_minute: u32,
-    fallback_store: &DashMap<String, KeyTracker>,
-) -> Result<RateLimitPass, RateLimitRejection> {
-    if let Some(global_limiter) = get_global_rate_limiter() {
-        let limit = global_limiter.limit();
-        let result = global_limiter.check(key).await;
-
-        if !result.allowed {
-            return Err(RateLimitRejection {
-                source: GLOBAL_LIMITER_SOURCE,
-                retry_after: result.retry_after_secs.unwrap_or(60),
-                limit,
-            });
-        }
-
-        return Ok(RateLimitPass {
-            source: GLOBAL_LIMITER_SOURCE,
-            limit,
-            remaining: result.remaining,
-        });
-    }
-
-    let window = Duration::from_secs(60);
-    let Some(mut tracker) = fallback_store.get_mut(key) else {
-        return Ok(RateLimitPass {
-            source: FALLBACK_LIMITER_SOURCE,
-            limit: requests_per_minute,
-            remaining: requests_per_minute,
-        });
-    };
-
-    let (allowed, retry_after) = tracker.check(requests_per_minute, window);
-    if !allowed {
-        return Err(RateLimitRejection {
-            source: FALLBACK_LIMITER_SOURCE,
-            retry_after,
-            limit: requests_per_minute,
-        });
-    }
-
-    Ok(RateLimitPass {
-        source: FALLBACK_LIMITER_SOURCE,
-        limit: requests_per_minute,
-        remaining: requests_per_minute.saturating_sub(tracker.timestamps.len() as u32),
-    })
-}
-
-fn auth_rejection_fallback_store() -> Arc<DashMap<String, KeyTracker>> {
-    AUTH_REJECTION_FALLBACK_STORE
+fn gateway_fallback_store() -> Arc<DashMap<String, KeyTracker>> {
+    GATEWAY_FALLBACK_STORE
         .get_or_init(|| Arc::new(DashMap::new()))
         .clone()
 }
 
-pub(super) async fn reject_if_rate_limited_for_auth_attempt(
+pub(super) async fn reserve_rate_limit_for_auth_attempt(
     req: &ServiceRequest,
     requests_per_minute: u32,
     trusted_proxies: &[String],
-) -> Result<(), actix_web::Error> {
+) -> Result<AuthRateLimitReservation, actix_web::Error> {
     let key = extract_client_key(req, trusted_proxies);
-    let fallback_store = auth_rejection_fallback_store();
+    let fallback_store = gateway_fallback_store();
 
-    match check_rate_limit_key_status(&key, requests_per_minute, &fallback_store).await {
+    match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await {
         Ok(pass) => {
             debug!(
                 client = %key,
                 limit = pass.limit,
                 remaining = pass.remaining,
-                "Rate limit pre-check passed for auth attempt ({} limiter)",
+                "Rate limit reservation passed for auth attempt ({} limiter)",
                 pass.source
             );
-            Ok(())
+            let source = if pass.source == GLOBAL_LIMITER_SOURCE {
+                RateLimitReservationSource::Global
+            } else {
+                RateLimitReservationSource::Fallback(fallback_store)
+            };
+            Ok(AuthRateLimitReservation { key, source })
         }
         Err(rejection) => {
             warn!(
@@ -269,7 +257,7 @@ pub(super) async fn enforce_rate_limit_for_rejected_auth(
     trusted_proxies: &[String],
 ) -> Result<(), actix_web::Error> {
     let key = extract_client_key(req, trusted_proxies);
-    let fallback_store = auth_rejection_fallback_store();
+    let fallback_store = gateway_fallback_store();
 
     match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await {
         Ok(pass) => {
@@ -364,7 +352,7 @@ where
         ready(Ok(RateLimitMiddlewareService {
             service,
             requests_per_minute: self.requests_per_minute,
-            fallback_store: Arc::new(DashMap::new()),
+            fallback_store: gateway_fallback_store(),
         }))
     }
 }
@@ -630,30 +618,34 @@ mod tests {
     }
 
     #[test]
-    fn test_key_tracker_status_check_does_not_record() {
+    fn test_key_tracker_release_removes_recorded_slot() {
         let mut tracker = KeyTracker::new();
         let window = Duration::from_secs(60);
 
-        let (allowed, retry_after) = tracker.check(1, window);
-
+        let (allowed, _) = tracker.check_and_record(1, window);
         assert!(allowed);
-        assert_eq!(retry_after, 0);
+        assert_eq!(tracker.timestamps.len(), 1);
+
+        tracker.release();
+
         assert!(tracker.timestamps.is_empty());
     }
 
     #[test]
-    fn test_key_tracker_status_check_rejects_full_bucket_without_recording() {
+    fn test_key_tracker_release_allows_new_reservation() {
         let mut tracker = KeyTracker::new();
         let window = Duration::from_secs(60);
         let (allowed, _) = tracker.check_and_record(1, window);
         assert!(allowed);
-        let recorded = tracker.timestamps.len();
-
-        let (allowed, retry_after) = tracker.check(1, window);
-
+        let (allowed, retry_after) = tracker.check_and_record(1, window);
         assert!(!allowed);
         assert!(retry_after > 0);
-        assert_eq!(tracker.timestamps.len(), recorded);
+
+        tracker.release();
+        let (allowed, retry_after) = tracker.check_and_record(1, window);
+
+        assert!(allowed);
+        assert_eq!(retry_after, 0);
     }
 
     #[test]

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -1,6 +1,6 @@
 //! Rate limiting middleware
 
-use crate::core::rate_limiter::{RateLimitRecordSource, get_global_rate_limiter};
+use crate::core::rate_limiter::{RateLimitReservation, get_global_rate_limiter};
 use crate::core::types::context::RequestContext;
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
@@ -44,12 +44,17 @@ impl KeyTracker {
         }
     }
 
-    fn release(&mut self) {
-        self.timestamps.pop();
+    fn release(&mut self, recorded_at: Instant) -> bool {
+        let Some(position) = self.timestamps.iter().position(|&ts| ts == recorded_at) else {
+            return false;
+        };
+
+        self.timestamps.remove(position);
+        true
     }
 
-    /// Check-and-record atomically: returns (allowed, retry_after_secs)
-    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
+    /// Check-and-record atomically: returns (allowed, retry_after_secs, recorded_at)
+    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64, Option<Instant>) {
         let now = Instant::now();
         self.timestamps
             .retain(|&ts| now.duration_since(ts) < window);
@@ -64,11 +69,11 @@ impl KeyTracker {
                     window.saturating_sub(age).as_secs().max(1)
                 })
                 .unwrap_or(window.as_secs());
-            return (false, retry_after);
+            return (false, retry_after, None);
         }
 
         self.timestamps.push(now);
-        (true, 0)
+        (true, 0, Some(now))
     }
 }
 
@@ -76,7 +81,7 @@ struct RateLimitPass {
     source: &'static str,
     limit: u32,
     remaining: u32,
-    record_source: Option<RateLimitRecordSource>,
+    reservation: RecordedRateLimitReservation,
 }
 
 struct RateLimitRejection {
@@ -86,9 +91,17 @@ struct RateLimitRejection {
 }
 
 enum RateLimitReservationSource {
-    Global(RateLimitRecordSource),
-    Fallback(Arc<DashMap<String, KeyTracker>>),
+    Global(RateLimitReservation),
+    Fallback {
+        store: Arc<DashMap<String, KeyTracker>>,
+        recorded_at: Instant,
+    },
     Noop,
+}
+
+enum RecordedRateLimitReservation {
+    Global(RateLimitReservation),
+    Fallback(Instant),
 }
 
 pub(super) struct AuthRateLimitReservation {
@@ -113,9 +126,18 @@ impl AuthRateLimitReservation {
                         .await;
                 }
             }
-            RateLimitReservationSource::Fallback(store) => {
-                if let Some(mut tracker) = store.get_mut(&self.key) {
-                    tracker.release();
+            RateLimitReservationSource::Fallback { store, recorded_at } => {
+                let should_remove = {
+                    let Some(mut tracker) = store.get_mut(&self.key) else {
+                        return;
+                    };
+
+                    tracker.release(recorded_at);
+                    tracker.timestamps.is_empty()
+                };
+
+                if should_remove {
+                    store.remove(&self.key);
                 }
             }
             RateLimitReservationSource::Noop => {}
@@ -161,7 +183,7 @@ async fn check_rate_limit_key(
 ) -> Result<RateLimitPass, RateLimitRejection> {
     if let Some(global_limiter) = get_global_rate_limiter() {
         let limit = global_limiter.limit();
-        let (result, record_source) = global_limiter.check_and_record_with_source(key).await;
+        let (result, reservation) = global_limiter.check_and_record_with_source(key).await;
 
         if !result.allowed {
             return Err(RateLimitRejection {
@@ -175,12 +197,12 @@ async fn check_rate_limit_key(
             source: GLOBAL_LIMITER_SOURCE,
             limit,
             remaining: result.remaining,
-            record_source: Some(record_source),
+            reservation: RecordedRateLimitReservation::Global(reservation),
         });
     }
 
     let window = Duration::from_secs(60);
-    let (allowed, retry_after) = {
+    let (allowed, retry_after, recorded_at) = {
         let mut tracker = fallback_store
             .entry(key.to_string())
             .or_insert_with(KeyTracker::new);
@@ -198,6 +220,14 @@ async fn check_rate_limit_key(
         });
     }
 
+    let Some(recorded_at) = recorded_at else {
+        return Err(RateLimitRejection {
+            source: FALLBACK_LIMITER_SOURCE,
+            retry_after: window.as_secs().max(1),
+            limit: requests_per_minute,
+        });
+    };
+
     let remaining = fallback_store
         .get(key)
         .map(|tracker| requests_per_minute.saturating_sub(tracker.timestamps.len() as u32))
@@ -207,7 +237,7 @@ async fn check_rate_limit_key(
         source: FALLBACK_LIMITER_SOURCE,
         limit: requests_per_minute,
         remaining,
-        record_source: None,
+        reservation: RecordedRateLimitReservation::Fallback(recorded_at),
     })
 }
 
@@ -234,10 +264,17 @@ pub(super) async fn reserve_rate_limit_for_auth_attempt(
                 "Rate limit reservation passed for auth attempt ({} limiter)",
                 pass.source
             );
-            let source = pass
-                .record_source
-                .map(RateLimitReservationSource::Global)
-                .unwrap_or_else(|| RateLimitReservationSource::Fallback(fallback_store));
+            let source = match pass.reservation {
+                RecordedRateLimitReservation::Global(reservation) => {
+                    RateLimitReservationSource::Global(reservation)
+                }
+                RecordedRateLimitReservation::Fallback(recorded_at) => {
+                    RateLimitReservationSource::Fallback {
+                        store: fallback_store,
+                        recorded_at,
+                    }
+                }
+            };
             Ok(AuthRateLimitReservation { key, source })
         }
         Err(rejection) => {
@@ -508,6 +545,13 @@ mod tests {
     use actix_web::test::TestRequest;
     use uuid::Uuid;
 
+    fn require_recorded_at(value: Option<Instant>) -> Instant {
+        match value {
+            Some(value) => value,
+            None => panic!("allowed reservation should record a timestamp"),
+        }
+    }
+
     #[test]
     fn test_parse_peer_ip_ipv4_with_port() {
         assert_eq!(parse_peer_ip("127.0.0.1:1234"), "127.0.0.1");
@@ -626,11 +670,12 @@ mod tests {
         let mut tracker = KeyTracker::new();
         let window = Duration::from_secs(60);
 
-        let (allowed, _) = tracker.check_and_record(1, window);
+        let (allowed, _, recorded_at) = tracker.check_and_record(1, window);
         assert!(allowed);
+        let recorded_at = require_recorded_at(recorded_at);
         assert_eq!(tracker.timestamps.len(), 1);
 
-        tracker.release();
+        tracker.release(recorded_at);
 
         assert!(tracker.timestamps.is_empty());
     }
@@ -639,17 +684,38 @@ mod tests {
     fn test_key_tracker_release_allows_new_reservation() {
         let mut tracker = KeyTracker::new();
         let window = Duration::from_secs(60);
-        let (allowed, _) = tracker.check_and_record(1, window);
+        let (allowed, _, recorded_at) = tracker.check_and_record(1, window);
         assert!(allowed);
-        let (allowed, retry_after) = tracker.check_and_record(1, window);
+        let recorded_at = require_recorded_at(recorded_at);
+        let (allowed, retry_after, _) = tracker.check_and_record(1, window);
         assert!(!allowed);
         assert!(retry_after > 0);
 
-        tracker.release();
-        let (allowed, retry_after) = tracker.check_and_record(1, window);
+        tracker.release(recorded_at);
+        let (allowed, retry_after, _) = tracker.check_and_record(1, window);
 
         assert!(allowed);
         assert_eq!(retry_after, 0);
+    }
+
+    #[test]
+    fn test_key_tracker_release_keeps_newer_rejected_auth_slot() {
+        let mut tracker = KeyTracker::new();
+        let window = Duration::from_secs(60);
+
+        let (first_allowed, _, first_recorded_at) = tracker.check_and_record(2, window);
+        assert!(first_allowed);
+        let first_recorded_at = require_recorded_at(first_recorded_at);
+
+        std::thread::sleep(Duration::from_millis(1));
+
+        let (second_allowed, _, second_recorded_at) = tracker.check_and_record(2, window);
+        assert!(second_allowed);
+        let second_recorded_at = require_recorded_at(second_recorded_at);
+
+        tracker.release(first_recorded_at);
+
+        assert_eq!(tracker.timestamps, vec![second_recorded_at]);
     }
 
     #[test]

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -49,6 +49,21 @@ if remaining < 0 then remaining = 0 end
 return {allowed, current, limit, remaining, ttl}
 "#;
 
+const RELEASE_SCRIPT: &str = r#"
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+if current <= 0 then
+  return 0
+end
+
+current = redis.call("DECR", KEYS[1])
+if current <= 0 then
+  redis.call("DEL", KEYS[1])
+  return 0
+end
+
+return current
+"#;
+
 fn redis_rate_limit_key(key: &str) -> String {
     format!("litellm-rs:rate_limit:v1:{}", key)
 }
@@ -162,6 +177,25 @@ impl RedisPool {
                 retry_after_secs: None,
             })
         }
+    }
+
+    /// Release one previously-recorded request from a distributed fixed window.
+    pub async fn rate_limit_release(&self, key: &str) -> Result<()> {
+        if self.noop_mode {
+            return Ok(());
+        }
+
+        let redis_key = redis_rate_limit_key(key);
+        let mut conn = self.get_connection().await?;
+        if let Some(ref mut c) = conn.conn {
+            let _: i64 = redis::Script::new(RELEASE_SCRIPT)
+                .key(redis_key)
+                .invoke_async(c)
+                .await
+                .map_err(GatewayError::from)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -50,9 +50,23 @@ return {allowed, current, limit, remaining, ttl}
 "#;
 
 const RELEASE_SCRIPT: &str = r#"
+local reservation_ttl = tonumber(ARGV[1])
+if reservation_ttl == nil or reservation_ttl <= 0 then
+  return 0
+end
+
 local current = tonumber(redis.call("GET", KEYS[1]) or "0")
 if current <= 0 then
   return 0
+end
+
+local ttl = redis.call("TTL", KEYS[1])
+if ttl < 0 then
+  return current
+end
+
+if ttl > (reservation_ttl + 1) then
+  return current
 end
 
 current = redis.call("DECR", KEYS[1])
@@ -180,8 +194,8 @@ impl RedisPool {
     }
 
     /// Release one previously-recorded request from a distributed fixed window.
-    pub async fn rate_limit_release(&self, key: &str) -> Result<()> {
-        if self.noop_mode {
+    pub async fn rate_limit_release(&self, key: &str, reservation_ttl_secs: u64) -> Result<()> {
+        if self.noop_mode || reservation_ttl_secs == 0 {
             return Ok(());
         }
 
@@ -190,6 +204,7 @@ impl RedisPool {
         if let Some(ref mut c) = conn.conn {
             let _: i64 = redis::Script::new(RELEASE_SCRIPT)
                 .key(redis_key)
+                .arg(reservation_ttl_secs)
                 .invoke_async(c)
                 .await
                 .map_err(GatewayError::from)?;
@@ -204,6 +219,13 @@ mod tests {
     use super::*;
     use crate::config::models::storage::RedisConfig;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn must<T>(result: Result<T>, context: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{context}: {err}"),
+        }
+    }
 
     #[test]
     fn parses_redis_rate_limit_result() {
@@ -252,6 +274,44 @@ mod tests {
         assert_eq!(second.remaining, 0);
 
         let _ = pool.delete(&redis_rate_limit_key(&key)).await;
+    }
+
+    #[tokio::test]
+    async fn live_redis_release_skips_newer_window_after_original_expiry() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+
+        let key = unique_test_key("rate-limit-release-expired");
+        let first = must(
+            pool.rate_limit_check_and_record(&key, 1, 1).await,
+            "first check should succeed",
+        );
+        assert!(first.allowed);
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+        let second = must(
+            pool.rate_limit_check_and_record(&key, 1, 30).await,
+            "second check should succeed in a new window",
+        );
+        assert!(second.allowed);
+
+        must(
+            pool.rate_limit_release(&key, 1).await,
+            "stale release should be handled",
+        );
+
+        let status = must(
+            pool.rate_limit_status(&key, 1, 30).await,
+            "status should succeed",
+        );
+        assert_eq!(status.current_count, 1);
+        assert_eq!(status.remaining, 0);
+
+        if let Err(err) = pool.delete(&redis_rate_limit_key(&key)).await {
+            eprintln!("failed to clean up Redis rate-limit test key {key}: {err}");
+        }
     }
 
     async fn live_redis_pool() -> Option<RedisPool> {

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -281,6 +281,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_valid_auth_releases_gateway_auth_attempt_reservation() {
+        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let principal = seed_valid_principal(&state).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::new(1))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let valid = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.103:1000".parse().unwrap())
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let response = test::call_service(&app, valid).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let invalid = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.103:1001".parse().unwrap())
+            .insert_header(("x-api-key", "gw-invalid-after-valid-auth"))
+            .to_request();
+        let invalid_error = test::try_call_service(&app, invalid)
+            .await
+            .expect_err("first invalid auth after valid auth should not inherit the reservation");
+        assert_eq!(
+            invalid_error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn test_auth_middleware_accepts_valid_auth_and_propagates_principal_context() {
         let state = build_test_state(true, true).await;
         let principal = seed_valid_principal(&state).await;

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
+    async fn test_rotating_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
         let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
         let hit_counter = Arc::new(AtomicUsize::new(0));
 
@@ -268,11 +268,11 @@ mod tests {
         let second = test::TestRequest::get()
             .uri(AUTH_PROBE_PATH)
             .peer_addr("203.0.113.102:1001".parse().unwrap())
-            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key-rotated"))
             .to_request();
         let second_error = test::try_call_service(&app, second)
             .await
-            .expect_err("second invalid-auth request should hit gateway rate limit");
+            .expect_err("second rotating invalid-auth request should hit gateway rate limit");
         assert_eq!(
             second_error.as_response_error().status_code(),
             StatusCode::TOO_MANY_REQUESTS

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -11,7 +11,7 @@ mod tests {
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
     use litellm_rs::core::types::context::RequestContext;
     use litellm_rs::server::http::HttpServer;
-    use litellm_rs::server::middleware::AuthMiddleware;
+    use litellm_rs::server::middleware::{AuthMiddleware, RateLimitMiddleware};
     use litellm_rs::server::state::AppState;
     use litellm_rs::utils::auth::crypto::keys::{extract_api_key_prefix, hash_api_key};
     use serde::{Deserialize, Serialize};
@@ -61,7 +61,11 @@ mod tests {
         HttpResponse::Ok().json(payload)
     }
 
-    async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {
+    async fn build_test_state_with_rate_limit(
+        enable_jwt: bool,
+        enable_api_key: bool,
+        default_rpm: Option<u32>,
+    ) -> AppState {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = enable_jwt;
         config.gateway.auth.enable_api_key = enable_api_key;
@@ -69,6 +73,10 @@ mod tests {
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        if let Some(default_rpm) = default_rpm {
+            config.gateway.rate_limit.enabled = true;
+            config.gateway.rate_limit.default_rpm = default_rpm;
+        }
 
         let server = HttpServer::new(&config)
             .await
@@ -80,6 +88,10 @@ mod tests {
             .await
             .expect("failed to run in-memory DB migrations for auth middleware integration test");
         state
+    }
+
+    async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {
+        build_test_state_with_rate_limit(enable_jwt, enable_api_key, None).await
     }
 
     async fn seed_valid_principal(state: &AppState) -> SeededPrincipal {
@@ -182,6 +194,90 @@ mod tests {
         );
         assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
         assert!(error.to_string().contains("Invalid API key"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
+        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::new(1))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.101:1000".parse().unwrap())
+            .to_request();
+        let first_error = test::try_call_service(&app, first)
+            .await
+            .expect_err("first missing-auth request should fail in auth middleware");
+        assert_eq!(
+            first_error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.101:1001".parse().unwrap())
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second missing-auth request should hit gateway rate limit");
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
+        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::new(1))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.102:1000".parse().unwrap())
+            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+            .to_request();
+        let first_error = test::try_call_service(&app, first)
+            .await
+            .expect_err("first invalid-auth request should fail in auth middleware");
+        assert_eq!(
+            first_error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.102:1001".parse().unwrap())
+            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second invalid-auth request should hit gateway rate limit");
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- apply the configured gateway rate limiter to protected requests that AuthMiddleware rejects before calling the inner service
- keep successful authenticated requests on the existing AuthMiddleware -> RateLimitMiddleware path so API key/user RequestContext buckets are preserved
- add missing-auth and invalid-auth regression coverage for the current Actix wrap order

Fixes #653

## Tests
- cargo fmt --check
- cargo check
- cargo test gateway_rate_limit_before_auth_short_circuit --features gateway,storage
- cargo test --features gateway,storage