### PR TITLE
fix(provider): harden Azure native provider parity

### DIFF
--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -225,6 +225,9 @@ impl AzureChatHandler {
         if let Some(max_tokens) = request.max_tokens {
             body["max_tokens"] = json!(max_tokens);
         }
+        if let Some(max_completion_tokens) = request.max_completion_tokens {
+            body["max_completion_tokens"] = json!(max_completion_tokens);
+        }
         if let Some(top_p) = request.top_p {
             body["top_p"] = json!(top_p);
         }

--- a/src/core/providers/azure/chat_tests.rs
+++ b/src/core/providers/azure/chat_tests.rs
@@ -120,6 +120,7 @@ fn test_transform_request_with_options() {
         messages: vec![create_test_message(MessageRole::User, "Hello")],
         temperature: Some(0.7),
         max_tokens: Some(100),
+        max_completion_tokens: Some(120),
         top_p: Some(0.9),
         frequency_penalty: Some(0.5),
         presence_penalty: Some(0.3),
@@ -134,6 +135,7 @@ fn test_transform_request_with_options() {
     let value = result.unwrap();
     assert!((value["temperature"].as_f64().unwrap() - 0.7).abs() < 0.001);
     assert_eq!(value["max_tokens"], 100);
+    assert_eq!(value["max_completion_tokens"], 120);
     assert!((value["top_p"].as_f64().unwrap() - 0.9).abs() < 0.001);
     assert!(value["stop"].is_array());
     assert!(value["stream"].as_bool().unwrap());

--- a/src/core/providers/azure/config.rs
+++ b/src/core/providers/azure/config.rs
@@ -24,6 +24,10 @@ pub struct AzureConfig {
     pub subscription_id: Option<String>,
     /// Custom headers
     pub custom_headers: HashMap<String, String>,
+    /// Request timeout in seconds
+    pub timeout: u64,
+    /// Maximum retry attempts
+    pub max_retries: u32,
 }
 
 impl Default for AzureConfig {
@@ -37,6 +41,8 @@ impl Default for AzureConfig {
             resource_group: None,
             subscription_id: None,
             custom_headers: HashMap::new(),
+            timeout: 60,
+            max_retries: 3,
         }
     }
 }
@@ -135,11 +141,11 @@ impl crate::core::traits::provider::ProviderConfig for AzureConfig {
     }
 
     fn timeout(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(60) // Default 60 seconds timeout
+        std::time::Duration::from_secs(self.timeout)
     }
 
     fn max_retries(&self) -> u32 {
-        3 // Default retry 3 times
+        self.max_retries
     }
 }
 
@@ -165,6 +171,8 @@ mod tests {
         assert!(config.azure_endpoint.is_none());
         assert_eq!(config.api_version, "2024-02-01");
         assert!(config.deployment_name.is_none());
+        assert_eq!(config.timeout, 60);
+        assert_eq!(config.max_retries, 3);
     }
 
     #[test]
@@ -233,6 +241,12 @@ mod tests {
         assert_eq!(config.api_base(), Some("https://test.openai.azure.com"));
         assert_eq!(config.timeout(), std::time::Duration::from_secs(60));
         assert_eq!(config.max_retries(), 3);
+
+        let mut custom_config = config;
+        custom_config.timeout = 12;
+        custom_config.max_retries = 5;
+        assert_eq!(custom_config.timeout(), std::time::Duration::from_secs(12));
+        assert_eq!(custom_config.max_retries(), 5);
     }
 
     #[test]

--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -124,6 +124,23 @@ impl AzureOpenAIProvider {
     }
 }
 
+fn build_azure_models_health_url(azure_endpoint: &str, api_version: &str) -> String {
+    let base = azure_endpoint.trim_end_matches('/');
+    let resource_base = base
+        .split_once("/openai/deployments/")
+        .map(|(resource_base, _)| resource_base)
+        .unwrap_or(base);
+
+    if resource_base.ends_with("/openai") {
+        format!("{}/models?api-version={}", resource_base, api_version)
+    } else {
+        format!(
+            "{}/openai/models?api-version={}",
+            resource_base, api_version
+        )
+    }
+}
+
 // Azure error mapper is now re-exported from common_utils
 
 /// Implement the unified LLMProvider trait for AzureOpenAIProvider
@@ -149,10 +166,15 @@ impl LLMProvider for AzureOpenAIProvider {
         &[]
     }
 
