### PR TITLE
fix(provider): migrate OpenAI streaming callers

### DIFF
--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -9,7 +9,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::core::providers::base::{
-    GlobalPoolManager, HeaderPair, HttpMethod, header, header_owned, streaming_client,
+    GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
+    read_streaming_error_body, send_streaming_request, streaming_unbounded_client,
 };
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
@@ -152,39 +153,32 @@ impl OpenAIProvider {
         let mut openai_request = self.transform_chat_request(request)?;
         openai_request["stream"] = Value::Bool(true);
 
-        // Get API key
-        let api_key =
-            self.config
-                .base
-                .api_key
-                .as_ref()
-                .ok_or_else(|| ProviderError::Authentication {
-                    provider: "openai",
-                    message: "API key is required".to_string(),
-                })?;
+        if self.config.base.api_key.is_none() {
+            return Err(ProviderError::Authentication {
+                provider: "openai",
+                message: "API key is required".to_string(),
+            });
+        }
 
-        // Execute streaming request using the global connection pool
+        // Execute streaming request without a total response-lifetime timeout.
         let url = format!("{}/chat/completions", self.config.get_api_base());
-        let client = streaming_client();
-        let mut req = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .json(&openai_request);
+        let headers = self.get_request_headers();
+        let req = apply_headers(
+            streaming_unbounded_client()
+                .post(&url)
+                .json(&openai_request),
+            headers,
+        );
 
-        // Add organization header if present
-        if let Some(org) = &self.config.organization {
-            req = req.header("OpenAI-Organization", org);
+        let response = send_streaming_request(req, "openai").await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = read_streaming_error_body(response)
+                .await
+                .map_err(|e| e.into_provider_error("openai"))?;
+            let mapper = super::error_mapper::OpenAIErrorMapper;
+            return Err(mapper.map_http_error(status.as_u16(), &body));
         }
-
-        // Add project header if present
-        if let Some(project) = &self.config.project {
-            req = req.header("OpenAI-Project", project);
-        }
-
-        let response = req.send().await.map_err(|e| ProviderError::Network {
-            provider: "openai",
-            message: e.to_string(),
-        })?;
 
         // Create OpenAI-specific stream handler using unified SSE parser
         let stream = response.bytes_stream();

--- a/src/core/providers/openai/mod.rs
+++ b/src/core/providers/openai/mod.rs
@@ -15,6 +15,8 @@ pub mod error;
 pub mod error_mapper;
 pub mod models;
 pub mod streaming;
+#[cfg(test)]
+mod streaming_request_tests;
 pub mod transformer;
 
 pub use client::OpenAIProvider;

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -1,0 +1,80 @@
+use super::{OpenAIConfig, OpenAIProvider};
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::chat::{ChatMessage, ChatRequest};
+use crate::core::types::context::RequestContext;
+use crate::core::types::message::{MessageContent, MessageRole};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+async fn response_url(status: &str, body: &str) -> std::io::Result<String> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr = listener.local_addr()?;
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    tokio::spawn(async move {
+        let (mut socket, _) = match listener.accept().await {
+            Ok(connection) => connection,
+            Err(err) => panic!("test server failed to accept request: {err}"),
+        };
+        let mut buffer = [0_u8; 1024];
+        if let Err(err) = socket.read(&mut buffer).await {
+            panic!("test server failed to read request: {err}");
+        }
+        if let Err(err) = socket.write_all(response.as_bytes()).await {
+            panic!("test server failed to write response: {err}");
+        }
+    });
+
+    Ok(format!("http://{addr}"))
+}
+
+fn openai_chat_stream_request() -> ChatRequest {
+    ChatRequest {
+        model: "gpt-4".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("hello".to_string())),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn test_openai_streaming_maps_non_success_status_before_sse()
+-> Result<(), Box<dyn std::error::Error>> {
+    let body = r#"{"error":{"type":"rate_limit_error","message":"slow down"}}"#;
+    let api_base = response_url("429 Too Many Requests", body).await?;
+
+    let mut config = OpenAIConfig::default();
+    config.base.api_key = Some("sk-test123456789012345678901234567890123456".to_string());
+    config.base.api_base = Some(api_base);
+    let provider = OpenAIProvider::new(config).await?;
+
+    let err = match LLMProvider::chat_completion_stream(
+        &provider,
+        openai_chat_stream_request(),
+        RequestContext::default(),
+    )
+    .await
+    {
+        Ok(_) => panic!("streaming response should map upstream status to provider error"),
+        Err(err) => err,
+    };
+
+    match err {
+        ProviderError::RateLimit {
+            provider, message, ..
+        } => {
+            assert_eq!(provider, "openai");
+            assert!(message.contains("rate_limit_error"));
+        }
+        other => panic!("expected OpenAI rate limit error, got {other:?}"),
+    }
+
+    Ok(())
+}

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -5,7 +5,37 @@ use crate::core::types::chat::{ChatMessage, ChatRequest};
 use crate::core::types::context::RequestContext;
 use crate::core::types::message::{MessageContent, MessageRole};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
+
+async fn read_full_http_request(socket: &mut TcpStream) -> std::io::Result<()> {
+    let mut request_bytes = Vec::new();
+    let mut buffer = [0_u8; 1024];
+
+    loop {
+        let bytes_read = socket.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            return Ok(());
+        }
+
+        request_bytes.extend_from_slice(&buffer[..bytes_read]);
+        if let Some(header_end) = request_bytes.windows(4).position(|w| w == b"\r\n\r\n") {
+            let headers = String::from_utf8_lossy(&request_bytes[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+
+            if request_bytes.len() >= header_end + 4 + content_length {
+                return Ok(());
+            }
+        }
+    }
+}
 
 async fn response_url(status: &str, body: &str) -> std::io::Result<String> {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
@@ -20,8 +50,7 @@ async fn response_url(status: &str, body: &str) -> std::io::Result<String> {
             Ok(connection) => connection,
             Err(err) => panic!("test server failed to accept request: {err}"),
         };
-        let mut buffer = [0_u8; 1024];
-        if let Err(err) = socket.read(&mut buffer).await {
+        if let Err(err) = read_full_http_request(&mut socket).await {
             panic!("test server failed to read request: {err}");
         }
         if let Err(err) = socket.write_all(response.as_bytes()).await {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use crate::core::providers::base::{
     GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
+    read_streaming_error_body, send_streaming_request, streaming_unbounded_client,
 };
 use crate::core::providers::openai::{OpenAIResponseTransformer, models::OpenAIChatResponse};
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
@@ -159,18 +160,21 @@ impl OpenAILikeProvider {
         openai_request["stream"] = Value::Bool(true);
 
         let url = format!("{}/chat/completions", self.config.get_api_base());
-        let client = self.pool_manager.client();
         let headers = self.get_request_headers();
-        let req = apply_headers(client.post(&url).json(&openai_request), headers);
+        let req = apply_headers(
+            streaming_unbounded_client()
+                .post(&url)
+                .json(&openai_request),
+            headers,
+        );
 
-        let response = req
-            .send()
-            .await
-            .map_err(|e| OpenAILikeError::network(PROVIDER_NAME, e.to_string()))?;
+        let response = send_streaming_request(req, PROVIDER_NAME).await?;
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_streaming_error_body(response)
+                .await
+                .map_err(|e| e.into_provider_error(PROVIDER_NAME))?;
             return Err(self.map_error_response(status.as_u16(), &body));
         }
 

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -1,4 +1,46 @@
 use super::*;
+use crate::core::types::chat::ChatMessage;
+use crate::core::types::context::RequestContext;
+use crate::core::types::message::{MessageContent, MessageRole};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+async fn openai_like_stream_response_url(status: &str, body: &str) -> std::io::Result<String> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr = listener.local_addr()?;
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    tokio::spawn(async move {
+        let (mut socket, _) = match listener.accept().await {
+            Ok(connection) => connection,
+            Err(err) => panic!("test server failed to accept request: {err}"),
+        };
+        let mut buffer = [0_u8; 1024];
+        if let Err(err) = socket.read(&mut buffer).await {
+            panic!("test server failed to read request: {err}");
+        }
+        if let Err(err) = socket.write_all(response.as_bytes()).await {
+            panic!("test server failed to write response: {err}");
+        }
+    });
+
+    Ok(format!("http://{addr}"))
+}
+
+fn openai_like_chat_stream_request() -> ChatRequest {
+    ChatRequest {
+        model: "test-model".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("hello".to_string())),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
 
 #[tokio::test]
 async fn test_provider_creation_with_api_base() {
@@ -7,6 +49,42 @@ async fn test_provider_creation_with_api_base() {
 
     let provider = provider.unwrap();
     assert_eq!(provider.name(), "openai_like");
+}
+
+#[tokio::test]
+async fn test_openai_like_streaming_maps_non_success_status_before_sse()
+-> Result<(), Box<dyn std::error::Error>> {
+    use crate::core::providers::unified_provider::ProviderError;
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    let body = r#"{"error":{"type":"rate_limit_error","message":"slow down","retry_after":5}}"#;
+    let api_base = openai_like_stream_response_url("429 Too Many Requests", body).await?;
+    let provider = OpenAILikeProvider::with_api_base(api_base).await?;
+
+    let err = match LLMProvider::chat_completion_stream(
+        &provider,
+        openai_like_chat_stream_request(),
+        RequestContext::default(),
+    )
+    .await
+    {
+        Ok(_) => panic!("streaming response should map upstream status to provider error"),
+        Err(err) => err,
+    };
+
+    match err {
+        ProviderError::RateLimit {
+            provider,
+            retry_after,
+            ..
+        } => {
+            assert_eq!(provider, PROVIDER_NAME);
+            assert_eq!(retry_after, Some(5));
+        }
+        other => panic!("expected OpenAI-like rate limit error, got {other:?}"),
+    }
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -3,7 +3,37 @@ use crate::core::types::chat::ChatMessage;
 use crate::core::types::context::RequestContext;
 use crate::core::types::message::{MessageContent, MessageRole};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
+
+async fn read_full_http_request(socket: &mut TcpStream) -> std::io::Result<()> {
+    let mut request_bytes = Vec::new();
+    let mut buffer = [0_u8; 1024];
+
+    loop {
+        let bytes_read = socket.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            return Ok(());
+        }
+
+        request_bytes.extend_from_slice(&buffer[..bytes_read]);
+        if let Some(header_end) = request_bytes.windows(4).position(|w| w == b"\r\n\r\n") {
+            let headers = String::from_utf8_lossy(&request_bytes[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+
+            if request_bytes.len() >= header_end + 4 + content_length {
+                return Ok(());
+            }
+        }
+    }
+}
 
 async fn openai_like_stream_response_url(status: &str, body: &str) -> std::io::Result<String> {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
@@ -18,8 +48,7 @@ async fn openai_like_stream_response_url(status: &str, body: &str) -> std::io::R
             Ok(connection) => connection,
             Err(err) => panic!("test server failed to accept request: {err}"),
         };
-        let mut buffer = [0_u8; 1024];
-        if let Err(err) = socket.read(&mut buffer).await {
+        if let Err(err) = read_full_http_request(&mut socket).await {
             panic!("test server failed to read request: {err}");
         }
         if let Err(err) = socket.write_all(response.as_bytes()).await {


### PR DESCRIPTION
## Summary
- Migrate OpenAI and OpenAI-like streaming requests to `streaming_unbounded_client()` plus `send_streaming_request()`.
- Read non-success streaming response bodies through the bounded streaming error-body helper before SSE parsing.
- Add local TCP regression coverage for OpenAI and OpenAI-like streaming error responses.

Refs #647

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test --all-features streaming_maps_non_success_status_before_sse`
- `cargo test --all-features test_streaming_send_timeout_does_not_bound_body`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`

## Note
- The VibeGuard pre-commit hook timed out after 10s while running its own cargo check. The same `cargo check --all-features` command passed in this session in about 13.3s, and the full test suite passed before commit.