### PR TITLE
fix(streaming): avoid shared request timeout

### DIFF
--- a/src/core/http/outbound.rs
+++ b/src/core/http/outbound.rs
@@ -98,9 +98,52 @@ mod tests {
     }
 
     #[test]
-    fn build_streaming_outbound_client_accepts_default_profile_without_total_timeout() {
+    fn build_streaming_outbound_client_accepts_default_profile() {
         let client = build_streaming_outbound_client(OutboundProfile::default());
         assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn streaming_client_ignores_request_timeout_as_total_deadline()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+
+        let server = tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let (mut stream, _) = listener.accept().await?;
+            let mut buffer = [0_u8; 1024];
+            let mut request = Vec::with_capacity(1024);
+            loop {
+                let bytes_read = stream.read(&mut buffer).await?;
+                if bytes_read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .await?;
+            Ok::<(), std::io::Error>(())
+        });
+
+        let profile = OutboundProfile {
+            request_timeout: Duration::from_millis(1),
+            connect_timeout: Duration::from_secs(1),
+            ..OutboundProfile::default()
+        };
+        let client = build_streaming_outbound_client(profile)?;
+        let response = client.get(format!("http://{address}/")).send().await?;
+
+        assert!(response.status().is_success());
+        assert_eq!(response.text().await?, "ok");
+        server.await??;
+        Ok(())
     }
 
     #[test]

--- a/src/core/http/outbound.rs
+++ b/src/core/http/outbound.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 static DEFAULT_CLIENT: OnceLock<Client> = OnceLock::new();
+static STREAMING_CLIENT: OnceLock<Client> = OnceLock::new();
 
 /// Return the process-wide default outbound HTTP client.
 ///
@@ -14,6 +15,19 @@ pub fn default_outbound_client() -> &'static Client {
     DEFAULT_CLIENT.get_or_init(|| {
         build_outbound_client(OutboundProfile::default())
             .expect("default outbound client must build")
+    })
+}
+
+/// Return the process-wide outbound HTTP client for streaming responses.
+///
+/// This client keeps connect and pool limits from the default profile, but does
+/// not set reqwest's total request timeout. Streaming routes enforce their own
+/// idle timeout while bytes are being read; a total response-lifetime timeout
+/// would cut off valid long generations.
+pub fn streaming_outbound_client() -> &'static Client {
+    STREAMING_CLIENT.get_or_init(|| {
+        build_streaming_outbound_client(OutboundProfile::default())
+            .expect("streaming outbound client must build")
     })
 }
 
@@ -41,13 +55,25 @@ impl Default for OutboundProfile {
 
 /// Build an outbound client from a profile.
 pub fn build_outbound_client(profile: OutboundProfile) -> reqwest::Result<Client> {
+    outbound_client_builder(&profile)
+        .timeout(profile.request_timeout)
+        .build()
+}
+
+/// Build an outbound streaming client from a profile.
+///
+/// Intentionally omits `ClientBuilder::timeout`, because reqwest treats that as
+/// a total request deadline rather than an idle/read timeout.
+pub fn build_streaming_outbound_client(profile: OutboundProfile) -> reqwest::Result<Client> {
+    outbound_client_builder(&profile).build()
+}
+
+fn outbound_client_builder(profile: &OutboundProfile) -> ClientBuilder {
     ClientBuilder::new()
         .connect_timeout(profile.connect_timeout)
-        .timeout(profile.request_timeout)
         .pool_idle_timeout(Some(profile.pool_idle_timeout))
         .pool_max_idle_per_host(profile.pool_idle_per_host)
-        .user_agent(profile.user_agent)
-        .build()
+        .user_agent(profile.user_agent.clone())
 }
 
 #[cfg(test)]
@@ -72,10 +98,25 @@ mod tests {
     }
 
     #[test]
+    fn build_streaming_outbound_client_accepts_default_profile_without_total_timeout() {
+        let client = build_streaming_outbound_client(OutboundProfile::default());
+        assert!(client.is_ok());
+    }
+
+    #[test]
     fn default_outbound_client_is_singleton() {
         let first = default_outbound_client();
         let second = default_outbound_client();
 
         assert!(std::ptr::eq(first, second));
+    }
+
+    #[test]
+    fn streaming_outbound_client_is_separate_singleton() {
+        let first = streaming_outbound_client();
+        let second = streaming_outbound_client();
+
+        assert!(std::ptr::eq(first, second));
+        assert!(!std::ptr::eq(first, default_outbound_client()));
     }
 }

