### PR TITLE
fix(rate-limit): add releasable reservations

### DIFF
--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -4,9 +4,74 @@ use super::types::{RateLimitEntry, RateLimitResult};
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
 use dashmap::DashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(feature = "gateway")]
 use tracing::warn;
+
+/// Backend that recorded a rate-limit reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitRecordSource {
+    Disabled,
+    Local,
+    Distributed,
+}
+
+/// A concrete rate-limit record that may later be released.
+///
+/// The auth middleware consumes this in the follow-up split PR; keep the
+/// primitive here so the core limiter behavior can land separately.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct RateLimitReservation {
+    source: RateLimitRecordSource,
+    recorded_at: Instant,
+    expires_at: Option<Instant>,
+}
+
+#[allow(dead_code)]
+impl RateLimitReservation {
+    fn new(source: RateLimitRecordSource, recorded_at: Instant, reset_after_secs: u64) -> Self {
+        let expires_at = match source {
+            RateLimitRecordSource::Disabled => None,
+            RateLimitRecordSource::Local | RateLimitRecordSource::Distributed => {
+                Some(recorded_at + Duration::from_secs(reset_after_secs.max(1)))
+            }
+        };
+
+        Self {
+            source,
+            recorded_at,
+            expires_at,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        source: RateLimitRecordSource,
+        recorded_at: Instant,
+        reset_after_secs: u64,
+    ) -> Self {
+        Self::new(source, recorded_at, reset_after_secs)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source(&self) -> RateLimitRecordSource {
+        self.source
+    }
+
+    fn remaining_window_secs(&self) -> u64 {
+        let Some(expires_at) = self.expires_at else {
+            return 0;
+        };
+
+        let remaining = expires_at.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            0
+        } else {
+            remaining.as_secs().max(1)
+        }
+    }
+}
 
 /// Rate limiter implementation
 pub struct RateLimiter {
@@ -22,6 +87,29 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
+    pub(super) fn token_bucket_reservation_window(&self) -> Duration {
+        self.window
+    }
+
+    fn local_reservation_reset_after_secs(&self, result: &RateLimitResult) -> u64 {
+        match self.config.strategy {
+            RateLimitStrategy::TokenBucket => self.token_bucket_reservation_window().as_secs(),
+            RateLimitStrategy::SlidingWindow => self.window.as_secs(),
+            RateLimitStrategy::FixedWindow => result.reset_after_secs,
+        }
+    }
+
+    fn disabled_result(&self) -> RateLimitResult {
+        RateLimitResult {
+            allowed: true,
+            current_count: 0,
+            limit: self.config.default_rpm,
+            remaining: self.config.default_rpm,
+            reset_after_secs: 0,
+            retry_after_secs: None,
+        }
+    }
+
     /// Create a new rate limiter
     pub fn new(config: RateLimitConfig) -> Self {
         Self {
@@ -64,14 +152,7 @@ impl RateLimiter {
     /// Use check_and_record() for atomic check-then-record operations.
     pub async fn check(&self, key: &str) -> RateLimitResult {
         if !self.config.enabled {
-            return RateLimitResult {
-                allowed: true,
-                current_count: 0,
-                limit: self.config.default_rpm,
-                remaining: self.config.default_rpm,
-                reset_after_secs: 0,
-                retry_after_secs: None,
-            };
+            return self.disabled_result();
         }
 
         #[cfg(feature = "gateway")]
@@ -91,9 +172,18 @@ impl RateLimiter {
         }
 
         match self.config.strategy {
-            RateLimitStrategy::SlidingWindow => self.check_sliding_window_impl(key, false).await,
-            RateLimitStrategy::TokenBucket => self.check_token_bucket_impl(key, false).await,
-            RateLimitStrategy::FixedWindow => self.check_fixed_window_impl(key, false).await,
+            RateLimitStrategy::SlidingWindow => {
+                self.check_sliding_window_impl(key, false, Instant::now())
+                    .await
+            }
+            RateLimitStrategy::TokenBucket => {
+                self.check_token_bucket_impl(key, false, Instant::now())
+                    .await
+            }
+            RateLimitStrategy::FixedWindow => {
+                self.check_fixed_window_impl(key, false, Instant::now())
+                    .await
+            }
         }
     }
 
@@ -102,15 +192,20 @@ impl RateLimiter {
     /// This is the preferred method for rate limiting as it performs both
     /// the check and record operations in a single lock acquisition.
     pub async fn check_and_record(&self, key: &str) -> RateLimitResult {
+        self.check_and_record_with_source(key).await.0
+    }
+
+    /// Atomically check and record a request, returning the backend used.
+    pub(crate) async fn check_and_record_with_source(
+        &self,
+        key: &str,
+    ) -> (RateLimitResult, RateLimitReservation) {
         if !self.config.enabled {
-            return RateLimitResult {
-                allowed: true,
-                current_count: 0,
-                limit: self.config.default_rpm,
-                remaining: self.config.default_rpm,
-                reset_after_secs: 0,
-                retry_after_secs: None,
-            };
+            let recorded_at = Instant::now();
+            return (
+                self.disabled_result(),
+                RateLimitReservation::new(RateLimitRecordSource::Disabled, recorded_at, 0),
+            );
         }
 
         #[cfg(feature = "gateway")]
@@ -119,7 +214,22 @@ impl RateLimiter {
                 .rate_limit_check_and_record(key, self.config.default_rpm, self.window.as_secs())
                 .await
             {
-                Ok(result) => return result,
+                Ok(result) => {
+                    let reservation = if result.allowed {
+                        RateLimitReservation::new(
+                            RateLimitRecordSource::Distributed,
+                            Instant::now(),
+                            result.reset_after_secs,
+                        )
+                    } else {
+                        RateLimitReservation::new(
+                            RateLimitRecordSource::Disabled,
+                            Instant::now(),
+                            0,
+                        )
+                    };
+                    return (result, reservation);
+                }
                 Err(err) => {
                     warn!(
                         "Redis rate-limit check failed for key {}; falling back to in-process limiter: {}",
@@ -129,11 +239,115 @@ impl RateLimiter {
             }
         }
 
+        let recorded_at = Instant::now();
+        let result = self.check_and_record_local(key, recorded_at).await;
+        let reservation = if result.allowed {
+            let reset_after_secs = self.local_reservation_reset_after_secs(&result);
+            RateLimitReservation::new(RateLimitRecordSource::Local, recorded_at, reset_after_secs)
+        } else {
+            RateLimitReservation::new(RateLimitRecordSource::Disabled, recorded_at, 0)
+        };
+        (result, reservation)
+    }
+
+    async fn check_and_record_local(&self, key: &str, recorded_at: Instant) -> RateLimitResult {
         match self.config.strategy {
-            RateLimitStrategy::SlidingWindow => self.check_sliding_window_impl(key, true).await,
-            RateLimitStrategy::TokenBucket => self.check_token_bucket_impl(key, true).await,
-            RateLimitStrategy::FixedWindow => self.check_fixed_window_impl(key, true).await,
+            RateLimitStrategy::SlidingWindow => {
+                self.check_sliding_window_impl(key, true, recorded_at).await
+            }
+            RateLimitStrategy::TokenBucket => {
+                self.check_token_bucket_impl(key, true, recorded_at).await
+            }
+            RateLimitStrategy::FixedWindow => {
+                self.check_fixed_window_impl(key, true, recorded_at).await
+            }
         }
+    }
+
+    /// Release one request previously reserved by the given backend.
+    #[allow(dead_code)]
+    pub(crate) async fn release_recorded(&self, key: &str, reservation: RateLimitReservation) {
+        if !self.config.enabled {
+            return;
+        }
+
+        match reservation.source {
+            RateLimitRecordSource::Disabled => {}
+            RateLimitRecordSource::Local => {
+                if reservation.remaining_window_secs() == 0 {
+                    return;
+                }
+
+                self.release_local(key, Some(reservation.recorded_at));
+            }
+            RateLimitRecordSource::Distributed => {
+                let remaining_window_secs = reservation.remaining_window_secs();
+                if remaining_window_secs == 0 {
+                    return;
+                }
+
+                #[cfg(feature = "gateway")]
+                if let Some(redis) = &self.redis
+                    && let Err(err) = redis.rate_limit_release(key, remaining_window_secs).await
+                {
+                    warn!("Redis rate-limit release failed for key {}: {}", key, err);
+                }
+            }
+        }
+    }
+
+    fn release_local(&self, key: &str, recorded_at: Option<Instant>) {
+        let limit = self.config.default_rpm as f64;
+        let strategy = self.config.strategy.clone();
+        let reservation_window = self.token_bucket_reservation_window();
+
+        let _removed_entry = self.entries.remove_if_mut(key, |_, entry| {
+            match &strategy {
+                RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                    if let Some(recorded_at) = recorded_at {
+                        if let Some(position) =
+                            entry.timestamps.iter().position(|&ts| ts == recorded_at)
+                        {
+                            entry.timestamps.remove(position);
+                        }
+                    } else {
+                        entry.timestamps.pop();
+                    }
+                }
+                RateLimitStrategy::TokenBucket => {
+                    let should_refund = if let Some(recorded_at) = recorded_at {
+                        let now = Instant::now();
+                        entry
+                            .timestamps
+                            .retain(|&ts| now.saturating_duration_since(ts) < reservation_window);
+
+                        if let Some(position) =
+                            entry.timestamps.iter().position(|&ts| ts == recorded_at)
+                        {
+                            entry.timestamps.remove(position);
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        true
+                    };
+
+                    if should_refund {
+                        entry.tokens = (entry.tokens + 1.0).min(limit);
+                    }
+                }
+            }
+
+            match &strategy {
+                RateLimitStrategy::SlidingWindow | RateLimitStrategy::FixedWindow => {
+                    entry.timestamps.is_empty()
+                }
+                RateLimitStrategy::TokenBucket => {
+                    entry.timestamps.is_empty() && entry.tokens >= limit
+                }
+            }
+        });
     }
 
     /// Record a request (increments counter)

--- a/src/core/rate_limiter/mod.rs
+++ b/src/core/rate_limiter/mod.rs
@@ -12,6 +12,8 @@ mod tests;
 
 // Re-export public types
 pub use limiter::RateLimiter;
+#[cfg(test)]
+pub(crate) use limiter::{RateLimitRecordSource, RateLimitReservation};
 pub use types::RateLimitResult;
 
 use crate::config::models::rate_limit::RateLimitConfig;

--- a/src/core/rate_limiter/strategies.rs
+++ b/src/core/rate_limiter/strategies.rs
@@ -12,8 +12,8 @@ impl RateLimiter {
         &self,
         key: &str,
         record: bool,
+        now: Instant,
     ) -> RateLimitResult {
-        let now = Instant::now();
         let window_start = now - self.window;
         let limit = self.config.default_rpm;
 
@@ -68,8 +68,12 @@ impl RateLimiter {
 
     /// Token bucket rate limiting implementation
     /// If `record` is true, atomically consumes a token if allowed
-    pub(super) async fn check_token_bucket_impl(&self, key: &str, record: bool) -> RateLimitResult {
-        let now = Instant::now();
+    pub(super) async fn check_token_bucket_impl(
+        &self,
+        key: &str,
+        record: bool,
+        now: Instant,
+    ) -> RateLimitResult {
         let limit = self.config.default_rpm;
         let tokens_per_second = limit as f64 / 60.0;
 
@@ -81,6 +85,11 @@ impl RateLimiter {
                 last_refill: now,
                 timestamps: Vec::new(),
             });
+
+        let reservation_window = self.token_bucket_reservation_window();
+        entry
+            .timestamps
+            .retain(|&ts| now.saturating_duration_since(ts) < reservation_window);
 
         // Refill tokens based on elapsed time
         let elapsed = now.duration_since(entry.last_refill);
@@ -105,6 +114,7 @@ impl RateLimiter {
             // Atomically consume token if allowed and record flag is set
             if record {
                 entry.tokens -= 1.0;
+                entry.timestamps.push(now);
             }
             None
         };
@@ -126,31 +136,29 @@ impl RateLimiter {
 
     /// Fixed window rate limiting implementation
     /// If `record` is true, atomically records the request if allowed
-    pub(super) async fn check_fixed_window_impl(&self, key: &str, record: bool) -> RateLimitResult {
-        let now = Instant::now();
+    pub(super) async fn check_fixed_window_impl(
+        &self,
+        key: &str,
+        record: bool,
+        now: Instant,
+    ) -> RateLimitResult {
         let limit = self.config.default_rpm;
 
         let mut entry = self.entries.entry(key.to_string()).or_default();
 
-        // Check if we need to reset the window
-        let window_start = if let Some(&first) = entry.timestamps.first() {
-            let elapsed = now.duration_since(first);
-            if elapsed >= self.window {
-                entry.timestamps.clear();
-                now
-            } else {
-                first
-            }
-        } else {
-            now
-        };
+        if entry.timestamps.is_empty() {
+            entry.last_refill = now;
+        } else if now.duration_since(entry.last_refill) >= self.window {
+            entry.timestamps.clear();
+            entry.last_refill = now;
+        }
 
         let current_count = entry.timestamps.len() as u32;
         let allowed = current_count < limit;
         let remaining = limit.saturating_sub(current_count);
 
         // Calculate reset time
-        let elapsed = now.duration_since(window_start);
+        let elapsed = now.duration_since(entry.last_refill);
         let reset_after_secs = self.window.saturating_sub(elapsed).as_secs();
 
         let retry_after_secs = if !allowed {

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -2,15 +2,25 @@
 
 #[cfg(test)]
 use super::limiter::RateLimiter;
+use super::types::RateLimitEntry;
+use super::{RateLimitRecordSource, RateLimitReservation};
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn test_config(enabled: bool, rpm: u32) -> RateLimitConfig {
+    test_config_with_strategy(enabled, rpm, RateLimitStrategy::SlidingWindow)
+}
+
+fn test_config_with_strategy(
+    enabled: bool,
+    rpm: u32,
+    strategy: RateLimitStrategy,
+) -> RateLimitConfig {
     RateLimitConfig {
         enabled,
         default_rpm: rpm,
         default_tpm: 100000,
-        strategy: RateLimitStrategy::SlidingWindow,
+        strategy,
         ..Default::default()
     }
 }
@@ -146,6 +156,237 @@ async fn test_atomic_check_and_record() {
     // 4th request should be blocked
     let r4 = limiter.check_and_record("atomic-key").await;
     assert!(!r4.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_local_source_restores_capacity() {
+    let limiter = RateLimiter::new(test_config(true, 1));
+
+    let (result, reservation) = limiter.check_and_record_with_source("auth-ip").await;
+    assert!(result.allowed);
+    assert_eq!(reservation.source(), RateLimitRecordSource::Local);
+
+    let blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!blocked.allowed);
+
+    limiter.release_recorded("auth-ip", reservation).await;
+
+    let allowed_again = limiter.check_and_record("auth-ip").await;
+    assert!(allowed_again.allowed);
+}
+
+#[tokio::test]
+async fn test_denied_check_returns_disabled_reservation() {
+    let limiter = RateLimiter::new(test_config(true, 1));
+
+    let (first, first_reservation) = limiter.check_and_record_with_source("auth-ip").await;
+    assert!(first.allowed);
+    assert_eq!(first_reservation.source(), RateLimitRecordSource::Local);
+
+    let (blocked, blocked_reservation) = limiter.check_and_record_with_source("auth-ip").await;
+    assert!(!blocked.allowed);
+    assert_eq!(
+        blocked_reservation.source(),
+        RateLimitRecordSource::Disabled
+    );
+
+    limiter
+        .release_recorded("auth-ip", blocked_reservation)
+        .await;
+
+    let still_blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!still_blocked.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_sliding_and_fixed_windows_remove_empty_entry() {
+    for strategy in [
+        RateLimitStrategy::SlidingWindow,
+        RateLimitStrategy::FixedWindow,
+    ] {
+        let limiter = RateLimiter::new(test_config_with_strategy(true, 1, strategy));
+
+        let (result, reservation) = limiter.check_and_record_with_source("auth-ip").await;
+        assert!(result.allowed);
+        assert!(limiter.entries.contains_key("auth-ip"));
+
+        limiter.release_recorded("auth-ip", reservation).await;
+
+        assert!(!limiter.entries.contains_key("auth-ip"));
+    }
+}
+
+#[tokio::test]
+async fn test_release_recorded_sliding_window_uses_recorded_timestamp_lifetime() {
+    let limiter = RateLimiter::with_window(
+        test_config_with_strategy(true, 2, RateLimitStrategy::SlidingWindow),
+        Duration::from_secs(2),
+    );
+    let key = "auth-ip";
+    let now = Instant::now();
+    limiter.entries.insert(
+        key.to_string(),
+        RateLimitEntry {
+            timestamps: vec![now - Duration::from_millis(1500)],
+            tokens: 0.0,
+            last_refill: now,
+        },
+    );
+
+    let (result, reservation) = limiter.check_and_record_with_source(key).await;
+    assert!(result.allowed);
+
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    limiter.release_recorded(key, reservation).await;
+
+    let first_after_release = limiter.check_and_record(key).await;
+    let second_after_release = limiter.check_and_record(key).await;
+
+    assert!(first_after_release.allowed);
+    assert!(
+        second_after_release.allowed,
+        "release must remove the successful auth reservation for its full sliding window lifetime"
+    );
+}
+
+#[tokio::test]
+async fn test_release_recorded_token_bucket_restores_fresh_reservation() {
+    let limiter = RateLimiter::new(test_config_with_strategy(
+        true,
+        1,
+        RateLimitStrategy::TokenBucket,
+    ));
+
+    let (result, reservation) = limiter.check_and_record_with_source("auth-ip").await;
+    assert!(result.allowed);
+
+    let blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!blocked.allowed);
+
+    limiter.release_recorded("auth-ip", reservation).await;
+
+    let allowed_again = limiter.check_and_record("auth-ip").await;
+    assert!(allowed_again.allowed);
+}
+
+#[tokio::test]
+async fn test_release_recorded_token_bucket_keeps_burst_reservations_releasable() {
+    let limiter = RateLimiter::new(test_config_with_strategy(
+        true,
+        60,
+        RateLimitStrategy::TokenBucket,
+    ));
+    let key = "auth-ip";
+    let original_success = Instant::now() - Duration::from_secs(2);
+
+    limiter.entries.insert(
+        key.to_string(),
+        RateLimitEntry {
+            timestamps: vec![original_success],
+            tokens: 0.0,
+            last_refill: Instant::now(),
+        },
+    );
+
+    limiter
+        .release_recorded(
+            key,
+            RateLimitReservation::for_test(RateLimitRecordSource::Local, original_success, 60),
+        )
+        .await;
+
+    let allowed_again = limiter.check_and_record(key).await;
+    assert!(
+        allowed_again.allowed,
+        "burst reservations must stay releasable beyond one token refill interval"
+    );
+}
+
+#[tokio::test]
+async fn test_release_recorded_token_bucket_skips_expired_reservation() {
+    let limiter = RateLimiter::new(test_config_with_strategy(
+        true,
+        60,
+        RateLimitStrategy::TokenBucket,
+    ));
+    let key = "auth-ip";
+    let original_success = Instant::now() - Duration::from_secs(2);
+    let later_rejected_auth = Instant::now();
+
+    limiter.entries.insert(
+        key.to_string(),
+        RateLimitEntry {
+            timestamps: vec![original_success, later_rejected_auth],
+            tokens: 0.0,
+            last_refill: later_rejected_auth,
+        },
+    );
+
+    limiter
+        .release_recorded(
+            key,
+            RateLimitReservation::for_test(RateLimitRecordSource::Local, original_success, 1),
+        )
+        .await;
+
+    let blocked = limiter.check_and_record(key).await;
+    assert!(
+        !blocked.allowed,
+        "expired success release must not refund a later rejected-auth token"
+    );
+}
+
+#[tokio::test]
+async fn test_release_recorded_fixed_window_preserves_window_anchor() {
+    let limiter = RateLimiter::with_window(
+        test_config_with_strategy(true, 1, RateLimitStrategy::FixedWindow),
+        Duration::from_millis(200),
+    );
+    let key = "auth-ip";
+    let window_start = Instant::now() - Duration::from_millis(150);
+    let later_hit = window_start + Duration::from_millis(50);
+
+    limiter.entries.insert(
+        key.to_string(),
+        RateLimitEntry {
+            timestamps: vec![window_start, later_hit],
+            tokens: 0.0,
+            last_refill: window_start,
+        },
+    );
+
+    limiter
+        .release_recorded(
+            key,
+            RateLimitReservation::for_test(RateLimitRecordSource::Local, window_start, 1),
+        )
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(70)).await;
+    let allowed_after_original_window = limiter.check_and_record(key).await;
+
+    assert!(
+        allowed_after_original_window.allowed,
+        "fixed-window releases must not move the remaining request's window anchor"
+    );
+}
+
+#[tokio::test]
+async fn test_release_recorded_distributed_source_keeps_local_capacity() {
+    let limiter = RateLimiter::new(test_config(true, 1));
+
+    let result = limiter.check_and_record("auth-ip").await;
+    assert!(result.allowed);
+
+    limiter
+        .release_recorded(
+            "auth-ip",
+            RateLimitReservation::for_test(RateLimitRecordSource::Distributed, Instant::now(), 60),
+        )
+        .await;
+
+    let blocked = limiter.check_and_record("auth-ip").await;
+    assert!(!blocked.allowed);
 }
 
 #[tokio::test]

--- a/src/core/rate_limiter/utils.rs
+++ b/src/core/rate_limiter/utils.rs
@@ -2,6 +2,7 @@
 
 use super::limiter::RateLimiter;
 use super::types::RateLimitResult;
+use crate::config::models::rate_limit::RateLimitStrategy;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -13,10 +14,27 @@ impl RateLimiter {
 
         let limit = self.config.default_rpm as f64;
         self.entries.retain(|_, entry| {
-            entry.timestamps.retain(|&t| t > window_start);
-            // Keep entry if it has recent timestamps OR has consumed tokens (not full bucket).
-            // A full bucket (tokens == limit) with no timestamps means the key is idle.
-            !entry.timestamps.is_empty() || entry.tokens < limit
+            match self.config.strategy {
+                RateLimitStrategy::SlidingWindow => {
+                    entry.timestamps.retain(|&t| t > window_start);
+                    !entry.timestamps.is_empty()
+                }
+                RateLimitStrategy::FixedWindow => {
+                    if now.duration_since(entry.last_refill) >= self.window {
+                        entry.timestamps.clear();
+                    }
+                    !entry.timestamps.is_empty()
+                }
+                RateLimitStrategy::TokenBucket => {
+                    let reservation_window = self.token_bucket_reservation_window();
+                    entry
+                        .timestamps
+                        .retain(|&t| now.saturating_duration_since(t) < reservation_window);
+                    // Keep entry if it has recent timestamps OR has consumed tokens (not full bucket).
+                    // A full bucket (tokens == limit) with no timestamps means the key is idle.
+                    !entry.timestamps.is_empty() || entry.tokens < limit
+                }
+            }
         });
     }
 

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -49,6 +49,35 @@ if remaining < 0 then remaining = 0 end
 return {allowed, current, limit, remaining, ttl}
 "#;
 
+const RELEASE_SCRIPT: &str = r#"
+local reservation_ttl = tonumber(ARGV[1])
+if reservation_ttl == nil or reservation_ttl <= 0 then
+  return 0
+end
+
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+if current <= 0 then
+  return 0
+end
+
+local ttl = redis.call("TTL", KEYS[1])
+if ttl < 0 then
+  return current
+end
+
+if ttl > (reservation_ttl + 1) then
+  return current
+end
+
+current = redis.call("DECR", KEYS[1])
+if current <= 0 then
+  redis.call("DEL", KEYS[1])
+  return 0
+end
+
+return current
+"#;
+
 fn redis_rate_limit_key(key: &str) -> String {
     format!("litellm-rs:rate_limit:v1:{}", key)
 }
@@ -163,6 +192,26 @@ impl RedisPool {
             })
         }
     }
+
+    /// Release one previously-recorded request from a distributed fixed window.
+    pub async fn rate_limit_release(&self, key: &str, reservation_ttl_secs: u64) -> Result<()> {
+        if self.noop_mode || reservation_ttl_secs == 0 {
+            return Ok(());
+        }
+
+        let redis_key = redis_rate_limit_key(key);
+        let mut conn = self.get_connection().await?;
+        if let Some(ref mut c) = conn.conn {
+            let _: i64 = redis::Script::new(RELEASE_SCRIPT)
+                .key(redis_key)
+                .arg(reservation_ttl_secs)
+                .invoke_async(c)
+                .await
+                .map_err(GatewayError::from)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -170,6 +219,13 @@ mod tests {
     use super::*;
     use crate::config::models::storage::RedisConfig;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn must<T>(result: Result<T>, context: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{context}: {err}"),
+        }
+    }
 
     #[test]
     fn parses_redis_rate_limit_result() {
@@ -218,6 +274,44 @@ mod tests {
         assert_eq!(second.remaining, 0);
 
         let _ = pool.delete(&redis_rate_limit_key(&key)).await;
+    }
+
+    #[tokio::test]
+    async fn live_redis_release_skips_newer_window_after_original_expiry() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+
+        let key = unique_test_key("rate-limit-release-expired");
+        let first = must(
+            pool.rate_limit_check_and_record(&key, 1, 1).await,
+            "first check should succeed",
+        );
+        assert!(first.allowed);
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+        let second = must(
+            pool.rate_limit_check_and_record(&key, 1, 30).await,
+            "second check should succeed in a new window",
+        );
+        assert!(second.allowed);
+
+        must(
+            pool.rate_limit_release(&key, 1).await,
+            "stale release should be handled",
+        );
+
+        let status = must(
+            pool.rate_limit_status(&key, 1, 30).await,
+            "status should succeed",
+        );
+        assert_eq!(status.current_count, 1);
+        assert_eq!(status.remaining, 0);
+
+        if let Err(err) = pool.delete(&redis_rate_limit_key(&key)).await {
+            eprintln!("failed to clean up Redis rate-limit test key {key}: {err}");
+        }
     }
 
     async fn live_redis_pool() -> Option<RedisPool> {


### PR DESCRIPTION
## Summary
- add rate-limit reservations that remember the backend and record timestamp
- support releasing exact local reservations for sliding/fixed/token-bucket strategies
- add Redis release support for distributed reservations

## Split plan
This supersedes part of #669. It lands only the core limiter/Redis primitives so the follow-up auth middleware PR can reserve before credential verification and release on successful auth without exceeding the scope guard.

## Verification
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh
- cargo test --all-features rate_limiter
- cargo check --all-features

Note: local Rust 1.95 clippy still fails on unrelated pre-existing warnings in sagemaker/vertex_ai files outside this PR.