### PR TITLE
fix(anthropic): reject n!=1 and preserve cache usage details

### DIFF
--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -18,7 +18,7 @@ use crate::core::types::{
     chat::ChatRequest,
     content::ContentPart,
     message::MessageRole,
-    responses::{ChatChoice, ChatResponse, FinishReason, PromptTokensDetails, Usage},
+    responses::{ChatChoice, ChatResponse, FinishReason},
     thinking::ThinkingContent,
 };
 
@@ -759,35 +759,7 @@ impl AnthropicClient {
             logprobs: None,
         };
 
-        // Build usage — Anthropic bills cache creation/read tokens as input
-        // tokens, so they must count toward prompt_tokens and total_tokens.
-        let usage = response.get("usage").map(|usage_data| {
-            let read = |key: &str| usage_data.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
-            // Saturate instead of `as u32`, which silently wraps on overflow.
-            let to_u32 = |v: u64| u32::try_from(v).unwrap_or(u32::MAX);
-            let cache_creation = read("cache_creation_input_tokens");
-            let cache_read = read("cache_read_input_tokens");
-            let prompt_tokens = read("input_tokens") + cache_creation + cache_read;
-            let completion_tokens = read("output_tokens");
-
-            Usage {
-                prompt_tokens: to_u32(prompt_tokens),
-                completion_tokens: to_u32(completion_tokens),
-                total_tokens: to_u32(prompt_tokens + completion_tokens),
-                completion_tokens_details: None,
-                prompt_tokens_details: if cache_creation > 0 || cache_read > 0 {
-                    Some(PromptTokensDetails {
-                        cached_tokens: Some(to_u32(cache_read)),
-                        cache_creation_tokens: Some(to_u32(cache_creation)),
-                        cache_read_tokens: Some(to_u32(cache_read)),
-                        audio_tokens: None,
-                    })
-                } else {
-                    None
-                },
-                thinking_usage: None,
-            }
-        });
+        let usage = response.get("usage").map(usage::build_usage);
 
         Ok(ChatResponse {
             id,
@@ -800,6 +772,8 @@ impl AnthropicClient {
         })
     }
 }
+
+mod usage;
 
 #[cfg(test)]
 mod tests;

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -251,6 +251,39 @@ impl AnthropicClient {
             anthropic_api_error(400, format!("Unsupported model: {}", request.model))
         })?;
 
+        // The Messages API only returns a single candidate; any n other than 1
+        // (including 0) cannot be honored, so reject it instead of silently
+        // returning the wrong number of choices.
+        if let Some(n) = request.n
+            && n != 1
+        {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!("anthropic only supports n=1 (got n={})", n),
+            ));
+        }
+
+        // Warn once about OpenAI-style parameters Anthropic has no equivalent for.
+        let mut ignored_params = Vec::new();
+        if request.frequency_penalty.is_some() {
+            ignored_params.push("frequency_penalty");
+        }
+        if request.presence_penalty.is_some() {
+            ignored_params.push("presence_penalty");
+        }
+        if request.seed.is_some() {
+            ignored_params.push("seed");
+        }
+        if request.logit_bias.is_some() {
+            ignored_params.push("logit_bias");
+        }
+        if !ignored_params.is_empty() {
+            tracing::warn!(
+                "Anthropic request ignores unsupported parameters: {}",
+                ignored_params.join(", ")
+            );
+        }
+
         // Separate system messages from user messages
         let (system_message, messages) = self.separate_system_messages(&request.messages)?;
 
@@ -726,37 +759,27 @@ impl AnthropicClient {
             logprobs: None,
         };
 
