### PR TITLE
Fix request ID middleware pre-routing panic

### DIFF
--- a/src/server/middleware/request_id.rs
+++ b/src/server/middleware/request_id.rs
@@ -67,9 +67,6 @@ where
 
         debug!("Processing request: {}", request_id);
 
-        // Clone the HttpRequest so we can build an error ServiceResponse when the
-        // inner service returns Err — ensuring x-request-id appears on all responses.
-        let http_req = req.request().clone();
         let fut = self.service.call(req);
         Box::pin(async move {
             let header_name = actix_web::http::header::HeaderName::from_static("x-request-id");
@@ -81,12 +78,29 @@ where
                     res.headers_mut().insert(header_name, header_value);
                     Ok(res.map_into_boxed_body())
                 }
-                Err(err) => {
-                    let mut response = err.error_response();
-                    response.headers_mut().insert(header_name, header_value);
-                    Ok(ServiceResponse::new(http_req, response))
-                }
+                Err(err) => Err(err),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{App, HttpResponse, http::StatusCode, test, web};
+
+    #[actix_web::test]
+    async fn middleware_does_not_clone_request_before_routing() {
+        let app = test::init_service(App::new().wrap(RequestIdMiddleware).route(
+            "/health",
+            web::get().to(|| async { HttpResponse::Ok().finish() }),
+        ))
+        .await;
+
+        let req = test::TestRequest::get().uri("/health").to_request();
+        let res = test::call_service(&app, req).await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(res.headers().contains_key("x-request-id"));
     }
 }

--- a/src/server/middleware/request_id.rs
+++ b/src/server/middleware/request_id.rs
@@ -78,7 +78,11 @@ where
                     res.headers_mut().insert(header_name, header_value);
                     Ok(res.map_into_boxed_body())
                 }
-                Err(err) => Err(err),
+                Err(err) => {
+                    let mut response = err.error_response();
+                    response.headers_mut().insert(header_name, header_value);
+                    Err(actix_web::error::InternalError::from_response(err, response).into())
+                }
             }
         })
     }
@@ -101,6 +105,23 @@ mod tests {
         let res = test::call_service(&app, req).await;
 
         assert_eq!(res.status(), StatusCode::OK);
+        assert!(res.headers().contains_key("x-request-id"));
+    }
+
+    #[actix_web::test]
+    async fn middleware_adds_request_id_to_error_responses() {
+        let app = test::init_service(App::new().wrap(RequestIdMiddleware).route(
+            "/error",
+            web::get().to(|| async {
+                Err::<HttpResponse, _>(actix_web::error::ErrorInternalServerError("test error"))
+            }),
+        ))
+        .await;
+
+        let req = test::TestRequest::get().uri("/error").to_request();
+        let res = test::call_service(&app, req).await;
+
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert!(res.headers().contains_key("x-request-id"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #701.

- Removes the pre-routing `HttpRequest` clone from `RequestIdMiddleware`.
- Keeps `x-request-id` injection on successful responses.
- Adds an Actix app regression test proving a wrapped route no longer panics during route recognition.

## Root Cause

`RequestIdMiddleware` cloned `HttpRequest` before Actix route recognition. Actix later calls `HttpRequest::match_info_mut()` while matching routes, which requires unique ownership through `Rc::get_mut()`. The clone made that unwrap fail, causing worker panics and `curl: (52) Empty reply from server` on basic routes such as `GET /health`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test middleware_does_not_clone_request_before_routing --all-features`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Live Smoke

Using a local Xiaomi MiMo Token Plan gateway config after this fix:

- `GET /health` -> 200
- `GET /v1/models` -> 200
- `POST /v1/chat/completions` with `mimo-v2.5` -> 200
- streaming `POST /v1/chat/completions` with `mimo-v2.5` -> 200 with `[DONE]`
