### PR TITLE
fix(provider): wire GitHub Copilot native dispatch

### DIFF
--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -3,10 +3,14 @@
 //! Contains config extraction helpers and per-provider config builder functions
 //! used by the factory when constructing provider instances.
 
+#[cfg(feature = "providers-extended")]
+use super::super::github_copilot;
 use super::super::unified_provider::ProviderError;
 use super::super::{anthropic, bedrock, cloudflare, macros, mistral, openai, openai_like};
 #[cfg(feature = "providers-extra")]
 use super::super::{azure, azure_ai};
+#[cfg(feature = "providers-extended")]
+use crate::core::traits::provider::ProviderConfig as _;
 use std::env;
 
 // ==================== Config Extraction Helpers ====================
@@ -590,27 +594,50 @@ pub(super) fn build_replicate_config_from_factory(
     Ok(oai_config)
 }
 
+#[cfg(feature = "providers-extended")]
 pub(super) fn build_github_copilot_config_from_factory(
     config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "github_copilot")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://api.githubcopilot.com");
+) -> Result<github_copilot::GitHubCopilotConfig, ProviderError> {
+    if config_str(config, "api_key").is_some() {
+        return Err(ProviderError::invalid_request(
+            "github_copilot",
+            "GitHub Copilot native auth does not accept static api_key; configure token_dir, access_token_file, or api_key_file",
+        ));
+    }
 
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "github_copilot".to_string();
+    let mut copilot_config = github_copilot::GitHubCopilotConfig::default();
 
+    if let Some(api_base) =
+        config_str(config, "base_url").or_else(|| config_str(config, "api_base"))
+    {
+        copilot_config.api_base = Some(api_base.to_string());
+    }
+    if let Some(token_dir) = config_str(config, "token_dir") {
+        copilot_config.token_dir = Some(token_dir.to_string());
+    }
+    if let Some(access_token_file) = config_str(config, "access_token_file") {
+        copilot_config.access_token_file = Some(access_token_file.to_string());
+    }
+    if let Some(api_key_file) = config_str(config, "api_key_file") {
+        copilot_config.api_key_file = Some(api_key_file.to_string());
+    }
     if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
+        copilot_config.timeout = timeout;
     }
     if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
+        copilot_config.max_retries = max_retries;
     }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+    if let Some(disable_system_to_assistant) = config_bool(config, "disable_system_to_assistant") {
+        copilot_config.disable_system_to_assistant = disable_system_to_assistant;
+    }
+    if let Some(debug) = config_bool(config, "debug") {
+        copilot_config.debug = debug;
+    }
 
-    Ok(oai_config)
+    copilot_config
+        .validate()
+        .map_err(|err| ProviderError::configuration("github_copilot", err))?;
+    Ok(copilot_config)
 }
 
 pub(super) fn build_openai_like_config_from_factory(

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -3,6 +3,8 @@
 //! Implements `Provider::from_config_async`, which maps each `ProviderType`
 //! to its concrete provider instantiation logic.
 
+#[cfg(feature = "providers-extended")]
+use crate::core::providers::github_copilot;
 use crate::core::providers::provider_type::ProviderType;
 use crate::core::providers::registry as provider_registry;
 use crate::core::providers::unified_provider::ProviderError;
@@ -12,13 +14,14 @@ use crate::core::providers::{
 #[cfg(feature = "providers-extra")]
 use crate::core::providers::{azure, azure_ai};
 
+#[cfg(feature = "providers-extended")]
+use super::builder::build_github_copilot_config_from_factory;
 use super::builder::{
     apply_tier1_openai_like_overrides, build_anthropic_config_from_factory,
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
-    build_fal_ai_config_from_factory, build_github_copilot_config_from_factory,
-    build_mistral_config_from_factory, build_openai_config_from_factory,
-    build_openai_like_config_from_factory, build_replicate_config_from_factory,
-    build_vertex_ai_config_from_factory, config_str,
+    build_fal_ai_config_from_factory, build_mistral_config_from_factory,
+    build_openai_config_from_factory, build_openai_like_config_from_factory,
+    build_replicate_config_from_factory, build_vertex_ai_config_from_factory, config_str,
 };
 #[cfg(feature = "providers-extra")]
 use super::builder::{build_azure_ai_config_from_factory, build_azure_config_from_factory};
@@ -135,11 +138,23 @@ impl Provider {
                 Ok(Provider::OpenAILike(provider))
             }
             ProviderType::GitHubCopilot => {
-                let oai_config = build_github_copilot_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("github_copilot", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extended")]
+                {
+                    let copilot_config = build_github_copilot_config_from_factory(&config)?;
+                    let provider = github_copilot::GitHubCopilotProvider::new(copilot_config)
+                        .await
+                        .map_err(|e| {
+                            ProviderError::initialization("github_copilot", e.to_string())
+                        })?;
+                    Ok(Provider::GitHubCopilot(provider))
+                }
+                #[cfg(not(feature = "providers-extended"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "github_copilot",
+                        "GitHub Copilot native dispatch requires the providers-extended feature",
+                    ))
+                }
             }
             // Catalog-covered provider types: delegate to the Tier 1 registry after
             // all explicit branches, so catalog metadata cannot shadow provider-specific builders.
