### PR TITLE
fix(router): harden deployment reservations

### DIFF
--- a/docs/plan/router-budget-provider-infra-hardening-spec.md
+++ b/docs/plan/router-budget-provider-infra-hardening-spec.md
@@ -1,0 +1,341 @@
+# Router, Budget, and Provider Infrastructure Hardening Spec
+
+Date: 2026-06-25
+Review base: `origin/main` at `328636373d783bc686da85584ec5e95e0b661643`
+Implementation base: `origin/main` at `f9c5e4ab01a6165dce31e47b374d269db6b6bc33`
+
+Tracking issues:
+
+- `#709`: Router hard parallel reservations and lease cleanup
+- `#710`: Router routing metadata snapshot boundary
+- `#711`: Budget reserve and settle semantics
+- `#713`: Provider enum / trait / handle contract alignment
+- `#714`: Provider registry declaration and conformance tests
+- `#715`: Provider failure / retry policy / HTTP mapping split
+- `#716`: SDK / router / gateway / provider / storage workspace RFC
+- `#519`: Existing provider/type-tree architecture meta issue
+
+## Goal
+
+Turn the June 2026 static review into a bounded implementation roadmap for
+hard routing limits, consistent routing metadata, budget pre-authorization, and
+provider abstraction cleanup.
+
+The review is substantially correct. The main risk is not Rust syntax or local
+compile health; it is that several user-visible hard constraints are currently
+implemented as soft counters or split state without a single consistency
+boundary.
+
+## Non-Goals
+
+- Do not rewrite the whole router, provider system, budget system, and crate
+  layout in one PR.
+- Do not weaken existing tests to make a refactor pass.
+- Do not break public APIs without an explicit migration PR and release note.
+- Do not treat successful local `cargo check` as proof of runtime quota
+  correctness.
+
+## Findings
+
+### F1. Router parallel limits are not atomic reservations
+
+`select_deployment` checks `active_requests` before selection and increments
+the selected deployment afterwards. Concurrent callers can observe the same
+pre-increment value and all pass the limit. This makes
+`max_parallel_requests` a best-effort statistic rather than a hard cap.
+
+Cancellation risk also exists because selection returns a plain deployment ID
+and relies on callers to pair it with `release_deployment`. Some server-side
+streaming code already works around this with a local RAII lease, but the core
+router API has not absorbed that contract.
+
+RPM and TPM checks are also pre-flight observations, not reservations. RPM is
+incremented only by `record_success`; failed requests are counted as failures
+but do not consume the current-minute RPM counter before the upstream call.
+TPM cannot be reserved accurately with the current selection signature because
+no request token estimate is available at selection time.
+
+### F2. Routing metadata has no snapshot boundary
+
+The router maintains separate `deployments`, `model_index`, and `model_aliases`
+maps. Individual `DashMap` operations are thread-safe, but the business
+invariant across maps is not atomic.
+
+Concrete bugs:
+
+- Re-adding the same deployment ID appends duplicate IDs to `model_index`.
+- Re-adding an existing ID under a different model leaves the old model index
+  stale.
+- Selection reads IDs from `model_index` and does not validate that the loaded
+  deployment still belongs to the resolved model.
+- `set_model_list` builds new maps locally but installs them entry by entry, so
+  readers can observe mixed generations during hot update.
+- Alias cycle detection walks alias chains, but selection resolves only one
+  alias hop.
+- `DeploymentState::clone` copies atomic values into new atomics, so cloned
+  deployments diverge instead of sharing runtime counters.
+
+### F3. Budget checks are not atomic pre-authorizations
+
+`BudgetTracker::check_spend` reads whether an amount would fit, while
+`record_spend` later mutates the balance. There is no atomic
+`reserve + settle` token that prevents concurrent callers from all seeing the
+last remaining budget.
+
+Budget amounts are represented as `f64` and spend mutation does not reject
+negative, NaN, or infinite values at the value boundary. Floating point is
+acceptable for display and estimates, but not as the only type used for hard
+authorization or persisted accounting.
+
+### F4. Provider abstraction has split contracts
+
+`LLMProvider` is documented as the core provider abstraction, while router
+deployments store the closed `Provider` enum. Third-party implementors of
+`LLMProvider` cannot be routed without modifying the enum and dispatch code.
+
+`ProviderHandle` is public and advertised as a type-erased routing wrapper, but
+its core methods are stubs: chat completion returns unimplemented, model/tool
+support return true, health is always healthy, cost is zero, latency is fixed,
+and success rate is 100%.
+
+This should be resolved in favor of either a closed built-in provider set or an
+object-safe custom provider path. Until then, `ProviderHandle` must not be
+presented as a real routing abstraction.
+
+### F5. Provider registration has multiple sources of truth
+
+Provider availability is split across module declarations, feature gates,
+`ProviderType`, factory paths, dispatch macro arms, data-driven Tier 1 catalog
+entries, capability declarations, and documentation. The existing meta issue
+`#519` already tracks the broader provider/type-tree drift, but this review
+adds a concrete acceptance criterion: every advertised provider must be
+constructible from config and callable through the same router dispatch path for
+its declared endpoint.
+
+### F6. Provider errors mix facts, retry policy, and HTTP mapping
+
+`ProviderError` variants store upstream facts but also decide retryability,
+retry delay, and HTTP status. Correct retry behavior depends on request context:
+operation idempotency, stream stage, emitted tokens, retry budget, deadline, and
+provider `Retry-After`. A variant alone cannot know these.
+
+The dynamic `LLMProvider::name()` plus static `ProviderError` provider string
+is another signal that provider identity and error facts need a clearer model.
+
+### F7. SDK, gateway, and infrastructure live in one crate
+
+The crate exposes SDK and gateway surfaces together. Default features pull in
+storage, Redis, HTTP server, auth, and related dependencies. The current
+feature setup is workable for a single package, but long-term kernel stability
+would improve with a workspace split.
+
+## Architecture Direction
+
+### Router
+
+- Introduce a core `DeploymentLease`/reservation API.
+- Enforce `max_parallel_requests` with an atomic compare-and-reserve operation,
+  not a read-then-increment sequence.
+- Use RAII for router-owned execution paths so cancellation drops the lease.
+- Add a follow-up `RateReservation` API that reserves RPM before upstream calls
+  and supports TPM estimate/settle semantics.
+- Move routing metadata toward an immutable `RoutingSnapshot` installed with one
+  swap:
+
+```text
+RoutingSnapshot {
+  by_id: HashMap<DeploymentId, Arc<Deployment>>,
+  by_model: HashMap<ModelName, Arc<[DeploymentId]>>,
+  aliases: HashMap<ModelName, ModelName>,
+}
+```
+
+Runtime counters should be stored in shared runtime state rather than copied by
+`DeploymentState::clone`.
+
+### Budget
+
+- Introduce a fixed-point money type for authorization paths.
+- Add `reserve_spend(scope, max_amount) -> BudgetReservation`.
+- Add `settle(actual_amount)` and refund unused reservation amount.
+- Reject negative, NaN, and infinite amounts at API boundaries while the
+  transition still accepts legacy `f64` display inputs.
+- For distributed deployment, implement provider/model/global reservation in a
+  database transaction or Redis Lua script.
+
+### Provider
+
+- Either document the provider set as closed and remove public routing stubs, or
+  add an object-safe `DynProvider`/`CustomProvider` adapter.
+- Generate or validate provider registration from one declaration source.
+- Add conformance tests proving every advertised provider selector can be
+  instantiated and dispatched for declared capabilities.
+
+### Errors
+
+- Split `ProviderFailure` facts from `RetryPolicy` decisions.
+- Move HTTP status mapping to HTTP adapters.
+- Make retry decisions accept request context including stream stage and
+  idempotency.
+
+## PR Plan
+
+### PR 1: Router hard parallel cap and low-risk consistency guards
+
+Scope:
+
+- Add atomic active-request reservation for `max_parallel_requests`.
+- Add a router-owned lease for non-streaming execution paths.
+- Keep existing public `select_deployment` compatibility, but route internal
+  execution through lease-safe APIs.
+- Make `add_deployment` de-duplicate index entries and remove stale model-index
+  references when an ID changes model.
+- Revalidate `deployment.model_name` against the resolved model during
+  selection.
+- Resolve aliases consistently or reject alias-to-alias explicitly.
+
+Tests:
+
+- `max_parallel_requests = 1` with many concurrent selections never admits more
+  than one active request.
+- Aborting an in-flight `execute_once` returns the active request slot.
+- Re-adding the same deployment ID does not duplicate `model_index`.
+- Re-adding a deployment under a new model does not leave the old model
+  routable.
+- Alias chains either resolve fully or are explicitly rejected.
+
+Tracking:
+
+- `#709`
+- `#710`
+
+### PR 2: Atomic routing snapshot
+
+Scope:
+
+- Replace split mutable routing maps with an immutable `RoutingSnapshot`.
+- Build, validate, de-duplicate, and swap the full table in one step.
+- Preserve runtime state through shared runtime handles.
+
+Tests:
+
+- Hot update during sustained routing never returns a deployment for the wrong
+  model and never emits transient `ModelNotFound` for models present in either
+  complete generation unless explicitly removed.
+- `DeploymentState` clone/runtime sharing behavior is made impossible or tested
+  as shared state.
+
+Tracking:
+
+- `#710`
+
+### PR 3: Budget reservation API
+
+Scope:
+
+- Add fixed-point authorization type.
+- Add atomic reserve/settle/refund guard.
+- Keep legacy `record_spend` as a compatibility wrapper where possible.
+- Reject invalid numeric inputs.
+
+Tests:
+
+- Multiple concurrent requests competing for the final budget allow at most one
+  reservation.
+- Dropping/cancelling a reservation refunds the amount unless settled.
+- Negative, NaN, and infinite spend values are rejected.
+
+Tracking:
+
+- `#711`
+
+### PR 4: Provider abstraction decision
+
+Scope:
+
+- Mark `ProviderHandle` deprecated or replace it with a real object-safe
+  adapter.
+- Align public docs with either closed built-in providers or custom-provider
+  support.
+- Link this work to `#519`.
+
+Tests:
+
+- `ProviderHandle` no longer returns optimistic stub routing data.
+- If custom providers are supported, a mock provider can be routed through the
+  same router path as built-ins.
+
+Tracking:
+
+- `#713`
+- `#519`
+
+### PR 5: Provider registration conformance
+
+Scope:
+
+- Add a declaration table or validation harness for provider selectors,
+  factory creation, enum/dispatch support, capabilities, feature gates, and
+  docs matrix.
+- Generate docs or fail tests when docs drift.
+
+Tests:
+
+- Every advertised provider selector is constructible under the feature set that
+  documents it.
+- Every constructed provider can dispatch each declared endpoint through the
+  router path.
+
+Tracking:
+
+- `#714`
+- `#519`
+
+### PR 6: Retry/error/HTTP split
+
+Scope:
+
+- Introduce fact-only provider failure data.
+- Add retry policy inputs for idempotency, stream stage, deadline, retry budget,
+  and provider retry hints.
+- Move HTTP mapping into gateway adapters.
+
+Tests:
+
+- Streaming errors after emitted chunks are not automatically retried.
+- Provider `Retry-After` participates in delay decisions.
+- HTTP mapping tests do not depend on core provider error policy methods.
+
+Tracking:
+
+- `#715`
+
+### PR 7: Workspace split RFC
+
+Scope:
+
+- Write an RFC for splitting core, provider API, providers, router, gateway,
+  and storage into workspace crates.
+- Include feature compatibility and migration plan.
+
+Tests:
+
+- RFC only; no code behavior change.
+
+Tracking:
+
+- `#716`
+
+## Merge Gate
+
+Every implementation PR must provide fresh evidence from the current head:
+
+- `cargo check`
+- targeted `cargo test` for touched modules
+- full `cargo test` before merge, unless CI is the explicitly recorded
+  full-suite truth source
+- current PR head SHA, check rollup, merge state, and review-thread state
+  before merge
+
+No PR may merge if it has unresolved actionable review threads or if
+`origin/main` advanced over overlapping files after verification.

