### PR TITLE
fix(provider): wire Gemini native dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ lite = ["metrics", "tracing"]
 
 # Provider compilation tiers (for reducing build size when using --no-default-features)
 # - providers-extra: additional built-in provider implementations used by enum variants
-# - providers-extended: direct provider modules not wired into the unified enum/factory path
+# - providers-extended: optional direct provider modules and explicitly wired native selectors
 providers-extra = []
 providers-extended = []
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |
 | Google Vertex AI (`vertex_ai`) | native factory (`providers-extra`) | ✅ | ✅ | ✅ | ✅ | – | Uses native Vertex auth and Google-specific URLs when `providers-extra` is enabled; otherwise explicitly unsupported. |
+| Google Gemini (`gemini`) | native factory (`providers-extended`) | ✅ | ✅ | – | – | – | Uses native Google AI Studio Gemini auth; use `vertex_ai` for Vertex AI project/location credentials. |
 | Meta Llama API (`meta_llama`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Vercel v0 (`v0`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Amazon Nova (`amazon_nova`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
@@ -153,7 +154,7 @@ All entries below route through `OpenAILikeProvider`. Chat and streaming work fo
 
 The following modules exist under `src/core/providers/` (gated on `providers-extra` or `providers-extended`) but are **not wired into the unified `Provider` enum or the factory** today. They compile but cannot be selected through `create_provider`/`from_config_async`. Treat them as experimental scaffolding subject to change:
 
-`ai21`, `baseten`, `clarifai`, `codestral`, `cohere`, `custom_api`, `databricks`, `datarobot`, `deepgram`, `deepl`, `elevenlabs`, `empower`, `exa_ai`, `firecrawl`, `gemini`, `gigachat`, `google_pse`, `gradient_ai`, `huggingface`, `jina`, `langgraph`, `manus`, `milvus`, `morph`, `nlp_cloud`, `oci`, `ollama`, `petals`, `pg_vector`, `predibase`, `ragflow`, `recraft`, `runwayml`, `sagemaker`, `sap_ai`, `searxng`, `snowflake`, `spark`, `stability`, `tavily`, `topaz`, `triton`, `vercel_ai`, `voyage`, `watsonx`
+`ai21`, `baseten`, `clarifai`, `codestral`, `cohere`, `custom_api`, `databricks`, `datarobot`, `deepgram`, `deepl`, `elevenlabs`, `empower`, `exa_ai`, `firecrawl`, `gigachat`, `google_pse`, `gradient_ai`, `huggingface`, `jina`, `langgraph`, `manus`, `milvus`, `morph`, `nlp_cloud`, `oci`, `ollama`, `petals`, `pg_vector`, `predibase`, `ragflow`, `recraft`, `runwayml`, `sagemaker`, `sap_ai`, `searxng`, `snowflake`, `spark`, `stability`, `tavily`, `topaz`, `triton`, `vercel_ai`, `voyage`, `watsonx`
 
 For self-hosted or unlisted OpenAI-compatible endpoints, prefer the generic `openai_compatible` provider type instead.
 

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -39,7 +39,7 @@ pub(super) fn config_bool(config: &serde_json::Value, key: &str) -> Option<bool>
     config.get(key).and_then(serde_json::Value::as_bool)
 }
 
-fn config_str_any<'a>(config: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> {
+pub(super) fn config_str_any<'a>(config: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> {
     keys.iter().find_map(|key| config_str(config, key))
 }
 

--- a/src/core/providers/factory/gemini_builder.rs
+++ b/src/core/providers/factory/gemini_builder.rs
@@ -1,0 +1,77 @@
+//! Gemini provider config builder.
+
+#![cfg(feature = "providers-extended")]
+
+use super::builder::{
+    config_bool, config_str, config_str_any, config_u32, config_u64, env_str_any,
+    merge_string_headers,
+};
+use crate::core::providers::{gemini, unified_provider::ProviderError};
+use crate::core::traits::provider::ProviderConfig as _;
+
+pub(super) fn build_gemini_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<gemini::GeminiConfig, ProviderError> {
+    if config_bool(config, "use_vertex_ai").unwrap_or(false)
+        || config_str_any(config, &["project_id", "location", "service_account_json"]).is_some()
+    {
+        return Err(ProviderError::invalid_request(
+            "gemini",
+            "Gemini provider selector uses Google AI Studio API-key auth; use vertex_ai for Vertex AI project/location credentials",
+        ));
+    }
+
+    let api_key = config_str_any(config, &["api_key", "google_api_key", "gemini_api_key"])
+        .map(str::to_string)
+        .or_else(|| env_str_any(&["GEMINI_API_KEY", "GOOGLE_API_KEY"]))
+        .ok_or_else(|| {
+            ProviderError::configuration("gemini", "api_key or GEMINI_API_KEY is required")
+        })?;
+
+    let mut gemini_config = gemini::GeminiConfig::new_google_ai(api_key);
+
+    if let Some(base_url) =
+        config_str(config, "base_url").or_else(|| config_str(config, "api_base"))
+    {
+        gemini_config.base_url = base_url.to_string();
+    }
+    if let Some(api_version) = config_str(config, "api_version") {
+        gemini_config.api_version = api_version.to_string();
+    }
+    if let Some(timeout) = config_u64(config, "timeout") {
+        gemini_config.request_timeout = timeout;
+    }
+    if let Some(connect_timeout) = config_u64(config, "connect_timeout") {
+        gemini_config.connect_timeout = connect_timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        gemini_config.max_retries = max_retries;
+    }
+    if let Some(retry_delay_ms) = config_u64(config, "retry_delay_ms") {
+        gemini_config.retry_delay_ms = retry_delay_ms;
+    }
+    if let Some(enable_caching) = config_bool(config, "enable_caching") {
+        gemini_config.enable_caching = enable_caching;
+    }
+    if let Some(cache_ttl_seconds) = config_u64(config, "cache_ttl_seconds") {
+        gemini_config.cache_ttl_seconds = cache_ttl_seconds;
+    }
+    if let Some(enable_search_grounding) = config_bool(config, "enable_search_grounding") {
+        gemini_config.enable_search_grounding = enable_search_grounding;
+    }
+    if let Some(proxy_url) = config_str(config, "proxy_url").or_else(|| config_str(config, "proxy"))
+    {
+        gemini_config.proxy_url = Some(proxy_url.to_string());
+    }
+    if let Some(debug) = config_bool(config, "debug") {
+        gemini_config.debug = debug;
+    }
+
+    merge_string_headers(&mut gemini_config.custom_headers, config, "headers");
+    merge_string_headers(&mut gemini_config.custom_headers, config, "custom_headers");
+
+    gemini_config
+        .validate()
+        .map_err(|err| ProviderError::configuration("gemini", err))?;
+    Ok(gemini_config)
+}

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -8,6 +8,8 @@
 mod builder;
 #[cfg(test)]
 mod builder_tests;
+#[cfg(feature = "providers-extended")]
+mod gemini_builder;
 mod registry;
 mod resolver;
 

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -3,8 +3,6 @@
 //! Implements `Provider::from_config_async`, which maps each `ProviderType`
 //! to its concrete provider instantiation logic.
 
-#[cfg(feature = "providers-extended")]
-use crate::core::providers::github_copilot;
 use crate::core::providers::provider_type::ProviderType;
 use crate::core::providers::registry as provider_registry;
 use crate::core::providers::unified_provider::ProviderError;
@@ -13,6 +11,8 @@ use crate::core::providers::{
 };
 #[cfg(feature = "providers-extra")]
 use crate::core::providers::{azure, azure_ai, vertex_ai};
+#[cfg(feature = "providers-extended")]
+use crate::core::providers::{gemini, github_copilot};
 
 #[cfg(feature = "providers-extended")]
 use super::builder::build_github_copilot_config_from_factory;
@@ -32,6 +32,8 @@ use super::builder::{
 use super::builder::{
     build_azure_ai_openai_like_config_from_factory, build_azure_openai_like_config_from_factory,
 };
+#[cfg(feature = "providers-extended")]
+use super::gemini_builder::build_gemini_config_from_factory;
 
 impl Provider {
     /// Create provider from configuration asynchronously
@@ -143,6 +145,22 @@ impl Provider {
                     ))
                 }
             }
