### PR TITLE
fix(audio): enforce multipart upload limits

### DIFF
--- a/src/server/routes/ai/audio/mod.rs
+++ b/src/server/routes/ai/audio/mod.rs
@@ -3,6 +3,7 @@
 mod speech;
 mod transcriptions;
 mod translations;
+mod upload;
 
 // Re-export the public functions
 pub use speech::audio_speech;

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -9,6 +9,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
+use super::upload::{drain_field, read_audio_file, read_text_field, upload_error_response};
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
 use crate::server::routes::ai::provider_selection::select_provider_for_model;
@@ -55,7 +56,12 @@ pub async fn audio_transcriptions(
 
         let field_name = match field.name() {
             Some(name) => name.to_string(),
-            None => continue,
+            None => {
+                if let Err(e) = drain_field(&mut field).await {
+                    return Ok(upload_error_response(e));
+                }
+                continue;
+            }
         };
 
         match field_name.as_str() {
@@ -67,49 +73,44 @@ pub async fn audio_transcriptions(
                     filename = fname.to_string();
                 }
 
-                // Read file data
-                let mut data = Vec::new();
-                while let Some(chunk) = field.next().await {
-                    match chunk {
-                        Ok(bytes) => data.extend_from_slice(&bytes),
-                        Err(e) => {
-                            error!("Error reading file chunk: {}", e);
-                            return Ok(openai_errors::validation_error("Error reading file"));
-                        }
-                    }
-                }
+                let data = match read_audio_file(&mut field).await {
+                    Ok(data) => data,
+                    Err(e) => return Ok(upload_error_response(e)),
+                };
                 file_data = Some(data);
             }
-            "model" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    model = String::from_utf8_lossy(&bytes).to_string();
+            "model" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => model = value,
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "language" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => language = Some(value),
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "prompt" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => prompt = Some(value),
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "response_format" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => response_format = Some(value),
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "temperature" => match read_text_field(&mut field).await {
+                Ok(value) => {
+                    if let Ok(temp) = value.parse::<f32>() {
+                        temperature = Some(temp);
+                    }
                 }
-            }
-            "language" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    language = Some(String::from_utf8_lossy(&bytes).to_string());
-                }
-            }
-            "prompt" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    prompt = Some(String::from_utf8_lossy(&bytes).to_string());
-                }
-            }
-            "response_format" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    response_format = Some(String::from_utf8_lossy(&bytes).to_string());
-                }
-            }
-            "temperature" => {
-                if let Some(Ok(bytes)) = field.next().await
-                    && let Ok(temp) = String::from_utf8_lossy(&bytes).parse::<f32>()
-                {
-                    temperature = Some(temp);
-                }
-            }
+                Err(e) => return Ok(upload_error_response(e)),
+            },
             _ => {
-                // Skip unknown fields
-                while field.next().await.is_some() {}
+                if let Err(e) = drain_field(&mut field).await {
+                    return Ok(upload_error_response(e));
+                }
             }
         }
     }

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -9,6 +9,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
+use super::upload::{drain_field, read_audio_file, read_text_field, upload_error_response};
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
 use crate::server::routes::ai::provider_selection::select_provider_for_model;
@@ -54,7 +55,12 @@ pub async fn audio_translations(
 
         let field_name = match field.name() {
             Some(name) => name.to_string(),
-            None => continue,
+            None => {
+                if let Err(e) = drain_field(&mut field).await {
+                    return Ok(upload_error_response(e));
+                }
+                continue;
+            }
         };
 
         match field_name.as_str() {
@@ -64,37 +70,40 @@ pub async fn audio_translations(
                 {
                     filename = fname.to_string();
                 }
-                let mut data = Vec::new();
-                while let Some(chunk) = field.next().await {
-                    if let Ok(bytes) = chunk {
-                        data.extend_from_slice(&bytes);
-                    }
-                }
+                let data = match read_audio_file(&mut field).await {
+                    Ok(data) => data,
+                    Err(e) => return Ok(upload_error_response(e)),
+                };
                 file_data = Some(data);
             }
-            "model" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    model = String::from_utf8_lossy(&bytes).to_string();
+            "model" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => model = value,
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "prompt" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => prompt = Some(value),
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "response_format" => match read_text_field(&mut field).await {
+                Ok(value) if !value.is_empty() => response_format = Some(value),
+                Ok(_) => {}
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            "temperature" => match read_text_field(&mut field).await {
+                Ok(value) => {
+                    if let Ok(temp) = value.parse::<f32>() {
+                        temperature = Some(temp);
+                    }
+                }
+                Err(e) => return Ok(upload_error_response(e)),
+            },
+            _ => {
+                if let Err(e) = drain_field(&mut field).await {
+                    return Ok(upload_error_response(e));
                 }
             }
-            "prompt" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    prompt = Some(String::from_utf8_lossy(&bytes).to_string());
-                }
-            }
-            "response_format" => {
-                if let Some(Ok(bytes)) = field.next().await {
-                    response_format = Some(String::from_utf8_lossy(&bytes).to_string());
-                }
-            }
-            "temperature" => {
-                if let Some(Ok(bytes)) = field.next().await
-                    && let Ok(temp) = String::from_utf8_lossy(&bytes).parse::<f32>()
-                {
-                    temperature = Some(temp);
-                }
-            }
-            _ => while field.next().await.is_some() {},
         }
     }
 

