### PR TITLE
fix(provider): wire Cohere native dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Anthropic (`anthropic`) | always | ✅ | ✅ | – | – | – | Native Anthropic messages API. |
 | Mistral (`mistral`) | always | ✅ | ✅ | passthrough | – | – | Native client. |
 | Cloudflare Workers AI (`cloudflare`) | always | ✅ | – | – | – | – | Native client with account-id auth; streaming and embeddings currently return `NotSupported`. |
-| Cohere (`cohere`) | native factory (`providers-extended`) | ✅ | ✅ | ✅ | – | – | Uses native Cohere `/v2/chat`, `/v2/embed`, and `/v1/rerank`; explicitly unsupported without `providers-extended`. |
+| Cohere (`cohere`) | native factory (`providers-extended`) | ✅ | ✅ | ✅ | – | – | Uses native Cohere `/v2/chat` and `/v2/embed`; the concrete provider also exposes a `/v1/rerank` helper. Explicitly unsupported without `providers-extended`. |
 | Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Anthropic (`anthropic`) | always | ✅ | ✅ | – | – | – | Native Anthropic messages API. |
 | Mistral (`mistral`) | always | ✅ | ✅ | passthrough | – | – | Native client. |
 | Cloudflare Workers AI (`cloudflare`) | always | ✅ | – | – | – | – | Native client with account-id auth; streaming and embeddings currently return `NotSupported`. |
