### PR TITLE
fix(config): fail fast for explicit config files

### DIFF
--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -42,6 +42,9 @@ const ENV_RATE_LIMIT_ENABLED: &str = "LITELLM_RATE_LIMIT_ENABLED";
 const ENV_ENTERPRISE_ENABLED: &str = "LITELLM_ENTERPRISE_ENABLED";
 const DEFAULT_PRICING_SOURCE: &str = "config/model_prices_extended.json";
 
+#[cfg(test)]
+pub(crate) static GATEWAY_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 fn env_var(key: &str) -> Option<String> {
     env::var(key)
         .ok()

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -1,8 +1,5 @@
 use super::*;
 use crate::config::models::enterprise::SsoConfig;
-use std::sync::Mutex;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 const TEST_ENV_KEYS: [&str; 23] = [
     ENV_HOST,
@@ -75,7 +72,7 @@ fn test_gateway_config_default() {
 
 #[test]
 fn test_gateway_config_from_env() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_HOST, "127.0.0.1");
@@ -140,7 +137,7 @@ fn test_gateway_config_from_env() {
 
 #[test]
 fn test_gateway_config_from_env_allows_local_provider_without_api_key() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -162,7 +159,7 @@ fn test_gateway_config_from_env_allows_local_provider_without_api_key() {
 
 #[test]
 fn test_gateway_config_from_env_requires_providers() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -178,7 +175,7 @@ fn test_gateway_config_from_env_requires_providers() {
 
 #[test]
 fn test_gateway_config_from_env_invalid_port() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_PORT, "invalid-port");
@@ -555,7 +552,7 @@ fn test_gateway_config_clone() {
 
 #[test]
 fn test_gateway_config_from_env_cache_enabled() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -574,7 +571,7 @@ fn test_gateway_config_from_env_cache_enabled() {
 
 #[test]
 fn test_gateway_config_from_env_rate_limit_enabled() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -593,7 +590,7 @@ fn test_gateway_config_from_env_rate_limit_enabled() {
 
 #[test]
 fn test_gateway_config_from_env_enterprise_enabled() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -612,7 +609,7 @@ fn test_gateway_config_from_env_enterprise_enabled() {
 
 #[test]
 fn test_gateway_config_from_env_all_features_enabled() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -635,7 +632,7 @@ fn test_gateway_config_from_env_all_features_enabled() {
 
 #[test]
 fn test_gateway_config_from_env_features_disabled() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
@@ -658,7 +655,7 @@ fn test_gateway_config_from_env_features_disabled() {
 
 #[test]
 fn test_gateway_config_from_env_invalid_cache_enabled() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -589,7 +589,7 @@ fn test_gateway_config_merge_pricing_uses_explicit_default_overlay_source() {
 
 #[test]
 fn test_gateway_config_merge_pricing_uses_env_default_overlay_source() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_test_env();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "false");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@
 
 #![allow(missing_docs)]
 
-use clap::{Parser, Subcommand};
+use clap::parser::ValueSource;
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use litellm_rs::server;
 use litellm_rs::storage::database::Database;
 use litellm_rs::{Config, VERSION};
@@ -12,6 +13,8 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 #[cfg(any(feature = "tracing", test))]
 use tracing::Level;
+
+const DEFAULT_CONFIG_PATH: &str = "config/gateway.yaml";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -25,7 +28,7 @@ struct Cli {
         short,
         long,
         global = true,
-        default_value = "config/gateway.yaml",
+        default_value = DEFAULT_CONFIG_PATH,
         value_name = "FILE"
     )]
     config: PathBuf,
@@ -63,6 +66,27 @@ enum Commands {
 enum DatabaseCommands {
     /// Run database migrations.
     Migrate,
+}
+
+#[derive(Debug)]
+struct ParsedCli {
+    cli: Cli,
+    config_is_explicit: bool,
+}
+
+fn parse_cli_from<I, T>(args: I) -> Result<ParsedCli, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let matches = Cli::command().try_get_matches_from(args)?;
+    let config_is_explicit = matches.value_source("config") == Some(ValueSource::CommandLine);
+    let cli = Cli::from_arg_matches(&matches)?;
+
+    Ok(ParsedCli {
+        cli,
+        config_is_explicit,
+    })
 }
 
 #[cfg(any(feature = "tracing", test))]
@@ -111,18 +135,29 @@ async fn load_config_with_overrides(
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    let cli = Cli::parse();
+    let ParsedCli {
+        cli,
+        config_is_explicit,
+    } = parse_cli_from(std::env::args_os()).unwrap_or_else(|error| error.exit());
     init_logging(cli.log_level.as_deref());
 
     let command = cli.command.unwrap_or(Commands::Serve);
     let result = match command {
         Commands::Serve => {
-            server::builder::run_server_with_config_overrides(
-                &cli.config,
-                cli.host.as_deref(),
-                cli.port,
-            )
-            .await
+            if config_is_explicit {
+                server::builder::run_server_with_config_overrides(
+                    &cli.config,
+                    cli.host.as_deref(),
+                    cli.port,
+                )
+                .await
+            } else {
+                server::builder::run_server_with_default_config_overrides(
+                    cli.host.as_deref(),
+                    cli.port,
+                )
+                .await
+            }
         }
         Commands::ValidateConfig => {
             match load_config_with_overrides(&cli.config, cli.host.as_deref(), cli.port).await {
@@ -166,16 +201,20 @@ mod tests {
 
     #[test]
     fn parses_trailing_global_config_for_migration() {
-        let cli = Cli::try_parse_from([
+        let parsed = match parse_cli_from([
             "gateway",
             "database",
             "migrate",
             "--config",
             "/tmp/gateway.yaml",
-        ])
-        .unwrap();
+        ]) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("expected database migrate args to parse: {error}"),
+        };
+        let cli = parsed.cli;
 
         assert_eq!(cli.config, PathBuf::from("/tmp/gateway.yaml"));
+        assert!(parsed.config_is_explicit);
         match cli.command {
             Some(Commands::Database {
                 command: DatabaseCommands::Migrate,
@@ -186,14 +225,32 @@ mod tests {
 
     #[test]
     fn defaults_to_config_file_when_omitted() {
-        let cli = Cli::try_parse_from(["gateway", "validate-config"]).unwrap();
+        let parsed = match parse_cli_from(["gateway", "validate-config"]) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("expected validate-config args to parse: {error}"),
+        };
+        let cli = parsed.cli;
         assert_eq!(cli.config, PathBuf::from("config/gateway.yaml"));
+        assert!(!parsed.config_is_explicit);
         assert!(matches!(cli.command, Some(Commands::ValidateConfig)));
     }
 
     #[test]
+    fn serve_without_config_uses_implicit_default_config() {
+        let parsed = match parse_cli_from(["gateway", "serve"]) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("expected serve args to parse: {error}"),
+        };
+        let cli = parsed.cli;
+
+        assert_eq!(cli.config, PathBuf::from(DEFAULT_CONFIG_PATH));
+        assert!(!parsed.config_is_explicit);
+        assert!(matches!(cli.command, Some(Commands::Serve)));
+    }
+
+    #[test]
     fn accepts_legacy_startup_overrides() {
-        let cli = Cli::try_parse_from([
+        let parsed = match parse_cli_from([
             "gateway",
             "--config",
             "/tmp/gateway.yaml",
@@ -203,10 +260,14 @@ mod tests {
             "8080",
             "--log-level",
             "debug",
-        ])
-        .unwrap();
+        ]) {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("expected legacy startup args to parse: {error}"),
+        };
+        let cli = parsed.cli;
 
         assert_eq!(cli.config, PathBuf::from("/tmp/gateway.yaml"));
+        assert!(parsed.config_is_explicit);
         assert_eq!(cli.host.as_deref(), Some("0.0.0.0"));
         assert_eq!(cli.port, Some(8080));
         assert_eq!(cli.log_level.as_deref(), Some("debug"));

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -44,7 +44,10 @@ impl Default for ServerBuilder {
 
 /// Run the server with automatic configuration loading
 pub async fn run_server() -> Result<()> {
-    run_server_with_config_path("config/gateway.yaml").await
+    info!("🚀 Starting Rust LiteLLM Gateway");
+
+    let config = load_default_config_or_env(Path::new("config/gateway.yaml")).await?;
+    run_server_with_loaded_config(config, None, None).await
 }
 
 /// Run the server with an explicit configuration path.
@@ -66,14 +69,21 @@ where
 {
     info!("🚀 Starting Rust LiteLLM Gateway");
 
-    // Auto-load configuration file
     let config_path = config_path.as_ref();
-    info!("📄 Loading configuration file: {}", config_path.display());
+    let config = load_explicit_config(config_path).await?;
+    run_server_with_loaded_config(config, host, port).await
+}
 
-    let mut config = match Config::from_file(config_path).await {
+pub(super) async fn load_default_config_or_env(config_path: &Path) -> Result<Config> {
+    info!(
+        "📄 Loading default configuration file: {}",
+        config_path.display()
+    );
+
+    match Config::from_file(config_path).await {
         Ok(config) => {
             info!("✅ Configuration file loaded successfully");
-            config
+            Ok(config)
         }
         Err(file_error) => {
             info!(
@@ -84,18 +94,37 @@ where
             match Config::from_env() {
                 Ok(config) => {
                     info!("✅ Loaded configuration from environment variables");
-                    config
+                    Ok(config)
                 }
-                Err(env_error) => {
-                    return Err(GatewayError::Config(format!(
-                        "Failed to load configuration from file ({}) and environment ({}).",
-                        file_error, env_error
-                    )));
-                }
+                Err(env_error) => Err(GatewayError::Config(format!(
+                    "Failed to load default configuration file ({}) and environment ({}).",
+                    file_error, env_error
+                ))),
             }
         }
-    };
+    }
+}
 
+pub(super) async fn load_explicit_config(config_path: &Path) -> Result<Config> {
+    info!(
+        "📄 Loading explicit configuration file: {}",
+        config_path.display()
+    );
+
+    Config::from_file(config_path).await.map_err(|file_error| {
+        GatewayError::Config(format!(
+            "Failed to load explicit configuration file {}: {}",
+            config_path.display(),
+            file_error
+        ))
+    })
+}
+
+async fn run_server_with_loaded_config(
+    mut config: Config,
+    host: Option<&str>,
+    port: Option<u16>,
+) -> Result<()> {
     if let Some(host) = host {
         config.gateway.server.host = host.to_string();
     }

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -9,6 +9,8 @@ use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::path::Path;
 use tracing::info;
 
+const DEFAULT_CONFIG_PATH: &str = "config/gateway.yaml";
+
 /// Server builder for easier configuration
 pub struct ServerBuilder {
     config: Option<Config>,
@@ -44,10 +46,18 @@ impl Default for ServerBuilder {
 
 /// Run the server with automatic configuration loading
 pub async fn run_server() -> Result<()> {
+    run_server_with_default_config_overrides(None, None).await
+}
+
+/// Run the server with automatic configuration loading and CLI overrides.
+pub async fn run_server_with_default_config_overrides(
+    host: Option<&str>,
+    port: Option<u16>,
+) -> Result<()> {
     info!("🚀 Starting Rust LiteLLM Gateway");
 
-    let config = load_default_config_or_env(Path::new("config/gateway.yaml")).await?;
-    run_server_with_loaded_config(config, None, None).await
+    let config = load_default_config_or_env(Path::new(DEFAULT_CONFIG_PATH)).await?;
+    run_server_with_loaded_config(config, host, port).await
 }
 
 /// Run the server with an explicit configuration path.

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2,13 +2,12 @@
 //!
 //! This module contains all tests for the server components.
 
+use crate::config::models::gateway::GATEWAY_ENV_LOCK;
 #[cfg(test)]
 use crate::server::builder::{ServerBuilder, load_default_config_or_env, load_explicit_config};
 use crate::server::types::ServerRequestMetrics;
 use crate::utils::error::gateway_error::GatewayError;
 use std::io::Write;
-
-static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 const GATEWAY_ENV_KEYS: &[&str] = &[
     "LITELLM_HOST",
@@ -145,7 +144,7 @@ async fn explicit_config_path_parse_error_fails_without_env_fallback() {
 
 #[tokio::test]
 async fn default_config_path_can_fall_back_to_env_when_file_is_missing() {
-    let _env_lock = ENV_LOCK.lock().await;
+    let _env_lock = GATEWAY_ENV_LOCK.lock().await;
     let _env = EnvGuard::with_minimal_gateway_config();
     let temp_dir = match tempfile::tempdir() {
         Ok(temp_dir) => temp_dir,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3,9 +3,91 @@
 //! This module contains all tests for the server components.
 
 #[cfg(test)]
-use crate::server::builder::ServerBuilder;
+use crate::server::builder::{ServerBuilder, load_default_config_or_env, load_explicit_config};
 use crate::server::types::ServerRequestMetrics;
 use crate::utils::error::gateway_error::GatewayError;
+use std::io::Write;
+
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const GATEWAY_ENV_KEYS: &[&str] = &[
+    "LITELLM_HOST",
+    "LITELLM_PORT",
+    "LITELLM_WORKERS",
+    "LITELLM_TIMEOUT",
+    "LITELLM_DATABASE_URL",
+    "LITELLM_DATABASE_MAX_CONNECTIONS",
+    "LITELLM_DATABASE_CONNECTION_TIMEOUT",
+    "LITELLM_DATABASE_SSL",
+    "LITELLM_DATABASE_ENABLED",
+    "LITELLM_DATABASE_AUTO_MIGRATE",
+    "LITELLM_REDIS_URL",
+    "LITELLM_REDIS_ENABLED",
+    "LITELLM_REDIS_MAX_CONNECTIONS",
+    "LITELLM_REDIS_CONNECTION_TIMEOUT",
+    "LITELLM_REDIS_CLUSTER",
+    "LITELLM_ENABLE_JWT",
+    "LITELLM_ENABLE_API_KEY",
+    "LITELLM_JWT_SECRET",
+    "LITELLM_JWT_EXPIRATION",
+    "LITELLM_API_KEY_HEADER",
+    "LITELLM_PROVIDERS",
+    "LITELLM_PRICING_SOURCE",
+    "LITELLM_CACHE_ENABLED",
+    "LITELLM_RATE_LIMIT_ENABLED",
+    "LITELLM_ENTERPRISE_ENABLED",
+    "LITELLM_PROVIDER_OPENAI_TYPE",
+    "LITELLM_PROVIDER_OPENAI_API_KEY",
+    "LITELLM_PROVIDER_OPENAI_BASE_URL",
+    "LITELLM_PROVIDER_OPENAI_API_VERSION",
+    "LITELLM_PROVIDER_OPENAI_ORGANIZATION",
+    "LITELLM_PROVIDER_OPENAI_PROJECT",
+    "LITELLM_PROVIDER_OPENAI_WEIGHT",
+    "LITELLM_PROVIDER_OPENAI_RPM",
+    "LITELLM_PROVIDER_OPENAI_TPM",
+    "LITELLM_PROVIDER_OPENAI_MAX_CONCURRENT_REQUESTS",
+    "LITELLM_PROVIDER_OPENAI_TIMEOUT",
+    "LITELLM_PROVIDER_OPENAI_MAX_RETRIES",
+    "LITELLM_PROVIDER_OPENAI_ENABLED",
+    "LITELLM_PROVIDER_OPENAI_MODELS",
+    "LITELLM_PROVIDER_OPENAI_TAGS",
+];
+
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn with_minimal_gateway_config() -> Self {
+        let saved = GATEWAY_ENV_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        for key in GATEWAY_ENV_KEYS {
+            unsafe { std::env::remove_var(key) };
+        }
+
+        unsafe {
+            std::env::set_var("LITELLM_PROVIDERS", "openai");
+            std::env::set_var("LITELLM_PROVIDER_OPENAI_TYPE", "openai");
+            std::env::set_var("LITELLM_PROVIDER_OPENAI_API_KEY", "sk-test-key");
+        }
+
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_server_builder_requires_config() {
@@ -19,6 +101,65 @@ async fn test_server_builder_requires_config() {
         GatewayError::Config(message) => assert_eq!(message, "Configuration is required"),
         other => panic!("expected config error, got: {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn explicit_config_path_missing_file_fails_without_env_fallback() {
+    let temp_dir = match tempfile::tempdir() {
+        Ok(temp_dir) => temp_dir,
+        Err(error) => panic!("failed to create temp dir: {error}"),
+    };
+    let missing_config = temp_dir.path().join("missing-gateway.yaml");
+
+    let error = match load_explicit_config(&missing_config).await {
+        Err(error) => error,
+        Ok(_) => panic!("missing explicit config path should fail"),
+    };
+    let message = error.to_string();
+
+    assert!(message.contains("Failed to load explicit configuration file"));
+    assert!(message.contains("Failed to read config file"));
+    assert!(!message.contains("environment"));
+}
+
+#[tokio::test]
+async fn explicit_config_path_parse_error_fails_without_env_fallback() {
+    let mut config_file = match tempfile::NamedTempFile::new() {
+        Ok(config_file) => config_file,
+        Err(error) => panic!("failed to create temp file: {error}"),
+    };
+    if let Err(error) = config_file.write_all(b"server: [\n") {
+        panic!("failed to write invalid config: {error}");
+    }
+
+    let error = match load_explicit_config(config_file.path()).await {
+        Err(error) => error,
+        Ok(_) => panic!("invalid explicit config path should fail"),
+    };
+    let message = error.to_string();
+
+    assert!(message.contains("Failed to load explicit configuration file"));
+    assert!(message.contains("Failed to parse config"));
+    assert!(!message.contains("environment"));
+}
+
+#[tokio::test]
+async fn default_config_path_can_fall_back_to_env_when_file_is_missing() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::with_minimal_gateway_config();
+    let temp_dir = match tempfile::tempdir() {
+        Ok(temp_dir) => temp_dir,
+        Err(error) => panic!("failed to create temp dir: {error}"),
+    };
+    let missing_config = temp_dir.path().join("missing-gateway.yaml");
+
+    let config = match load_default_config_or_env(&missing_config).await {
+        Ok(config) => config,
+        Err(error) => panic!("default config path should fall back to env: {error}"),
+    };
+
+    assert_eq!(config.providers().len(), 1);
+    assert_eq!(config.providers()[0].name, "openai");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- split default config loading from explicit config loading in the server builder
- make explicit config paths fail fast on file load/parse errors instead of falling back to environment config
- add tests for missing explicit files, invalid explicit files, and the default-path environment fallback

## Validation
- cargo check --all-features
- cargo test --lib server::tests --all-features
- cargo test --all-features
- git diff --check origin/main..HEAD

Closes #650
