### PR TITLE
fix(ci): scope release token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,15 @@ env:
   RELEASE_FEATURES: postgres,sqlite,redis,s3,metrics,tracing,websockets,analytics,providers-extra,providers-extended,mcp-validation
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   # Create GitHub release
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -54,6 +55,8 @@ jobs:
     name: Build Release
     needs: create-release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
@@ -149,6 +152,9 @@ jobs:
     name: Docker Release
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Check Docker credentials
       id: docker_credentials


### PR DESCRIPTION
Summary
- Reduce the release workflow default GITHUB_TOKEN permissions to read-only contents access.
- Scope contents: write to release creation and release asset upload jobs.
- Scope packages: write to the Docker/GHCR publishing job.

Validation
- ruby YAML.load_file .github/workflows/release.yml
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh
- cargo fmt --all -- --check
- cargo check --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features

Fixes #649