### PR TITLE
fix(providers): preserve choice index, usage, logprobs and refusal in streaming

### DIFF
--- a/src/core/providers/base/sse/gemini.rs
+++ b/src/core/providers/base/sse/gemini.rs
@@ -95,7 +95,15 @@ impl SSETransformer for GeminiTransformer {
         }
 
         let mut choices = Vec::new();
-        for (index, candidate) in candidates.iter().enumerate() {
+        for (position, candidate) in candidates.iter().enumerate() {
+            // Prefer the upstream candidate index (n>1 sends real indices);
+            // fall back to the array position only when absent.
+            let index = candidate
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32)
+                .unwrap_or(position as u32);
+
             let empty_parts = vec![];
             let parts = candidate
                 .get("content")
@@ -122,7 +130,7 @@ impl SSETransformer for GeminiTransformer {
                 });
 
             choices.push(ChatStreamChoice {
-                index: index as u32,
+                index,
                 delta: ChatDelta {
                     role: if !delta_content.is_empty() || finish_reason.is_some() {
                         Some(MessageRole::Assistant)

--- a/src/core/providers/base/sse/openai.rs
+++ b/src/core/providers/base/sse/openai.rs
@@ -95,22 +95,55 @@ impl SSETransformer for OpenAICompatibleTransformer {
                 .and_then(|v| v.as_str())
                 .and_then(|s| self.parse_finish_reason(s));
 
-            let logprobs = choice
-                .get("logprobs")
-                .and_then(|v| serde_json::from_value(v.clone()).ok());
+            // Prefer the upstream choice index: with n>1 each chunk carries a
+            // single choice with its real index, so the array position is wrong.
+            let index = choice
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32)
+                .unwrap_or(index as u32);
+
+            let logprobs = match choice.get("logprobs") {
+                None | Some(Value::Null) => None,
+                Some(v) => match serde_json::from_value(v.clone()) {
+                    Ok(parsed) => Some(parsed),
+                    Err(e) => {
+                        tracing::error!(
+                            "{}: failed to parse 'logprobs' in SSE chunk: {} (raw: {})",
+                            self.provider,
+                            e,
+                            crate::utils::truncate_string(&v.to_string(), 200)
+                        );
+                        None
+                    }
+                },
+            };
 
             stream_choices.push(ChatStreamChoice {
-                index: index as u32,
+                index,
                 delta: delta_obj,
                 finish_reason,
                 logprobs,
             });
         }
 
-        // Parse usage (optional)
-        let usage = json_value
-            .get("usage")
-            .and_then(|v| serde_json::from_value(v.clone()).ok());
+        // Parse usage (optional). A parse failure must not drop the chunk, but
+        // usage feeds billing, so it must not be silently discarded either.
+        let usage = match json_value.get("usage") {
+            None | Some(Value::Null) => None,
+            Some(v) => match serde_json::from_value(v.clone()) {
+                Ok(parsed) => Some(parsed),
+                Err(e) => {
+                    tracing::error!(
+                        "{}: failed to parse 'usage' in SSE chunk: {} (raw: {})",
+                        self.provider,
+                        e,
+                        crate::utils::truncate_string(&v.to_string(), 200)
+                    );
+                    None
+                }
+            },
+        };
 
         Ok(Some(ChatChunk {
             id,
@@ -124,5 +157,59 @@ impl SSETransformer for OpenAICompatibleTransformer {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preserves_upstream_choice_index() {
+        let transformer = OpenAICompatibleTransformer::new("test");
+        // n>1: upstream sends one choice per chunk carrying its real index.
+        let chunk = r#"{
+            "id": "id",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4",
+            "choices": [{"index": 2, "delta": {"content": "x"}, "finish_reason": null}]
+        }"#;
+        let result = transformer.transform_chunk(chunk).unwrap().unwrap();
+        assert_eq!(result.choices[0].index, 2);
+    }
+
+    #[test]
+    fn test_missing_index_falls_back_to_position() {
+        let transformer = OpenAICompatibleTransformer::new("test");
+        let chunk = r#"{
+            "id": "id",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4",
+            "choices": [{"delta": {"content": "x"}, "finish_reason": null}]
+        }"#;
+        let result = transformer.transform_chunk(chunk).unwrap().unwrap();
+        assert_eq!(result.choices[0].index, 0);
+    }
+
+    #[test]
+    fn test_malformed_logprobs_does_not_drop_usage() {
+        let transformer = OpenAICompatibleTransformer::new("test");
+        // logprobs is the wrong shape; it must not fail the chunk or drop usage.
+        let chunk = r#"{
+            "id": "id",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4",
+            "choices": [{"index": 0, "delta": {"content": "x"}, "logprobs": 42}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+        }"#;
+        let result = transformer.transform_chunk(chunk).unwrap().unwrap();
+        assert!(result.choices[0].logprobs.is_none());
+        let usage = result
+            .usage
+            .expect("usage must survive a logprobs parse error");
+        assert_eq!(usage.total_tokens, 12);
     }
 }

--- a/src/core/providers/openai/transformer/response.rs
+++ b/src/core/providers/openai/transformer/response.rs
@@ -218,7 +218,11 @@ impl OpenAIResponseTransformer {
                         .collect()
                 })
                 .unwrap_or_default(),
-            refusal: logprobs.refusal.map(|_| "filtered".to_string()),
+            // Pass the real refusal through instead of masking it with a constant.
+            refusal: logprobs.refusal.map(|r| match r {
+                serde_json::Value::String(s) => s,
+                other => other.to_string(),
+            }),
         }
     }
 

--- a/src/core/providers/openai/transformer/response_tests.rs
+++ b/src/core/providers/openai/transformer/response_tests.rs
@@ -724,3 +724,24 @@ fn test_transform_delta_falls_back_to_openai_reasoning_when_reasoning_content_em
     };
     assert_eq!(out.thinking_content(), Some("openai fallback reasoning"));
 }
