### PR TITLE
fix(provider): wire Vertex AI native dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |
-| Google Vertex AI (`vertex_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
+| Google Vertex AI (`vertex_ai`) | native factory (`providers-extra`) | ✅ | ✅ | ✅ | ✅ | – | Uses native Vertex auth and Google-specific URLs when `providers-extra` is enabled; otherwise explicitly unsupported. |
 | Meta Llama API (`meta_llama`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Vercel v0 (`v0`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Amazon Nova (`amazon_nova`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -8,10 +8,12 @@ use super::super::github_copilot;
 use super::super::unified_provider::ProviderError;
 use super::super::{anthropic, bedrock, cloudflare, macros, mistral, openai, openai_like};
 #[cfg(feature = "providers-extra")]
-use super::super::{azure, azure_ai};
-#[cfg(feature = "providers-extended")]
+use super::super::{azure, azure_ai, vertex_ai};
+#[cfg(any(feature = "providers-extra", feature = "providers-extended"))]
 use crate::core::traits::provider::ProviderConfig as _;
 use std::env;
+#[cfg(feature = "providers-extra")]
+use std::fs;
 
 // ==================== Config Extraction Helpers ====================
 
@@ -548,27 +550,125 @@ pub(super) fn build_bedrock_config_from_factory(
     Ok(bedrock_config)
 }
 
+#[cfg(feature = "providers-extra")]
 pub(super) fn build_vertex_ai_config_from_factory(
     config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "vertex_ai")?;
-    let api_base = config_str(config, "base_url")
+) -> Result<vertex_ai::VertexAIProviderConfig, ProviderError> {
+    if config_str(config, "api_key").is_some() {
+        return Err(ProviderError::invalid_request(
+            "vertex_ai",
+            "Vertex AI native auth does not accept static api_key; configure project/project_id with access_token, credentials_json, credentials_file, or Application Default Credentials",
+        ));
+    }
+
+    let project_id = config_str_any(
+        config,
+        &["project_id", "project", "gcp_project", "google_project_id"],
+    )
+    .map(str::to_string)
+    .or_else(|| {
+        env_str_any(&[
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_PROJECT_ID",
+            "GCP_PROJECT",
+            "GCLOUD_PROJECT",
+        ])
+    })
+    .ok_or_else(|| {
+        ProviderError::configuration("vertex_ai", "project_id (or project) is required")
+    })?;
+
+    let mut vertex_config = vertex_ai::VertexAIProviderConfig {
+        project_id,
+        ..Default::default()
+    };
+
+    if let Some(location) = config_str_any(config, &["location", "region", "vertex_location"])
+        .map(str::to_string)
+        .or_else(|| env_str_any(&["GOOGLE_CLOUD_LOCATION", "VERTEX_AI_LOCATION"]))
+    {
+        vertex_config.location = location;
+    }
+    if let Some(api_version) = config_str(config, "api_version") {
+        vertex_config.api_version = api_version.to_string();
+    }
+    if let Some(api_base) = config_str(config, "base_url")
         .or_else(|| config_str(config, "api_base"))
-        .ok_or_else(|| ProviderError::configuration("vertex_ai", "base_url is required"))?;
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "vertex_ai".to_string();
-
+        .or_else(|| config_str(config, "endpoint"))
+    {
+        vertex_config.api_base = Some(api_base.to_string());
+    }
     if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
+        vertex_config.timeout_seconds = timeout;
     }
     if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
+        vertex_config.max_retries = max_retries;
     }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
+    if let Some(enable_experimental) = config_bool(config, "enable_experimental") {
+        vertex_config.enable_experimental = enable_experimental;
+    }
+    vertex_config.credentials = build_vertex_credentials_from_factory(config)?;
 
-    Ok(oai_config)
+    vertex_config
+        .validate()
+        .map_err(|err| ProviderError::configuration("vertex_ai", err))?;
+    Ok(vertex_config)
+}
+
+#[cfg(feature = "providers-extra")]
+fn build_vertex_credentials_from_factory(
+    config: &serde_json::Value,
+) -> Result<vertex_ai::VertexCredentials, ProviderError> {
+    if let Some(access_token) = config_str_any(
+        config,
+        &[
+            "access_token",
+            "vertex_access_token",
+            "google_access_token",
+            "bearer_token",
+        ],
+    ) {
+        return Ok(vertex_ai::VertexCredentials::AccessToken(
+            access_token.to_string(),
+        ));
+    }
+
+    if let Some(credentials_json) = config_str_any(
+        config,
+        &[
+            "credentials_json",
+            "vertex_ai_credentials",
+            "google_credentials_json",
+        ],
+    ) {
+        return vertex_ai::VertexAuth::parse_credentials(credentials_json).map_err(|err| {
+            ProviderError::configuration("vertex_ai", format!("invalid credentials_json: {err}"))
+        });
+    }
+
+    if let Some(credentials_file) = config_str_any(
+        config,
+        &[
+            "credentials_file",
+            "credential_file",
+            "google_application_credentials",
+        ],
+    )
+    .map(str::to_string)
+    .or_else(|| env_str_any(&["GOOGLE_APPLICATION_CREDENTIALS"]))
+    {
+        let contents = fs::read_to_string(&credentials_file).map_err(|err| {
+            ProviderError::configuration(
+                "vertex_ai",
+                format!("failed to read credentials file '{credentials_file}': {err}"),
+            )
+        })?;
+        return vertex_ai::VertexAuth::parse_credentials(&contents).map_err(|err| {
+            ProviderError::configuration("vertex_ai", format!("invalid credentials file: {err}"))
+        });
+    }
+
+    Ok(vertex_ai::VertexCredentials::ApplicationDefault)
 }
 
 pub(super) fn build_replicate_config_from_factory(

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -12,7 +12,7 @@ use crate::core::providers::{
     Provider, anthropic, bedrock, cloudflare, mistral, openai, openai_like,
 };
 #[cfg(feature = "providers-extra")]
-use crate::core::providers::{azure, azure_ai};
+use crate::core::providers::{azure, azure_ai, vertex_ai};
 
 #[cfg(feature = "providers-extended")]
 use super::builder::build_github_copilot_config_from_factory;
@@ -21,10 +21,13 @@ use super::builder::{
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
     build_fal_ai_config_from_factory, build_mistral_config_from_factory,
     build_openai_config_from_factory, build_openai_like_config_from_factory,
-    build_replicate_config_from_factory, build_vertex_ai_config_from_factory, config_str,
+    build_replicate_config_from_factory, config_str,
 };
 #[cfg(feature = "providers-extra")]
-use super::builder::{build_azure_ai_config_from_factory, build_azure_config_from_factory};
+use super::builder::{
+    build_azure_ai_config_from_factory, build_azure_config_from_factory,
+    build_vertex_ai_config_from_factory,
+};
 #[cfg(not(feature = "providers-extra"))]
 use super::builder::{
     build_azure_ai_openai_like_config_from_factory, build_azure_openai_like_config_from_factory,
@@ -124,11 +127,21 @@ impl Provider {
                 Ok(Provider::Bedrock(provider))
             }
             ProviderType::VertexAI => {
-                let oai_config = build_vertex_ai_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("vertex_ai", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extra")]
+                {
+                    let vertex_config = build_vertex_ai_config_from_factory(&config)?;
+                    let provider = vertex_ai::VertexAIProvider::new(vertex_config)
+                        .await
+                        .map_err(|e| ProviderError::initialization("vertex_ai", e.to_string()))?;
+                    Ok(Provider::VertexAI(provider))
+                }
+                #[cfg(not(feature = "providers-extra"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "vertex_ai",
+                        "Vertex AI native dispatch requires the providers-extra feature",
+                    ))
+                }
             }
             ProviderType::Replicate => {
                 let oai_config = build_replicate_config_from_factory(&config)?;
@@ -224,8 +237,17 @@ mod tests {
     }
 
     fn minimal_dispatch_config_for(provider_type: &ProviderType) -> serde_json::Value {
-        if matches!(provider_type, ProviderType::GitHubCopilot) {
-            serde_json::json!({
+        match provider_type {
+            ProviderType::VertexAI => serde_json::json!({
+                "project_id": "test-project",
+                "location": "us-central1",
+                "api_version": "v1",
+                "access_token": "ya29.test-token",
+                "timeout": 30,
+                "max_retries": 2,
+                "enable_experimental": true
+            }),
+            ProviderType::GitHubCopilot => serde_json::json!({
                 "token_dir": "/tmp/litellm-rs-github-copilot-test",
                 "access_token_file": "access-token",
                 "api_key_file": "api-key.json",
@@ -234,9 +256,8 @@ mod tests {
                 "max_retries": 2,
                 "disable_system_to_assistant": true,
                 "debug": true
-            })
-        } else {
-            minimal_dispatch_config()
+            }),
+            _ => minimal_dispatch_config(),
         }
     }
 
@@ -268,7 +289,8 @@ mod tests {
                     | (ProviderType::Cloudflare, Provider::Cloudflare(_)) => {}
                     #[cfg(feature = "providers-extra")]
                     (ProviderType::Azure, Provider::Azure(_))
-                    | (ProviderType::AzureAI, Provider::AzureAI(_)) => {}
+                    | (ProviderType::AzureAI, Provider::AzureAI(_))
+                    | (ProviderType::VertexAI, Provider::VertexAI(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::GitHubCopilot, Provider::GitHubCopilot(_)) => {}
                     _ => panic!(
@@ -390,6 +412,44 @@ mod tests {
         )
         .await
         .expect_err("github_copilot native auth should reject static api_key");
+
+        assert!(
+            matches!(err, ProviderError::InvalidRequest { .. }),
+            "expected InvalidRequest, got {err}"
+        );
+        assert!(
+            err.to_string().contains("static api_key"),
+            "error should identify static api_key rejection: {err}"
+        );
+    }
+
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_from_config_async_vertex_ai_creates_native_with_access_token() {
+        let provider = Provider::from_config_async(
+            ProviderType::VertexAI,
+            minimal_dispatch_config_for(&ProviderType::VertexAI),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("vertex_ai should create native provider: {err}"));
+
+        assert!(matches!(provider, Provider::VertexAI(_)));
+        assert_eq!(provider.name(), "vertex_ai");
+        assert_eq!(provider.provider_type(), ProviderType::VertexAI);
+    }
+
+    #[cfg(feature = "providers-extra")]
+    #[tokio::test]
+    async fn test_from_config_async_vertex_ai_rejects_static_api_key() {
+        let err = Provider::from_config_async(
+            ProviderType::VertexAI,
+            serde_json::json!({
+                "api_key": "sk-test",
+                "project_id": "test-project"
+            }),
+        )
+        .await
+        .expect_err("vertex_ai native auth should reject static api_key");
 
         assert!(
             matches!(err, ProviderError::InvalidRequest { .. }),

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -268,6 +268,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::VertexAI(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
@@ -285,6 +287,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extra")]
+            Provider::VertexAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
@@ -302,6 +306,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extra")]
+            Provider::VertexAI(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
@@ -319,6 +325,8 @@ macro_rules! dispatch_provider {
             Provider::Azure(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extra")]
+            Provider::VertexAI(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
@@ -360,6 +368,8 @@ pub enum Provider {
     Azure(azure::AzureOpenAIProvider),
     #[cfg(feature = "providers-extra")]
     AzureAI(azure_ai::AzureAIProvider),
+    #[cfg(feature = "providers-extra")]
+    VertexAI(vertex_ai::VertexAIProvider),
     #[cfg(feature = "providers-extended")]
     GitHubCopilot(github_copilot::GitHubCopilotProvider),
     Mistral(mistral::MistralProvider),
@@ -379,6 +389,8 @@ impl Provider {
             Provider::Azure(_) => "azure",
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(_) => "azure_ai",
+            #[cfg(feature = "providers-extra")]
+            Provider::VertexAI(_) => "vertex_ai",
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => "github_copilot",
             Provider::Mistral(_) => "mistral",
@@ -400,6 +412,8 @@ impl Provider {
             Provider::Azure(_) => ProviderType::Azure,
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(_) => ProviderType::AzureAI,
+            #[cfg(feature = "providers-extra")]
+            Provider::VertexAI(_) => ProviderType::VertexAI,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => ProviderType::GitHubCopilot,
             Provider::Mistral(_) => ProviderType::Mistral,

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -249,9 +249,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "vercel_ai",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    stub(
+    provider_extra_wire(
         "vertex_ai",
-        "native Vertex AI module retained; ProviderType::VertexAI currently uses a generic OpenAI-compatible adapter",
+        "ProviderType::VertexAI dispatches to native Vertex AI auth when providers-extra is enabled",
     ),
     stub(
         "voyage",
@@ -340,7 +340,14 @@ mod tests {
     #[test]
     fn lifecycle_classifies_phase0_key_provider_modules() {
         assert_eq!(lifecycle_for("bedrock"), ProviderModuleLifecycle::Wire);
-        assert_eq!(lifecycle_for("vertex_ai"), ProviderModuleLifecycle::Stub);
+        assert_eq!(
+            lifecycle_for("vertex_ai"),
+            if cfg!(feature = "providers-extra") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
         assert_eq!(
             lifecycle_for("azure"),
             if cfg!(feature = "providers-extra") {
@@ -389,6 +396,8 @@ mod tests {
             "mistral",
             "openai",
             "openai_like",
+            #[cfg(feature = "providers-extra")]
+            "vertex_ai",
         ]
         .into_iter()
         .collect::<BTreeSet<_>>();

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -85,7 +85,7 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::VertexAI,
         "vertex_ai",
         &["vertexai", "vertex-ai"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        provider_extra_only_native_dispatch_kind(),
         false,
     ),
     entry(
@@ -343,6 +343,14 @@ const fn providers_extended_native_dispatch_kind() -> ProviderDispatchKind {
     }
 }
 
+const fn provider_extra_only_native_dispatch_kind() -> ProviderDispatchKind {
+    if cfg!(feature = "providers-extra") {
+        ProviderDispatchKind::Native
+    } else {
+        ProviderDispatchKind::UnsupportedEnum
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -419,6 +427,8 @@ mod tests {
             ProviderType::Azure,
             #[cfg(feature = "providers-extra")]
             ProviderType::AzureAI,
+            #[cfg(feature = "providers-extra")]
+            ProviderType::VertexAI,
             #[cfg(feature = "providers-extended")]
             ProviderType::GitHubCopilot,
         ])
@@ -435,7 +445,7 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::VertexAI),
-            ProviderDispatchKind::ExplicitOpenAiLike
+            provider_extra_only_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Azure),


### PR DESCRIPTION
## Summary
- Route `ProviderType::VertexAI` to the native Vertex AI provider when `providers-extra` is enabled.
- Reject static `api_key` config for native Vertex auth and map project/location/credentials inputs into `VertexAIProviderConfig`.
- Return explicit unsupported errors when `providers-extra` is disabled, and update dispatch/lifecycle tests plus the README capability row.

Closes #600

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo check --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended"`
- `cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" vertex_ai -- --nocapture`
- `cargo test test_from_config_async_unsupported_variants_return_not_implemented -- --nocapture`
- `cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" test_dispatch_kind_matches_runtime_variant -- --nocapture`
- `cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" lifecycle_wire_entries_are_native_runtime_modules -- --nocapture`
- `cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" -- -D warnings`
- `cargo test --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended" --quiet`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`