### PR TITLE
feat(anthropic): allow compatible model ids

### DIFF
--- a/docs/providers/xiaomi-mimo.md
+++ b/docs/providers/xiaomi-mimo.md
@@ -61,8 +61,7 @@ providers:
     provider_type: anthropic
     api_key: "${MIMO_API_KEY}"
     base_url: "https://token-plan-sgp.xiaomimimo.com/anthropic"
-    settings:
-      allow_unknown_models: true
+    allow_unknown_models: true
     models:
       - "mimo-v2.5"
       - "mimo-v2.5-pro"

--- a/docs/providers/xiaomi-mimo.md
+++ b/docs/providers/xiaomi-mimo.md
@@ -4,6 +4,11 @@ LiteLLM-RS routes Xiaomi MiMo through the OpenAI-compatible provider catalog.
 The official pay-as-you-go OpenAI-compatible API base is
 `https://api.xiaomimimo.com/v1`.
 
+Token Plan uses region-specific bases. For Singapore, use
+`https://token-plan-sgp.xiaomimimo.com/v1` for OpenAI-compatible chat
+completions and `https://token-plan-sgp.xiaomimimo.com/anthropic` for the
+Anthropic-compatible messages API.
+
 ## Models
 
 | Model | Context | Max Output | Pricing per 1M tokens | Notes |