--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -27,13 +27,14 @@ use crate::core::providers::base::{
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::streaming::utils::is_done_marker;
 use crate::core::traits::provider::ProviderConfig;
-use crate::utils::net::http::create_custom_client;
+use crate::utils::net::http::{create_custom_client, create_streaming_client};
 
 /// Azure OpenAI chat handler
 #[derive(Debug, Clone)]
 pub struct AzureChatHandler {
     config: AzureConfig,
     client: reqwest::Client,
+    streaming_client: reqwest::Client,
 }
 
 impl AzureChatHandler {
@@ -41,8 +42,15 @@ impl AzureChatHandler {
     pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
         let client = create_custom_client(ProviderConfig::timeout(&config))
             .map_err(|e| azure_config_error(format!("Failed to create HTTP client: {}", e)))?;
+        let streaming_client = create_streaming_client().map_err(|e| {
+            azure_config_error(format!("Failed to create streaming HTTP client: {}", e))
+        })?;
 
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            streaming_client,
+        })
     }
 
     /// Build request headers using the unified HeaderPair pattern.
@@ -154,9 +162,12 @@ impl AzureChatHandler {
         let headers = self.get_request_headers().await?;
 
         // Execute streaming request
-        let response = apply_headers(self.client.post(&url).json(&azure_request), headers)
-            .send()
-            .await?;
+        let response = apply_headers(
+            self.streaming_client.post(&url).json(&azure_request),
+            headers,
+        )
+        .send()
+        .await?;
 
         // Check status
         if !response.status().is_success() {

--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -114,10 +114,10 @@ impl AzureChatHandler {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("azure"))?;
             return Err(azure_api_error(status, error_body));
         }
 
@@ -174,10 +174,10 @@ impl AzureChatHandler {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("azure"))?;
             return Err(azure_api_error(status, error_body));
         }
 

--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -162,11 +162,13 @@ impl AzureChatHandler {
         let headers = self.get_request_headers().await?;
 
         // Execute streaming request
-        let response = apply_headers(
-            self.streaming_client.post(&url).json(&azure_request),
-            headers,
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            apply_headers(
+                self.streaming_client.post(&url).json(&azure_request),
+                headers,
+            ),
+            "azure",
         )
-        .send()
         .await?;
 
         // Check status

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -21,13 +21,14 @@ use super::config::{AzureAIConfig, AzureAIEndpointType};
 use crate::core::providers::base::HttpErrorMapper;
 use crate::core::providers::base::sse::{SSETransformer, UnifiedSSEStream};
 use crate::core::providers::unified_provider::ProviderError;
-use crate::utils::net::http::create_custom_client_with_headers;
+use crate::utils::net::http::{create_custom_client_with_headers, create_streaming_client};
 
 /// Azure AI chat handler - complete implementation
 #[derive(Debug, Clone)]
 pub struct AzureAIChatHandler {
     config: AzureAIConfig,
     client: reqwest::Client,
+    streaming_client: reqwest::Client,
 }
 
 impl AzureAIChatHandler {
@@ -53,8 +54,18 @@ impl AzureAIChatHandler {
         let client = create_custom_client_with_headers(config.timeout(), headers).map_err(|e| {
             ProviderError::configuration("azure_ai", format!("Failed to create HTTP client: {}", e))
         })?;
+        let streaming_client = create_streaming_client().map_err(|e| {
+            ProviderError::configuration(
+                "azure_ai",
+                format!("Failed to create streaming HTTP client: {}", e),
+            )
+        })?;
 
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            streaming_client,
+        })
     }
 
     /// Create chat completion