+    fn supports_model(&self, model: &str) -> bool {
+        !model.trim().is_empty()
+    }
+
     fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
         &[
             "temperature",
             "max_tokens",
+            "max_completion_tokens",
             "top_p",
             "frequency_penalty",
             "presence_penalty",
@@ -253,10 +275,30 @@ impl LLMProvider for AzureOpenAIProvider {
     }
 
     async fn health_check(&self) -> HealthStatus {
-        if self.config.api_key.is_some() {
-            HealthStatus::Healthy
-        } else {
-            HealthStatus::Unhealthy
+        let endpoint = match self.config.get_effective_azure_endpoint() {
+            Some(endpoint) => endpoint,
+            None => return HealthStatus::Unhealthy,
+        };
+        if self.config.api_version.is_empty() {
+            return HealthStatus::Unhealthy;
+        }
+
+        let api_key = match self.config.get_effective_api_key().await {
+            Some(api_key) => api_key,
+            None => return HealthStatus::Unhealthy,
+        };
+
+        let url = build_azure_models_health_url(&endpoint, &self.config.api_version);
+        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let mut request = client.get(url).header("api-key", api_key);
+        for (key, value) in &self.config.custom_headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+
+        match request.send().await {
+            Ok(response) if response.status().is_success() => HealthStatus::Healthy,
+            Ok(_) => HealthStatus::Degraded,
+            Err(_) => HealthStatus::Unhealthy,
         }
     }
 }
@@ -281,5 +323,112 @@ impl AzureProviderFactory {
     /// Create provider from environment variables
     pub fn create_from_env() -> Result<AzureOpenAIProvider, ProviderError> {
         AzureOpenAIProvider::from_env()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    fn test_config(endpoint: String) -> AzureConfig {
+        AzureConfig::new()
+            .with_api_key("test-key".to_string())
+            .with_azure_endpoint(endpoint)
+            .with_api_version("2024-02-01".to_string())
+    }
+
+    async fn read_http_headers(socket: &mut TcpStream) -> std::io::Result<()> {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+
+        loop {
+            let bytes_read = socket.read(&mut buffer).await?;
+            if bytes_read == 0 {
+                return Ok(());
+            }
+            request.extend_from_slice(&buffer[..bytes_read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                return Ok(());
+            }
+        }
+    }
+
+    async fn health_response_base_url(status: &str) -> std::io::Result<String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let addr = listener.local_addr()?;
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+        );
+
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            if read_http_headers(&mut socket).await.is_err() {
+                return;
+            }
+            if socket.write_all(response.as_bytes()).await.is_err() {
+                return;
+            }
+        });
+
+        Ok(format!("http://{addr}"))
+    }
+
+    #[test]
+    fn test_supports_dynamic_deployment_names() {
+        let provider = match AzureOpenAIProvider::new(test_config(
+            "https://test.openai.azure.com".to_string(),
+        )) {
+            Ok(provider) => provider,
+            Err(error) => panic!("provider should be created: {error}"),
+        };
+
+        assert!(provider.supports_model("customer-gpt4o-prod"));
+        assert!(!provider.supports_model("   "));
+    }
+
+    #[test]
+    fn test_health_url_strips_deployment_base() {
+        let url = build_azure_models_health_url(
+            "https://test.openai.azure.com/openai/deployments/prod",
+            "2024-02-01",
+        );
+
+        assert_eq!(
+            url,
+            "https://test.openai.azure.com/openai/models?api-version=2024-02-01"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_health_check_success_requires_endpoint_success() {
+        let api_base = match health_response_base_url("200 OK").await {
+            Ok(url) => url,
+            Err(error) => panic!("test server should start: {error}"),
+        };
+        let provider = match AzureOpenAIProvider::new(test_config(api_base)) {
+            Ok(provider) => provider,
+            Err(error) => panic!("provider should be created: {error}"),
+        };
+
+        assert_eq!(provider.health_check().await, HealthStatus::Healthy);
+    }
+
+    #[tokio::test]
+    async fn test_health_check_degrades_on_endpoint_failure() {
+        let api_base = match health_response_base_url("500 Internal Server Error").await {
+            Ok(url) => url,
+            Err(error) => panic!("test server should start: {error}"),
+        };
+        let provider = match AzureOpenAIProvider::new(test_config(api_base)) {
+            Ok(provider) => provider,
+            Err(error) => panic!("provider should be created: {error}"),
+        };
+
+        assert_eq!(provider.health_check().await, HealthStatus::Degraded);
     }
 }

--- a/src/core/providers/azure/utils.rs
+++ b/src/core/providers/azure/utils.rs
@@ -53,9 +53,15 @@ impl AzureUtils {
             AzureEndpointType::Models => "models",
         };
 
+        let deployment_base = if base.contains("/openai/deployments/") {
+            base.to_string()
+        } else {
+            format!("{}/openai/deployments/{}", base, deployment_name)
+        };
+
         format!(
-            "{}/openai/deployments/{}/{}?api-version={}",
-            base, deployment_name, endpoint_path, api_version
+            "{}/{}?api-version={}",
+            deployment_base, endpoint_path, api_version
         )
     }
 
