### PR TITLE
fix(providers): report requested factory provider

### DIFF
--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -18,6 +18,12 @@ use super::unified_provider::ProviderError;
 use super::{Provider, openai_like, registry as provider_registry};
 use tracing::warn;
 
+fn provider_diagnostic_name(provider_type: &ProviderType) -> &'static str {
+    provider_registry::entry_for_type(provider_type)
+        .map(|entry| entry.canonical_name)
+        .unwrap_or("custom")
+}
+
 /// Create a provider from configuration
 ///
 /// This is the main factory function for creating providers
@@ -97,7 +103,7 @@ pub async fn create_provider(
 
     if !Provider::factory_supported_provider_types().contains(&provider_type_enum) {
         return Err(ProviderError::not_implemented(
-            "unknown",
+            provider_diagnostic_name(&provider_type_enum),
             format!("Factory for {:?} not yet implemented", provider_type_enum),
         ));
     }
@@ -185,6 +191,7 @@ mod tests {
             "Expected NotImplemented error, got {}",
             err
         );
+        assert_eq!(err.provider(), "pydantic_ai");
     }
 
     #[tokio::test]
@@ -204,6 +211,7 @@ mod tests {
             "Expected NotImplemented error, got {}",
             err
         );
+        assert_eq!(err.provider(), "pydantic_ai");
     }
 
     #[tokio::test]

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -22,6 +22,12 @@ use super::builder::{
     config_u64,
 };
 
+fn provider_diagnostic_name(provider_type: &ProviderType) -> &'static str {
+    provider_registry::entry_for_type(provider_type)
+        .map(|entry| entry.canonical_name)
+        .unwrap_or("custom")
+}
+
 impl Provider {
     /// Create provider from configuration asynchronously
     ///
@@ -153,7 +159,7 @@ impl Provider {
                     Some(d) => d,
                     None => {
                         return Err(ProviderError::not_implemented(
-                            "unknown",
+                            provider_diagnostic_name(pt),
                             format!("Catalog definition for '{}' disappeared unexpectedly", name),
                         ));
                     }
@@ -177,7 +183,7 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             _ => Err(ProviderError::not_implemented(
-                "unknown",
+                provider_diagnostic_name(&provider_type),
                 format!("Factory for {:?} not yet implemented", provider_type),
             )),
         }
@@ -290,6 +296,11 @@ mod tests {
                 "Expected NotImplemented for {:?}, got {}",
                 provider_type,
                 err
+            );
+            assert_eq!(
+                err.provider(),
+                provider_type.to_string(),
+                "NotImplemented provider name should identify the requested provider"
             );
         }
     }

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -22,12 +22,6 @@ use super::builder::{
     config_u64,
 };
 
-fn provider_diagnostic_name(provider_type: &ProviderType) -> &'static str {
-    provider_registry::entry_for_type(provider_type)
-        .map(|entry| entry.canonical_name)
-        .unwrap_or("custom")
-}
-
 impl Provider {
     /// Create provider from configuration asynchronously
     ///
@@ -159,7 +153,7 @@ impl Provider {
                     Some(d) => d,
                     None => {
                         return Err(ProviderError::not_implemented(
-                            provider_diagnostic_name(pt),
+                            super::provider_diagnostic_name(pt),
                             format!("Catalog definition for '{}' disappeared unexpectedly", name),
                         ));
                     }
@@ -183,7 +177,7 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             _ => Err(ProviderError::not_implemented(
-                provider_diagnostic_name(&provider_type),
+                super::provider_diagnostic_name(&provider_type),
                 format!("Factory for {:?} not yet implemented", provider_type),
             )),
         }


### PR DESCRIPTION
## Summary
- Report the requested provider canonical name in `from_config_async` NotImplemented diagnostics instead of `unknown`
- Reuse the same diagnostic name for `create_provider` unsupported enum preflight errors
- Cover both factory paths with regression assertions

## Validation
- cargo fmt --check
- cargo test test_create_provider_ --lib
- cargo test test_from_config_async_unsupported_variants_return_not_implemented --lib
- cargo check
- cargo test

Closes #645