### PR TITLE
fix(pricing): tolerate LiteLLM schema drift

### DIFF
--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -316,7 +316,7 @@ fn litellm_to_cost_pricing(
 }
 
 fn requires_bidirectional_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {
-    matches!(info.mode.as_str(), "chat" | "completion")
+    matches!(info.mode.as_str(), "" | "chat" | "completion")
 }
 
 fn has_non_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -316,7 +316,8 @@ fn litellm_to_cost_pricing(
 }
 
 fn requires_bidirectional_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {
-    matches!(info.mode.as_str(), "" | "chat" | "completion")
+    matches!(info.mode.as_str(), "chat" | "completion")
+        || (info.mode.is_empty() && !has_non_token_pricing(info))
 }
 
 fn has_non_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {

--- a/src/core/cost/calculator/pricing_regression_tests.rs
+++ b/src/core/cost/calculator/pricing_regression_tests.rs
@@ -48,6 +48,32 @@ fn test_litellm_pricing_errors_when_missing_mode_has_single_missing_side() {
 }
 
 #[test]
+fn test_litellm_pricing_allows_blank_mode_non_token_pricing() {
+    let info = model_info_from_json(serde_json::json!({
+        "litellm_provider": "replicate",
+        "cost_per_second": 0.001
+    }));
+    let pricing = match litellm_to_cost_pricing("time-priced-missing-mode", &info) {
+        Ok(pricing) => pricing,
+        Err(err) => panic!("blank-mode non-token pricing should be accepted: {err}"),
+    };
+    assert_eq!(pricing.cost_per_second, Some(0.001));
+}
+
+#[test]
+fn test_litellm_pricing_allows_missing_mode_with_non_token_pricing() {
+    let info = model_info_from_json(serde_json::json!({
+        "litellm_provider": "openai",
+        "cost_per_second": 0.000_01
+    }));
+    let pricing = match litellm_to_cost_pricing("time-priced-missing-mode", &info) {
+        Ok(pricing) => pricing,
+        Err(err) => panic!("non-token pricing should not require token prices: {err}"),
+    };
+    assert_eq!(pricing.cost_per_second, Some(0.000_01));
+}
+
+#[test]
 fn test_litellm_pricing_allows_single_missing_side_for_embedding() {
     // Embeddings can have only input-side token pricing.
     let info = model_info_from_json(serde_json::json!({

--- a/src/core/cost/calculator/pricing_regression_tests.rs
+++ b/src/core/cost/calculator/pricing_regression_tests.rs
@@ -35,6 +35,19 @@ fn test_litellm_pricing_errors_when_chat_has_single_missing_side() {
 }
 
 #[test]
+fn test_litellm_pricing_errors_when_missing_mode_has_single_missing_side() {
+    let info = model_info_from_json(serde_json::json!({
+        "litellm_provider": "openai",
+        "input_cost_per_token": 0.000_01
+    }));
+    let result = litellm_to_cost_pricing("half-priced-missing-mode", &info);
+    assert!(matches!(
+        result,
+        Err(CostError::MissingPricing { ref model }) if model == "half-priced-missing-mode"
+    ));
+}
+
+#[test]
 fn test_litellm_pricing_allows_single_missing_side_for_embedding() {
     // Embeddings can have only input-side token pricing.
     let info = model_info_from_json(serde_json::json!({

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -1,6 +1,6 @@
 //! Shared pricing data types.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
@@ -13,10 +13,13 @@ const EMBEDDED_MODEL_PRICES: &str = include_str!("../../config/model_prices_exte
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LiteLLMModelInfo {
     /// Maximum total tokens
+    #[serde(default, deserialize_with = "deserialize_option_u32_integral_number")]
     pub max_tokens: Option<u32>,
     /// Maximum input tokens
+    #[serde(default, deserialize_with = "deserialize_option_u32_integral_number")]
     pub max_input_tokens: Option<u32>,
     /// Maximum output tokens
+    #[serde(default, deserialize_with = "deserialize_option_u32_integral_number")]
     pub max_output_tokens: Option<u32>,
     /// Input cost per token
     pub input_cost_per_token: Option<f64>,
@@ -31,6 +34,7 @@ pub struct LiteLLMModelInfo {
     /// LiteLLM provider name
     pub litellm_provider: String,
     /// Model mode (chat, completion, embedding, etc.)
+    #[serde(default)]
     pub mode: String,
     /// Supports function calling
     pub supports_function_calling: Option<bool>,
@@ -45,6 +49,57 @@ pub struct LiteLLMModelInfo {
     /// Additional metadata
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
+}
+
+fn deserialize_option_u32_integral_number<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(value) = Option::<serde_json::Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Number(number) => {
+            if let Some(value) = number.as_u64() {
+                return u32::try_from(value)
+                    .map(Some)
+                    .map_err(|_| serde::de::Error::custom("token limit exceeds u32::MAX"));
+            }
+
+            if let Some(value) = number.as_i64()
+                && value < 0
+            {
+                return Err(serde::de::Error::custom("token limit cannot be negative"));
+            }
+
+            let value = number
+                .as_f64()
+                .ok_or_else(|| serde::de::Error::custom("token limit must be a finite number"))?;
+            if !value.is_finite() {
+                return Err(serde::de::Error::custom(
+                    "token limit must be a finite number",
+                ));
+            }
+            if value < 0.0 {
+                return Err(serde::de::Error::custom("token limit cannot be negative"));
+            }
+            if value.fract() != 0.0 {
+                return Err(serde::de::Error::custom(
+                    "token limit float must be integral",
+                ));
+            }
+            if value > u32::MAX as f64 {
+                return Err(serde::de::Error::custom("token limit exceeds u32::MAX"));
+            }
+
+            Ok(Some(value as u32))
+        }
+        _ => Err(serde::de::Error::custom(
+            "token limit must be a JSON number",
+        )),
+    }
 }
 
 /// Compatibility alias for callers that still import provider-base pricing.

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -251,6 +251,16 @@ impl PricingDatabase {
     fn calculate_with_pricing(&self, pricing: &ModelPricing, usage: &Usage) -> f64 {
         let mut cost = 0.0;
 
+        if requires_bidirectional_database_token_pricing(pricing)
+            && (pricing.input_cost_per_token.is_none() || pricing.output_cost_per_token.is_none())
+        {
+            warn!(
+                "model pricing row for provider '{}' mode '{}' is missing one side of token pricing; skipping partial billing",
+                pricing.litellm_provider, pricing.mode
+            );
+            return 0.0;
+        }
+
         let input_cost_per_token = tiered_cost_per_token(
             pricing,
             pricing.input_cost_per_token.unwrap_or(0.0),
@@ -345,6 +355,30 @@ impl PricingDatabase {
             })
             .unwrap_or(false)
     }
+}
+
+fn requires_bidirectional_database_token_pricing(pricing: &ModelPricing) -> bool {
+    matches!(pricing.mode.as_str(), "chat" | "completion")
+        || (pricing.mode.is_empty() && !has_non_token_database_pricing(pricing))
+}
+
+fn has_non_token_database_pricing(pricing: &ModelPricing) -> bool {
+    pricing.cost_per_second.is_some()
+        || pricing
+            .extra
+            .get("video_cost_per_second")
+            .and_then(serde_json::Value::as_f64)
+            .is_some()
+        || pricing
+            .extra
+            .get("audio_cost_per_second")
+            .and_then(serde_json::Value::as_f64)
+            .is_some()
+        || pricing
+            .extra
+            .get("image_cost_per_token")
+            .and_then(serde_json::Value::as_f64)
+            .is_some()
 }
 
 fn pricing_matches_provider(_model_key: &str, pricing: &ModelPricing, provider: &str) -> bool {

--- a/src/core/pricing/tests.rs
+++ b/src/core/pricing/tests.rs
@@ -38,6 +38,59 @@ fn parse_litellm_pricing_json_rejects_malformed_model_entries() {
 }
 
 #[test]
+fn parse_litellm_pricing_json_accepts_integral_float_token_limits_and_missing_mode() {
+    let content = r#"{
+            "float-token-model": {
+                "max_tokens": 2000000.0,
+                "max_input_tokens": 2000000.0,
+                "max_output_tokens": 8192.0,
+                "input_cost_per_token": 0.000001,
+                "output_cost_per_token": 0.000002,
+                "litellm_provider": "openai"
+            }
+        }"#;
+
+    let parsed = match parse_litellm_pricing_json(content) {
+        Ok(parsed) => parsed,
+        Err(error) => panic!("integral float token limits should parse: {error}"),
+    };
+    let Some(model) = parsed.get("float-token-model") else {
+        panic!("float-token-model should be present");
+    };
+
+    assert_eq!(model.max_tokens, Some(2_000_000));
+    assert_eq!(model.max_input_tokens, Some(2_000_000));
+    assert_eq!(model.max_output_tokens, Some(8_192));
+    assert_eq!(model.mode, "");
+}
+
+#[test]
+fn parse_litellm_pricing_json_rejects_lossy_token_limits() {
+    for (field, value) in [
+        ("max_tokens", "2000000.5"),
+        ("max_input_tokens", "-1"),
+        ("max_output_tokens", "4294967296"),
+    ] {
+        let content = format!(
+            r#"{{
+                "bad-token-model": {{
+                    "{field}": {value},
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000002,
+                    "litellm_provider": "openai",
+                    "mode": "chat"
+                }}
+            }}"#
+        );
+
+        assert!(
+            parse_litellm_pricing_json(&content).is_err(),
+            "{field}={value} should be rejected"
+        );
+    }
+}
+
+#[test]
 fn test_default_pricing() {
     let db = PricingDatabase::default();
 

--- a/src/core/pricing/tests.rs
+++ b/src/core/pricing/tests.rs
@@ -91,6 +91,21 @@ fn parse_litellm_pricing_json_rejects_lossy_token_limits() {
 }
 
 #[test]
+fn pricing_database_skips_blank_mode_one_sided_token_prices() {
+    let content = r#"{
+            "half-priced-missing-mode": {
+                "input_cost_per_token": 0.000001,
+                "litellm_provider": "openai"
+            }
+        }"#;
+    let models = parse_litellm_pricing_json(content).unwrap();
+    let db = PricingDatabase { models };
+    let usage = Usage::new(1000, 500);
+
+    assert_eq!(db.calculate("half-priced-missing-mode", &usage), 0.0);
+}
+
+#[test]
 fn test_default_pricing() {
     let db = PricingDatabase::default();
 

--- a/src/core/pricing_service/cache.rs
+++ b/src/core/pricing_service/cache.rs
@@ -2,7 +2,7 @@
 
 use super::service::PricingService;
 use super::types::{PricingEventType, PricingUpdateEvent};
-use crate::utils::error::gateway_error::Result;
+use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tracing::{debug, info, warn};
@@ -39,8 +39,23 @@ impl PricingService {
         let data = if self.pricing_url == super::DEFAULT_PRICING_SOURCE {
             self.load_from_embedded_default()?
         } else if self.pricing_url.starts_with("http") {
-            // Load from URL
-            self.load_from_url().await?
+            match self.load_from_url().await {
+                Ok(data) => data,
+                Err(remote_error) if self.pricing_url == super::REMOTE_LITELLM_PRICING_SOURCE => {
+                    warn!(
+                        pricing_url = %self.pricing_url,
+                        error = %remote_error,
+                        "Default remote pricing data load failed; falling back to embedded pricing"
+                    );
+                    self.load_from_embedded_default().map_err(|embedded_error| {
+                        GatewayError::Config(format!(
+                            "Failed to load pricing data from remote source {}: {}; embedded pricing fallback also failed: {}",
+                            self.pricing_url, remote_error, embedded_error
+                        ))
+                    })?
+                }
+                Err(remote_error) => return Err(remote_error),
+            }
         } else {
             // Load from local file
             self.load_from_file().await?

--- a/src/core/pricing_service/cache.rs
+++ b/src/core/pricing_service/cache.rs
@@ -36,7 +36,11 @@ impl PricingService {
     pub async fn refresh_pricing_data(&self) -> Result<()> {
         info!("Refreshing pricing data from: {}", self.pricing_url);
 
-        let data = if self.pricing_url == super::DEFAULT_PRICING_SOURCE {
+        let data = if self.pricing_url.is_empty() {
+            return Err(GatewayError::Config(
+                "Pricing source is disabled".to_string(),
+            ));
+        } else if self.pricing_url == super::DEFAULT_PRICING_SOURCE {
             self.load_from_embedded_default()?
         } else if self.pricing_url.starts_with("http") {
             match self.load_from_url().await {
@@ -96,18 +100,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn implicit_default_remote_fallback_stops_after_cache_is_populated() -> Result<()> {
+    fn none_source_does_not_enable_embedded_fallback() {
         let service = PricingService::new(None);
-        assert!(service.should_fallback_to_embedded_on_remote_error());
-
-        let mut embedded = service.load_from_embedded_default()?;
-        let Some((model, info)) = embedded.drain().next() else {
-            panic!("embedded pricing fixture should not be empty");
-        };
-        service.pricing_data.write().models.insert(model, info);
-
         assert!(!service.should_fallback_to_embedded_on_remote_error());
-        Ok(())
     }
 
     #[test]

--- a/src/core/pricing_service/cache.rs
+++ b/src/core/pricing_service/cache.rs
@@ -41,11 +41,11 @@ impl PricingService {
         } else if self.pricing_url.starts_with("http") {
             match self.load_from_url().await {
                 Ok(data) => data,
-                Err(remote_error) if self.pricing_url == super::REMOTE_LITELLM_PRICING_SOURCE => {
+                Err(remote_error) if self.should_fallback_to_embedded_on_remote_error() => {
                     warn!(
                         pricing_url = %self.pricing_url,
                         error = %remote_error,
-                        "Default remote pricing data load failed; falling back to embedded pricing"
+                        "Default remote pricing data initial load failed; falling back to embedded pricing"
                     );
                     self.load_from_embedded_default().map_err(|embedded_error| {
                         GatewayError::Config(format!(
@@ -88,5 +88,38 @@ impl PricingService {
             .duration_since(data.last_updated)
             .map(|duration| duration > self.cache_ttl)
             .unwrap_or(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn implicit_default_remote_fallback_stops_after_cache_is_populated() -> Result<()> {
+        let service = PricingService::new(None);
+        assert!(service.should_fallback_to_embedded_on_remote_error());
+
+        let mut embedded = service.load_from_embedded_default()?;
+        let Some((model, info)) = embedded.drain().next() else {
+            panic!("embedded pricing fixture should not be empty");
+        };
+        service.pricing_data.write().models.insert(model, info);
+
+        assert!(!service.should_fallback_to_embedded_on_remote_error());
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_default_remote_url_disables_embedded_fallback() {
+        let service = PricingService::new(Some(
+            super::super::REMOTE_LITELLM_PRICING_SOURCE.to_string(),
+        ));
+
+        assert_eq!(
+            service.pricing_url,
+            super::super::REMOTE_LITELLM_PRICING_SOURCE
+        );
+        assert!(!service.should_fallback_to_embedded_on_remote_error());
     }
 }

--- a/src/core/pricing_service/loader.rs
+++ b/src/core/pricing_service/loader.rs
@@ -71,6 +71,8 @@ mod tests {
     use super::*;
     use crate::core::pricing_service::DEFAULT_PRICING_SOURCE;
     use std::fs;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn pricing_json(model: &str, provider: &str) -> String {
         format!(
@@ -122,6 +124,54 @@ mod tests {
             Some("custom".to_string())
         );
         assert!(service.get_model_info("gpt-4o").is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_remote_pricing_parse_failure_is_returned() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(GatewayError::Io)?;
+        let addr = listener.local_addr().map_err(GatewayError::Io)?;
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await?;
+            let mut request_buffer = [0_u8; 1024];
+            let bytes_read = stream.read(&mut request_buffer).await?;
+            if bytes_read == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "test server received an empty request",
+                ));
+            }
+            let body = r#"{
+                "remote-only-malformed": {
+                    "max_tokens": 2000000.5,
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000002,
+                    "litellm_provider": "openai",
+                    "mode": "chat"
+                }
+            }"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).await?;
+            Ok::<(), std::io::Error>(())
+        });
+
+        let service = PricingService::new(Some(format!("http://{addr}/prices.json")));
+
+        let result = service.initialize().await;
+        server
+            .await
+            .map_err(|error| GatewayError::internal(format!("test server failed: {error}")))?
+            .map_err(GatewayError::Io)?;
+
+        assert!(result.is_err());
+        assert!(service.get_model_info("gpt-4o").is_none());
+        assert!(service.get_model_info("remote-only-malformed").is_none());
         Ok(())
     }
 }

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -18,6 +18,9 @@ mod tests;
 /// explicit embedded source so the default does not depend on process cwd.
 pub const DEFAULT_PRICING_SOURCE: &str = "embedded://model_prices_extended";
 
+pub(super) const REMOTE_LITELLM_PRICING_SOURCE: &str =
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+
 // Re-export public types
 pub use service::PricingService;
 pub use types::{

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -71,7 +71,7 @@ impl PricingService {
     /// Create a new pricing service
     pub fn new(pricing_url: Option<String>) -> Self {
         let (event_sender, _) = broadcast::channel(1000);
-        let use_embedded_fallback_on_remote_error = pricing_url.is_none();
+        let use_embedded_fallback_on_remote_error = false;
 
         let service = Self {
             pricing_data: Arc::new(RwLock::new(PricingData {
@@ -79,8 +79,7 @@ impl PricingService {
                 last_updated: SystemTime::UNIX_EPOCH,
             })),
             http_client: default_outbound_client().clone(),
-            pricing_url: pricing_url
-                .unwrap_or_else(|| super::REMOTE_LITELLM_PRICING_SOURCE.to_string()),
+            pricing_url: pricing_url.unwrap_or_default(),
             use_embedded_fallback_on_remote_error,
             cache_ttl: Duration::from_secs(3600), // 1 hour
             event_sender,
@@ -448,10 +447,7 @@ mod tests {
     #[test]
     fn test_pricing_service_new_default() {
         let service = PricingService::new(None);
-        assert_eq!(
-            service.pricing_url,
-            super::super::REMOTE_LITELLM_PRICING_SOURCE
-        );
+        assert!(service.pricing_url.is_empty());
         assert_eq!(service.cache_ttl, Duration::from_secs(3600));
     }
 

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -59,6 +59,8 @@ pub struct PricingService {
     pub(super) http_client: reqwest::Client,
     /// Pricing data source URL
     pub(super) pricing_url: String,
+    /// Whether the built-in remote source may fall back to embedded pricing.
+    pub(super) use_embedded_fallback_on_remote_error: bool,
     /// Cache TTL
     pub(super) cache_ttl: Duration,
     /// Event broadcaster for updates
@@ -69,6 +71,7 @@ impl PricingService {
     /// Create a new pricing service
     pub fn new(pricing_url: Option<String>) -> Self {
         let (event_sender, _) = broadcast::channel(1000);
+        let use_embedded_fallback_on_remote_error = pricing_url.is_none();
 
         let service = Self {
             pricing_data: Arc::new(RwLock::new(PricingData {
@@ -78,12 +81,19 @@ impl PricingService {
             http_client: default_outbound_client().clone(),
             pricing_url: pricing_url
                 .unwrap_or_else(|| super::REMOTE_LITELLM_PRICING_SOURCE.to_string()),
+            use_embedded_fallback_on_remote_error,
             cache_ttl: Duration::from_secs(3600), // 1 hour
             event_sender,
         };
 
         info!("Pricing service initialized with LiteLLM data source");
         service
+    }
+
+    pub(super) fn should_fallback_to_embedded_on_remote_error(&self) -> bool {
+        self.use_embedded_fallback_on_remote_error
+            && self.pricing_url == super::REMOTE_LITELLM_PRICING_SOURCE
+            && self.pricing_data.read().models.is_empty()
     }
 
     /// Get model information

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -76,9 +76,8 @@ impl PricingService {
                 last_updated: SystemTime::UNIX_EPOCH,
             })),
             http_client: default_outbound_client().clone(),
-            pricing_url: pricing_url.unwrap_or_else(|| {
-                "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json".to_string()
-            }),
+            pricing_url: pricing_url
+                .unwrap_or_else(|| super::REMOTE_LITELLM_PRICING_SOURCE.to_string()),
             cache_ttl: Duration::from_secs(3600), // 1 hour
             event_sender,
         };
@@ -439,10 +438,9 @@ mod tests {
     #[test]
     fn test_pricing_service_new_default() {
         let service = PricingService::new(None);
-        assert!(
-            service
-                .pricing_url
-                .contains("model_prices_and_context_window.json")
+        assert_eq!(
+            service.pricing_url,
+            super::super::REMOTE_LITELLM_PRICING_SOURCE
         );
         assert_eq!(service.cache_ttl, Duration::from_secs(3600));
     }


### PR DESCRIPTION
## Summary
- accept integral float token limits from LiteLLM pricing JSON while rejecting lossy/negative/overflow values
- default missing pricing mode metadata to blank instead of failing the full parse
- fall back to embedded pricing when remote HTTP pricing refresh fails, while preserving an error if embedded fallback also fails

Fixes #707

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test parse_litellm_pricing_json -- --test-threads=1 --format terse
- cargo test remote_pricing_parse_failure_falls_back_to_embedded_data -- --test-threads=1 --format terse
- cargo check