### PR TITLE
fix(cost): price Xiaomi MiMo anthropic-compatible routes

### DIFF
--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -155,13 +155,7 @@ pub fn get_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, Co
 }
 
 fn is_xiaomi_mimo_model(model: &str) -> bool {
-    let normalized_model = crate::core::pricing::normalize_model_key(model);
-    let model_id = normalized_model
-        .rsplit_once('/')
-        .map(|(_, model_id)| model_id)
-        .unwrap_or(normalized_model);
-
-    model_id.starts_with("mimo-")
+    crate::core::pricing::normalize_model_key(model).starts_with("mimo-")
 }
 
 fn get_pricing_with_shared_source<F>(

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -106,6 +106,14 @@ pub fn get_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, Co
 
     match normalized_provider.as_str() {
         "openai" => get_pricing_with_shared_source(model, &["openai"], get_openai_pricing),
+        "anthropic" if is_xiaomi_mimo_model(model) => {
+            get_pricing_with_shared_source(model, &["xiaomi_mimo", "xiaomi", "mimo"], |model| {
+                Err(CostError::ModelNotSupported {
+                    model: model.to_string(),
+                    provider: "anthropic".to_string(),
+                })
+            })
+        }
         "anthropic" => get_pricing_with_shared_source(model, &["anthropic"], get_anthropic_pricing),
         "azure" => get_azure_pricing(model),
         "vertex_ai" => {
@@ -144,6 +152,16 @@ pub fn get_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, Co
             provider: provider.to_string(),
         }),
     }
+}
+
+fn is_xiaomi_mimo_model(model: &str) -> bool {
+    let normalized_model = crate::core::pricing::normalize_model_key(model);
+    let model_id = normalized_model
+        .rsplit_once('/')
+        .map(|(_, model_id)| model_id)
+        .unwrap_or(normalized_model);
+
+    model_id.starts_with("mimo-")
 }
 
 fn get_pricing_with_shared_source<F>(

--- a/src/core/cost/calculator/tests.rs
+++ b/src/core/cost/calculator/tests.rs
@@ -242,6 +242,28 @@ fn test_runtime_pricing_reaches_groq_and_native_gemini_shared_rows() {
 }
 
 #[test]
+fn test_runtime_pricing_uses_xiaomi_for_anthropic_compatible_mimo_models() {
+    let usage = create_usage(1000, 500);
+
+    let breakdown = generic_cost_per_token("mimo-v2.5", &usage, "anthropic")
+        .expect("MiMo Anthropic-compatible routing should use Xiaomi pricing");
+
+    assert_eq!(breakdown.provider, "anthropic");
+    assert_cost_eq(breakdown.total_cost, 0.00028);
+}
+
+#[test]
+fn test_runtime_pricing_keeps_unknown_anthropic_models_strict() {
+    let usage = create_usage(1000, 500);
+    let result = generic_cost_per_token("unknown-compatible-model", &usage, "anthropic");
+
+    assert!(matches!(
+        result,
+        Err(CostError::ModelNotSupported { provider, .. }) if provider == "anthropic"
+    ));
+}
+
+#[test]
 fn test_runtime_pricing_normalizes_provider_prefixed_shared_models() {
     let usage = create_usage(1000, 500);
 


### PR DESCRIPTION
Fixes #705.

## Summary
- Price `anthropic` gateway routes for Xiaomi MiMo model IDs with the existing Xiaomi MiMo pricing rows.
- Keep normal Anthropic unknown-model pricing strict; only `mimo-*` model IDs take the compatible Xiaomi pricing path.
- Add runtime cost tests for both Xiaomi MiMo Anthropic-compatible pricing and strict unknown Anthropic model behavior.

## Verification
- `cargo test test_runtime_pricing_uses_xiaomi_for_anthropic_compatible_mimo_models --all-features`
- `cargo test test_runtime_pricing_keeps_unknown_anthropic_models_strict --all-features`
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

## Notes
This is intentionally separate from #704. #704 enables routing compatible Anthropic model IDs; this PR fixes the billing/budget attribution discovered during live Xiaomi gateway testing.
