### PR TITLE
fix(server): record budget spend and key usage for chat completions

### DIFF
--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -269,19 +269,25 @@ pub async fn handle_chat_completion_with_state(
     request: ChatCompletionRequest,
     context: RequestContext,
 ) -> Result<ChatCompletionResponse, GatewayError> {
-    let unified_router = &state.unified_router;
-    handle_chat_completion_internal(unified_router, request, context).await
+    handle_chat_completion_internal(state, request, context).await
 }
 
 async fn handle_chat_completion_internal(
-    unified_router: &crate::core::router::UnifiedRouter,
+    state: &AppState,
     request: ChatCompletionRequest,
     context: RequestContext,
 ) -> Result<ChatCompletionResponse, GatewayError> {
+    let unified_router = &state.unified_router;
     let requested_model = request.model.clone();
     let core_request = build_core_chat_request(request, requested_model, false)?;
     let requested_model = core_request.model.clone();
     let context_for_execution = context.clone();
+
+    // Owned handles captured into the (retryable) execution closure so that the
+    // successful attempt records budget spend and per-key usage.
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let api_key_id = context.api_key_id();
 
     let core_response = execute_with_selected_deployment(
         unified_router,
@@ -290,9 +296,11 @@ async fn handle_chat_completion_internal(
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
+            let budget_limits = budget_limits.clone();
+            let key_manager = key_manager.clone();
             async move {
                 let mut request_for_provider = core_request.clone();
-                request_for_provider.model = selected_model;
+                request_for_provider.model = selected_model.clone();
                 let response = provider
                     .chat_completion(request_for_provider, context)
                     .await?;
@@ -301,6 +309,15 @@ async fn handle_chat_completion_internal(
                     .as_ref()
                     .map(|usage| u64::from(usage.total_tokens))
                     .unwrap_or_default();
+                super::spend::record_completion_spend(
+                    &budget_limits,
+                    &key_manager,
+                    api_key_id,
+                    provider.name(),
+                    &selected_model,
+                    response.usage.as_ref(),
+                )
+                .await;
                 Ok((response, tokens))
             }
         },

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -15,6 +15,7 @@ mod openai_errors;
 mod provider_selection;
 mod responses;
 mod responses_stream;
+mod spend;
 
 // Public re-exports for backward compatibility
 pub use audio::{audio_speech, audio_transcriptions, audio_translations};

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -1,0 +1,140 @@
+//! Spend and usage recording for completed requests.
+//!
+//! Wires the otherwise-dead budget and per-key usage tracking into the request
+//! path: once a completion succeeds and its token usage is known, the served
+//! provider/model budget spend and the calling key's usage are recorded.
+
+use uuid::Uuid;
+
+use crate::core::budget::UnifiedBudgetLimits;
+use crate::core::cost::calculator::generic_cost_per_token;
+use crate::core::cost::types::UsageTokens;
+use crate::core::keys::KeyManager;
+use crate::core::types::responses::Usage;
+
+/// Record provider/model budget spend and per-key usage for a completed request.
+///
+/// Best-effort and non-fatal: the completion already succeeded, so failures here
+/// are logged at error level (never silently swallowed) but do not fail the
+/// response. When the cost cannot be priced, token usage is still recorded but
+/// budget spend is skipped rather than booked at $0 — under-counting a budget is
+/// worse than leaving it unchanged with a loud error.
+pub(super) async fn record_completion_spend(
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+) {
+    let Some(usage) = usage else {
+        tracing::error!(
+            "provider '{provider}' returned no usage for model '{model}'; spend not recorded"
+        );
+        return;
+    };
+
+    let total_tokens = u64::from(usage.total_tokens);
+    let usage_tokens: UsageTokens = usage.clone().into();
+
+    let cost = match generic_cost_per_token(model, &usage_tokens, provider) {
+        Ok(breakdown) => Some(breakdown.total_cost),
+        Err(e) => {
+            tracing::error!(
+                "cost calculation failed for '{provider}'/'{model}': {e}; \
+                 recording token usage without cost and skipping budget spend"
+            );
+            None
+        }
+    };
+
+    if let Some(cost) = cost {
+        budget_limits.record_spend(provider, model, cost);
+    }
+
+    if let Some(key_id) = api_key_id {
+        // Token counts are factual even when pricing is unavailable; record them
+        // with the cost we have (0.0 only when pricing failed, already logged).
+        if let Err(e) = key_manager
+            .record_usage(key_id, total_tokens, cost.unwrap_or(0.0))
+            .await
+        {
+            tracing::error!("failed to record usage for key {key_id}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::budget::{ProviderLimitConfig, ResetPeriod};
+    use crate::core::keys::InMemoryKeyRepository;
+    use crate::core::types::responses::Usage;
+
+    fn usage(prompt: u32, completion: u32) -> Usage {
+        Usage {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            total_tokens: prompt + completion,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+            thinking_usage: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn records_provider_spend_for_priced_model() {
+        let budget = UnifiedBudgetLimits::new();
+        budget.providers.set_provider_limit(
+            "openai",
+            ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+        );
+        let keys = KeyManager::new(InMemoryKeyRepository::new());
+
+        record_completion_spend(
+            &budget,
+            &keys,
+            None,
+            "openai",
+            "gpt-4o",
+            Some(&usage(1000, 1000)),
+        )
+        .await;
+
+        let spent = budget
+            .providers
+            .get_provider_usage("openai")
+            .map(|u| u.current_spend)
+            .unwrap_or(0.0);
+        assert!(spent > 0.0, "priced completion must record provider spend");
+    }
+
+    #[tokio::test]
+    async fn unpriced_model_records_no_budget_spend() {
+        let budget = UnifiedBudgetLimits::new();
+        budget.providers.set_provider_limit(
+            "openai",
+            ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+        );
+        let keys = KeyManager::new(InMemoryKeyRepository::new());
+
+        // Unknown model has no pricing: budget spend must stay at 0 rather than
+        // being booked at a fabricated $0 cost silently.
+        record_completion_spend(
+            &budget,
+            &keys,
+            None,
+            "openai",
+            "definitely-not-a-real-model-xyz",
+            Some(&usage(1000, 1000)),
+        )
+        .await;
+
+        let spent = budget
+            .providers
+            .get_provider_usage("openai")
+            .map(|u| u.current_spend)
+            .unwrap_or(0.0);
+        assert_eq!(spent, 0.0);
+    }
+}


### PR DESCRIPTION
## What/Why
预算/计费链路是死代码：`UnifiedBudgetLimits::record_spend` 和 key usage 记账都存在，但请求路径从不调用——`src/server/routes/ai/**` 零 `record_spend`/`record_usage`。结果：provider/model 预算永不累加、限额永不生效、per-key 用量永不记录。任何持有效 key 的用户可无限消费上游资源而网关不计账（审计 C1，Critical）。

## 改动
- 新增共享 helper `src/server/routes/ai/spend.rs::record_completion_spend`：补全成功后用成本计算器对 usage 定价，记录 provider+model 预算 spend（`UnifiedBudgetLimits::record_spend`）与 per-key 用量（`KeyManager::record_usage`）。
- 接入**非流式** chat completion 成功路径（`handle_chat_completion_internal` 的执行闭包内，已知 served provider/model + usage）。
- 失败语义（U-29）：定价失败 → `error!` 且**跳过预算 spend**（不按伪造的 $0 入账），但仍记录事实性 token 用量；记账失败 → `error!` 但不影响已成功的响应（best-effort，非致命）。

## Proof
- `cargo test --all-features ai::spend`：2 passed（已定价模型记录 spend；未定价模型预算保持 0）
- `cargo check --all-features` 通过；`cargo fmt --check` 干净

## AI Role
AI 生成 + 人工设计/复审。风险等级：高（热路径 + 计费正确性，按 SEC-11 需人工复审）。

## Review Focus
1. 记账在执行闭包内、仅成功 attempt 触发——重试不会重复计账，确认这一点。
2. **范围**：本 PR 只接入非流式 chat。流式（经 lease 的 `finish_success`）、`/responses`、embeddings 的 spend 接入作为后续 PR（依赖 usage 在各路径的不同流动方式）。
3. 依赖 #688（缺价返回 Err）以获得正确的"未定价→不计费"语义。

来源：`docs/audit/2026-06-10-design-audit-fix-spec.md` ISSUE-05

🤖 Generated with [Claude Code](https://claude.com/claude-code)