@@ -33,6 +38,39 @@ providers:
     timeout: 30
     max_retries: 3
 ```
+
+For Singapore Token Plan OpenAI-compatible routing, override the base URL:
+
+```yaml
+providers:
+  - name: xiaomi_mimo_token_plan_sgp
+    provider_type: xiaomi_mimo
+    api_key: "${MIMO_API_KEY}"
+    base_url: "https://token-plan-sgp.xiaomimimo.com/v1"
+    models:
+      - "mimo-v2.5"
+      - "mimo-v2.5-pro"
+```
+
+For the Anthropic-compatible Token Plan endpoint, configure the native
+Anthropic provider with an explicit compatible-model opt-in:
+
+```yaml
+providers:
+  - name: xiaomi_mimo_token_plan_sgp_anthropic
+    provider_type: anthropic
+    api_key: "${MIMO_API_KEY}"
+    base_url: "https://token-plan-sgp.xiaomimimo.com/anthropic"
+    settings:
+      allow_unknown_models: true
+    models:
+      - "mimo-v2.5"
+      - "mimo-v2.5-pro"
+```
+
+`allow_unknown_models` is required because MiMo model IDs are not Claude model
+IDs. It keeps first-party Anthropic providers strict by default while allowing
+explicit Anthropic-compatible upstreams.
 
 ## Usage
 

--- a/docs/providers/xiaomi-mimo.md
+++ b/docs/providers/xiaomi-mimo.md
@@ -61,7 +61,8 @@ providers:
     provider_type: anthropic
     api_key: "${MIMO_API_KEY}"
     base_url: "https://token-plan-sgp.xiaomimimo.com/anthropic"
-    allow_unknown_models: true
+    settings:
+      allow_unknown_models: true
     models:
       - "mimo-v2.5"
       - "mimo-v2.5-pro"

--- a/docs/providers/xiaomi-mimo.md
+++ b/docs/providers/xiaomi-mimo.md
@@ -63,6 +63,8 @@ providers:
     base_url: "https://token-plan-sgp.xiaomimimo.com/anthropic"
     settings:
       allow_unknown_models: true
+      multimodal_models:
+        - "mimo-v2.5"
     models:
       - "mimo-v2.5"
       - "mimo-v2.5-pro"

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -60,6 +60,14 @@ impl AnthropicClient {
         self.config.allows_unknown_model(model)
     }
 
+    pub(crate) fn uses_compatible_model_allow_list(&self) -> bool {
+        self.config.uses_compatible_model_allow_list()
+    }
+
+    pub(crate) fn allows_unknown_model_image_input(&self, model: &str) -> bool {
+        self.config.allows_unknown_model_image_input(model)
+    }
+
     /// Request
     pub async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, ProviderError> {
         let anthropic_request = self.transform_chat_request(&request)?;
@@ -268,6 +276,18 @@ impl AnthropicClient {
                 "anthropic",
                 format!(
                     "Unknown model {} only supports text and image content",
+                    request.model
+                ),
+            ));
+        }
+        if model_spec.is_none()
+            && Self::has_image_content(request)
+            && !self.config.allows_unknown_model_image_input(&request.model)
+        {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} does not support image input",
                     request.model
                 ),
             ));
@@ -547,6 +567,20 @@ impl AnthropicClient {
                                         ));
                                     }
                                 }
+                                ContentPart::Image { source, .. }
+                                    if model_spec.is_none_or(|spec| {
+                                        spec.features.contains(&ModelFeature::MultimodalSupport)
+                                    }) =>
+                                {
+                                    anthropic_parts.push(json!({
+                                        "type": "image",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": source.media_type,
+                                            "data": source.data
+                                        }
+                                    }));
+                                }
                                 ContentPart::Document { source, .. }
                                     if model_spec.is_some_and(|spec| {
                                         spec.features.contains(&ModelFeature::MultimodalSupport)
@@ -640,6 +674,19 @@ impl AnthropicClient {
         })
     }
 
+    pub(crate) fn has_image_content(request: &ChatRequest) -> bool {
+        request.messages.iter().any(|message| {
+            matches!(
+                &message.content,
+                Some(crate::core::types::message::MessageContent::Parts(parts))
+                    if parts.iter().any(|part| matches!(
+                        part,
+                        ContentPart::ImageUrl { .. } | ContentPart::Image { .. }
+                    ))
+            )
+        })
+    }
+
     fn content_value_to_blocks(content: &Value) -> Vec<Value> {
         if let Some(text) = content.as_str() {
             if text.is_empty() {
@@ -720,5 +767,7 @@ impl AnthropicClient {
 mod response;
 mod usage;
 
+#[cfg(test)]
+mod compatible_tests;
 #[cfg(test)]
 mod tests;

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -56,8 +56,8 @@ impl AnthropicClient {
         })
     }
 
-    pub(crate) fn allows_unknown_models(&self) -> bool {
-        self.config.allow_unknown_models
+    pub(crate) fn allows_unknown_model(&self, model: &str) -> bool {
+        self.config.allows_unknown_model(model)
     }
 
     /// Request
@@ -248,17 +248,26 @@ impl AnthropicClient {
 
         // Check
         let model_spec = registry.get_model_spec(&request.model);
-        if model_spec.is_none() && !self.config.allow_unknown_models {
+        if model_spec.is_none() && !self.config.allows_unknown_model(&request.model) {
             return Err(anthropic_api_error(
                 400,
                 format!("Unsupported model: {}", request.model),
             ));
         }
-        if model_spec.is_none() && self.has_multimodal_content(request) {
+        if model_spec.is_none() && Self::has_multimodal_content(request) {
             return Err(ProviderError::not_supported(
                 "anthropic",
                 format!(
                     "Unknown model {} cannot declare multimodal support",
+                    request.model
+                ),
+            ));
+        }
+        if model_spec.is_none() && Self::has_anthropic_tools_extra_param(request) {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} cannot declare tool calling support",
                     request.model
                 ),
             ));
@@ -592,7 +601,7 @@ impl AnthropicClient {
         Ok(anthropic_messages)
     }
 
-    fn has_multimodal_content(&self, request: &ChatRequest) -> bool {
+    pub(crate) fn has_multimodal_content(request: &ChatRequest) -> bool {
         request.messages.iter().any(|msg| {
             if let Some(crate::core::types::message::MessageContent::Parts(parts)) = &msg.content {
                 parts
@@ -602,6 +611,14 @@ impl AnthropicClient {
                 false
             }
         })
+    }
+
+    pub(crate) fn has_anthropic_tools_extra_param(request: &ChatRequest) -> bool {
+        request
+            .extra_params
+            .get("anthropic_tools")
+            .and_then(|value| value.as_array())
+            .is_some_and(|tools| !tools.is_empty())
     }
 
     fn content_value_to_blocks(content: &Value) -> Vec<Value> {

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -14,12 +14,8 @@ use crate::core::providers::base::{
 use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::{
-    chat::ChatMessage,
-    chat::ChatRequest,
-    content::ContentPart,
-    message::MessageRole,
-    responses::{ChatChoice, ChatResponse, FinishReason},
-    thinking::ThinkingContent,
+    chat::ChatMessage, chat::ChatRequest, content::ContentPart, message::MessageRole,
+    responses::ChatResponse,
 };
 
 use super::config::AnthropicConfig;
@@ -58,6 +54,10 @@ impl AnthropicClient {
             config,
             http_client,
         })
+    }
+
+    pub(crate) fn allows_unknown_models(&self) -> bool {
+        self.config.allow_unknown_models
     }
 
     /// Request
@@ -247,9 +247,22 @@ impl AnthropicClient {
         let registry = get_anthropic_registry();
 
         // Check
-        let model_spec = registry.get_model_spec(&request.model).ok_or_else(|| {
-            anthropic_api_error(400, format!("Unsupported model: {}", request.model))
-        })?;
+        let model_spec = registry.get_model_spec(&request.model);
+        if model_spec.is_none() && !self.config.allow_unknown_models {
+            return Err(anthropic_api_error(
+                400,
+                format!("Unsupported model: {}", request.model),
+            ));
+        }
+        if model_spec.is_none() && self.has_multimodal_content(request) {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} cannot declare multimodal support",
+                    request.model
+                ),
+            ));
+        }
 
         // The Messages API only returns a single candidate; any n other than 1
         // (including 0) cannot be honored, so reject it instead of silently
@@ -316,9 +329,22 @@ impl AnthropicClient {
         }
 
         // Add tool support
-        if let Some(tools) = &request.tools
-            && model_spec.features.contains(&ModelFeature::ToolCalling)
-        {
+        if let Some(tools) = &request.tools {
+            let Some(model_spec) = model_spec else {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare tool calling support",
+                        request.model
+                    ),
+                ));
+            };
+            if !model_spec.features.contains(&ModelFeature::ToolCalling) {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!("Model {} does not support tool calling", request.model),
+                ));
+            }
             let anthropic_tools = self.transform_tools(tools)?;
             anthropic_request["tools"] = json!(anthropic_tools);
 
@@ -331,8 +357,22 @@ impl AnthropicClient {
         // Add thinking configuration
         if let Some(thinking) = &request.thinking
             && thinking.enabled
-            && model_spec.features.contains(&ModelFeature::ThinkingMode)
         {
+            let Some(model_spec) = model_spec else {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare thinking support",
+                        request.model
+                    ),
+                ));
+            };
+            if !model_spec.features.contains(&ModelFeature::ThinkingMode) {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!("Model {} does not support thinking", request.model),
+                ));
+            }
             let budget = thinking.budget_tokens.unwrap_or(10_000);
             // Anthropic requires max_tokens > budget_tokens. If the default (4096)
             // is not greater than budget_tokens, raise max_tokens to budget + 1.
@@ -422,7 +462,7 @@ impl AnthropicClient {
     fn transform_messages(
         &self,
         messages: Vec<ChatMessage>,
-        model_spec: &super::models::ModelSpec,
+        model_spec: Option<&super::models::ModelSpec>,
     ) -> Result<Vec<Value>, ProviderError> {
         let mut anthropic_messages = Vec::new();
 
@@ -466,9 +506,9 @@ impl AnthropicClient {
                                     }));
                                 }
                                 ContentPart::ImageUrl { image_url }
-                                    if model_spec
-                                        .features
-                                        .contains(&ModelFeature::MultimodalSupport) =>
+                                    if model_spec.is_some_and(|spec| {
+                                        spec.features.contains(&ModelFeature::MultimodalSupport)
+                                    }) =>
                                 {
                                     // Handle
                                     if image_url.url.starts_with("data:") {
@@ -499,9 +539,9 @@ impl AnthropicClient {
                                     }
                                 }
                                 ContentPart::Document { source, .. }
-                                    if model_spec
-                                        .features
-                                        .contains(&ModelFeature::MultimodalSupport) =>
+                                    if model_spec.is_some_and(|spec| {
+                                        spec.features.contains(&ModelFeature::MultimodalSupport)
+                                    }) =>
                                 {
                                     anthropic_parts.push(json!({
                                         "type": "document",
@@ -550,6 +590,18 @@ impl AnthropicClient {
         }
 
         Ok(anthropic_messages)
+    }
+
+    fn has_multimodal_content(&self, request: &ChatRequest) -> bool {
+        request.messages.iter().any(|msg| {
+            if let Some(crate::core::types::message::MessageContent::Parts(parts)) = &msg.content {
+                parts
+                    .iter()
+                    .any(|part| !matches!(part, ContentPart::Text { .. }))
+            } else {
+                false
+            }
+        })
     }
 
     fn content_value_to_blocks(content: &Value) -> Vec<Value> {
@@ -603,18 +655,6 @@ impl AnthropicClient {
         Ok(anthropic_tools)
     }
 
-    fn parse_anthropic_stop_reason(reason: &str) -> FinishReason {
-        match reason {
-            "end_turn" => FinishReason::Stop,
-            "max_tokens" => FinishReason::Length,
-            "tool_use" => FinishReason::ToolCalls,
-            "stop_sequence" => FinishReason::StopSequence,
-            "refusal" => FinishReason::Refusal,
-            "pause_turn" => FinishReason::PauseTurn,
-            _ => FinishReason::Stop,
-        }
-    }
-
     /// Transform tool choice
     fn transform_tool_choice(
         &self,
@@ -639,140 +679,9 @@ impl AnthropicClient {
             }
         }
     }
-
-    /// Response
-    fn transform_chat_response(&self, response: Value) -> Result<ChatResponse, ProviderError> {
-        // Extract basic information
-        let id = response
-            .get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        let model = response
-            .get("model")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        let created = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
-
-        // Handle content
-        let content = response
-            .get("content")
-            .and_then(|v| v.as_array())
-            .ok_or_else(|| anthropic_parse_error("Missing or invalid content array"))?;
-
-        let mut message_content = String::new();
-        let mut thinking_parts = Vec::new();
-        let mut thinking_signature = None;
-        let mut has_redacted_thinking = false;
-        let mut tool_calls = Vec::new();
-
-        for item in content {
-            match item.get("type").and_then(|t| t.as_str()) {
-                Some("text") => {
-                    if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
-                        message_content.push_str(text);
-                    }
-                }
-                Some("tool_use") => {
-                    if let (Some(id), Some(name), Some(input)) = (
-                        item.get("id").and_then(|v| v.as_str()),
-                        item.get("name").and_then(|v| v.as_str()),
-                        item.get("input"),
-                    ) {
-                        tool_calls.push(crate::core::types::tools::ToolCall {
-                            id: id.to_string(),
-                            tool_type: "function".to_string(),
-                            function: crate::core::types::tools::FunctionCall {
-                                name: name.to_string(),
-                                arguments: input.to_string(),
-                            },
-                        });
-                    }
-                }
-                Some("thinking") => {
-                    if let Some(thinking) = item.get("thinking").and_then(|t| t.as_str()) {
-                        thinking_parts.push(thinking.to_string());
-                    }
-                    if let Some(signature) = item.get("signature").and_then(|s| s.as_str()) {
-                        thinking_signature = Some(signature.to_string());
-                    }
-                }
-                Some("redacted_thinking") => {
-                    has_redacted_thinking = true;
-                }
-                Some("refusal") => {
-                    if let Some(refusal) = item.get("refusal").and_then(|r| r.as_str()) {
-                        message_content.push_str(refusal);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let thinking = if !thinking_parts.is_empty() {
-            Some(ThinkingContent::Text {
-                text: thinking_parts.join(""),
-                signature: thinking_signature,
-            })
-        } else if has_redacted_thinking {
-            Some(ThinkingContent::Redacted { token_count: None })
-        } else {
-            None
-        };
-
-        // Build message
-        let message = ChatMessage {
-            role: MessageRole::Assistant,
-            content: if message_content.is_empty() {
-                None
-            } else {
-                Some(crate::core::types::message::MessageContent::Text(
-                    message_content,
-                ))
-            },
-            thinking,
-            audio: None,
-            name: None,
-            tool_calls: if tool_calls.is_empty() {
-                None
-            } else {
-                Some(tool_calls)
-            },
-            tool_call_id: None,
-            function_call: None,
-        };
-
-        // Build choice
-        let choice = ChatChoice {
-            index: 0,
-            message,
-            finish_reason: response
-                .get("stop_reason")
-                .and_then(|r| r.as_str())
-                .map(Self::parse_anthropic_stop_reason),
-            logprobs: None,
-        };
-
-        let usage = response.get("usage").map(usage::build_usage);
-
-        Ok(ChatResponse {
-            id,
-            object: "chat.completion".to_string(),
-            created,
-            model,
-            choices: vec![choice],
-            usage,
-            system_fingerprint: None,
-        })
-    }
 }
 
+mod response;
 mod usage;
 
 #[cfg(test)]

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -252,10 +252,23 @@ impl AnthropicClient {
 
     /// Request
     fn transform_chat_request(&self, request: &ChatRequest) -> Result<Value, ProviderError> {
+        if self.config.uses_compatible_model_allow_list()
+            && !self.config.allows_unknown_model(&request.model)
+        {
+            return Err(anthropic_api_error(
+                400,
+                format!("Unsupported model: {}", request.model),
+            ));
+        }
+
         let registry = get_anthropic_registry();
 
         // Check
-        let model_spec = registry.get_model_spec(&request.model);
+        let model_spec = if self.config.uses_compatible_model_allow_list() {
+            None
+        } else {
+            registry.get_model_spec(&request.model)
+        };
         if model_spec.is_none() && !self.config.allows_unknown_model(&request.model) {
             return Err(anthropic_api_error(
                 400,

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -254,15 +254,6 @@ impl AnthropicClient {
                 format!("Unsupported model: {}", request.model),
             ));
         }
-        if model_spec.is_none() && Self::has_multimodal_content(request) {
-            return Err(ProviderError::not_supported(
-                "anthropic",
-                format!(
-                    "Unknown model {} cannot declare multimodal support",
-                    request.model
-                ),
-            ));
-        }
         if model_spec.is_none() && Self::has_anthropic_tools_extra_param(request) {
             return Err(ProviderError::not_supported(
                 "anthropic",
@@ -515,7 +506,7 @@ impl AnthropicClient {
                                     }));
                                 }
                                 ContentPart::ImageUrl { image_url }
-                                    if model_spec.is_some_and(|spec| {
+                                    if model_spec.is_none_or(|spec| {
                                         spec.features.contains(&ModelFeature::MultimodalSupport)
                                     }) =>
                                 {
@@ -548,7 +539,7 @@ impl AnthropicClient {
                                     }
                                 }
                                 ContentPart::Document { source, .. }
-                                    if model_spec.is_some_and(|spec| {
+                                    if model_spec.is_none_or(|spec| {
                                         spec.features.contains(&ModelFeature::MultimodalSupport)
                                     }) =>
                                 {

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -263,6 +263,15 @@ impl AnthropicClient {
                 ),
             ));
         }
+        if model_spec.is_none() && Self::has_unsupported_unknown_model_content(request) {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} only supports text and image content",
+                    request.model
+                ),
+            ));
+        }
 
         // The Messages API only returns a single candidate; any n other than 1
         // (including 0) cannot be honored, so reject it instead of silently
@@ -539,7 +548,7 @@ impl AnthropicClient {
                                     }
                                 }
                                 ContentPart::Document { source, .. }
-                                    if model_spec.is_none_or(|spec| {
+                                    if model_spec.is_some_and(|spec| {
                                         spec.features.contains(&ModelFeature::MultimodalSupport)
                                     }) =>
                                 {
@@ -610,6 +619,25 @@ impl AnthropicClient {
             .get("anthropic_tools")
             .and_then(|value| value.as_array())
             .is_some_and(|tools| !tools.is_empty())
+    }
+
+    pub(crate) fn has_unsupported_unknown_model_content(request: &ChatRequest) -> bool {
+        request.messages.iter().any(|message| {
+            message
+                .tool_calls
+                .as_ref()
+                .is_some_and(|calls| !calls.is_empty())
+                || matches!(
+                    &message.content,
+                    Some(crate::core::types::message::MessageContent::Parts(parts))
+                        if parts.iter().any(|part| !matches!(
+                            part,
+                            ContentPart::Text { .. }
+                                | ContentPart::ImageUrl { .. }
+                                | ContentPart::Image { .. }
+                        ))
+                )
+        })
     }
 
     fn content_value_to_blocks(content: &Value) -> Vec<Value> {

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -681,10 +681,12 @@ impl AnthropicClient {
     pub(crate) fn has_unsupported_unknown_model_content(request: &ChatRequest) -> bool {
         request.messages.iter().any(|message| {
             matches!(message.role, MessageRole::Tool | MessageRole::Function)
+                || message.thinking.is_some()
                 || message
                     .tool_calls
                     .as_ref()
                     .is_some_and(|calls| !calls.is_empty())
+                || message.function_call.is_some()
                 || matches!(
                     &message.content,
                     Some(crate::core::types::message::MessageContent::Parts(parts))

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -275,7 +275,15 @@ impl AnthropicClient {
                 format!("Unsupported model: {}", request.model),
             ));
         }
-        if model_spec.is_none() && Self::has_anthropic_tools_extra_param(request) {
+        if model_spec.is_none()
+            && (request
+                .tools
+                .as_ref()
+                .is_some_and(|tools| !tools.is_empty())
+                || Self::has_anthropic_tools_extra_param(request)
+                || request.functions.as_ref().is_some_and(|f| !f.is_empty())
+                || request.function_call.is_some())
+        {
             return Err(ProviderError::not_supported(
                 "anthropic",
                 format!(
@@ -371,7 +379,9 @@ impl AnthropicClient {
         }
 
         // Add tool support
-        if let Some(tools) = &request.tools {
+        if let Some(tools) = &request.tools
+            && !tools.is_empty()
+        {
             let Some(model_spec) = model_spec else {
                 return Err(ProviderError::not_supported(
                     "anthropic",

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -680,10 +680,11 @@ impl AnthropicClient {
 
     pub(crate) fn has_unsupported_unknown_model_content(request: &ChatRequest) -> bool {
         request.messages.iter().any(|message| {
-            message
-                .tool_calls
-                .as_ref()
-                .is_some_and(|calls| !calls.is_empty())
+            matches!(message.role, MessageRole::Tool | MessageRole::Function)
+                || message
+                    .tool_calls
+                    .as_ref()
+                    .is_some_and(|calls| !calls.is_empty())
                 || matches!(
                     &message.content,
                     Some(crate::core::types::message::MessageContent::Parts(parts))

--- a/src/core/providers/anthropic/client/compatible_tests.rs
+++ b/src/core/providers/anthropic/client/compatible_tests.rs
@@ -112,3 +112,23 @@ fn text_only_configured_unknown_model_rejects_image_input() {
 
     assert!(format!("{err}").contains("does not support image input"));
 }
+
+#[test]
+fn compatible_allow_list_rejects_registry_model_ids_not_configured() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let request = ChatRequest::new("claude-3-haiku-20240307").add_user_message("Hello");
+
+    let err = match client.transform_chat_request(&request) {
+        Ok(_) => panic!("compatible allow-list must reject unlisted registry model IDs"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("Unsupported model: claude-3-haiku-20240307"));
+}

--- a/src/core/providers/anthropic/client/compatible_tests.rs
+++ b/src/core/providers/anthropic/client/compatible_tests.rs
@@ -132,3 +132,44 @@ fn compatible_allow_list_rejects_registry_model_ids_not_configured() {
 
     assert!(format!("{err}").contains("Unsupported model: claude-3-haiku-20240307"));
 }
+
+#[test]
+fn compatible_models_allow_empty_tools_without_forwarding_tools() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let mut request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+    request.tools = Some(vec![]);
+
+    let transformed = client
+        .transform_chat_request(&request)
+        .unwrap_or_else(|err| panic!("empty tools should not declare tool support: {err}"));
+
+    assert!(transformed.get("tools").is_none());
+}
+
+#[test]
+fn compatible_models_reject_legacy_functions() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let mut request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+    request.functions = Some(vec![serde_json::json!({"name": "lookup"})]);
+
+    let err = match client.transform_chat_request(&request) {
+        Ok(_) => panic!("compatible models must reject legacy function definitions"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("tool calling support"));
+}

--- a/src/core/providers/anthropic/client/compatible_tests.rs
+++ b/src/core/providers/anthropic/client/compatible_tests.rs
@@ -1,8 +1,11 @@
 use super::*;
 use crate::core::providers::anthropic::config::AnthropicConfig;
 use crate::core::types::{
+    chat::ChatMessage,
     content::{ContentPart, ImageSource, ImageUrl},
     message::{MessageContent, MessageRole},
+    thinking::ThinkingContent,
+    tools::FunctionCall,
 };
 
 #[test]
@@ -191,6 +194,61 @@ fn compatible_models_reject_tool_role_messages() {
 
     let err = match client.transform_chat_request(&request) {
         Ok(_) => panic!("compatible models must reject tool-role messages"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("only supports text and image content"));
+}
+
+#[test]
+fn compatible_models_reject_message_function_calls() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let mut request = ChatRequest::new("mimo-v2.5");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Text("calling lookup".to_string())),
+        function_call: Some(FunctionCall {
+            name: "lookup".to_string(),
+            arguments: "{}".to_string(),
+        }),
+        ..Default::default()
+    });
+
+    let err = match client.transform_chat_request(&request) {
+        Ok(_) => panic!("compatible models must reject message-level function calls"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("only supports text and image content"));
+}
+
+#[test]
+fn compatible_models_reject_message_thinking() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let mut request = ChatRequest::new("mimo-v2.5");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Text("answer".to_string())),
+        thinking: Some(ThinkingContent::text("hidden reasoning")),
+        ..Default::default()
+    });
+
+    let err = match client.transform_chat_request(&request) {
+        Ok(_) => panic!("compatible models must reject message-level thinking"),
         Err(err) => err,
     };
 

--- a/src/core/providers/anthropic/client/compatible_tests.rs
+++ b/src/core/providers/anthropic/client/compatible_tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+use crate::core::providers::anthropic::config::AnthropicConfig;
+use crate::core::types::{
+    content::{ContentPart, ImageSource, ImageUrl},
+    message::{MessageContent, MessageRole},
+};
+
+#[test]
+fn configured_unknown_model_serializes_image_url_parts() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()])
+        .with_configured_multimodal_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let request = ChatRequest::new("mimo-v2.5").add_message(
+        MessageRole::User,
+        MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "Describe this image".to_string(),
+            },
+            ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "data:image/png;base64,ZmFrZQ==".to_string(),
+                    detail: None,
+                },
+            },
+        ]),
+    );
+
+    let result = match client.transform_chat_request(&request) {
+        Ok(result) => result,
+        Err(err) => panic!("configured multimodal model should serialize image input: {err}"),
+    };
+
+    assert_eq!(result["model"], "mimo-v2.5");
+    assert_eq!(result["messages"][0]["content"][1]["type"], "image");
+}
+
+#[test]
+fn configured_unknown_model_serializes_image_parts() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()])
+        .with_configured_multimodal_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let request = ChatRequest::new("mimo-v2.5").add_message(
+        MessageRole::User,
+        MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "Describe this image".to_string(),
+            },
+            ContentPart::Image {
+                source: ImageSource {
+                    media_type: "image/png".to_string(),
+                    data: "ZmFrZQ==".to_string(),
+                },
+                detail: None,
+                image_url: None,
+            },
+        ]),
+    );
+
+    let result = match client.transform_chat_request(&request) {
+        Ok(result) => result,
+        Err(err) => panic!("configured multimodal model should serialize image input: {err}"),
+    };
+
+    assert_eq!(result["messages"][0]["content"][1]["type"], "image");
+    assert_eq!(
+        result["messages"][0]["content"][1]["source"]["data"],
+        "ZmFrZQ=="
+    );
+}
+
+#[test]
+fn text_only_configured_unknown_model_rejects_image_input() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5-pro".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let request = ChatRequest::new("mimo-v2.5-pro").add_message(
+        MessageRole::User,
+        MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "Describe this image".to_string(),
+            },
+            ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "data:image/png;base64,ZmFrZQ==".to_string(),
+                    detail: None,
+                },
+            },
+        ]),
+    );
+
+    let err = match client.transform_chat_request(&request) {
+        Ok(_) => panic!("text-only compatible model must reject image input"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("does not support image input"));
+}

--- a/src/core/providers/anthropic/client/compatible_tests.rs
+++ b/src/core/providers/anthropic/client/compatible_tests.rs
@@ -173,3 +173,26 @@ fn compatible_models_reject_legacy_functions() {
 
     assert!(format!("{err}").contains("tool calling support"));
 }
+
+#[test]
+fn compatible_models_reject_tool_role_messages() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
+    let request = ChatRequest::new("mimo-v2.5").add_message(
+        MessageRole::Tool,
+        MessageContent::Text("tool result".to_string()),
+    );
+
+    let err = match client.transform_chat_request(&request) {
+        Ok(_) => panic!("compatible models must reject tool-role messages"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("only supports text and image content"));
+}

--- a/src/core/providers/anthropic/client/response.rs
+++ b/src/core/providers/anthropic/client/response.rs
@@ -1,0 +1,159 @@
+use serde_json::Value;
+
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::{
+    chat::ChatMessage,
+    message::{MessageContent, MessageRole},
+    responses::{ChatChoice, ChatResponse, FinishReason},
+    thinking::ThinkingContent,
+    tools::{FunctionCall, ToolCall},
+};
+
+use super::{AnthropicClient, anthropic_parse_error, usage};
+
+fn parse_anthropic_stop_reason(reason: &str) -> FinishReason {
+    match reason {
+        "end_turn" => FinishReason::Stop,
+        "max_tokens" => FinishReason::Length,
+        "tool_use" => FinishReason::ToolCalls,
+        "stop_sequence" => FinishReason::StopSequence,
+        "refusal" => FinishReason::Refusal,
+        "pause_turn" => FinishReason::PauseTurn,
+        _ => FinishReason::Stop,
+    }
+}
+
+impl AnthropicClient {
+    /// Response
+    pub(super) fn transform_chat_response(
+        &self,
+        response: Value,
+    ) -> Result<ChatResponse, ProviderError> {
+        // Extract basic information
+        let id = response
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let model = response
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let created = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        // Handle content
+        let content = response
+            .get("content")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| anthropic_parse_error("Missing or invalid content array"))?;
+
+        let mut message_content = String::new();
+        let mut thinking_parts = Vec::new();
+        let mut thinking_signature = None;
+        let mut has_redacted_thinking = false;
+        let mut tool_calls = Vec::new();
+
+        for item in content {
+            match item.get("type").and_then(|t| t.as_str()) {
+                Some("text") => {
+                    if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                        message_content.push_str(text);
+                    }
+                }
+                Some("tool_use") => {
+                    if let (Some(id), Some(name), Some(input)) = (
+                        item.get("id").and_then(|v| v.as_str()),
+                        item.get("name").and_then(|v| v.as_str()),
+                        item.get("input"),
+                    ) {
+                        tool_calls.push(ToolCall {
+                            id: id.to_string(),
+                            tool_type: "function".to_string(),
+                            function: FunctionCall {
+                                name: name.to_string(),
+                                arguments: input.to_string(),
+                            },
+                        });
+                    }
+                }
+                Some("thinking") => {
+                    if let Some(thinking) = item.get("thinking").and_then(|t| t.as_str()) {
+                        thinking_parts.push(thinking.to_string());
+                    }
+                    if let Some(signature) = item.get("signature").and_then(|s| s.as_str()) {
+                        thinking_signature = Some(signature.to_string());
+                    }
+                }
+                Some("redacted_thinking") => {
+                    has_redacted_thinking = true;
+                }
+                Some("refusal") => {
+                    if let Some(refusal) = item.get("refusal").and_then(|r| r.as_str()) {
+                        message_content.push_str(refusal);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let thinking = if !thinking_parts.is_empty() {
+            Some(ThinkingContent::Text {
+                text: thinking_parts.join(""),
+                signature: thinking_signature,
+            })
+        } else if has_redacted_thinking {
+            Some(ThinkingContent::Redacted { token_count: None })
+        } else {
+            None
+        };
+
+        // Build message
+        let message = ChatMessage {
+            role: MessageRole::Assistant,
+            content: if message_content.is_empty() {
+                None
+            } else {
+                Some(MessageContent::Text(message_content))
+            },
+            thinking,
+            audio: None,
+            name: None,
+            tool_calls: if tool_calls.is_empty() {
+                None
+            } else {
+                Some(tool_calls)
+            },
+            tool_call_id: None,
+            function_call: None,
+        };
+
+        // Build choice
+        let choice = ChatChoice {
+            index: 0,
+            message,
+            finish_reason: response
+                .get("stop_reason")
+                .and_then(|r| r.as_str())
+                .map(parse_anthropic_stop_reason),
+            logprobs: None,
+        };
+
+        let usage = response.get("usage").map(usage::build_usage);
+
+        Ok(ChatResponse {
+            id,
+            object: "chat.completion".to_string(),
+            created,
+            model,
+            choices: vec![choice],
+            usage,
+            system_fingerprint: None,
+        })
+    }
+}

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -709,6 +709,7 @@ fn test_transform_chat_request_allows_n_equal_one_and_ignores_unsupported_params
 #[test]
 fn test_transform_chat_request_allows_unknown_model_when_configured() {
     let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
         .with_allow_unknown_models(true)
         .with_configured_models(vec!["mimo-v2.5".to_string()]);
     let client = match AnthropicClient::new(config) {
@@ -729,9 +730,13 @@ fn test_transform_chat_request_allows_unknown_model_when_configured() {
 #[test]
 fn test_transform_chat_request_allows_configured_unknown_model_image_input() {
     let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
         .with_allow_unknown_models(true)
         .with_configured_models(vec!["mimo-v2.5".to_string()]);
-    let client = AnthropicClient::new(config).unwrap();
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
 
     let request = ChatRequest::new("mimo-v2.5").add_message(
         crate::core::types::message::MessageRole::User,
@@ -748,7 +753,10 @@ fn test_transform_chat_request_allows_configured_unknown_model_image_input() {
         ]),
     );
 
-    let result = client.transform_chat_request(&request).unwrap();
+    let result = match client.transform_chat_request(&request) {
+        Ok(result) => result,
+        Err(err) => panic!("configured compatible model should accept image input: {err}"),
+    };
 
     assert_eq!(result["model"], "mimo-v2.5");
     assert_eq!(result["messages"][0]["content"][1]["type"], "image");

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -732,11 +732,9 @@ fn test_transform_chat_request_allows_configured_unknown_model_image_input() {
     let config = AnthropicConfig::new_test("test-key")
         .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
         .with_allow_unknown_models(true)
-        .with_configured_models(vec!["mimo-v2.5".to_string()]);
-    let client = match AnthropicClient::new(config) {
-        Ok(client) => client,
-        Err(err) => panic!("client should build: {err}"),
-    };
+        .with_configured_models(vec!["mimo-v2.5".to_string()])
+        .with_configured_multimodal_models(vec!["mimo-v2.5".to_string()]);
+    let client = AnthropicClient::new(config).unwrap();
 
     let request = ChatRequest::new("mimo-v2.5").add_message(
         crate::core::types::message::MessageRole::User,
@@ -753,11 +751,7 @@ fn test_transform_chat_request_allows_configured_unknown_model_image_input() {
         ]),
     );
 
-    let result = match client.transform_chat_request(&request) {
-        Ok(result) => result,
-        Err(err) => panic!("configured compatible model should accept image input: {err}"),
-    };
-
+    let result = client.transform_chat_request(&request).unwrap();
     assert_eq!(result["model"], "mimo-v2.5");
     assert_eq!(result["messages"][0]["content"][1]["type"], "image");
 }

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::core::providers::anthropic::config::AnthropicConfig;
 use crate::core::types::message::MessageContent;
+use crate::core::types::thinking::ThinkingContent;
 
 // ==================== Client Creation Tests ====================
 
@@ -303,7 +304,9 @@ fn test_anthropic_transform_messages_preserves_assistant_text_with_tool_use() {
         audio: None,
     }];
 
-    let transformed = client.transform_messages(messages, model_spec).unwrap();
+    let transformed = client
+        .transform_messages(messages, Some(model_spec))
+        .unwrap();
     assert_eq!(transformed[0]["role"], "assistant");
     let content = transformed[0]["content"].as_array().unwrap();
     assert_eq!(content[0]["type"], "text");
@@ -333,7 +336,9 @@ fn test_anthropic_transform_messages_tool_role_to_tool_result() {
         audio: None,
     }];
 
-    let transformed = client.transform_messages(messages, model_spec).unwrap();
+    let transformed = client
+        .transform_messages(messages, Some(model_spec))
+        .unwrap();
     assert_eq!(transformed[0]["role"], "user");
     let content = transformed[0]["content"].as_array().unwrap();
     assert_eq!(content[0]["type"], "tool_result");
@@ -699,6 +704,29 @@ fn test_transform_chat_request_allows_n_equal_one_and_ignores_unsupported_params
     // Ignored params must not leak into the Anthropic request body
     assert!(result.get("frequency_penalty").is_none());
     assert!(result.get("seed").is_none());
+}
+
+#[test]
+fn test_transform_chat_request_allows_unknown_model_when_configured() {
+    let config = AnthropicConfig::new_test("test-key").with_allow_unknown_models(true);
+    let client = AnthropicClient::new(config).unwrap();
+
+    let request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+
+    let result = client.transform_chat_request(&request).unwrap();
+    assert_eq!(result["model"], "mimo-v2.5");
+    assert_eq!(result["max_tokens"], 4096);
+}
+
+#[test]
+fn test_transform_chat_request_rejects_unknown_model_by_default() {
+    let config = AnthropicConfig::new_test("test-key");
+    let client = AnthropicClient::new(config).unwrap();
+
+    let request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+
+    let error = client.transform_chat_request(&request).unwrap_err();
+    assert!(format!("{error}").contains("Unsupported model: mimo-v2.5"));
 }
 
 #[test]

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -708,14 +708,50 @@ fn test_transform_chat_request_allows_n_equal_one_and_ignores_unsupported_params
 
 #[test]
 fn test_transform_chat_request_allows_unknown_model_when_configured() {
-    let config = AnthropicConfig::new_test("test-key").with_allow_unknown_models(true);
-    let client = AnthropicClient::new(config).unwrap();
+    let config = AnthropicConfig::new_test("test-key")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = match AnthropicClient::new(config) {
+        Ok(client) => client,
+        Err(err) => panic!("client should build: {err}"),
+    };
 
     let request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
 
-    let result = client.transform_chat_request(&request).unwrap();
+    let result = match client.transform_chat_request(&request) {
+        Ok(result) => result,
+        Err(err) => panic!("configured compatible model should accept image input: {err}"),
+    };
     assert_eq!(result["model"], "mimo-v2.5");
     assert_eq!(result["max_tokens"], 4096);
+}
+
+#[test]
+fn test_transform_chat_request_allows_configured_unknown_model_image_input() {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    let client = AnthropicClient::new(config).unwrap();
+
+    let request = ChatRequest::new("mimo-v2.5").add_message(
+        crate::core::types::message::MessageRole::User,
+        crate::core::types::message::MessageContent::Parts(vec![
+            crate::core::types::content::ContentPart::Text {
+                text: "Describe this image".to_string(),
+            },
+            crate::core::types::content::ContentPart::ImageUrl {
+                image_url: crate::core::types::content::ImageUrl {
+                    url: "data:image/png;base64,ZmFrZQ==".to_string(),
+                    detail: None,
+                },
+            },
+        ]),
+    );
+
+    let result = client.transform_chat_request(&request).unwrap();
+
+    assert_eq!(result["model"], "mimo-v2.5");
+    assert_eq!(result["messages"][0]["content"][1]["type"], "image");
 }
 
 #[test]

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -1,0 +1,42 @@
+use super::{AnthropicConfig, AnthropicProvider};
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::{chat::ChatRequest, context::RequestContext};
+
+fn compatible_provider() -> AnthropicProvider {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+        .with_allow_unknown_models(true)
+        .with_configured_models(vec!["mimo-v2.5".to_string()]);
+    AnthropicProvider::new(config).unwrap_or_else(|err| panic!("provider should build: {err}"))
+}
+
+#[tokio::test]
+async fn compatible_models_allow_empty_tools_without_forwarding_tools() {
+    let provider = compatible_provider();
+    let mut request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+    request.tools = Some(vec![]);
+
+    let transformed = provider
+        .transform_request(request, RequestContext::new())
+        .await
+        .unwrap_or_else(|err| panic!("empty tools should not declare tool support: {err}"));
+
+    assert!(transformed.get("tools").is_none());
+}
+
+#[tokio::test]
+async fn compatible_models_reject_legacy_functions() {
+    let provider = compatible_provider();
+    let mut request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+    request.functions = Some(vec![serde_json::json!({"name": "lookup"})]);
+
+    let err = match provider
+        .transform_request(request, RequestContext::new())
+        .await
+    {
+        Ok(_) => panic!("compatible models must reject legacy function definitions"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("tool calling support"));
+}

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -1,6 +1,10 @@
 use super::{AnthropicConfig, AnthropicProvider};
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
-use crate::core::types::{chat::ChatRequest, context::RequestContext};
+use crate::core::types::{
+    chat::ChatRequest,
+    context::RequestContext,
+    message::{MessageContent, MessageRole},
+};
 
 fn compatible_provider() -> AnthropicProvider {
     let config = AnthropicConfig::new_test("test-key")
@@ -39,4 +43,23 @@ async fn compatible_models_reject_legacy_functions() {
     };
 
     assert!(format!("{err}").contains("tool calling support"));
+}
+
+#[tokio::test]
+async fn compatible_models_reject_tool_role_messages() {
+    let provider = compatible_provider();
+    let request = ChatRequest::new("mimo-v2.5").add_message(
+        MessageRole::Tool,
+        MessageContent::Text("tool result".to_string()),
+    );
+
+    let err = match provider
+        .transform_request(request, RequestContext::new())
+        .await
+    {
+        Ok(_) => panic!("compatible models must reject tool-role messages"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("only supports text and image content"));
 }

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -1,9 +1,11 @@
 use super::{AnthropicConfig, AnthropicProvider};
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::{
-    chat::ChatRequest,
+    chat::{ChatMessage, ChatRequest},
     context::RequestContext,
     message::{MessageContent, MessageRole},
+    thinking::ThinkingContent,
+    tools::FunctionCall,
 };
 
 fn compatible_provider() -> AnthropicProvider {
@@ -58,6 +60,53 @@ async fn compatible_models_reject_tool_role_messages() {
         .await
     {
         Ok(_) => panic!("compatible models must reject tool-role messages"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("only supports text and image content"));
+}
+
+#[tokio::test]
+async fn compatible_models_reject_message_function_calls() {
+    let provider = compatible_provider();
+    let mut request = ChatRequest::new("mimo-v2.5");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Text("calling lookup".to_string())),
+        function_call: Some(FunctionCall {
+            name: "lookup".to_string(),
+            arguments: "{}".to_string(),
+        }),
+        ..Default::default()
+    });
+
+    let err = match provider
+        .transform_request(request, RequestContext::new())
+        .await
+    {
+        Ok(_) => panic!("compatible models must reject message-level function calls"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("only supports text and image content"));
+}
+
+#[tokio::test]
+async fn compatible_models_reject_message_thinking() {
+    let provider = compatible_provider();
+    let mut request = ChatRequest::new("mimo-v2.5");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Text("answer".to_string())),
+        thinking: Some(ThinkingContent::text("hidden reasoning")),
+        ..Default::default()
+    });
+
+    let err = match provider
+        .transform_request(request, RequestContext::new())
+        .await
+    {
+        Ok(_) => panic!("compatible models must reject message-level thinking"),
         Err(err) => err,
     };
 

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -37,6 +37,8 @@ pub struct AnthropicConfig {
     pub enable_computer_use: bool,
     /// Enable experimental features
     pub enable_experimental: bool,
+    /// Allow Anthropic-compatible upstreams to use non-Anthropic model IDs.
+    pub allow_unknown_models: bool,
 }
 
 impl Default for AnthropicConfig {
@@ -55,6 +57,7 @@ impl Default for AnthropicConfig {
             enable_cache_control: true,
             enable_computer_use: false, // Default disabled
             enable_experimental: false,
+            allow_unknown_models: false,
         }
     }
 }
@@ -128,6 +131,10 @@ impl AnthropicConfig {
             config.enable_experimental = experimental.parse().unwrap_or(false);
         }
 
+        if let Ok(allow_unknown_models) = env::var("ANTHROPIC_ALLOW_UNKNOWN_MODELS") {
+            config.allow_unknown_models = allow_unknown_models.parse().unwrap_or(false);
+        }
+
         Ok(config)
     }
 
@@ -188,6 +195,12 @@ impl AnthropicConfig {
     /// Enable experimental features
     pub fn with_experimental(mut self, enabled: bool) -> Self {
         self.enable_experimental = enabled;
+        self
+    }
+
+    /// Allow Anthropic-compatible upstreams to use non-Anthropic model IDs.
+    pub fn with_allow_unknown_models(mut self, enabled: bool) -> Self {
+        self.allow_unknown_models = enabled;
         self
     }
 
@@ -315,6 +328,12 @@ impl AnthropicConfigBuilder {
     pub fn experimental(mut self, enabled: bool) -> Self {
         self.config.enable_experimental = enabled;
         self.config.enable_computer_use = enabled; // Computer tools are part of experimental features
+        self
+    }
+
+    /// Allow Anthropic-compatible upstreams to use non-Anthropic model IDs.
+    pub fn allow_unknown_models(mut self, enabled: bool) -> Self {
+        self.config.allow_unknown_models = enabled;
         self
     }
 

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -39,6 +39,8 @@ pub struct AnthropicConfig {
     pub enable_experimental: bool,
     /// Allow Anthropic-compatible upstreams to use non-Anthropic model IDs.
     pub allow_unknown_models: bool,
+    /// Explicit non-Anthropic model IDs allowed for compatible upstreams.
+    pub configured_models: Vec<String>,
 }
 
 impl Default for AnthropicConfig {
@@ -58,6 +60,7 @@ impl Default for AnthropicConfig {
             enable_computer_use: false, // Default disabled
             enable_experimental: false,
             allow_unknown_models: false,
+            configured_models: Vec::new(),
         }
     }
 }
@@ -204,6 +207,22 @@ impl AnthropicConfig {
         self
     }
 
+    /// Set explicit model IDs for Anthropic-compatible upstreams.
+    pub fn with_configured_models(mut self, models: Vec<String>) -> Self {
+        self.configured_models = models;
+        self
+    }
+
+    /// Check if a non-Anthropic model ID is explicitly allowed.
+    pub fn allows_unknown_model(&self, model: &str) -> bool {
+        self.allow_unknown_models
+            && (self.configured_models.is_empty()
+                || self
+                    .configured_models
+                    .iter()
+                    .any(|configured| configured == model))
+    }
+
     /// Get
     pub fn get_api_url(&self, endpoint: &str) -> String {
         format!("{}{}", self.base_url.trim_end_matches('/'), endpoint)
@@ -228,13 +247,18 @@ impl ProviderConfig for AnthropicConfig {
             return Err("API key cannot be empty".to_string());
         }
 
-        if !api_key.starts_with("sk-ant-") {
+        let first_party_anthropic =
+            self.base_url.trim_end_matches('/') == "https://api.anthropic.com";
+        let compatible_upstream = self.allow_unknown_models && !first_party_anthropic;
+
+        if !compatible_upstream && !api_key.starts_with("sk-ant-") {
             return Err(
                 "Invalid Anthropic API key format. Keys should start with 'sk-ant-'".to_string(),
             );
         }
 
-        if api_key.len() < 20 {
+        let minimum_key_len = if compatible_upstream { 8 } else { 20 };
+        if api_key.len() < minimum_key_len {
             return Err("API key appears to be too short".to_string());
         }
 
@@ -337,6 +361,12 @@ impl AnthropicConfigBuilder {
         self
     }
 
+    /// Set explicit model IDs for Anthropic-compatible upstreams.
+    pub fn configured_models(mut self, models: Vec<String>) -> Self {
+        self.config.configured_models = models;
+        self
+    }
+
     /// Configuration
     pub fn build(self) -> Result<AnthropicConfig, ProviderError> {
         self.config
@@ -391,12 +421,32 @@ mod tests {
             .multimodal(false)
             .build();
 
-        assert!(config.is_ok());
-        let config = config.unwrap();
+        let config = match config {
+            Ok(config) => config,
+            Err(err) => panic!("compatible upstream config should build: {err}"),
+        };
         assert_eq!(config.api_key, Some("sk-ant-test1234567890123".to_string()));
         assert_eq!(config.base_url, "https://custom.api.com");
         assert_eq!(config.request_timeout, 60);
         assert!(!config.enable_multimodal);
+    }
+
+    #[test]
+    fn test_config_builder_allows_compatible_upstream_keys() {
+        let config = AnthropicConfigBuilder::new()
+            .api_key("xiaomi-compatible-key")
+            .base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .allow_unknown_models(true)
+            .configured_models(vec!["mimo-v2.5".to_string()])
+            .build();
+
+        let config = match config {
+            Ok(config) => config,
+            Err(err) => panic!("compatible upstream key should validate: {err}"),
+        };
+        assert_eq!(config.api_key.as_deref(), Some("xiaomi-compatible-key"));
+        assert!(config.allows_unknown_model("mimo-v2.5"));
+        assert!(!config.allows_unknown_model("unlisted-model"));
     }
 
     #[test]

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -216,11 +216,10 @@ impl AnthropicConfig {
     /// Check if a non-Anthropic model ID is explicitly allowed.
     pub fn allows_unknown_model(&self, model: &str) -> bool {
         self.allow_unknown_models
-            && (self.configured_models.is_empty()
-                || self
-                    .configured_models
-                    .iter()
-                    .any(|configured| configured == model))
+            && self
+                .configured_models
+                .iter()
+                .any(|configured| configured == model)
     }
 
     /// Get
@@ -250,6 +249,10 @@ impl ProviderConfig for AnthropicConfig {
         let first_party_anthropic =
             self.base_url.trim_end_matches('/') == "https://api.anthropic.com";
         let compatible_upstream = self.allow_unknown_models && !first_party_anthropic;
+
+        if compatible_upstream && self.configured_models.is_empty() {
+            return Err("allow_unknown_models requires an explicit models allow-list".to_string());
+        }
 
         if !compatible_upstream && !api_key.starts_with("sk-ant-") {
             return Err(
@@ -447,6 +450,20 @@ mod tests {
         assert_eq!(config.api_key.as_deref(), Some("xiaomi-compatible-key"));
         assert!(config.allows_unknown_model("mimo-v2.5"));
         assert!(!config.allows_unknown_model("unlisted-model"));
+    }
+
+    #[test]
+    fn test_config_builder_requires_compatible_model_allow_list() {
+        let config = AnthropicConfigBuilder::new()
+            .api_key("xiaomi-compatible-key")
+            .base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .allow_unknown_models(true)
+            .build();
+
+        let Err(err) = config else {
+            panic!("compatible upstreams should require explicit model IDs");
+        };
+        assert!(format!("{err}").contains("explicit models allow-list"));
     }
 
     #[test]

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -41,6 +41,8 @@ pub struct AnthropicConfig {
     pub allow_unknown_models: bool,
     /// Explicit non-Anthropic model IDs allowed for compatible upstreams.
     pub configured_models: Vec<String>,
+    /// Explicit compatible model IDs allowed to receive image input.
+    pub configured_multimodal_models: Vec<String>,
 }
 
 impl Default for AnthropicConfig {
@@ -61,6 +63,7 @@ impl Default for AnthropicConfig {
             enable_experimental: false,
             allow_unknown_models: false,
             configured_models: Vec::new(),
+            configured_multimodal_models: Vec::new(),
         }
     }
 }
@@ -213,6 +216,12 @@ impl AnthropicConfig {
         self
     }
 
+    /// Set explicit compatible model IDs that support image input.
+    pub fn with_configured_multimodal_models(mut self, models: Vec<String>) -> Self {
+        self.configured_multimodal_models = models;
+        self
+    }
+
     /// Check if a non-Anthropic model ID is explicitly allowed.
     pub fn allows_unknown_model(&self, model: &str) -> bool {
         self.allow_unknown_models
@@ -221,6 +230,29 @@ impl AnthropicConfig {
                 .configured_models
                 .iter()
                 .any(|configured| configured == model)
+    }
+
+    pub fn uses_compatible_model_allow_list(&self) -> bool {
+        self.allow_unknown_models
+            && self.base_url.trim_end_matches('/') != "https://api.anthropic.com"
+    }
+
+    pub fn allows_unknown_model_image_input(&self, model: &str) -> bool {
+        self.enable_multimodal
+            && self.allows_unknown_model(model)
+            && self
+                .configured_multimodal_models
+                .iter()
+                .any(|configured| configured == model)
+    }
+
+    pub fn has_unknown_multimodal_model_outside_allow_list(&self) -> bool {
+        self.configured_multimodal_models.iter().any(|model| {
+            !self
+                .configured_models
+                .iter()
+                .any(|configured| configured == model)
+        })
     }
 
     /// Get
@@ -259,6 +291,12 @@ impl ProviderConfig for AnthropicConfig {
 
         if compatible_upstream && self.configured_models.is_empty() {
             return Err("allow_unknown_models requires an explicit models allow-list".to_string());
+        }
+
+        if compatible_upstream && self.has_unknown_multimodal_model_outside_allow_list() {
+            return Err(
+                "multimodal_models must be included in the explicit models allow-list".to_string(),
+            );
         }
 
         if !compatible_upstream && !api_key.starts_with("sk-ant-") {
@@ -377,6 +415,12 @@ impl AnthropicConfigBuilder {
         self
     }
 
+    /// Set explicit compatible model IDs that support image input.
+    pub fn configured_multimodal_models(mut self, models: Vec<String>) -> Self {
+        self.config.configured_multimodal_models = models;
+        self
+    }
+
     /// Configuration
     pub fn build(self) -> Result<AnthropicConfig, ProviderError> {
         self.config
@@ -471,6 +515,22 @@ mod tests {
             panic!("compatible upstreams should require explicit model IDs");
         };
         assert!(format!("{err}").contains("explicit models allow-list"));
+    }
+
+    #[test]
+    fn test_config_builder_rejects_multimodal_model_outside_allow_list() {
+        let config = AnthropicConfigBuilder::new()
+            .api_key("xiaomi-compatible-key")
+            .base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .allow_unknown_models(true)
+            .configured_models(vec!["mimo-v2.5-pro".to_string()])
+            .configured_multimodal_models(vec!["mimo-v2.5".to_string()])
+            .build();
+
+        let Err(err) = config else {
+            panic!("compatible multimodal models should stay inside the model allow-list");
+        };
+        assert!(format!("{err}").contains("multimodal_models"));
     }
 
     #[test]

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -216,6 +216,7 @@ impl AnthropicConfig {
     /// Check if a non-Anthropic model ID is explicitly allowed.
     pub fn allows_unknown_model(&self, model: &str) -> bool {
         self.allow_unknown_models
+            && self.base_url.trim_end_matches('/') != "https://api.anthropic.com"
             && self
                 .configured_models
                 .iter()
@@ -249,6 +250,12 @@ impl ProviderConfig for AnthropicConfig {
         let first_party_anthropic =
             self.base_url.trim_end_matches('/') == "https://api.anthropic.com";
         let compatible_upstream = self.allow_unknown_models && !first_party_anthropic;
+
+        if self.allow_unknown_models && first_party_anthropic {
+            return Err(
+                "allow_unknown_models requires a non-Anthropic compatible base URL".to_string(),
+            );
+        }
 
         if compatible_upstream && self.configured_models.is_empty() {
             return Err("allow_unknown_models requires an explicit models allow-list".to_string());
@@ -464,6 +471,20 @@ mod tests {
             panic!("compatible upstreams should require explicit model IDs");
         };
         assert!(format!("{err}").contains("explicit models allow-list"));
+    }
+
+    #[test]
+    fn test_config_builder_rejects_first_party_unknown_model_opt_in() {
+        let config = AnthropicConfigBuilder::new()
+            .api_key("sk-ant-test1234567890123")
+            .allow_unknown_models(true)
+            .configured_models(vec!["mimo-v2.5".to_string()])
+            .build();
+
+        let Err(err) = config else {
+            panic!("first-party Anthropic should not accept unknown-model opt-in");
+        };
+        assert!(format!("{err}").contains("non-Anthropic compatible base URL"));
     }
 
     #[test]

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -151,6 +151,10 @@ impl AnthropicConfig {
             config.configured_multimodal_models = models;
         }
 
+        config
+            .validate()
+            .map_err(|e| ProviderError::configuration("anthropic", e))?;
+
         Ok(config)
     }
 
@@ -626,6 +630,49 @@ mod tests {
             vec!["mimo-v2.5".to_string()]
         );
         assert!(config.validate().is_ok());
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+
+    #[test]
+    fn from_env_rejects_compatible_opt_in_without_model_allow_list() {
+        const KEYS: &[&str] = &[
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_ALLOW_UNKNOWN_MODELS",
+            "ANTHROPIC_MODELS",
+            "ANTHROPIC_CONFIGURED_MODELS",
+            "ANTHROPIC_MULTIMODAL_MODELS",
+            "ANTHROPIC_CONFIGURED_MULTIMODAL_MODELS",
+        ];
+        let previous: Vec<(&str, Option<String>)> = KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        for key in KEYS {
+            unsafe { std::env::remove_var(key) };
+        }
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", "xiaomi-compatible-key");
+            std::env::set_var(
+                "ANTHROPIC_BASE_URL",
+                "https://token-plan-sgp.xiaomimimo.com/anthropic",
+            );
+            std::env::set_var("ANTHROPIC_ALLOW_UNKNOWN_MODELS", "true");
+        }
+
+        let err = match AnthropicConfig::from_env() {
+            Ok(_) => panic!("compatible env opt-in must require explicit model IDs"),
+            Err(err) => err,
+        };
+        assert!(format!("{err}").contains("explicit models allow-list"));
 
         for (key, value) in previous {
             match value {

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -291,7 +291,8 @@ impl ProviderConfig for AnthropicConfig {
 
         let first_party_anthropic =
             self.base_url.trim_end_matches('/') == "https://api.anthropic.com";
-        let compatible_upstream = self.allow_unknown_models && !first_party_anthropic;
+        let custom_anthropic_base = !first_party_anthropic;
+        let compatible_unknown_models = self.allow_unknown_models && custom_anthropic_base;
 
         if self.allow_unknown_models && first_party_anthropic {
             return Err(
@@ -299,23 +300,23 @@ impl ProviderConfig for AnthropicConfig {
             );
         }
 
-        if compatible_upstream && self.configured_models.is_empty() {
+        if compatible_unknown_models && self.configured_models.is_empty() {
             return Err("allow_unknown_models requires an explicit models allow-list".to_string());
         }
 
-        if compatible_upstream && self.has_unknown_multimodal_model_outside_allow_list() {
+        if compatible_unknown_models && self.has_unknown_multimodal_model_outside_allow_list() {
             return Err(
                 "multimodal_models must be included in the explicit models allow-list".to_string(),
             );
         }
 
-        if !compatible_upstream && !api_key.starts_with("sk-ant-") {
+        if !custom_anthropic_base && !api_key.starts_with("sk-ant-") {
             return Err(
                 "Invalid Anthropic API key format. Keys should start with 'sk-ant-'".to_string(),
             );
         }
 
-        let minimum_key_len = if compatible_upstream { 8 } else { 20 };
+        let minimum_key_len = if custom_anthropic_base { 8 } else { 20 };
         if api_key.len() < minimum_key_len {
             return Err("API key appears to be too short".to_string());
         }
@@ -521,6 +522,23 @@ mod tests {
         assert_eq!(config.api_key.as_deref(), Some("xiaomi-compatible-key"));
         assert!(config.allows_unknown_model("mimo-v2.5"));
         assert!(!config.allows_unknown_model("unlisted-model"));
+    }
+
+    #[test]
+    fn test_config_builder_allows_gateway_keys_on_custom_base_without_unknown_models() {
+        let config = AnthropicConfigBuilder::new()
+            .api_key("gateway-compatible-key")
+            .base_url("https://gateway.example.com/anthropic")
+            .build();
+
+        let config = match config {
+            Ok(config) => config,
+            Err(err) => {
+                panic!("custom Anthropic-compatible base should accept gateway keys: {err}")
+            }
+        };
+        assert_eq!(config.api_key.as_deref(), Some("gateway-compatible-key"));
+        assert!(!config.allow_unknown_models);
     }
 
     #[test]

--- a/src/core/providers/anthropic/config.rs
+++ b/src/core/providers/anthropic/config.rs
@@ -140,6 +140,16 @@ impl AnthropicConfig {
         if let Ok(allow_unknown_models) = env::var("ANTHROPIC_ALLOW_UNKNOWN_MODELS") {
             config.allow_unknown_models = allow_unknown_models.parse().unwrap_or(false);
         }
+        if let Some(models) = env_model_list("ANTHROPIC_MODELS")
+            .or_else(|| env_model_list("ANTHROPIC_CONFIGURED_MODELS"))
+        {
+            config.configured_models = models;
+        }
+        if let Some(models) = env_model_list("ANTHROPIC_MULTIMODAL_MODELS")
+            .or_else(|| env_model_list("ANTHROPIC_CONFIGURED_MULTIMODAL_MODELS"))
+        {
+            config.configured_multimodal_models = models;
+        }
 
         Ok(config)
     }
@@ -352,6 +362,16 @@ impl ProviderConfig for AnthropicConfig {
     }
 }
 
+fn env_model_list(name: &str) -> Option<Vec<String>> {
+    env::var(name).ok().map(|raw| {
+        raw.split(',')
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .map(str::to_string)
+            .collect()
+    })
+}
+
 /// Configuration
 pub struct AnthropicConfigBuilder {
     config: AnthropicConfig,
@@ -545,6 +565,56 @@ mod tests {
             panic!("first-party Anthropic should not accept unknown-model opt-in");
         };
         assert!(format!("{err}").contains("non-Anthropic compatible base URL"));
+    }
+
+    #[test]
+    fn from_env_reads_compatible_model_allow_lists() {
+        const KEYS: &[&str] = &[
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_ALLOW_UNKNOWN_MODELS",
+            "ANTHROPIC_MODELS",
+            "ANTHROPIC_MULTIMODAL_MODELS",
+        ];
+        let previous: Vec<_> = KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        for key in KEYS {
+            unsafe { std::env::remove_var(key) };
+        }
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", "xiaomi-compatible-key");
+            std::env::set_var(
+                "ANTHROPIC_BASE_URL",
+                "https://token-plan-sgp.xiaomimimo.com/anthropic",
+            );
+            std::env::set_var("ANTHROPIC_ALLOW_UNKNOWN_MODELS", "true");
+            std::env::set_var("ANTHROPIC_MODELS", "mimo-v2.5, mimo-v2.5-pro");
+            std::env::set_var("ANTHROPIC_MULTIMODAL_MODELS", "mimo-v2.5");
+        }
+
+        let config = AnthropicConfig::from_env()
+            .unwrap_or_else(|err| panic!("env config should parse: {err}"));
+        assert!(config.allow_unknown_models);
+        assert_eq!(
+            config.configured_models,
+            vec!["mimo-v2.5".to_string(), "mimo-v2.5-pro".to_string()]
+        );
+        assert_eq!(
+            config.configured_multimodal_models,
+            vec!["mimo-v2.5".to_string()]
+        );
+        assert!(config.validate().is_ok());
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
     }
 
     #[test]

--- a/src/core/providers/anthropic/mod.rs
+++ b/src/core/providers/anthropic/mod.rs
@@ -13,6 +13,9 @@ pub mod models;
 pub mod provider;
 pub mod streaming;
 
+#[cfg(test)]
+mod compatible_provider_tests;
+
 // Re-export core components
 pub use client::AnthropicClient;
 pub use config::{AnthropicConfig, AnthropicConfigBuilder};

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -60,12 +60,56 @@ impl AnthropicProvider {
     fn validate_request(&self, request: &ChatRequest) -> Result<(), ProviderError> {
         let registry = get_anthropic_registry();
 
-        let model_spec = registry.get_model_spec(&request.model).ok_or_else(|| {
-            ProviderError::invalid_request(
+        let Some(model_spec) = registry.get_model_spec(&request.model) else {
+            if !self.client.allows_unknown_models() {
+                return Err(ProviderError::invalid_request(
+                    "anthropic",
+                    format!("Unsupported model: {}", request.model),
+                ));
+            }
+
+            crate::core::providers::base::validate_chat_request_common(
                 "anthropic",
-                format!("Unsupported model: {}", request.model),
-            )
-        })?;
+                request,
+                u32::MAX,
+            )?;
+
+            if Self::has_multimodal_content(request) {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare multimodal support",
+                        request.model
+                    ),
+                ));
+            }
+
+            if request.tools.is_some() {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare tool calling support",
+                        request.model
+                    ),
+                ));
+            }
+
+            if request
+                .thinking
+                .as_ref()
+                .is_some_and(|thinking| thinking.enabled)
+            {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare thinking support",
+                        request.model
+                    ),
+                ));
+            }
+
+            return Ok(());
+        };
 
         // Common validation: empty messages + max_tokens
         crate::core::providers::base::validate_chat_request_common(
@@ -75,15 +119,7 @@ impl AnthropicProvider {
         )?;
 
         // Check multimodal content
-        let has_multimodal_content = request.messages.iter().any(|msg| {
-            if let Some(crate::core::types::message::MessageContent::Parts(parts)) = &msg.content {
-                parts.iter().any(|part| {
-                    !matches!(part, crate::core::types::content::ContentPart::Text { .. })
-                })
-            } else {
-                false
-            }
-        });
+        let has_multimodal_content = Self::has_multimodal_content(request);
 
         if has_multimodal_content
             && !model_spec
@@ -108,6 +144,18 @@ impl AnthropicProvider {
         }
 
         Ok(())
+    }
+
+    fn has_multimodal_content(request: &ChatRequest) -> bool {
+        request.messages.iter().any(|msg| {
+            if let Some(crate::core::types::message::MessageContent::Parts(parts)) = &msg.content {
+                parts.iter().any(|part| {
+                    !matches!(part, crate::core::types::content::ContentPart::Text { .. })
+                })
+            } else {
+                false
+            }
+        })
     }
 }
 
@@ -249,13 +297,10 @@ impl LLMProvider for AnthropicProvider {
         self.validate_request(&request)?;
 
         let registry = get_anthropic_registry();
-        let model_spec = registry.get_model_spec(&request.model).ok_or_else(|| {
-            ProviderError::not_supported("anthropic", format!("Unknown model: {}", request.model))
-        })?;
-
-        if !model_spec
-            .features
-            .contains(&ModelFeature::StreamingSupport)
+        if let Some(model_spec) = registry.get_model_spec(&request.model)
+            && !model_spec
+                .features
+                .contains(&ModelFeature::StreamingSupport)
         {
             return Err(ProviderError::not_supported(
                 "anthropic",
@@ -409,5 +454,34 @@ mod tests {
         assert!(provider.supports_model("claude-3-5-sonnet-20241022"));
         assert!(provider.supports_model("claude-3-haiku-20240307"));
         assert!(!provider.supports_model("gpt-4"));
+    }
+
+    #[tokio::test]
+    async fn unknown_models_are_rejected_by_default() {
+        let config = AnthropicConfig::new_test("test-key");
+        let provider = AnthropicProvider::new(config).unwrap();
+        let request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+
+        let err = provider
+            .transform_request(request, RequestContext::new())
+            .await
+            .expect_err("unknown model should be rejected without explicit opt-in");
+
+        assert!(format!("{err}").contains("Unsupported model: mimo-v2.5"));
+    }
+
+    #[tokio::test]
+    async fn allow_unknown_models_accepts_anthropic_compatible_model_ids() {
+        let config = AnthropicConfig::new_test("test-key").with_allow_unknown_models(true);
+        let provider = AnthropicProvider::new(config).unwrap();
+        let request = ChatRequest::new("mimo-v2.5")
+            .add_user_message("Reply with exactly: anthropic-compatible-ok");
+
+        let transformed = provider
+            .transform_request(request, RequestContext::new())
+            .await
+            .expect("explicit opt-in should allow non-Anthropic model IDs");
+
+        assert_eq!(transformed["model"], "mimo-v2.5");
     }
 }

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use crate::core::providers::base::GlobalPoolManager;
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::traits::provider::ProviderConfig as _;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::{
     chat::ChatRequest,
@@ -112,7 +113,13 @@ impl AnthropicProvider {
                 COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS,
             )?;
 
-            if request.tools.is_some() || AnthropicClient::has_anthropic_tools_extra_param(request)
+            if request
+                .tools
+                .as_ref()
+                .is_some_and(|tools| !tools.is_empty())
+                || AnthropicClient::has_anthropic_tools_extra_param(request)
+                || request.functions.as_ref().is_some_and(|f| !f.is_empty())
+                || request.function_call.is_some()
             {
                 return Err(ProviderError::not_supported(
                     "anthropic",
@@ -187,7 +194,12 @@ impl AnthropicProvider {
         }
 
         // Check tool calling support
-        if request.tools.is_some() && !model_spec.features.contains(&ModelFeature::ToolCalling) {
+        if request
+            .tools
+            .as_ref()
+            .is_some_and(|tools| !tools.is_empty())
+            && !model_spec.features.contains(&ModelFeature::ToolCalling)
+        {
             return Err(ProviderError::not_supported(
                 "anthropic",
                 format!("Model {} does not support tool calling", request.model),
@@ -301,7 +313,9 @@ impl LLMProvider for AnthropicProvider {
             anthropic_request["stream"] = Value::Bool(request.stream);
         }
 
-        if let Some(tools) = request.tools {
+        if let Some(tools) = request.tools
+            && !tools.is_empty()
+        {
             anthropic_request["tools"] = serde_json::to_value(tools)?;
         }
 
@@ -363,8 +377,16 @@ impl LLMProvider for AnthropicProvider {
     }
 
     async fn health_check(&self) -> HealthStatus {
+        let health_check_model = if self.client.uses_compatible_model_allow_list() {
+            self.supported_models.first().map(|model| model.id.clone())
+        } else {
+            Some("claude-3-haiku-20240307".to_string())
+        };
+        let Some(model) = health_check_model else {
+            return HealthStatus::Unhealthy;
+        };
         let test_request = ChatRequest {
-            model: "claude-3-haiku-20240307".to_string(),
+            model,
             messages: vec![crate::core::types::chat::ChatMessage {
                 role: crate::core::types::message::MessageRole::User,
                 content: Some(crate::core::types::message::MessageContent::Text(
@@ -459,6 +481,9 @@ pub fn create_anthropic_provider(
 /// Create
 pub fn create_anthropic_provider_from_env() -> Result<AnthropicProvider, ProviderError> {
     let config = AnthropicConfig::from_env()?;
+    config
+        .validate()
+        .map_err(|e| ProviderError::configuration("anthropic", e))?;
     AnthropicProvider::new(config)
 }
 

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -61,7 +61,7 @@ impl AnthropicProvider {
         let registry = get_anthropic_registry();
 
         let Some(model_spec) = registry.get_model_spec(&request.model) else {
-            if !self.client.allows_unknown_models() {
+            if !self.client.allows_unknown_model(&request.model) {
                 return Err(ProviderError::invalid_request(
                     "anthropic",
                     format!("Unsupported model: {}", request.model),
@@ -74,7 +74,7 @@ impl AnthropicProvider {
                 u32::MAX,
             )?;
 
-            if Self::has_multimodal_content(request) {
+            if AnthropicClient::has_multimodal_content(request) {
                 return Err(ProviderError::not_supported(
                     "anthropic",
                     format!(
@@ -84,7 +84,8 @@ impl AnthropicProvider {
                 ));
             }
 
-            if request.tools.is_some() {
+            if request.tools.is_some() || AnthropicClient::has_anthropic_tools_extra_param(request)
+            {
                 return Err(ProviderError::not_supported(
                     "anthropic",
                     format!(
@@ -119,7 +120,7 @@ impl AnthropicProvider {
         )?;
 
         // Check multimodal content
-        let has_multimodal_content = Self::has_multimodal_content(request);
+        let has_multimodal_content = AnthropicClient::has_multimodal_content(request);
 
         if has_multimodal_content
             && !model_spec
@@ -145,18 +146,6 @@ impl AnthropicProvider {
 
         Ok(())
     }
-
-    fn has_multimodal_content(request: &ChatRequest) -> bool {
-        request.messages.iter().any(|msg| {
-            if let Some(crate::core::types::message::MessageContent::Parts(parts)) = &msg.content {
-                parts.iter().any(|part| {
-                    !matches!(part, crate::core::types::content::ContentPart::Text { .. })
-                })
-            } else {
-                false
-            }
-        })
-    }
 }
 
 impl LLMProvider for AnthropicProvider {
@@ -178,6 +167,11 @@ impl LLMProvider for AnthropicProvider {
 
     fn models(&self) -> &[ModelInfo] {
         &self.supported_models
+    }
+
+    fn supports_model(&self, model: &str) -> bool {
+        self.supported_models.iter().any(|info| info.id == model)
+            || self.client.allows_unknown_model(model)
     }
 
     fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
@@ -456,6 +450,20 @@ mod tests {
         assert!(!provider.supports_model("gpt-4"));
     }
 
+    #[test]
+    fn configured_unknown_models_are_visible_to_support_checks() {
+        let config = AnthropicConfig::new_test("test-key")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+
+        assert!(provider.supports_model("mimo-v2.5"));
+        assert!(!provider.supports_model("unlisted-compatible-model"));
+    }
+
     #[tokio::test]
     async fn unknown_models_are_rejected_by_default() {
         let config = AnthropicConfig::new_test("test-key");
@@ -483,5 +491,31 @@ mod tests {
             .expect("explicit opt-in should allow non-Anthropic model IDs");
 
         assert_eq!(transformed["model"], "mimo-v2.5");
+    }
+
+    #[tokio::test]
+    async fn unknown_models_reject_anthropic_tools_extra_param() {
+        let config = AnthropicConfig::new_test("test-key")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+        let mut request = ChatRequest::new("mimo-v2.5").add_user_message("Hello");
+        request.extra_params.insert(
+            "anthropic_tools".to_string(),
+            serde_json::json!([{"type": "computer_20241022", "name": "computer"}]),
+        );
+
+        let err = match provider
+            .transform_request(request, RequestContext::new())
+            .await
+        {
+            Ok(_) => panic!("unknown models must fail closed for Anthropic built-in tools"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("tool calling support"));
     }
 }

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -74,16 +74,6 @@ impl AnthropicProvider {
                 u32::MAX,
             )?;
 
-            if AnthropicClient::has_multimodal_content(request) {
-                return Err(ProviderError::not_supported(
-                    "anthropic",
-                    format!(
-                        "Unknown model {} cannot declare multimodal support",
-                        request.model
-                    ),
-                ));
-            }
-
             if request.tools.is_some() || AnthropicClient::has_anthropic_tools_extra_param(request)
             {
                 return Err(ProviderError::not_supported(
@@ -480,8 +470,13 @@ mod tests {
 
     #[tokio::test]
     async fn allow_unknown_models_accepts_anthropic_compatible_model_ids() {
-        let config = AnthropicConfig::new_test("test-key").with_allow_unknown_models(true);
-        let provider = AnthropicProvider::new(config).unwrap();
+        let config = AnthropicConfig::new_test("test-key")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
         let request = ChatRequest::new("mimo-v2.5")
             .add_user_message("Reply with exactly: anthropic-compatible-ok");
 
@@ -491,6 +486,57 @@ mod tests {
             .expect("explicit opt-in should allow non-Anthropic model IDs");
 
         assert_eq!(transformed["model"], "mimo-v2.5");
+    }
+
+    #[tokio::test]
+    async fn allow_listed_unknown_models_accept_base64_images() {
+        use crate::core::types::{
+            content::{ContentPart, ImageUrl},
+            message::{MessageContent, MessageRole},
+        };
+
+        let config = AnthropicConfig::new_test("test-key")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+        let request = ChatRequest {
+            model: "mimo-v2.5".to_string(),
+            messages: vec![crate::core::types::chat::ChatMessage {
+                role: MessageRole::User,
+                content: Some(MessageContent::Parts(vec![
+                    ContentPart::Text {
+                        text: "Describe this image".to_string(),
+                    },
+                    ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "data:image/png;base64,aGVsbG8=".to_string(),
+                            detail: None,
+                        },
+                    },
+                ])),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let transformed = match provider
+            .transform_request(request, RequestContext::new())
+            .await
+        {
+            Ok(transformed) => transformed,
+            Err(err) => {
+                panic!("explicit compatible model should preserve base64 image input: {err}")
+            }
+        };
+
+        assert_eq!(transformed["model"], "mimo-v2.5");
+        assert_eq!(
+            transformed["messages"][0]["content"][1]["type"],
+            "image_url"
+        );
     }
 
     #[tokio::test]

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -26,6 +26,8 @@ use super::models::{ModelFeature, get_anthropic_registry};
 use super::streaming::AnthropicStream;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
+const COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS: u32 = 128_000;
+
 /// Anthropic Provider - unified implementation
 #[derive(Debug, Clone)]
 pub struct AnthropicProvider {
@@ -52,7 +54,7 @@ impl AnthropicProvider {
                     name: model.clone(),
                     provider: "anthropic".to_string(),
                     max_context_length: 1_000_000,
-                    max_output_length: Some(128_000),
+                    max_output_length: Some(COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS),
                     supports_streaming: true,
                     supports_tools: false,
                     supports_multimodal: config.allows_unknown_model_image_input(model),
@@ -84,7 +86,19 @@ impl AnthropicProvider {
     fn validate_request(&self, request: &ChatRequest) -> Result<(), ProviderError> {
         let registry = get_anthropic_registry();
 
-        let Some(model_spec) = registry.get_model_spec(&request.model) else {
+        let model_spec = if self.client.uses_compatible_model_allow_list() {
+            if !self.client.allows_unknown_model(&request.model) {
+                return Err(ProviderError::invalid_request(
+                    "anthropic",
+                    format!("Unsupported model: {}", request.model),
+                ));
+            }
+            None
+        } else {
+            registry.get_model_spec(&request.model)
+        };
+
+        let Some(model_spec) = model_spec else {
             if !self.client.allows_unknown_model(&request.model) {
                 return Err(ProviderError::invalid_request(
                     "anthropic",
@@ -95,7 +109,7 @@ impl AnthropicProvider {
             crate::core::providers::base::validate_chat_request_common(
                 "anthropic",
                 request,
-                u32::MAX,
+                COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS,
             )?;
 
             if request.tools.is_some() || AnthropicClient::has_anthropic_tools_extra_param(request)
@@ -543,6 +557,54 @@ mod tests {
             .expect("explicit opt-in should allow non-Anthropic model IDs");
 
         assert_eq!(transformed["model"], "mimo-v2.5");
+    }
+
+    #[tokio::test]
+    async fn compatible_allow_list_rejects_registry_model_ids_not_configured() {
+        let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+        let request = ChatRequest::new("claude-3-haiku-20240307").add_user_message("Hello");
+
+        let err = match provider
+            .transform_request(request, RequestContext::new())
+            .await
+        {
+            Ok(_) => panic!("compatible allow-list must reject unlisted registry model IDs"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("Unsupported model: claude-3-haiku-20240307"));
+    }
+
+    #[tokio::test]
+    async fn compatible_models_enforce_configured_output_limit() {
+        let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+        let request = ChatRequest::new("mimo-v2.5")
+            .add_user_message("Hello")
+            .with_max_tokens(COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS + 1);
+
+        let err = match provider
+            .transform_request(request, RequestContext::new())
+            .await
+        {
+            Ok(_) => panic!("compatible models must enforce max output tokens"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("max_tokens 128001 exceeds model limit of 128000"));
     }
 
     #[tokio::test]

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -85,6 +85,16 @@ impl AnthropicProvider {
                 ));
             }
 
+            if AnthropicClient::has_unsupported_unknown_model_content(request) {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} only supports text and image content",
+                        request.model
+                    ),
+                ));
+            }
+
             if request
                 .thinking
                 .as_ref()
@@ -443,6 +453,7 @@ mod tests {
     #[test]
     fn configured_unknown_models_are_visible_to_support_checks() {
         let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
             .with_configured_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
@@ -471,6 +482,7 @@ mod tests {
     #[tokio::test]
     async fn allow_unknown_models_accepts_anthropic_compatible_model_ids() {
         let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
             .with_configured_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
@@ -496,6 +508,7 @@ mod tests {
         };
 
         let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
             .with_configured_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
@@ -542,6 +555,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_models_reject_anthropic_tools_extra_param() {
         let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
             .with_configured_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
@@ -563,5 +577,45 @@ mod tests {
         };
 
         assert!(format!("{err}").contains("tool calling support"));
+    }
+
+    #[tokio::test]
+    async fn unknown_models_reject_message_level_tool_blocks() {
+        use crate::core::types::{
+            content::ContentPart,
+            message::{MessageContent, MessageRole},
+        };
+
+        let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+        let request = ChatRequest {
+            model: "mimo-v2.5".to_string(),
+            messages: vec![crate::core::types::chat::ChatMessage {
+                role: MessageRole::User,
+                content: Some(MessageContent::Parts(vec![ContentPart::ToolUse {
+                    id: "toolu_1".to_string(),
+                    name: "computer".to_string(),
+                    input: serde_json::json!({}),
+                }])),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let err = match provider
+            .transform_request(request, RequestContext::new())
+            .await
+        {
+            Ok(_) => panic!("unknown models must reject message-level tool blocks"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("only supports text and image content"));
     }
 }

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -43,12 +43,36 @@ impl AnthropicProvider {
         let _pool_manager = Arc::new(GlobalPoolManager::new()?);
 
         // Get supported models
-        let registry = get_anthropic_registry();
-        let supported_models = registry
-            .list_models()
-            .into_iter()
-            .map(|spec| spec.model_info.clone())
-            .collect();
+        let supported_models = if config.uses_compatible_model_allow_list() {
+            config
+                .configured_models
+                .iter()
+                .map(|model| ModelInfo {
+                    id: model.clone(),
+                    name: model.clone(),
+                    provider: "anthropic".to_string(),
+                    max_context_length: 1_000_000,
+                    max_output_length: Some(128_000),
+                    supports_streaming: true,
+                    supports_tools: false,
+                    supports_multimodal: config.allows_unknown_model_image_input(model),
+                    input_cost_per_1k_tokens: None,
+                    output_cost_per_1k_tokens: None,
+                    currency: "USD".to_string(),
+                    capabilities: vec![ProviderCapability::ChatCompletion],
+                    created_at: None,
+                    updated_at: None,
+                    metadata: HashMap::new(),
+                })
+                .collect()
+        } else {
+            let registry = get_anthropic_registry();
+            registry
+                .list_models()
+                .into_iter()
+                .map(|spec| spec.model_info.clone())
+                .collect()
+        };
 
         Ok(Self {
             client,
@@ -90,6 +114,18 @@ impl AnthropicProvider {
                     "anthropic",
                     format!(
                         "Unknown model {} only supports text and image content",
+                        request.model
+                    ),
+                ));
+            }
+
+            if AnthropicClient::has_image_content(request)
+                && !self.client.allows_unknown_model_image_input(&request.model)
+            {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} does not support image input",
                         request.model
                     ),
                 ));
@@ -170,6 +206,10 @@ impl LLMProvider for AnthropicProvider {
     }
 
     fn supports_model(&self, model: &str) -> bool {
+        if self.client.uses_compatible_model_allow_list() {
+            return self.client.allows_unknown_model(model);
+        }
+
         self.supported_models.iter().any(|info| info.id == model)
             || self.client.allows_unknown_model(model)
     }
@@ -455,7 +495,8 @@ mod tests {
         let config = AnthropicConfig::new_test("test-key")
             .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
-            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+            .with_configured_models(vec!["mimo-v2.5".to_string()])
+            .with_configured_multimodal_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
             Ok(provider) => provider,
             Err(err) => panic!("provider should build: {err}"),
@@ -463,6 +504,9 @@ mod tests {
 
         assert!(provider.supports_model("mimo-v2.5"));
         assert!(!provider.supports_model("unlisted-compatible-model"));
+        assert!(!provider.supports_model("claude-3-5-sonnet-20241022"));
+        assert_eq!(provider.models().len(), 1);
+        assert_eq!(provider.models()[0].id, "mimo-v2.5");
     }
 
     #[tokio::test]
@@ -484,7 +528,8 @@ mod tests {
         let config = AnthropicConfig::new_test("test-key")
             .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
-            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+            .with_configured_models(vec!["mimo-v2.5".to_string()])
+            .with_configured_multimodal_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
             Ok(provider) => provider,
             Err(err) => panic!("provider should build: {err}"),
@@ -510,7 +555,8 @@ mod tests {
         let config = AnthropicConfig::new_test("test-key")
             .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
             .with_allow_unknown_models(true)
-            .with_configured_models(vec!["mimo-v2.5".to_string()]);
+            .with_configured_models(vec!["mimo-v2.5".to_string()])
+            .with_configured_multimodal_models(vec!["mimo-v2.5".to_string()]);
         let provider = match AnthropicProvider::new(config) {
             Ok(provider) => provider,
             Err(err) => panic!("provider should build: {err}"),
@@ -550,6 +596,52 @@ mod tests {
             transformed["messages"][0]["content"][1]["type"],
             "image_url"
         );
+    }
+
+    #[tokio::test]
+    async fn text_only_unknown_models_reject_image_input() {
+        use crate::core::types::{
+            content::{ContentPart, ImageUrl},
+            message::{MessageContent, MessageRole},
+        };
+
+        let config = AnthropicConfig::new_test("test-key")
+            .with_base_url("https://token-plan-sgp.xiaomimimo.com/anthropic")
+            .with_allow_unknown_models(true)
+            .with_configured_models(vec!["mimo-v2.5-pro".to_string()]);
+        let provider = match AnthropicProvider::new(config) {
+            Ok(provider) => provider,
+            Err(err) => panic!("provider should build: {err}"),
+        };
+        let request = ChatRequest {
+            model: "mimo-v2.5-pro".to_string(),
+            messages: vec![crate::core::types::chat::ChatMessage {
+                role: MessageRole::User,
+                content: Some(MessageContent::Parts(vec![
+                    ContentPart::Text {
+                        text: "Describe this image".to_string(),
+                    },
+                    ContentPart::ImageUrl {
+                        image_url: ImageUrl {
+                            url: "data:image/png;base64,aGVsbG8=".to_string(),
+                            detail: None,
+                        },
+                    },
+                ])),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let err = match provider
+            .transform_request(request, RequestContext::new())
+            .await
+        {
+            Ok(_) => panic!("text-only compatible model must reject image input"),
+            Err(err) => err,
+        };
+
+        assert!(format!("{err}").contains("does not support image input"));
     }
 
     #[tokio::test]

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -347,6 +347,15 @@ pub(super) fn build_anthropic_config_from_factory(
             .filter_map(|value| value.as_str().map(str::to_string))
             .collect();
     }
+    if let Some(models) = config
+        .get("multimodal_models")
+        .and_then(|value| value.as_array())
+    {
+        anthropic_config.configured_multimodal_models = models
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect();
+    }
 
     Ok(anthropic_config)
 }

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -341,6 +341,12 @@ pub(super) fn build_anthropic_config_from_factory(
     if let Some(allow_unknown_models) = config_bool(config, "allow_unknown_models") {
         anthropic_config.allow_unknown_models = allow_unknown_models;
     }
+    if let Some(models) = config.get("models").and_then(|value| value.as_array()) {
+        anthropic_config.configured_models = models
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect();
+    }
 
     Ok(anthropic_config)
 }

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -9,7 +9,6 @@ use super::super::unified_provider::ProviderError;
 use super::super::{anthropic, bedrock, cloudflare, macros, mistral, openai, openai_like};
 #[cfg(feature = "providers-extra")]
 use super::super::{azure, azure_ai, vertex_ai};
-#[cfg(any(feature = "providers-extra", feature = "providers-extended"))]
 use crate::core::traits::provider::ProviderConfig as _;
 use std::env;
 #[cfg(feature = "providers-extra")]
@@ -356,6 +355,10 @@ pub(super) fn build_anthropic_config_from_factory(
             .filter_map(|value| value.as_str().map(str::to_string))
             .collect();
     }
+
+    anthropic_config
+        .validate()
+        .map_err(|e| ProviderError::configuration("anthropic", e))?;
 
     Ok(anthropic_config)
 }

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -338,6 +338,9 @@ pub(super) fn build_anthropic_config_from_factory(
     if let Some(enable_experimental) = config_bool(config, "enable_experimental") {
         anthropic_config.enable_experimental = enable_experimental;
     }
+    if let Some(allow_unknown_models) = config_bool(config, "allow_unknown_models") {
+        anthropic_config.allow_unknown_models = allow_unknown_models;
+    }
 
     Ok(anthropic_config)
 }

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -171,6 +171,22 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
 }
 
 #[test]
+fn test_build_anthropic_config_from_factory_validates_compatible_models() {
+    let config = serde_json::json!({
+        "api_key": "xiaomi-compatible-key",
+        "api_base": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+        "allow_unknown_models": true
+    });
+
+    let err = match build_anthropic_config_from_factory(&config) {
+        Ok(_) => panic!("compatible Anthropic config should require models"),
+        Err(err) => err,
+    };
+
+    assert!(format!("{err}").contains("explicit models allow-list"));
+}
+
+#[test]
 fn test_build_mistral_config_from_factory_maps_optional_fields() {
     let config = serde_json::json!({
         "api_key": "mistral-key",

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -124,7 +124,8 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
         "enable_computer_use": true,
         "enable_experimental": true,
         "allow_unknown_models": true,
-        "models": ["mimo-v2.5", "mimo-v2.5-pro"]
+        "models": ["mimo-v2.5", "mimo-v2.5-pro"],
+        "multimodal_models": ["mimo-v2.5"]
     });
 
     let anthropic_config = build_anthropic_config_from_factory(&config)
@@ -162,6 +163,10 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
     assert_eq!(
         anthropic_config.configured_models,
         vec!["mimo-v2.5".to_string(), "mimo-v2.5-pro".to_string()]
+    );
+    assert_eq!(
+        anthropic_config.configured_multimodal_models,
+        vec!["mimo-v2.5".to_string()]
     );
 }
 

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -122,7 +122,8 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
         "enable_multimodal": false,
         "enable_cache_control": false,
         "enable_computer_use": true,
-        "enable_experimental": true
+        "enable_experimental": true,
+        "allow_unknown_models": true
     });
 
     let anthropic_config = build_anthropic_config_from_factory(&config)
@@ -156,6 +157,7 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
     assert!(!anthropic_config.enable_cache_control);
     assert!(anthropic_config.enable_computer_use);
     assert!(anthropic_config.enable_experimental);
+    assert!(anthropic_config.allow_unknown_models);
 }
 
 #[test]

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -123,7 +123,8 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
         "enable_cache_control": false,
         "enable_computer_use": true,
         "enable_experimental": true,
-        "allow_unknown_models": true
+        "allow_unknown_models": true,
+        "models": ["mimo-v2.5", "mimo-v2.5-pro"]
     });
 
     let anthropic_config = build_anthropic_config_from_factory(&config)
@@ -158,6 +159,10 @@ fn test_build_anthropic_config_from_factory_maps_optional_fields() {
     assert!(anthropic_config.enable_computer_use);
     assert!(anthropic_config.enable_experimental);
     assert!(anthropic_config.allow_unknown_models);
+    assert_eq!(
+        anthropic_config.configured_models,
+        vec!["mimo-v2.5".to_string(), "mimo-v2.5-pro".to_string()]
+    );
 }
 
 #[test]

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -51,6 +51,7 @@ pub async fn create_provider(
         timeout,
         max_retries,
         settings,
+        models,
         ..
     } = config;
 
@@ -138,6 +139,12 @@ pub async fn create_provider(
     }
     factory_config.insert("timeout".to_string(), Value::Number(timeout.into()));
     factory_config.insert("max_retries".to_string(), Value::Number(max_retries.into()));
+    if !models.is_empty() {
+        factory_config.insert(
+            "models".to_string(),
+            Value::Array(models.into_iter().map(Value::String).collect()),
+        );
+    }
 
     for (key, value) in settings {
         factory_config.entry(key).or_insert(value);

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -296,6 +296,12 @@ mod tests {
 
     fn minimal_dispatch_config_for(provider_type: &ProviderType) -> serde_json::Value {
         match provider_type {
+            ProviderType::Anthropic => serde_json::json!({
+                "api_key": "sk-ant-test1234567890123",
+                "api_base": "https://api.anthropic.com",
+                "timeout": 30,
+                "max_retries": 2
+            }),
             ProviderType::VertexAI => serde_json::json!({
                 "project_id": "test-project",
                 "location": "us-central1",

--- a/tests/integration/provider_factory_tests.rs
+++ b/tests/integration/provider_factory_tests.rs
@@ -31,7 +31,7 @@ mod tests {
     #[tokio::test]
     async fn test_anthropic_provider_from_config() {
         let config = json!({
-            "api_key": "sk-ant-test-key"
+            "api_key": "sk-ant-test1234567890123"
         });
 
         let result = Provider::from_config_async(ProviderType::Anthropic, config).await;


### PR DESCRIPTION
Fixes #703.

## Summary
- Add an opt-in `allow_unknown_models` Anthropic provider setting for OpenAI/Anthropic-compatible gateways that expose non-Anthropic model IDs such as Xiaomi MiMo Token Plan models.
- Keep default Anthropic behavior unchanged: unknown models are still rejected unless the setting is enabled.
- Fail closed for unknown compatible models when requests use Anthropic-specific capabilities that require registry metadata: multimodal content, tools, or thinking.
- Split Anthropic response parsing into `client/response.rs` to keep the client file below the hard size ceiling while preserving behavior.
- Document Xiaomi Token Plan SGP OpenAI-compatible and Anthropic-compatible gateway configuration.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test allow_unknown_models --all-features`
- `cargo test unknown_model --all-features`
- `cargo test test_build_anthropic_config_from_factory_maps_optional_fields --all-features`
- `cargo test test_transform_chat_response_text --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Notes
Gateway live testing for Xiaomi Anthropic-compatible routing also needs #702, which fixes a pre-routing panic in request ID middleware. The direct Xiaomi Anthropic-compatible endpoint was verified separately, and this PR removes the model-registry blocker once #702 is present.