+
+#[test]
+fn test_transform_logprobs_passes_refusal_through() {
+    // A string refusal must arrive verbatim, not as a "filtered" constant.
+    let logprobs = OpenAILogprobs {
+        content: None,
+        refusal: Some(serde_json::json!("I cannot help with that")),
+    };
+    let result = OpenAIResponseTransformer::transform_logprobs(logprobs);
+    assert_eq!(result.refusal, Some("I cannot help with that".to_string()));
+
+    // Non-string refusal payloads are preserved as serialized JSON.
+    let logprobs = OpenAILogprobs {
+        content: None,
+        refusal: Some(serde_json::json!([{"token": "I", "logprob": -0.1}])),
+    };
+    let result = OpenAIResponseTransformer::transform_logprobs(logprobs);
+    let parsed: serde_json::Value =
+        serde_json::from_str(result.refusal.as_deref().unwrap()).unwrap();
+    assert_eq!(parsed[0]["token"], "I");
+}


### PR DESCRIPTION
## What/Why
流式响应转换器的三个保真缺陷（`base/sse/openai.rs`、`base/sse/gemini.rs`、`openai/transformer/response.rs`）：
1. **choice index 串台**：用 `enumerate()` 数组下标覆盖上游 choice 自带的 `index`。`n>1` 时上游每 chunk 单 choice 携带真实 index 0/1/2…，全被改写为 0，客户端按 index 重组时多路候选串台。
2. **logprobs/usage 静默吞错**：`serde_json::from_value(...).ok()` 把解析失败等同于"无该字段"，usage 丢失导致计费缺失。
3. **refusal 被常量替换**：`refusal.map(|_| "filtered")` 丢弃真实拒绝内容。

## 改动
- index 优先读 `choice["index"]`/`candidate["index"]`，缺失才回退数组位置（OpenAI + Gemini）。
- logprobs/usage 解析失败时 `tracing::error!`（用共享 `utils::truncate_string` 截断原始 JSON），usage 失败不让整个 chunk 失败但不再无声 None。
- refusal 透传真实值（字符串原样，非字符串序列化为 JSON）。

## Proof
- `cargo test --all-features sse::openai`：3 新测试通过（n>1 index 保留、缺失回退、畸形 logprobs 不丢 usage）
- `cargo test --all-features transformer::response`：22 passed（含 refusal 透传测试）
- `cargo check --all-features` 通过；`cargo fmt --check` 干净

## AI Role
AI 生成 + 对抗审查 + 人工复审修复（truncate_json 复用共享 helper、测试去除 key-order 依赖）。风险等级：中（流式数据正确性 + 计费）。

## Review Focus
n=1 常规路径 index 行为零变化（上游本就带 index:0）。

来源：`docs/audit/2026-06-10-design-audit-fix-spec.md` ISSUE-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)