### PR TITLE
fix(server): reject chat completions when budget is exhausted

### DIFF
--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -299,6 +299,13 @@ async fn handle_chat_completion_internal(
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             async move {
+                // Reject before spending upstream tokens when the selected
+                // provider/model budget is already exhausted.
+                super::spend::ensure_budget_available(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                )?;
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = selected_model.clone();
                 let response = provider

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -10,7 +10,34 @@ use crate::core::budget::UnifiedBudgetLimits;
 use crate::core::cost::calculator::generic_cost_per_token;
 use crate::core::cost::types::UsageTokens;
 use crate::core::keys::KeyManager;
+use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::responses::Usage;
+
+/// Reject a request before it reaches the upstream provider when the served
+/// provider or model budget is already exhausted.
+///
+/// No-ops when budgets are disabled or unconfigured (the availability checks
+/// return true). Returns a non-retryable `QuotaExceeded` error (HTTP 402) so
+/// the router does not pointlessly retry an over-budget request.
+pub(super) fn ensure_budget_available(
+    budget_limits: &UnifiedBudgetLimits,
+    provider: &str,
+    model: &str,
+) -> Result<(), ProviderError> {
+    if !budget_limits.is_provider_available(provider) {
+        return Err(ProviderError::quota_exceeded(
+            "budget",
+            format!("provider '{provider}' budget exceeded"),
+        ));
+    }
+    if !budget_limits.is_model_available(model) {
+        return Err(ProviderError::quota_exceeded(
+            "budget",
+            format!("model '{model}' budget exceeded"),
+        ));
+    }
+    Ok(())
+}
 
 /// Record provider/model budget spend and per-key usage for a completed request.
 ///
@@ -136,5 +163,26 @@ mod tests {
             .map(|u| u.current_spend)
             .unwrap_or(0.0);
         assert_eq!(spent, 0.0);
+    }
+    #[test]
+    fn budget_available_when_unconfigured() {
+        // No limits set: precheck must allow the request through.
+        let budget = UnifiedBudgetLimits::new();
+        assert!(ensure_budget_available(&budget, "openai", "gpt-4o").is_ok());
+    }
+
+    #[test]
+    fn budget_rejects_when_provider_exhausted() {
+        let budget = UnifiedBudgetLimits::new();
+        budget.providers.set_provider_limit(
+            "openai",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        // Drive the provider over its limit.
+        budget.providers.record_provider_spend("openai", 2.0);
+
+        let err = ensure_budget_available(&budget, "openai", "gpt-4o")
+            .expect_err("exhausted provider budget must be rejected");
+        assert!(matches!(err, ProviderError::QuotaExceeded { .. }));
     }
 }


### PR DESCRIPTION
## What/Why
预算限额此前从不在请求前生效（审计 C1 / ISSUE-08）。本 PR 在已选定 provider/model、调用上游之前加预算守卫：若该 provider 或 model 预算已耗尽，直接拒绝，不浪费上游 token。

> **Stacked PR**：基于 #689（spend 记账接线，引入 `spend.rs`）。请先合并 #689，或将本 PR base 切到 `main` 后 review 仅看本 commit。

## 改动
- `spend.rs::ensure_budget_available`：用 `UnifiedBudgetLimits::is_provider_available` / `is_model_available` 检查；已耗尽返回 `ProviderError::QuotaExceeded`（HTTP 402，非重试——`is_retryable_error` 不含 QuotaExceeded，避免对超预算请求无谓重试）。
- 在非流式 chat completion 执行闭包内、provider 调用前调用。
- 预算未启用/未配置时 no-op（availability 检查返回 true）。

## Proof
- `cargo test --all-features ai::spend`：4 passed（含未配置放行、provider 耗尽拒绝 QuotaExceeded）
- `cargo check --all-features` 通过；`cargo fmt --check` 干净

## AI Role
AI 生成 + 人工设计/复审。风险等级：高（热路径 + 计费门禁）。

## Review Focus
1. tokenizer-free 设计：预检基于"预算是否已耗尽"而非精确成本估算（请求未 tokenize，精确估算不可行）——确认这是可接受的守卫语义。
2. 402 vs 429：复用 codebase 既有的 `QuotaExceeded → 402`，语义上比 429 更贴合"预算耗尽"。
3. **Follow-up（U-24）**：`core/budget/middleware.rs` 的空 `BudgetMiddleware`（从未接入 app）现已被本守卫取代，作为独立清理 PR 删除。

来源：`docs/audit/2026-06-10-design-audit-fix-spec.md` ISSUE-08（依赖 ISSUE-04/05）

🤖 Generated with [Claude Code](https://claude.com/claude-code)