@@ -338,6 +344,21 @@ mod tests {
         );
         // Should not have double slashes
         assert!(!url.contains("//openai"));
+    }
+
+    #[test]
+    fn test_build_azure_url_preserves_legacy_deployment_base() {
+        let url = AzureUtils::build_azure_url(
+            "https://test.openai.azure.com/openai/deployments/prod",
+            "ignored-model",
+            "2024-02-01",
+            AzureEndpointType::ChatCompletions,
+        );
+        assert_eq!(
+            url,
+            "https://test.openai.azure.com/openai/deployments/prod/chat/completions?api-version=2024-02-01"
+        );
+        assert!(!url.contains("prod/openai/deployments"));
     }
 
     #[test]

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -2,7 +2,7 @@
 //!
 //! Complete chat completion implementation for Azure AI Foundry
 
-use futures::{Stream, StreamExt};
+use futures::Stream;
 use reqwest::header::HeaderMap;
 use serde_json::{Value, json};
 use std::pin::Pin;
@@ -19,6 +19,7 @@ use crate::core::types::{
 
 use super::config::{AzureAIConfig, AzureAIEndpointType};
 use crate::core::providers::base::HttpErrorMapper;
+use crate::core::providers::base::sse::{SSETransformer, UnifiedSSEStream};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::net::http::create_custom_client_with_headers;
 
@@ -149,18 +150,34 @@ impl AzureAIChatHandler {
             ));
         }
 
-        // Create SSE stream
-        let model = request.model.clone();
-        let stream = response.bytes_stream().map(move |chunk_result| {
-            chunk_result
-                .map_err(|e| ProviderError::network("azure_ai", format!("Stream error: {}", e)))
-                .and_then(|chunk| {
-                    let chunk_str = String::from_utf8_lossy(&chunk);
-                    AzureAIChatUtils::parse_streaming_chunk(&chunk_str, &model)
-                })
-        });
-
+        let transformer = AzureAISSETransformer::new(request.model.clone());
+        let stream = UnifiedSSEStream::new(Box::pin(response.bytes_stream()), transformer);
         Ok(Box::pin(stream))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AzureAISSETransformer {
+    model: String,
+}
+
+impl AzureAISSETransformer {
+    fn new(model: String) -> Self {
+        Self { model }
+    }
+}
+
+impl SSETransformer for AzureAISSETransformer {
+    fn provider_name(&self) -> &'static str {
+        "azure_ai"
+    }
+
+    fn transform_chunk(&self, data: &str) -> Result<Option<ChatChunk>, ProviderError> {
+        let chunk_data: Value = serde_json::from_str(data).map_err(|e| {
+            ProviderError::response_parsing("azure_ai", format!("Failed to parse SSE JSON: {}", e))
+        })?;
+
+        AzureAIChatUtils::transform_streaming_chunk(chunk_data, &self.model).map(Some)
     }
 }
 

