### PR TITLE
fix(router): distinguish unsupported capabilities

### DIFF
--- a/src/core/router/error.rs
+++ b/src/core/router/error.rs
@@ -38,6 +38,10 @@ pub enum RouterError {
     #[error("No available deployment for model: {0}")]
     NoAvailableDeployment(String),
 
+    /// The model exists, but no deployment supports the requested capability
+    #[error("Model '{model}' does not support capability: {capability}")]
+    UnsupportedCapability { model: String, capability: String },
+
     /// Deployment not found by ID
     #[error("Deployment not found: {0}")]
     DeploymentNotFound(String),
@@ -175,6 +179,18 @@ mod tests {
     }
 
     #[test]
+    fn test_router_error_unsupported_capability() {
+        let error = RouterError::UnsupportedCapability {
+            model: "gpt-4".to_string(),
+            capability: "TextToSpeech".to_string(),
+        };
+        assert_eq!(
+            error.to_string(),
+            "Model 'gpt-4' does not support capability: TextToSpeech"
+        );
+    }
+
+    #[test]
     fn test_router_error_deployment_not_found() {
         let error = RouterError::DeploymentNotFound("dep-123".to_string());
         assert_eq!(error.to_string(), "Deployment not found: dep-123");
@@ -245,6 +261,10 @@ mod tests {
         let errors = vec![
             RouterError::ModelNotFound("a".to_string()),
             RouterError::NoAvailableDeployment("b".to_string()),
+            RouterError::UnsupportedCapability {
+                model: "b".to_string(),
+                capability: "c".to_string(),
+            },
             RouterError::DeploymentNotFound("c".to_string()),
             RouterError::AllDeploymentsInCooldown("d".to_string()),
             RouterError::RateLimitExceeded("e".to_string()),
@@ -252,7 +272,7 @@ mod tests {
             RouterError::FallbackCycle("g".to_string()),
         ];
 
-        assert_eq!(errors.len(), 7);
+        assert_eq!(errors.len(), 8);
         for error in errors {
             assert!(!error.to_string().is_empty());
         }

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -93,6 +93,10 @@ pub fn router_error_to_provider_error(err: RouterError) -> ProviderError {
             provider: "router",
             message: format!("No available deployment: {}", msg),
         },
+        RouterError::UnsupportedCapability { model, capability } => ProviderError::invalid_request(
+            "router",
+            format!("Model '{model}' does not support capability {capability}"),
+        ),
         RouterError::AllDeploymentsInCooldown(msg) => ProviderError::ProviderUnavailable {
             provider: "router",
             message: format!("All deployments in cooldown: {}", msg),

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -23,7 +23,7 @@ impl Router {
     /// 4. Select based on routing strategy
     /// 5. Increment active_requests counter
     pub fn select_deployment(&self, model_name: &str) -> Result<DeploymentId, RouterError> {
-        self.select_deployment_matching(model_name, |_| true)
+        self.select_deployment_matching(model_name, |_| true, None)
     }
 
     /// Select the best deployment for a model that supports `capability`.
@@ -36,13 +36,22 @@ impl Router {
         model_name: &str,
         capability: &ProviderCapability,
     ) -> Result<DeploymentId, RouterError> {
-        self.select_deployment_matching(model_name, |deployment| {
-            deployment
-                .provider
-                .capabilities()
-                .iter()
-                .any(|cap| cap == capability)
-        })
+        let no_matching_candidate_error = RouterError::UnsupportedCapability {
+            model: model_name.to_string(),
+            capability: format!("{capability:?}"),
+        };
+
+        self.select_deployment_matching(
+            model_name,
+            |deployment| {
+                deployment
+                    .provider
+                    .capabilities()
+                    .iter()
+                    .any(|cap| cap == capability)
+            },
+            Some(no_matching_candidate_error),
+        )
     }
 
     /// Select a deployment ID from pre-built routing contexts.
@@ -84,6 +93,7 @@ impl Router {
         &self,
         model_name: &str,
         is_candidate: F,
+        no_matching_candidate_error: Option<RouterError>,
     ) -> Result<DeploymentId, RouterError>
     where
         F: Fn(&Deployment) -> bool,
@@ -109,12 +119,15 @@ impl Router {
         // 3. Filter and build routing contexts in one pass to avoid cloning a
         // temporary candidate ID vector and then looking everything up again.
         let total_deployments = deployment_ids_ref.len();
+        let mut existing_deployments = 0;
+        let mut matching_deployments = 0;
         let mut routing_contexts = Vec::with_capacity(total_deployments);
 
         for id in deployment_ids_ref.iter() {
             let Some(deployment) = self.deployments.get(id.as_str()) else {
                 continue;
             };
+            existing_deployments += 1;
 
             if !is_candidate(&deployment) {
                 tracing::trace!(
@@ -125,6 +138,7 @@ impl Router {
                 );
                 continue;
             }
+            matching_deployments += 1;
 
             // Check cooldown first: is_in_cooldown() resets health
             // from Cooldown to Degraded when the cooldown period expires.
@@ -201,6 +215,13 @@ impl Router {
         }
 
         if routing_contexts.is_empty() {
+            if existing_deployments > 0
+                && matching_deployments == 0
+                && let Some(err) = no_matching_candidate_error
+            {
+                return Err(err);
+            }
+
             tracing::warn!(
                 model = %model_name,
                 total_deployments = total_deployments,

--- a/src/core/router/tests/selection_tests.rs
+++ b/src/core/router/tests/selection_tests.rs
@@ -6,7 +6,9 @@
 use super::router_tests::create_test_deployment;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::deployment::HealthStatus;
+use crate::core::router::error::RouterError;
 use crate::core::router::unified::Router;
+use crate::core::types::model::ProviderCapability;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering::Relaxed;
 
@@ -132,6 +134,38 @@ async fn test_simple_shuffle_increments_active_requests() {
         after, 0,
         "release_deployment should decrement active_requests"
     );
+}
+
+#[tokio::test]
+async fn test_capability_selection_reports_unsupported_capability() {
+    let router = Router::default();
+    let d = create_test_deployment("chat-only", "shared-model").await;
+    d.state.health.store(HealthStatus::Healthy as u8, Relaxed);
+    router.add_deployment(d);
+
+    let err = router
+        .select_deployment_for_capability("shared-model", &ProviderCapability::TextToSpeech)
+        .expect_err("unsupported capability should not look unavailable");
+
+    assert!(matches!(
+        err,
+        RouterError::UnsupportedCapability { model, capability }
+            if model == "shared-model" && capability == "TextToSpeech"
+    ));
+}
+
+#[tokio::test]
+async fn test_capability_selection_reports_unavailable_when_capable_deployment_is_unhealthy() {
+    let router = Router::default();
+    let d = create_test_deployment("chat-capable", "shared-model").await;
+    d.state.health.store(HealthStatus::Unhealthy as u8, Relaxed);
+    router.add_deployment(d);
+
+    let err = router
+        .select_deployment_for_capability("shared-model", &ProviderCapability::ChatCompletion)
+        .expect_err("unhealthy capable deployment should be unavailable");
+
+    assert!(matches!(err, RouterError::NoAvailableDeployment(model) if model == "shared-model"));
 }
 
 // ==================== RoundRobin ====================

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -320,6 +320,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_execute_with_selected_deployment_rejects_unsupported_capability() {
+        let router = build_mixed_capability_router().await;
+
+        let err = execute_with_selected_deployment(
+            &router,
+            "shared-model",
+            ProviderCapability::TextToSpeech,
+            |_provider, _model| async { Ok::<_, ProviderError>(("should not run", 0)) },
+        )
+        .await
+        .expect_err("unsupported capability should fail before execution");
+
+        assert!(matches!(
+            err,
+            GatewayError::Provider(ProviderError::InvalidRequest { .. })
+        ));
+    }
+
+    #[tokio::test]
     async fn test_execute_with_selected_deployment_maps_provider_error() {
         let router = build_test_router().await;
 


### PR DESCRIPTION
## Summary
- add a distinct router error for models whose deployments do not support the requested capability
- map unsupported capability to a non-retryable invalid request instead of provider unavailable
- add router and AI execution regressions covering unsupported capability vs unavailable capable deployment

Fixes #652

## Tests
- cargo fmt --check
- cargo check --features gateway,storage
- cargo test --features gateway,storage
