### PR TITLE
fix(provider): wire Fal AI native image dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Meta Llama API (`meta_llama`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Vercel v0 (`v0`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Amazon Nova (`amazon_nova`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
-| fal.ai (`fal_ai`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
+| fal.ai (`fal_ai`) | native factory (`providers-extended`) | – | – | – | ✅ | – | Uses native Fal AI image-generation endpoints; chat and streaming are explicitly unsupported. |
 | Replicate (`replicate`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
 | GitHub Models (`github`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | GitHub Copilot (`github_copilot`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -432,29 +432,6 @@ pub(super) fn build_azure_ai_config_from_factory(
     Ok(azure_ai_config)
 }
 
-pub(super) fn build_fal_ai_config_from_factory(
-    config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "fal_ai")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://fal.run");
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "fal_ai".to_string();
-
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
-    }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
-
-    Ok(oai_config)
-}
-
 #[cfg(feature = "providers-extra")]
 pub(super) fn build_azure_config_from_factory(
     config: &serde_json::Value,

--- a/src/core/providers/factory/fal_ai_builder.rs
+++ b/src/core/providers/factory/fal_ai_builder.rs
@@ -1,0 +1,41 @@
+//! Fal AI provider config builder.
+
+use super::builder::{config_bool, config_str, config_u32, config_u64, env_str_any};
+use crate::core::providers::{fal_ai, unified_provider::ProviderError};
+use crate::core::traits::provider::ProviderConfig as _;
+
+pub(super) fn build_fal_ai_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<fal_ai::FalAIConfig, ProviderError> {
+    let api_key = config_str(config, "api_key")
+        .map(str::to_string)
+        .or_else(|| env_str_any(&["FAL_AI_API_KEY"]))
+        .ok_or_else(|| {
+            ProviderError::configuration("fal_ai", "api_key or FAL_AI_API_KEY is required")
+        })?;
+
+    let mut fal_config = fal_ai::FalAIConfig::with_api_key(api_key);
+
+    if let Some(api_base) =
+        config_str(config, "base_url").or_else(|| config_str(config, "api_base"))
+    {
+        fal_config.base.api_base = Some(api_base.to_string());
+    }
+    if let Some(timeout) = config_u64(config, "timeout") {
+        fal_config.base.timeout = timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        fal_config.base.max_retries = max_retries;
+    }
+    if let Some(output_format) = config_str(config, "output_format") {
+        fal_config.output_format = output_format.trim().to_ascii_lowercase();
+    }
+    if let Some(sync_mode) = config_bool(config, "sync_mode") {
+        fal_config.sync_mode = sync_mode;
+    }
+
+    fal_config
+        .validate()
+        .map_err(|err| ProviderError::configuration("fal_ai", err))?;
+    Ok(fal_config)
+}

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -11,6 +11,8 @@ mod builder_tests;
 #[cfg(feature = "providers-extended")]
 mod cohere_builder;
 #[cfg(feature = "providers-extended")]
+mod fal_ai_builder;
+#[cfg(feature = "providers-extended")]
 mod gemini_builder;
 mod registry;
 mod resolver;
@@ -132,6 +134,8 @@ pub async fn create_provider(
     if let Some(value) = project.filter(|v| !v.is_empty()) {
         factory_config.insert("project".to_string(), Value::String(value));
     }
+    factory_config.insert("timeout".to_string(), Value::Number(timeout.into()));
+    factory_config.insert("max_retries".to_string(), Value::Number(max_retries.into()));
 
     for (key, value) in settings {
         factory_config.entry(key).or_insert(value);
@@ -268,6 +272,50 @@ mod tests {
                 "Expected NotImplemented error, got {err}"
             );
             assert_eq!(err.provider(), "cohere");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_provider_fal_ai_feature_split() {
+        let mut config = crate::config::models::provider::ProviderConfig {
+            name: "fal_ai".to_string(),
+            provider_type: "fal_ai".to_string(),
+            api_key: "test-fal-ai-key".to_string(),
+            base_url: Some("https://fal.run".to_string()),
+            timeout: 30,
+            max_retries: 2,
+            ..Default::default()
+        };
+        config
+            .settings
+            .insert("output_format".to_string(), serde_json::json!("png"));
+        config
+            .settings
+            .insert("sync_mode".to_string(), serde_json::json!(true));
+
+        let result = create_provider(config).await;
+
+        #[cfg(feature = "providers-extended")]
+        {
+            let provider =
+                result.unwrap_or_else(|err| panic!("fal_ai should create native provider: {err}"));
+            assert!(matches!(provider, Provider::FalAI(_)));
+            assert_eq!(provider.name(), "fal_ai");
+            assert!(
+                provider
+                    .capabilities()
+                    .contains(&crate::core::types::model::ProviderCapability::ImageGeneration)
+            );
+        }
+
+        #[cfg(not(feature = "providers-extended"))]
+        {
+            let err = result.expect_err("fal_ai should be unsupported without providers-extended");
+            assert!(
+                matches!(err, ProviderError::NotImplemented { .. }),
+                "Expected NotImplemented error, got {err}"
+            );
+            assert_eq!(err.provider(), "fal_ai");
         }
     }
 

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -12,16 +12,15 @@ use crate::core::providers::{
 #[cfg(feature = "providers-extra")]
 use crate::core::providers::{azure, azure_ai, vertex_ai};
 #[cfg(feature = "providers-extended")]
-use crate::core::providers::{cohere, gemini, github_copilot};
+use crate::core::providers::{cohere, fal_ai, gemini, github_copilot};
 
 #[cfg(feature = "providers-extended")]
 use super::builder::build_github_copilot_config_from_factory;
 use super::builder::{
     apply_tier1_openai_like_overrides, build_anthropic_config_from_factory,
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
-    build_fal_ai_config_from_factory, build_mistral_config_from_factory,
-    build_openai_config_from_factory, build_openai_like_config_from_factory,
-    build_replicate_config_from_factory, config_str,
+    build_mistral_config_from_factory, build_openai_config_from_factory,
+    build_openai_like_config_from_factory, build_replicate_config_from_factory, config_str,
 };
 #[cfg(feature = "providers-extra")]
 use super::builder::{
@@ -34,6 +33,8 @@ use super::builder::{
 };
 #[cfg(feature = "providers-extended")]
 use super::cohere_builder::build_cohere_config_from_factory;
+#[cfg(feature = "providers-extended")]
+use super::fal_ai_builder::build_fal_ai_config_from_factory;
 #[cfg(feature = "providers-extended")]
 use super::gemini_builder::build_gemini_config_from_factory;
 
@@ -117,11 +118,20 @@ impl Provider {
                 }
             }
             ProviderType::FalAI => {
-                let oai_config = build_fal_ai_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("fal_ai", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extended")]
+                {
+                    let fal_config = build_fal_ai_config_from_factory(&config)?;
+                    let provider = fal_ai::FalAIProvider::new(fal_config)
+                        .map_err(|e| ProviderError::initialization("fal_ai", e.to_string()))?;
+                    Ok(Provider::FalAI(provider))
+                }
+                #[cfg(not(feature = "providers-extended"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "fal_ai",
+                        "Fal AI native image-generation dispatch requires the providers-extended feature",
+                    ))
+                }
             }
             ProviderType::Azure => {
                 #[cfg(feature = "providers-extra")]
@@ -311,6 +321,14 @@ mod tests {
                 "max_retries": 2,
                 "default_embedding_input_type": "search_query"
             }),
+            ProviderType::FalAI => serde_json::json!({
+                "api_key": "test-fal-ai-key",
+                "api_base": "https://fal.run",
+                "timeout": 30,
+                "max_retries": 2,
+                "output_format": "png",
+                "sync_mode": true
+            }),
             _ => minimal_dispatch_config(),
         }
     }
@@ -347,6 +365,8 @@ mod tests {
                     | (ProviderType::VertexAI, Provider::VertexAI(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::Cohere, Provider::Cohere(_)) => {}
+                    #[cfg(feature = "providers-extended")]
+                    (ProviderType::FalAI, Provider::FalAI(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::Gemini, Provider::Gemini(_)) => {}
                     #[cfg(feature = "providers-extended")]
@@ -499,6 +519,26 @@ mod tests {
                 panic!("cloudflare should be creatable from alias fields: {err}")
             });
         assert!(matches!(provider, Provider::Cloudflare(_)));
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_fal_ai_creates_native_image_provider() {
+        let provider = Provider::from_config_async(
+            ProviderType::FalAI,
+            minimal_dispatch_config_for(&ProviderType::FalAI),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("fal_ai should create native provider: {err}"));
+
+        assert!(matches!(provider, Provider::FalAI(_)));
+        assert_eq!(provider.name(), "fal_ai");
+        assert_eq!(provider.provider_type(), ProviderType::FalAI);
+        assert!(
+            provider
+                .capabilities()
+                .contains(&crate::core::types::model::ProviderCapability::ImageGeneration)
+        );
     }
 
     #[tokio::test]

--- a/src/core/providers/fal_ai/config.rs
+++ b/src/core/providers/fal_ai/config.rs
@@ -95,6 +95,9 @@ impl ProviderConfig for FalAIConfig {
         if self.base.timeout == 0 {
             return Err("Timeout must be greater than 0".to_string());
         }
+        if self.base.max_retries > 10 {
+            return Err("Max retries must not exceed 10".to_string());
+        }
         Ok(())
     }
 
@@ -148,6 +151,15 @@ mod tests {
     fn test_validate_success() {
         let config = FalAIConfig::with_api_key("test-key");
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_excessive_retries() {
+        let mut config = FalAIConfig::with_api_key("test-key");
+        config.base.max_retries = 11;
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Max retries"));
     }
 
     #[test]

--- a/src/core/providers/fal_ai/provider.rs
+++ b/src/core/providers/fal_ai/provider.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use crate::core::providers::base::{
-    GlobalPoolManager, HeaderPair, HttpErrorMapper, HttpMethod, header,
+    GlobalPoolManager, HeaderPair, HttpErrorMapper, apply_headers, header,
 };
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::{
@@ -158,6 +158,78 @@ impl FalAIProvider {
 
         Ok(ImageGenerationResponse { created, data })
     }
+
+    fn build_image_request_body(
+        &self,
+        request: &ImageGenerationRequest,
+    ) -> Result<Value, ProviderError> {
+        let mut body = serde_json::json!({
+            "prompt": request.prompt,
+            "output_format": self.config.output_format,
+            "sync_mode": self.config.sync_mode,
+        });
+
+        if let Some(n) = request.n {
+            body["num_images"] = serde_json::json!(n);
+        }
+
+        if let Some(size) = &request.size {
+            let image_size = super::models::ImageSize::from_openai_size(size);
+            body["image_size"] = serde_json::to_value(image_size)
+                .map_err(|e| ProviderError::invalid_request("fal_ai", e.to_string()))?;
+        }
+
+        if let Some(format) = &request.response_format {
+            let output_format = match format.as_str() {
+                "b64_json" | "url" => "jpeg",
+                f => f,
+            };
+            body["output_format"] = serde_json::json!(output_format);
+        }
+
+        Ok(body)
+    }
+
+    fn transport_attempts(&self) -> u32 {
+        self.config.base.max_retries.saturating_add(1)
+    }
+
+    async fn execute_image_request(
+        &self,
+        url: &str,
+        headers: Vec<HeaderPair>,
+        body: Value,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let mut last_error = None;
+
+        for attempt in 0..self.transport_attempts() {
+            let request_builder = self
+                .pool_manager
+                .client()
+                .post(url)
+                .timeout(self.config.timeout())
+                .json(&body);
+            let request_builder = apply_headers(request_builder, headers.clone());
+
+            match request_builder.send().await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let provider_err = if err.is_timeout() {
+                        ProviderError::timeout("fal_ai", err.to_string())
+                    } else {
+                        ProviderError::network("fal_ai", err.to_string())
+                    };
+                    if attempt + 1 == self.transport_attempts() {
+                        return Err(provider_err);
+                    }
+                    last_error = Some(provider_err);
+                }
+            }
+        }
+
+        Err(last_error
+            .unwrap_or_else(|| ProviderError::network("fal_ai", "request failed before execution")))
+    }
 }
 
 impl LLMProvider for FalAIProvider {
@@ -248,37 +320,11 @@ impl LLMProvider for FalAIProvider {
     ) -> Result<ImageGenerationResponse, ProviderError> {
         let model = request.model.as_deref().unwrap_or("fal-ai/flux/schnell");
         let url = self.get_model_endpoint(model);
-
-        // Build request body
-        let mut body = serde_json::json!({
-            "prompt": request.prompt,
-        });
-
-        // Map optional parameters
-        if let Some(n) = request.n {
-            body["num_images"] = serde_json::json!(n);
-        }
-
-        if let Some(size) = &request.size {
-            let image_size = super::models::ImageSize::from_openai_size(size);
-            body["image_size"] = serde_json::to_value(image_size)
-                .map_err(|e| ProviderError::invalid_request("fal_ai", e.to_string()))?;
-        }
-
-        if let Some(format) = &request.response_format {
-            let output_format = match format.as_str() {
-                "b64_json" | "url" => "jpeg",
-                f => f,
-            };
-            body["output_format"] = serde_json::json!(output_format);
-        }
+        let body = self.build_image_request_body(&request)?;
 
         let headers = self.get_request_headers();
 
-        let response = self
-            .pool_manager
-            .execute_request(&url, HttpMethod::POST, headers, Some(body))
-            .await?;
+        let response = self.execute_image_request(&url, headers, body).await?;
 
         let status = response.status();
         let response_bytes = response
@@ -479,5 +525,63 @@ mod tests {
         let mapped = result.unwrap();
         assert!(mapped.contains_key("num_images"));
         assert!(mapped.contains_key("image_size"));
+    }
+
+    #[test]
+    fn test_build_image_request_body_uses_config_defaults() {
+        let mut config = FalAIConfig::with_api_key("test-key");
+        config.output_format = "png".to_string();
+        config.sync_mode = false;
+        let provider = FalAIProvider::new(config).unwrap();
+
+        let body = provider
+            .build_image_request_body(&ImageGenerationRequest {
+                prompt: "test prompt".to_string(),
+                model: Some("fal-ai/flux/schnell".to_string()),
+                n: Some(2),
+                size: Some("1024x1024".to_string()),
+                quality: None,
+                response_format: None,
+                style: None,
+                user: None,
+            })
+            .unwrap();
+
+        assert_eq!(body["prompt"], "test prompt");
+        assert_eq!(body["num_images"], 2);
+        assert_eq!(body["output_format"], "png");
+        assert_eq!(body["sync_mode"], false);
+        assert_eq!(body["image_size"], "square_hd");
+    }
+
+    #[test]
+    fn test_build_image_request_body_response_format_overrides_default() {
+        let mut config = FalAIConfig::with_api_key("test-key");
+        config.output_format = "png".to_string();
+        let provider = FalAIProvider::new(config).unwrap();
+
+        let body = provider
+            .build_image_request_body(&ImageGenerationRequest {
+                prompt: "test prompt".to_string(),
+                model: Some("fal-ai/flux/schnell".to_string()),
+                n: None,
+                size: None,
+                quality: None,
+                response_format: Some("url".to_string()),
+                style: None,
+                user: None,
+            })
+            .unwrap();
+
+        assert_eq!(body["output_format"], "jpeg");
+    }
+
+    #[test]
+    fn test_transport_attempts_include_initial_request() {
+        let mut config = FalAIConfig::with_api_key("test-key");
+        config.base.max_retries = 2;
+        let provider = FalAIProvider::new(config).unwrap();
+
+        assert_eq!(provider.transport_attempts(), 3);
     }
 }

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -274,6 +274,8 @@ macro_rules! dispatch_provider {
             Provider::Gemini(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::FalAI(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extended")]
@@ -297,6 +299,8 @@ macro_rules! dispatch_provider {
             Provider::Gemini(p) => LLMProvider::$method(p.as_ref(), $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extended")]
+            Provider::FalAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
@@ -320,6 +324,8 @@ macro_rules! dispatch_provider {
             Provider::Gemini(p) => LLMProvider::$method(p.as_ref(), $($arg),*),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::FalAI(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extended")]
@@ -343,6 +349,8 @@ macro_rules! dispatch_provider {
             Provider::Gemini(p) => LLMProvider::$method(p.as_ref()).await,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extended")]
+            Provider::FalAI(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
             Provider::Cloudflare(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extended")]
@@ -390,6 +398,8 @@ pub enum Provider {
     Gemini(std::sync::Arc<gemini::GeminiProvider>),
     #[cfg(feature = "providers-extended")]
     GitHubCopilot(github_copilot::GitHubCopilotProvider),
+    #[cfg(feature = "providers-extended")]
+    FalAI(fal_ai::FalAIProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
     #[cfg(feature = "providers-extended")]
@@ -415,6 +425,8 @@ impl Provider {
             Provider::Gemini(_) => "gemini",
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => "github_copilot",
+            #[cfg(feature = "providers-extended")]
+            Provider::FalAI(_) => "fal_ai",
             Provider::Mistral(_) => "mistral",
             Provider::Cloudflare(_) => "cloudflare",
             #[cfg(feature = "providers-extended")]
@@ -442,6 +454,8 @@ impl Provider {
             Provider::Gemini(_) => ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => ProviderType::GitHubCopilot,
+            #[cfg(feature = "providers-extended")]
+            Provider::FalAI(_) => ProviderType::FalAI,
             Provider::Mistral(_) => ProviderType::Mistral,
             Provider::Cloudflare(_) => ProviderType::Cloudflare,
             #[cfg(feature = "providers-extended")]

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -99,9 +99,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "specialized provider module; not wired through the LLM factory yet",
     ),
     internal("factory", "provider construction infrastructure"),
-    stub(
+    providers_extended_wire(
         "fal_ai",
-        "native Fal AI module retained; ProviderType::FalAI currently uses a generic OpenAI-compatible adapter",
+        "ProviderType::FalAI dispatches to native image-generation endpoints when providers-extended is enabled",
     ),
     stub(
         "firecrawl",
@@ -381,6 +381,14 @@ mod tests {
             }
         );
         assert_eq!(
+            lifecycle_for("fal_ai"),
+            if cfg!(feature = "providers-extended") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
+        assert_eq!(
             lifecycle_for("gemini"),
             if cfg!(feature = "providers-extended") {
                 ProviderModuleLifecycle::Wire
@@ -407,6 +415,8 @@ mod tests {
             "cloudflare",
             #[cfg(feature = "providers-extended")]
             "cohere",
+            #[cfg(feature = "providers-extended")]
+            "fal_ai",
             #[cfg(feature = "providers-extended")]
             "gemini",
             #[cfg(feature = "providers-extended")]

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -211,7 +211,7 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::FalAI,
         "fal_ai",
         &["fal-ai", "fal"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        providers_extended_native_dispatch_kind(),
         false,
     ),
     entry(
@@ -446,6 +446,8 @@ mod tests {
             #[cfg(feature = "providers-extended")]
             ProviderType::Cohere,
             #[cfg(feature = "providers-extended")]
+            ProviderType::FalAI,
+            #[cfg(feature = "providers-extended")]
             ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             ProviderType::GitHubCopilot,
@@ -483,6 +485,10 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Cohere),
+            providers_extended_native_dispatch_kind()
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::FalAI),
             providers_extended_native_dispatch_kind()
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- switch ProviderType::FalAI away from generic OpenAILike chat dispatch
- create native Provider::FalAI behind providers-extended, with explicit NotImplemented when the feature is disabled
- wire Fal AI image-generation request config so output_format, sync_mode, timeout, and retry settings are not silently ignored
- update registry/lifecycle classifications, provider matrix docs, and dispatch tests

Fixes #604

## Verification
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- cargo check
- cargo check --features "providers-extended"
- cargo test test_create_provider_fal_ai_feature_split -- --nocapture
- cargo test --features "providers-extended" test_from_config_async_fal_ai_creates_native_image_provider -- --nocapture
- cargo test --features "providers-extended" test_create_provider_fal_ai_feature_split -- --nocapture
- cargo test --features "providers-extended" test_dispatch_kind_matches_runtime_variant -- --nocapture
- cargo test --features "providers-extended" provider_registry_phase0_key_provider_classifications -- --nocapture
- cargo test --features "providers-extended" lifecycle_classifies_phase0_key_provider_modules -- --nocapture
- cargo test --features "providers-extended" lifecycle_wire_entries_are_native_runtime_modules -- --nocapture
- cargo test test_from_config_async_unsupported_variants_return_not_implemented -- --nocapture
- cargo test -p litellm-rs fal_ai --features "providers-extended" -- --nocapture
- cargo check --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features --quiet
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh