### PR TITLE
fix(provider): wire Azure native dispatch

### DIFF
--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -5,6 +5,8 @@
 
 use super::super::unified_provider::ProviderError;
 use super::super::{anthropic, bedrock, cloudflare, macros, mistral, openai, openai_like};
+#[cfg(feature = "providers-extra")]
+use super::super::{azure, azure_ai};
 use std::env;
 
 // ==================== Config Extraction Helpers ====================
@@ -68,6 +70,84 @@ pub(super) fn merge_string_headers_value(
         return true;
     }
     false
+}
+
+#[cfg(not(feature = "providers-extra"))]
+fn build_azure_openai_like_config_for_factory(
+    config: &serde_json::Value,
+    provider_name: &'static str,
+    endpoint_alias: &'static str,
+) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+    let api_key = macros::require_config_str(config, "api_key", provider_name)?;
+    let api_base = config_str(config, "base_url")
+        .or_else(|| config_str(config, "api_base"))
+        .or_else(|| config_str(config, "endpoint"))
+        .map(Ok)
+        .or_else(|| {
+            config_str(config, endpoint_alias)
+                .map(|endpoint| validate_openai_like_azure_fallback_base(provider_name, endpoint))
+        })
+        .unwrap_or_else(|| {
+            Err(ProviderError::configuration(
+                provider_name,
+                "base_url (or endpoint) is required",
+            ))
+        })?;
+
+    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
+    oai_config.provider_name = provider_name.to_string();
+
+    if let Some(api_version) = config_str(config, "api_version") {
+        oai_config.base.api_version = Some(api_version.to_string());
+    }
+    if let Some(timeout) = config_u64(config, "timeout") {
+        oai_config.base.timeout = timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        oai_config.base.max_retries = max_retries;
+    }
+    merge_string_headers(&mut oai_config.base.headers, config, "headers");
+    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+
+    Ok(oai_config)
+}
+
+#[cfg(not(feature = "providers-extra"))]
+fn validate_openai_like_azure_fallback_base<'a>(
+    provider_name: &'static str,
+    endpoint: &'a str,
+) -> Result<&'a str, ProviderError> {
+    let normalized = endpoint.trim_end_matches('/');
+    let is_openai_like = match provider_name {
+        "azure" => normalized.contains("/openai/deployments/"),
+        "azure_ai" => normalized.ends_with("/models") || normalized.contains("/models/"),
+        _ => true,
+    };
+
+    if is_openai_like {
+        Ok(endpoint)
+    } else {
+        Err(ProviderError::configuration(
+            provider_name,
+            format!(
+                "{provider_name} fallback requires base_url/api_base with an OpenAI-compatible path; enable providers-extra for bare Azure endpoints"
+            ),
+        ))
+    }
+}
+
+#[cfg(not(feature = "providers-extra"))]
+pub(super) fn build_azure_ai_openai_like_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+    build_azure_openai_like_config_for_factory(config, "azure_ai", "azure_ai_endpoint")
+}
+
+#[cfg(not(feature = "providers-extra"))]
+pub(super) fn build_azure_openai_like_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+    build_azure_openai_like_config_for_factory(config, "azure", "azure_endpoint")
 }
 
 pub(super) fn apply_tier1_openai_like_overrides(
@@ -360,33 +440,36 @@ pub(super) fn build_v0_config_from_factory(
     Ok(oai_config)
 }
 
+#[cfg(feature = "providers-extra")]
 pub(super) fn build_azure_ai_config_from_factory(
     config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+) -> Result<azure_ai::AzureAIConfig, ProviderError> {
     let api_key = macros::require_config_str(config, "api_key", "azure_ai")?;
     let api_base = config_str(config, "base_url")
         .or_else(|| config_str(config, "api_base"))
         .or_else(|| config_str(config, "endpoint"))
+        .or_else(|| config_str(config, "azure_ai_endpoint"))
         .ok_or_else(|| {
             ProviderError::configuration("azure_ai", "base_url (or endpoint) is required")
         })?;
 
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "azure_ai".to_string();
+    let mut azure_ai_config = azure_ai::AzureAIConfig::new("azure_ai");
+    azure_ai_config.base.api_key = Some(api_key.to_string());
+    azure_ai_config.base.api_base = Some(api_base.to_string());
 
     if let Some(api_version) = config_str(config, "api_version") {
-        oai_config.base.api_version = Some(api_version.to_string());
+        azure_ai_config.base.api_version = Some(api_version.to_string());
     }
     if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
+        azure_ai_config.base.timeout = timeout;
     }
     if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
+        azure_ai_config.base.max_retries = max_retries;
     }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+    merge_string_headers(&mut azure_ai_config.base.headers, config, "headers");
