### PR TITLE
fix(audio): fail closed for unwired audio routes

### DIFF
--- a/src/core/providers/deepl/model_info.rs
+++ b/src/core/providers/deepl/model_info.rs
@@ -14,7 +14,7 @@ pub fn get_supported_models() -> Vec<ModelInfo> {
         supports_streaming: false,
         supports_tools: false,
         supports_multimodal: false,
-        capabilities: vec![ProviderCapability::AudioTranslation],
+        capabilities: vec![ProviderCapability::ChatCompletion],
         currency: "USD".to_string(),
         ..Default::default()
     }]
@@ -47,6 +47,11 @@ mod tests {
         let translate_model = models.iter().find(|m| m.id == "deepl-translate").unwrap();
         assert!(
             translate_model
+                .capabilities
+                .contains(&ProviderCapability::ChatCompletion)
+        );
+        assert!(
+            !translate_model
                 .capabilities
                 .contains(&ProviderCapability::AudioTranslation)
         );

--- a/src/core/providers/deepl/provider.rs
+++ b/src/core/providers/deepl/provider.rs
@@ -36,7 +36,7 @@ crate::define_http_provider_with_hooks!(
     error_mapper: super::error_mapper::DeepLErrorMapper,
     model_info: super::model_info::get_supported_models,
     capabilities: &[
-        crate::core::types::model::ProviderCapability::AudioTranslation,
+        crate::core::types::model::ProviderCapability::ChatCompletion,
     ],
     url_builder: |provider: &DeepLProvider| -> String {
         let base_url = provider
@@ -356,8 +356,8 @@ mod tests {
         let provider = DeepLProvider::new(config).unwrap();
 
         let caps = provider.capabilities();
-        assert!(caps.contains(&ProviderCapability::AudioTranslation));
-        assert!(!caps.contains(&ProviderCapability::ChatCompletion));
+        assert!(caps.contains(&ProviderCapability::ChatCompletion));
+        assert!(!caps.contains(&ProviderCapability::AudioTranslation));
     }
 
     #[test]

--- a/src/server/routes/ai/provider_selection.rs
+++ b/src/server/routes/ai/provider_selection.rs
@@ -13,6 +13,8 @@ pub fn select_provider_for_model(
         return Err(GatewayError::validation("Model is required"));
     }
 
+    reject_unimplemented_route_capability(&capability)?;
+
     let deployments = router.get_deployments_for_model(model);
     let supports_capability = deployments.iter().any(|deployment_id| {
         router
@@ -44,6 +46,19 @@ pub fn select_provider_for_model(
         })?;
 
     Ok(deployment.model)
+}
+
+fn reject_unimplemented_route_capability(
+    capability: &ProviderCapability,
+) -> Result<(), GatewayError> {
+    match capability {
+        ProviderCapability::AudioTranscription
+        | ProviderCapability::AudioTranslation
+        | ProviderCapability::TextToSpeech => Err(GatewayError::not_implemented(
+            "Audio routes are not wired to provider execution yet",
+        )),
+        _ => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -95,10 +110,27 @@ mod tests {
     async fn select_provider_for_model_reports_validation_for_unsupported_capability() {
         let router = build_embeddings_router().await;
 
-        let err =
-            select_provider_for_model(&router, "embedding-model", ProviderCapability::TextToSpeech)
-                .expect_err("unsupported capability should be a validation failure");
+        let err = select_provider_for_model(
+            &router,
+            "embedding-model",
+            ProviderCapability::CodeExecution,
+        )
+        .expect_err("unsupported capability should be a validation failure");
 
         assert!(matches!(err, GatewayError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn select_provider_for_model_rejects_audio_capability_before_selection() {
+        let router = build_embeddings_router().await;
+
+        let err = select_provider_for_model(
+            &router,
+            "embedding-model",
+            ProviderCapability::AudioTranscription,
+        )
+        .expect_err("audio capabilities should fail closed until provider execution is wired");
+
+        assert!(matches!(err, GatewayError::NotImplemented(_)));
     }
 }


### PR DESCRIPTION
Closes #675.

## Summary
- Fail closed in capability-based provider selection for `AudioTranscription`, `AudioTranslation`, and `TextToSpeech` while the `/audio/*` routes still have no provider execution contract.
- Keep the existing validation error path for non-audio unsupported capabilities.
- Correct DeepL metadata from `AudioTranslation` to `ChatCompletion`, matching the current text-translation-through-chat implementation.

## Diagnosis
The HTTP audio routes selected a deployment by audio capability, then discarded that selected provider and called local `AudioService` methods. Those service methods are stubs and return `not_implemented`, so a deployment could look supported while the request could never reach provider code.

There is also no audio method on the shared provider dispatch contract yet, so this PR chooses fail-closed behavior instead of pretending audio execution is wired. OpenAI still has legacy audio capability metadata; this PR prevents route selection from using it until provider execution is implemented in a follow-up.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features --quiet`
- `cargo test --all-features provider_selection -- --nocapture`
- `cargo test --all-features deepl:: -- --nocapture`
- `cargo test --all-features --quiet`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Known baseline failure
`cargo clippy --all-targets --all-features -- -D warnings` still fails on pre-existing `origin/main` lint errors outside this PR:
- `src/core/providers/azure_ai/config.rs:80` (`clippy::map_identity`)
- `src/core/providers/sagemaker/sigv4.rs:74` (`clippy::unnecessary_sort_by`)
- `src/core/providers/vertex_ai/transformers.rs:81` (`clippy::manual_map`)
- `src/core/providers/azure/mod.rs:374` (`clippy::needless_return`)
- `src/core/providers/azure_ai/mod.rs:357` (`clippy::needless_return`)