-        // Build usage
+        // Build usage — Anthropic bills cache creation/read tokens as input
+        // tokens, so they must count toward prompt_tokens and total_tokens.
         let usage = response.get("usage").map(|usage_data| {
-            let input_tokens = usage_data
-                .get("input_tokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0) as u32;
-            let output_tokens = usage_data
-                .get("output_tokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0) as u32;
-            let cache_creation_tokens = usage_data
-                .get("cache_creation_input_tokens")
-                .and_then(|v| v.as_u64())
-                .map(|tokens| tokens as u32);
-            let cache_read_tokens = usage_data
-                .get("cache_read_input_tokens")
-                .and_then(|v| v.as_u64())
-                .map(|tokens| tokens as u32);
+            let read = |key: &str| usage_data.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+            // Saturate instead of `as u32`, which silently wraps on overflow.
+            let to_u32 = |v: u64| u32::try_from(v).unwrap_or(u32::MAX);
+            let cache_creation = read("cache_creation_input_tokens");
+            let cache_read = read("cache_read_input_tokens");
+            let prompt_tokens = read("input_tokens") + cache_creation + cache_read;
+            let completion_tokens = read("output_tokens");
 
             Usage {
-                prompt_tokens: input_tokens,
-                completion_tokens: output_tokens,
-                total_tokens: input_tokens + output_tokens,
+                prompt_tokens: to_u32(prompt_tokens),
+                completion_tokens: to_u32(completion_tokens),
+                total_tokens: to_u32(prompt_tokens + completion_tokens),
                 completion_tokens_details: None,
-                prompt_tokens_details: if cache_creation_tokens.is_some()
-                    || cache_read_tokens.is_some()
-                {
+                prompt_tokens_details: if cache_creation > 0 || cache_read > 0 {
                     Some(PromptTokensDetails {
-                        cached_tokens: cache_read_tokens,
-                        cache_creation_tokens,
-                        cache_read_tokens,
+                        cached_tokens: Some(to_u32(cache_read)),
+                        cache_creation_tokens: Some(to_u32(cache_creation)),
+                        cache_read_tokens: Some(to_u32(cache_read)),
                         audio_tokens: None,
                     })
                 } else {

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -702,7 +702,7 @@ fn test_transform_chat_request_allows_n_equal_one_and_ignores_unsupported_params
 }
 
 #[test]
-fn test_transform_chat_response_bills_cache_tokens_in_totals() {
+fn test_transform_chat_response_preserves_cache_details_without_double_counting() {
     let config = AnthropicConfig::new_test("test-key");
     let client = AnthropicClient::new(config).unwrap();
 
@@ -723,8 +723,8 @@ fn test_transform_chat_response_bills_cache_tokens_in_totals() {
         .unwrap()
         .usage
         .unwrap();
-    // Anthropic bills cache tokens as input: prompt = 100 + 30 + 20
-    assert_eq!(usage.prompt_tokens, 150);
+    // Anthropic input_tokens already includes cache_creation and cache_read tokens.
+    assert_eq!(usage.prompt_tokens, 100);
     assert_eq!(usage.completion_tokens, 50);
-    assert_eq!(usage.total_tokens, 200);
+    assert_eq!(usage.total_tokens, 150);
 }

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -650,3 +650,81 @@ fn test_transform_chat_response_finish_reasons() {
         Some(crate::core::types::responses::FinishReason::PauseTurn)
     ));
 }
+
+// ==================== Unsupported Parameter Tests ====================
+
+#[test]
+fn test_transform_chat_request_rejects_n_greater_than_one() {
+    let config = AnthropicConfig::new_test("test-key");
+    let client = AnthropicClient::new(config).unwrap();
+
+    let mut request = ChatRequest::new("claude-opus-4-6").add_user_message("Hello");
+    request.n = Some(3);
+
+    let error = client.transform_chat_request(&request).unwrap_err();
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+    assert!(
+        format!("{}", error).contains("only supports n=1"),
+        "unexpected error message"
+    );
+}
+
+#[test]
+fn test_transform_chat_request_rejects_n_zero() {
+    let config = AnthropicConfig::new_test("test-key");
+    let client = AnthropicClient::new(config).unwrap();
+
+    // n=0 is as unsatisfiable as n>1: the API always returns one candidate.
+    let mut request = ChatRequest::new("claude-opus-4-6").add_user_message("Hello");
+    request.n = Some(0);
+
+    let error = client.transform_chat_request(&request).unwrap_err();
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+}
+
+#[test]
+fn test_transform_chat_request_allows_n_equal_one_and_ignores_unsupported_params() {
+    let config = AnthropicConfig::new_test("test-key");
+    let client = AnthropicClient::new(config).unwrap();
+
+    // n=1 plus unsupported-but-ignorable params must not fail the request
+    let mut request = ChatRequest::new("claude-opus-4-6").add_user_message("Hello");
+    request.n = Some(1);
+    request.frequency_penalty = Some(0.5);
+    request.presence_penalty = Some(0.5);
+    request.seed = Some(42);
+
+    let result = client.transform_chat_request(&request).unwrap();
+    assert_eq!(result["model"], "claude-opus-4-6");
+    // Ignored params must not leak into the Anthropic request body
+    assert!(result.get("frequency_penalty").is_none());
+    assert!(result.get("seed").is_none());
+}
+
+#[test]
+fn test_transform_chat_response_bills_cache_tokens_in_totals() {
+    let config = AnthropicConfig::new_test("test-key");
+    let client = AnthropicClient::new(config).unwrap();
+
+    let response = json!({
+        "id": "msg_123",
+        "model": "claude-3-opus-20240229",
+        "content": [{"type": "text", "text": "Hi"}],
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 30,
+            "cache_read_input_tokens": 20
+        }
+    });
+
+    let usage = client
+        .transform_chat_response(response)
+        .unwrap()
+        .usage
+        .unwrap();
+    // Anthropic bills cache tokens as input: prompt = 100 + 30 + 20
+    assert_eq!(usage.prompt_tokens, 150);
+    assert_eq!(usage.completion_tokens, 50);
+    assert_eq!(usage.total_tokens, 200);
+}

--- a/src/core/providers/anthropic/client/usage.rs
+++ b/src/core/providers/anthropic/client/usage.rs
@@ -1,0 +1,33 @@
+use serde_json::Value;
+
+use crate::core::types::responses::{PromptTokensDetails, Usage};
+
+pub(super) fn build_usage(usage_data: &Value) -> Usage {
+    let read = |key: &str| usage_data.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+    // Saturate instead of `as u32`, which silently wraps on overflow.
+    let to_u32 = |v: u64| u32::try_from(v).unwrap_or(u32::MAX);
+    let cache_creation = read("cache_creation_input_tokens");
+    let cache_read = read("cache_read_input_tokens");
+    // Anthropic input_tokens already includes cache creation/read tokens;
+    // expose cache details without double-counting prompt or total tokens.
+    let prompt_tokens = read("input_tokens");
+    let completion_tokens = read("output_tokens");
+
+    Usage {
+        prompt_tokens: to_u32(prompt_tokens),
+        completion_tokens: to_u32(completion_tokens),
+        total_tokens: to_u32(prompt_tokens + completion_tokens),
+        completion_tokens_details: None,
+        prompt_tokens_details: if cache_creation > 0 || cache_read > 0 {
+            Some(PromptTokensDetails {
+                cached_tokens: Some(to_u32(cache_read)),
+                cache_creation_tokens: Some(to_u32(cache_creation)),
+                cache_read_tokens: Some(to_u32(cache_read)),
+                audio_tokens: None,
+            })
+        } else {
+            None
+        },
+        thinking_usage: None,
+    }
+}


### PR DESCRIPTION
## What/Why
Anthropic provider 的保真问题：
1. `transform_chat_request` 静默忽略 `n`，但 Messages API 只返回 1 个候选；`n=0` 同样无意义。
2. 不支持的 OpenAI 风格参数（`frequency_penalty`/`presence_penalty`/`seed`/`logit_bias`）此前会静默丢弃。
3. usage 转换需要避免 u64→u32 回绕，并保留 cache creation/read 明细；Anthropic `input_tokens` 已包含 cache tokens，因此不能把 cache tokens 再加进 `prompt_tokens`/`total_tokens`。

## 改动
- `n != 1`（含 0）返回 `InvalidRequest`，不再静默返回错误数量的候选。
- 不支持的参数出现时 `tracing::warn!` 一次性列出被忽略的参数名。
- usage 构建改为 `prompt_tokens = input_tokens`、`total_tokens = input_tokens + output_tokens`，同时保留 `prompt_tokens_details.cached_tokens/cache_creation_tokens/cache_read_tokens`。
- token 数 u64→u32 使用饱和转换，避免静默回绕。

## Proof
- GitHub CI 9/9 checks green on latest head.
- Added/updated tests for n>1 rejection, n=0 rejection, n=1 with ignored params, cache usage details without double-counting.

## Review Focus
Anthropic cache usage semantics: expose cache details without double-counting `input_tokens`.

来源：`docs/audit/2026-06-10-design-audit-fix-spec.md` ISSUE-06