### PR TITLE
fix(rate-limit): enforce limiter on auth rejections

### DIFF
--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -7,6 +7,7 @@ use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
 use crate::server::middleware::helpers::{
     extract_auth_method_with_api_key_header, is_public_route,
 };
+use crate::server::middleware::rate_limit::enforce_rate_limit_for_rejected_auth;
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{HttpMessage, HttpRequest, web};
@@ -77,6 +78,9 @@ where
             let enable_jwt = cfg.auth().enable_jwt;
             let enable_api_key = cfg.auth().enable_api_key;
             let api_key_header = cfg.auth().api_key_header.clone();
+            let rate_limit_enabled = cfg.gateway.rate_limit.enabled;
+            let rate_limit_rpm = cfg.gateway.rate_limit.default_rpm;
+            let trusted_proxies = cfg.server().trusted_proxies.clone();
 
             let context = build_request_context(&mut req);
             let auth_method =
@@ -96,6 +100,13 @@ where
             }
 
             if let Err(wait_seconds) = rate_limiter.check_allowed(&client_id) {
+                enforce_gateway_rate_limit_for_auth_rejection(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
+                )
+                .await?;
                 return Err(actix_web::error::ErrorTooManyRequests(format!(
                     "Too many failed attempts. Try again in {} seconds",
                     wait_seconds
@@ -105,12 +116,26 @@ where
             let auth_method = match auth_method {
                 AuthMethod::Jwt(_) if !enable_jwt => {
                     rate_limiter.record_failure(&client_id);
+                    enforce_gateway_rate_limit_for_auth_rejection(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?;
                     return Err(actix_web::error::ErrorUnauthorized(
                         "JWT authentication disabled",
                     ));
                 }
                 AuthMethod::ApiKey(_) if !enable_api_key => {
                     rate_limiter.record_failure(&client_id);
+                    enforce_gateway_rate_limit_for_auth_rejection(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?;
                     return Err(actix_web::error::ErrorUnauthorized(
                         "API key authentication disabled",
                     ));
@@ -120,6 +145,13 @@ where
 
             if matches!(auth_method, AuthMethod::None) {
                 rate_limiter.record_failure(&client_id);
+                enforce_gateway_rate_limit_for_auth_rejection(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
+                )
+                .await?;
                 return Err(actix_web::error::ErrorUnauthorized(
                     "Missing authentication",
                 ));
@@ -149,6 +181,13 @@ where
                             .clone()
                             .unwrap_or_else(|| "unauthorized".to_string())
                     );
+                    enforce_gateway_rate_limit_for_auth_rejection(
+                        &req,
+                        rate_limit_enabled,
+                        rate_limit_rpm,
+                        &trusted_proxies,
+                    )
+                    .await?;
                     Err(actix_web::error::ErrorUnauthorized(
                         result.error.unwrap_or_else(|| "Unauthorized".to_string()),
                     ))
@@ -163,6 +202,19 @@ where
             }
         })
     }
+}
+
+async fn enforce_gateway_rate_limit_for_auth_rejection(
+    req: &ServiceRequest,
+    enabled: bool,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    if !enabled {
+        return Ok(());
+    }
+
+    enforce_rate_limit_for_rejected_auth(req, requests_per_minute, trusted_proxies).await
 }
 
 /// Extract request context from request

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -7,7 +7,9 @@ use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
 use crate::server::middleware::helpers::{
     extract_auth_method_with_api_key_header, is_public_route,
 };
-use crate::server::middleware::rate_limit::enforce_rate_limit_for_rejected_auth;
+use crate::server::middleware::rate_limit::{
+    enforce_rate_limit_for_rejected_auth, reject_if_rate_limited_for_auth_attempt,
+};
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{HttpMessage, HttpRequest, web};
@@ -157,6 +159,16 @@ where
                 ));
             }
 