--- a/src/server/routes/ai/audio/upload.rs
+++ b/src/server/routes/ai/audio/upload.rs
@@ -1,0 +1,185 @@
+use crate::server::routes::ai::openai_errors;
+use actix_web::HttpResponse;
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use std::fmt::Display;
+use tracing::error;
+
+const MAX_AUDIO_FILE_SIZE_BYTES: usize = 25 * 1024 * 1024;
+const MAX_AUDIO_FORM_FIELD_SIZE_BYTES: usize = 64 * 1024;
+const AUDIO_FILE_TOO_LARGE_MESSAGE: &str = "Audio file too large (max 25MB)";
+const AUDIO_FIELD_TOO_LARGE_MESSAGE: &str = "Audio form field too large (max 64KB)";
+const AUDIO_FILE_READ_ERROR_MESSAGE: &str = "Error reading file";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum AudioUploadError {
+    FileTooLarge,
+    FieldTooLarge,
+    ReadChunk,
+}
+
+pub(super) fn upload_error_response(error: AudioUploadError) -> HttpResponse {
+    match error {
+        AudioUploadError::FileTooLarge => {
+            openai_errors::validation_error(AUDIO_FILE_TOO_LARGE_MESSAGE)
+        }
+        AudioUploadError::FieldTooLarge => {
+            openai_errors::validation_error(AUDIO_FIELD_TOO_LARGE_MESSAGE)
+        }
+        AudioUploadError::ReadChunk => {
+            openai_errors::validation_error(AUDIO_FILE_READ_ERROR_MESSAGE)
+        }
+    }
+}
+
+fn ensure_field_within_limit(
+    current_size: usize,
+    chunk_size: usize,
+    max_size: usize,
+    too_large_error: AudioUploadError,
+) -> Result<(), AudioUploadError> {
+    match current_size.checked_add(chunk_size) {
+        Some(total_size) if total_size <= max_size => Ok(()),
+        _ => Err(too_large_error),
+    }
+}
+
+async fn read_limited_field<S, E>(
+    field: &mut S,
+    max_size: usize,
+    too_large_error: AudioUploadError,
+    log_context: &str,
+) -> Result<Vec<u8>, AudioUploadError>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: Display,
+{
+    let mut data = Vec::new();
+
+    while let Some(chunk) = field.next().await {
+        let bytes = chunk.map_err(|e| {
+            error!("Error reading {} chunk: {}", log_context, e);
+            AudioUploadError::ReadChunk
+        })?;
+
+        ensure_field_within_limit(data.len(), bytes.len(), max_size, too_large_error)?;
+        data.extend_from_slice(&bytes);
+    }
+
+    Ok(data)
+}
+
+pub(super) async fn read_audio_file<S, E>(field: &mut S) -> Result<Vec<u8>, AudioUploadError>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: Display,
+{
+    read_limited_field(
+        field,
+        MAX_AUDIO_FILE_SIZE_BYTES,
+        AudioUploadError::FileTooLarge,
+        "file",
+    )
+    .await
+}
+
+pub(super) async fn read_text_field<S, E>(field: &mut S) -> Result<String, AudioUploadError>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: Display,
+{
+    let data = read_limited_field(
+        field,
+        MAX_AUDIO_FORM_FIELD_SIZE_BYTES,
+        AudioUploadError::FieldTooLarge,
+        "multipart field",
+    )
+    .await?;
+
+    Ok(String::from_utf8_lossy(&data).to_string())
+}
+
+pub(super) async fn drain_field<S, E>(field: &mut S) -> Result<(), AudioUploadError>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: Display,
+{
+    let _ = read_limited_field(
+        field,
+        MAX_AUDIO_FORM_FIELD_SIZE_BYTES,
+        AudioUploadError::FieldTooLarge,
+        "multipart field",
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct TestChunkError;
+
+    impl fmt::Display for TestChunkError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("chunk failed")
+        }
+    }
+
+    #[test]
+    fn audio_file_limit_allows_exact_25mb() {
+        assert_eq!(
+            ensure_field_within_limit(
+                MAX_AUDIO_FILE_SIZE_BYTES - 1,
+                1,
+                MAX_AUDIO_FILE_SIZE_BYTES,
+                AudioUploadError::FileTooLarge,
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn audio_file_limit_rejects_chunk_that_exceeds_25mb() {
+        assert_eq!(
+            ensure_field_within_limit(
+                MAX_AUDIO_FILE_SIZE_BYTES,
+                1,
+                MAX_AUDIO_FILE_SIZE_BYTES,
+                AudioUploadError::FileTooLarge,
+            ),
+            Err(AudioUploadError::FileTooLarge)
+        );
+    }
+
+    #[actix_web::test]
+    async fn text_field_limit_rejects_oversized_chunk() {
+        let mut chunks = stream::iter(vec![Ok::<Bytes, TestChunkError>(Bytes::from(vec![
+            b'a';
+            MAX_AUDIO_FORM_FIELD_SIZE_BYTES
+                + 1
+        ]))]);
+
+        assert_eq!(
+            read_text_field(&mut chunks).await,
+            Err(AudioUploadError::FieldTooLarge)
+        );
+    }
+
+    #[actix_web::test]
+    async fn read_audio_file_returns_error_for_chunk_read_failure() {
+        let mut chunks = stream::iter(vec![
+            Ok::<Bytes, TestChunkError>(Bytes::from_static(b"ok")),
+            Err(TestChunkError),
+        ]);
+
+        assert_eq!(
+            read_audio_file(&mut chunks).await,
+            Err(AudioUploadError::ReadChunk)
+        );
+    }
+}

--- a/src/server/routes/ai/audio/upload.rs
+++ b/src/server/routes/ai/audio/upload.rs
@@ -96,7 +96,8 @@ where
     )
     .await?;
 
-    Ok(String::from_utf8_lossy(&data).to_string())
+    Ok(String::from_utf8(data)
+        .unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned()))
 }
 
 pub(super) async fn drain_field<S, E>(field: &mut S) -> Result<(), AudioUploadError>