--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -33,8 +33,8 @@ impl Router {
             let start = std::time::Instant::now();
 
             // Try to select a deployment
-            let deployment_id = match self.select_deployment(model_name) {
-                Ok(id) => id,
+            let deployment_lease = match self.select_deployment_lease(model_name) {
+                Ok(lease) => lease,
                 Err(router_err) => {
                     let provider_err = router_error_to_provider_error(router_err);
 
@@ -48,6 +48,7 @@ impl Router {
                     }
                 }
             };
+            let deployment_id = deployment_lease.clone_deployment_id();
 
             // Execute the operation
             let result = operation(deployment_id.clone()).await;
@@ -56,12 +57,12 @@ impl Router {
 
             match result {
                 Ok((value, tokens_used)) => {
-                    self.release_deployment(&deployment_id);
+                    drop(deployment_lease);
                     self.record_success(&deployment_id, tokens_used, latency_us);
                     return Ok((value, deployment_id, attempt, latency_us));
                 }
                 Err(err) => {
-                    self.release_deployment(&deployment_id);
+                    drop(deployment_lease);
 
                     if is_retryable_error(&err) && attempt < max_attempts {
                         // Use ConsecutiveFailures so the deployment only enters
@@ -111,34 +112,35 @@ impl Router {
         for attempt in 1..=max_attempts {
             let start = std::time::Instant::now();
 
-            let deployment_id = match self.select_deployment_for_capability(model_name, capability)
-            {
-                Ok(id) => id,
-                Err(router_err) => {
-                    let provider_err = router_error_to_provider_error(router_err);
+            let deployment_lease =
+                match self.select_deployment_lease_for_capability(model_name, capability) {
+                    Ok(lease) => lease,
+                    Err(router_err) => {
+                        let provider_err = router_error_to_provider_error(router_err);
 
-                    if is_retryable_error(&provider_err) && attempt < max_attempts {
-                        let delay = calculate_retry_delay(&self.config, attempt);
-                        last_error = Some(provider_err);
-                        tokio::time::sleep(delay).await;
-                        continue;
-                    } else {
-                        return Err((provider_err, attempt));
+                        if is_retryable_error(&provider_err) && attempt < max_attempts {
+                            let delay = calculate_retry_delay(&self.config, attempt);
+                            last_error = Some(provider_err);
+                            tokio::time::sleep(delay).await;
+                            continue;
+                        } else {
+                            return Err((provider_err, attempt));
+                        }
                     }
-                }
-            };
+                };
+            let deployment_id = deployment_lease.clone_deployment_id();
 
             let result = operation(deployment_id.clone()).await;
             let latency_us = start.elapsed().as_micros() as u64;
 
             match result {
                 Ok((value, tokens_used)) => {
-                    self.release_deployment(&deployment_id);
+                    drop(deployment_lease);
                     self.record_success(&deployment_id, tokens_used, latency_us);
                     return Ok((value, deployment_id, attempt, latency_us));
                 }
                 Err(err) => {
-                    self.release_deployment(&deployment_id);
+                    drop(deployment_lease);
 
                     if is_retryable_error(&err) && attempt < max_attempts {
                         self.record_failure_with_reason(
@@ -261,13 +263,14 @@ impl Router {
     {
         let start = std::time::Instant::now();
 
-        let deployment_id = self.select_deployment(model_name)?;
+        let deployment_lease = self.select_deployment_lease(model_name)?;
+        let deployment_id = deployment_lease.clone_deployment_id();
 
         let result = operation(deployment_id.clone()).await;
 
         let latency_us = start.elapsed().as_micros() as u64;
 
-        self.release_deployment(&deployment_id);
+        drop(deployment_lease);
 
         match result {
             Ok((value, tokens_used)) => {

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -191,7 +191,7 @@ impl Router {
             };
 
             if deployment.model_name != resolved_name {
-                tracing::warn!(
+                tracing::debug!(
                     deployment_id = id.as_str(),
                     requested_model = %model_name,
                     resolved_model = %resolved_name,

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -10,7 +10,51 @@ use super::strategy_impl::{self, RoutingContext};
 use super::unified::Router;
 use crate::core::types::model::ProviderCapability;
 use dashmap::DashMap;
-use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::sync::atomic::{
+    AtomicUsize,
+    Ordering::{AcqRel, Acquire, Relaxed},
+};
+
+/// Active-request reservation for a selected deployment.
+///
+/// Dropping the lease releases the selected deployment unless ownership was
+/// explicitly converted back into the legacy deployment-id API.
+pub struct DeploymentLease<'router> {
+    router: &'router Router,
+    deployment_id: DeploymentId,
+    release_on_drop: bool,
+}
+
+impl<'router> DeploymentLease<'router> {
+    fn new(router: &'router Router, deployment_id: DeploymentId) -> Self {
+        Self {
+            router,
+            deployment_id,
+            release_on_drop: true,
+        }
+    }
+
+    pub fn deployment_id(&self) -> &str {
+        &self.deployment_id
+    }
+
+    pub fn clone_deployment_id(&self) -> DeploymentId {
+        self.deployment_id().to_string()
+    }
+
+    pub fn into_deployment_id(mut self) -> DeploymentId {
+        self.release_on_drop = false;
+        std::mem::take(&mut self.deployment_id)
+    }
+}
+
+impl Drop for DeploymentLease<'_> {
+    fn drop(&mut self) {
+        if self.release_on_drop {
+            self.router.release_deployment(&self.deployment_id);
+        }
+    }
+}
 
 impl Router {
     /// Select the best deployment for a given model (core routing method)
@@ -23,6 +67,18 @@ impl Router {
     /// 4. Select based on routing strategy
     /// 5. Increment active_requests counter
     pub fn select_deployment(&self, model_name: &str) -> Result<DeploymentId, RouterError> {
+        self.select_deployment_lease(model_name)
+            .map(DeploymentLease::into_deployment_id)
+    }
+
+    /// Select and reserve the best deployment for a given model.
+    ///
+    /// The returned lease releases the deployment on drop, which protects
+    /// router-owned execution paths from cancellation leaks.
+    pub fn select_deployment_lease(
+        &self,
+        model_name: &str,
+    ) -> Result<DeploymentLease<'_>, RouterError> {
         self.select_deployment_matching(model_name, |_| true, None)
     }
 
@@ -36,6 +92,17 @@ impl Router {
         model_name: &str,
         capability: &ProviderCapability,
     ) -> Result<DeploymentId, RouterError> {
+        self.select_deployment_lease_for_capability(model_name, capability)
+            .map(DeploymentLease::into_deployment_id)
+    }
+
+    /// Select and reserve the best deployment for a model that supports
+    /// `capability`.
+    pub fn select_deployment_lease_for_capability(
+        &self,
+        model_name: &str,
+        capability: &ProviderCapability,
+    ) -> Result<DeploymentLease<'_>, RouterError> {
         let no_matching_candidate_error = RouterError::UnsupportedCapability {
             model: model_name.to_string(),
             capability: format!("{capability:?}"),
@@ -94,22 +161,17 @@ impl Router {
         model_name: &str,
         is_candidate: F,
         no_matching_candidate_error: Option<RouterError>,
-    ) -> Result<DeploymentId, RouterError>
+    ) -> Result<DeploymentLease<'_>, RouterError>
     where
         F: Fn(&Deployment) -> bool,
     {
-        // 1. Resolve model name with a borrowed fast path so the hot routing
-        // path only allocates when we finally return the selected deployment ID.
-        let alias_guard = self.maybe_model_alias(model_name);
-        let resolved_name = alias_guard
-            .as_ref()
-            .map(|alias| alias.value().as_str())
-            .unwrap_or(model_name);
+        // 1. Resolve model aliases consistently with the public resolver.
+        let resolved_name = self.resolve_model_name(model_name);
 
         // 2. Get all deployment IDs for this model.
         let deployment_ids_ref = self
             .model_index
-            .get(resolved_name)
+            .get(&resolved_name)
             .ok_or_else(|| RouterError::ModelNotFound(model_name.to_string()))?;
 
         if deployment_ids_ref.is_empty() {
@@ -127,6 +189,17 @@ impl Router {
             let Some(deployment) = self.deployments.get(id.as_str()) else {
                 continue;
             };
+
+            if deployment.model_name != resolved_name {
+                tracing::warn!(
+                    deployment_id = id.as_str(),
+                    requested_model = %model_name,
+                    resolved_model = %resolved_name,
+                    deployment_model = %deployment.model_name,
+                    "deployment index entry points at a different model"
+                );
+                continue;
+            }
             existing_deployments += 1;
 
             if !is_candidate(&deployment) {
@@ -230,32 +303,80 @@ impl Router {
             return Err(RouterError::NoAvailableDeployment(model_name.to_string()));
         }
 
-        // 4. Select based on the immutable routing contexts.
-        let selected_id = Self::select_from_routing_contexts(
-            self.config.routing_strategy,
-            resolved_name,
-            &routing_contexts,
-            &self.round_robin_counters,
-        )
-        .ok_or_else(|| RouterError::NoAvailableDeployment(model_name.to_string()))?
-        .clone();
+        // 4. Select based on immutable routing contexts, then atomically reserve
+        // the selected deployment. If another caller wins the race for the last
+        // slot, remove that candidate and retry within this selection attempt.
+        while !routing_contexts.is_empty() {
+            let selected_id = Self::select_from_routing_contexts(
+                self.config.routing_strategy,
+                &resolved_name,
+                &routing_contexts,
+                &self.round_robin_counters,
+            )
+            .ok_or_else(|| RouterError::NoAvailableDeployment(model_name.to_string()))?
+            .clone();
 
-        // 5. Increment active_requests counter and routing metrics.
-        if let Some(deployment) = self.deployments.get(&selected_id) {
-            deployment.state.active_requests.fetch_add(1, Relaxed);
+            if self.try_reserve_deployment(&selected_id) {
+                self.provider_selected_count.fetch_add(1, Relaxed);
+                self.strategy_used_count.fetch_add(1, Relaxed);
+
+                tracing::debug!(
+                    model = %model_name,
+                    strategy = ?self.config.routing_strategy,
+                    candidate_count = routing_contexts.len(),
+                    selected_id = %selected_id,
+                    "deployment selected for routing"
+                );
+
+                return Ok(DeploymentLease::new(self, selected_id));
+            }
+
+            if let Some(pos) = routing_contexts
+                .iter()
+                .position(|ctx| ctx.deployment_id == &selected_id)
+            {
+                routing_contexts.swap_remove(pos);
+            } else {
+                break;
+            }
         }
-        self.provider_selected_count.fetch_add(1, Relaxed);
-        self.strategy_used_count.fetch_add(1, Relaxed);
 
-        tracing::debug!(
+        tracing::warn!(
             model = %model_name,
-            strategy = ?self.config.routing_strategy,
-            candidate_count = routing_contexts.len(),
-            selected_id = %selected_id,
-            "deployment selected for routing"
+            "no available deployments after reservation"
         );
+        Err(RouterError::NoAvailableDeployment(model_name.to_string()))
+    }
 
-        Ok(selected_id)
+    fn try_reserve_deployment(&self, deployment_id: &str) -> bool {
+        let Some(deployment) = self.deployments.get(deployment_id) else {
+            return false;
+        };
+
+        match deployment.config.max_parallel_requests {
+            Some(limit) => {
+                let mut current = deployment.state.active_requests.load(Acquire);
+                loop {
+                    if current >= limit {
+                        return false;
+                    }
+
+                    match deployment.state.active_requests.compare_exchange_weak(
+                        current,
+                        current + 1,
+                        AcqRel,
+                        Acquire,
+                    ) {
+                        Ok(_) => return true,
+                        Err(next) => current = next,
+                    }
+                }
+            }
+            None => {
+                deployment.state.active_requests.fetch_add(1, Relaxed);
+                true
+            }
+        }
     }
 
     /// Release a deployment after request completion

--- a/src/core/router/tests/concurrency_edge_case_tests.rs
+++ b/src/core/router/tests/concurrency_edge_case_tests.rs
@@ -177,6 +177,114 @@ async fn test_concurrent_select_deployment_least_busy() {
 }
 
 #[tokio::test]
+async fn test_concurrent_select_deployment_enforces_max_parallel_requests() {
+    let router = Arc::new(Router::new(RouterConfig {
+        routing_strategy: RoutingStrategy::SimpleShuffle,
+        ..Default::default()
+    }));
+
+    let d = create_test_deployment("limited-1", "gpt-4")
+        .await
+        .with_config(DeploymentConfig {
+            max_parallel_requests: Some(1),
+            ..Default::default()
+        });
+    d.state
+        .health
+        .store(HealthStatus::Healthy as u8, Ordering::Relaxed);
+    router.add_deployment(d);
+
+    let barrier = Arc::new(tokio::sync::Barrier::new(101));
+    let mut handles = Vec::new();
+
+    for _ in 0..100 {
+        let r = router.clone();
+        let b = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            b.wait().await;
+            r.select_deployment("gpt-4").ok()
+        }));
+    }
+
+    barrier.wait().await;
+
+    let mut selected_ids = Vec::new();
+    for handle in handles {
+        if let Some(id) = handle.await.unwrap() {
+            selected_ids.push(id);
+        }
+    }
+
+    assert_eq!(
+        selected_ids.len(),
+        1,
+        "only one concurrent selector should reserve the single parallel slot"
+    );
+
+    let d = router.get_deployment("limited-1").unwrap();
+    assert_eq!(d.state.active_requests.load(Ordering::Relaxed), 1);
+    drop(d);
+
+    router.release_deployment(&selected_ids[0]);
+
+    let d = router.get_deployment("limited-1").unwrap();
+    assert_eq!(d.state.active_requests.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn test_aborted_execute_once_releases_parallel_slot() {
+    let router = Arc::new(Router::default());
+    let d = create_test_deployment("abort-1", "gpt-4")
+        .await
+        .with_config(DeploymentConfig {
+            max_parallel_requests: Some(1),
+            ..Default::default()
+        });
+    router.add_deployment(d);
+
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let handle = {
+        let r = router.clone();
+        tokio::spawn(async move {
+            r.execute_once("gpt-4", move |_deployment_id| async move {
+                let _ = entered_tx.send(());
+                std::future::pending::<
+                    Result<((), u64), crate::core::providers::unified_provider::ProviderError>,
+                >()
+                .await
+            })
+            .await
+        })
+    };
+
+    entered_rx
+        .await
+        .expect("operation should start after deployment selection");
+
+    let d = router.get_deployment("abort-1").unwrap();
+    assert_eq!(d.state.active_requests.load(Ordering::Relaxed), 1);
+    drop(d);
+
+    handle.abort();
+    let cancelled = handle.await.expect_err("task should be cancelled");
+    assert!(cancelled.is_cancelled());
+
+    for _ in 0..10 {
+        if router
+            .get_deployment("abort-1")
+            .map(|d| d.state.active_requests.load(Ordering::Relaxed))
+            == Some(0)
+        {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let d = router.get_deployment("abort-1").unwrap();
+    assert_eq!(d.state.active_requests.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
 async fn test_concurrent_record_success_and_failure() {
     let router = Arc::new(Router::new(RouterConfig {
         allowed_fails: 1000, // high to prevent cooldown

--- a/src/core/router/tests/router_tests.rs
+++ b/src/core/router/tests/router_tests.rs
@@ -76,6 +76,37 @@ async fn test_add_multiple_deployments_same_model() {
 }
 
 #[tokio::test]
+async fn test_add_same_deployment_id_does_not_duplicate_model_index() {
+    let router = Router::default();
+    let deployment1 = create_test_deployment("test-1", "gpt-4").await;
+    let deployment2 = create_test_deployment("test-1", "gpt-4").await;
+
+    router.add_deployment(deployment1);
+    router.add_deployment(deployment2);
+
+    assert_eq!(router.list_deployments().len(), 1);
+    assert_eq!(router.get_deployments_for_model("gpt-4"), vec!["test-1"]);
+}
+
+#[tokio::test]
+async fn test_add_same_deployment_id_reindexes_when_model_changes() {
+    let router = Router::default();
+    let deployment1 = create_test_deployment("test-1", "gpt-4").await;
+    let deployment2 = create_test_deployment("test-1", "claude").await;
+
+    router.add_deployment(deployment1);
+    router.add_deployment(deployment2);
+
+    assert!(router.get_deployments_for_model("gpt-4").is_empty());
+    assert_eq!(router.get_deployments_for_model("claude"), vec!["test-1"]);
+
+    assert!(router.select_deployment("gpt-4").is_err());
+    let selected = router.select_deployment("claude").unwrap();
+    assert_eq!(selected, "test-1");
+    router.release_deployment(&selected);
+}
+
+#[tokio::test]
 async fn test_add_multiple_models() {
     let router = Router::default();
     let deployment1 = create_test_deployment("test-1", "gpt-4").await;
@@ -144,6 +175,20 @@ async fn test_set_model_list() {
 }
 
 #[tokio::test]
+async fn test_set_model_list_duplicate_id_reindexes_without_empty_old_model() {
+    let router = Router::default();
+
+    router.set_model_list(vec![
+        create_test_deployment("test-1", "gpt-4").await,
+        create_test_deployment("test-1", "claude").await,
+    ]);
+
+    assert!(!router.list_models().contains(&"gpt-4".to_string()));
+    assert!(router.get_deployments_for_model("gpt-4").is_empty());
+    assert_eq!(router.get_deployments_for_model("claude"), vec!["test-1"]);
+}
+
+#[tokio::test]
 async fn test_model_aliases() {
     let router = Router::default();
     let deployment = create_test_deployment("test-1", "gpt-4").await;
@@ -151,21 +196,30 @@ async fn test_model_aliases() {
     router.add_deployment(deployment);
     router.add_model_alias("gpt4", "gpt-4").unwrap();
     router.add_model_alias("gpt-4-latest", "gpt-4").unwrap();
+    router.add_model_alias("best", "gpt4").unwrap();
 
     assert_eq!(router.resolve_model_name("gpt4"), "gpt-4");
     assert_eq!(router.resolve_model_name("gpt-4-latest"), "gpt-4");
+    assert_eq!(router.resolve_model_name("best"), "gpt-4");
     assert_eq!(router.resolve_model_name("gpt-4"), "gpt-4");
     assert_eq!(router.resolve_model_name("unknown"), "unknown");
 
     let deployments1 = router.get_deployments_for_model("gpt-4");
     let deployments2 = router.get_deployments_for_model("gpt4");
     let deployments3 = router.get_deployments_for_model("gpt-4-latest");
+    let deployments4 = router.get_deployments_for_model("best");
 
     assert_eq!(deployments1.len(), 1);
     assert_eq!(deployments2.len(), 1);
     assert_eq!(deployments3.len(), 1);
+    assert_eq!(deployments4.len(), 1);
     assert_eq!(deployments1, deployments2);
     assert_eq!(deployments2, deployments3);
+    assert_eq!(deployments3, deployments4);
+
+    let selected = router.select_deployment("best").unwrap();
+    assert_eq!(selected, "test-1");
+    router.release_deployment(&selected);
 }
 
 #[tokio::test]

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -13,10 +13,11 @@ use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::model::ProviderCapability;
 use dashmap::DashMap;
 use dashmap::mapref::one::Ref;
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering::Relaxed};
 use std::time::Duration;
+
+const MAX_ALIAS_HOPS: usize = 16;
 
 /// Snapshot of routing metrics counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -264,15 +265,21 @@ impl Router {
         }
 
         let mut current = name.to_string();
-        let mut visited = HashSet::new();
 
-        while visited.insert(current.clone()) {
-            let Some(next) = self.model_aliases.get(&current) else {
+        for _ in 0..MAX_ALIAS_HOPS {
+            if let Some(next) = self.model_aliases.get(&current) {
+                current = next.value().clone();
+            } else {
                 return current;
-            };
-            current = next.value().clone();
+            }
         }
 
+        tracing::debug!(
+            requested_model = %name,
+            resolved_model = %current,
+            max_alias_hops = MAX_ALIAS_HOPS,
+            "model alias resolution hit hop limit"
+        );
         current
     }
 

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -13,6 +13,7 @@ use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::model::ProviderCapability;
 use dashmap::DashMap;
 use dashmap::mapref::one::Ref;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering::Relaxed};
 use std::time::Duration;
@@ -125,25 +126,45 @@ impl Router {
         let model_name = deployment.model_name.clone();
         let deployment_id = deployment.id.clone();
 
+        if let Some(existing) = self.deployments.get(&deployment_id) {
+            let old_model_name = existing.model_name.clone();
+            drop(existing);
+
+            if old_model_name != model_name {
+                self.remove_from_model_index(&old_model_name, &deployment_id);
+            }
+        }
+
         self.deployments.insert(deployment_id.clone(), deployment);
 
-        self.model_index
-            .entry(model_name)
-            .or_default()
-            .push(deployment_id);
+        let mut entry = self.model_index.entry(model_name).or_default();
+        if !entry.iter().any(|id| id == &deployment_id) {
+            entry.push(deployment_id);
+        }
     }
 
     /// Remove a deployment from the router
     pub fn remove_deployment(&self, id: &str) -> Option<Deployment> {
         let removed = self.deployments.remove(id).map(|(_, v)| v);
 
-        if let Some(ref deployment) = removed
-            && let Some(mut entry) = self.model_index.get_mut(&deployment.model_name)
-        {
-            entry.retain(|did| did != id);
+        if let Some(ref deployment) = removed {
+            self.remove_from_model_index(&deployment.model_name, id);
         }
 
         removed
+    }
+
+    fn remove_from_model_index(&self, model_name: &str, deployment_id: &str) {
+        let should_remove = if let Some(mut entry) = self.model_index.get_mut(model_name) {
+            entry.retain(|did| did != deployment_id);
+            entry.is_empty()
+        } else {
+            false
+        };
+
+        if should_remove {
+            self.model_index.remove(model_name);
+        }
     }
 
     /// Get a deployment by ID
@@ -162,8 +183,27 @@ impl Router {
         for deployment in deployments {
             let model_name = deployment.model_name.clone();
             let id = deployment.id.clone();
-            new_deployments.insert(id.clone(), deployment);
-            new_index.entry(model_name).or_default().push(id);
+            if let Some(old) = new_deployments.insert(id.clone(), deployment)
+                && old.model_name != model_name
+            {
+                let old_model_name = old.model_name;
+                let should_remove = if let Some(mut old_entry) = new_index.get_mut(&old_model_name)
+                {
+                    old_entry.retain(|did| did != &id);
+                    old_entry.is_empty()
+                } else {
+                    false
+                };
+
+                if should_remove {
+                    new_index.remove(&old_model_name);
+                }
+            }
+
+            let mut entry = new_index.entry(model_name).or_default();
+            if !entry.iter().any(|existing| existing == &id) {
+                entry.push(id);
+            }
         }
 
         self.deployments
@@ -217,47 +257,42 @@ impl Router {
         Ok(())
     }
 
-    #[inline]
-    pub(crate) fn maybe_model_alias<'a>(&'a self, name: &str) -> Option<Ref<'a, String, String>> {
-        if self.has_model_aliases.load(Relaxed) {
-            self.model_aliases.get(name)
-        } else {
-            None
-        }
-    }
-
     /// Resolve a model name (handles aliases)
     pub fn resolve_model_name(&self, name: &str) -> String {
-        self.maybe_model_alias(name)
-            .map(|v| v.clone())
-            .unwrap_or_else(|| name.to_string())
+        if !self.has_model_aliases.load(Relaxed) {
+            return name.to_string();
+        }
+
+        let mut current = name.to_string();
+        let mut visited = HashSet::new();
+
+        while visited.insert(current.clone()) {
+            let Some(next) = self.model_aliases.get(&current) else {
+                return current;
+            };
+            current = next.value().clone();
+        }
+
+        current
     }
 
     // ========== Query Methods ==========
 
     /// Get all deployment IDs for a given model
     pub fn get_deployments_for_model(&self, model_name: &str) -> Vec<DeploymentId> {
-        let alias_guard = self.maybe_model_alias(model_name);
-        let resolved_name = alias_guard
-            .as_ref()
-            .map(|alias| alias.value().as_str())
-            .unwrap_or(model_name);
+        let resolved_name = self.resolve_model_name(model_name);
 
         self.model_index
-            .get(resolved_name)
+            .get(&resolved_name)
             .map(|v| v.clone())
             .unwrap_or_default()
     }
 
     /// Get healthy deployment IDs for a given model
     pub fn get_healthy_deployments(&self, model_name: &str) -> Vec<DeploymentId> {
-        let alias_guard = self.maybe_model_alias(model_name);
-        let resolved_name = alias_guard
-            .as_ref()
-            .map(|alias| alias.value().as_str())
-            .unwrap_or(model_name);
+        let resolved_name = self.resolve_model_name(model_name);
 
-        let Some(deployment_ids) = self.model_index.get(resolved_name) else {
+        let Some(deployment_ids) = self.model_index.get(&resolved_name) else {
             return Vec::new();
         };
 
@@ -285,18 +320,18 @@ impl Router {
         model_name: &str,
         capability: &ProviderCapability,
     ) -> Option<CapabilityDeployment> {
-        let alias_guard = self.maybe_model_alias(model_name);
-        let resolved_name = alias_guard
-            .as_ref()
-            .map(|alias| alias.value().as_str())
-            .unwrap_or(model_name);
+        let resolved_name = self.resolve_model_name(model_name);
 
-        let deployment_ids = self.model_index.get(resolved_name)?;
+        let deployment_ids = self.model_index.get(&resolved_name)?;
 
         for id in deployment_ids.iter() {
             let Some(deployment) = self.deployments.get(id.as_str()) else {
                 continue;
             };
+
+            if deployment.model_name != resolved_name {
+                continue;
+            }
 
             if deployment.is_in_cooldown() || !deployment.is_healthy() {
                 continue;

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -113,9 +113,9 @@ where
     for attempt in 1..=max_attempts {
         let started_at = Instant::now();
 
-        let deployment_id =
-            match router.select_deployment_for_capability(requested_model, &capability) {
-                Ok(id) => id,
+        let deployment_lease =
+            match router.select_deployment_lease_for_capability(requested_model, &capability) {
+                Ok(lease) => lease,
                 Err(router_err) => {
                     let provider_err = router_error_to_provider_error(router_err);
 
@@ -129,9 +129,10 @@ where
                     return Err(GatewayError::Provider(provider_err));
                 }
             };
+        let deployment_id = deployment_lease.clone_deployment_id();
 
         let Some(deployment) = router.get_deployment(&deployment_id) else {
-            router.release_deployment(&deployment_id);
+            drop(deployment_lease);
             let err = ProviderError::other("router", "Selected deployment not found");
             if is_retryable_error(&err) && attempt < max_attempts {
                 let delay = calculate_retry_delay(router.config(), attempt);
@@ -148,12 +149,13 @@ where
 
         match operation.clone()(provider, selected_model).await {
             Ok(stream) => {
+                let deployment_id = deployment_lease.into_deployment_id();
                 let lease =
                     StreamingDeploymentLease::new(router.clone(), deployment_id, started_at);
                 return Ok((stream, lease));
             }
             Err(err) => {
-                router.release_deployment(&deployment_id);
+                drop(deployment_lease);
 
                 if is_retryable_error(&err) && attempt < max_attempts {
                     router.record_failure_with_reason(
@@ -432,5 +434,66 @@ mod tests {
             .expect("deployment should exist");
         assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 0);
         assert_eq!(deployment.state.fail_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_stream_startup_abort_releases_parallel_slot() {
+        let router = Arc::new(UnifiedRouter::default());
+        let Ok(openai_provider) = OpenAIProvider::with_api_key("sk-test-key").await else {
+            panic!("test provider should build");
+        };
+        let provider = Provider::OpenAI(openai_provider);
+        router.add_deployment(
+            Deployment::new(
+                "deployment-1".to_string(),
+                provider,
+                "gpt-4o-mini".to_string(),
+                "gpt-4".to_string(),
+            )
+            .with_config(DeploymentConfig {
+                max_parallel_requests: Some(1),
+                ..Default::default()
+            }),
+        );
+
+        let operation_entered = Arc::new(tokio::sync::Notify::new());
+        let handle = {
+            let router = router.clone();
+            let operation_entered = operation_entered.clone();
+            tokio::spawn(async move {
+                execute_stream_with_selected_deployment(
+                    router,
+                    "gpt-4",
+                    ProviderCapability::ChatCompletionStream,
+                    move |_provider, _model| {
+                        let operation_entered = operation_entered.clone();
+                        async move {
+                            operation_entered.notify_one();
+                            std::future::pending::<Result<String, ProviderError>>().await
+                        }
+                    },
+                )
+                .await
+            })
+        };
+
+        operation_entered.notified().await;
+
+        let Some(deployment) = router.get_deployment("deployment-1") else {
+            panic!("deployment should exist");
+        };
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 1);
+        drop(deployment);
+
+        handle.abort();
+        match handle.await {
+            Err(cancelled) => assert!(cancelled.is_cancelled()),
+            Ok(_) => panic!("task should be cancelled"),
+        }
+
+        let Some(deployment) = router.get_deployment("deployment-1") else {
+            panic!("deployment should exist");
+        };
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
## Summary
- add the router hardening spec for the reviewed router, budget, provider, retry, and workspace issues
- make deployment selection return a lease-backed reservation path and update retry/streaming execution to hold the lease across awaited provider startup
- prevent duplicate/stale model index entries, resolve alias chains consistently, and revalidate deployment model membership during selection
- add concurrency, cancellation, alias, and reindexing regression tests

## Scope
This PR is the first implementation slice for the June 24 static audit. It addresses the router hard parallel reservation/cancellation leaks and the most immediate routing metadata consistency bugs. It does not implement RPM/TPM pre-reservation, ArcSwap full snapshots, budget reserve/settle, provider abstraction changes, registry generation, retry-policy split, or workspace decomposition; those are tracked separately.

## Tracking
Refs #709
Refs #710
Refs #711
Refs #713
Refs #714
Refs #715
Refs #716
Refs #519

## Verification
- cargo fmt
- cargo check --message-format=short
- cargo test core::router::tests
- cargo test server::routes::ai::execution::tests
- cargo test
- cargo check --all-features --locked --message-format=short

## Threads
- read-only router review: Maxwell / 019efabe-e5e3-79e2-863c-427249f75018
- read-only provider-budget-retry review: Poincare / 019efabe-ff9a-71c0-912f-56e247b6a67d
- independent blocker review: Harvey / 019efad3-951e-7e73-84bd-27b15230d2a9