+            if requires_auth_verification(&auth_method) {
+                reject_if_gateway_rate_limited_before_auth(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
+                )
+                .await?;
+            }
+
             match app_state.auth.authenticate(auth_method, context).await {
                 Ok(result) if result.success => {
                     rate_limiter.record_success(&client_id);
@@ -215,6 +227,26 @@ async fn enforce_gateway_rate_limit_for_auth_rejection(
     }
 
     enforce_rate_limit_for_rejected_auth(req, requests_per_minute, trusted_proxies).await
+}
+
+async fn reject_if_gateway_rate_limited_before_auth(
+    req: &ServiceRequest,
+    enabled: bool,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    if !enabled {
+        return Ok(());
+    }
+
+    reject_if_rate_limited_for_auth_attempt(req, requests_per_minute, trusted_proxies).await
+}
+
+fn requires_auth_verification(auth_method: &AuthMethod) -> bool {
+    matches!(
+        auth_method,
+        AuthMethod::Jwt(_) | AuthMethod::ApiKey(_) | AuthMethod::Session(_)
+    )
 }
 
 /// Extract request context from request
@@ -382,5 +414,19 @@ mod tests {
             get_client_identifier(&req_b, &auth_b)
         );
         assert_eq!(get_client_identifier(&req_a, &auth_a), "ip:203.0.113.80");
+    }
+
+    #[test]
+    fn auth_verification_precheck_only_applies_to_present_credentials() {
+        assert!(requires_auth_verification(&AuthMethod::Jwt(
+            "jwt-token".to_string()
+        )));
+        assert!(requires_auth_verification(&AuthMethod::ApiKey(
+            "api-key".to_string()
+        )));
+        assert!(requires_auth_verification(&AuthMethod::Session(
+            "session-id".to_string()
+        )));
+        assert!(!requires_auth_verification(&AuthMethod::None));
     }
 }

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -14,6 +14,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
@@ -25,6 +26,11 @@ use tracing::{debug, info, warn};
 /// attacker rotates source addresses. The value matches `AuthRateLimiter`'s
 /// `DEFAULT_MAX_ENTRIES`.
 const MAX_FALLBACK_ENTRIES: usize = 10_000;
+
+static AUTH_REJECTION_FALLBACK_STORE: OnceLock<Arc<DashMap<String, KeyTracker>>> = OnceLock::new();
+
+const GLOBAL_LIMITER_SOURCE: &str = "global";
+const FALLBACK_LIMITER_SOURCE: &str = "fallback";
 
 /// Fallback per-key tracker for sliding window when global rate limiter is unavailable
 struct KeyTracker {
@@ -64,6 +70,18 @@ impl KeyTracker {
     }
 }
 
+struct RateLimitPass {
+    source: &'static str,
+    limit: u32,
+    remaining: u32,
+}
+
+struct RateLimitRejection {
+    source: &'static str,
+    retry_after: u64,
+    limit: u32,
+}
+
 /// Evict trackers when the fallback store exceeds the cap.
 ///
 /// Two-pass strategy: first drop trackers whose latest timestamp is already
@@ -92,6 +110,101 @@ fn enforce_fallback_capacity(store: &DashMap<String, KeyTracker>, window: Durati
     candidates.sort_by_key(|(ts, _)| *ts);
     for (_, key) in candidates.into_iter().take(overflow) {
         store.remove(&key);
+    }
+}
+
+async fn check_rate_limit_key(
+    key: &str,
+    requests_per_minute: u32,
+    fallback_store: &DashMap<String, KeyTracker>,
+) -> Result<RateLimitPass, RateLimitRejection> {
+    if let Some(global_limiter) = get_global_rate_limiter() {
+        let limit = global_limiter.limit();
+        let result = global_limiter.check_and_record(key).await;
+
+        if !result.allowed {
+            return Err(RateLimitRejection {
+                source: GLOBAL_LIMITER_SOURCE,
+                retry_after: result.retry_after_secs.unwrap_or(60),
+                limit,
+            });
+        }
+
+        return Ok(RateLimitPass {
+            source: GLOBAL_LIMITER_SOURCE,
+            limit,
+            remaining: result.remaining,
+        });
+    }
+
+    let window = Duration::from_secs(60);
+    let (allowed, retry_after) = {
+        let mut tracker = fallback_store
+            .entry(key.to_string())
+            .or_insert_with(KeyTracker::new);
+        tracker.check_and_record(requests_per_minute, window)
+    };
+    if fallback_store.len() > MAX_FALLBACK_ENTRIES {
+        enforce_fallback_capacity(fallback_store, window);
+    }
+
+    if !allowed {
+        return Err(RateLimitRejection {
+            source: FALLBACK_LIMITER_SOURCE,
+            retry_after,
+            limit: requests_per_minute,
+        });
+    }
+
+    let remaining = fallback_store
+        .get(key)
+        .map(|tracker| requests_per_minute.saturating_sub(tracker.timestamps.len() as u32))
+        .unwrap_or(requests_per_minute);
+
+    Ok(RateLimitPass {
+        source: FALLBACK_LIMITER_SOURCE,
+        limit: requests_per_minute,
+        remaining,
+    })
+}
+
+fn auth_rejection_fallback_store() -> Arc<DashMap<String, KeyTracker>> {
+    AUTH_REJECTION_FALLBACK_STORE
+        .get_or_init(|| Arc::new(DashMap::new()))
+        .clone()
+}
+
+pub(super) async fn enforce_rate_limit_for_rejected_auth(
+    req: &ServiceRequest,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    let key = extract_client_key(req, trusted_proxies);
+    let fallback_store = auth_rejection_fallback_store();
+
+    match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await {
+        Ok(pass) => {
+            debug!(
+                client = %key,
+                limit = pass.limit,
+                remaining = pass.remaining,
+                "Rate limit check passed for rejected auth path ({} limiter)",
+                pass.source
+            );
+            Ok(())
+        }
+        Err(rejection) => {
+            warn!(
+                client = %key,
+                "Rate limit exceeded for rejected auth path ({} limiter): retry after {}s",
+                rejection.source,
+                rejection.retry_after
+            );
+            Err(actix_web::Error::from(RateLimitError {
+                retry_after: rejection.retry_after,
+                limit: rejection.limit,
+            }))
+        }
     }
 }
 