@@ -126,12 +137,17 @@ impl AzureAIChatHandler {
             .config
             .build_endpoint_url(AzureAIEndpointType::ChatCompletions.as_path())
             .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
+        let headers = self
+            .config
+            .create_default_headers()
+            .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
 
         // Execute streaming request
-        let response = self
-            .client
-            .post(&url)
-            .json(&azure_request)
+        let mut request_builder = self.streaming_client.post(&url).json(&azure_request);
+        for (key, value) in headers {
+            request_builder = request_builder.header(key, value);
+        }
+        let response = request_builder
             .send()
             .await
             .map_err(|e| ProviderError::network("azure_ai", format!("Request failed: {}", e)))?;

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -98,10 +98,10 @@ impl AzureAIChatHandler {
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,
@@ -156,10 +156,10 @@ impl AzureAIChatHandler {
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -147,10 +147,11 @@ impl AzureAIChatHandler {
         for (key, value) in headers {
             request_builder = request_builder.header(key, value);
         }
-        let response = request_builder
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("azure_ai", format!("Request failed: {}", e)))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            request_builder,
+            "azure_ai",
+        )
+        .await?;
 
         // Handle error responses
         if !response.status().is_success() {

--- a/src/core/providers/baseten/provider.rs
+++ b/src/core/providers/baseten/provider.rs
@@ -261,12 +261,16 @@ impl LLMProvider for BasetenProvider {
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
             return Err(match status {
-                400 => BasetenError::invalid_request(
-                    "baseten",
-                    body.unwrap_or_else(|| "Bad request".to_string()),
-                ),
+                400 => {
+                    let body =
+                        crate::core::providers::base::connection_pool::read_streaming_error_body(
+                            response,
+                        )
+                        .await
+                        .map_err(|err| err.into_provider_error("baseten"))?;
+                    BasetenError::invalid_request("baseten", body)
+                }
                 401 => BasetenError::authentication("baseten", "Invalid API key"),
                 429 => BasetenError::rate_limit("baseten", None),
                 _ => BasetenError::api_error(

--- a/src/core/providers/baseten/provider.rs
+++ b/src/core/providers/baseten/provider.rs
@@ -248,7 +248,7 @@ impl LLMProvider for BasetenProvider {
         let api_base = self.get_api_base_for_request(&request.model);
         let url = format!("{}/chat/completions", api_base);
 
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .header("Authorization", format!("Bearer {}", api_key))

--- a/src/core/providers/baseten/provider.rs
+++ b/src/core/providers/baseten/provider.rs
@@ -249,14 +249,15 @@ impl LLMProvider for BasetenProvider {
         let url = format!("{}/chat/completions", api_base);
 
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| BasetenError::network("baseten", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&request),
+            "baseten",
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/core/providers/clarifai/provider.rs
+++ b/src/core/providers/clarifai/provider.rs
@@ -282,12 +282,16 @@ impl LLMProvider for ClarifaiProvider {
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
             return Err(match status {
-                400 => ClarifaiError::invalid_request(
-                    "clarifai",
-                    body.unwrap_or_else(|| "Bad request".to_string()),
-                ),
+                400 => {
+                    let body =
+                        crate::core::providers::base::connection_pool::read_streaming_error_body(
+                            response,
+                        )
+                        .await
+                        .map_err(|err| err.into_provider_error("clarifai"))?;
+                    ClarifaiError::invalid_request("clarifai", body)
+                }
                 401 => ClarifaiError::authentication("clarifai", "Invalid API key"),
                 429 => ClarifaiError::rate_limit("clarifai", None),
                 _ => ClarifaiError::api_error(

--- a/src/core/providers/clarifai/provider.rs
+++ b/src/core/providers/clarifai/provider.rs
@@ -269,7 +269,7 @@ impl LLMProvider for ClarifaiProvider {
 
         let url = format!("{}/chat/completions", self.config.get_api_base());
 
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .header("Authorization", format!("Bearer {}", api_key))

--- a/src/core/providers/clarifai/provider.rs
+++ b/src/core/providers/clarifai/provider.rs
@@ -270,14 +270,15 @@ impl LLMProvider for ClarifaiProvider {
         let url = format!("{}/chat/completions", self.config.get_api_base());
 
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| ClarifaiError::network("clarifai", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&request),
+            "clarifai",
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/core/providers/codestral/provider.rs
+++ b/src/core/providers/codestral/provider.rs
@@ -270,7 +270,7 @@ impl LLMProvider for CodestralProvider {
             .ok_or_else(|| ProviderError::authentication("codestral", "API key required"))?;
 
         let url = format!("{}/chat/completions", self.config.get_api_base());
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
 
         let response = client
             .post(&url)

--- a/src/core/providers/codestral/provider.rs
+++ b/src/core/providers/codestral/provider.rs
@@ -272,14 +272,15 @@ impl LLMProvider for CodestralProvider {
         let url = format!("{}/chat/completions", self.config.get_api_base());
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
 
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("codestral", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&request),
+            "codestral",
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/core/providers/databricks/provider.rs
+++ b/src/core/providers/databricks/provider.rs
@@ -438,15 +438,16 @@ impl LLMProvider for DatabricksProvider {
             })?;
 
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .header("User-Agent", DatabricksConfig::build_user_agent(None))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("databricks", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .header("User-Agent", DatabricksConfig::build_user_agent(None))
+                .json(&body),
+            "databricks",
+        )
+        .await?;
 
         let status = response.status();
         if !status.is_success() {

--- a/src/core/providers/databricks/provider.rs
+++ b/src/core/providers/databricks/provider.rs
@@ -451,10 +451,10 @@ impl LLMProvider for DatabricksProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let error_text = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_text =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("databricks"))?;
             return Err(self
                 .get_error_mapper()
                 .map_http_error(status.as_u16(), &error_text));

--- a/src/core/providers/databricks/provider.rs
+++ b/src/core/providers/databricks/provider.rs
@@ -437,7 +437,7 @@ impl LLMProvider for DatabricksProvider {
                 ProviderError::authentication("databricks", "API key is required")
             })?;
 
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .header("Authorization", format!("Bearer {}", api_key))

--- a/src/core/providers/exa_ai/provider.rs
+++ b/src/core/providers/exa_ai/provider.rs
@@ -179,14 +179,15 @@ impl LLMProvider for ExaAiProvider {
             .ok_or_else(|| ProviderError::authentication("exa_ai", "API key is required"))?;
 
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("exa_ai", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&body),
+            "exa_ai",
+        )
+        .await?;
 
         let status = response.status();
         if !status.is_success() {

--- a/src/core/providers/exa_ai/provider.rs
+++ b/src/core/providers/exa_ai/provider.rs
@@ -178,7 +178,7 @@ impl LLMProvider for ExaAiProvider {
             .get_effective_api_key("exa_ai")
             .ok_or_else(|| ProviderError::authentication("exa_ai", "API key is required"))?;
 
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .header("Authorization", format!("Bearer {}", api_key))

--- a/src/core/providers/exa_ai/provider.rs
+++ b/src/core/providers/exa_ai/provider.rs
@@ -191,10 +191,10 @@ impl LLMProvider for ExaAiProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let error_text = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_text =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("exa_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "exa_ai",
                 status.as_u16(),

--- a/src/core/providers/github/provider.rs
+++ b/src/core/providers/github/provider.rs
@@ -264,7 +264,7 @@ impl LLMProvider for GitHubProvider {
 
         // Execute streaming request using reqwest directly for SSE
         let url = format!("{}/chat/completions", self.config.get_api_base());
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .header("Authorization", format!("Bearer {}", api_key))

--- a/src/core/providers/github/provider.rs
+++ b/src/core/providers/github/provider.rs
@@ -278,8 +278,10 @@ impl LLMProvider for GitHubProvider {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
-            let body_str = body.unwrap_or_else(|| "Unknown error".to_string());
+            let body_str =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("github"))?;
             return Err(match status {
                 401 => ProviderError::authentication("github", "Invalid API key"),
                 404 => ProviderError::model_not_found("github", body_str.clone()),

--- a/src/core/providers/github/provider.rs
+++ b/src/core/providers/github/provider.rs
@@ -265,14 +265,15 @@ impl LLMProvider for GitHubProvider {
         // Execute streaming request using reqwest directly for SSE
         let url = format!("{}/chat/completions", self.config.get_api_base());
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&stream_request)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("github", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&stream_request),
+            "github",
+        )
+        .await?;
 
         // Check status
         if !response.status().is_success() {

--- a/src/core/providers/github_copilot/provider.rs
+++ b/src/core/providers/github_copilot/provider.rs
@@ -480,8 +480,10 @@ impl LLMProvider for GitHubCopilotProvider {
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
-            let body_str = body.unwrap_or_else(|| "Unknown error".to_string());
+            let body_str =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("github_copilot"))?;
 
             // Clear cache on auth errors
             if status == 401 {

--- a/src/core/providers/github_copilot/provider.rs
+++ b/src/core/providers/github_copilot/provider.rs
@@ -404,7 +404,7 @@ impl LLMProvider for GitHubCopilotProvider {
         let url = format!("{}/chat/completions", api_base.trim_end_matches('/'));
 
         // Execute request
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .headers(headers)
@@ -471,7 +471,7 @@ impl LLMProvider for GitHubCopilotProvider {
         let url = format!("{}/chat/completions", api_base.trim_end_matches('/'));
 
         // Execute request
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .headers(headers)
@@ -679,21 +679,21 @@ impl Stream for GitHubCopilotStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::types::message::MessageContent;
 
     #[tokio::test]
     async fn test_github_copilot_provider_creation() {
-        let config = GitHubCopilotConfig::default();
-        let provider = GitHubCopilotProvider::new(config).await;
-        assert!(provider.is_ok());
-
-        let provider = provider.unwrap();
+        let provider = GitHubCopilotProvider::new(GitHubCopilotConfig::default())
+            .await
+            .expect("provider should build");
         assert_eq!(provider.name(), "github_copilot");
     }
 
     #[tokio::test]
     async fn test_github_copilot_provider_capabilities() {
-        let config = GitHubCopilotConfig::default();
-        let provider = GitHubCopilotProvider::new(config).await.unwrap();
+        let provider = GitHubCopilotProvider::new(GitHubCopilotConfig::default())
+            .await
+            .expect("provider should build");
         let capabilities = provider.capabilities();
 
         assert!(capabilities.contains(&ProviderCapability::ChatCompletion));
@@ -703,13 +703,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_github_copilot_provider_models() {
-        let config = GitHubCopilotConfig::default();
-        let provider = GitHubCopilotProvider::new(config).await.unwrap();
+        let provider = GitHubCopilotProvider::new(GitHubCopilotConfig::default())
+            .await
+            .expect("provider should build");
         let models = provider.models();
 
         assert!(!models.is_empty());
-
-        // Check that we have expected models
         let model_ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
         assert!(model_ids.contains(&"gpt-4o"));
         assert!(model_ids.contains(&"claude-3.5-sonnet"));
@@ -717,21 +716,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_github_copilot_provider_supported_params() {
-        let config = GitHubCopilotConfig::default();
-        let provider = GitHubCopilotProvider::new(config).await.unwrap();
+        let provider = GitHubCopilotProvider::new(GitHubCopilotConfig::default())
+            .await
+            .expect("provider should build");
 
-        // Non-reasoning model
         let params = provider.get_supported_openai_params("gpt-4o");
         assert!(params.contains(&"temperature"));
         assert!(params.contains(&"max_tokens"));
         assert!(params.contains(&"tools"));
         assert!(!params.contains(&"reasoning_effort"));
 
-        // Reasoning model
         let params = provider.get_supported_openai_params("o1-preview");
         assert!(params.contains(&"reasoning_effort"));
 
-        // Claude reasoning model
         let params = provider.get_supported_openai_params("claude-3-7-sonnet");
         assert!(params.contains(&"thinking"));
         assert!(params.contains(&"reasoning_effort"));
@@ -758,57 +755,43 @@ mod tests {
         assert_eq!(chunk.choices.len(), 1);
     }
 
+    fn text_message(role: MessageRole, text: &str) -> ChatMessage {
+        ChatMessage {
+            role,
+            content: Some(MessageContent::Text(text.to_string())),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn test_determine_initiator() {
         let config = GitHubCopilotConfig::default();
-        // Create a sync provider for testing
-        let authenticator = CopilotAuthenticator::new(&config);
         let provider = GitHubCopilotProvider {
+            authenticator: CopilotAuthenticator::new(&config),
             config,
-            authenticator,
             models: vec![],
             cached_api_key: Arc::new(RwLock::new(None)),
             cached_api_base: Arc::new(RwLock::new(None)),
         };
 
-        // User message only
-        let messages = vec![ChatMessage {
-            role: MessageRole::User,
-            content: Some(crate::core::types::message::MessageContent::Text(
-                "Hello".to_string(),
-            )),
-            ..Default::default()
-        }];
+        let messages = vec![text_message(MessageRole::User, "Hello")];
         assert_eq!(provider.determine_initiator(&messages), "user");
 
-        // Assistant message present
         let messages = vec![
-            ChatMessage {
-                role: MessageRole::User,
-                content: Some(crate::core::types::message::MessageContent::Text(
-                    "Hello".to_string(),
-                )),
-                ..Default::default()
-            },
-            ChatMessage {
-                role: MessageRole::Assistant,
-                content: Some(crate::core::types::message::MessageContent::Text(
-                    "Hi!".to_string(),
-                )),
-                ..Default::default()
-            },
+            text_message(MessageRole::User, "Hello"),
+            text_message(MessageRole::Assistant, "Hi!"),
         ];
         assert_eq!(provider.determine_initiator(&messages), "agent");
     }
 
     #[tokio::test]
     async fn test_github_copilot_provider_cost_calculation() {
-        let config = GitHubCopilotConfig::default();
-        let provider = GitHubCopilotProvider::new(config).await.unwrap();
+        let provider = GitHubCopilotProvider::new(GitHubCopilotConfig::default())
+            .await
+            .expect("provider should build");
 
-        // Copilot is subscription-based, cost should be 0
         let cost = provider.calculate_cost("gpt-4o", 1000, 500).await;
         assert!(cost.is_ok());
-        assert_eq!(cost.unwrap(), 0.0);
+        assert_eq!(cost.expect("cost should be available"), 0.0);
     }
 }

--- a/src/core/providers/github_copilot/provider.rs
+++ b/src/core/providers/github_copilot/provider.rs
@@ -404,7 +404,7 @@ impl LLMProvider for GitHubCopilotProvider {
         let url = format!("{}/chat/completions", api_base.trim_end_matches('/'));
 
         // Execute request
-        let client = crate::core::http::outbound::streaming_outbound_client().clone();
+        let client = crate::core::http::outbound::default_outbound_client().clone();
         let response = client
             .post(&url)
             .headers(headers)
@@ -472,13 +472,11 @@ impl LLMProvider for GitHubCopilotProvider {
 
         // Execute request
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .headers(headers)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("github_copilot", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client.post(&url).headers(headers).json(&request),
+            "github_copilot",
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/core/providers/gradient_ai/provider.rs
+++ b/src/core/providers/gradient_ai/provider.rs
@@ -280,7 +280,7 @@ impl LLMProvider for GradientAIProvider {
         let url = self.config.get_complete_url();
         let request_body = self.build_request_body(&request);
 
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&url)
             .header("Authorization", format!("Bearer {}", api_key))

--- a/src/core/providers/gradient_ai/provider.rs
+++ b/src/core/providers/gradient_ai/provider.rs
@@ -293,12 +293,16 @@ impl LLMProvider for GradientAIProvider {
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
             return Err(match status {
-                400 => ProviderError::invalid_request(
-                    "gradient_ai",
-                    body.unwrap_or_else(|| "Bad request".to_string()),
-                ),
+                400 => {
+                    let body =
+                        crate::core::providers::base::connection_pool::read_streaming_error_body(
+                            response,
+                        )
+                        .await
+                        .map_err(|err| err.into_provider_error("gradient_ai"))?;
+                    ProviderError::invalid_request("gradient_ai", body)
+                }
                 401 => ProviderError::authentication("gradient_ai", "Invalid API key"),
                 429 => ProviderError::rate_limit("gradient_ai", None),
                 _ => ProviderError::streaming_error(

--- a/src/core/providers/gradient_ai/provider.rs
+++ b/src/core/providers/gradient_ai/provider.rs
@@ -281,14 +281,15 @@ impl LLMProvider for GradientAIProvider {
         let request_body = self.build_request_body(&request);
 
         let client = crate::core::http::outbound::streaming_outbound_client().clone();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&request_body)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("gradient_ai", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&request_body),
+            "gradient_ai",
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/core/providers/oci/provider.rs
+++ b/src/core/providers/oci/provider.rs
@@ -396,11 +396,11 @@ impl LLMProvider for OciProvider {
             req_builder = req_builder.header(key, value);
         }
 
-        let response = req_builder
-            .json(&payload)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("oci", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            req_builder.json(&payload),
+            "oci",
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/core/providers/oci/provider.rs
+++ b/src/core/providers/oci/provider.rs
@@ -404,9 +404,12 @@ impl LLMProvider for OciProvider {
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
+            let body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("oci"))?;
             let mapper = OciErrorMapper;
-            return Err(mapper.map_http_error(status, &body.unwrap_or_default()));
+            return Err(mapper.map_http_error(status, &body));
         }
 
         let stream = super::streaming::create_oci_stream(response.bytes_stream());

--- a/src/core/providers/oci/provider.rs
+++ b/src/core/providers/oci/provider.rs
@@ -389,7 +389,7 @@ impl LLMProvider for OciProvider {
         }
 
         // Execute streaming request
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let mut req_builder = client.post(&url);
 
         for (key, value) in headers {

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -561,7 +561,7 @@ impl LLMProvider for OllamaProvider {
 
         // Use reqwest directly for streaming
         let url = self.config.get_chat_endpoint();
-        let mut req = crate::core::http::outbound::default_outbound_client()
+        let mut req = crate::core::http::outbound::streaming_outbound_client()
             .clone()
             .post(&url);
 

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -570,30 +570,26 @@ impl LLMProvider for OllamaProvider {
             req = req.header("Authorization", format!("Bearer {}", api_key));
         }
 
-        let response = req
-            .header("Content-Type", "application/json")
-            .json(&request_body)
-            .send()
-            .await
-            .map_err(|e| {
-                let error_msg = e.to_string();
-                if error_msg.contains("Connection refused") || error_msg.contains("connect error") {
-                    ProviderError::network(
-                        "ollama",
-                        format!(
-                            "Failed to connect to Ollama server at {}. Is Ollama running?",
-                            self.config.get_api_base()
-                        ),
-                    )
-                } else if error_msg.contains("timed out") || error_msg.contains("timeout") {
-                    ProviderError::Timeout {
-                        provider: "ollama",
-                        message: error_msg,
-                    }
-                } else {
-                    ProviderError::network("ollama", error_msg)
-                }
-            })?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            req.header("Content-Type", "application/json")
+                .json(&request_body),
+            "ollama",
+        )
+        .await
+        .map_err(|error| {
+            let error_msg = error.to_string();
+            if error_msg.contains("Connection refused") || error_msg.contains("connect error") {
+                ProviderError::network(
+                    "ollama",
+                    format!(
+                        "Failed to connect to Ollama server at {}. Is Ollama running?",
+                        self.config.get_api_base()
+                    ),
+                )
+            } else {
+                error
+            }
+        })?;
 
         // Check status
         if !response.status().is_success() {

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -594,12 +594,11 @@ impl LLMProvider for OllamaProvider {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
-            return Err(HttpErrorMapper::map_status_code(
-                "ollama",
-                status,
-                &body.unwrap_or_default(),
-            ));
+            let body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("ollama"))?;
+            return Err(HttpErrorMapper::map_status_code("ollama", status, &body));
         }
 
         // Create NDJSON stream

--- a/src/core/providers/replicate/provider.rs
+++ b/src/core/providers/replicate/provider.rs
@@ -338,13 +338,14 @@ impl LLMProvider for ReplicateProvider {
                 })?;
 
             let client = crate::core::http::outbound::streaming_outbound_client().clone();
-            let response = client
-                .get(stream_url)
-                .header("Authorization", format!("Token {}", api_key))
-                .header("Accept", "text/event-stream")
-                .send()
-                .await
-                .map_err(|e| ProviderError::network("replicate", e.to_string()))?;
+            let response = crate::core::providers::base::connection_pool::send_streaming_request(
+                client
+                    .get(stream_url)
+                    .header("Authorization", format!("Token {}", api_key))
+                    .header("Accept", "text/event-stream"),
+                "replicate",
+            )
+            .await?;
 
             if !response.status().is_success() {
                 let status_code = response.status().as_u16();

--- a/src/core/providers/replicate/provider.rs
+++ b/src/core/providers/replicate/provider.rs
@@ -337,7 +337,7 @@ impl LLMProvider for ReplicateProvider {
                     ProviderError::authentication("replicate", "API token required")
                 })?;
 
-            let client = crate::core::http::outbound::default_outbound_client().clone();
+            let client = crate::core::http::outbound::streaming_outbound_client().clone();
             let response = client
                 .get(stream_url)
                 .header("Authorization", format!("Token {}", api_key))

--- a/src/core/providers/replicate/provider.rs
+++ b/src/core/providers/replicate/provider.rs
@@ -349,10 +349,12 @@ impl LLMProvider for ReplicateProvider {
 
             if !response.status().is_success() {
                 let status_code = response.status().as_u16();
-                let error_text = response
-                    .text()
+                let error_text =
+                    crate::core::providers::base::connection_pool::read_streaming_error_body(
+                        response,
+                    )
                     .await
-                    .unwrap_or_else(|_| "Unknown error".to_string());
+                    .map_err(|err| err.into_provider_error("replicate"))?;
                 return Err(ProviderError::replicate_api_error(status_code, error_text));
             }
 

--- a/src/core/providers/watsonx/provider.rs
+++ b/src/core/providers/watsonx/provider.rs
@@ -176,7 +176,7 @@ impl WatsonxProvider {
         let iam_url = self.config.get_iam_url();
         debug!("Generating IAM token from {}", iam_url);
 
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let response = client
             .post(&iam_url)
             .header("Content-Type", "application/x-www-form-urlencoded")
@@ -544,7 +544,7 @@ impl LLMProvider for WatsonxProvider {
         let payload = self.prepare_payload(&request.model, &request)?;
 
         // Execute streaming request using reqwest directly for SSE
-        let client = crate::core::http::outbound::default_outbound_client().clone();
+        let client = crate::core::http::outbound::streaming_outbound_client().clone();
         let mut req_builder = client.post(&url);
 
         for (key, value) in headers {

--- a/src/core/providers/watsonx/provider.rs
+++ b/src/core/providers/watsonx/provider.rs
@@ -176,7 +176,7 @@ impl WatsonxProvider {
         let iam_url = self.config.get_iam_url();
         debug!("Generating IAM token from {}", iam_url);
 
-        let client = crate::core::http::outbound::streaming_outbound_client().clone();
+        let client = crate::core::http::outbound::default_outbound_client().clone();
         let response = client
             .post(&iam_url)
             .header("Content-Type", "application/x-www-form-urlencoded")
@@ -551,11 +551,11 @@ impl LLMProvider for WatsonxProvider {
             req_builder = req_builder.header(key, value);
         }
 
-        let response = req_builder
-            .json(&payload)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("watsonx", e.to_string()))?;
+        let response = crate::core::providers::base::connection_pool::send_streaming_request(
+            req_builder.json(&payload),
+            "watsonx",
+        )
+        .await?;
 
         // Check status
         if !response.status().is_success() {

--- a/src/core/providers/watsonx/provider.rs
+++ b/src/core/providers/watsonx/provider.rs
@@ -560,9 +560,12 @@ impl LLMProvider for WatsonxProvider {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let body = response.text().await.ok();
+            let body =
+                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
+                    .await
+                    .map_err(|err| err.into_provider_error("watsonx"))?;
             let mapper = WatsonxErrorMapper;
-            return Err(mapper.map_http_error(status, &body.unwrap_or_default()));
+            return Err(mapper.map_http_error(status, &body));
         }
 
         // Create SSE stream


### PR DESCRIPTION
## Summary
- add a shared streaming outbound client that omits reqwest total request timeout
- route direct provider streaming requests through streaming clients while keeping non-streaming clients bounded
- keep GitHub Copilot provider below the file-size hard limit while preserving its private tests

## Verification
- cargo fmt --all -- --check
- cargo check --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended"
- cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended"
- cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" -- -D warnings
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh

Closes #647