### PR TITLE
fix(ci): update quinn-proto audit advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,18 @@ jobs:
           REDIS_URL: redis://localhost:6379
           JWT_SECRET: test-secret-key-for-ci
           RUST_LOG: debug
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- update Cargo.lock to quinn-proto 0.11.15 to resolve RUSTSEC-2026-0185
- add a PR-level Security Audit job so cargo audit failures are caught before merging to main

## Verification
- cargo fmt --all -- --check
- git diff --check
- bash scripts/guards/check_schema_duplicates.sh && bash scripts/guards/check_api_runtime_boundary.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml:ok"'\n- cargo audit\n- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo clippy --all-targets --features "$FEATURES" -- -D warnings --force-warn clippy::collapsible-if\n- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" DATABASE_URL="postgresql://postgres:postgres@localhost:5432/gateway_test" REDIS_URL="redis://localhost:6379" JWT_SECRET="test-secret-key-for-ci" RUST_LOG="debug" cargo test --workspace --locked --features "$FEATURES" --verbose\n- cargo build --release --locked --features "postgres sqlite redis s3 metrics tracing websockets analytics"