@@ -104,13 +105,22 @@ where
     S: Stream<Item = Result<Bytes, E>> + Unpin,
     E: Display,
 {
-    let _ = read_limited_field(
-        field,
-        MAX_AUDIO_FORM_FIELD_SIZE_BYTES,
-        AudioUploadError::FieldTooLarge,
-        "multipart field",
-    )
-    .await?;
+    let mut total_size = 0;
+
+    while let Some(chunk) = field.next().await {
+        let bytes = chunk.map_err(|e| {
+            error!("Error draining multipart field chunk: {}", e);
+            AudioUploadError::ReadChunk
+        })?;
+
+        ensure_field_within_limit(
+            total_size,
+            bytes.len(),
+            MAX_AUDIO_FORM_FIELD_SIZE_BYTES,
+            AudioUploadError::FieldTooLarge,
+        )?;
+        total_size += bytes.len();
+    }
 
     Ok(())
 }
@@ -180,6 +190,20 @@ mod tests {
         assert_eq!(
             read_audio_file(&mut chunks).await,
             Err(AudioUploadError::ReadChunk)
+        );
+    }
+
+    #[actix_web::test]
+    async fn drain_field_limit_rejects_oversized_chunk() {
+        let mut chunks = stream::iter(vec![Ok::<Bytes, TestChunkError>(Bytes::from(vec![
+            b'a';
+            MAX_AUDIO_FORM_FIELD_SIZE_BYTES
+                + 1
+        ]))]);
+
+        assert_eq!(
+            drain_field(&mut chunks).await,
+            Err(AudioUploadError::FieldTooLarge)
         );
     }
 }


### PR DESCRIPTION
## Summary
- Enforces the documented 25MB audio file limit while reading multipart chunks instead of after buffering the full file.
- Adds a small bounded reader for audio multipart fields and caps non-file fields at 64KB.
- Stops silently ignoring multipart chunk read failures in audio translation requests.

Closes #676.

## Verification
- `cargo fmt --all -- --check`
- `cargo test audio::upload --all-features -- --nocapture`
- `cargo test --all-features`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Known pre-existing gate failure
`cargo clippy --all-targets --all-features -- -D warnings` still fails on existing lint warnings in files not touched by this PR:
- `src/core/providers/azure_ai/config.rs:80` (`clippy::map_identity`)
- `src/core/providers/sagemaker/sigv4.rs:74` (`clippy::unnecessary_sort_by`)
- `src/core/providers/vertex_ai/transformers.rs:81` (`clippy::manual_map`)
- `src/core/providers/azure/mod.rs:374` (`clippy::needless_return`)
- `src/core/providers/azure_ai/mod.rs:357` (`clippy::needless_return`)