@@ -259,84 +372,39 @@ where
 
         let client_key = extract_client_key(&req, &trusted_proxies);
 
-        // --- Try global rate limiter first ---
-        if let Some(global_limiter) = get_global_rate_limiter() {
-            let limit = global_limiter.limit();
-            // service.call() returns a lazy future; it only executes on .await.
-            // We must call it here because it consumes `req`, but we will NOT
-            // await it if the rate check fails — so no downstream work is wasted.
-            let fut = self.service.call(req);
-            let key = client_key.clone();
-
-            return Box::pin(async move {
-                let result = global_limiter.check_and_record(&key).await;
-
-                if !result.allowed {
-                    let retry_after = result.retry_after_secs.unwrap_or(60);
-                    warn!(
-                        client = %key,
-                        path = %path,
-                        "Rate limit exceeded (global limiter): retry after {}s",
-                        retry_after
-                    );
-                    let err = RateLimitError { retry_after, limit };
-                    return Err(actix_web::Error::from(err));
-                }
-
-                debug!(
-                    client = %key,
-                    remaining = result.remaining,
-                    "Rate limit check passed (global limiter)"
-                );
-
-                let res = fut.await?;
-                let duration = start_time.elapsed();
-                info!(
-                    "{} {} completed in {:?} with status {}",
-                    method,
-                    path,
-                    duration,
-                    res.status()
-                );
-                Ok(res)
-            });
-        }
-
-        // --- Fallback: in-process sliding window using middleware's requests_per_minute ---
         let fallback_store = self.fallback_store.clone();
+        // service.call() returns a lazy future; it only executes on .await.
+        // We must call it here because it consumes `req`, but we will NOT
+        // await it if the rate check fails, so no downstream work is wasted.
         let fut = self.service.call(req);
         let key = client_key.clone();
 
         Box::pin(async move {
-            let window = Duration::from_secs(60);
-            let (allowed, retry_after) = {
-                let mut tracker = fallback_store
-                    .entry(key.clone())
-                    .or_insert_with(KeyTracker::new);
-                tracker.check_and_record(requests_per_minute, window)
+            let pass = match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await
+            {
+                Ok(pass) => pass,
+                Err(rejection) => {
+                    warn!(
+                        client = %key,
+                        path = %path,
+                        "Rate limit exceeded ({} limiter): retry after {}s",
+                        rejection.source,
+                        rejection.retry_after
+                    );
+                    let err = RateLimitError {
+                        retry_after: rejection.retry_after,
+                        limit: rejection.limit,
+                    };
+                    return Err(actix_web::Error::from(err));
+                }
             };
-            if fallback_store.len() > MAX_FALLBACK_ENTRIES {
-                enforce_fallback_capacity(&fallback_store, window);
-            }
-
-            if !allowed {
-                warn!(
-                    client = %key,
-                    path = %path,
-                    "Rate limit exceeded (fallback limiter): retry after {}s",
-                    retry_after
-                );
-                let err = RateLimitError {
-                    retry_after,
-                    limit: requests_per_minute,
-                };
-                return Err(actix_web::Error::from(err));
-            }
 
             debug!(
                 client = %key,
-                limit = requests_per_minute,
-                "Rate limit check passed (fallback limiter)"
+                limit = pass.limit,
+                remaining = pass.remaining,
+                "Rate limit check passed ({} limiter)",
+                pass.source
             );
 
             let res = fut.await?;

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -44,16 +44,13 @@ impl KeyTracker {
         }
     }
 
-    /// Check-and-record atomically: returns (allowed, retry_after_secs)
-    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
+    fn check(&mut self, limit: u32, window: Duration) -> (bool, u64) {
         let now = Instant::now();
-        // Evict timestamps outside the window
         self.timestamps
             .retain(|&ts| now.duration_since(ts) < window);
 
         let count = self.timestamps.len() as u32;
         if count >= limit {
-            // Estimate when the oldest entry expires
             let retry_after = self
                 .timestamps
                 .first()
@@ -62,11 +59,20 @@ impl KeyTracker {
                     window.saturating_sub(age).as_secs().max(1)
                 })
                 .unwrap_or(window.as_secs());
-            (false, retry_after)
-        } else {
-            self.timestamps.push(now);
-            (true, 0)
+            return (false, retry_after);
         }
+
+        (true, 0)
+    }
+
+    /// Check-and-record atomically: returns (allowed, retry_after_secs)
+    fn check_and_record(&mut self, limit: u32, window: Duration) -> (bool, u64) {
+        let (allowed, retry_after) = self.check(limit, window);
+        if allowed {
+            self.timestamps.push(Instant::now());
+        }
+
+        (allowed, retry_after)
     }
 }
 