+| Cohere (`cohere`) | native factory (`providers-extended`) | ✅ | ✅ | ✅ | – | – | Uses native Cohere `/v2/chat`, `/v2/embed`, and `/v1/rerank`; explicitly unsupported without `providers-extended`. |
 | Azure OpenAI (`azure`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | Azure AI Inference (`azure_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but the factory path uses OpenAILike chat/stream only. |
 | AWS Bedrock (`bedrock`) | always | ✅ | ✅ | ✅ | helper API | – | Native AWS Bedrock runtime path with SigV4 signing. Use `openai_compatible` for Bedrock Access Gateway or other OpenAI-compatible proxies. |
@@ -154,7 +155,7 @@ All entries below route through `OpenAILikeProvider`. Chat and streaming work fo
 
 The following modules exist under `src/core/providers/` (gated on `providers-extra` or `providers-extended`) but are **not wired into the unified `Provider` enum or the factory** today. They compile but cannot be selected through `create_provider`/`from_config_async`. Treat them as experimental scaffolding subject to change:
 
-`ai21`, `baseten`, `clarifai`, `codestral`, `cohere`, `custom_api`, `databricks`, `datarobot`, `deepgram`, `deepl`, `elevenlabs`, `empower`, `exa_ai`, `firecrawl`, `gigachat`, `google_pse`, `gradient_ai`, `huggingface`, `jina`, `langgraph`, `manus`, `milvus`, `morph`, `nlp_cloud`, `oci`, `ollama`, `petals`, `pg_vector`, `predibase`, `ragflow`, `recraft`, `runwayml`, `sagemaker`, `sap_ai`, `searxng`, `snowflake`, `spark`, `stability`, `tavily`, `topaz`, `triton`, `vercel_ai`, `voyage`, `watsonx`
+`ai21`, `baseten`, `clarifai`, `codestral`, `custom_api`, `databricks`, `datarobot`, `deepgram`, `deepl`, `elevenlabs`, `empower`, `exa_ai`, `firecrawl`, `gigachat`, `google_pse`, `gradient_ai`, `huggingface`, `jina`, `langgraph`, `manus`, `milvus`, `morph`, `nlp_cloud`, `oci`, `ollama`, `petals`, `pg_vector`, `predibase`, `ragflow`, `recraft`, `runwayml`, `sagemaker`, `sap_ai`, `searxng`, `snowflake`, `spark`, `stability`, `tavily`, `topaz`, `triton`, `vercel_ai`, `voyage`, `watsonx`
 
 For self-hosted or unlisted OpenAI-compatible endpoints, prefer the generic `openai_compatible` provider type instead.
 

--- a/src/core/providers/cohere/mod.rs
+++ b/src/core/providers/cohere/mod.rs
@@ -18,7 +18,7 @@ mod streaming;
 mod tests;
 
 // Re-export main types
-pub use config::CohereConfig;
+pub use config::{CohereApiVersion, CohereConfig};
 pub use error::CohereError;
 pub use provider::CohereProvider;
 pub use rerank::{RerankRequest, RerankResponse, RerankResult};

--- a/src/core/providers/factory/cohere_builder.rs
+++ b/src/core/providers/factory/cohere_builder.rs
@@ -1,0 +1,52 @@
+//! Cohere provider config builder.
+
+use super::builder::{config_str, config_u32, config_u64, env_str_any};
+use crate::core::providers::{cohere, unified_provider::ProviderError};
+use crate::core::traits::provider::ProviderConfig as _;
+
+pub(super) fn build_cohere_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<cohere::CohereConfig, ProviderError> {
+    let api_key = config_str(config, "api_key")
+        .map(str::to_string)
+        .or_else(|| env_str_any(&["COHERE_API_KEY"]))
+        .ok_or_else(|| {
+            ProviderError::configuration("cohere", "api_key or COHERE_API_KEY is required")
+        })?;
+
+    let mut cohere_config = cohere::CohereConfig::new(api_key);
+
+    if let Some(api_base) =
+        config_str(config, "base_url").or_else(|| config_str(config, "api_base"))
+    {
+        cohere_config.api_base = api_base.to_string();
+    }
+    if let Some(api_version) = config_str(config, "api_version") {
+        cohere_config.api_version = match api_version.trim().to_ascii_lowercase().as_str() {
+            "v1" | "1" => cohere::CohereApiVersion::V1,
+            "v2" | "2" => cohere::CohereApiVersion::V2,
+            _ => {
+                return Err(ProviderError::configuration(
+                    "cohere",
+                    "api_version must be v1 or v2",
+                ));
+            }
+        };
+    }
+    if let Some(timeout) =
+        config_u64(config, "timeout_seconds").or_else(|| config_u64(config, "timeout"))
+    {
+        cohere_config.timeout_seconds = timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        cohere_config.max_retries = max_retries;
+    }
+    if let Some(input_type) = config_str(config, "default_embedding_input_type") {
+        cohere_config.default_embedding_input_type = input_type.to_string();
+    }
+
+    cohere_config
+        .validate()
+        .map_err(|err| ProviderError::configuration("cohere", err))?;
+    Ok(cohere_config)
+}

--- a/src/core/providers/factory/cohere_builder.rs
+++ b/src/core/providers/factory/cohere_builder.rs
@@ -42,11 +42,23 @@ pub(super) fn build_cohere_config_from_factory(
         cohere_config.max_retries = max_retries;
     }
     if let Some(input_type) = config_str(config, "default_embedding_input_type") {
-        cohere_config.default_embedding_input_type = input_type.to_string();
+        cohere_config.default_embedding_input_type =
+            normalize_default_embedding_input_type(input_type)?;
     }
 
     cohere_config
         .validate()
         .map_err(|err| ProviderError::configuration("cohere", err))?;
     Ok(cohere_config)
+}
+
+fn normalize_default_embedding_input_type(input_type: &str) -> Result<String, ProviderError> {
+    let normalized = input_type.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "search_document" | "search_query" | "classification" | "clustering" => Ok(normalized),
+        _ => Err(ProviderError::configuration(
+            "cohere",
+            "default_embedding_input_type must be one of search_document, search_query, classification, or clustering",
+        )),
+    }
 }

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -9,6 +9,8 @@ mod builder;
 #[cfg(test)]
 mod builder_tests;
 #[cfg(feature = "providers-extended")]
+mod cohere_builder;
+#[cfg(feature = "providers-extended")]
 mod gemini_builder;
 mod registry;
 mod resolver;

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -234,6 +234,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_provider_cohere_feature_split() {
+        let mut config = crate::config::models::provider::ProviderConfig {
+            name: "cohere".to_string(),
+            provider_type: "cohere".to_string(),
+            api_key: "test-cohere-key".to_string(),
+            base_url: Some("https://api.cohere.ai".to_string()),
+            api_version: Some("v2".to_string()),
+            timeout: 30,
+            max_retries: 2,
+            ..Default::default()
+        };
+        config.settings.insert(
+            "default_embedding_input_type".to_string(),
+            serde_json::json!("search_query"),
+        );
+
+        let result = create_provider(config).await;
+
+        #[cfg(feature = "providers-extended")]
+        {
+            let provider =
+                result.unwrap_or_else(|err| panic!("cohere should create native provider: {err}"));
+            assert!(matches!(provider, Provider::Cohere(_)));
+            assert_eq!(provider.name(), "cohere");
+        }
+
+        #[cfg(not(feature = "providers-extended"))]
+        {
+            let err = result.expect_err("cohere should be unsupported without providers-extended");
+            assert!(
+                matches!(err, ProviderError::NotImplemented { .. }),
+                "Expected NotImplemented error, got {err}"
+            );
+            assert_eq!(err.provider(), "cohere");
+        }
+    }
+
+    #[tokio::test]
     async fn test_create_provider_tier1_catalog_applies_openai_like_overrides() {
         let mut config = crate::config::models::provider::ProviderConfig {
             name: "perplexity".to_string(),

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -12,7 +12,7 @@ use crate::core::providers::{
 #[cfg(feature = "providers-extra")]
 use crate::core::providers::{azure, azure_ai, vertex_ai};
 #[cfg(feature = "providers-extended")]
-use crate::core::providers::{gemini, github_copilot};
+use crate::core::providers::{cohere, gemini, github_copilot};
 
 #[cfg(feature = "providers-extended")]
 use super::builder::build_github_copilot_config_from_factory;
@@ -32,6 +32,8 @@ use super::builder::{
 use super::builder::{
     build_azure_ai_openai_like_config_from_factory, build_azure_openai_like_config_from_factory,
 };
+#[cfg(feature = "providers-extended")]
+use super::cohere_builder::build_cohere_config_from_factory;
 #[cfg(feature = "providers-extended")]
 use super::gemini_builder::build_gemini_config_from_factory;
 
@@ -70,6 +72,23 @@ impl Provider {
                     .await
                     .map_err(|e| ProviderError::initialization("cloudflare", e.to_string()))?;
                 Ok(Provider::Cloudflare(provider))
+            }
+            ProviderType::Cohere => {
+                #[cfg(feature = "providers-extended")]
+                {
+                    let cohere_config = build_cohere_config_from_factory(&config)?;
+                    let provider = cohere::CohereProvider::new(cohere_config)
+                        .await
+                        .map_err(|e| ProviderError::initialization("cohere", e.to_string()))?;
+                    Ok(Provider::Cohere(provider))
+                }
+                #[cfg(not(feature = "providers-extended"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "cohere",
+                        "Cohere native dispatch requires the providers-extended feature",
+                    ))
+                }
             }
             ProviderType::OpenAICompatible => {
                 let oai_like = build_openai_like_config_from_factory(&config)?;
@@ -284,6 +303,14 @@ mod tests {
                 "disable_system_to_assistant": true,
                 "debug": true
             }),
+            ProviderType::Cohere => serde_json::json!({
+                "api_key": "test-cohere-key",
+                "api_base": "https://api.cohere.ai",
+                "api_version": "v2",
+                "timeout": 30,
+                "max_retries": 2,
+                "default_embedding_input_type": "search_query"
+            }),
             _ => minimal_dispatch_config(),
         }
     }
@@ -318,6 +345,8 @@ mod tests {
                     (ProviderType::Azure, Provider::Azure(_))
                     | (ProviderType::AzureAI, Provider::AzureAI(_))
                     | (ProviderType::VertexAI, Provider::VertexAI(_)) => {}
+                    #[cfg(feature = "providers-extended")]
+                    (ProviderType::Cohere, Provider::Cohere(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::Gemini, Provider::Gemini(_)) => {}
                     #[cfg(feature = "providers-extended")]
@@ -386,6 +415,51 @@ mod tests {
                 "NotImplemented provider name should identify the requested provider"
             );
         }
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_cohere_creates_native_provider() {
+        let provider = Provider::from_config_async(
+            ProviderType::Cohere,
+            serde_json::json!({
+                "api_key": "test-cohere-key",
+                "api_base": "https://api.cohere.ai",
+                "api_version": "v2",
+                "timeout": 30,
+                "max_retries": 2,
+                "default_embedding_input_type": "search_query"
+            }),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("cohere should create native provider: {err}"));
+
+        assert!(matches!(provider, Provider::Cohere(_)));
+        assert_eq!(provider.name(), "cohere");
+        assert_eq!(provider.provider_type(), ProviderType::Cohere);
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_cohere_rejects_invalid_api_version() {
+        let err = Provider::from_config_async(
+            ProviderType::Cohere,
+            serde_json::json!({
+                "api_key": "test-cohere-key",
+                "api_version": "v3"
+            }),
+        )
+        .await
+        .expect_err("cohere should reject invalid API versions");
+
+        assert!(
+            matches!(err, ProviderError::Configuration { .. }),
+            "expected Configuration, got {err}"
+        );
+        assert!(
+            err.to_string().contains("api_version must be v1 or v2"),
+            "error should identify valid Cohere API versions: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -462,6 +462,30 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_cohere_rejects_invalid_embedding_input_type() {
+        let err = Provider::from_config_async(
+            ProviderType::Cohere,
+            serde_json::json!({
+                "api_key": "test-cohere-key",
+                "default_embedding_input_type": "chat"
+            }),
+        )
+        .await
+        .expect_err("cohere should reject invalid default embedding input types");
+
+        assert!(
+            matches!(err, ProviderError::Configuration { .. }),
+            "expected Configuration, got {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("default_embedding_input_type must be one of"),
+            "error should identify valid Cohere embedding input types: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn test_from_config_async_cloudflare_accepts_alias_fields() {
         let config = serde_json::json!({

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -276,6 +276,8 @@ macro_rules! dispatch_provider {
             Provider::GitHubCopilot(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::Cohere(p) => p.$method($($arg),*),
             Provider::OpenAILike(p) => p.$method($($arg),*),
         }
     };
@@ -297,6 +299,8 @@ macro_rules! dispatch_provider {
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extended")]
+            Provider::Cohere(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
         }
     };
@@ -318,6 +322,8 @@ macro_rules! dispatch_provider {
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::Cohere(p) => LLMProvider::$method(p, $($arg),*),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*),
         }
     };
@@ -339,6 +345,8 @@ macro_rules! dispatch_provider {
             Provider::GitHubCopilot(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
             Provider::Cloudflare(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extended")]
+            Provider::Cohere(p) => LLMProvider::$method(p).await,
             Provider::OpenAILike(p) => LLMProvider::$method(p).await,
         }
     };
@@ -384,6 +392,8 @@ pub enum Provider {
     GitHubCopilot(github_copilot::GitHubCopilotProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
+    #[cfg(feature = "providers-extended")]
+    Cohere(cohere::CohereProvider),
     /// Tier 1: data-driven OpenAI-compatible providers (groq, together, fireworks, etc.)
     OpenAILike(openai_like::OpenAILikeProvider),
 }
@@ -407,6 +417,8 @@ impl Provider {
             Provider::GitHubCopilot(_) => "github_copilot",
             Provider::Mistral(_) => "mistral",
             Provider::Cloudflare(_) => "cloudflare",
+            #[cfg(feature = "providers-extended")]
+            Provider::Cohere(_) => "cohere",
             Provider::OpenAILike(p) => {
                 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
                 p.name()
@@ -432,6 +444,8 @@ impl Provider {
             Provider::GitHubCopilot(_) => ProviderType::GitHubCopilot,
             Provider::Mistral(_) => ProviderType::Mistral,
             Provider::Cloudflare(_) => ProviderType::Cloudflare,
+            #[cfg(feature = "providers-extended")]
+            Provider::Cohere(_) => ProviderType::Cohere,
             Provider::OpenAILike(_) => ProviderType::OpenAICompatible,
         }
     }

--- a/src/core/providers/provider_type.rs
+++ b/src/core/providers/provider_type.rs
@@ -22,6 +22,7 @@ pub enum ProviderType {
     Groq,
     XAI,
     Cloudflare,
+    Cohere,
     Perplexity,
     Replicate,
     FalAI,
@@ -110,6 +111,7 @@ pub fn all_non_custom_provider_types() -> Vec<ProviderType> {
         ProviderType::Groq,
         ProviderType::XAI,
         ProviderType::Cloudflare,
+        ProviderType::Cohere,
         ProviderType::Perplexity,
         ProviderType::Replicate,
         ProviderType::FalAI,
@@ -217,6 +219,12 @@ mod tests {
     }
 
     #[test]
+    fn test_provider_type_from_str_cohere() {
+        assert_eq!(ProviderType::from("cohere"), ProviderType::Cohere);
+        assert_eq!(ProviderType::from("cohere-ai"), ProviderType::Cohere);
+    }
+
+    #[test]
     fn test_provider_type_from_str_other_providers() {
         assert_eq!(ProviderType::from("openrouter"), ProviderType::OpenRouter);
         assert_eq!(ProviderType::from("groq"), ProviderType::Groq);
@@ -255,6 +263,7 @@ mod tests {
         assert_eq!(format!("{}", ProviderType::Groq), "groq");
         assert_eq!(format!("{}", ProviderType::XAI), "xai");
         assert_eq!(format!("{}", ProviderType::Cloudflare), "cloudflare");
+        assert_eq!(format!("{}", ProviderType::Cohere), "cohere");
     }
 
     #[test]

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -62,9 +62,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "codestral",
         "specialized provider module; not wired through the LLM factory yet",
     ),
-    stub(
+    providers_extended_wire(
         "cohere",
-        "specialized provider module; not wired through the LLM factory yet",
+        "ProviderType::Cohere dispatches to native Cohere API paths when providers-extended is enabled",
     ),
     stub(
         "custom_api",
@@ -372,7 +372,14 @@ mod tests {
                 ProviderModuleLifecycle::Stub
             }
         );
-        assert_eq!(lifecycle_for("cohere"), ProviderModuleLifecycle::Stub);
+        assert_eq!(
+            lifecycle_for("cohere"),
+            if cfg!(feature = "providers-extended") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
         assert_eq!(
             lifecycle_for("gemini"),
             if cfg!(feature = "providers-extended") {
@@ -398,6 +405,8 @@ mod tests {
             "azure_ai",
             "bedrock",
             "cloudflare",
+            #[cfg(feature = "providers-extended")]
+            "cohere",
             #[cfg(feature = "providers-extended")]
             "gemini",
             #[cfg(feature = "providers-extended")]

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -110,6 +110,13 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         false,
     ),
     entry(
+        ProviderType::Cohere,
+        "cohere",
+        &["cohere-ai"],
+        providers_extended_native_dispatch_kind(),
+        false,
+    ),
+    entry(
         ProviderType::DeepSeek,
         "deepseek",
         &["deep-seek"],
@@ -437,6 +444,8 @@ mod tests {
             #[cfg(feature = "providers-extra")]
             ProviderType::VertexAI,
             #[cfg(feature = "providers-extended")]
+            ProviderType::Cohere,
+            #[cfg(feature = "providers-extended")]
             ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             ProviderType::GitHubCopilot,
@@ -470,6 +479,10 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::GitHubCopilot),
+            providers_extended_native_dispatch_kind()
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::Cohere),
             providers_extended_native_dispatch_kind()
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- add Cohere as a ProviderType selector with native dispatch behind providers-extended
- return explicit NotImplemented when providers-extended is disabled instead of falling through to OpenAI-like routing
- add Cohere factory config builder, dispatch/lifecycle registry coverage, and provider matrix docs

Fixes #602

## Verification
- cargo fmt --all
- cargo fmt --all -- --check
- cargo check
- cargo test test_from_config_async_unsupported_variants_return_not_implemented -- --nocapture
- cargo check --features "providers-extended"
- cargo test --features "providers-extended" test_from_config_async_cohere -- --nocapture
- cargo test --features "providers-extended" test_dispatch_kind_matches_runtime_variant -- --nocapture
- cargo test --features "providers-extended" provider_registry_phase0_key_provider_classifications -- --nocapture
- cargo test --features "providers-extended" lifecycle_classifies_phase0_key_provider_modules -- --nocapture
- cargo test --features "providers-extended" lifecycle_wire_entries_are_native_runtime_modules -- --nocapture
- cargo check --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features --quiet
- git diff --cached --check
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh