### PR TITLE
fix(ci): restore clippy baseline

### DIFF
--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -370,8 +370,8 @@ mod tests {
             if read_http_headers(&mut socket).await.is_err() {
                 return;
             }
-            if socket.write_all(response.as_bytes()).await.is_err() {
-                return;
+            if let Err(err) = socket.write_all(response.as_bytes()).await {
+                eprintln!("test server failed to write response: {err}");
             }
         });
 

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -76,10 +76,7 @@ impl AzureAIConfig {
         }
 
         let host_and_path = base.split_once("://").map(|(_, rest)| rest).unwrap_or(base);
-        let (host, _) = host_and_path
-            .split_once('/')
-            .map(|(host, path)| (host, path))
-            .unwrap_or((host_and_path, ""));
+        let (host, _) = host_and_path.split_once('/').unwrap_or((host_and_path, ""));
 
         host.ends_with(".services.ai.azure.com") && !Self::has_models_path_segment(base)
     }

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -353,8 +353,8 @@ mod tests {
             if read_http_headers(&mut socket).await.is_err() {
                 return;
             }
-            if socket.write_all(response.as_bytes()).await.is_err() {
-                return;
+            if let Err(err) = socket.write_all(response.as_bytes()).await {
+                eprintln!("test server failed to write response: {err}");
             }
         });
 

--- a/src/core/providers/sagemaker/sigv4.rs
+++ b/src/core/providers/sagemaker/sigv4.rs
@@ -71,7 +71,11 @@ impl SagemakerSigV4Signer {
 
         // Sort headers by key (case-insensitive)
         let mut sorted_headers: Vec<_> = canonical_headers.iter().collect();
-        sorted_headers.sort_by_key(|(key, _)| key.to_lowercase());
+        sorted_headers.sort_by(|(a_key, _), (b_key, _)| {
+            let a_bytes = a_key.as_bytes().iter().map(|b| b.to_ascii_lowercase());
+            let b_bytes = b_key.as_bytes().iter().map(|b| b.to_ascii_lowercase());
+            a_bytes.cmp(b_bytes)
+        });
 
         // Build canonical headers string
         let canonical_headers_str = sorted_headers

--- a/src/core/providers/sagemaker/sigv4.rs
+++ b/src/core/providers/sagemaker/sigv4.rs
@@ -71,7 +71,7 @@ impl SagemakerSigV4Signer {
 
         // Sort headers by key (case-insensitive)
         let mut sorted_headers: Vec<_> = canonical_headers.iter().collect();
-        sorted_headers.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+        sorted_headers.sort_by_key(|(key, _)| key.to_lowercase());
 
         // Build canonical headers string
         let canonical_headers_str = sorted_headers

--- a/src/core/providers/vertex_ai/transformers.rs
+++ b/src/core/providers/vertex_ai/transformers.rs
@@ -78,8 +78,8 @@ impl GeminiTransformer {
         }
 
         // Handle tools/functions
-        let tools = if let Some(ref tools) = request.tools {
-            Some(vec![Tool {
+        let tools = request.tools.as_ref().map(|tools| {
+            vec![Tool {
                 function_declarations: tools
                     .iter()
                     .map(|tool| FunctionDeclaration {
@@ -88,10 +88,8 @@ impl GeminiTransformer {
                         parameters: tool.function.parameters.clone().unwrap_or(json!({})),
                     })
                     .collect(),
-            }])
-        } else {
-            None
-        };
+            }]
+        });
 
         // Build request body
         let mut body = json!({
@@ -540,12 +538,9 @@ impl PartnerModelTransformer {
         })
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::types::content::ContentPart;
-
     fn create_test_message(role: MessageRole, content: &str) -> ChatMessage {
         ChatMessage {
             role,
@@ -761,287 +756,7 @@ mod tests {
             Some(FinishReason::ContentFilter)
         );
     }
-
-    #[test]
-    fn test_transform_chat_response_with_usage() {
-        let transformer = GeminiTransformer::new();
-        let response = json!({
-            "candidates": [{
-                "content": {"parts": [{"text": "Response"}]},
-                "finishReason": "STOP"
-            }],
-            "usageMetadata": {
-                "promptTokenCount": 100,
-                "candidatesTokenCount": 50,
-                "totalTokenCount": 150
-            }
-        });
-        let model = VertexAIModel::GeminiPro;
-
-        let result = transformer
-            .transform_chat_response(response, &model)
-            .unwrap();
-        let usage = result.usage.unwrap();
-        assert_eq!(usage.prompt_tokens, 100);
-        assert_eq!(usage.completion_tokens, 50);
-        assert_eq!(usage.total_tokens, 150);
-    }
-
-    #[test]
-    fn test_transform_chat_response_missing_candidates() {
-        let transformer = GeminiTransformer::new();
-        let response = json!({});
-        let model = VertexAIModel::GeminiPro;
-
-        let result = transformer.transform_chat_response(response, &model);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_transform_chat_response_empty_candidates() {
-        let transformer = GeminiTransformer::new();
-        let response = json!({"candidates": []});
-        let model = VertexAIModel::GeminiPro;
-
-        let result = transformer.transform_chat_response(response, &model);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_message_content_to_parts_text() {
-        let transformer = GeminiTransformer::new();
-        let content = MessageContent::Text("Hello world".to_string());
-
-        let result = transformer.message_content_to_parts(&content);
-        assert!(result.is_ok());
-        let parts = result.unwrap();
-        assert_eq!(parts.len(), 1);
-        match &parts[0] {
-            Part::Text { text } => assert_eq!(text, "Hello world"),
-            _ => panic!("Expected text part"),
-        }
-    }
-
-    #[test]
-    fn test_message_content_to_parts_multipart_text() {
-        let transformer = GeminiTransformer::new();
-        let content = MessageContent::Parts(vec![
-            ContentPart::Text {
-                text: "Part 1".to_string(),
-            },
-            ContentPart::Text {
-                text: "Part 2".to_string(),
-            },
-        ]);
-
-        let result = transformer.message_content_to_parts(&content);
-        assert!(result.is_ok());
-        let parts = result.unwrap();
-        assert_eq!(parts.len(), 2);
-    }
-
-    // ==================== PartnerModelTransformer Tests ====================
-
-    #[test]
-    fn test_partner_transformer_new() {
-        let transformer = PartnerModelTransformer::new();
-        assert!(format!("{:?}", transformer).contains("PartnerModelTransformer"));
-    }
-
-    #[test]
-    fn test_partner_transformer_default() {
-        let transformer = PartnerModelTransformer;
-        assert!(format!("{:?}", transformer).contains("PartnerModelTransformer"));
-    }
-
-    #[test]
-    fn test_transform_claude_request() {
-        let transformer = PartnerModelTransformer::new();
-        let request = ChatRequest {
-            model: "claude-3-5-sonnet".to_string(),
-            messages: vec![
-                create_test_message(MessageRole::System, "You are helpful"),
-                create_test_message(MessageRole::User, "Hello"),
-            ],
-            max_tokens: Some(1000),
-            temperature: Some(0.7),
-            ..Default::default()
-        };
-        let model = VertexAIModel::Claude35Sonnet;
-
-        let result = transformer.transform_chat_request(&request, &model);
-        assert!(result.is_ok());
-        let body = result.unwrap();
-        assert!(body["instances"].is_array());
-        let instance = &body["instances"][0];
-        assert_eq!(instance["anthropic_version"], "vertex-2023-10-16");
-        assert!(instance["messages"].is_array());
-    }
-
-    #[test]
-    fn test_transform_llama_request() {
-        let transformer = PartnerModelTransformer::new();
-        let request = ChatRequest {
-            model: "llama3-70b".to_string(),
-            messages: vec![create_test_message(MessageRole::User, "Hello")],
-            temperature: Some(0.8),
-            max_tokens: Some(500),
-            ..Default::default()
-        };
-        let model = VertexAIModel::Llama3_70B;
-
-        let result = transformer.transform_chat_request(&request, &model);
-        assert!(result.is_ok());
-        let body = result.unwrap();
-        assert!(body["instances"].is_array());
-        assert!(body["instances"][0]["prompt"].is_string());
-        assert!(body["parameters"]["temperature"].is_number());
-    }
-
-    #[test]
-    fn test_transform_jamba_request() {
-        let transformer = PartnerModelTransformer::new();
-        let request = ChatRequest {
-            model: "jamba-1.5-large".to_string(),
-            messages: vec![create_test_message(MessageRole::User, "Hello")],
-            ..Default::default()
-        };
-        let model = VertexAIModel::Jamba15Large;
-
-        let result = transformer.transform_chat_request(&request, &model);
-        assert!(result.is_ok());
-        let body = result.unwrap();
-        assert!(body["instances"].is_array());
-        assert!(body["instances"][0]["messages"].is_array());
-    }
-
-    #[test]
-    fn test_transform_default_partner_request() {
-        let transformer = PartnerModelTransformer::new();
-        let request = ChatRequest {
-            model: "mistral-large".to_string(),
-            messages: vec![create_test_message(MessageRole::User, "Hello")],
-            ..Default::default()
-        };
-        let model = VertexAIModel::MistralLarge;
-
-        let result = transformer.transform_chat_request(&request, &model);
-        assert!(result.is_ok());
-        let body = result.unwrap();
-        assert!(body["instances"].is_array());
-    }
-
-    #[test]
-    fn test_messages_to_llama_prompt_user_only() {
-        let transformer = PartnerModelTransformer::new();
-        let messages = vec![create_test_message(MessageRole::User, "Hello")];
-
-        let prompt = transformer.messages_to_llama_prompt(&messages);
-        assert!(prompt.contains("[INST] Hello [/INST]"));
-    }
-
-    #[test]
-    fn test_messages_to_llama_prompt_with_system() {
-        let transformer = PartnerModelTransformer::new();
-        let messages = vec![
-            create_test_message(MessageRole::System, "You are helpful"),
-            create_test_message(MessageRole::User, "Hello"),
-        ];
-
-        let prompt = transformer.messages_to_llama_prompt(&messages);
-        assert!(prompt.contains("<<SYS>>"));
-        assert!(prompt.contains("You are helpful"));
-        assert!(prompt.contains("<</SYS>>"));
-    }
-
-    #[test]
-    fn test_messages_to_llama_prompt_conversation() {
-        let transformer = PartnerModelTransformer::new();
-        let messages = vec![
-            create_test_message(MessageRole::User, "Hi"),
-            create_test_message(MessageRole::Assistant, "Hello!"),
-            create_test_message(MessageRole::User, "How are you?"),
-        ];
-
-        let prompt = transformer.messages_to_llama_prompt(&messages);
-        assert!(prompt.contains("[INST] Hi [/INST]"));
-        assert!(prompt.contains("Hello!"));
-        assert!(prompt.contains("[INST] How are you? [/INST]"));
-    }
-
-    #[test]
-    fn test_transform_partner_response_basic() {
-        let transformer = PartnerModelTransformer::new();
-        let response = json!({
-            "predictions": [{
-                "content": "Hello! I'm Claude."
-            }]
-        });
-        let model = VertexAIModel::Claude35Sonnet;
-
-        let result = transformer.transform_chat_response(response, &model);
-        assert!(result.is_ok());
-        let chat_response = result.unwrap();
-        assert_eq!(chat_response.object, "chat.completion");
-        assert_eq!(chat_response.choices.len(), 1);
-    }
-
-    #[test]
-    fn test_transform_partner_response_with_text_field() {
-        let transformer = PartnerModelTransformer::new();
-        let response = json!({
-            "predictions": [{
-                "text": "Llama response"
-            }]
-        });
-        let model = VertexAIModel::Llama3_70B;
-
-        let result = transformer.transform_chat_response(response, &model);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_transform_partner_response_missing_predictions() {
-        let transformer = PartnerModelTransformer::new();
-        let response = json!({});
-        let model = VertexAIModel::Claude35Sonnet;
-
-        let result = transformer.transform_chat_response(response, &model);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_transform_partner_response_empty_predictions() {
-        let transformer = PartnerModelTransformer::new();
-        let response = json!({"predictions": []});
-        let model = VertexAIModel::Claude35Sonnet;
-
-        let result = transformer.transform_chat_response(response, &model);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_transform_partner_response_with_metadata() {
-        let transformer = PartnerModelTransformer::new();
-        let response = json!({
-            "predictions": [{
-                "content": "Response"
-            }],
-            "metadata": {
-                "tokenMetadata": {
-                    "inputTokens": {"totalTokens": 50},
-                    "outputTokens": {"totalTokens": 100}
-                }
-            }
-        });
-        let model = VertexAIModel::Claude35Sonnet;
-
-        let result = transformer
-            .transform_chat_response(response, &model)
-            .unwrap();
-        let usage = result.usage.unwrap();
-        assert_eq!(usage.prompt_tokens, 50);
-        assert_eq!(usage.completion_tokens, 100);
-        assert_eq!(usage.total_tokens, 150);
-    }
 }
+
+#[cfg(test)]
+mod split_tests;

--- a/src/core/providers/vertex_ai/transformers/split_tests.rs
+++ b/src/core/providers/vertex_ai/transformers/split_tests.rs
@@ -1,0 +1,298 @@
+use super::*;
+use crate::core::types::content::ContentPart;
+
+fn create_test_message(role: MessageRole, content: &str) -> ChatMessage {
+    ChatMessage {
+        role,
+        content: Some(MessageContent::Text(content.to_string())),
+        thinking: None,
+        audio: None,
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+    }
+}
+
+#[test]
+fn test_transform_chat_response_with_usage() {
+    let transformer = GeminiTransformer::new();
+    let response = json!({
+        "candidates": [{
+            "content": {"parts": [{"text": "Response"}]},
+            "finishReason": "STOP"
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 100,
+            "candidatesTokenCount": 50,
+            "totalTokenCount": 150
+        }
+    });
+    let model = VertexAIModel::GeminiPro;
+
+    let result = transformer
+        .transform_chat_response(response, &model)
+        .unwrap();
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.prompt_tokens, 100);
+    assert_eq!(usage.completion_tokens, 50);
+    assert_eq!(usage.total_tokens, 150);
+}
+
+#[test]
+fn test_transform_chat_response_missing_candidates() {
+    let transformer = GeminiTransformer::new();
+    let response = json!({});
+    let model = VertexAIModel::GeminiPro;
+
+    let result = transformer.transform_chat_response(response, &model);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_transform_chat_response_empty_candidates() {
+    let transformer = GeminiTransformer::new();
+    let response = json!({"candidates": []});
+    let model = VertexAIModel::GeminiPro;
+
+    let result = transformer.transform_chat_response(response, &model);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_message_content_to_parts_text() {
+    let transformer = GeminiTransformer::new();
+    let content = MessageContent::Text("Hello world".to_string());
+
+    let result = transformer.message_content_to_parts(&content);
+    assert!(result.is_ok());
+    let parts = result.unwrap();
+    assert_eq!(parts.len(), 1);
+    match &parts[0] {
+        Part::Text { text } => assert_eq!(text, "Hello world"),
+        _ => panic!("Expected text part"),
+    }
+}
+
+#[test]
+fn test_message_content_to_parts_multipart_text() {
+    let transformer = GeminiTransformer::new();
+    let content = MessageContent::Parts(vec![
+        ContentPart::Text {
+            text: "Part 1".to_string(),
+        },
+        ContentPart::Text {
+            text: "Part 2".to_string(),
+        },
+    ]);
+
+    let result = transformer.message_content_to_parts(&content);
+    assert!(result.is_ok());
+    let parts = result.unwrap();
+    assert_eq!(parts.len(), 2);
+}
+
+// ==================== PartnerModelTransformer Tests ====================
+
+#[test]
+fn test_partner_transformer_new() {
+    let transformer = PartnerModelTransformer::new();
+    assert!(format!("{:?}", transformer).contains("PartnerModelTransformer"));
+}
+
+#[test]
+fn test_partner_transformer_default() {
+    let transformer = PartnerModelTransformer;
+    assert!(format!("{:?}", transformer).contains("PartnerModelTransformer"));
+}
+
+#[test]
+fn test_transform_claude_request() {
+    let transformer = PartnerModelTransformer::new();
+    let request = ChatRequest {
+        model: "claude-3-5-sonnet".to_string(),
+        messages: vec![
+            create_test_message(MessageRole::System, "You are helpful"),
+            create_test_message(MessageRole::User, "Hello"),
+        ],
+        max_tokens: Some(1000),
+        temperature: Some(0.7),
+        ..Default::default()
+    };
+    let model = VertexAIModel::Claude35Sonnet;
+
+    let result = transformer.transform_chat_request(&request, &model);
+    assert!(result.is_ok());
+    let body = result.unwrap();
+    assert!(body["instances"].is_array());
+    let instance = &body["instances"][0];
+    assert_eq!(instance["anthropic_version"], "vertex-2023-10-16");
+    assert!(instance["messages"].is_array());
+}
+
+#[test]
+fn test_transform_llama_request() {
+    let transformer = PartnerModelTransformer::new();
+    let request = ChatRequest {
+        model: "llama3-70b".to_string(),
+        messages: vec![create_test_message(MessageRole::User, "Hello")],
+        temperature: Some(0.8),
+        max_tokens: Some(500),
+        ..Default::default()
+    };
+    let model = VertexAIModel::Llama3_70B;
+
+    let result = transformer.transform_chat_request(&request, &model);
+    assert!(result.is_ok());
+    let body = result.unwrap();
+    assert!(body["instances"].is_array());
+    assert!(body["instances"][0]["prompt"].is_string());
+    assert!(body["parameters"]["temperature"].is_number());
+}
+
+#[test]
+fn test_transform_jamba_request() {
+    let transformer = PartnerModelTransformer::new();
+    let request = ChatRequest {
+        model: "jamba-1.5-large".to_string(),
+        messages: vec![create_test_message(MessageRole::User, "Hello")],
+        ..Default::default()
+    };
+    let model = VertexAIModel::Jamba15Large;
+
+    let result = transformer.transform_chat_request(&request, &model);
+    assert!(result.is_ok());
+    let body = result.unwrap();
+    assert!(body["instances"].is_array());
+    assert!(body["instances"][0]["messages"].is_array());
+}
+
+#[test]
+fn test_transform_default_partner_request() {
+    let transformer = PartnerModelTransformer::new();
+    let request = ChatRequest {
+        model: "mistral-large".to_string(),
+        messages: vec![create_test_message(MessageRole::User, "Hello")],
+        ..Default::default()
+    };
+    let model = VertexAIModel::MistralLarge;
+
+    let result = transformer.transform_chat_request(&request, &model);
+    assert!(result.is_ok());
+    let body = result.unwrap();
+    assert!(body["instances"].is_array());
+}
+
+#[test]
+fn test_messages_to_llama_prompt_user_only() {
+    let transformer = PartnerModelTransformer::new();
+    let messages = vec![create_test_message(MessageRole::User, "Hello")];
+
+    let prompt = transformer.messages_to_llama_prompt(&messages);
+    assert!(prompt.contains("[INST] Hello [/INST]"));
+}
+
+#[test]
+fn test_messages_to_llama_prompt_with_system() {
+    let transformer = PartnerModelTransformer::new();
+    let messages = vec![
+        create_test_message(MessageRole::System, "You are helpful"),
+        create_test_message(MessageRole::User, "Hello"),
+    ];
+
+    let prompt = transformer.messages_to_llama_prompt(&messages);
+    assert!(prompt.contains("<<SYS>>"));
+    assert!(prompt.contains("You are helpful"));
+    assert!(prompt.contains("<</SYS>>"));
+}
+
+#[test]
+fn test_messages_to_llama_prompt_conversation() {
+    let transformer = PartnerModelTransformer::new();
+    let messages = vec![
+        create_test_message(MessageRole::User, "Hi"),
+        create_test_message(MessageRole::Assistant, "Hello!"),
+        create_test_message(MessageRole::User, "How are you?"),
+    ];
+
+    let prompt = transformer.messages_to_llama_prompt(&messages);
+    assert!(prompt.contains("[INST] Hi [/INST]"));
+    assert!(prompt.contains("Hello!"));
+    assert!(prompt.contains("[INST] How are you? [/INST]"));
+}
+
+#[test]
+fn test_transform_partner_response_basic() {
+    let transformer = PartnerModelTransformer::new();
+    let response = json!({
+        "predictions": [{
+            "content": "Hello! I'm Claude."
+        }]
+    });
+    let model = VertexAIModel::Claude35Sonnet;
+
+    let result = transformer.transform_chat_response(response, &model);
+    assert!(result.is_ok());
+    let chat_response = result.unwrap();
+    assert_eq!(chat_response.object, "chat.completion");
+    assert_eq!(chat_response.choices.len(), 1);
+}
+
+#[test]
+fn test_transform_partner_response_with_text_field() {
+    let transformer = PartnerModelTransformer::new();
+    let response = json!({
+        "predictions": [{
+            "text": "Llama response"
+        }]
+    });
+    let model = VertexAIModel::Llama3_70B;
+
+    let result = transformer.transform_chat_response(response, &model);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_transform_partner_response_missing_predictions() {
+    let transformer = PartnerModelTransformer::new();
+    let response = json!({});
+    let model = VertexAIModel::Claude35Sonnet;
+
+    let result = transformer.transform_chat_response(response, &model);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_transform_partner_response_empty_predictions() {
+    let transformer = PartnerModelTransformer::new();
+    let response = json!({"predictions": []});
+    let model = VertexAIModel::Claude35Sonnet;
+
+    let result = transformer.transform_chat_response(response, &model);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_transform_partner_response_with_metadata() {
+    let transformer = PartnerModelTransformer::new();
+    let response = json!({
+        "predictions": [{
+            "content": "Response"
+        }],
+        "metadata": {
+            "tokenMetadata": {
+                "inputTokens": {"totalTokens": 50},
+                "outputTokens": {"totalTokens": 100}
+            }
+        }
+    });
+    let model = VertexAIModel::Claude35Sonnet;
+
+    let result = transformer
+        .transform_chat_response(response, &model)
+        .unwrap();
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.prompt_tokens, 50);
+    assert_eq!(usage.completion_tokens, 100);
+    assert_eq!(usage.total_tokens, 150);
+}


### PR DESCRIPTION
Closes #681.

## Summary
- Apply the current clippy rewrites required by `-D warnings` on `origin/main`.
- Split the tail of the oversized Vertex AI transformer tests into `transformers/split_tests.rs` before touching `transformers.rs`, keeping both files under the 800-line hard limit.
- Keep provider behavior unchanged; this is a mechanical lint/baseline repair.

## Diagnosis
`cargo clippy --all-targets --all-features -- -D warnings` failed on five baseline lint errors in Azure AI, SageMaker, Vertex AI, and Azure test helpers. Those errors were unrelated to the audio/config fixes, but they made every feature branch report a known red clippy gate.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check --cached`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-features --quiet`
- `cargo test --all-features integration::completions_route_tests::tests::test_completions_non_stream_success_openai_envelope -- --nocapture`
- `cargo test --all-features --quiet`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

Note: one earlier full-test attempt was terminated after the integration test process hung; the same test passed when run directly, and the subsequent full `cargo test --all-features --quiet` completed successfully.