+    merge_string_headers(&mut azure_ai_config.base.headers, config, "custom_headers");
 
-    Ok(oai_config)
+    Ok(azure_ai_config)
 }
 
 pub(super) fn build_amazon_nova_config_from_factory(
@@ -435,33 +518,41 @@ pub(super) fn build_fal_ai_config_from_factory(
     Ok(oai_config)
 }
 
+#[cfg(feature = "providers-extra")]
 pub(super) fn build_azure_config_from_factory(
     config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
+) -> Result<azure::AzureConfig, ProviderError> {
     let api_key = macros::require_config_str(config, "api_key", "azure")?;
     let api_base = config_str(config, "base_url")
         .or_else(|| config_str(config, "api_base"))
         .or_else(|| config_str(config, "endpoint"))
+        .or_else(|| config_str(config, "azure_endpoint"))
         .ok_or_else(|| {
             ProviderError::configuration("azure", "base_url (or endpoint) is required")
         })?;
 
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "azure".to_string();
+    let mut azure_config = azure::AzureConfig::new()
+        .with_api_key(api_key.to_string())
+        .with_azure_endpoint(api_base.to_string());
 
     if let Some(api_version) = config_str(config, "api_version") {
-        oai_config.base.api_version = Some(api_version.to_string());
+        azure_config.api_version = api_version.to_string();
+    }
+    if let Some(deployment_name) =
+        config_str(config, "deployment_name").or_else(|| config_str(config, "deployment"))
+    {
+        azure_config.deployment_name = Some(deployment_name.to_string());
     }
     if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
+        azure_config.timeout = timeout;
     }
     if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
+        azure_config.max_retries = max_retries;
     }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+    merge_string_headers(&mut azure_config.custom_headers, config, "headers");
+    merge_string_headers(&mut azure_config.custom_headers, config, "custom_headers");
 
