### PR TITLE
fix(auth): fail closed when no auth method is enabled

### DIFF
--- a/config/gateway.dev.yaml.example
+++ b/config/gateway.dev.yaml.example
@@ -66,6 +66,7 @@ storage:
 auth:
   enable_jwt: false
   enable_api_key: false
+  allow_anonymous: true
   jwt_secret: ""
   jwt_expiration: 86400
   api_key_header: "Authorization"

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -109,6 +109,11 @@ auth:
   jwt_secret: "${LITELLM_JWT_SECRET}"
   jwt_expiration: 86400
   api_key_header: "Authorization"
+  # allow_anonymous: when both enable_jwt and enable_api_key are false, config
+  # validation rejects the combination unless this is explicitly set to true.
+  # Setting it to true allows unauthenticated access to all routes —
+  # development only, never use in production.
+  allow_anonymous: false
   rbac:
     enabled: false
     default_role: "user"

--- a/src/auth/jwt/tests.rs
+++ b/src/auth/jwt/tests.rs
@@ -13,6 +13,7 @@ async fn create_test_handler() -> JwtHandler {
         enable_api_key: true,
         enable_jwt: true,
         api_key_hmac_secret: None,
+        allow_anonymous: false,
         rbac: crate::config::models::auth::RbacConfig {
             enabled: true,
             default_role: "user".to_string(),

--- a/src/config/builder/tests.rs
+++ b/src/config/builder/tests.rs
@@ -16,6 +16,7 @@ fn test_config_builder() {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         })
         .add_provider(

--- a/src/config/models/auth.rs
+++ b/src/config/models/auth.rs
@@ -28,6 +28,11 @@ pub struct AuthConfig {
     /// for production deployments.
     #[serde(default)]
     pub api_key_hmac_secret: Option<String>,
+    /// Allow anonymous access when both JWT and API key authentication are
+    /// disabled. Development only — validate() rejects the double-disabled
+    /// combination unless this is explicitly set to true.
+    #[serde(default)]
+    pub allow_anonymous: bool,
     /// RBAC configuration
     #[serde(default)]
     pub rbac: RbacConfig,
@@ -45,6 +50,7 @@ impl std::fmt::Debug for AuthConfig {
                 "api_key_hmac_secret",
                 &self.api_key_hmac_secret.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("allow_anonymous", &self.allow_anonymous)
             .field("rbac", &self.rbac)
             .finish()
     }
@@ -59,6 +65,7 @@ impl Default for AuthConfig {
             jwt_expiration: default_jwt_expiration(),
             api_key_header: default_api_key_header(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         }
     }
@@ -85,12 +92,26 @@ impl AuthConfig {
         if other.api_key_hmac_secret.is_some() {
             self.api_key_hmac_secret = other.api_key_hmac_secret;
         }
+        if other.allow_anonymous {
+            self.allow_anonymous = true;
+        }
         self.rbac = self.rbac.merge(other.rbac);
         self
     }
 
     /// Validate authentication configuration
     pub fn validate(&self) -> Result<(), String> {
+        // Reject the fail-open combination: both auth methods disabled without
+        // an explicit opt-in to anonymous access.
+        if !self.enable_jwt && !self.enable_api_key && !self.allow_anonymous {
+            return Err(
+                "Both JWT and API key authentication are disabled. Enable at least one \
+                 authentication method, or explicitly set allow_anonymous: true to opt in \
+                 to unauthenticated access (development only)"
+                    .to_string(),
+            );
+        }
+
         // Validate JWT secret strength
         if self.enable_jwt {
             if self.jwt_secret.is_empty() {
@@ -144,7 +165,9 @@ impl AuthConfig {
         Ok(())
     }
 
-    /// Check if authentication is properly configured for production
+    /// Check if authentication is properly configured for production.
+    /// `allow_anonymous` only takes effect when both auth methods are
+    /// disabled, so an enabled auth method always means production ready.
     pub fn is_production_ready(&self) -> bool {
         self.enable_jwt || self.enable_api_key
     }
@@ -349,6 +372,7 @@ mod tests {
             jwt_expiration: 7200,
             api_key_header: "Authorization".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.enable_jwt);
@@ -365,6 +389,7 @@ mod tests {
             jwt_expiration: 1800,
             api_key_header: "X-Token".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -381,6 +406,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_err());
@@ -397,6 +423,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         // 8 ASCII bytes + 12 CJK * 3 bytes = 44 bytes >= 32, should pass length check
@@ -419,6 +446,7 @@ mod tests {
                 jwt_expiration: 3600,
                 api_key_header: "X-API-Key".to_string(),
                 api_key_hmac_secret: None,
+                allow_anonymous: false,
                 rbac: RbacConfig::default(),
             };
             assert!(
@@ -437,6 +465,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_err());
@@ -451,6 +480,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_err());
@@ -465,6 +495,7 @@ mod tests {
             jwt_expiration: 100, // less than 300
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_err());
@@ -479,6 +510,7 @@ mod tests {
             jwt_expiration: 86400 * 31, // more than 30 days
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_err());
@@ -493,6 +525,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_err());
@@ -507,6 +540,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(config.validate().is_ok());
@@ -524,9 +558,87 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         assert!(!disabled.is_production_ready());
+    }
+
+    #[test]
+    fn test_auth_config_validate_rejects_all_auth_disabled() {
+        let config = AuthConfig {
+            enable_jwt: false,
+            enable_api_key: false,
+            jwt_secret: String::new(),
+            jwt_expiration: 3600,
+            api_key_header: "X-API-Key".to_string(),
+            api_key_hmac_secret: None,
+            allow_anonymous: false,
+            rbac: RbacConfig::default(),
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("allow_anonymous"),
+            "Expected fail-closed error mentioning allow_anonymous, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_auth_config_validate_allow_anonymous_opt_in() {
+        let config = AuthConfig {
+            enable_jwt: false,
+            enable_api_key: false,
+            jwt_secret: String::new(),
+            jwt_expiration: 3600,
+            api_key_header: "X-API-Key".to_string(),
+            api_key_hmac_secret: None,
+            allow_anonymous: true,
+            rbac: RbacConfig::default(),
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_auth_config_allow_anonymous_not_production_ready() {
+        // The spec scenario: both auth methods disabled, anonymous opt-in.
+        // validate() accepts it, but it must never count as production ready.
+        let config = AuthConfig {
+            enable_jwt: false,
+            enable_api_key: false,
+            jwt_secret: secure_jwt_secret(),
+            jwt_expiration: 3600,
+            api_key_header: "X-API-Key".to_string(),
+            api_key_hmac_secret: None,
+            allow_anonymous: true,
+            rbac: RbacConfig::default(),
+        };
+        assert!(!config.is_production_ready());
+    }
+
+    #[test]
+    fn test_auth_config_allow_anonymous_with_auth_enabled_is_production_ready() {
+        // allow_anonymous is inert while an auth method is enabled; the
+        // "Authentication is disabled" warning must not fire here.
+        let config = AuthConfig {
+            enable_jwt: true,
+            enable_api_key: true,
+            jwt_secret: secure_jwt_secret(),
+            jwt_expiration: 3600,
+            api_key_header: "X-API-Key".to_string(),
+            api_key_hmac_secret: None,
+            allow_anonymous: true,
+            rbac: RbacConfig::default(),
+        };
+        assert!(config.is_production_ready());
+    }
+
+    #[test]
+    fn test_auth_config_allow_anonymous_defaults_to_false() {
+        assert!(!AuthConfig::default().allow_anonymous);
+        let json = r#"{"jwt_secret": ""}"#;
+        let config: AuthConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.allow_anonymous);
     }
 
     #[test]
@@ -539,6 +651,7 @@ mod tests {
             jwt_expiration: 3600,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         let merged = base.merge(other);
@@ -555,6 +668,7 @@ mod tests {
             jwt_expiration: 7200,
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         };
         let merged = base.merge(other);

--- a/src/config/validation/auth_validators.rs
+++ b/src/config/validation/auth_validators.rs
@@ -40,6 +40,7 @@ mod tests {
             jwt_expiration: 3600, // 1 hour
             api_key_header: "X-API-Key".to_string(),
             api_key_hmac_secret: None,
+            allow_anonymous: false,
             rbac: RbacConfig::default(),
         }
     }

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -20,7 +20,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::rc::Rc;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 /// Auth middleware for Actix-web
 pub struct AuthMiddleware;
@@ -98,6 +98,21 @@ where
 
             let auth_enabled = enable_jwt || enable_api_key;
             if !auth_enabled {
+                // Fail closed: both auth methods are disabled. Only allow the
+                // request through when anonymous access was explicitly opted
+                // into. AuthConfig::validate() already rejects this combination,
+                // but guard here as defense in depth in case validation was
+                // bypassed.
+                if !cfg.auth().allow_anonymous {
+                    error!(
+                        "All authentication methods are disabled and allow_anonymous is false; \
+                         rejecting request to non-public route. Enable JWT or API key auth, or \
+                         set allow_anonymous: true (development only)."
+                    );
+                    return Err(actix_web::error::ErrorUnauthorized(
+                        "Authentication is not configured",
+                    ));
+                }
                 req.extensions_mut().insert(context);
                 return service.call(req).await;
             }

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -64,11 +64,13 @@ mod tests {
     async fn build_test_state_with_rate_limit(
         enable_jwt: bool,
         enable_api_key: bool,
+        allow_anonymous: bool,
         default_rpm: Option<u32>,
     ) -> AppState {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = enable_jwt;
         config.gateway.auth.enable_api_key = enable_api_key;
+        config.gateway.auth.allow_anonymous = allow_anonymous;
         config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
@@ -91,7 +93,7 @@ mod tests {
     }
 
     async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {
-        build_test_state_with_rate_limit(enable_jwt, enable_api_key, None).await
+        build_test_state_with_rate_limit(enable_jwt, enable_api_key, false, None).await
     }
 
     async fn seed_valid_principal(state: &AppState) -> SeededPrincipal {
@@ -198,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
-        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let state = build_test_state_with_rate_limit(true, true, false, Some(1)).await;
         let hit_counter = Arc::new(AtomicUsize::new(0));
 
         let app = test::init_service(
@@ -239,7 +241,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rotating_invalid_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
-        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let state = build_test_state_with_rate_limit(true, true, false, Some(1)).await;
         let hit_counter = Arc::new(AtomicUsize::new(0));
 
         let app = test::init_service(
@@ -282,7 +284,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_valid_auth_releases_gateway_auth_attempt_reservation() {
-        let state = build_test_state_with_rate_limit(true, true, Some(1)).await;
+        let state = build_test_state_with_rate_limit(true, true, false, Some(1)).await;
         let principal = seed_valid_principal(&state).await;
         let hit_counter = Arc::new(AtomicUsize::new(0));
 
@@ -365,8 +367,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_auth_middleware_bypasses_auth_when_disabled_but_sets_context() {
+    async fn test_auth_middleware_fails_closed_when_disabled_without_anonymous_opt_in() {
         let state = build_test_state(false, false).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let request = test::TestRequest::get().uri(AUTH_PROBE_PATH).to_request();
+        let error = test::try_call_service(&app, request)
+            .await
+            .expect_err("disabled auth without allow_anonymous should fail closed");
+
+        assert_eq!(
+            error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+        assert!(
+            error
+                .to_string()
+                .contains("Authentication is not configured")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_bypasses_auth_when_disabled_but_sets_context() {
+        let state = build_test_state_with_rate_limit(false, false, true, None).await;
         let hit_counter = Arc::new(AtomicUsize::new(0));
 
         let app = test::init_service(

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -42,6 +42,7 @@ mod tests {
 
         assert!(!config.auth().enable_jwt);
         assert!(!config.auth().enable_api_key);
+        assert!(config.auth().allow_anonymous);
         assert!(config.gateway.pricing.source.is_none());
         assert_eq!(config.server().port, 8080);
         assert_eq!(config.providers()[0].provider_type, "vllm");

--- a/tests/integration/http_routes_tests.rs
+++ b/tests/integration/http_routes_tests.rs
@@ -46,6 +46,7 @@ mod tests {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
@@ -124,6 +125,7 @@ mod tests {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.storage.files.local_path = Some(storage_path.to_string_lossy().into_owned());
@@ -153,6 +155,7 @@ mod tests {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.database.url.clear();
         config.gateway.storage.redis.enabled = false;


### PR DESCRIPTION
## What/Why
当 `enable_jwt` 和 `enable_api_key` 同时为 false 时，`AuthMiddleware` 此前直接放行所有非公开路由（含 admin/keys/budget），且配置校验不拦截该组合（`src/server/middleware/auth.rs`、`src/config/models/auth.rs`）。一次误配置就会让整个网关零认证开放（OWASP A05/A07）。默认配置下 `enable_api_key=true` 不受影响，但这是 fail-open 设计。

## 改动
- `AuthConfig` 新增 `allow_anonymous: bool`（serde 默认 false）。
- `validate()` 在双认证关闭且 `!allow_anonymous` 时返回配置错误（提示需启用一种认证或显式 `allow_anonymous: true`，仅开发用）。
- 中间件防御纵深：双关闭且未开启匿名时对非公开路由返回 401，而非放行。
- `is_production_ready()` 保持准确：`allow_anonymous` 只在两种认证都关闭时才有意义，启用任一认证时不受影响（避免误报 "Authentication is disabled"）。
- `gateway.yaml.example` 注释新字段。

## Proof
- `cargo test --all-features auth`（lib）：828 passed；集成测试 `auth_middleware`：8 passed（含新增 fail-closed 401 与 allow_anonymous opt-in 两条）
- `cargo check --all-features` 通过；`cargo fmt --check` 干净

## AI Role
AI 生成 + 对抗审查 + 人工复审修复（is_production_ready 语义、测试 helper 合并）。风险等级：中（认证边界，已按 SEC-11 复审）。

## Review Focus
`allow_anonymous` 的默认 false + validate 拒绝双关闭组合，是否会破坏现有仅启用 api_key 的部署（不会，单认证启用即通过）。

来源：`docs/audit/2026-06-10-design-audit-fix-spec.md` ISSUE-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)