### PR TITLE
fix(provider): wire Replicate native dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 | Vercel v0 (`v0`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extra`, but runtime construction is catalog metadata. |
 | Amazon Nova (`amazon_nova`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | fal.ai (`fal_ai`) | native factory (`providers-extended`) | – | – | – | ✅ | – | Uses native Fal AI image-generation endpoints; chat and streaming are explicitly unsupported. |
-| Replicate (`replicate`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
+| Replicate (`replicate`) | native factory (`providers-extended`) | ✅ | ✅ | – | ✅ | – | Uses native Replicate prediction lifecycle handling for chat, streaming, and image generation; explicitly unsupported without `providers-extended`. |
 | GitHub Models (`github`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | GitHub Copilot (`github_copilot`) | wired via factory (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but the factory path uses OpenAILike chat/stream only. |
 | Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | – | – | – | For self-hosted / unlisted chat-completions endpoints. |

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -648,29 +648,6 @@ fn build_vertex_credentials_from_factory(
     Ok(vertex_ai::VertexCredentials::ApplicationDefault)
 }
 
-pub(super) fn build_replicate_config_from_factory(
-    config: &serde_json::Value,
-) -> Result<openai_like::OpenAILikeConfig, ProviderError> {
-    let api_key = macros::require_config_str(config, "api_key", "replicate")?;
-    let api_base = config_str(config, "base_url")
-        .or_else(|| config_str(config, "api_base"))
-        .unwrap_or("https://api.replicate.com/v1");
-
-    let mut oai_config = openai_like::OpenAILikeConfig::with_api_key(api_base, api_key);
-    oai_config.provider_name = "replicate".to_string();
-
-    if let Some(timeout) = config_u64(config, "timeout") {
-        oai_config.base.timeout = timeout;
-    }
-    if let Some(max_retries) = config_u32(config, "max_retries") {
-        oai_config.base.max_retries = max_retries;
-    }
-    merge_string_headers(&mut oai_config.base.headers, config, "headers");
-    merge_string_headers(&mut oai_config.custom_headers, config, "custom_headers");
-
-    Ok(oai_config)
-}
-
 #[cfg(feature = "providers-extended")]
 pub(super) fn build_github_copilot_config_from_factory(
     config: &serde_json::Value,

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -15,6 +15,8 @@ mod fal_ai_builder;
 #[cfg(feature = "providers-extended")]
 mod gemini_builder;
 mod registry;
+#[cfg(feature = "providers-extended")]
+mod replicate_builder;
 mod resolver;
 
 pub use resolver::is_provider_selector_supported;
@@ -316,6 +318,54 @@ mod tests {
                 "Expected NotImplemented error, got {err}"
             );
             assert_eq!(err.provider(), "fal_ai");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_provider_replicate_feature_split() {
+        let mut config = crate::config::models::provider::ProviderConfig {
+            name: "replicate".to_string(),
+            provider_type: "replicate".to_string(),
+            api_key: "test-replicate-token".to_string(),
+            base_url: Some("https://api.replicate.com/v1".to_string()),
+            timeout: 30,
+            max_retries: 2,
+            ..Default::default()
+        };
+        config
+            .settings
+            .insert("polling_delay_seconds".to_string(), serde_json::json!(1));
+        config
+            .settings
+            .insert("polling_retries".to_string(), serde_json::json!(3));
+        config
+            .settings
+            .insert("use_streaming".to_string(), serde_json::json!(true));
+
+        let result = create_provider(config).await;
+
+        #[cfg(feature = "providers-extended")]
+        {
+            let provider = result
+                .unwrap_or_else(|err| panic!("replicate should create native provider: {err}"));
+            assert!(matches!(provider, Provider::Replicate(_)));
+            assert_eq!(provider.name(), "replicate");
+            assert!(
+                provider
+                    .capabilities()
+                    .contains(&crate::core::types::model::ProviderCapability::ImageGeneration)
+            );
+        }
+
+        #[cfg(not(feature = "providers-extended"))]
+        {
+            let err =
+                result.expect_err("replicate should be unsupported without providers-extended");
+            assert!(
+                matches!(err, ProviderError::NotImplemented { .. }),
+                "Expected NotImplemented error, got {err}"
+            );
+            assert_eq!(err.provider(), "replicate");
         }
     }
 

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -12,7 +12,7 @@ use crate::core::providers::{
 #[cfg(feature = "providers-extra")]
 use crate::core::providers::{azure, azure_ai, vertex_ai};
 #[cfg(feature = "providers-extended")]
-use crate::core::providers::{cohere, fal_ai, gemini, github_copilot};
+use crate::core::providers::{cohere, fal_ai, gemini, github_copilot, replicate};
 
 #[cfg(feature = "providers-extended")]
 use super::builder::build_github_copilot_config_from_factory;
@@ -20,7 +20,7 @@ use super::builder::{
     apply_tier1_openai_like_overrides, build_anthropic_config_from_factory,
     build_bedrock_config_from_factory, build_cloudflare_config_from_factory,
     build_mistral_config_from_factory, build_openai_config_from_factory,
-    build_openai_like_config_from_factory, build_replicate_config_from_factory, config_str,
+    build_openai_like_config_from_factory, config_str,
 };
 #[cfg(feature = "providers-extra")]
 use super::builder::{
@@ -37,6 +37,8 @@ use super::cohere_builder::build_cohere_config_from_factory;
 use super::fal_ai_builder::build_fal_ai_config_from_factory;
 #[cfg(feature = "providers-extended")]
 use super::gemini_builder::build_gemini_config_from_factory;
+#[cfg(feature = "providers-extended")]
+use super::replicate_builder::build_replicate_config_from_factory;
 
 impl Provider {
     /// Create provider from configuration asynchronously
@@ -191,11 +193,20 @@ impl Provider {
                 }
             }
             ProviderType::Replicate => {
-                let oai_config = build_replicate_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization("replicate", e.to_string()))?;
-                Ok(Provider::OpenAILike(provider))
+                #[cfg(feature = "providers-extended")]
+                {
+                    let replicate_config = build_replicate_config_from_factory(&config)?;
+                    let provider = replicate::ReplicateProvider::new(replicate_config)
+                        .map_err(|e| ProviderError::initialization("replicate", e.to_string()))?;
+                    Ok(Provider::Replicate(provider))
+                }
+                #[cfg(not(feature = "providers-extended"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "replicate",
+                        "Replicate native prediction dispatch requires the providers-extended feature",
+                    ))
+                }
             }
             ProviderType::GitHubCopilot => {
                 #[cfg(feature = "providers-extended")]
@@ -329,6 +340,15 @@ mod tests {
                 "output_format": "png",
                 "sync_mode": true
             }),
+            ProviderType::Replicate => serde_json::json!({
+                "api_key": "test-replicate-token",
+                "api_base": "https://api.replicate.com/v1",
+                "timeout": 30,
+                "max_retries": 2,
+                "polling_delay_seconds": 1,
+                "polling_retries": 3,
+                "use_streaming": true
+            }),
             _ => minimal_dispatch_config(),
         }
     }
@@ -367,6 +387,8 @@ mod tests {
                     (ProviderType::Cohere, Provider::Cohere(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::FalAI, Provider::FalAI(_)) => {}
+                    #[cfg(feature = "providers-extended")]
+                    (ProviderType::Replicate, Provider::Replicate(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::Gemini, Provider::Gemini(_)) => {}
                     #[cfg(feature = "providers-extended")]
@@ -538,6 +560,77 @@ mod tests {
             provider
                 .capabilities()
                 .contains(&crate::core::types::model::ProviderCapability::ImageGeneration)
+        );
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_replicate_creates_native_prediction_provider() {
+        let provider = Provider::from_config_async(
+            ProviderType::Replicate,
+            minimal_dispatch_config_for(&ProviderType::Replicate),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("replicate should create native provider: {err}"));
+
+        assert!(matches!(provider, Provider::Replicate(_)));
+        assert_eq!(provider.name(), "replicate");
+        assert_eq!(provider.provider_type(), ProviderType::Replicate);
+        assert!(
+            provider
+                .capabilities()
+                .contains(&crate::core::types::model::ProviderCapability::ImageGeneration)
+        );
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn test_from_config_async_replicate_rejects_invalid_polling_delay() {
+        let result = Provider::from_config_async(
+            ProviderType::Replicate,
+            serde_json::json!({
+                "api_key": "test-replicate-token",
+                "polling_delay_seconds": 0
+            }),
+        )
+        .await;
+        let err = match result {
+            Ok(_) => panic!("replicate should reject zero polling delay"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, ProviderError::Configuration { .. }),
+            "expected Configuration, got {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("Polling delay must be greater than 0"),
+            "error should identify invalid Replicate polling delay: {err}"
+        );
+    }
+
+    #[cfg(not(feature = "providers-extended"))]
+    #[tokio::test]
+    async fn test_from_config_async_replicate_requires_providers_extended() {
+        let result = Provider::from_config_async(
+            ProviderType::Replicate,
+            serde_json::json!({"api_key": "test-replicate-token"}),
+        )
+        .await;
+        let err = match result {
+            Ok(_) => panic!("replicate should require providers-extended without the feature"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, ProviderError::NotImplemented { .. }),
+            "expected NotImplemented, got {err}"
+        );
+        assert_eq!(err.provider(), "replicate");
+        assert!(
+            err.to_string().contains("providers-extended"),
+            "error should identify required feature: {err}"
         );
     }
 

--- a/src/core/providers/factory/replicate_builder.rs
+++ b/src/core/providers/factory/replicate_builder.rs
@@ -1,0 +1,134 @@
+//! Replicate provider config builder.
+
+use super::builder::{
+    config_bool, config_str, config_str_any, config_u32, config_u64, env_str_any,
+    merge_string_headers,
+};
+use crate::core::providers::{replicate, unified_provider::ProviderError};
+use crate::core::traits::provider::ProviderConfig as _;
+
+pub(super) fn build_replicate_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<replicate::ReplicateConfig, ProviderError> {
+    reject_unsupported_fields(config)?;
+
+    let api_key = config_str_any(config, &["api_key", "api_token"])
+        .map(str::to_string)
+        .or_else(|| env_str_any(&["REPLICATE_API_TOKEN", "REPLICATE_API_KEY"]))
+        .ok_or_else(|| {
+            ProviderError::configuration("replicate", "api_key or REPLICATE_API_TOKEN is required")
+        })?;
+
+    let mut replicate_config = replicate::ReplicateConfig::new(api_key);
+
+    if let Some(api_base) =
+        config_str(config, "base_url").or_else(|| config_str(config, "api_base"))
+    {
+        replicate_config.base.api_base = Some(api_base.to_string());
+    }
+    if let Some(timeout) =
+        config_u64(config, "timeout_seconds").or_else(|| config_u64(config, "timeout"))
+    {
+        replicate_config.base.timeout = timeout;
+    }
+    if let Some(max_retries) = config_u32(config, "max_retries") {
+        replicate_config.base.max_retries = max_retries;
+    }
+    if let Some(polling_delay) = config_u64(config, "polling_delay_seconds") {
+        replicate_config.polling_delay_seconds = polling_delay;
+    }
+    if let Some(polling_retries) = config_u32(config, "polling_retries") {
+        replicate_config.polling_retries = polling_retries;
+    }
+    if let Some(use_streaming) = config_bool(config, "use_streaming") {
+        replicate_config.use_streaming = use_streaming;
+    }
+    merge_string_headers(&mut replicate_config.base.headers, config, "headers");
+    merge_string_headers(&mut replicate_config.base.headers, config, "custom_headers");
+
+    replicate_config
+        .validate()
+        .map_err(|err| ProviderError::configuration("replicate", err))?;
+    Ok(replicate_config)
+}
+
+fn reject_unsupported_fields(config: &serde_json::Value) -> Result<(), ProviderError> {
+    for field in ["api_version", "organization", "account_id", "project"] {
+        if config_str(config, field).is_some() {
+            return Err(ProviderError::invalid_request(
+                "replicate",
+                format!("Replicate native dispatch does not support `{field}`"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_replicate_config_accepts_aliases_and_headers() {
+        let config_result = build_replicate_config_from_factory(&serde_json::json!({
+            "api_token": "test-token",
+            "api_base": "https://replicate.example/v1",
+            "timeout_seconds": 45,
+            "max_retries": 4,
+            "polling_delay_seconds": 2,
+            "polling_retries": 5,
+            "use_streaming": true,
+            "headers": {"x-replicate-header": "one"},
+            "custom_headers": {"x-custom-header": "two"}
+        }));
+        let config = match config_result {
+            Ok(config) => config,
+            Err(err) => panic!("replicate config should accept supported native fields: {err}"),
+        };
+
+        assert_eq!(config.base.api_key.as_deref(), Some("test-token"));
+        assert_eq!(config.get_api_base(), "https://replicate.example/v1");
+        assert_eq!(config.base.timeout, 45);
+        assert_eq!(config.base.max_retries, 4);
+        assert_eq!(config.polling_delay_seconds, 2);
+        assert_eq!(config.polling_retries, 5);
+        assert!(config.use_streaming);
+        assert_eq!(
+            config
+                .base
+                .headers
+                .get("x-replicate-header")
+                .map(String::as_str),
+            Some("one")
+        );
+        assert_eq!(
+            config
+                .base
+                .headers
+                .get("x-custom-header")
+                .map(String::as_str),
+            Some("two")
+        );
+    }
+
+    #[test]
+    fn test_build_replicate_config_rejects_unsupported_fields() {
+        let result = build_replicate_config_from_factory(&serde_json::json!({
+            "api_key": "test-token",
+            "project": "unused-project"
+        }));
+        let err = match result {
+            Ok(_) => panic!("replicate should fail fast on unsupported project field"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, ProviderError::InvalidRequest { .. }),
+            "expected InvalidRequest, got {err}"
+        );
+        assert!(
+            err.to_string().contains("project"),
+            "error should identify unsupported field: {err}"
+        );
+    }
+}

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -280,6 +280,8 @@ macro_rules! dispatch_provider {
             Provider::Cloudflare(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extended")]
             Provider::Cohere(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::Replicate(p) => p.$method($($arg),*),
             Provider::OpenAILike(p) => p.$method($($arg),*),
         }
     };
@@ -305,6 +307,8 @@ macro_rules! dispatch_provider {
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
             Provider::Cohere(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extended")]
+            Provider::Replicate(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
         }
     };
@@ -330,6 +334,8 @@ macro_rules! dispatch_provider {
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extended")]
             Provider::Cohere(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extended")]
+            Provider::Replicate(p) => LLMProvider::$method(p, $($arg),*),
             Provider::OpenAILike(p) => LLMProvider::$method(p, $($arg),*),
         }
     };
@@ -355,6 +361,8 @@ macro_rules! dispatch_provider {
             Provider::Cloudflare(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extended")]
             Provider::Cohere(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extended")]
+            Provider::Replicate(p) => LLMProvider::$method(p).await,
             Provider::OpenAILike(p) => LLMProvider::$method(p).await,
         }
     };
@@ -404,6 +412,8 @@ pub enum Provider {
     Cloudflare(cloudflare::CloudflareProvider),
     #[cfg(feature = "providers-extended")]
     Cohere(cohere::CohereProvider),
+    #[cfg(feature = "providers-extended")]
+    Replicate(replicate::ReplicateProvider),
     /// Tier 1: data-driven OpenAI-compatible providers (groq, together, fireworks, etc.)
     OpenAILike(openai_like::OpenAILikeProvider),
 }
@@ -431,6 +441,8 @@ impl Provider {
             Provider::Cloudflare(_) => "cloudflare",
             #[cfg(feature = "providers-extended")]
             Provider::Cohere(_) => "cohere",
+            #[cfg(feature = "providers-extended")]
+            Provider::Replicate(_) => "replicate",
             Provider::OpenAILike(p) => {
                 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
                 p.name()
@@ -460,6 +472,8 @@ impl Provider {
             Provider::Cloudflare(_) => ProviderType::Cloudflare,
             #[cfg(feature = "providers-extended")]
             Provider::Cohere(_) => ProviderType::Cohere,
+            #[cfg(feature = "providers-extended")]
+            Provider::Replicate(_) => ProviderType::Replicate,
             Provider::OpenAILike(_) => ProviderType::OpenAICompatible,
         }
     }

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -196,9 +196,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "specialized provider module; not wired through the LLM factory yet",
     ),
     internal("registry", "provider catalog and lifecycle infrastructure"),
-    stub(
+    providers_extended_wire(
         "replicate",
-        "native Replicate module retained; ProviderType::Replicate currently uses a generic OpenAI-compatible adapter",
+        "ProviderType::Replicate dispatches to native prediction lifecycle paths when providers-extended is enabled",
     ),
     stub(
         "runwayml",
@@ -389,6 +389,14 @@ mod tests {
             }
         );
         assert_eq!(
+            lifecycle_for("replicate"),
+            if cfg!(feature = "providers-extended") {
+                ProviderModuleLifecycle::Wire
+            } else {
+                ProviderModuleLifecycle::Stub
+            }
+        );
+        assert_eq!(
             lifecycle_for("gemini"),
             if cfg!(feature = "providers-extended") {
                 ProviderModuleLifecycle::Wire
@@ -421,6 +429,8 @@ mod tests {
             "gemini",
             #[cfg(feature = "providers-extended")]
             "github_copilot",
+            #[cfg(feature = "providers-extended")]
+            "replicate",
             "mistral",
             "openai",
             "openai_like",

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -204,7 +204,7 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         ProviderType::Replicate,
         "replicate",
         &["replicate-ai"],
-        ProviderDispatchKind::ExplicitOpenAiLike,
+        providers_extended_native_dispatch_kind(),
         false,
     ),
     entry(
@@ -448,6 +448,8 @@ mod tests {
             #[cfg(feature = "providers-extended")]
             ProviderType::FalAI,
             #[cfg(feature = "providers-extended")]
+            ProviderType::Replicate,
+            #[cfg(feature = "providers-extended")]
             ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             ProviderType::GitHubCopilot,
@@ -489,6 +491,10 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::FalAI),
+            providers_extended_native_dispatch_kind()
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::Replicate),
             providers_extended_native_dispatch_kind()
         );
         assert_eq!(

--- a/src/core/providers/replicate/provider.rs
+++ b/src/core/providers/replicate/provider.rs
@@ -8,7 +8,9 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::core::providers::base::{GlobalPoolManager, HeaderPair, HttpMethod, header};
+use crate::core::providers::base::{
+    GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
+};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::{
     provider::ProviderConfig, provider::llm_provider::trait_definition::LLMProvider,
@@ -73,7 +75,15 @@ impl ReplicateProvider {
 
     /// Generate headers for Replicate API requests
     fn get_request_headers(&self) -> Vec<HeaderPair> {
-        let mut headers = Vec::with_capacity(2);
+        let mut headers = Vec::with_capacity(self.config.base.headers.len() + 2);
+
+        for (key, value) in &self.config.base.headers {
+            if key.eq_ignore_ascii_case("authorization") || key.eq_ignore_ascii_case("content-type")
+            {
+                continue;
+            }
+            headers.push(header_owned(key.clone(), value.clone()));
+        }
 
         if let Some(api_key) = &self.config.base.api_key {
             headers.push(header("Authorization", format!("Token {}", api_key)));
@@ -114,6 +124,70 @@ impl ReplicateProvider {
         self.poll_prediction(&polling_url).await
     }
 
+    fn transport_attempts(&self) -> u32 {
+        self.config.base.max_retries.saturating_add(1)
+    }
+
+    fn build_request(
+        &self,
+        url: &str,
+        method: &HttpMethod,
+        headers: Vec<HeaderPair>,
+        body: Option<&Value>,
+    ) -> reqwest::RequestBuilder {
+        let request_builder = match method {
+            HttpMethod::GET => self.pool_manager.client().get(url),
+            HttpMethod::POST => self.pool_manager.client().post(url),
+            HttpMethod::PUT => self.pool_manager.client().put(url),
+            HttpMethod::DELETE => self.pool_manager.client().delete(url),
+        }
+        .timeout(self.config.timeout());
+
+        let mut request_builder = apply_headers(request_builder, headers);
+
+        if let Some(body_data) = body {
+            request_builder = request_builder
+                .header("Content-Type", "application/json")
+                .json(body_data);
+        }
+
+        request_builder
+    }
+
+    async fn execute_request_with_config(
+        &self,
+        url: &str,
+        method: HttpMethod,
+        headers: Vec<HeaderPair>,
+        body: Option<Value>,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let attempts = self.transport_attempts();
+        let mut last_error = None;
+
+        for attempt in 0..attempts {
+            let request_builder = self.build_request(url, &method, headers.clone(), body.as_ref());
+
+            match request_builder.send().await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let provider_err = if err.is_timeout() {
+                        ProviderError::timeout("replicate", err.to_string())
+                    } else {
+                        ProviderError::network("replicate", err.to_string())
+                    };
+                    if attempt + 1 == attempts {
+                        return Err(provider_err);
+                    }
+                    last_error = Some(provider_err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            ProviderError::network("replicate", "request failed before execution")
+        }))
+    }
+
     /// Submit a prediction request
     async fn submit_prediction(
         &self,
@@ -125,8 +199,7 @@ impl ReplicateProvider {
             .map_err(|e| ProviderError::serialization("replicate", e.to_string()))?;
 
         let response = self
-            .pool_manager
-            .execute_request(url, HttpMethod::POST, headers, Some(body))
+            .execute_request_with_config(url, HttpMethod::POST, headers, Some(body))
             .await?;
 
         let status = response.status();
@@ -156,8 +229,7 @@ impl ReplicateProvider {
             tokio::time::sleep(polling_delay).await;
 
             let response = self
-                .pool_manager
-                .execute_request(url, HttpMethod::GET, headers.clone(), None)
+                .execute_request_with_config(url, HttpMethod::GET, headers.clone(), None)
                 .await?;
 
             let status = response.status();
@@ -167,8 +239,11 @@ impl ReplicateProvider {
                 .map_err(|e| ProviderError::network("replicate", e.to_string()))?;
 
             if !status.is_success() {
-                // Temporary failure, continue polling
-                continue;
+                let error_text = String::from_utf8_lossy(&response_bytes);
+                return Err(ProviderError::replicate_api_error(
+                    status.as_u16(),
+                    error_text.to_string(),
+                ));
             }
 
             let prediction: PredictionResponse = serde_json::from_slice(&response_bytes)
@@ -320,8 +395,11 @@ impl LLMProvider for ReplicateProvider {
 
         let input = ReplicateClient::transform_chat_request(&request);
         let version_hash = ReplicateConfig::extract_version_hash(model);
-        let prediction_request =
-            ReplicateClient::create_prediction_request(input, version_hash, true);
+        let prediction_request = ReplicateClient::create_prediction_request(
+            input,
+            version_hash,
+            self.config.use_streaming,
+        );
 
         // Submit prediction
         let prediction_url = self.config.get_prediction_url(model);
@@ -330,22 +408,20 @@ impl LLMProvider for ReplicateProvider {
             .await?;
 
         // Get stream URL if available
-        if let Some(stream_url) = prediction.get_stream_url() {
+        if self.config.use_streaming
+            && let Some(stream_url) = prediction.get_stream_url()
+        {
             // Use SSE streaming
-            let api_key =
-                self.config.base.api_key.as_ref().ok_or_else(|| {
-                    ProviderError::authentication("replicate", "API token required")
-                })?;
-
             let client = crate::core::http::outbound::streaming_outbound_client().clone();
-            let response = crate::core::providers::base::connection_pool::send_streaming_request(
-                client
-                    .get(stream_url)
-                    .header("Authorization", format!("Token {}", api_key))
-                    .header("Accept", "text/event-stream"),
-                "replicate",
-            )
-            .await?;
+            let request_builder = apply_headers(client.get(stream_url), self.get_request_headers())
+                .header("Accept", "text/event-stream");
+            let response =
+                crate::core::providers::base::connection_pool::send_streaming_request_with_timeout(
+                    request_builder,
+                    self.config.timeout(),
+                )
+                .await
+                .map_err(|err| err.into_provider_error("replicate"))?;
 
             if !response.status().is_success() {
                 let status_code = response.status().as_u16();
@@ -423,8 +499,7 @@ impl LLMProvider for ReplicateProvider {
         let headers = self.get_request_headers();
 
         match self
-            .pool_manager
-            .execute_request(&url, HttpMethod::GET, headers, None)
+            .execute_request_with_config(&url, HttpMethod::GET, headers, None)
             .await
         {
             Ok(response) if response.status().is_success() => HealthStatus::Healthy,
@@ -534,6 +609,70 @@ mod tests {
 
         assert!(headers.iter().any(|h| h.0 == "Authorization"));
         assert!(headers.iter().any(|h| h.0 == "Content-Type"));
+    }
+
+    #[test]
+    fn test_get_request_headers_includes_custom_headers() {
+        let mut config = ReplicateConfig::new("test-token");
+        config
+            .base
+            .headers
+            .insert("x-replicate-test".to_string(), "ok".to_string());
+        let provider = match ReplicateProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("replicate provider should accept test config: {err}"),
+        };
+        let headers = provider.get_request_headers();
+
+        assert!(
+            headers
+                .iter()
+                .any(|h| h.0.as_ref() == "x-replicate-test" && h.1.as_ref() == "ok")
+        );
+    }
+
+    #[test]
+    fn test_transport_attempts_include_initial_request() {
+        let mut config = ReplicateConfig::new("test-token");
+        config.base.max_retries = 4;
+        let provider = match ReplicateProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("replicate provider should accept test config: {err}"),
+        };
+
+        assert_eq!(provider.transport_attempts(), 5);
+    }
+
+    #[test]
+    fn test_streaming_prediction_flag_follows_config() {
+        let mut config = ReplicateConfig::new("test-token");
+        config.use_streaming = false;
+        let provider = match ReplicateProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("replicate provider should accept test config: {err}"),
+        };
+
+        let input = serde_json::json!({"prompt": "hello"});
+        let version_hash = ReplicateConfig::extract_version_hash("meta/llama-2-70b-chat");
+        let request = ReplicateClient::create_prediction_request(
+            input.clone(),
+            version_hash.clone(),
+            provider.config.use_streaming,
+        );
+        assert_eq!(request.stream, None);
+
+        let mut config = ReplicateConfig::new("test-token");
+        config.use_streaming = true;
+        let provider = match ReplicateProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("replicate provider should accept test config: {err}"),
+        };
+        let request = ReplicateClient::create_prediction_request(
+            input,
+            version_hash,
+            provider.config.use_streaming,
+        );
+        assert_eq!(request.stream, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Route `ProviderType::Replicate` to the native Replicate prediction lifecycle provider when `providers-extended` is enabled.
- Return explicit `NotImplemented` without `providers-extended` instead of using the generic OpenAI-like adapter.
- Add native Replicate factory config mapping for token aliases, base URL, timeout/retry, polling, streaming, and custom headers; reject unsupported no-op fields.
- Update provider dispatch metadata, lifecycle classification, provider enum arms, and README capability matrix.

## Review follow-up
- Fixed independent review findings: staged the new builder module, wired `use_streaming` into streaming prediction creation, and moved health checks onto the configured timeout/retry request helper.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test test_create_provider_replicate_feature_split -- --nocapture`
- `cargo test test_from_config_async_replicate_requires_providers_extended -- --nocapture`
- `cargo test --features "providers-extended" build_replicate_config -- --nocapture`
- `cargo test --features "providers-extended" test_get_request_headers -- --nocapture`
- `cargo test --features "providers-extended" test_transport_attempts_include_initial_request -- --nocapture`
- `cargo test --features "providers-extended" test_streaming_prediction_flag_follows_config -- --nocapture`
- `cargo test --features "providers-extended" test_from_config_async_replicate_creates_native_prediction_provider -- --nocapture`
- `cargo test --features "providers-extended" test_from_config_async_replicate_rejects_invalid_polling_delay -- --nocapture`
- `cargo test --features "providers-extended" test_dispatch_kind_matches_runtime_variant -- --nocapture`
- `cargo test --features "providers-extended" lifecycle_wire_entries_are_native_runtime_modules -- --nocapture`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --quiet`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

Closes #603