### PR TITLE
fix(provider): wire native Azure dispatch

### DIFF
--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -225,6 +225,9 @@ impl AzureChatHandler {
         if let Some(max_tokens) = request.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
+        if let Some(max_completion_tokens) = request.max_completion_tokens {
+            body["max_completion_tokens"] = json!(max_completion_tokens);
+        }
         if let Some(top_p) = request.top_p {
             body["top_p"] = json!(top_p);
         }

--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -243,6 +243,14 @@ impl AzureChatHandler {
         if request.stream {
             body["stream"] = json!(true);
         }
+        if let Some(stream_options) = &request.stream_options {
+            body["stream_options"] = serde_json::to_value(stream_options).map_err(|e| {
+                ProviderError::serialization(
+                    "azure",
+                    format!("Failed to serialize stream_options: {e}"),
+                )
+            })?;
+        }
 
         // Add tools/functions if present
         if let Some(tools) = &request.tools {
@@ -260,6 +268,43 @@ impl AzureChatHandler {
         // Add user if present
         if let Some(user) = &request.user {
             body["user"] = json!(user);
+        }
+
+        if let Some(seed) = request.seed {
+            body["seed"] = json!(seed);
+        }
+        if let Some(n) = request.n {
+            body["n"] = json!(n);
+        }
+        if let Some(logit_bias) = &request.logit_bias {
+            body["logit_bias"] = json!(logit_bias);
+        }
+        if let Some(logprobs) = request.logprobs {
+            body["logprobs"] = json!(logprobs);
+        }
+        if let Some(top_logprobs) = request.top_logprobs {
+            body["top_logprobs"] = json!(top_logprobs);
+        }
+        if let Some(reasoning_effort) = &request.reasoning_effort {
+            body["reasoning_effort"] = json!(reasoning_effort);
+        }
+        if let Some(store) = request.store {
+            body["store"] = json!(store);
+        }
+        if let Some(metadata) = &request.metadata {
+            body["metadata"] = json!(metadata);
+        }
+        if let Some(service_tier) = &request.service_tier {
+            body["service_tier"] = json!(service_tier);
+        }
+        if let Some(parallel_tool_calls) = request.parallel_tool_calls {
+            body["parallel_tool_calls"] = json!(parallel_tool_calls);
+        }
+
+        if let Some(obj) = body.as_object_mut() {
+            for (key, value) in &request.extra_params {
+                obj.entry(key.clone()).or_insert_with(|| value.clone());
+            }
         }
 
         Ok(body)

--- a/src/core/providers/azure/chat_tests.rs
+++ b/src/core/providers/azure/chat_tests.rs
@@ -142,6 +142,50 @@ fn test_transform_request_with_options() {
 }
 
 #[test]
+fn test_transform_request_preserves_stream_controls_and_extra_params() {
+    let config =
+        AzureConfig::new().with_azure_endpoint("https://test.openai.azure.com".to_string());
+    let handler = AzureChatHandler::new(config).unwrap();
+
+    let mut request = create_test_request();
+    request.stream_options = Some(crate::core::types::chat::StreamOptions {
+        include_usage: Some(true),
+    });
+    request.seed = Some(42);
+    request.n = Some(2);
+    request.logit_bias = Some(std::collections::HashMap::from([("123".to_string(), 0.5)]));
+    request.logprobs = Some(true);
+    request.top_logprobs = Some(3);
+    request.reasoning_effort = Some("medium".to_string());
+    request.store = Some(false);
+    request.metadata = Some(std::collections::HashMap::from([(
+        "trace".to_string(),
+        "abc".to_string(),
+    )]));
+    request.service_tier = Some("flex".to_string());
+    request.parallel_tool_calls = Some(false);
+    request
+        .extra_params
+        .insert("provider_knob".to_string(), json!("kept"));
+    request.extra_params.insert("seed".to_string(), json!(99));
+
+    let value = handler.transform_request(&request).unwrap();
+    assert_eq!(value["stream_options"]["include_usage"], true);
+    assert_eq!(value["seed"], 42);
+    assert_eq!(value["n"], 2);
+    assert_eq!(value["logit_bias"]["123"], 0.5);
+    assert_eq!(value["logprobs"], true);
+    assert_eq!(value["top_logprobs"], 3);
+    assert_eq!(value["reasoning_effort"], "medium");
+    assert_eq!(value["store"], false);
+    assert_eq!(value["metadata"]["trace"], "abc");
+    assert_eq!(value["service_tier"], "flex");
+    assert_eq!(value["parallel_tool_calls"], false);
+    assert_eq!(value["provider_knob"], "kept");
+    assert_eq!(value["seed"], 42);
+}
+
+#[test]
 fn test_transform_response() {
     let config =
         AzureConfig::new().with_azure_endpoint("https://test.openai.azure.com".to_string());

--- a/src/core/providers/azure/chat_tests.rs
+++ b/src/core/providers/azure/chat_tests.rs
@@ -120,6 +120,7 @@ fn test_transform_request_with_options() {
         messages: vec![create_test_message(MessageRole::User, "Hello")],
         temperature: Some(0.7),
         max_tokens: Some(100),
+        max_completion_tokens: Some(120),
         top_p: Some(0.9),
         frequency_penalty: Some(0.5),
         presence_penalty: Some(0.3),
@@ -134,6 +135,7 @@ fn test_transform_request_with_options() {
     let value = result.unwrap();
     assert!((value["temperature"].as_f64().unwrap() - 0.7).abs() < 0.001);
     assert_eq!(value["max_tokens"], 100);
+    assert_eq!(value["max_completion_tokens"], 120);
     assert!((value["top_p"].as_f64().unwrap() - 0.9).abs() < 0.001);
     assert!(value["stop"].is_array());
     assert!(value["stream"].as_bool().unwrap());

--- a/src/core/providers/azure/config.rs
+++ b/src/core/providers/azure/config.rs
@@ -5,6 +5,17 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_MAX_RETRIES: u32 = 3;
+
+fn default_timeout_secs() -> u64 {
+    DEFAULT_TIMEOUT_SECS
+}
+
+fn default_max_retries() -> u32 {
+    DEFAULT_MAX_RETRIES
+}
+
 /// Azure OpenAI configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AzureConfig {
@@ -22,6 +33,12 @@ pub struct AzureConfig {
     pub resource_group: Option<String>,
     /// Subscription ID
     pub subscription_id: Option<String>,
+    /// Request timeout in seconds
+    #[serde(default = "default_timeout_secs")]
+    pub timeout: u64,
+    /// Maximum retry attempts
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
     /// Custom headers
     pub custom_headers: HashMap<String, String>,
 }
@@ -36,6 +53,8 @@ impl Default for AzureConfig {
             deployment_name: None,
             resource_group: None,
             subscription_id: None,
+            timeout: DEFAULT_TIMEOUT_SECS,
+            max_retries: DEFAULT_MAX_RETRIES,
             custom_headers: HashMap::new(),
         }
     }
@@ -68,6 +87,18 @@ impl AzureConfig {
     /// Set deployment name
     pub fn with_deployment_name(mut self, deployment: String) -> Self {
         self.deployment_name = Some(deployment);
+        self
+    }
+
+    /// Set request timeout
+    pub fn with_timeout(mut self, timeout_secs: u64) -> Self {
+        self.timeout = timeout_secs;
+        self
+    }
+
+    /// Set maximum retry attempts
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
         self
     }
 
@@ -123,6 +154,14 @@ impl crate::core::traits::provider::ProviderConfig for AzureConfig {
             return Err("API version is required".to_string());
         }
 
+        if self.timeout == 0 {
+            return Err("Timeout must be greater than 0".to_string());
+        }
+
+        if self.max_retries > 10 {
+            return Err("Max retries cannot exceed 10".to_string());
+        }
+
         Ok(())
     }
 
@@ -135,11 +174,11 @@ impl crate::core::traits::provider::ProviderConfig for AzureConfig {
     }
 
     fn timeout(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(60) // Default 60 seconds timeout
+        std::time::Duration::from_secs(self.timeout)
     }
 
     fn max_retries(&self) -> u32 {
-        3 // Default retry 3 times
+        self.max_retries
     }
 }
 
@@ -165,6 +204,8 @@ mod tests {
         assert!(config.azure_endpoint.is_none());
         assert_eq!(config.api_version, "2024-02-01");
         assert!(config.deployment_name.is_none());
+        assert_eq!(config.timeout, DEFAULT_TIMEOUT_SECS);
+        assert_eq!(config.max_retries, DEFAULT_MAX_RETRIES);
     }
 
     #[test]
@@ -173,7 +214,9 @@ mod tests {
             .with_api_key("test-key".to_string())
             .with_azure_endpoint("https://test.openai.azure.com".to_string())
             .with_deployment_name("gpt-4".to_string())
-            .with_api_version("2024-03-01".to_string());
+            .with_api_version("2024-03-01".to_string())
+            .with_timeout(120)
+            .with_max_retries(5);
 
         assert_eq!(config.api_key, Some("test-key".to_string()));
         assert_eq!(
@@ -182,6 +225,8 @@ mod tests {
         );
         assert_eq!(config.deployment_name, Some("gpt-4".to_string()));
         assert_eq!(config.api_version, "2024-03-01");
+        assert_eq!(config.timeout, 120);
+        assert_eq!(config.max_retries, 5);
     }
 
     #[test]
@@ -233,6 +278,20 @@ mod tests {
         assert_eq!(config.api_base(), Some("https://test.openai.azure.com"));
         assert_eq!(config.timeout(), std::time::Duration::from_secs(60));
         assert_eq!(config.max_retries(), 3);
+    }
+
+    #[test]
+    fn test_azure_config_provider_config_trait_uses_configured_timeout_and_retries() {
+        use crate::core::traits::provider::ProviderConfig;
+
+        let config = AzureConfig::new()
+            .with_api_key("test-key".to_string())
+            .with_azure_endpoint("https://test.openai.azure.com".to_string())
+            .with_timeout(90)
+            .with_max_retries(4);
+
+        assert_eq!(config.timeout(), std::time::Duration::from_secs(90));
+        assert_eq!(config.max_retries(), 4);
     }
 
     #[test]

--- a/src/core/providers/azure/config.rs
+++ b/src/core/providers/azure/config.rs
@@ -139,7 +139,21 @@ impl AzureConfig {
         self.deployment_name
             .clone()
             .or_else(|| std::env::var("AZURE_DEPLOYMENT_NAME").ok())
-            .unwrap_or_else(|| model.to_string())
+            .unwrap_or_else(|| Self::deployment_name_from_model(model))
+    }
+
+    fn deployment_name_from_model(model: &str) -> String {
+        let trimmed = model.trim();
+        if let Some(stripped) = trimmed.strip_prefix("azure/") {
+            return stripped.to_string();
+        }
+
+        trimmed
+            .split('/')
+            .next_back()
+            .filter(|value| !value.is_empty())
+            .unwrap_or(trimmed)
+            .to_string()
     }
 }
 
@@ -240,6 +254,14 @@ mod tests {
         let config_no_deployment = AzureConfig::new();
         assert_eq!(
             config_no_deployment.get_effective_deployment_name("gpt-4"),
+            "gpt-4"
+        );
+        assert_eq!(
+            config_no_deployment.get_effective_deployment_name("azure/gpt-4"),
+            "gpt-4"
+        );
+        assert_eq!(
+            config_no_deployment.get_effective_deployment_name("openai/gpt-4"),
             "gpt-4"
         );
     }

--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -149,6 +149,10 @@ impl LLMProvider for AzureOpenAIProvider {
         &[]
     }
 
+    fn supports_model(&self, model: &str) -> bool {
+        !model.trim().is_empty()
+    }
+
     fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
         &[
             "temperature",
@@ -258,6 +262,31 @@ impl LLMProvider for AzureOpenAIProvider {
         } else {
             HealthStatus::Unhealthy
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    fn create_test_provider() -> AzureOpenAIProvider {
+        let config = AzureConfig::new()
+            .with_api_key("test-key".to_string())
+            .with_azure_endpoint("https://test.openai.azure.com".to_string());
+        match AzureOpenAIProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("test Azure provider should be created: {err}"),
+        }
+    }
+
+    #[test]
+    fn supports_custom_deployment_names() {
+        let provider = create_test_provider();
+
+        assert!(LLMProvider::supports_model(&provider, "gpt-4o-prod"));
+        assert!(LLMProvider::supports_model(&provider, "azure/gpt-4o-prod"));
+        assert!(!LLMProvider::supports_model(&provider, ""));
     }
 }
 

--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -161,14 +161,28 @@ impl LLMProvider for AzureOpenAIProvider {
         &[
             "temperature",
             "max_tokens",
+            "max_completion_tokens",
             "top_p",
             "frequency_penalty",
             "presence_penalty",
             "stream",
+            "stream_options",
             "functions",
             "function_call",
             "tools",
             "tool_choice",
+            "response_format",
+            "user",
+            "seed",
+            "n",
+            "logit_bias",
+            "logprobs",
+            "top_logprobs",
+            "reasoning_effort",
+            "store",
+            "metadata",
+            "service_tier",
+            "parallel_tool_calls",
         ]
     }
 

--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -269,6 +269,29 @@ impl LLMProvider for AzureOpenAIProvider {
     }
 }
 
+// ProviderConfig implementation is in common_utils.rs
+
+/// Azure provider factory
+pub struct AzureProviderFactory;
+
+impl AzureProviderFactory {
+    /// Create provider with default configuration
+    pub fn create_default() -> Result<AzureOpenAIProvider, ProviderError> {
+        let config = AzureConfig::new();
+        AzureOpenAIProvider::new(config)
+    }
+
+    /// Create provider with custom configuration
+    pub fn create_with_config(config: AzureConfig) -> Result<AzureOpenAIProvider, ProviderError> {
+        AzureOpenAIProvider::new(config)
+    }
+
+    /// Create provider from environment variables
+    pub fn create_from_env() -> Result<AzureOpenAIProvider, ProviderError> {
+        AzureOpenAIProvider::from_env()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -291,28 +314,5 @@ mod tests {
         assert!(LLMProvider::supports_model(&provider, "gpt-4o-prod"));
         assert!(LLMProvider::supports_model(&provider, "azure/gpt-4o-prod"));
         assert!(!LLMProvider::supports_model(&provider, ""));
-    }
-}
-
-// ProviderConfig implementation is in common_utils.rs
-
-/// Azure provider factory
-pub struct AzureProviderFactory;
-
-impl AzureProviderFactory {
-    /// Create provider with default configuration
-    pub fn create_default() -> Result<AzureOpenAIProvider, ProviderError> {
-        let config = AzureConfig::new();
-        AzureOpenAIProvider::new(config)
-    }
-
-    /// Create provider with custom configuration
-    pub fn create_with_config(config: AzureConfig) -> Result<AzureOpenAIProvider, ProviderError> {
-        AzureOpenAIProvider::new(config)
-    }
-
-    /// Create provider from environment variables
-    pub fn create_from_env() -> Result<AzureOpenAIProvider, ProviderError> {
-        AzureOpenAIProvider::from_env()
     }
 }

--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -62,7 +62,7 @@ use crate::core::types::{
 };
 
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
-use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::traits::provider::{ProviderConfig, llm_provider::trait_definition::LLMProvider};
 
 /// Main Azure OpenAI provider - complete implementation
 #[derive(Debug, Clone)]
@@ -77,6 +77,10 @@ pub struct AzureOpenAIProvider {
 impl AzureOpenAIProvider {
     /// Create new Azure OpenAI provider
     pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
+        config
+            .validate()
+            .map_err(|e| ProviderError::configuration("azure", e))?;
+
         let chat_handler = AzureChatHandler::new(config.clone())?;
         let embedding_handler = AzureEmbeddingHandler::new(config.clone())?;
         let image_handler = AzureImageHandler::new(config.clone())?;

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -15,6 +15,7 @@ use crate::core::types::{
     message::MessageContent,
     message::MessageRole,
     responses::{ChatChoice, ChatChunk, ChatResponse, FinishReason, Usage},
+    tools::{FunctionCall, ToolCall},
 };
 
 use super::config::{AzureAIConfig, AzureAIEndpointType};
@@ -419,14 +420,46 @@ impl AzureAIChatUtils {
             MessageContent::Text(String::new())
         };
 
+        let function_call = if let Some(value) = message_data
+            .get("function_call")
+            .filter(|value| !value.is_null())
+        {
+            Some(
+                serde_json::from_value::<FunctionCall>(value.clone()).map_err(|e| {
+                    ProviderError::response_parsing(
+                        "azure_ai",
+                        format!("Invalid function_call format: {e}"),
+                    )
+                })?,
+            )
+        } else {
+            None
+        };
+
+        let tool_calls = if let Some(value) = message_data
+            .get("tool_calls")
+            .filter(|value| !value.is_null())
+        {
+            Some(
+                serde_json::from_value::<Vec<ToolCall>>(value.clone()).map_err(|e| {
+                    ProviderError::response_parsing(
+                        "azure_ai",
+                        format!("Invalid tool_calls format: {e}"),
+                    )
+                })?,
+            )
+        } else {
+            None
+        };
+
         let message = ChatMessage {
             role,
             content: Some(content),
             thinking: None,
             audio: None,
             name: message_data["name"].as_str().map(|s| s.to_string()),
-            function_call: None, // NOTE: function call parsing not yet implemented
-            tool_calls: None,    // NOTE: tool call parsing not yet implemented
+            function_call,
+            tool_calls,
             tool_call_id: message_data["tool_call_id"].as_str().map(|s| s.to_string()),
         };
 

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -271,6 +271,12 @@ impl AzureAIChatUtils {
             })?;
         }
 
+        if let Some(obj) = azure_request.as_object_mut() {
+            for (key, value) in &request.extra_params {
+                obj.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
+
         Ok(azure_request)
     }
 

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -209,8 +209,9 @@ impl AzureAIChatUtils {
 
     /// Transform ChatRequest to Azure AI format
     pub fn transform_request(request: &ChatRequest) -> Result<Value, ProviderError> {
+        let model = super::config::normalize_model_name(&request.model);
         let mut azure_request = json!({
-            "model": request.model,
+            "model": model,
             "messages": Self::transform_messages(&request.messages)?
         });
 

--- a/src/core/providers/azure_ai/chat_tests.rs
+++ b/src/core/providers/azure_ai/chat_tests.rs
@@ -81,6 +81,7 @@ fn test_transform_request_with_options() {
     let mut request = create_test_request();
     request.temperature = Some(0.5);
     request.max_tokens = Some(100);
+    request.max_completion_tokens = Some(120);
     request.top_p = Some(0.9);
     request.frequency_penalty = Some(0.5);
     request.presence_penalty = Some(0.5);
@@ -92,10 +93,29 @@ fn test_transform_request_with_options() {
     // Use approximate comparison for floating point values
     assert!((value["temperature"].as_f64().unwrap() - 0.5).abs() < 0.001);
     assert_eq!(value["max_tokens"], 100);
+    assert_eq!(value["max_completion_tokens"], 120);
     assert!((value["top_p"].as_f64().unwrap() - 0.9).abs() < 0.001);
     assert!((value["frequency_penalty"].as_f64().unwrap() - 0.5).abs() < 0.001);
     assert!((value["presence_penalty"].as_f64().unwrap() - 0.5).abs() < 0.001);
     assert!(value["stop"].is_array());
+}
+
+#[test]
+fn test_transform_request_preserves_extra_params_without_overriding_known_fields() {
+    let mut request = create_test_request();
+    request.temperature = Some(0.5);
+    request
+        .extra_params
+        .insert("provider_knob".to_string(), json!("kept"));
+    request
+        .extra_params
+        .insert("temperature".to_string(), json!(1.5));
+
+    let result = AzureAIChatUtils::transform_request(&request);
+    assert!(result.is_ok());
+    let value = result.unwrap();
+    assert_eq!(value["provider_knob"], "kept");
+    assert!((value["temperature"].as_f64().unwrap() - 0.5).abs() < 0.001);
 }
 
 #[test]

--- a/src/core/providers/azure_ai/chat_tests.rs
+++ b/src/core/providers/azure_ai/chat_tests.rs
@@ -190,6 +190,64 @@ fn test_transform_response_finish_reasons() {
 }
 
 #[test]
+fn test_transform_response_preserves_tool_calls() {
+    let response = json!({
+        "id": "chatcmpl-tools",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"location\":\"NYC\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+
+    let result = AzureAIChatUtils::transform_response(response, "gpt-4").unwrap();
+    let tool_calls = result.choices[0].message.tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "call_abc");
+    assert_eq!(tool_calls[0].function.name, "get_weather");
+    assert_eq!(
+        result.choices[0].finish_reason,
+        Some(FinishReason::ToolCalls)
+    );
+}
+
+#[test]
+fn test_transform_response_preserves_function_call() {
+    let response = json!({
+        "id": "chatcmpl-function",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "function_call": {
+                    "name": "legacy_weather",
+                    "arguments": "{\"location\":\"NYC\"}"
+                }
+            },
+            "finish_reason": "function_call"
+        }]
+    });
+
+    let result = AzureAIChatUtils::transform_response(response, "gpt-4").unwrap();
+    let function_call = result.choices[0].message.function_call.as_ref().unwrap();
+    assert_eq!(function_call.name, "legacy_weather");
+    assert_eq!(
+        result.choices[0].finish_reason,
+        Some(FinishReason::FunctionCall)
+    );
+}
+
+#[test]
 fn test_parse_streaming_chunk_done() {
     let chunk = "data: [DONE]";
     let result = AzureAIChatUtils::parse_streaming_chunk(chunk, "gpt-4");

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -245,6 +245,30 @@ mod tests {
     }
 
     #[test]
+    fn test_create_default_headers_with_configured_api_version_and_headers() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_key = Some("test-api-key".to_string());
+        config.base.api_version = Some("2024-10-21".to_string());
+        config.base.headers.insert(
+            "x-ms-client-request-id".to_string(),
+            "request-1".to_string(),
+        );
+
+        let headers = config
+            .create_default_headers()
+            .unwrap_or_else(|err| panic!("headers should build: {err}"));
+
+        assert_eq!(
+            headers.get("api-version").map(String::as_str),
+            Some("2024-10-21")
+        );
+        assert_eq!(
+            headers.get("x-ms-client-request-id").map(String::as_str),
+            Some("request-1")
+        );
+    }
+
+    #[test]
     fn test_create_default_headers_no_api_key() {
         let config = AzureAIConfig::new("azure_ai");
         let result = config.create_default_headers();

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -11,6 +11,23 @@ use crate::define_provider_config;
 // Configuration
 define_provider_config!(AzureAIConfig {});
 
+/// Convert routed model names to Azure AI deployment/model names.
+pub(crate) fn normalize_model_name(model: &str) -> &str {
+    let trimmed = model.trim();
+    if let Some(stripped) = trimmed.strip_prefix("azure_ai/") {
+        return stripped;
+    }
+    if let Some(stripped) = trimmed.strip_prefix("azure/") {
+        return stripped;
+    }
+
+    trimmed
+        .split('/')
+        .next_back()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(trimmed)
+}
+
 impl AzureAIConfig {
     /// Create
     pub fn from_env() -> Self {
@@ -274,6 +291,27 @@ mod tests {
         let result = config.create_default_headers();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("API key not set"));
+    }
+
+    #[test]
+    fn test_normalize_model_name_strips_provider_prefixes() {
+        assert_eq!(
+            normalize_model_name("custom-deployment"),
+            "custom-deployment"
+        );
+        assert_eq!(
+            normalize_model_name("azure_ai/custom-deployment"),
+            "custom-deployment"
+        );
+        assert_eq!(
+            normalize_model_name("azure/custom-deployment"),
+            "custom-deployment"
+        );
+        assert_eq!(
+            normalize_model_name("openai/custom-deployment"),
+            "custom-deployment"
+        );
+        assert_eq!(normalize_model_name(""), "");
     }
 
     #[test]

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -69,8 +69,16 @@ impl AzureAIConfig {
         // Settings
         headers.insert("User-Agent".to_string(), "litellm-rust/0.1.0".to_string());
 
-        // Settings
-        headers.insert("api-version".to_string(), "2024-05-01-preview".to_string());
+        let api_version = self
+            .base
+            .api_version
+            .as_deref()
+            .unwrap_or("2024-05-01-preview");
+        headers.insert("api-version".to_string(), api_version.to_string());
+
+        for (key, value) in &self.base.headers {
+            headers.insert(key.clone(), value.clone());
+        }
 
         Ok(headers)
     }
@@ -189,12 +197,51 @@ mod tests {
     fn test_create_default_headers_with_api_key() {
         let mut config = AzureAIConfig::new("azure_ai");
         config.base.api_key = Some("test-api-key".to_string());
+        config.base.api_version = Some("2024-08-01-preview".to_string());
+        config
+            .base
+            .headers
+            .insert("x-routing-tenant".to_string(), "tenant-a".to_string());
 
-        let headers = config.create_default_headers().unwrap();
-        assert_eq!(headers.get("Authorization").unwrap(), "Bearer test-api-key");
-        assert_eq!(headers.get("Content-Type").unwrap(), "application/json");
-        assert_eq!(headers.get("User-Agent").unwrap(), "litellm-rust/0.1.0");
-        assert_eq!(headers.get("api-version").unwrap(), "2024-05-01-preview");
+        let headers = match config.create_default_headers() {
+            Ok(headers) => headers,
+            Err(err) => panic!("Azure AI headers should be created: {err}"),
+        };
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer test-api-key")
+        );
+        assert_eq!(
+            headers.get("Content-Type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(
+            headers.get("User-Agent").map(String::as_str),
+            Some("litellm-rust/0.1.0")
+        );
+        assert_eq!(
+            headers.get("api-version").map(String::as_str),
+            Some("2024-08-01-preview")
+        );
+        assert_eq!(
+            headers.get("x-routing-tenant").map(String::as_str),
+            Some("tenant-a")
+        );
+    }
+
+    #[test]
+    fn test_create_default_headers_uses_default_api_version() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_key = Some("test-api-key".to_string());
+
+        let headers = match config.create_default_headers() {
+            Ok(headers) => headers,
+            Err(err) => panic!("Azure AI headers should be created: {err}"),
+        };
+        assert_eq!(
+            headers.get("api-version").map(String::as_str),
+            Some("2024-05-01-preview")
+        );
     }
 
     #[test]

--- a/src/core/providers/azure_ai/embed.rs
+++ b/src/core/providers/azure_ai/embed.rs
@@ -152,8 +152,9 @@ impl AzureAIEmbeddingUtils {
 
     /// Transform EmbeddingRequest to Azure AI format
     pub fn transform_request(request: &EmbeddingRequest) -> Result<Value, ProviderError> {
+        let model = super::config::normalize_model_name(&request.model);
         let mut azure_request = json!({
-            "model": request.model,
+            "model": model,
             "input": request.input
         });
 

--- a/src/core/providers/azure_ai/image_generation.rs
+++ b/src/core/providers/azure_ai/image_generation.rs
@@ -43,8 +43,14 @@ impl AzureAIImageHandler {
         }
 
         // Build request
+        let model = request
+            .model
+            .as_deref()
+            .map(super::config::normalize_model_name)
+            .filter(|model| !model.is_empty())
+            .unwrap_or("flux-1.1-pro");
         let azure_request = json!({
-            "model": request.model.clone().unwrap_or_else(|| "flux-1.1-pro".to_string()),
+            "model": model,
             "prompt": request.prompt,
             "n": request.n.unwrap_or(1),
             "size": request.size.clone().unwrap_or_else(|| "1024x1024".to_string()),

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -146,6 +146,10 @@ impl LLMProvider for AzureAIProvider {
         MODELS.get_or_init(|| self.model_registry.to_model_infos())
     }
 
+    fn supports_model(&self, model: &str) -> bool {
+        !model.trim().is_empty()
+    }
+
     fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
         &[
             "temperature",
@@ -366,6 +370,19 @@ mod tests {
         assert!(caps.contains(&ProviderCapability::Embeddings));
         assert!(caps.contains(&ProviderCapability::ImageGeneration));
         assert_eq!(caps.len(), 4);
+    }
+
+    #[test]
+    fn test_supports_custom_deployment_names() {
+        let config = create_test_config();
+        let provider = match AzureAIProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("test Azure AI provider should be created: {err}"),
+        };
+
+        assert!(provider.supports_model("gpt-4o-prod"));
+        assert!(provider.supports_model("azure_ai/private-deployment"));
+        assert!(!provider.supports_model(""));
     }
 
     #[test]

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -136,7 +136,6 @@ impl LLMProvider for AzureAIProvider {
             ProviderCapability::ChatCompletion,
             ProviderCapability::ChatCompletionStream,
             ProviderCapability::Embeddings,
-            ProviderCapability::ImageGeneration,
         ]
     }
 
@@ -230,10 +229,10 @@ impl LLMProvider for AzureAIProvider {
 
     async fn image_generation(
         &self,
-        request: ImageGenerationRequest,
-        context: RequestContext,
+        _request: ImageGenerationRequest,
+        _context: RequestContext,
     ) -> Result<ImageGenerationResponse, ProviderError> {
-        self.image_handler.generate_image(request, context).await
+        Err(ProviderError::not_supported("azure_ai", "image_generation"))
     }
 
     async fn health_check(&self) -> HealthStatus {
@@ -366,8 +365,33 @@ mod tests {
         assert!(caps.contains(&ProviderCapability::ChatCompletion));
         assert!(caps.contains(&ProviderCapability::ChatCompletionStream));
         assert!(caps.contains(&ProviderCapability::Embeddings));
-        assert!(caps.contains(&ProviderCapability::ImageGeneration));
-        assert_eq!(caps.len(), 4);
+        assert!(!caps.contains(&ProviderCapability::ImageGeneration));
+        assert!(!provider.supports_image_generation());
+        assert_eq!(caps.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_image_generation_not_implemented_until_response_mapping_exists() {
+        let config = create_test_config();
+        let provider = match AzureAIProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("test Azure AI provider should be created: {err}"),
+        };
+        let request = ImageGenerationRequest {
+            prompt: "A test image".to_string(),
+            model: Some("flux-1.1-pro".to_string()),
+            n: None,
+            size: None,
+            quality: None,
+            response_format: None,
+            style: None,
+            user: None,
+        };
+
+        let result = provider
+            .image_generation(request, RequestContext::default())
+            .await;
+        assert!(matches!(result, Err(ProviderError::NotSupported { .. })));
     }
 
     #[test]

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -393,6 +393,17 @@ mod tests {
     }
 
     #[test]
+    fn test_supports_custom_deployment_models() {
+        let config = create_test_config();
+        let provider = AzureAIProvider::new(config)
+            .unwrap_or_else(|err| panic!("provider should be created: {err}"));
+
+        assert!(provider.supports_model("custom-foundry-deployment"));
+        assert!(provider.supports_model("azure_ai/custom-foundry-deployment"));
+        assert!(!provider.supports_model(""));
+    }
+
+    #[test]
     fn test_get_config() {
         let config = create_test_config();
         let provider = AzureAIProvider::new(config.clone()).unwrap();

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -141,13 +141,11 @@ impl LLMProvider for AzureAIProvider {
     }
 
     fn models(&self) -> &[ModelInfo] {
-        // Get
-        static MODELS: std::sync::OnceLock<Vec<ModelInfo>> = std::sync::OnceLock::new();
-        MODELS.get_or_init(|| self.model_registry.to_model_infos())
+        &[]
     }
 
     fn supports_model(&self, model: &str) -> bool {
-        !model.trim().is_empty()
+        !config::normalize_model_name(model).is_empty()
     }
 
     fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
@@ -386,10 +384,11 @@ mod tests {
     }
 
     #[test]
-    fn test_provider_models_not_empty() {
+    fn test_provider_models_are_deployment_driven() {
         let config = create_test_config();
         let provider = AzureAIProvider::new(config).unwrap();
-        assert!(!provider.models().is_empty());
+        assert!(provider.models().is_empty());
+        assert!(!provider.get_model_registry().get_all_models().is_empty());
     }
 
     #[test]

--- a/src/core/providers/azure_ai/rerank.rs
+++ b/src/core/providers/azure_ai/rerank.rs
@@ -213,8 +213,9 @@ impl AzureAIRerankUtils {
 
     /// Transform RerankRequest to Azure AI format
     pub fn transform_request(request: &RerankRequest) -> Result<Value, ProviderError> {
+        let model = super::config::normalize_model_name(&request.model);
         let mut azure_request = json!({
-            "model": request.model,
+            "model": model,
             "query": request.query,
             "documents": request.documents,
         });

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -5,6 +5,8 @@
 
 use super::super::unified_provider::ProviderError;
 use super::super::{anthropic, bedrock, cloudflare, macros, mistral, openai, openai_like};
+#[cfg(feature = "providers-extra")]
+use super::super::{azure, azure_ai};
 use std::env;
 
 // ==================== Config Extraction Helpers ====================
@@ -360,33 +362,36 @@ pub(super) fn build_v0_config_from_factory(
     Ok(oai_config)
 }
 
+#[cfg(feature = "providers-extra")]
 pub(super) fn build_azure_ai_config_from_factory(
     config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+) -> Result<azure_ai::AzureAIConfig, ProviderError> {
     let api_key = macros::require_config_str(config, "api_key", "azure_ai")?;
     let api_base = config_str(config, "base_url")
         .or_else(|| config_str(config, "api_base"))
         .or_else(|| config_str(config, "endpoint"))
+        .or_else(|| config_str(config, "azure_ai_endpoint"))
         .ok_or_else(|| {
             ProviderError::configuration("azure_ai", "base_url (or endpoint) is required")
         })?;
 
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "azure_ai".to_string();
+    let mut azure_ai_config = azure_ai::AzureAIConfig::new("azure_ai");
+    azure_ai_config.base.api_key = Some(api_key.to_string());
+    azure_ai_config.base.api_base = Some(api_base.to_string());
 
     if let Some(api_version) = config_str(config, "api_version") {
-        oai_config.base.api_version = Some(api_version.to_string());
+        azure_ai_config.base.api_version = Some(api_version.to_string());
     }
     if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
+        azure_ai_config.base.timeout = timeout;
     }
     if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
+        azure_ai_config.base.max_retries = max_retries;
     }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+    merge_string_headers(&mut azure_ai_config.base.headers, config, "headers");
+    merge_string_headers(&mut azure_ai_config.base.headers, config, "custom_headers");
 
-    Ok(oai_config)
+    Ok(azure_ai_config)
 }
 
 pub(super) fn build_amazon_nova_config_from_factory(
@@ -435,33 +440,35 @@ pub(super) fn build_fal_ai_config_from_factory(
     Ok(oai_config)
 }
 
+#[cfg(feature = "providers-extra")]
 pub(super) fn build_azure_config_from_factory(
     config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+) -> Result<azure::AzureConfig, ProviderError> {
     let api_key = macros::require_config_str(config, "api_key", "azure")?;
     let api_base = config_str(config, "base_url")
         .or_else(|| config_str(config, "api_base"))
         .or_else(|| config_str(config, "endpoint"))
+        .or_else(|| config_str(config, "azure_endpoint"))
         .ok_or_else(|| {
             ProviderError::configuration("azure", "base_url (or endpoint) is required")
         })?;
 
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "azure".to_string();
+    let mut azure_config = azure::AzureConfig::new()
+        .with_api_key(api_key.to_string())
+        .with_azure_endpoint(api_base.to_string());
 
     if let Some(api_version) = config_str(config, "api_version") {
-        oai_config.base.api_version = Some(api_version.to_string());
+        azure_config.api_version = api_version.to_string();
     }
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
+    if let Some(deployment_name) =
+        config_str(config, "deployment_name").or_else(|| config_str(config, "deployment"))
+    {
+        azure_config.deployment_name = Some(deployment_name.to_string());
     }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+    merge_string_headers(&mut azure_config.custom_headers, config, "headers");
+    merge_string_headers(&mut azure_config.custom_headers, config, "custom_headers");
 
-    Ok(oai_config)
+    Ok(azure_config)
 }
 
 pub(super) fn build_bedrock_config_from_factory(

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -37,6 +37,21 @@ fn config_str_any<'a>(config: &'a serde_json::Value, keys: &[&str]) -> Option<&'
     keys.iter().find_map(|key| config_str(config, key))
 }
 
+#[cfg(feature = "providers-extra")]
+fn normalize_azure_endpoint_and_deployment(api_base: &str) -> (String, Option<String>) {
+    let trimmed = api_base.trim_end_matches('/');
+    if let Some((endpoint, deployment_path)) = trimmed.split_once("/openai/deployments/") {
+        let deployment = deployment_path
+            .split('/')
+            .next()
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string);
+        (endpoint.to_string(), deployment)
+    } else {
+        (trimmed.to_string(), None)
+    }
+}
+
 pub(super) fn env_str_any(keys: &[&str]) -> Option<String> {
     keys.iter()
         .filter_map(|key| env::var(key).ok())
@@ -453,17 +468,20 @@ pub(super) fn build_azure_config_from_factory(
             ProviderError::configuration("azure", "base_url (or endpoint) is required")
         })?;
 
+    let (azure_endpoint, deployment_from_url) = normalize_azure_endpoint_and_deployment(api_base);
     let mut azure_config = azure::AzureConfig::new()
         .with_api_key(api_key.to_string())
-        .with_azure_endpoint(api_base.to_string());
+        .with_azure_endpoint(azure_endpoint);
 
     if let Some(api_version) = config_str(config, "api_version") {
         azure_config.api_version = api_version.to_string();
     }
-    if let Some(deployment_name) =
-        config_str(config, "deployment_name").or_else(|| config_str(config, "deployment"))
-    {
-        azure_config.deployment_name = Some(deployment_name.to_string());
+    let deployment_name = config_str(config, "deployment_name")
+        .or_else(|| config_str(config, "deployment"))
+        .map(str::to_string)
+        .or(deployment_from_url);
+    if let Some(deployment_name) = deployment_name {
+        azure_config.deployment_name = Some(deployment_name);
     }
     if let Some(timeout) = config_u64(config, "timeout") {
         azure_config.timeout = timeout;

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -87,6 +87,53 @@ pub(super) fn merge_string_headers_value(
     false
 }
 
+#[cfg(not(feature = "providers-extra"))]
+fn build_azure_openai_like_config_for_factory(
+    config: &serde_json::Value,
+    provider_name: &'static str,
+    endpoint_alias: &'static str,
+) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+    let api_key = macros::require_config_str(config, "api_key", provider_name)?;
+    let api_base = config_str(config, "base_url")
+        .or_else(|| config_str(config, "api_base"))
+        .or_else(|| config_str(config, "endpoint"))
+        .or_else(|| config_str(config, endpoint_alias))
+        .ok_or_else(|| {
+            ProviderError::configuration(provider_name, "base_url (or endpoint) is required")
+        })?;
+
+    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
+    oai_config.provider_name = provider_name.to_string();
+
+    if let Some(api_version) = config_str(config, "api_version") {
+        oai_config.base.api_version = Some(api_version.to_string());
+    }
+    if let Some(timeout) = config_u64(config, "timeout") {
+        oai_config.base.timeout = timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        oai_config.base.max_retries = max_retries;
+    }
+    merge_string_headers(&mut oai_config.base.headers, config, "headers");
+    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+
+    Ok(oai_config)
+}
+
+#[cfg(not(feature = "providers-extra"))]
+pub(super) fn build_azure_ai_openai_like_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+    build_azure_openai_like_config_for_factory(config, "azure_ai", "azure_ai_endpoint")
+}
+
+#[cfg(not(feature = "providers-extra"))]
+pub(super) fn build_azure_openai_like_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+    build_azure_openai_like_config_for_factory(config, "azure", "azure_endpoint")
+}
+
 pub(super) fn apply_tier1_openai_like_overrides(
     config: &mut openai_like::OpenAILikeConfig,
     settings: &std::collections::HashMap<String, serde_json::Value>,

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -465,6 +465,12 @@ pub(super) fn build_azure_config_from_factory(
     {
         azure_config.deployment_name = Some(deployment_name.to_string());
     }
+    if let Some(timeout) = config_u64(config, "timeout") {
+        azure_config.timeout = timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        azure_config.max_retries = max_retries;
+    }
     merge_string_headers(&mut azure_config.custom_headers, config, "headers");
     merge_string_headers(&mut azure_config.custom_headers, config, "custom_headers");
 

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -267,6 +267,100 @@ fn test_build_openai_like_config_from_factory_requires_api_base() {
     assert!(err.to_string().contains("base_url"));
 }
 
+#[cfg(feature = "providers-extra")]
+#[test]
+fn test_build_azure_config_from_factory_maps_native_fields() {
+    let config = serde_json::json!({
+        "api_key": "azure-key",
+        "azure_endpoint": "https://example-resource.openai.azure.com",
+        "deployment_name": "gpt-4o-prod",
+        "api_version": "2024-03-01",
+        "headers": {
+            "x-azure-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-custom": "custom"
+        }
+    });
+
+    let azure_config = build_azure_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure config should parse: {err}"));
+
+    assert_eq!(azure_config.api_key.as_deref(), Some("azure-key"));
+    assert_eq!(
+        azure_config.azure_endpoint.as_deref(),
+        Some("https://example-resource.openai.azure.com")
+    );
+    assert_eq!(azure_config.deployment_name.as_deref(), Some("gpt-4o-prod"));
+    assert_eq!(azure_config.api_version, "2024-03-01");
+    assert_eq!(
+        azure_config
+            .custom_headers
+            .get("x-azure-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        azure_config
+            .custom_headers
+            .get("x-azure-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+}
+
+#[cfg(feature = "providers-extra")]
+#[test]
+fn test_build_azure_ai_config_from_factory_maps_native_fields() {
+    let config = serde_json::json!({
+        "api_key": "azure-ai-key",
+        "azure_ai_endpoint": "https://example-resource.services.ai.azure.com",
+        "api_version": "2024-05-01-preview",
+        "timeout": 44,
+        "max_retries": 2,
+        "headers": {
+            "x-azure-ai-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-ai-custom": "custom"
+        }
+    });
+
+    let azure_ai_config = build_azure_ai_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure_ai config should parse: {err}"));
+
+    assert_eq!(
+        azure_ai_config.base.api_key.as_deref(),
+        Some("azure-ai-key")
+    );
+    assert_eq!(
+        azure_ai_config.base.api_base.as_deref(),
+        Some("https://example-resource.services.ai.azure.com")
+    );
+    assert_eq!(
+        azure_ai_config.base.api_version.as_deref(),
+        Some("2024-05-01-preview")
+    );
+    assert_eq!(azure_ai_config.base.timeout, 44);
+    assert_eq!(azure_ai_config.base.max_retries, 2);
+    assert_eq!(
+        azure_ai_config
+            .base
+            .headers
+            .get("x-azure-ai-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        azure_ai_config
+            .base
+            .headers
+            .get("x-azure-ai-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+}
+
 #[test]
 fn test_env_str_any_skips_empty_values() {
     let _guard = ENV_LOCK.lock().unwrap();

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -267,6 +267,101 @@ fn test_build_openai_like_config_from_factory_requires_api_base() {
     assert!(err.to_string().contains("base_url"));
 }
 
+#[cfg(not(feature = "providers-extra"))]
+#[test]
+fn test_build_azure_openai_like_config_from_factory_maps_fallback_fields() {
+    let config = serde_json::json!({
+        "api_key": "azure-key",
+        "azure_endpoint": "https://example-resource.openai.azure.com/openai/deployments/prod",
+        "api_version": "2024-03-01",
+        "timeout": 66,
+        "max_retries": 4,
+        "headers": {
+            "x-azure-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-custom": "custom"
+        }
+    });
+
+    let oai_config = build_azure_openai_like_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure fallback config should parse: {err}"));
+
+    assert_eq!(oai_config.provider_name, "azure");
+    assert_eq!(oai_config.base.api_key.as_deref(), Some("azure-key"));
+    assert_eq!(
+        oai_config.base.api_base.as_deref(),
+        Some("https://example-resource.openai.azure.com/openai/deployments/prod")
+    );
+    assert_eq!(oai_config.base.api_version.as_deref(), Some("2024-03-01"));
+    assert_eq!(oai_config.base.timeout, 66);
+    assert_eq!(oai_config.base.max_retries, 4);
+    assert_eq!(
+        oai_config
+            .base
+            .headers
+            .get("x-azure-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        oai_config
+            .custom_headers
+            .get("x-azure-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+}
+
+#[cfg(not(feature = "providers-extra"))]
+#[test]
+fn test_build_azure_ai_openai_like_config_from_factory_maps_fallback_fields() {
+    let config = serde_json::json!({
+        "api_key": "azure-ai-key",
+        "azure_ai_endpoint": "https://example-resource.services.ai.azure.com",
+        "api_version": "2024-05-01-preview",
+        "timeout": 44,
+        "max_retries": 2,
+        "headers": {
+            "x-azure-ai-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-ai-custom": "custom"
+        }
+    });
+
+    let oai_config = build_azure_ai_openai_like_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure_ai fallback config should parse: {err}"));
+
+    assert_eq!(oai_config.provider_name, "azure_ai");
+    assert_eq!(oai_config.base.api_key.as_deref(), Some("azure-ai-key"));
+    assert_eq!(
+        oai_config.base.api_base.as_deref(),
+        Some("https://example-resource.services.ai.azure.com")
+    );
+    assert_eq!(
+        oai_config.base.api_version.as_deref(),
+        Some("2024-05-01-preview")
+    );
+    assert_eq!(oai_config.base.timeout, 44);
+    assert_eq!(oai_config.base.max_retries, 2);
+    assert_eq!(
+        oai_config
+            .base
+            .headers
+            .get("x-azure-ai-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        oai_config
+            .custom_headers
+            .get("x-azure-ai-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+}
+
 #[cfg(feature = "providers-extra")]
 #[test]
 fn test_build_azure_config_from_factory_maps_native_fields() {
@@ -318,7 +413,7 @@ fn test_build_azure_config_from_factory_maps_native_fields() {
 fn test_build_azure_config_from_factory_normalizes_deployment_base_url() {
     let config = serde_json::json!({
         "api_key": "azure-key",
-        "base_url": "https://example-resource.openai.azure.com/openai/deployments/gpt-4o-prod",
+        "base_url": "https://example-resource.openai.azure.com/openai/deployments/prod-gpt4o/chat/completions",
         "api_version": "2024-03-01"
     });
 
@@ -329,7 +424,7 @@ fn test_build_azure_config_from_factory_normalizes_deployment_base_url() {
         azure_config.azure_endpoint.as_deref(),
         Some("https://example-resource.openai.azure.com")
     );
-    assert_eq!(azure_config.deployment_name.as_deref(), Some("gpt-4o-prod"));
+    assert_eq!(azure_config.deployment_name.as_deref(), Some("prod-gpt4o"));
 }
 
 #[cfg(feature = "providers-extra")]

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -315,6 +315,47 @@ fn test_build_azure_config_from_factory_maps_native_fields() {
 
 #[cfg(feature = "providers-extra")]
 #[test]
+fn test_build_azure_config_from_factory_normalizes_deployment_base_url() {
+    let config = serde_json::json!({
+        "api_key": "azure-key",
+        "base_url": "https://example-resource.openai.azure.com/openai/deployments/gpt-4o-prod",
+        "api_version": "2024-03-01"
+    });
+
+    let azure_config = build_azure_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure config should parse: {err}"));
+
+    assert_eq!(
+        azure_config.azure_endpoint.as_deref(),
+        Some("https://example-resource.openai.azure.com")
+    );
+    assert_eq!(azure_config.deployment_name.as_deref(), Some("gpt-4o-prod"));
+}
+
+#[cfg(feature = "providers-extra")]
+#[test]
+fn test_build_azure_config_from_factory_prefers_explicit_deployment_name() {
+    let config = serde_json::json!({
+        "api_key": "azure-key",
+        "base_url": "https://example-resource.openai.azure.com/openai/deployments/url-deployment/chat/completions",
+        "deployment_name": "explicit-deployment"
+    });
+
+    let azure_config = build_azure_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure config should parse: {err}"));
+
+    assert_eq!(
+        azure_config.azure_endpoint.as_deref(),
+        Some("https://example-resource.openai.azure.com")
+    );
+    assert_eq!(
+        azure_config.deployment_name.as_deref(),
+        Some("explicit-deployment")
+    );
+}
+
+#[cfg(feature = "providers-extra")]
+#[test]
 fn test_build_azure_ai_config_from_factory_maps_native_fields() {
     let config = serde_json::json!({
         "api_key": "azure-ai-key",

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -275,6 +275,8 @@ fn test_build_azure_config_from_factory_maps_native_fields() {
         "azure_endpoint": "https://example-resource.openai.azure.com",
         "deployment_name": "gpt-4o-prod",
         "api_version": "2024-03-01",
+        "timeout": 66,
+        "max_retries": 4,
         "headers": {
             "x-azure-base": "base"
         },
@@ -293,6 +295,8 @@ fn test_build_azure_config_from_factory_maps_native_fields() {
     );
     assert_eq!(azure_config.deployment_name.as_deref(), Some("gpt-4o-prod"));
     assert_eq!(azure_config.api_version, "2024-03-01");
+    assert_eq!(azure_config.timeout, 66);
+    assert_eq!(azure_config.max_retries, 4);
     assert_eq!(
         azure_config
             .custom_headers

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -24,6 +24,10 @@ use super::builder::{
 };
 #[cfg(feature = "providers-extra")]
 use super::builder::{build_azure_ai_config_from_factory, build_azure_config_from_factory};
+#[cfg(not(feature = "providers-extra"))]
+use super::builder::{
+    build_azure_ai_openai_like_config_from_factory, build_azure_openai_like_config_from_factory,
+};
 
 impl Provider {
     /// Create provider from configuration asynchronously
@@ -93,8 +97,7 @@ impl Provider {
                 }
                 #[cfg(not(feature = "providers-extra"))]
                 {
-                    let mut oai_config = build_openai_like_config_from_factory(&config)?;
-                    oai_config.provider_name = "azure_ai".to_string();
+                    let oai_config = build_azure_ai_openai_like_config_from_factory(&config)?;
                     let provider = openai_like::OpenAILikeProvider::new(oai_config)
                         .await
                         .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
@@ -124,8 +127,7 @@ impl Provider {
                 }
                 #[cfg(not(feature = "providers-extra"))]
                 {
-                    let mut oai_config = build_openai_like_config_from_factory(&config)?;
-                    oai_config.provider_name = "azure".to_string();
+                    let oai_config = build_azure_openai_like_config_from_factory(&config)?;
                     let provider = openai_like::OpenAILikeProvider::new(oai_config)
                         .await
                         .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -93,10 +93,12 @@ impl Provider {
                 }
                 #[cfg(not(feature = "providers-extra"))]
                 {
-                    Err(ProviderError::not_implemented(
-                        "azure_ai",
-                        "native Azure AI dispatch requires the `providers-extra` feature",
-                    ))
+                    let mut oai_config = build_openai_like_config_from_factory(&config)?;
+                    oai_config.provider_name = "azure_ai".to_string();
+                    let provider = openai_like::OpenAILikeProvider::new(oai_config)
+                        .await
+                        .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
+                    Ok(Provider::OpenAILike(provider))
                 }
             }
             ProviderType::AmazonNova => {
@@ -122,10 +124,12 @@ impl Provider {
                 }
                 #[cfg(not(feature = "providers-extra"))]
                 {
-                    Err(ProviderError::not_implemented(
-                        "azure",
-                        "native Azure dispatch requires the `providers-extra` feature",
-                    ))
+                    let mut oai_config = build_openai_like_config_from_factory(&config)?;
+                    oai_config.provider_name = "azure".to_string();
+                    let provider = openai_like::OpenAILikeProvider::new(oai_config)
+                        .await
+                        .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
+                    Ok(Provider::OpenAILike(provider))
                 }
             }
             ProviderType::Bedrock => {

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -9,10 +9,11 @@ use crate::core::providers::unified_provider::ProviderError;
 use crate::core::providers::{
     Provider, anthropic, bedrock, cloudflare, mistral, openai, openai_like,
 };
+#[cfg(feature = "providers-extra")]
+use crate::core::providers::{azure, azure_ai};
 
 use super::builder::{
     build_amazon_nova_config_from_factory, build_anthropic_config_from_factory,
-    build_azure_ai_config_from_factory, build_azure_config_from_factory,
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
     build_fal_ai_config_from_factory, build_github_config_from_factory,
     build_github_copilot_config_from_factory, build_meta_llama_config_from_factory,
@@ -21,6 +22,8 @@ use super::builder::{
     build_v0_config_from_factory, build_vertex_ai_config_from_factory, config_str, config_u32,
     config_u64,
 };
+#[cfg(feature = "providers-extra")]
+use super::builder::{build_azure_ai_config_from_factory, build_azure_config_from_factory};
 
 impl Provider {
     /// Create provider from configuration asynchronously
@@ -82,11 +85,20 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             ProviderType::AzureAI => {
-                let oai_config = build_azure_ai_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extra")]
+                {
+                    let azure_ai_config = build_azure_ai_config_from_factory(&config)?;
+                    let provider = azure_ai::AzureAIProvider::new(azure_ai_config)
+                        .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
+                    Ok(Provider::AzureAI(provider))
+                }
+                #[cfg(not(feature = "providers-extra"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "azure_ai",
+                        "native Azure AI dispatch requires the `providers-extra` feature",
+                    ))
+                }
             }
             ProviderType::AmazonNova => {
                 let oai_config = build_amazon_nova_config_from_factory(&config)?;
@@ -103,11 +115,20 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             ProviderType::Azure => {
-                let oai_config = build_azure_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extra")]
+                {
+                    let azure_config = build_azure_config_from_factory(&config)?;
+                    let provider = azure::AzureOpenAIProvider::new(azure_config)
+                        .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
+                    Ok(Provider::Azure(provider))
+                }
+                #[cfg(not(feature = "providers-extra"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "azure",
+                        "native Azure dispatch requires the `providers-extra` feature",
+                    ))
+                }
             }
             ProviderType::Bedrock => {
                 let bedrock_config = build_bedrock_config_from_factory(&config)?;
@@ -233,6 +254,9 @@ mod tests {
                     | (ProviderType::Bedrock, Provider::Bedrock(_))
                     | (ProviderType::Mistral, Provider::Mistral(_))
                     | (ProviderType::Cloudflare, Provider::Cloudflare(_)) => {}
+                    #[cfg(feature = "providers-extra")]
+                    (ProviderType::Azure, Provider::Azure(_))
+                    | (ProviderType::AzureAI, Provider::AzureAI(_)) => {}
                     _ => panic!(
                         "{:?} is classified Native but created runtime provider {:?}",
                         entry.provider_type,

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -88,8 +88,7 @@ impl Provider {
                 #[cfg(feature = "providers-extra")]
                 {
                     let azure_ai_config = build_azure_ai_config_from_factory(&config)?;
-                    let provider = azure_ai::AzureAIProvider::new(azure_ai_config)
-                        .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
+                    let provider = azure_ai::AzureAIProvider::new(azure_ai_config)?;
                     Ok(Provider::AzureAI(provider))
                 }
                 #[cfg(not(feature = "providers-extra"))]
@@ -118,8 +117,7 @@ impl Provider {
                 #[cfg(feature = "providers-extra")]
                 {
                     let azure_config = build_azure_config_from_factory(&config)?;
-                    let provider = azure::AzureOpenAIProvider::new(azure_config)
-                        .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
+                    let provider = azure::AzureOpenAIProvider::new(azure_config)?;
                     Ok(Provider::Azure(provider))
                 }
                 #[cfg(not(feature = "providers-extra"))]

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -264,6 +264,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => p.$method($($arg),*),
             Provider::Anthropic(p) => p.$method($($arg),*),
             Provider::Bedrock(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
             Provider::OpenAILike(p) => p.$method($($arg),*),
@@ -275,6 +279,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Anthropic(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Bedrock(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
@@ -286,6 +294,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Anthropic(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Bedrock(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*),
@@ -297,6 +309,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => LLMProvider::$method(p).await,
             Provider::Anthropic(p) => LLMProvider::$method(p).await,
             Provider::Bedrock(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
             Provider::Cloudflare(p) => LLMProvider::$method(p).await,
             Provider::OpenAILike(p) => LLMProvider::$method(p).await,
@@ -332,6 +348,10 @@ pub enum Provider {
     OpenAI(openai::OpenAIProvider),
     Anthropic(anthropic::AnthropicProvider),
     Bedrock(bedrock::BedrockProvider),
+    #[cfg(feature = "providers-extra")]
+    Azure(azure::AzureOpenAIProvider),
+    #[cfg(feature = "providers-extra")]
+    AzureAI(azure_ai::AzureAIProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
     /// Tier 1: data-driven OpenAI-compatible providers (groq, together, fireworks, etc.)
@@ -345,6 +365,10 @@ impl Provider {
             Provider::OpenAI(_) => "openai",
             Provider::Anthropic(_) => "anthropic",
             Provider::Bedrock(_) => "bedrock",
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(_) => "azure",
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(_) => "azure_ai",
             Provider::Mistral(_) => "mistral",
             Provider::Cloudflare(_) => "cloudflare",
             Provider::OpenAILike(p) => {
@@ -360,6 +384,10 @@ impl Provider {
             Provider::OpenAI(_) => ProviderType::OpenAI,
             Provider::Anthropic(_) => ProviderType::Anthropic,
             Provider::Bedrock(_) => ProviderType::Bedrock,
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(_) => ProviderType::Azure,
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(_) => ProviderType::AzureAI,
             Provider::Mistral(_) => ProviderType::Mistral,
             Provider::Cloudflare(_) => ProviderType::Cloudflare,
             Provider::OpenAILike(_) => ProviderType::OpenAICompatible,

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -39,13 +39,13 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "native module retained; ProviderType::AmazonNova currently uses a generic OpenAI-compatible adapter",
     ),
     wire("anthropic", "native Provider enum variant"),
-    stub(
+    provider_extra_wire(
         "azure",
-        "native Azure module retained; ProviderType::Azure currently uses a generic OpenAI-compatible adapter",
+        "native Provider enum variant when providers-extra is enabled; otherwise unsupported without generic fallback",
     ),
-    stub(
+    provider_extra_wire(
         "azure_ai",
-        "native Azure AI module retained; ProviderType::AzureAI currently uses a generic OpenAI-compatible adapter",
+        "native Provider enum variant when providers-extra is enabled; otherwise unsupported without generic fallback",
     ),
     internal("base", "shared provider infrastructure"),
     stub(
@@ -279,6 +279,18 @@ const fn internal(module_name: &'static str, reason: &'static str) -> ProviderMo
     entry(module_name, ProviderModuleLifecycle::Internal, reason)
 }
 
+const fn provider_extra_wire(
+    module_name: &'static str,
+    reason: &'static str,
+) -> ProviderModuleLifecycleEntry {
+    let lifecycle = if cfg!(feature = "providers-extra") {
+        ProviderModuleLifecycle::Wire
+    } else {
+        ProviderModuleLifecycle::Stub
+    };
+    entry(module_name, lifecycle, reason)
+}
+
 const fn entry(
     module_name: &'static str,
     lifecycle: ProviderModuleLifecycle,
@@ -317,8 +329,22 @@ mod tests {
     fn lifecycle_classifies_phase0_key_provider_modules() {
         assert_eq!(lifecycle_for("bedrock"), ProviderModuleLifecycle::Wire);
         assert_eq!(lifecycle_for("vertex_ai"), ProviderModuleLifecycle::Stub);
-        assert_eq!(lifecycle_for("azure"), ProviderModuleLifecycle::Stub);
-        assert_eq!(lifecycle_for("azure_ai"), ProviderModuleLifecycle::Stub);
+        assert_eq!(
+            lifecycle_for("azure"),
+            if cfg!(feature = "providers-extra") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
+        assert_eq!(
+            lifecycle_for("azure_ai"),
+            if cfg!(feature = "providers-extra") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
         assert_eq!(lifecycle_for("cohere"), ProviderModuleLifecycle::Stub);
         assert_eq!(lifecycle_for("gemini"), ProviderModuleLifecycle::Stub);
     }
@@ -332,6 +358,10 @@ mod tests {
             .collect::<BTreeSet<_>>();
         let expected = [
             "anthropic",
+            #[cfg(feature = "providers-extra")]
+            "azure",
+            #[cfg(feature = "providers-extra")]
+            "azure_ai",
             "bedrock",
             "cloudflare",
             "mistral",

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -406,15 +406,12 @@ mod tests {
             ProviderType::Cloudflare,
         ]
         .into_iter()
-        .chain(
-            [
-                #[cfg(feature = "providers-extra")]
-                ProviderType::Azure,
-                #[cfg(feature = "providers-extra")]
-                ProviderType::AzureAI,
-            ]
-            .into_iter(),
-        )
+        .chain([
+            #[cfg(feature = "providers-extra")]
+            ProviderType::Azure,
+            #[cfg(feature = "providers-extra")]
+            ProviderType::AzureAI,
+        ])
         .collect::<HashSet<_>>();
 
         assert_eq!(native_types, expected);

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -92,14 +92,14 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::Azure,
         "azure",
         &["azure-openai"],
-        provider_extra_native_dispatch_kind(),
+        azure_dispatch_kind(),
         false,
     ),
     entry(
         ProviderType::AzureAI,
         "azure_ai",
         &["azureai", "azure-ai"],
-        provider_extra_native_dispatch_kind(),
+        azure_dispatch_kind(),
         false,
     ),
     entry(
@@ -327,11 +327,11 @@ const fn entry(
     }
 }
 
-const fn provider_extra_native_dispatch_kind() -> ProviderDispatchKind {
+const fn azure_dispatch_kind() -> ProviderDispatchKind {
     if cfg!(feature = "providers-extra") {
         ProviderDispatchKind::Native
     } else {
-        ProviderDispatchKind::UnsupportedEnum
+        ProviderDispatchKind::ExplicitOpenAiLike
     }
 }
 
@@ -429,11 +429,11 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Azure),
-            provider_extra_native_dispatch_kind()
+            azure_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::AzureAI),
-            provider_extra_native_dispatch_kind()
+            azure_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::OpenAICompatible),

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -92,14 +92,14 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::Azure,
         "azure",
         &["azure-openai"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        provider_extra_native_dispatch_kind(),
         false,
     ),
     entry(
         ProviderType::AzureAI,
         "azure_ai",
         &["azureai", "azure-ai"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        provider_extra_native_dispatch_kind(),
         false,
     ),
     entry(
@@ -327,6 +327,14 @@ const fn entry(
     }
 }
 
+const fn provider_extra_native_dispatch_kind() -> ProviderDispatchKind {
+    if cfg!(feature = "providers-extra") {
+        ProviderDispatchKind::Native
+    } else {
+        ProviderDispatchKind::UnsupportedEnum
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -398,6 +406,15 @@ mod tests {
             ProviderType::Cloudflare,
         ]
         .into_iter()
+        .chain(
+            [
+                #[cfg(feature = "providers-extra")]
+                ProviderType::Azure,
+                #[cfg(feature = "providers-extra")]
+                ProviderType::AzureAI,
+            ]
+            .into_iter(),
+        )
         .collect::<HashSet<_>>();
 
         assert_eq!(native_types, expected);
@@ -415,11 +432,11 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Azure),
-            ProviderDispatchKind::ExplicitOpenAiLike
+            provider_extra_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::AzureAI),
-            ProviderDispatchKind::ExplicitOpenAiLike
+            provider_extra_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::OpenAICompatible),

--- a/tests/integration/provider_factory_tests.rs
+++ b/tests/integration/provider_factory_tests.rs
@@ -310,6 +310,41 @@ mod tests {
         assert!(matches!(provider, Provider::Azure(_)));
     }
 
+    /// Test native Azure validates config at provider construction.
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_azure_provider_native_dispatch_rejects_invalid_config() {
+        let zero_timeout = json!({
+            "api_key": "azure-test-key",
+            "azure_endpoint": "https://test-resource.openai.azure.com",
+            "deployment_name": "gpt-4o-deployment",
+            "timeout": 0
+        });
+
+        let err = Provider::from_config_async(ProviderType::Azure, zero_timeout)
+            .await
+            .expect_err("native Azure should reject zero timeout");
+        assert!(
+            err.to_string().contains("Timeout must be greater than 0"),
+            "unexpected error: {err}"
+        );
+
+        let excessive_retries = json!({
+            "api_key": "azure-test-key",
+            "azure_endpoint": "https://test-resource.openai.azure.com",
+            "deployment_name": "gpt-4o-deployment",
+            "max_retries": 11
+        });
+
+        let err = Provider::from_config_async(ProviderType::Azure, excessive_retries)
+            .await
+            .expect_err("native Azure should reject excessive retries");
+        assert!(
+            err.to_string().contains("Max retries cannot exceed 10"),
+            "unexpected error: {err}"
+        );
+    }
+
     /// Test Azure AI uses the native provider path when providers-extra is enabled.
     #[cfg(feature = "providers-extra")]
     #[tokio::test]

--- a/tests/integration/provider_factory_tests.rs
+++ b/tests/integration/provider_factory_tests.rs
@@ -233,6 +233,59 @@ mod tests {
         assert!(matches!(provider, Provider::OpenAILike(_)));
     }
 
+    /// Test Azure OpenAI uses the native provider path when providers-extra is enabled.
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_azure_provider_uses_native_dispatch() {
+        let config = json!({
+            "api_key": "azure-test-key",
+            "azure_endpoint": "https://test-resource.openai.azure.com",
+            "deployment_name": "gpt-4o-deployment",
+            "api_version": "2024-02-01"
+        });
+
+        let result = Provider::from_config_async(ProviderType::Azure, config).await;
+        assert!(
+            result.is_ok(),
+            "Failed to create native Azure provider: {:?}",
+            result.err()
+        );
+
+        let provider = match result {
+            Ok(provider) => provider,
+            Err(err) => panic!("native Azure provider should be created: {err}"),
+        };
+        assert_eq!(provider.name(), "azure");
+        assert_eq!(provider.provider_type(), ProviderType::Azure);
+        assert!(matches!(provider, Provider::Azure(_)));
+    }
+
+    /// Test Azure AI uses the native provider path when providers-extra is enabled.
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_azure_ai_provider_uses_native_dispatch() {
+        let config = json!({
+            "api_key": "azure-ai-test-key",
+            "base_url": "https://test-resource.services.ai.azure.com",
+            "api_version": "2024-05-01-preview"
+        });
+
+        let result = Provider::from_config_async(ProviderType::AzureAI, config).await;
+        assert!(
+            result.is_ok(),
+            "Failed to create native Azure AI provider: {:?}",
+            result.err()
+        );
+
+        let provider = match result {
+            Ok(provider) => provider,
+            Err(err) => panic!("native Azure AI provider should be created: {err}"),
+        };
+        assert_eq!(provider.name(), "azure_ai");
+        assert_eq!(provider.provider_type(), ProviderType::AzureAI);
+        assert!(matches!(provider, Provider::AzureAI(_)));
+    }
+
     /// Test provider creation fails with missing api_key
     #[tokio::test]
     async fn test_provider_creation_fails_without_api_key() {

--- a/tests/integration/provider_factory_tests.rs
+++ b/tests/integration/provider_factory_tests.rs
@@ -371,6 +371,31 @@ mod tests {
         assert!(matches!(provider, Provider::AzureAI(_)));
     }
 
+    /// Test native Azure AI keeps gateway routing deployment-driven.
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_azure_ai_native_dispatch_uses_provider_name_when_models_omitted() {
+        use litellm_rs::config::models::provider::ProviderConfig as GatewayProviderConfig;
+        use litellm_rs::core::router::UnifiedRouter;
+
+        let provider = GatewayProviderConfig {
+            name: "private-foundry-deployment".to_string(),
+            provider_type: "azure_ai".to_string(),
+            api_key: "azure-ai-test-key".to_string(),
+            base_url: Some("https://test-resource.services.ai.azure.com".to_string()),
+            enabled: true,
+            models: vec![],
+            ..GatewayProviderConfig::default()
+        };
+
+        let router = UnifiedRouter::from_gateway_config(&[provider], None)
+            .await
+            .unwrap_or_else(|err| panic!("router should build from Azure AI config: {err}"));
+
+        let models = router.list_models();
+        assert_eq!(models, vec!["private-foundry-deployment".to_string()]);
+    }
+
     /// Test provider creation fails with missing api_key
     #[tokio::test]
     async fn test_provider_creation_fails_without_api_key() {

--- a/tests/integration/provider_factory_tests.rs
+++ b/tests/integration/provider_factory_tests.rs
@@ -233,6 +233,56 @@ mod tests {
         assert!(matches!(provider, Provider::OpenAILike(_)));
     }
 
+    /// Test Azure OpenAI falls back to OpenAI-compatible dispatch by default.
+    #[cfg(not(feature = "providers-extra"))]
+    #[tokio::test]
+    async fn test_azure_provider_uses_openai_like_dispatch_without_providers_extra() {
+        let config = json!({
+            "api_key": "azure-test-key",
+            "base_url": "https://test-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions"
+        });
+
+        let result = Provider::from_config_async(ProviderType::Azure, config).await;
+        assert!(
+            result.is_ok(),
+            "Failed to create fallback Azure provider: {:?}",
+            result.err()
+        );
+
+        let provider = match result {
+            Ok(provider) => provider,
+            Err(err) => panic!("fallback Azure provider should be created: {err}"),
+        };
+        assert_eq!(provider.name(), "azure");
+        assert_eq!(provider.provider_type(), ProviderType::OpenAICompatible);
+        assert!(matches!(provider, Provider::OpenAILike(_)));
+    }
+
+    /// Test Azure AI falls back to OpenAI-compatible dispatch by default.
+    #[cfg(not(feature = "providers-extra"))]
+    #[tokio::test]
+    async fn test_azure_ai_provider_uses_openai_like_dispatch_without_providers_extra() {
+        let config = json!({
+            "api_key": "azure-ai-test-key",
+            "base_url": "https://test-resource.services.ai.azure.com"
+        });
+
+        let result = Provider::from_config_async(ProviderType::AzureAI, config).await;
+        assert!(
+            result.is_ok(),
+            "Failed to create fallback Azure AI provider: {:?}",
+            result.err()
+        );
+
+        let provider = match result {
+            Ok(provider) => provider,
+            Err(err) => panic!("fallback Azure AI provider should be created: {err}"),
+        };
+        assert_eq!(provider.name(), "azure_ai");
+        assert_eq!(provider.provider_type(), ProviderType::OpenAICompatible);
+        assert!(matches!(provider, Provider::OpenAILike(_)));
+    }
+
     /// Test Azure OpenAI uses the native provider path when providers-extra is enabled.
     #[cfg(feature = "providers-extra")]
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add native Azure and AzureAI Provider enum variants behind providers-extra
- route ProviderType::Azure/AzureAI through native factory builders instead of OpenAILike
- make registry/lifecycle dispatch feature-aware and add focused provider dispatch tests

Fixes #599

## Validation
- cargo fmt
- git diff --check
- cargo check --all-features
- cargo check
- cargo test --all-features test_dispatch_kind_matches_runtime_variant -- --nocapture
- cargo test --all-features uses_native_dispatch -- --nocapture
- cargo test --all-features maps_native_fields -- --nocapture
- cargo test --all-features phase0_key_provider -- --nocapture
- cargo test --all-features -- --test-threads=1

Note: the unthrottled parallel all-features test run hit the local file-descriptor limit (`Too many open files`), so the full suite was rerun serialized and passed.