+            ProviderType::Gemini => {
+                #[cfg(feature = "providers-extended")]
+                {
+                    let gemini_config = build_gemini_config_from_factory(&config)?;
+                    let provider = gemini::GeminiProvider::new(gemini_config)
+                        .map_err(|e| ProviderError::initialization("gemini", e.to_string()))?;
+                    Ok(Provider::Gemini(std::sync::Arc::new(provider)))
+                }
+                #[cfg(not(feature = "providers-extended"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "gemini",
+                        "Gemini native dispatch requires the providers-extended feature",
+                    ))
+                }
+            }
             ProviderType::Replicate => {
                 let oai_config = build_replicate_config_from_factory(&config)?;
                 let provider = openai_like::OpenAILikeProvider::new(oai_config)
@@ -247,6 +265,15 @@ mod tests {
                 "max_retries": 2,
                 "enable_experimental": true
             }),
+            ProviderType::Gemini => serde_json::json!({
+                "api_key": "test-gemini-api-key-1234567890",
+                "api_version": "v1beta",
+                "timeout": 30,
+                "connect_timeout": 5,
+                "max_retries": 2,
+                "enable_caching": false,
+                "debug": true
+            }),
             ProviderType::GitHubCopilot => serde_json::json!({
                 "token_dir": "/tmp/litellm-rs-github-copilot-test",
                 "access_token_file": "access-token",
@@ -291,6 +318,8 @@ mod tests {
                     (ProviderType::Azure, Provider::Azure(_))
                     | (ProviderType::AzureAI, Provider::AzureAI(_))
                     | (ProviderType::VertexAI, Provider::VertexAI(_)) => {}
+                    #[cfg(feature = "providers-extended")]
+                    (ProviderType::Gemini, Provider::Gemini(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::GitHubCopilot, Provider::GitHubCopilot(_)) => {}
                     _ => panic!(
@@ -386,6 +415,45 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("openai_compatible should be creatable: {err}"));
         assert!(matches!(provider, Provider::OpenAILike(_)));
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_gemini_creates_native_google_ai_provider() {
+        let provider = Provider::from_config_async(
+            ProviderType::Gemini,
+            minimal_dispatch_config_for(&ProviderType::Gemini),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("gemini should create native provider: {err}"));
+
+        assert!(matches!(provider, Provider::Gemini(_)));
+        assert_eq!(provider.name(), "gemini");
+        assert_eq!(provider.provider_type(), ProviderType::Gemini);
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_gemini_rejects_vertex_ai_fields() {
+        let err = Provider::from_config_async(
+            ProviderType::Gemini,
+            serde_json::json!({
+                "api_key": "test-gemini-api-key-1234567890",
+                "project_id": "test-project",
+                "location": "us-central1"
+            }),
+        )
+        .await
+        .expect_err("gemini selector should reject Vertex AI project/location credentials");
+
+        assert!(
+            matches!(err, ProviderError::InvalidRequest { .. }),
+            "expected InvalidRequest, got {err}"
+        );
+        assert!(
+            err.to_string().contains("use vertex_ai"),
+            "error should point callers to vertex_ai selector: {err}"
+        );
     }
 
     #[cfg(feature = "providers-extended")]

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -271,6 +271,8 @@ macro_rules! dispatch_provider {
             #[cfg(feature = "providers-extra")]
             Provider::VertexAI(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extended")]
+            Provider::Gemini(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
@@ -289,6 +291,8 @@ macro_rules! dispatch_provider {
             Provider::AzureAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extra")]
             Provider::VertexAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extended")]
+            Provider::Gemini(p) => LLMProvider::$method(p.as_ref(), $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
@@ -309,6 +313,8 @@ macro_rules! dispatch_provider {
             #[cfg(feature = "providers-extra")]
             Provider::VertexAI(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extended")]
+            Provider::Gemini(p) => LLMProvider::$method(p.as_ref(), $($arg),*),
+            #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
@@ -327,6 +333,8 @@ macro_rules! dispatch_provider {
             Provider::AzureAI(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extra")]
             Provider::VertexAI(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extended")]
+            Provider::Gemini(p) => LLMProvider::$method(p.as_ref()).await,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
@@ -371,6 +379,8 @@ pub enum Provider {
     #[cfg(feature = "providers-extra")]
     VertexAI(vertex_ai::VertexAIProvider),
     #[cfg(feature = "providers-extended")]
+    Gemini(std::sync::Arc<gemini::GeminiProvider>),
+    #[cfg(feature = "providers-extended")]
     GitHubCopilot(github_copilot::GitHubCopilotProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
@@ -391,6 +401,8 @@ impl Provider {
             Provider::AzureAI(_) => "azure_ai",
             #[cfg(feature = "providers-extra")]
             Provider::VertexAI(_) => "vertex_ai",
+            #[cfg(feature = "providers-extended")]
+            Provider::Gemini(_) => "gemini",
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => "github_copilot",
             Provider::Mistral(_) => "mistral",
@@ -414,6 +426,8 @@ impl Provider {
             Provider::AzureAI(_) => ProviderType::AzureAI,
             #[cfg(feature = "providers-extra")]
             Provider::VertexAI(_) => ProviderType::VertexAI,
+            #[cfg(feature = "providers-extended")]
+            Provider::Gemini(_) => ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => ProviderType::GitHubCopilot,
             Provider::Mistral(_) => ProviderType::Mistral,

--- a/src/core/providers/provider_type.rs
+++ b/src/core/providers/provider_type.rs
@@ -8,6 +8,7 @@ pub enum ProviderType {
     Bedrock,
     OpenRouter,
     VertexAI,
+    Gemini,
     Azure,
     AzureAI,
     DeepSeek,
@@ -95,6 +96,7 @@ pub fn all_non_custom_provider_types() -> Vec<ProviderType> {
         ProviderType::Bedrock,
         ProviderType::OpenRouter,
         ProviderType::VertexAI,
+        ProviderType::Gemini,
         ProviderType::Azure,
         ProviderType::AzureAI,
         ProviderType::DeepSeek,
@@ -153,6 +155,14 @@ mod tests {
         assert_eq!(ProviderType::from("vertex_ai"), ProviderType::VertexAI);
         assert_eq!(ProviderType::from("vertexai"), ProviderType::VertexAI);
         assert_eq!(ProviderType::from("vertex-ai"), ProviderType::VertexAI);
+    }
+
+    #[test]
+    fn test_provider_type_from_str_gemini() {
+        assert_eq!(ProviderType::from("gemini"), ProviderType::Gemini);
+        assert_eq!(ProviderType::from("google-gemini"), ProviderType::Gemini);
+        assert_eq!(ProviderType::from("google_ai"), ProviderType::Gemini);
+        assert_eq!(ProviderType::from("google-ai"), ProviderType::Gemini);
     }
 
     #[test]
@@ -233,6 +243,7 @@ mod tests {
         assert_eq!(format!("{}", ProviderType::Bedrock), "bedrock");
         assert_eq!(format!("{}", ProviderType::OpenRouter), "openrouter");
         assert_eq!(format!("{}", ProviderType::VertexAI), "vertex_ai");
+        assert_eq!(format!("{}", ProviderType::Gemini), "gemini");
         assert_eq!(format!("{}", ProviderType::Azure), "azure");
         assert_eq!(format!("{}", ProviderType::AzureAI), "azure_ai");
         assert_eq!(format!("{}", ProviderType::DeepSeek), "deepseek");

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -107,9 +107,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "firecrawl",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    stub(
+    providers_extended_wire(
         "gemini",
-        "specialized provider module used for model metadata but not wired through the LLM factory",
+        "ProviderType::Gemini dispatches to native Google AI Studio Gemini auth when providers-extended is enabled",
     ),
     stub(
         "github",
@@ -373,7 +373,14 @@ mod tests {
             }
         );
         assert_eq!(lifecycle_for("cohere"), ProviderModuleLifecycle::Stub);
-        assert_eq!(lifecycle_for("gemini"), ProviderModuleLifecycle::Stub);
+        assert_eq!(
+            lifecycle_for("gemini"),
+            if cfg!(feature = "providers-extended") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
     }
 
     #[test]
@@ -391,6 +398,8 @@ mod tests {
             "azure_ai",
             "bedrock",
             "cloudflare",
+            #[cfg(feature = "providers-extended")]
+            "gemini",
             #[cfg(feature = "providers-extended")]
             "github_copilot",
             "mistral",

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -89,6 +89,13 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         false,
     ),
     entry(
+        ProviderType::Gemini,
+        "gemini",
+        &["google-gemini", "google_ai", "google-ai"],
+        providers_extended_native_dispatch_kind(),
+        false,
+    ),
+    entry(
         ProviderType::Azure,
         "azure",
         &["azure-openai"],
@@ -430,6 +437,8 @@ mod tests {
             #[cfg(feature = "providers-extra")]
             ProviderType::VertexAI,
             #[cfg(feature = "providers-extended")]
+            ProviderType::Gemini,
+            #[cfg(feature = "providers-extended")]
             ProviderType::GitHubCopilot,
         ])
         .collect::<HashSet<_>>();
@@ -446,6 +455,10 @@ mod tests {
         assert_eq!(
             dispatch_kind_for(&ProviderType::VertexAI),
             provider_extra_only_native_dispatch_kind()
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::Gemini),
+            providers_extended_native_dispatch_kind()
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Azure),


### PR DESCRIPTION
## Summary
- Add `ProviderType::Gemini` and route it to the native Gemini provider when `providers-extended` is enabled.
- Return explicit unsupported behavior without `providers-extended`, and reject Vertex AI project/location credentials on the `gemini` selector so callers use `vertex_ai` for that auth path.
- Keep dispatch/lifecycle/provider-type contracts aligned and update README/Cargo feature docs.

Closes #601

## Review notes
- Independent read-only reviewer found no code regressions.
- Fixed its documentation findings: removed Gemini from the module-only list and updated the `providers-extended` Cargo feature comment.

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo check --features "providers-extended"`
- `cargo test --features "providers-extended" test_from_config_async_gemini -- --nocapture`
- `cargo test test_from_config_async_unsupported_variants_return_not_implemented -- --nocapture`
- `cargo test --features "providers-extended" test_dispatch_kind_matches_runtime_variant -- --nocapture`
- `cargo test --features "providers-extended" lifecycle_wire_entries_are_native_runtime_modules -- --nocapture`
- `cargo test --features "providers-extended" provider_registry_phase0_key_provider_classifications -- --nocapture`
- `cargo test --features "providers-extended" lifecycle_classifies_phase0_key_provider_modules -- --nocapture`
- `cargo test --features "providers-extended" test_provider_type_from_str_gemini -- --nocapture`
- `cargo test --features "providers-extended" provider_registry_aliases_parse_to_declared_type -- --nocapture`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --quiet`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`