@@ -168,10 +174,93 @@ async fn check_rate_limit_key(
     })
 }
 
+async fn check_rate_limit_key_status(
+    key: &str,
+    requests_per_minute: u32,
+    fallback_store: &DashMap<String, KeyTracker>,
+) -> Result<RateLimitPass, RateLimitRejection> {
+    if let Some(global_limiter) = get_global_rate_limiter() {
+        let limit = global_limiter.limit();
+        let result = global_limiter.check(key).await;
+
+        if !result.allowed {
+            return Err(RateLimitRejection {
+                source: GLOBAL_LIMITER_SOURCE,
+                retry_after: result.retry_after_secs.unwrap_or(60),
+                limit,
+            });
+        }
+
+        return Ok(RateLimitPass {
+            source: GLOBAL_LIMITER_SOURCE,
+            limit,
+            remaining: result.remaining,
+        });
+    }
+
+    let window = Duration::from_secs(60);
+    let Some(mut tracker) = fallback_store.get_mut(key) else {
+        return Ok(RateLimitPass {
+            source: FALLBACK_LIMITER_SOURCE,
+            limit: requests_per_minute,
+            remaining: requests_per_minute,
+        });
+    };
+
+    let (allowed, retry_after) = tracker.check(requests_per_minute, window);
+    if !allowed {
+        return Err(RateLimitRejection {
+            source: FALLBACK_LIMITER_SOURCE,
+            retry_after,
+            limit: requests_per_minute,
+        });
+    }
+
+    Ok(RateLimitPass {
+        source: FALLBACK_LIMITER_SOURCE,
+        limit: requests_per_minute,
+        remaining: requests_per_minute.saturating_sub(tracker.timestamps.len() as u32),
+    })
+}
+
 fn auth_rejection_fallback_store() -> Arc<DashMap<String, KeyTracker>> {
     AUTH_REJECTION_FALLBACK_STORE
         .get_or_init(|| Arc::new(DashMap::new()))
         .clone()
+}
+
+pub(super) async fn reject_if_rate_limited_for_auth_attempt(
+    req: &ServiceRequest,
+    requests_per_minute: u32,
+    trusted_proxies: &[String],
+) -> Result<(), actix_web::Error> {
+    let key = extract_client_key(req, trusted_proxies);
+    let fallback_store = auth_rejection_fallback_store();
+
+    match check_rate_limit_key_status(&key, requests_per_minute, &fallback_store).await {
+        Ok(pass) => {
+            debug!(
+                client = %key,
+                limit = pass.limit,
+                remaining = pass.remaining,
+                "Rate limit pre-check passed for auth attempt ({} limiter)",
+                pass.source
+            );
+            Ok(())
+        }
+        Err(rejection) => {
+            warn!(
+                client = %key,
+                "Rate limit exceeded before auth verification ({} limiter): retry after {}s",
+                rejection.source,
+                rejection.retry_after
+            );
+            Err(actix_web::Error::from(RateLimitError {
+                retry_after: rejection.retry_after,
+                limit: rejection.limit,
+            }))
+        }
+    }
 }
 
 pub(super) async fn enforce_rate_limit_for_rejected_auth(
@@ -538,6 +627,33 @@ mod tests {
         let key = extract_client_key(&req, &[]);
 
         assert_eq!(key, "user:user-123");
+    }
+
+    #[test]
+    fn test_key_tracker_status_check_does_not_record() {
+        let mut tracker = KeyTracker::new();
+        let window = Duration::from_secs(60);
+
+        let (allowed, retry_after) = tracker.check(1, window);
+
+        assert!(allowed);
+        assert_eq!(retry_after, 0);
+        assert!(tracker.timestamps.is_empty());
+    }
+
+    #[test]
+    fn test_key_tracker_status_check_rejects_full_bucket_without_recording() {
+        let mut tracker = KeyTracker::new();
+        let window = Duration::from_secs(60);
+        let (allowed, _) = tracker.check_and_record(1, window);
+        assert!(allowed);
+        let recorded = tracker.timestamps.len();
+
+        let (allowed, retry_after) = tracker.check(1, window);
+
+        assert!(!allowed);
+        assert!(retry_after > 0);
+        assert_eq!(tracker.timestamps.len(), recorded);
     }
 
     #[test]

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
+    async fn test_rotating_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
         let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
         let hit_counter = Arc::new(AtomicUsize::new(0));
 
@@ -268,11 +268,11 @@ mod tests {
         let second = test::TestRequest::get()
             .uri(AUTH_PROBE_PATH)
             .peer_addr("203.0.113.102:1001".parse().unwrap())
-            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key-rotated"))
             .to_request();
         let second_error = test::try_call_service(&app, second)
             .await
-            .expect_err("second invalid-auth request should hit gateway rate limit");
+            .expect_err("second rotating invalid-auth request should hit gateway rate limit");
         assert_eq!(
             second_error.as_response_error().status_code(),
             StatusCode::TOO_MANY_REQUESTS

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -11,7 +11,7 @@ mod tests {
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
     use litellm_rs::core::types::context::RequestContext;
     use litellm_rs::server::http::HttpServer;
-    use litellm_rs::server::middleware::AuthMiddleware;
+    use litellm_rs::server::middleware::{AuthMiddleware, RateLimitMiddleware};
     use litellm_rs::server::state::AppState;
     use litellm_rs::utils::auth::crypto::keys::{extract_api_key_prefix, hash_api_key};
     use serde::{Deserialize, Serialize};
@@ -61,7 +61,11 @@ mod tests {
         HttpResponse::Ok().json(payload)
     }
 
-    async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {
+    async fn build_test_state_with_rate_limit(
+        enable_jwt: bool,
+        enable_api_key: bool,
+        default_rpm: Option<u32>,
+    ) -> AppState {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = enable_jwt;
         config.gateway.auth.enable_api_key = enable_api_key;
@@ -69,6 +73,10 @@ mod tests {
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        if let Some(default_rpm) = default_rpm {
+            config.gateway.rate_limit.enabled = true;
+            config.gateway.rate_limit.default_rpm = default_rpm;
+        }
 
         let server = HttpServer::new(&config)
             .await
@@ -80,6 +88,10 @@ mod tests {
             .await
             .expect("failed to run in-memory DB migrations for auth middleware integration test");
         state
+    }
+
+    async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {
+        build_test_state_with_rate_limit(enable_jwt, enable_api_key, None).await
     }
 
     async fn seed_valid_principal(state: &AppState) -> SeededPrincipal {
@@ -182,6 +194,90 @@ mod tests {
         );
         assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
         assert!(error.to_string().contains("Invalid API key"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
+        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::new(1))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.101:1000".parse().unwrap())
+            .to_request();
+        let first_error = test::try_call_service(&app, first)
+            .await
+            .expect_err("first missing-auth request should fail in auth middleware");
+        assert_eq!(
+            first_error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.101:1001".parse().unwrap())
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second missing-auth request should hit gateway rate limit");
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
+        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::new(1))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.102:1000".parse().unwrap())
+            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+            .to_request();
+        let first_error = test::try_call_service(&app, first)
+            .await
+            .expect_err("first invalid-auth request should fail in auth middleware");
+        assert_eq!(
+            first_error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.102:1001".parse().unwrap())
+            .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second invalid-auth request should hit gateway rate limit");
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Split replacement for the first slice of #658. Refs #653.\n\nThis slice is based on latest main and keeps the change focused on applying the gateway limiter before auth short-circuits for missing/invalid auth. Follow-up split PRs will carry the reservation/release race-safety work from #658.\n\nVerification from this session:\n- cargo fmt --all -- --check\n- git diff --check origin/main...HEAD\n- bash scripts/guards/check_pr_scope.sh\n- cargo test --all-features auth_middleware\n- cargo check --all-features\n\nScope gate: 3 files / 354 changed lines.