### PR TITLE
fix(provider): catalogify OpenAI-like adapter providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |
 | Google Vertex AI (`vertex_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
-| Meta Llama API (`meta_llama`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
-| Vercel v0 (`v0`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
-| Amazon Nova (`amazon_nova`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
+| Meta Llama API (`meta_llama`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
+| Vercel v0 (`v0`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
+| Amazon Nova (`amazon_nova`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | fal.ai (`fal_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
 | Replicate (`replicate`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
-| GitHub Models (`github`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
+| GitHub Models (`github`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | GitHub Copilot (`github_copilot`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
 | Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | – | – | – | For self-hosted / unlisted chat-completions endpoints. |
 

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -394,52 +394,6 @@ pub(super) fn build_cloudflare_config_from_factory(
     Ok(cf_config)
 }
 
-pub(super) fn build_meta_llama_config_from_factory(
-    config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "meta_llama")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://api.llama.com/compat/v1");
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "meta_llama".to_string();
-
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
-    }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
-
-    Ok(oai_config)
-}
-
-pub(super) fn build_v0_config_from_factory(
-    config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "v0")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://api.v0.dev/v1");
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "v0".to_string();
-
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
-    }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
-
-    Ok(oai_config)
-}
-
 #[cfg(feature = "providers-extra")]
 pub(super) fn build_azure_ai_config_from_factory(
     config: &serde_json::Value,
@@ -470,29 +424,6 @@ pub(super) fn build_azure_ai_config_from_factory(
     merge_string_headers(&mut azure_ai_config.base.headers, config, "custom_headers");
 
     Ok(azure_ai_config)
-}
-
-pub(super) fn build_amazon_nova_config_from_factory(
-    config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "amazon_nova")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://api.nova.amazon.com/v1");
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "amazon_nova".to_string();
-
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
-    }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
-
-    Ok(oai_config)
 }
 
 pub(super) fn build_fal_ai_config_from_factory(
@@ -646,29 +577,6 @@ pub(super) fn build_replicate_config_from_factory(
 
     let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
     oai_config.provider_name = "replicate".to_string();
-
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
-    }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
-
-    Ok(oai_config)
-}
-
-pub(super) fn build_github_config_from_factory(
-    config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "github")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://models.inference.ai.azure.com");
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "github".to_string();
 
     if let Some(timeout) = config_u64(config, "timeout") {
         oai_config.base.timeout = timeout;

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -13,14 +13,12 @@ use crate::core::providers::{
 use crate::core::providers::{azure, azure_ai};
 
 use super::builder::{
-    build_amazon_nova_config_from_factory, build_anthropic_config_from_factory,
+    apply_tier1_openai_like_overrides, build_anthropic_config_from_factory,
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
-    build_fal_ai_config_from_factory, build_github_config_from_factory,
-    build_github_copilot_config_from_factory, build_meta_llama_config_from_factory,
+    build_fal_ai_config_from_factory, build_github_copilot_config_from_factory,
     build_mistral_config_from_factory, build_openai_config_from_factory,
     build_openai_like_config_from_factory, build_replicate_config_from_factory,
-    build_v0_config_from_factory, build_vertex_ai_config_from_factory, config_str, config_u32,
-    config_u64,
+    build_vertex_ai_config_from_factory, config_str,
 };
 #[cfg(feature = "providers-extra")]
 use super::builder::{build_azure_ai_config_from_factory, build_azure_config_from_factory};
@@ -74,20 +72,6 @@ impl Provider {
                     })?;
                 Ok(Provider::OpenAILike(provider))
             }