--- a/src/core/providers/azure_ai/chat_tests.rs
+++ b/src/core/providers/azure_ai/chat_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::providers::base::sse::UnifiedSSEParser;
 
 fn create_test_request() -> ChatRequest {
     ChatRequest {
@@ -200,6 +201,40 @@ fn test_parse_streaming_chunk_empty() {
     assert!(result.is_ok());
     let chat_chunk = result.unwrap();
     assert_eq!(chat_chunk.id, "empty");
+}
+
+#[test]
+fn test_sse_parser_buffers_split_and_multiple_events() {
+    let transformer = AzureAISSETransformer::new("gpt-4".to_string());
+    let mut parser = UnifiedSSEParser::new(transformer);
+
+    let first = match parser
+        .process_bytes(br#"data: {"id":"chunk-1","choices":[{"delta":{"content":"Hel"#)
+    {
+        Ok(chunks) => chunks,
+        Err(error) => panic!("partial SSE bytes should be buffered: {error}"),
+    };
+    assert!(first.is_empty());
+
+    let second = match parser.process_bytes(
+        br#"lo"}}]}
+
+data: {"id":"chunk-2","choices":[{"delta":{"content":" World"}}]}
+
+data: [DONE]
+
+"#,
+    ) {
+        Ok(chunks) => chunks,
+        Err(error) => panic!("complete SSE events should parse: {error}"),
+    };
+
+    assert_eq!(second.len(), 2);
+    assert_eq!(second[0].choices[0].delta.content.as_deref(), Some("Hello"));
+    assert_eq!(
+        second[1].choices[0].delta.content.as_deref(),
+        Some(" World")
+    );
 }
 
 #[test]

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -48,8 +48,28 @@ impl AzureAIConfig {
         // Ensure base URL ends with '/' and path doesn't start with '/'
         let base = base_url.trim_end_matches('/');
         let endpoint_path = path.trim_start_matches('/');
+        let base = if Self::needs_models_prefix(base, endpoint_path) {
+            format!("{}/models", base)
+        } else {
+            base.to_string()
+        };
 
         Ok(format!("{}/{}", base, endpoint_path))
+    }
+
+    fn needs_models_prefix(base: &str, endpoint_path: &str) -> bool {
+        if endpoint_path == "models" || endpoint_path.starts_with("models/") {
+            return false;
+        }
+
+        let host_and_path = base.split_once("://").map(|(_, rest)| rest).unwrap_or(base);
+        let (host, path) = host_and_path
+            .split_once('/')
+            .map(|(host, path)| (host, path))
+            .unwrap_or((host_and_path, ""));
+
+        host.ends_with(".services.ai.azure.com")
+            && !path.split('/').any(|segment| segment == "models")
     }
 
     /// Default
@@ -69,8 +89,16 @@ impl AzureAIConfig {
         // Settings
         headers.insert("User-Agent".to_string(), "litellm-rust/0.1.0".to_string());
 
-        // Settings
-        headers.insert("api-version".to_string(), "2024-05-01-preview".to_string());
+        let api_version = self
+            .base
+            .api_version
+            .as_deref()
+            .unwrap_or("2024-05-01-preview");
+        headers.insert("api-version".to_string(), api_version.to_string());
+
+        for (key, value) in &self.base.headers {
+            headers.insert(key.clone(), value.clone());
+        }
 
         Ok(headers)
     }
@@ -177,6 +205,30 @@ mod tests {
     }
 
     #[test]
+    fn test_build_endpoint_url_adds_models_for_resource_root() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_base = Some("https://resource.services.ai.azure.com".to_string());
+
+        let url = config.build_endpoint_url("chat/completions").unwrap();
+        assert_eq!(
+            url,
+            "https://resource.services.ai.azure.com/models/chat/completions"
+        );
+    }
+
+    #[test]
+    fn test_build_endpoint_url_does_not_duplicate_models() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_base = Some("https://resource.services.ai.azure.com/models".to_string());
+
+        let url = config.build_endpoint_url("chat/completions").unwrap();
+        assert_eq!(
+            url,
+            "https://resource.services.ai.azure.com/models/chat/completions"
+        );
+    }
+
+    #[test]
     fn test_build_endpoint_url_no_base() {
         // Use Default to get a config without default api_base
         let config = AzureAIConfig::default();
@@ -189,12 +241,45 @@ mod tests {
     fn test_create_default_headers_with_api_key() {
         let mut config = AzureAIConfig::new("azure_ai");
         config.base.api_key = Some("test-api-key".to_string());
+        config.base.api_version = Some("2024-08-01-preview".to_string());
+        config
+            .base
+            .headers
+            .insert("x-routing-tenant".to_string(), "tenant-a".to_string());
 
         let headers = config.create_default_headers().unwrap();
-        assert_eq!(headers.get("Authorization").unwrap(), "Bearer test-api-key");
-        assert_eq!(headers.get("Content-Type").unwrap(), "application/json");
-        assert_eq!(headers.get("User-Agent").unwrap(), "litellm-rust/0.1.0");
-        assert_eq!(headers.get("api-version").unwrap(), "2024-05-01-preview");
+        assert_eq!(
+            headers.get("Authorization").map(String::as_str),
+            Some("Bearer test-api-key")
+        );
+        assert_eq!(
+            headers.get("Content-Type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(
+            headers.get("User-Agent").map(String::as_str),
+            Some("litellm-rust/0.1.0")
+        );
+        assert_eq!(
+            headers.get("api-version").map(String::as_str),
+            Some("2024-08-01-preview")
+        );
+        assert_eq!(
+            headers.get("x-routing-tenant").map(String::as_str),
+            Some("tenant-a")
+        );
+    }
+
+    #[test]
+    fn test_create_default_headers_uses_default_api_version() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_key = Some("test-api-key".to_string());
+
+        let headers = config.create_default_headers().unwrap();
+        assert_eq!(
+            headers.get("api-version").map(String::as_str),
+            Some("2024-05-01-preview")
+        );
     }
 
     #[test]

--- a/src/core/providers/azure_ai/image_generation.rs
+++ b/src/core/providers/azure_ai/image_generation.rs
@@ -91,21 +91,32 @@ impl AzureAIImageHandler {
         }
 
         // Parse response
-        let _response_json: Value = response.json().await.map_err(|e| {
+        let response_json: Value = response.json().await.map_err(|e| {
             ProviderError::serialization("azure_ai", format!("Failed to parse response: {}", e))
         })?;
 
-        // Create response
-        let data = vec![ImageData {
-            url: Some("https://example.com/generated_image.jpg".to_string()),
-            b64_json: None,
-            revised_prompt: None,
-        }];
+        Self::transform_response(response_json)
+    }
 
-        Ok(ImageGenerationResponse {
-            created: chrono::Utc::now().timestamp() as u64,
-            data,
-        })
+    fn transform_response(response: Value) -> Result<ImageGenerationResponse, ProviderError> {
+        let created = response["created"]
+            .as_u64()
+            .unwrap_or_else(|| chrono::Utc::now().timestamp() as u64);
+
+        let data = response["data"]
+            .as_array()
+            .ok_or_else(|| ProviderError::serialization("azure_ai", "Missing data array"))?
+            .iter()
+            .map(|item| ImageData {
+                url: item["url"].as_str().map(|url| url.to_string()),
+                b64_json: item["b64_json"].as_str().map(|b64| b64.to_string()),
+                revised_prompt: item["revised_prompt"]
+                    .as_str()
+                    .map(|prompt| prompt.to_string()),
+            })
+            .collect();
+
+        Ok(ImageGenerationResponse { created, data })
     }
 }
 
@@ -117,5 +128,27 @@ mod tests {
     fn test_handler_creation() {
         let config = AzureAIConfig::new("azure_ai");
         let _result = AzureAIImageHandler::new(config);
+    }
+
+    #[test]
+    fn test_transform_response_preserves_returned_image_url() {
+        let response = json!({
+            "created": 1700000000_u64,
+            "data": [{
+                "url": "https://cdn.example.com/generated.png",
+                "revised_prompt": "a generated image"
+            }]
+        });
+
+        let result = AzureAIImageHandler::transform_response(response).unwrap();
+        assert_eq!(result.created, 1700000000);
+        assert_eq!(
+            result.data[0].url.as_deref(),
+            Some("https://cdn.example.com/generated.png")
+        );
+        assert_ne!(
+            result.data[0].url.as_deref(),
+            Some("https://example.com/generated_image.jpg")
+        );
     }
 }

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -146,6 +146,10 @@ impl LLMProvider for AzureAIProvider {
         MODELS.get_or_init(|| self.model_registry.to_model_infos())
     }
 
+    fn supports_model(&self, model: &str) -> bool {
+        !model.trim().is_empty()
+    }
+
     fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
         &[
             "temperature",
@@ -240,9 +244,26 @@ impl LLMProvider for AzureAIProvider {
             return HealthStatus::Unhealthy;
         }
 
-        // Try a simple ping to the API
-        // For now just return healthy if config is valid
-        HealthStatus::Healthy
+        let url = match self.config.build_endpoint_url("models") {
+            Ok(url) => url,
+            Err(_) => return HealthStatus::Unhealthy,
+        };
+        let headers = match self.config.create_default_headers() {
+            Ok(headers) => headers,
+            Err(_) => return HealthStatus::Unhealthy,
+        };
+
+        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let mut request = client.get(url);
+        for (key, value) in headers {
+            request = request.header(key, value);
+        }
+
+        match request.send().await {
+            Ok(response) if response.status().is_success() => HealthStatus::Healthy,
+            Ok(_) => HealthStatus::Degraded,
+            Err(_) => HealthStatus::Unhealthy,
+        }
     }
 
     async fn calculate_cost(
@@ -292,12 +313,52 @@ impl AzureAIProviderFactory {
 mod tests {
     use super::*;
     use crate::core::types::{chat::ChatMessage, message::MessageContent, message::MessageRole};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
 
     fn create_test_config() -> AzureAIConfig {
         let mut config = AzureAIConfig::new("azure_ai");
         config.base.api_key = Some("test_api_key".to_string());
         config.base.api_base = Some("https://test.ai.azure.com".to_string());
         config
+    }
+
+    async fn read_http_headers(socket: &mut TcpStream) -> std::io::Result<()> {
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+
+        loop {
+            let bytes_read = socket.read(&mut buffer).await?;
+            if bytes_read == 0 {
+                return Ok(());
+            }
+            request.extend_from_slice(&buffer[..bytes_read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                return Ok(());
+            }
+        }
+    }
+
+    async fn health_response_base_url(status: &str) -> std::io::Result<String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let addr = listener.local_addr()?;
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+        );
+
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            if read_http_headers(&mut socket).await.is_err() {
+                return;
+            }
+            if socket.write_all(response.as_bytes()).await.is_err() {
+                return;
+            }
+        });
+
+        Ok(format!("http://{addr}"))
     }
 
     // ==================== Provider Creation Tests ====================
@@ -373,6 +434,18 @@ mod tests {
         let config = create_test_config();
         let provider = AzureAIProvider::new(config).unwrap();
         assert!(!provider.models().is_empty());
+    }
+
+    #[test]
+    fn test_supports_dynamic_deployment_names() {
+        let config = create_test_config();
+        let provider = match AzureAIProvider::new(config) {
+            Ok(provider) => provider,
+            Err(error) => panic!("provider should be created: {error}"),
+        };
+
+        assert!(provider.supports_model("customer-gpt4o-prod"));
+        assert!(!provider.supports_model("   "));
     }
 
     #[test]
@@ -518,13 +591,37 @@ mod tests {
     // ==================== Health Check Tests ====================
 
     #[tokio::test]
-    async fn test_health_check_valid_config() {
-        let config = create_test_config();
-        let provider = AzureAIProvider::new(config).unwrap();
+    async fn test_health_check_success_requires_endpoint_success() {
+        let mut config = create_test_config();
+        config.base.api_base = Some(match health_response_base_url("200 OK").await {
+            Ok(url) => url,
+            Err(error) => panic!("test server should start: {error}"),
+        });
+        let provider = match AzureAIProvider::new(config) {
+            Ok(provider) => provider,
+            Err(error) => panic!("provider should be created: {error}"),
+        };
 
         let status = provider.health_check().await;
-        // With valid config, should return Healthy
         assert_eq!(status, HealthStatus::Healthy);
+    }
+
+    #[tokio::test]
+    async fn test_health_check_degrades_on_endpoint_failure() {
+        let mut config = create_test_config();
+        config.base.api_base = Some(
+            match health_response_base_url("500 Internal Server Error").await {
+                Ok(url) => url,
+                Err(error) => panic!("test server should start: {error}"),
+            },
+        );
+        let provider = match AzureAIProvider::new(config) {
+            Ok(provider) => provider,
+            Err(error) => panic!("provider should be created: {error}"),
+        };
+
+        let status = provider.health_check().await;
+        assert_eq!(status, HealthStatus::Degraded);
     }
 
     // ==================== Cost Calculation Tests ====================


### PR DESCRIPTION
Split from the larger Azure native dispatch PR so this slice stays within the PR scope guard.\n\nThis PR prepares the native Azure/Azure AI providers before the factory dispatch switch:\n- buffer Azure AI streaming through the unified SSE parser\n- make Azure and Azure AI health checks hit their endpoints\n- accept dynamic Azure deployment/model names in supports_model\n- transform Azure AI image responses instead of returning a placeholder\n- preserve Azure timeout/retry and endpoint URL behavior\n\nVerification:\n- cargo fmt --all -- --check\n- git diff --check origin/main...HEAD\n- bash scripts/guards/check_pr_scope.sh\n- bash scripts/guards/check_pr_overlap.sh\n- cargo test --all-features azure\n\nFollow-up: a smaller PR will wire the factory/native dispatch after this parity slice lands.