### PR TITLE
fix(provider): patch Azure review follow-ups

### DIFF
--- a/src/core/providers/azure/config.rs
+++ b/src/core/providers/azure/config.rs
@@ -25,9 +25,19 @@ pub struct AzureConfig {
     /// Custom headers
     pub custom_headers: HashMap<String, String>,
     /// Request timeout in seconds
+    #[serde(default = "default_timeout_seconds")]
     pub timeout: u64,
     /// Maximum retry attempts
+    #[serde(default = "default_max_retries")]
     pub max_retries: u32,
+}
+
+fn default_timeout_seconds() -> u64 {
+    60
+}
+
+fn default_max_retries() -> u32 {
+    3
 }
 
 impl Default for AzureConfig {
@@ -247,6 +257,22 @@ mod tests {
         custom_config.max_retries = 5;
         assert_eq!(custom_config.timeout(), std::time::Duration::from_secs(12));
         assert_eq!(custom_config.max_retries(), 5);
+    }
+
+    #[test]
+    fn test_azure_config_deserializes_defaults_for_timeout_and_retries() {
+        let config: AzureConfig = serde_json::from_str(
+            r#"{
+                "api_key": "test-key",
+                "azure_endpoint": "https://test.openai.azure.com",
+                "api_version": "2024-02-01",
+                "custom_headers": {}
+            }"#,
+        )
+        .unwrap_or_else(|error| panic!("AzureConfig should deserialize with defaults: {error}"));
+
+        assert_eq!(config.timeout, 60);
+        assert_eq!(config.max_retries, 3);
     }
 
     #[test]

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -48,6 +48,9 @@ impl AzureAIConfig {
         // Ensure base URL ends with '/' and path doesn't start with '/'
         let base = base_url.trim_end_matches('/');
         let endpoint_path = path.trim_start_matches('/');
+        if endpoint_path == "models" && Self::has_models_path_segment(base) {
+            return Ok(base.to_string());
+        }
         let base = if Self::needs_models_prefix(base, endpoint_path) {
             format!("{}/models", base)
         } else {
@@ -57,19 +60,28 @@ impl AzureAIConfig {
         Ok(format!("{}/{}", base, endpoint_path))
     }
 
+    fn has_models_path_segment(base: &str) -> bool {
+        let host_and_path = base.split_once("://").map(|(_, rest)| rest).unwrap_or(base);
+        let path = host_and_path
+            .split_once('/')
+            .map(|(_, path)| path)
+            .unwrap_or("");
+
+        path.split('/').any(|segment| segment == "models")
+    }
+
     fn needs_models_prefix(base: &str, endpoint_path: &str) -> bool {
         if endpoint_path == "models" || endpoint_path.starts_with("models/") {
             return false;
         }
 
         let host_and_path = base.split_once("://").map(|(_, rest)| rest).unwrap_or(base);
-        let (host, path) = host_and_path
+        let (host, _) = host_and_path
             .split_once('/')
             .map(|(host, path)| (host, path))
             .unwrap_or((host_and_path, ""));
 
-        host.ends_with(".services.ai.azure.com")
-            && !path.split('/').any(|segment| segment == "models")
+        host.ends_with(".services.ai.azure.com") && !Self::has_models_path_segment(base)
     }
 
     /// Default
@@ -226,6 +238,18 @@ mod tests {
             url,
             "https://resource.services.ai.azure.com/models/chat/completions"
         );
+    }
+
+    #[test]
+    fn test_build_endpoint_url_does_not_duplicate_models_for_health_path() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_base = Some("https://resource.services.ai.azure.com/models".to_string());
+
+        let url = match config.build_endpoint_url("models") {
+            Ok(url) => url,
+            Err(error) => panic!("models endpoint should build: {error}"),
+        };
+        assert_eq!(url, "https://resource.services.ai.azure.com/models");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up for post-merge review feedback on #668.

Changes:
- Add serde defaults for AzureConfig timeout and max_retries so existing serialized configs still deserialize.
- Avoid duplicating /models when Azure AI health checks use a Foundry models-root api_base.

Validation:
- cargo test --features providers-extra test_azure_config_deserializes_defaults_for_timeout_and_retries
- cargo test --features providers-extra test_build_endpoint_url_does_not_duplicate_models_for_health_path
- cargo test --features providers-extra test_build_endpoint_url_does_not_duplicate_models
- cargo check --features providers-extra