-            ProviderType::MetaLlama => {
-                let oai_config = build_meta_llama_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("meta_llama", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
-            }
-            ProviderType::V0 => {
-                let oai_config = build_v0_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("v0", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
-            }
             ProviderType::AzureAI => {
                 #[cfg(feature = "providers-extra")]
                 {
@@ -104,13 +88,6 @@ impl Provider {
                         .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
                     Ok(Provider::OpenAILike(provider))
                 }
-            }
-            ProviderType::AmazonNova => {
-                let oai_config = build_amazon_nova_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("amazon_nova", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
             }
             ProviderType::FalAI => {
                 let oai_config = build_fal_ai_config_from_factory(&config)?;
@@ -157,13 +134,6 @@ impl Provider {
                     .map_err(|e| ProviderError::initialization("replicate", e.to_string()))?;
                 Ok(Provider::OpenAILike(provider))
             }
-            ProviderType::GitHub => {
-                let oai_config = build_github_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("github", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
-            }
             ProviderType::GitHubCopilot => {
                 let oai_config = build_github_copilot_config_from_factory(&config)?;
                 let provider = openai_like::OpenAILikeProvider::new(oai_config)
@@ -192,11 +162,13 @@ impl Provider {
                     config_str(&config, "base_url").or_else(|| config_str(&config, "api_base"));
                 let mut oai_config =
                     def.to_openai_like_config(api_key.as_deref(), base_url_override);
-                if let Some(timeout) = config_u64(&config, "timeout") {
-                    oai_config.base.timeout = timeout;
-                }
-                if let Some(max_retries) = config_u32(&config, "max_retries") {
-                    oai_config.base.max_retries = max_retries;
+                if let Some(settings) = config.as_object() {
+                    let settings = settings
+                        .iter()
+                        .map(|(key, value)| (key.clone(), value.clone()))
+                        .collect();
+                    let _ignored_settings =
+                        apply_tier1_openai_like_overrides(&mut oai_config, &settings);
                 }
                 let provider = openai_like::OpenAILikeProvider::new(oai_config)
                     .await
@@ -356,5 +328,31 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("openai_compatible should be creatable: {err}"));
         assert!(matches!(provider, Provider::OpenAILike(_)));
+    }
+
+    #[tokio::test]
+    async fn issue_606_catalogified_candidates_use_catalog_runtime_path() {
+        for provider_type in [
+            ProviderType::MetaLlama,
+            ProviderType::V0,
+            ProviderType::AmazonNova,
+            ProviderType::GitHub,
+        ] {
+            let provider = Provider::from_config_async(
+                provider_type.clone(),
+                serde_json::json!({
+                    "api_key": "sk-test-key",
+                    "headers": {"x-test-header": "test-value"},
+                    "custom_headers": {"x-custom-header": "custom-value"},
+                    "timeout": 42,
+                    "max_retries": 4
+                }),
+            )
+            .await
+            .unwrap_or_else(|err| panic!("{provider_type:?} should be creatable: {err}"));
+
+            assert!(matches!(provider, Provider::OpenAILike(_)));
+            assert_eq!(provider.name(), provider_type.to_string());
+        }
     }
 }

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -134,6 +134,25 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
             "https://api.friendli.ai/v1",
             "FRIENDLIAI_API_KEY",
         ),
+        def(
+            "meta_llama",
+            "Meta Llama API",
+            "https://api.llama.com/compat/v1",
+            "META_LLAMA_API_KEY",
+        ),
+        def("v0", "Vercel v0", "https://api.v0.dev/v1", "V0_API_KEY"),
+        def(
+            "amazon_nova",
+            "Amazon Nova",
+            "https://api.nova.amazon.com/v1",
+            "AMAZON_NOVA_API_KEY",
+        ),
+        def(
+            "github",
+            "GitHub Models",
+            "https://models.inference.ai.azure.com",
+            "GITHUB_TOKEN",
+        ),
         // xAI publishes OpenAI-compatible chat endpoints; model IDs are
         // passed through instead of enumerated in this static provider catalog.
         ProviderDefinition {
@@ -354,5 +373,37 @@ mod tests {
 
         let config = definition.to_openai_like_config(Some("sk-test"), None);
         assert_eq!(config.model_prefix.as_deref(), Some("xai/"));
+    }
+
+    #[test]
+    fn issue_606_openai_like_candidates_are_catalog_entries() {
+        let expected = [
+            (
+                "meta_llama",
+                "https://api.llama.com/compat/v1",
+                "META_LLAMA_API_KEY",
+            ),
+            ("v0", "https://api.v0.dev/v1", "V0_API_KEY"),
+            (
+                "amazon_nova",
+                "https://api.nova.amazon.com/v1",
+                "AMAZON_NOVA_API_KEY",
+            ),
+            (
+                "github",
+                "https://models.inference.ai.azure.com",
+                "GITHUB_TOKEN",
+            ),
+        ];
+
+        for (name, base_url, auth_env_var) in expected {
+            let Some(definition) = get_definition(name) else {
+                panic!("{name} provider definition should be registered");
+            };
+            assert_eq!(definition.base_url, base_url);
+            assert_eq!(definition.auth_env_var, auth_env_var);
+            assert_eq!(definition.auth_type, AuthType::Bearer);
+            assert!(!definition.skip_api_key);
+        }
     }
 }

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -120,15 +120,15 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::V0,
         "v0",
         &[],
-        ProviderDispatchKind::ExplicitOpenAiLike,
-        false,
+        ProviderDispatchKind::CatalogOpenAiLike,
+        true,
     ),
     entry(
         ProviderType::MetaLlama,
         "meta_llama",
         &["llama", "meta-llama"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
-        false,
+        ProviderDispatchKind::CatalogOpenAiLike,
+        true,
     ),
     entry(
         ProviderType::Mistral,
@@ -204,15 +204,15 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::AmazonNova,
         "amazon_nova",
         &["amazon-nova", "nova"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
-        false,
+        ProviderDispatchKind::CatalogOpenAiLike,
+        true,
     ),
     entry(
         ProviderType::GitHub,
         "github",
         &["github-models"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
-        false,
+        ProviderDispatchKind::CatalogOpenAiLike,
+        true,
     ),
     entry(
         ProviderType::GitHubCopilot,
@@ -439,6 +439,18 @@ mod tests {
             dispatch_kind_for(&ProviderType::OpenAICompatible),
             ProviderDispatchKind::ExplicitOpenAiLike
         );
+        for provider_type in [
+            ProviderType::MetaLlama,
+            ProviderType::V0,
+            ProviderType::AmazonNova,
+            ProviderType::GitHub,
+        ] {
+            assert_eq!(
+                dispatch_kind_for(&provider_type),
+                ProviderDispatchKind::CatalogOpenAiLike,
+                "{provider_type:?} should be catalog-only metadata"
+            );
+        }
         assert_eq!(
             dispatch_kind_for(&ProviderType::PydanticAI),
             ProviderDispatchKind::UnsupportedEnum


### PR DESCRIPTION
## Summary
- move Meta Llama, Vercel v0, Amazon Nova, and GitHub Models into the Tier 1 provider catalog
- remove their redundant explicit OpenAI-like factory builders/branches so runtime construction is catalog-backed
- update registry guards and README classification for the migrated providers

Closes #606

## Validation
- cargo test issue_606 --all-features
- cargo test provider_registry_catalog_flags_match_catalog --all-features
- cargo test test_dispatch_kind_matches_runtime_variant --all-features
- cargo check --all-features
- cargo test --all-features