@@ -208,6 +223,23 @@ mod tests {
         })
     }
 
+    fn minimal_dispatch_config_for(provider_type: &ProviderType) -> serde_json::Value {
+        if matches!(provider_type, ProviderType::GitHubCopilot) {
+            serde_json::json!({
+                "token_dir": "/tmp/litellm-rs-github-copilot-test",
+                "access_token_file": "access-token",
+                "api_key_file": "api-key.json",
+                "api_base": "https://example.test",
+                "timeout": 30,
+                "max_retries": 2,
+                "disable_system_to_assistant": true,
+                "debug": true
+            })
+        } else {
+            minimal_dispatch_config()
+        }
+    }
+
     #[tokio::test]
     async fn test_dispatch_kind_matches_runtime_variant() {
         for entry in provider_type_registry() {
@@ -215,15 +247,17 @@ mod tests {
                 continue;
             }
 
-            let provider =
-                Provider::from_config_async(entry.provider_type.clone(), minimal_dispatch_config())
-                    .await
-                    .unwrap_or_else(|err| {
-                        panic!(
-                            "{:?} should be creatable for dispatch-kind guard: {}",
-                            entry.provider_type, err
-                        )
-                    });
+            let provider = Provider::from_config_async(
+                entry.provider_type.clone(),
+                minimal_dispatch_config_for(&entry.provider_type),
+            )
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "{:?} should be creatable for dispatch-kind guard: {}",
+                    entry.provider_type, err
+                )
+            });
 
             match entry.dispatch_kind {
                 ProviderDispatchKind::Native => match (&entry.provider_type, &provider) {
@@ -235,6 +269,8 @@ mod tests {
                     #[cfg(feature = "providers-extra")]
                     (ProviderType::Azure, Provider::Azure(_))
                     | (ProviderType::AzureAI, Provider::AzureAI(_)) => {}
+                    #[cfg(feature = "providers-extended")]
+                    (ProviderType::GitHubCopilot, Provider::GitHubCopilot(_)) => {}
                     _ => panic!(
                         "{:?} is classified Native but created runtime provider {:?}",
                         entry.provider_type,
@@ -328,6 +364,41 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("openai_compatible should be creatable: {err}"));
         assert!(matches!(provider, Provider::OpenAILike(_)));
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_github_copilot_creates_native_without_static_key() {
+        let provider = Provider::from_config_async(
+            ProviderType::GitHubCopilot,
+            minimal_dispatch_config_for(&ProviderType::GitHubCopilot),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("github_copilot should create native provider: {err}"));
+
+        assert!(matches!(provider, Provider::GitHubCopilot(_)));
+        assert_eq!(provider.name(), "github_copilot");
+        assert_eq!(provider.provider_type(), ProviderType::GitHubCopilot);
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_github_copilot_rejects_static_api_key() {
+        let err = Provider::from_config_async(
+            ProviderType::GitHubCopilot,
+            serde_json::json!({"api_key": "sk-test"}),
+        )
+        .await
+        .expect_err("github_copilot native auth should reject static api_key");
+
+        assert!(
+            matches!(err, ProviderError::InvalidRequest { .. }),
+            "expected InvalidRequest, got {err}"
+        );
+        assert!(
+            err.to_string().contains("static api_key"),
+            "error should identify static api_key rejection: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -268,6 +268,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::GitHubCopilot(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
             Provider::OpenAILike(p) => p.$method($($arg),*),
@@ -283,6 +285,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extended")]
+            Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
@@ -298,6 +302,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*),
@@ -313,6 +319,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extended")]
+            Provider::GitHubCopilot(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
             Provider::Cloudflare(p) => LLMProvider::$method(p).await,
             Provider::OpenAILike(p) => LLMProvider::$method(p).await,
@@ -352,6 +360,8 @@ pub enum Provider {
     Azure(azure::AzureOpenAIProvider),
     #[cfg(feature = "providers-extra")]
     AzureAI(azure_ai::AzureAIProvider),
+    #[cfg(feature = "providers-extended")]
+    GitHubCopilot(github_copilot::GitHubCopilotProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
     /// Tier 1: data-driven OpenAI-compatible providers (groq, together, fireworks, etc.)
@@ -369,6 +379,8 @@ impl Provider {
             Provider::Azure(_) => "azure",
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(_) => "azure_ai",
+            #[cfg(feature = "providers-extended")]
+            Provider::GitHubCopilot(_) => "github_copilot",
             Provider::Mistral(_) => "mistral",
             Provider::Cloudflare(_) => "cloudflare",
             Provider::OpenAILike(p) => {
@@ -388,6 +400,8 @@ impl Provider {
             Provider::Azure(_) => ProviderType::Azure,
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(_) => ProviderType::AzureAI,
+            #[cfg(feature = "providers-extended")]
+            Provider::GitHubCopilot(_) => ProviderType::GitHubCopilot,
             Provider::Mistral(_) => ProviderType::Mistral,
             Provider::Cloudflare(_) => ProviderType::Cloudflare,
             Provider::OpenAILike(_) => ProviderType::OpenAICompatible,

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -115,9 +115,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "github",
         "native GitHub module retained; ProviderType::GitHub currently uses a generic OpenAI-compatible adapter",
     ),
-    stub(
+    providers_extended_wire(
         "github_copilot",
-        "native GitHub Copilot module retained; ProviderType::GitHubCopilot currently uses a generic OpenAI-compatible adapter",
+        "ProviderType::GitHubCopilot dispatches to native GitHub Copilot auth when providers-extended is enabled",
     ),
     stub(
         "gigachat",
@@ -291,6 +291,18 @@ const fn provider_extra_wire(
     entry(module_name, lifecycle, reason)
 }
 
+const fn providers_extended_wire(
+    module_name: &'static str,
+    reason: &'static str,
+) -> ProviderModuleLifecycleEntry {
+    let lifecycle = if cfg!(feature = "providers-extended") {
+        ProviderModuleLifecycle::Wire
+    } else {
+        ProviderModuleLifecycle::Stub
+    };
+    entry(module_name, lifecycle, reason)
+}
+
 const fn entry(
     module_name: &'static str,
     lifecycle: ProviderModuleLifecycle,
@@ -345,6 +357,14 @@ mod tests {
                 ProviderModuleLifecycle::Stub
             }
         );
+        assert_eq!(
+            lifecycle_for("github_copilot"),
+            if cfg!(feature = "providers-extended") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
         assert_eq!(lifecycle_for("cohere"), ProviderModuleLifecycle::Stub);
         assert_eq!(lifecycle_for("gemini"), ProviderModuleLifecycle::Stub);
     }
@@ -364,6 +384,8 @@ mod tests {
             "azure_ai",
             "bedrock",
             "cloudflare",
+            #[cfg(feature = "providers-extended")]
+            "github_copilot",
             "mistral",
             "openai",
             "openai_like",

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -218,7 +218,7 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::GitHubCopilot,
         "github_copilot",
         &["github-copilot", "copilot"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        providers_extended_native_dispatch_kind(),
         false,
     ),
     entry(
@@ -335,6 +335,14 @@ const fn provider_extra_native_dispatch_kind() -> ProviderDispatchKind {
     }
 }
 
+const fn providers_extended_native_dispatch_kind() -> ProviderDispatchKind {
+    if cfg!(feature = "providers-extended") {
+        ProviderDispatchKind::Native
+    } else {
+        ProviderDispatchKind::UnsupportedEnum
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -411,6 +419,8 @@ mod tests {
             ProviderType::Azure,
             #[cfg(feature = "providers-extra")]
             ProviderType::AzureAI,
+            #[cfg(feature = "providers-extended")]
+            ProviderType::GitHubCopilot,
         ])
         .collect::<HashSet<_>>();
 
@@ -434,6 +444,10 @@ mod tests {
         assert_eq!(
             dispatch_kind_for(&ProviderType::AzureAI),
             provider_extra_native_dispatch_kind()
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::GitHubCopilot),
+            providers_extended_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::OpenAICompatible),


### PR DESCRIPTION
## Summary
- route ProviderType::GitHubCopilot to the native GitHubCopilotProvider when providers-extended is enabled
- explicitly reject GitHub Copilot factory dispatch without providers-extended instead of using generic OpenAI-like fallback
- map token-file/OAuth config fields into GitHubCopilotConfig and reject static api_key for native auth
- update registry/lifecycle tests so Copilot native wiring is feature-gated consistently

Closes #605

## Verification
- cargo fmt --all -- --check
- cargo check
- cargo check --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended"
- cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" github_copilot -- --nocapture
- cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" test_dispatch_kind_matches_runtime_variant -- --nocapture
- cargo test test_from_config_async_unsupported_variants_return_not_implemented -- --nocapture
- cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" -- -D warnings
- cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" --quiet
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh

## Review
- independent read-only thread found lifecycle feature-gating inconsistency; fixed with providers_extended_wire and re-ran targeted/full tests