-    Ok(oai_config)
+    Ok(azure_config)
 }
 
 pub(super) fn build_bedrock_config_from_factory(

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -267,6 +267,194 @@ fn test_build_openai_like_config_from_factory_requires_api_base() {
     assert!(err.to_string().contains("base_url"));
 }
 
+#[cfg(not(feature = "providers-extra"))]
+#[test]
+fn test_build_azure_openai_like_fallback_configs_map_fields() {
+    let azure = serde_json::json!({
+        "api_key": "azure-key",
+        "azure_endpoint": "https://example-resource.openai.azure.com/openai/deployments/prod",
+        "api_version": "2024-03-01",
+        "timeout": 66,
+        "max_retries": 4,
+        "headers": {
+            "x-azure-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-custom": "custom"
+        }
+    });
+    let azure_config = build_azure_openai_like_config_from_factory(&azure)
+        .unwrap_or_else(|err| panic!("azure fallback config should parse: {err}"));
+
+    assert_eq!(azure_config.provider_name, "azure");
+    assert_eq!(azure_config.base.api_key.as_deref(), Some("azure-key"));
+    assert_eq!(
+        azure_config.base.api_base.as_deref(),
+        Some("https://example-resource.openai.azure.com/openai/deployments/prod")
+    );
+    assert_eq!(azure_config.base.api_version.as_deref(), Some("2024-03-01"));
+    assert_eq!(azure_config.base.timeout, 66);
+    assert_eq!(azure_config.base.max_retries, 4);
+    assert_eq!(
+        azure_config
+            .base
+            .headers
+            .get("x-azure-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        azure_config
+            .custom_headers
+            .get("x-azure-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+
+    let azure_ai = serde_json::json!({
+        "api_key": "azure-ai-key",
+        "azure_ai_endpoint": "https://example-resource.services.ai.azure.com/models",
+        "api_version": "2024-05-01-preview"
+    });
+    let azure_ai_config = build_azure_ai_openai_like_config_from_factory(&azure_ai)
+        .unwrap_or_else(|err| panic!("azure_ai fallback config should parse: {err}"));
+
+    assert_eq!(azure_ai_config.provider_name, "azure_ai");
+    assert_eq!(
+        azure_ai_config.base.api_key.as_deref(),
+        Some("azure-ai-key")
+    );
+    assert_eq!(
+        azure_ai_config.base.api_base.as_deref(),
+        Some("https://example-resource.services.ai.azure.com/models")
+    );
+    assert_eq!(
+        azure_ai_config.base.api_version.as_deref(),
+        Some("2024-05-01-preview")
+    );
+}
+
+#[cfg(not(feature = "providers-extra"))]
+#[test]
+fn test_azure_openai_like_fallback_rejects_bare_resource_endpoints() {
+    let azure = serde_json::json!({
+        "api_key": "azure-key",
+        "azure_endpoint": "https://example-resource.openai.azure.com",
+        "deployment_name": "prod"
+    });
+    let err = build_azure_openai_like_config_from_factory(&azure)
+        .err()
+        .unwrap_or_else(|| panic!("bare Azure endpoint should be rejected"));
+    assert!(err.to_string().contains("providers-extra"));
+
+    let azure_ai = serde_json::json!({
+        "api_key": "azure-ai-key",
+        "azure_ai_endpoint": "https://example-resource.services.ai.azure.com"
+    });
+    let err = build_azure_ai_openai_like_config_from_factory(&azure_ai)
+        .err()
+        .unwrap_or_else(|| panic!("bare Azure AI endpoint should be rejected"));
+    assert!(err.to_string().contains("providers-extra"));
+}
+
+#[cfg(feature = "providers-extra")]
+#[test]
+fn test_build_azure_config_from_factory_maps_native_fields() {
+    let config = serde_json::json!({
+        "api_key": "azure-key",
+        "azure_endpoint": "https://example-resource.openai.azure.com",
+        "deployment_name": "gpt-4o-prod",
+        "api_version": "2024-03-01",
+        "timeout": 31,
+        "max_retries": 6,
+        "headers": {
+            "x-azure-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-custom": "custom"
+        }
+    });
+
+    let azure_config = build_azure_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure config should parse: {err}"));
+
+    assert_eq!(azure_config.api_key.as_deref(), Some("azure-key"));
+    assert_eq!(
+        azure_config.azure_endpoint.as_deref(),
+        Some("https://example-resource.openai.azure.com")
+    );
+    assert_eq!(azure_config.deployment_name.as_deref(), Some("gpt-4o-prod"));
+    assert_eq!(azure_config.api_version, "2024-03-01");
+    assert_eq!(azure_config.timeout, 31);
+    assert_eq!(azure_config.max_retries, 6);
+    assert_eq!(
+        azure_config
+            .custom_headers
+            .get("x-azure-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        azure_config
+            .custom_headers
+            .get("x-azure-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+}
+
+#[cfg(feature = "providers-extra")]
+#[test]
+fn test_build_azure_ai_config_from_factory_maps_native_fields() {
+    let config = serde_json::json!({
+        "api_key": "azure-ai-key",
+        "azure_ai_endpoint": "https://example-resource.services.ai.azure.com",
+        "api_version": "2024-05-01-preview",
+        "timeout": 44,
+        "max_retries": 2,
+        "headers": {
+            "x-azure-ai-base": "base"
+        },
+        "custom_headers": {
+            "x-azure-ai-custom": "custom"
+        }
+    });
+
+    let azure_ai_config = build_azure_ai_config_from_factory(&config)
+        .unwrap_or_else(|err| panic!("azure_ai config should parse: {err}"));
+
+    assert_eq!(
+        azure_ai_config.base.api_key.as_deref(),
+        Some("azure-ai-key")
+    );
+    assert_eq!(
+        azure_ai_config.base.api_base.as_deref(),
+        Some("https://example-resource.services.ai.azure.com")
+    );
+    assert_eq!(
+        azure_ai_config.base.api_version.as_deref(),
+        Some("2024-05-01-preview")
+    );
+    assert_eq!(azure_ai_config.base.timeout, 44);
+    assert_eq!(azure_ai_config.base.max_retries, 2);
+    assert_eq!(
+        azure_ai_config
+            .base
+            .headers
+            .get("x-azure-ai-base")
+            .map(String::as_str),
+        Some("base")
+    );
+    assert_eq!(
+        azure_ai_config
+            .base
+            .headers
+            .get("x-azure-ai-custom")
+            .map(String::as_str),
+        Some("custom")
+    );
+}
+
 #[test]
 fn test_env_str_any_skips_empty_values() {
     let _guard = ENV_LOCK.lock().unwrap();

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -9,10 +9,11 @@ use crate::core::providers::unified_provider::ProviderError;
 use crate::core::providers::{
     Provider, anthropic, bedrock, cloudflare, mistral, openai, openai_like,
 };
+#[cfg(feature = "providers-extra")]
+use crate::core::providers::{azure, azure_ai};
 
 use super::builder::{
     build_amazon_nova_config_from_factory, build_anthropic_config_from_factory,
-    build_azure_ai_config_from_factory, build_azure_config_from_factory,
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
     build_fal_ai_config_from_factory, build_github_config_from_factory,
     build_github_copilot_config_from_factory, build_meta_llama_config_from_factory,
@@ -20,6 +21,12 @@ use super::builder::{
     build_openai_like_config_from_factory, build_replicate_config_from_factory,
     build_v0_config_from_factory, build_vertex_ai_config_from_factory, config_str, config_u32,
     config_u64,
+};
+#[cfg(feature = "providers-extra")]
+use super::builder::{build_azure_ai_config_from_factory, build_azure_config_from_factory};
+#[cfg(not(feature = "providers-extra"))]
+use super::builder::{
+    build_azure_ai_openai_like_config_from_factory, build_azure_openai_like_config_from_factory,
 };
 
 impl Provider {
@@ -82,11 +89,21 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             ProviderType::AzureAI => {
-                let oai_config = build_azure_ai_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extra")]
+                {
+                    let azure_ai_config = build_azure_ai_config_from_factory(&config)?;
+                    let provider = azure_ai::AzureAIProvider::new(azure_ai_config)
+                        .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
+                    Ok(Provider::AzureAI(provider))
+                }
+                #[cfg(not(feature = "providers-extra"))]
+                {
+                    let oai_config = build_azure_ai_openai_like_config_from_factory(&config)?;
+                    let provider = openai_like::OpenAILikeProvider::new(oai_config)
+                        .await
+                        .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
+                    Ok(Provider::OpenAILike(provider))
+                }
             }
             ProviderType::AmazonNova => {
                 let oai_config = build_amazon_nova_config_from_factory(&config)?;
@@ -103,11 +120,21 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             ProviderType::Azure => {
-                let oai_config = build_azure_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extra")]
+                {
+                    let azure_config = build_azure_config_from_factory(&config)?;
+                    let provider = azure::AzureOpenAIProvider::new(azure_config)
+                        .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
+                    Ok(Provider::Azure(provider))
+                }
+                #[cfg(not(feature = "providers-extra"))]
+                {
+                    let oai_config = build_azure_openai_like_config_from_factory(&config)?;
+                    let provider = openai_like::OpenAILikeProvider::new(oai_config)
+                        .await
+                        .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
+                    Ok(Provider::OpenAILike(provider))
+                }
             }
             ProviderType::Bedrock => {
                 let bedrock_config = build_bedrock_config_from_factory(&config)?;
@@ -233,6 +260,9 @@ mod tests {
                     | (ProviderType::Bedrock, Provider::Bedrock(_))
                     | (ProviderType::Mistral, Provider::Mistral(_))
                     | (ProviderType::Cloudflare, Provider::Cloudflare(_)) => {}
+                    #[cfg(feature = "providers-extra")]
+                    (ProviderType::Azure, Provider::Azure(_))
+                    | (ProviderType::AzureAI, Provider::AzureAI(_)) => {}
                     _ => panic!(
                         "{:?} is classified Native but created runtime provider {:?}",
                         entry.provider_type,

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -264,6 +264,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => p.$method($($arg),*),
             Provider::Anthropic(p) => p.$method($($arg),*),
             Provider::Bedrock(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
             Provider::OpenAILike(p) => p.$method($($arg),*),
@@ -275,6 +279,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Anthropic(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Bedrock(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
@@ -286,6 +294,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Anthropic(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Bedrock(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*),
@@ -297,6 +309,10 @@ macro_rules! dispatch_provider {
             Provider::OpenAI(p) => LLMProvider::$method(p).await,
             Provider::Anthropic(p) => LLMProvider::$method(p).await,
             Provider::Bedrock(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
             Provider::Cloudflare(p) => LLMProvider::$method(p).await,
             Provider::OpenAILike(p) => LLMProvider::$method(p).await,
@@ -332,6 +348,10 @@ pub enum Provider {
     OpenAI(openai::OpenAIProvider),
     Anthropic(anthropic::AnthropicProvider),
     Bedrock(bedrock::BedrockProvider),
+    #[cfg(feature = "providers-extra")]
+    Azure(azure::AzureOpenAIProvider),
+    #[cfg(feature = "providers-extra")]
+    AzureAI(azure_ai::AzureAIProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
     /// Tier 1: data-driven OpenAI-compatible providers (groq, together, fireworks, etc.)
@@ -345,6 +365,10 @@ impl Provider {
             Provider::OpenAI(_) => "openai",
             Provider::Anthropic(_) => "anthropic",
             Provider::Bedrock(_) => "bedrock",
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(_) => "azure",
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(_) => "azure_ai",
             Provider::Mistral(_) => "mistral",
             Provider::Cloudflare(_) => "cloudflare",
             Provider::OpenAILike(p) => {
@@ -360,6 +384,10 @@ impl Provider {
             Provider::OpenAI(_) => ProviderType::OpenAI,
             Provider::Anthropic(_) => ProviderType::Anthropic,
             Provider::Bedrock(_) => ProviderType::Bedrock,
+            #[cfg(feature = "providers-extra")]
+            Provider::Azure(_) => ProviderType::Azure,
+            #[cfg(feature = "providers-extra")]
+            Provider::AzureAI(_) => ProviderType::AzureAI,
             Provider::Mistral(_) => ProviderType::Mistral,
             Provider::Cloudflare(_) => ProviderType::Cloudflare,
             Provider::OpenAILike(_) => ProviderType::OpenAICompatible,

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -39,13 +39,13 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "native module retained; ProviderType::AmazonNova currently uses a generic OpenAI-compatible adapter",
     ),
     wire("anthropic", "native Provider enum variant"),
-    stub(
+    provider_extra_wire(
         "azure",
-        "native Azure module retained; ProviderType::Azure currently uses a generic OpenAI-compatible adapter",
+        "native Provider enum variant when providers-extra is enabled; otherwise unsupported without generic fallback",
     ),
-    stub(
+    provider_extra_wire(
         "azure_ai",
-        "native Azure AI module retained; ProviderType::AzureAI currently uses a generic OpenAI-compatible adapter",
+        "native Provider enum variant when providers-extra is enabled; otherwise unsupported without generic fallback",
     ),
     internal("base", "shared provider infrastructure"),
     stub(
@@ -279,6 +279,18 @@ const fn internal(module_name: &'static str, reason: &'static str) -> ProviderMo
     entry(module_name, ProviderModuleLifecycle::Internal, reason)
 }
 
+const fn provider_extra_wire(
+    module_name: &'static str,
+    reason: &'static str,
+) -> ProviderModuleLifecycleEntry {
+    let lifecycle = if cfg!(feature = "providers-extra") {
+        ProviderModuleLifecycle::Wire
+    } else {
+        ProviderModuleLifecycle::Stub
+    };
+    entry(module_name, lifecycle, reason)
+}
+
 const fn entry(
     module_name: &'static str,
     lifecycle: ProviderModuleLifecycle,
@@ -317,8 +329,22 @@ mod tests {
     fn lifecycle_classifies_phase0_key_provider_modules() {
         assert_eq!(lifecycle_for("bedrock"), ProviderModuleLifecycle::Wire);
         assert_eq!(lifecycle_for("vertex_ai"), ProviderModuleLifecycle::Stub);
-        assert_eq!(lifecycle_for("azure"), ProviderModuleLifecycle::Stub);
-        assert_eq!(lifecycle_for("azure_ai"), ProviderModuleLifecycle::Stub);
+        assert_eq!(
+            lifecycle_for("azure"),
+            if cfg!(feature = "providers-extra") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
+        assert_eq!(
+            lifecycle_for("azure_ai"),
+            if cfg!(feature = "providers-extra") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
         assert_eq!(lifecycle_for("cohere"), ProviderModuleLifecycle::Stub);
         assert_eq!(lifecycle_for("gemini"), ProviderModuleLifecycle::Stub);
     }
@@ -332,6 +358,10 @@ mod tests {
             .collect::<BTreeSet<_>>();
         let expected = [
             "anthropic",
+            #[cfg(feature = "providers-extra")]
+            "azure",
+            #[cfg(feature = "providers-extra")]
+            "azure_ai",
             "bedrock",
             "cloudflare",
             "mistral",

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -92,14 +92,14 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::Azure,
         "azure",
         &["azure-openai"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        provider_extra_native_dispatch_kind(),
         false,
     ),
     entry(
         ProviderType::AzureAI,
         "azure_ai",
         &["azureai", "azure-ai"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        provider_extra_native_dispatch_kind(),
         false,
     ),
     entry(
@@ -327,6 +327,14 @@ const fn entry(
     }
 }
 
+const fn provider_extra_native_dispatch_kind() -> ProviderDispatchKind {
+    if cfg!(feature = "providers-extra") {
+        ProviderDispatchKind::Native
+    } else {
+        ProviderDispatchKind::ExplicitOpenAiLike
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -398,6 +406,12 @@ mod tests {
             ProviderType::Cloudflare,
         ]
         .into_iter()
+        .chain([
+            #[cfg(feature = "providers-extra")]
+            ProviderType::Azure,
+            #[cfg(feature = "providers-extra")]
+            ProviderType::AzureAI,
+        ])
         .collect::<HashSet<_>>();
 
         assert_eq!(native_types, expected);
@@ -415,11 +429,11 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Azure),
-            ProviderDispatchKind::ExplicitOpenAiLike
+            provider_extra_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::AzureAI),
-            ProviderDispatchKind::ExplicitOpenAiLike
+            provider_extra_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::OpenAICompatible),

--- a/tests/integration/provider_factory_tests.rs
+++ b/tests/integration/provider_factory_tests.rs
@@ -233,6 +233,59 @@ mod tests {
         assert!(matches!(provider, Provider::OpenAILike(_)));
     }
 
+    /// Test Azure OpenAI uses the native provider path when providers-extra is enabled.
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_azure_provider_uses_native_dispatch() {
+        let config = json!({
+            "api_key": "azure-test-key",
+            "azure_endpoint": "https://test-resource.openai.azure.com",
+            "deployment_name": "gpt-4o-deployment",
+            "api_version": "2024-02-01"
+        });
+
+        let result = Provider::from_config_async(ProviderType::Azure, config).await;
+        assert!(
+            result.is_ok(),
+            "Failed to create native Azure provider: {:?}",
+            result.err()
+        );
+
+        let provider = match result {
+            Ok(provider) => provider,
+            Err(err) => panic!("native Azure provider should be created: {err}"),
+        };
+        assert_eq!(provider.name(), "azure");
+        assert_eq!(provider.provider_type(), ProviderType::Azure);
+        assert!(matches!(provider, Provider::Azure(_)));
+    }
+
+    /// Test Azure AI uses the native provider path when providers-extra is enabled.
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_azure_ai_provider_uses_native_dispatch() {
+        let config = json!({
+            "api_key": "azure-ai-test-key",
+            "base_url": "https://test-resource.services.ai.azure.com",
+            "api_version": "2024-05-01-preview"
+        });
+
+        let result = Provider::from_config_async(ProviderType::AzureAI, config).await;
+        assert!(
+            result.is_ok(),
+            "Failed to create native Azure AI provider: {:?}",
+            result.err()
+        );
+
+        let provider = match result {
+            Ok(provider) => provider,
+            Err(err) => panic!("native Azure AI provider should be created: {err}"),
+        };
+        assert_eq!(provider.name(), "azure_ai");
+        assert_eq!(provider.provider_type(), ProviderType::AzureAI);
+        assert!(matches!(provider, Provider::AzureAI(_)));
+    }
+
     /// Test provider creation fails with missing api_key
     #[tokio::test]
     async fn test_provider_creation_fails_without_api_key() {


### PR DESCRIPTION
Follow-up to #668. That PR merged the Azure/Azure AI provider parity fixes first; this smaller slice only switches the factory/registry dispatch to the native Azure providers.\n\nChanges:\n- classify Azure/AzureAI as native dispatch when providers-extra is enabled\n- keep non-extra/default builds on the existing OpenAI-like fallback path\n- map Azure/AzureAI factory config fields into native configs\n- add dispatch and factory regression tests\n\nLocal verification on f5ec9554:\n- cargo fmt --all -- --check\n- git diff --check origin/main...HEAD\n- bash scripts/guards/check_pr_scope.sh\n- bash scripts/guards/check_pr_overlap.sh\n- cargo test --all-features azure