### PR TITLE
fix(router): install atomic routing snapshots

### DIFF
--- a/src/core/router/deployment.rs
+++ b/src/core/router/deployment.rs
@@ -21,6 +21,8 @@
 //! - Cache-friendly: Hot path fields grouped together
 
 use crate::core::providers::Provider;
+use std::ops::Deref;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -110,8 +112,25 @@ impl Default for DeploymentConfig {
 ///
 /// TPM/RPM counters are reset every minute by a background task.
 /// The `minute_reset_at` timestamp tracks when the last reset occurred.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeploymentState {
+    inner: Arc<DeploymentStateInner>,
+}
+
+impl Deref for DeploymentState {
+    type Target = DeploymentStateInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Shared deployment runtime counters.
+///
+/// `DeploymentState` is a cheap cloneable handle around this inner state so
+/// cloned deployments and routing snapshots cannot fork runtime counters.
+#[derive(Debug)]
+pub struct DeploymentStateInner {
     /// Health status (0=unknown, 1=healthy, 2=degraded, 3=unhealthy, 4=cooldown)
     pub health: AtomicU8,
 
@@ -157,19 +176,21 @@ impl DeploymentState {
     pub fn new() -> Self {
         let now = current_timestamp();
         Self {
-            health: AtomicU8::new(HealthStatus::Healthy as u8),
-            tpm_current: AtomicU64::new(0),
-            rpm_current: AtomicU64::new(0),
-            active_requests: AtomicU32::new(0),
-            total_requests: AtomicU64::new(0),
-            success_requests: AtomicU64::new(0),
-            fail_requests: AtomicU64::new(0),
-            fails_this_minute: AtomicU32::new(0),
-            cooldown_until: AtomicU64::new(0),
-            last_request_at: AtomicU64::new(0),
-            avg_latency_us: AtomicU64::new(0),
-            consecutive_successes: AtomicU32::new(0),
-            minute_reset_at: AtomicU64::new(now),
+            inner: Arc::new(DeploymentStateInner {
+                health: AtomicU8::new(HealthStatus::Healthy as u8),
+                tpm_current: AtomicU64::new(0),
+                rpm_current: AtomicU64::new(0),
+                active_requests: AtomicU32::new(0),
+                total_requests: AtomicU64::new(0),
+                success_requests: AtomicU64::new(0),
+                fail_requests: AtomicU64::new(0),
+                fails_this_minute: AtomicU32::new(0),
+                cooldown_until: AtomicU64::new(0),
+                last_request_at: AtomicU64::new(0),
+                avg_latency_us: AtomicU64::new(0),
+                consecutive_successes: AtomicU32::new(0),
+                minute_reset_at: AtomicU64::new(now),
+            }),
         }
     }
 
@@ -193,29 +214,6 @@ impl DeploymentState {
 impl Default for DeploymentState {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-// Manual Clone implementation because AtomicU64 doesn't implement Clone
-impl Clone for DeploymentState {
-    fn clone(&self) -> Self {
-        Self {
-            health: AtomicU8::new(self.health.load(Ordering::Relaxed)),
-            tpm_current: AtomicU64::new(self.tpm_current.load(Ordering::Relaxed)),
-            rpm_current: AtomicU64::new(self.rpm_current.load(Ordering::Relaxed)),
-            active_requests: AtomicU32::new(self.active_requests.load(Ordering::Relaxed)),
-            total_requests: AtomicU64::new(self.total_requests.load(Ordering::Relaxed)),
-            success_requests: AtomicU64::new(self.success_requests.load(Ordering::Relaxed)),
-            fail_requests: AtomicU64::new(self.fail_requests.load(Ordering::Relaxed)),
-            fails_this_minute: AtomicU32::new(self.fails_this_minute.load(Ordering::Relaxed)),
-            cooldown_until: AtomicU64::new(self.cooldown_until.load(Ordering::Relaxed)),
-            last_request_at: AtomicU64::new(self.last_request_at.load(Ordering::Relaxed)),
-            avg_latency_us: AtomicU64::new(self.avg_latency_us.load(Ordering::Relaxed)),
-            consecutive_successes: AtomicU32::new(
-                self.consecutive_successes.load(Ordering::Relaxed),
-            ),
-            minute_reset_at: AtomicU64::new(self.minute_reset_at.load(Ordering::Relaxed)),
-        }
     }
 }
 
@@ -564,6 +562,34 @@ mod tests {
         let cloned = state.clone();
         assert_eq!(cloned.total_requests.load(Ordering::Relaxed), 100);
         assert_eq!(cloned.success_requests.load(Ordering::Relaxed), 95);
+
+        cloned.total_requests.store(101, Ordering::Relaxed);
+        state.success_requests.store(96, Ordering::Relaxed);
+
+        assert_eq!(state.total_requests.load(Ordering::Relaxed), 101);
+        assert_eq!(cloned.success_requests.load(Ordering::Relaxed), 96);
+    }
+
+    #[tokio::test]
+    async fn test_deployment_clone_shares_runtime_state()
+    -> Result<(), crate::core::providers::unified_provider::ProviderError> {
+        let deployment = Deployment::new(
+            "test-1".to_string(),
+            Provider::OpenAI(
+                crate::core::providers::openai::OpenAIProvider::with_api_key(
+                    "sk-test-key-for-unit-testing-only",
+                )
+                .await?,
+            ),
+            "gpt-4-turbo".to_string(),
+            "gpt-4".to_string(),
+        );
+
+        let cloned = deployment.clone();
+        cloned.state.active_requests.store(7, Ordering::Relaxed);
+
+        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 7);
+        Ok(())
     }
 
     // ==================== current_timestamp Tests ====================

--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains the execute, execute_once, and execute_with_retry methods.
 
-use super::deployment::DeploymentId;
+use super::deployment::{Deployment, DeploymentId};
 use super::error::{CooldownReason, RouterError};
 use super::execution::{
     build_execution_result, calculate_retry_delay, infer_cooldown_reason, is_retryable_error,
@@ -12,11 +12,38 @@ use super::fallback::{ExecutionResult, FallbackType};
 use super::unified::Router;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::model::ProviderCapability;
+use std::sync::Arc;
 
 impl Router {
     /// Execute a request for a single model with retry logic
     ///
     /// Attempts to execute the operation with retry on transient failures.
+    pub async fn execute_with_selected_deployment_retry<T, F, Fut>(
+        &self,
+        model_name: &str,
+        operation: F,
+    ) -> Result<(T, DeploymentId, u32, u64), (ProviderError, u32)>
+    where
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.execute_with_retry_inner(model_name, operation)
+            .await
+            .map(
+                |(value, deployment_id, _model_used, attempts, latency_us)| {
+                    (value, deployment_id, attempts, latency_us)
+                },
+            )
+    }
+
+    /// Execute a request for a single model with retry logic.
+    ///
+    /// Prefer `execute_with_selected_deployment_retry`; ID-only callbacks can
+    /// re-read a newer snapshot with the same deployment ID.
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use execute_with_selected_deployment_retry so callbacks receive the selected snapshot deployment"
+    )]
     pub async fn execute_with_retry<T, F, Fut>(
         &self,
         model_name: &str,
@@ -24,6 +51,21 @@ impl Router {
     ) -> Result<(T, DeploymentId, u32, u64), (ProviderError, u32)>
     where
         F: Fn(DeploymentId) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.execute_with_selected_deployment_retry(model_name, move |deployment| {
+            operation(deployment.id.clone())
+        })
+        .await
+    }
+
+    async fn execute_with_retry_inner<T, F, Fut>(
+        &self,
+        model_name: &str,
+        operation: F,
+    ) -> Result<(T, DeploymentId, String, u32, u64), (ProviderError, u32)>
+    where
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
         let max_attempts = self.config.num_retries + 1;
@@ -48,37 +90,46 @@ impl Router {
                     }
                 }
             };
-            let deployment_id = deployment_lease.clone_deployment_id();
+            let selected_deployment = deployment_lease.clone_deployment();
+            let deployment_id = selected_deployment.id.clone();
 
             // Execute the operation
-            let result = operation(deployment_id.clone()).await;
+            let result = operation(selected_deployment.clone()).await;
 
             let latency_us = start.elapsed().as_micros() as u64;
 
             match result {
                 Ok((value, tokens_used)) => {
+                    let model_used = selected_deployment.model.clone();
+                    self.record_success_for_deployment(
+                        deployment_lease.deployment(),
+                        tokens_used,
+                        latency_us,
+                    );
                     drop(deployment_lease);
-                    self.record_success(&deployment_id, tokens_used, latency_us);
-                    return Ok((value, deployment_id, attempt, latency_us));
+                    return Ok((value, deployment_id, model_used, attempt, latency_us));
                 }
                 Err(err) => {
-                    drop(deployment_lease);
-
                     if is_retryable_error(&err) && attempt < max_attempts {
                         // Use ConsecutiveFailures so the deployment only enters
                         // cooldown after exceeding allowed_fails threshold,
                         // giving retries a chance to succeed.
-                        self.record_failure_with_reason(
-                            &deployment_id,
+                        self.record_failure_with_reason_for_deployment(
+                            deployment_lease.deployment(),
                             CooldownReason::ConsecutiveFailures,
                         );
+                        drop(deployment_lease);
                         let delay = calculate_retry_delay(&self.config, attempt);
                         last_error = Some(err);
                         tokio::time::sleep(delay).await;
                         continue;
                     } else {
                         let cooldown_reason = infer_cooldown_reason(&err);
-                        self.record_failure_with_reason(&deployment_id, cooldown_reason);
+                        self.record_failure_with_reason_for_deployment(
+                            deployment_lease.deployment(),
+                            cooldown_reason,
+                        );
+                        drop(deployment_lease);
                         return Err((err, attempt));
                     }
                 }
@@ -96,14 +147,14 @@ impl Router {
 
     /// Execute a request for a single model with retry logic, constrained to
     /// deployments that support the requested provider capability.
-    pub async fn execute_with_capability_retry<T, F, Fut>(
+    pub async fn execute_with_selected_deployment_capability_retry<T, F, Fut>(
         &self,
         model_name: &str,
         capability: &ProviderCapability,
         operation: F,
     ) -> Result<(T, DeploymentId, u32, u64), (ProviderError, u32)>
     where
-        F: Fn(DeploymentId) -> Fut + Clone,
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
         let max_attempts = self.config.num_retries + 1;
@@ -128,32 +179,40 @@ impl Router {
                         }
                     }
                 };
-            let deployment_id = deployment_lease.clone_deployment_id();
+            let selected_deployment = deployment_lease.clone_deployment();
+            let deployment_id = selected_deployment.id.clone();
 
-            let result = operation(deployment_id.clone()).await;
+            let result = operation(selected_deployment.clone()).await;
             let latency_us = start.elapsed().as_micros() as u64;
 
             match result {
                 Ok((value, tokens_used)) => {
+                    self.record_success_for_deployment(
+                        deployment_lease.deployment(),
+                        tokens_used,
+                        latency_us,
+                    );
                     drop(deployment_lease);
-                    self.record_success(&deployment_id, tokens_used, latency_us);
                     return Ok((value, deployment_id, attempt, latency_us));
                 }
                 Err(err) => {
-                    drop(deployment_lease);
-
                     if is_retryable_error(&err) && attempt < max_attempts {
-                        self.record_failure_with_reason(
-                            &deployment_id,
+                        self.record_failure_with_reason_for_deployment(
+                            deployment_lease.deployment(),
                             CooldownReason::ConsecutiveFailures,
                         );
+                        drop(deployment_lease);
                         let delay = calculate_retry_delay(&self.config, attempt);
                         last_error = Some(err);
                         tokio::time::sleep(delay).await;
                         continue;
                     } else {
                         let cooldown_reason = infer_cooldown_reason(&err);
-                        self.record_failure_with_reason(&deployment_id, cooldown_reason);
+                        self.record_failure_with_reason_for_deployment(
+                            deployment_lease.deployment(),
+                            cooldown_reason,
+                        );
+                        drop(deployment_lease);
                         return Err((err, attempt));
                     }
                 }
@@ -169,19 +228,46 @@ impl Router {
         ))
     }
 
+    /// Execute a request for a single model with retry logic, constrained to
+    /// deployments that support the requested provider capability.
+    ///
+    /// Prefer `execute_with_selected_deployment_capability_retry`; ID-only
+    /// callbacks can re-read a newer snapshot with the same deployment ID.
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use execute_with_selected_deployment_capability_retry so callbacks receive the selected snapshot deployment"
+    )]
+    pub async fn execute_with_capability_retry<T, F, Fut>(
+        &self,
+        model_name: &str,
+        capability: &ProviderCapability,
+        operation: F,
+    ) -> Result<(T, DeploymentId, u32, u64), (ProviderError, u32)>
+    where
+        F: Fn(DeploymentId) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.execute_with_selected_deployment_capability_retry(
+            model_name,
+            capability,
+            move |deployment| operation(deployment.id.clone()),
+        )
+        .await
+    }
+
     /// Execute a request with full retry and fallback support
     ///
     /// This is the main execution method that implements the complete flow:
     /// 1. Try the original model with retries
     /// 2. On failure, try fallback models with retries
     /// 3. Respect max_fallbacks limit
-    pub async fn execute<T, F, Fut>(
+    pub async fn execute_with_selected_deployment<T, F, Fut>(
         &self,
         model_name: &str,
         operation: F,
     ) -> Result<ExecutionResult<T>, RouterError>
     where
-        F: Fn(DeploymentId) -> Fut + Clone,
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
         let start = std::time::Instant::now();
@@ -214,16 +300,13 @@ impl Router {
                 );
             }
 
-            match self.execute_with_retry(model, operation.clone()).await {
-                Ok((result, deployment_id, attempts, _latency_us)) => {
+            match self
+                .execute_with_retry_inner(model, operation.clone())
+                .await
+            {
+                Ok((result, deployment_id, model_used, attempts, _latency_us)) => {
                     total_attempts += attempts;
                     let total_latency_us = start.elapsed().as_micros() as u64;
-
-                    let model_used = if let Some(deployment) = self.get_deployment(&deployment_id) {
-                        deployment.model.clone()
-                    } else {
-                        model.clone()
-                    };
 
                     return Ok(build_execution_result(
                         result,
@@ -248,39 +331,61 @@ impl Router {
         }
     }
 
-    /// Execute a request once without retry or fallback
+    /// Execute a request with full retry and fallback support.
     ///
-    /// This is a simplified execution method for testing or scenarios where
-    /// retry/fallback is not desired.
-    pub async fn execute_once<T, F, Fut>(
+    /// Prefer `execute_with_selected_deployment`; ID-only callbacks can re-read
+    /// a newer snapshot with the same deployment ID.
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use execute_with_selected_deployment so callbacks receive the selected snapshot deployment"
+    )]
+    pub async fn execute<T, F, Fut>(
         &self,
         model_name: &str,
         operation: F,
     ) -> Result<ExecutionResult<T>, RouterError>
     where
-        F: FnOnce(DeploymentId) -> Fut,
+        F: Fn(DeploymentId) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.execute_with_selected_deployment(model_name, move |deployment| {
+            operation(deployment.id.clone())
+        })
+        .await
+    }
+
+    /// Execute a request once without retry or fallback
+    ///
+    /// This is a simplified execution method for testing or scenarios where
+    /// retry/fallback is not desired.
+    pub async fn execute_once_with_selected_deployment<T, F, Fut>(
+        &self,
+        model_name: &str,
+        operation: F,
+    ) -> Result<ExecutionResult<T>, RouterError>
+    where
+        F: FnOnce(Arc<Deployment>) -> Fut,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
         let start = std::time::Instant::now();
 
         let deployment_lease = self.select_deployment_lease(model_name)?;
-        let deployment_id = deployment_lease.clone_deployment_id();
+        let selected_deployment = deployment_lease.clone_deployment();
+        let deployment_id = selected_deployment.id.clone();
 
-        let result = operation(deployment_id.clone()).await;
+        let result = operation(selected_deployment.clone()).await;
 
         let latency_us = start.elapsed().as_micros() as u64;
 
-        drop(deployment_lease);
-
         match result {
             Ok((value, tokens_used)) => {
-                self.record_success(&deployment_id, tokens_used, latency_us);
-
-                let model_used = if let Some(deployment) = self.get_deployment(&deployment_id) {
-                    deployment.model.clone()
-                } else {
-                    model_name.to_string()
-                };
+                let model_used = selected_deployment.model.clone();
+                self.record_success_for_deployment(
+                    deployment_lease.deployment(),
+                    tokens_used,
+                    latency_us,
+                );
+                drop(deployment_lease);
 
                 Ok(build_execution_result(
                     value,
@@ -293,10 +398,37 @@ impl Router {
             }
             Err(err) => {
                 let cooldown_reason = infer_cooldown_reason(&err);
-                self.record_failure_with_reason(&deployment_id, cooldown_reason);
+                self.record_failure_with_reason_for_deployment(
+                    deployment_lease.deployment(),
+                    cooldown_reason,
+                );
+                drop(deployment_lease);
 
                 Err(provider_error_to_router_error(err, model_name))
             }
         }
+    }
+
+    /// Execute a request once without retry or fallback.
+    ///
+    /// Prefer `execute_once_with_selected_deployment`; ID-only callbacks can
+    /// re-read a newer snapshot with the same deployment ID.
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use execute_once_with_selected_deployment so callbacks receive the selected snapshot deployment"
+    )]
+    pub async fn execute_once<T, F, Fut>(
+        &self,
+        model_name: &str,
+        operation: F,
+    ) -> Result<ExecutionResult<T>, RouterError>
+    where
+        F: FnOnce(DeploymentId) -> Fut,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.execute_once_with_selected_deployment(model_name, move |deployment| {
+            operation(deployment.id.clone())
+        })
+        .await
     }
 }

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -10,6 +10,7 @@ use super::strategy_impl::{self, RoutingContext};
 use super::unified::Router;
 use crate::core::types::model::ProviderCapability;
 use dashmap::DashMap;
+use std::sync::Arc;
 use std::sync::atomic::{
     AtomicUsize,
     Ordering::{AcqRel, Acquire, Relaxed},
@@ -19,39 +20,49 @@ use std::sync::atomic::{
 ///
 /// Dropping the lease releases the selected deployment unless ownership was
 /// explicitly converted back into the legacy deployment-id API.
-pub struct DeploymentLease<'router> {
-    router: &'router Router,
-    deployment_id: DeploymentId,
+pub struct DeploymentLease {
+    deployment: Arc<Deployment>,
     release_on_drop: bool,
 }
 
-impl<'router> DeploymentLease<'router> {
-    fn new(router: &'router Router, deployment_id: DeploymentId) -> Self {
+impl DeploymentLease {
+    fn new(deployment: Arc<Deployment>) -> Self {
         Self {
-            router,
-            deployment_id,
+            deployment,
             release_on_drop: true,
         }
     }
 
     pub fn deployment_id(&self) -> &str {
-        &self.deployment_id
+        &self.deployment.id
+    }
+
+    pub fn deployment(&self) -> &Deployment {
+        &self.deployment
     }
 
     pub fn clone_deployment_id(&self) -> DeploymentId {
         self.deployment_id().to_string()
     }
 
+    pub fn clone_deployment(&self) -> Arc<Deployment> {
+        self.deployment.clone()
+    }
+
+    /// Convert this lease into the legacy deployment-id API.
+    ///
+    /// Prefer keeping the lease alive so drop releases the exact snapshot
+    /// deployment. This exists for deprecated ID-returning selectors.
     pub fn into_deployment_id(mut self) -> DeploymentId {
         self.release_on_drop = false;
-        std::mem::take(&mut self.deployment_id)
+        self.deployment_id().to_string()
     }
 }
 
-impl Drop for DeploymentLease<'_> {
+impl Drop for DeploymentLease {
     fn drop(&mut self) {
         if self.release_on_drop {
-            self.router.release_deployment(&self.deployment_id);
+            Router::release_selected_deployment(self.deployment());
         }
     }
 }
@@ -66,6 +77,10 @@ impl Router {
     /// 3. Filter: healthy + not in cooldown + not rate limited
     /// 4. Select based on routing strategy
     /// 5. Increment active_requests counter
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use select_deployment_lease so the selected snapshot deployment is released by RAII"
+    )]
     pub fn select_deployment(&self, model_name: &str) -> Result<DeploymentId, RouterError> {
         self.select_deployment_lease(model_name)
             .map(DeploymentLease::into_deployment_id)
@@ -78,7 +93,7 @@ impl Router {
     pub fn select_deployment_lease(
         &self,
         model_name: &str,
-    ) -> Result<DeploymentLease<'_>, RouterError> {
+    ) -> Result<DeploymentLease, RouterError> {
         self.select_deployment_matching(model_name, |_| true, None)
     }
 
@@ -87,6 +102,10 @@ impl Router {
     /// This uses the same health, cooldown, concurrency, rate-limit, and
     /// strategy filters as `select_deployment`, then reserves the selected
     /// deployment by incrementing its active request count.
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use select_deployment_lease_for_capability so the selected snapshot deployment is released by RAII"
+    )]
     pub fn select_deployment_for_capability(
         &self,
         model_name: &str,
@@ -102,7 +121,7 @@ impl Router {
         &self,
         model_name: &str,
         capability: &ProviderCapability,
-    ) -> Result<DeploymentLease<'_>, RouterError> {
+    ) -> Result<DeploymentLease, RouterError> {
         let no_matching_candidate_error = RouterError::UnsupportedCapability {
             model: model_name.to_string(),
             capability: format!("{capability:?}"),
@@ -161,15 +180,17 @@ impl Router {
         model_name: &str,
         is_candidate: F,
         no_matching_candidate_error: Option<RouterError>,
-    ) -> Result<DeploymentLease<'_>, RouterError>
+    ) -> Result<DeploymentLease, RouterError>
     where
         F: Fn(&Deployment) -> bool,
     {
-        // 1. Resolve model aliases consistently with the public resolver.
-        let resolved_name = self.resolve_model_name(model_name);
+        // 1. Resolve model aliases and deployment indexes from one immutable
+        // routing generation.
+        let snapshot = self.routing_snapshot.load();
+        let resolved_name = snapshot.resolve_model_name(model_name);
 
         // 2. Get all deployment IDs for this model.
-        let deployment_ids_ref = self
+        let deployment_ids_ref = snapshot
             .model_index
             .get(&resolved_name)
             .ok_or_else(|| RouterError::ModelNotFound(model_name.to_string()))?;
@@ -186,7 +207,7 @@ impl Router {
         let mut routing_contexts = Vec::with_capacity(total_deployments);
 
         for id in deployment_ids_ref.iter() {
-            let Some(deployment) = self.deployments.get(id.as_str()) else {
+            let Some(deployment) = snapshot.deployments.get(id.as_str()) else {
                 continue;
             };
 
@@ -202,7 +223,7 @@ impl Router {
             }
             existing_deployments += 1;
 
-            if !is_candidate(&deployment) {
+            if !is_candidate(deployment) {
                 tracing::trace!(
                     deployment_id = id.as_str(),
                     model = %resolved_name,
@@ -316,7 +337,11 @@ impl Router {
             .ok_or_else(|| RouterError::NoAvailableDeployment(model_name.to_string()))?
             .clone();
 
-            if self.try_reserve_deployment(&selected_id) {
+            let Some(deployment) = snapshot.deployments.get(&selected_id).cloned() else {
+                continue;
+            };
+
+            if self.try_reserve_deployment(&deployment, &resolved_name) {
                 self.provider_selected_count.fetch_add(1, Relaxed);
                 self.strategy_used_count.fetch_add(1, Relaxed);
 
@@ -328,7 +353,7 @@ impl Router {
                     "deployment selected for routing"
                 );
 
-                return Ok(DeploymentLease::new(self, selected_id));
+                return Ok(DeploymentLease::new(deployment));
             }
 
             if let Some(pos) = routing_contexts
@@ -348,10 +373,10 @@ impl Router {
         Err(RouterError::NoAvailableDeployment(model_name.to_string()))
     }
 
-    fn try_reserve_deployment(&self, deployment_id: &str) -> bool {
-        let Some(deployment) = self.deployments.get(deployment_id) else {
+    fn try_reserve_deployment(&self, deployment: &Deployment, expected_model: &str) -> bool {
+        if deployment.model_name != expected_model {
             return false;
-        };
+        }
 
         match deployment.config.max_parallel_requests {
             Some(limit) => {
@@ -382,12 +407,22 @@ impl Router {
     /// Release a deployment after request completion
     ///
     /// Decrements the active_requests counter for the deployment.
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use select_deployment_lease so release targets the selected snapshot deployment"
+    )]
     pub fn release_deployment(&self, deployment_id: &str) {
-        if let Some(deployment) = self.deployments.get(deployment_id) {
-            let _ = deployment
-                .state
-                .active_requests
-                .fetch_update(Relaxed, Relaxed, |v| Some(v.saturating_sub(1)));
+        let snapshot = self.routing_snapshot.load();
+        if let Some(deployment) = snapshot.deployments.get(deployment_id) {
+            Self::release_selected_deployment(deployment);
         }
+    }
+
+    pub(crate) fn release_selected_deployment(deployment: &Deployment) {
+        let result = deployment
+            .state
+            .active_requests
+            .fetch_update(Relaxed, Relaxed, |v| Some(v.saturating_sub(1)));
+        debug_assert!(result.is_ok());
     }
 }

--- a/src/core/router/tests/concurrency_edge_case_tests.rs
+++ b/src/core/router/tests/concurrency_edge_case_tests.rs
@@ -7,6 +7,8 @@
 //! 4. EMA latency calculation edge cases (overflow, boundary values)
 //! 5. Cooldown expiry race conditions
 
+#![allow(deprecated)]
+
 use super::router_tests::create_test_deployment;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::deployment::{
@@ -461,13 +463,15 @@ async fn test_set_model_list_with_concurrent_selectors() {
         total_error += e;
     }
 
-    // The vast majority should succeed; transient errors during swap are acceptable
+    // Snapshot swaps install one complete generation, so selectors should see
+    // either the old or the new deployment set without transient routing gaps.
     assert!(
-        total_success > total_error * 10,
-        "too many errors: {} success vs {} errors",
+        total_error == 0,
+        "snapshot swap should not produce transient selector errors: {} success vs {} errors",
         total_success,
         total_error
     );
+    assert!(total_success > 0, "selectors should have made progress");
 }
 
 // ====================================================================================

--- a/src/core/router/tests/execution_tests.rs
+++ b/src/core/router/tests/execution_tests.rs
@@ -1,5 +1,7 @@
 //! Execution flow tests
 
+#![allow(deprecated)]
+
 use super::router_tests::create_test_deployment;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::router::config::RouterConfig;
@@ -59,6 +61,36 @@ async fn test_execute_once_success() {
     assert_eq!(exec_result.attempts, 1);
     assert!(!exec_result.used_fallback);
     assert!(exec_result.latency_us > 0);
+}
+
+#[tokio::test]
+async fn test_execute_once_with_selected_deployment_keeps_snapshot_after_same_id_swap() {
+    let router = std::sync::Arc::new(Router::default());
+    let deployment = create_test_deployment("same-id", "gpt-4").await;
+    router.add_deployment(deployment);
+
+    let router_for_operation = router.clone();
+    let result = router
+        .execute_once_with_selected_deployment("gpt-4", move |deployment| {
+            let router = router_for_operation.clone();
+            async move {
+                let selected_model = deployment.model.clone();
+                let mut replacement = create_test_deployment("same-id", "gpt-4").await;
+                replacement.model = "replacement-model".to_string();
+                router.set_model_list(vec![replacement]);
+                let current_model = router.get_deployment("same-id").unwrap().model.clone();
+                Ok(((selected_model, current_model), 100u64))
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.result.0, "gpt-4-turbo");
+    assert_eq!(result.result.1, "replacement-model");
+    assert_eq!(result.deployment_id, "same-id");
+    assert_eq!(result.model_used, "gpt-4-turbo");
+    let current = router.get_deployment("same-id").unwrap();
+    assert_eq!(current.state.total_requests.load(Ordering::Relaxed), 1);
 }
 
 #[tokio::test]

--- a/src/core/router/tests/router_tests.rs
+++ b/src/core/router/tests/router_tests.rs
@@ -1,9 +1,11 @@
 //! Core router tests
 
+#![allow(deprecated)]
+
 use crate::core::providers::Provider;
 use crate::core::providers::openai::OpenAIProvider;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
-use crate::core::router::deployment::Deployment;
+use crate::core::router::deployment::{Deployment, HealthStatus};
 use crate::core::router::unified::Router;
 use crate::core::types::model::ProviderCapability;
 use std::sync::atomic::Ordering;
@@ -107,6 +109,30 @@ async fn test_add_same_deployment_id_reindexes_when_model_changes() {
 }
 
 #[tokio::test]
+async fn test_add_same_deployment_id_preserves_runtime_state_when_model_changes() {
+    let router = Router::default();
+    let deployment1 = create_test_deployment("test-1", "gpt-4").await;
+    deployment1.state.tpm_current.store(321, Ordering::Relaxed);
+    deployment1.state.rpm_current.store(9, Ordering::Relaxed);
+    deployment1
+        .state
+        .active_requests
+        .store(3, Ordering::Relaxed);
+    deployment1.enter_cooldown(60);
+
+    router.add_deployment(deployment1);
+    router.add_deployment(create_test_deployment("test-1", "claude").await);
+
+    let current = router.get_deployment("test-1").unwrap();
+    assert_eq!(current.model_name, "claude");
+    assert_eq!(current.state.tpm_current.load(Ordering::Relaxed), 321);
+    assert_eq!(current.state.rpm_current.load(Ordering::Relaxed), 9);
+    assert_eq!(current.state.active_requests.load(Ordering::Relaxed), 3);
+    assert_eq!(current.state.health_status(), HealthStatus::Cooldown);
+    assert!(current.is_in_cooldown());
+}
+
+#[tokio::test]
 async fn test_add_multiple_models() {
     let router = Router::default();
     let deployment1 = create_test_deployment("test-1", "gpt-4").await;
@@ -186,6 +212,74 @@ async fn test_set_model_list_duplicate_id_reindexes_without_empty_old_model() {
     assert!(!router.list_models().contains(&"gpt-4".to_string()));
     assert!(router.get_deployments_for_model("gpt-4").is_empty());
     assert_eq!(router.get_deployments_for_model("claude"), vec!["test-1"]);
+}
+
+#[tokio::test]
+async fn test_set_model_list_installs_complete_snapshot_generation() {
+    let router = Router::default();
+
+    router.add_deployment(create_test_deployment("old-1", "gpt-4").await);
+    let old_snapshot = router.routing_snapshot.load_full();
+
+    router.set_model_list(vec![create_test_deployment("new-1", "claude").await]);
+    let new_snapshot = router.routing_snapshot.load_full();
+
+    assert!(old_snapshot.deployments.contains_key("old-1"));
+    assert_eq!(
+        old_snapshot.model_index.get("gpt-4"),
+        Some(&vec!["old-1".to_string()])
+    );
+    assert!(!old_snapshot.deployments.contains_key("new-1"));
+
+    assert!(new_snapshot.deployments.contains_key("new-1"));
+    assert_eq!(
+        new_snapshot.model_index.get("claude"),
+        Some(&vec!["new-1".to_string()])
+    );
+    assert!(!new_snapshot.deployments.contains_key("old-1"));
+    assert!(!new_snapshot.model_index.contains_key("gpt-4"));
+}
+
+#[tokio::test]
+async fn test_deployment_lease_releases_selected_snapshot_after_same_id_swap() {
+    let router = Router::default();
+
+    router.add_deployment(create_test_deployment("shared-id", "gpt-4").await);
+    let lease = router.select_deployment_lease("gpt-4").unwrap();
+    let selected_state = lease.deployment().state.clone();
+    assert_eq!(selected_state.active_requests.load(Ordering::Relaxed), 1);
+
+    router.set_model_list(vec![create_test_deployment("shared-id", "gpt-4").await]);
+
+    let current = router.get_deployment("shared-id").unwrap();
+    assert_eq!(current.state.active_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(selected_state.active_requests.load(Ordering::Relaxed), 1);
+
+    drop(lease);
+
+    assert_eq!(selected_state.active_requests.load(Ordering::Relaxed), 0);
+    assert_eq!(current.state.active_requests.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn test_set_model_list_preserves_runtime_state_for_existing_deployment_id() {
+    let router = Router::default();
+    let deployment = create_test_deployment("shared-id", "gpt-4").await;
+    deployment.state.tpm_current.store(123, Ordering::Relaxed);
+    deployment.state.rpm_current.store(7, Ordering::Relaxed);
+    deployment.state.active_requests.store(2, Ordering::Relaxed);
+    deployment.enter_cooldown(60);
+    router.add_deployment(deployment);
+
+    router.set_model_list(vec![create_test_deployment("shared-id", "claude").await]);
+
+    let current = router.get_deployment("shared-id").unwrap();
+    assert_eq!(current.model_name, "claude");
+    assert_eq!(current.state.tpm_current.load(Ordering::Relaxed), 123);
+    assert_eq!(current.state.rpm_current.load(Ordering::Relaxed), 7);
+    assert_eq!(current.state.active_requests.load(Ordering::Relaxed), 2);
+    assert_eq!(current.state.health_status(), HealthStatus::Cooldown);
+    assert!(current.is_in_cooldown());
 }
 
 #[tokio::test]

--- a/src/core/router/tests/selection_tests.rs
+++ b/src/core/router/tests/selection_tests.rs
@@ -3,6 +3,8 @@
 //! Tests edge cases and deterministic behavior for SimpleShuffle,
 //! RoundRobin, and LatencyBased strategies via `select_deployment`.
 
+#![allow(deprecated)]
+
 use super::router_tests::create_test_deployment;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::deployment::HealthStatus;

--- a/src/core/router/tests/strategy_tests.rs
+++ b/src/core/router/tests/strategy_tests.rs
@@ -1,5 +1,7 @@
 //! Strategy selection tests
 
+#![allow(deprecated)]
+
 use super::router_tests::create_test_deployment;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::deployment::HealthStatus;

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -11,10 +11,12 @@ use super::fallback::{FallbackConfig, FallbackType};
 use crate::core::providers::Provider;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::model::ProviderCapability;
+use arc_swap::ArcSwap;
 use dashmap::DashMap;
-use dashmap::mapref::one::Ref;
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering::Relaxed};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed};
 use std::time::Duration;
 
 const MAX_ALIAS_HOPS: usize = 16;
@@ -38,26 +40,149 @@ pub struct CapabilityDeployment {
     pub model: String,
 }
 
+/// Immutable deployment routing generation.
+///
+/// Each snapshot owns a complete, internally consistent view of deployments,
+/// model indexes, and aliases. Router readers load one snapshot and never walk
+/// split mutable maps from different generations.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RoutingSnapshot {
+    pub(crate) deployments: HashMap<DeploymentId, Arc<Deployment>>,
+    pub(crate) model_index: HashMap<String, Vec<DeploymentId>>,
+    pub(crate) model_aliases: HashMap<String, String>,
+}
+
+impl RoutingSnapshot {
+    fn from_deployments_preserving_state(
+        deployments: Vec<Deployment>,
+        previous: &RoutingSnapshot,
+    ) -> Self {
+        let mut snapshot = Self {
+            model_aliases: previous.model_aliases.clone(),
+            ..Default::default()
+        };
+
+        for mut deployment in deployments {
+            if let Some(old) = previous.deployments.get(&deployment.id) {
+                deployment.state = old.state.clone();
+            }
+            snapshot.insert_deployment(deployment);
+        }
+
+        snapshot
+    }
+
+    fn insert_deployment(&mut self, mut deployment: Deployment) {
+        let model_name = deployment.model_name.clone();
+        let deployment_id = deployment.id.clone();
+        if let Some(old) = self.deployments.get(&deployment_id) {
+            deployment.state = old.state.clone();
+        }
+
+        if let Some(old) = self
+            .deployments
+            .insert(deployment_id.clone(), Arc::new(deployment))
+            && old.model_name != model_name
+        {
+            self.remove_from_model_index(&old.model_name, &deployment_id);
+        }
+
+        let entry = self.model_index.entry(model_name).or_default();
+        if !entry.iter().any(|id| id == &deployment_id) {
+            entry.push(deployment_id);
+        }
+    }
+
+    fn remove_deployment(&mut self, id: &str) -> Option<Deployment> {
+        let removed = self.deployments.remove(id);
+
+        if let Some(ref deployment) = removed {
+            self.remove_from_model_index(&deployment.model_name, id);
+        }
+
+        removed.map(|deployment| deployment.as_ref().clone())
+    }
+
+    fn remove_from_model_index(&mut self, model_name: &str, deployment_id: &str) {
+        let should_remove = if let Some(entry) = self.model_index.get_mut(model_name) {
+            entry.retain(|did| did != deployment_id);
+            entry.is_empty()
+        } else {
+            false
+        };
+
+        if should_remove {
+            self.model_index.remove(model_name);
+        }
+    }
+
+    fn add_model_alias(
+        &mut self,
+        alias: &str,
+        model_name: &str,
+    ) -> Result<(), super::error::RouterError> {
+        if alias == model_name {
+            return Err(super::error::RouterError::AliasCycle(format!(
+                "'{alias}' -> '{model_name}' would create a cycle"
+            )));
+        }
+
+        let mut current = model_name.to_string();
+        let mut visited = HashSet::new();
+        visited.insert(alias.to_string());
+
+        while let Some(next) = self.model_aliases.get(&current) {
+            let next_val = next.clone();
+            if !visited.insert(next_val.clone()) {
+                return Err(super::error::RouterError::AliasCycle(format!(
+                    "'{alias}' -> '{model_name}' would create a cycle"
+                )));
+            }
+            current = next_val;
+        }
+
+        self.model_aliases
+            .insert(alias.to_string(), model_name.to_string());
+        Ok(())
+    }
+
+    pub(crate) fn resolve_model_name(&self, name: &str) -> String {
+        if self.model_aliases.is_empty() {
+            return name.to_string();
+        }
+
+        let mut current = name.to_string();
+
+        for _ in 0..MAX_ALIAS_HOPS {
+            if let Some(next) = self.model_aliases.get(&current) {
+                current = next.clone();
+            } else {
+                return current;
+            }
+        }
+
+        tracing::debug!(
+            requested_model = %name,
+            resolved_model = %current,
+            max_alias_hops = MAX_ALIAS_HOPS,
+            "model alias resolution hit hop limit"
+        );
+        current
+    }
+}
+
 /// Unified Router
 ///
 /// The central orchestrator for deployment management and intelligent routing.
 /// Uses lock-free data structures for high-performance concurrent access.
 #[derive(Debug)]
 pub struct Router {
-    /// All deployments (DashMap for lock-free concurrent access)
-    pub(crate) deployments: DashMap<DeploymentId, Deployment>,
+    /// Atomically installed routing metadata generation.
+    pub(crate) routing_snapshot: ArcSwap<RoutingSnapshot>,
 
-    /// Model name to deployment IDs index (for fast lookup)
-    pub(crate) model_index: DashMap<String, Vec<DeploymentId>>,
-
-    /// Model name aliases: "gpt4" -> "gpt-4"
-    pub(crate) model_aliases: DashMap<String, String>,
-
-    /// Fast-path gate for alias lookups in hot routing paths.
-    ///
-    /// Most deployments do not use aliases; this avoids an unnecessary DashMap
-    /// lookup when `model_aliases` is known to be empty.
-    pub(crate) has_model_aliases: AtomicBool,
+    /// Serializes snapshot writers so concurrent updates cannot overwrite one
+    /// another while readers keep using lock-free ArcSwap loads.
+    pub(crate) routing_snapshot_write_lock: Mutex<()>,
 
     /// Router configuration
     pub(crate) config: RouterConfig,
@@ -82,13 +207,11 @@ impl Router {
     /// Create a new router with the given configuration
     pub fn new(config: RouterConfig) -> Self {
         Self {
-            deployments: DashMap::new(),
-            model_index: DashMap::new(),
-            model_aliases: DashMap::new(),
-            has_model_aliases: AtomicBool::new(false),
+            routing_snapshot: ArcSwap::from_pointee(RoutingSnapshot::default()),
+            routing_snapshot_write_lock: Mutex::new(()),
             config,
             fallback_config: FallbackConfig::default(),
-            round_robin_counters: DashMap::new(),
+            round_robin_counters: Default::default(),
             provider_selected_count: AtomicU64::new(0),
             strategy_used_count: AtomicU64::new(0),
             fallback_triggered_count: AtomicU64::new(0),
@@ -122,101 +245,40 @@ impl Router {
 
     // ========== Deployment Management ==========
 
+    fn update_routing_snapshot(&self, update: impl FnOnce(&mut RoutingSnapshot)) {
+        let _guard = self.routing_snapshot_write_lock.lock();
+        let mut next = self.routing_snapshot.load_full().as_ref().clone();
+        update(&mut next);
+        self.routing_snapshot.store(Arc::new(next));
+    }
+
     /// Add a deployment to the router
     pub fn add_deployment(&self, deployment: Deployment) {
-        let model_name = deployment.model_name.clone();
-        let deployment_id = deployment.id.clone();
-
-        if let Some(existing) = self.deployments.get(&deployment_id) {
-            let old_model_name = existing.model_name.clone();
-            drop(existing);
-
-            if old_model_name != model_name {
-                self.remove_from_model_index(&old_model_name, &deployment_id);
-            }
-        }
-
-        self.deployments.insert(deployment_id.clone(), deployment);
-
-        let mut entry = self.model_index.entry(model_name).or_default();
-        if !entry.iter().any(|id| id == &deployment_id) {
-            entry.push(deployment_id);
-        }
+        self.update_routing_snapshot(|snapshot| snapshot.insert_deployment(deployment));
     }
 
     /// Remove a deployment from the router
     pub fn remove_deployment(&self, id: &str) -> Option<Deployment> {
-        let removed = self.deployments.remove(id).map(|(_, v)| v);
-
-        if let Some(ref deployment) = removed {
-            self.remove_from_model_index(&deployment.model_name, id);
-        }
-
+        let mut removed = None;
+        self.update_routing_snapshot(|snapshot| {
+            removed = snapshot.remove_deployment(id);
+        });
         removed
     }
 
-    fn remove_from_model_index(&self, model_name: &str, deployment_id: &str) {
-        let should_remove = if let Some(mut entry) = self.model_index.get_mut(model_name) {
-            entry.retain(|did| did != deployment_id);
-            entry.is_empty()
-        } else {
-            false
-        };
-
-        if should_remove {
-            self.model_index.remove(model_name);
-        }
-    }
-
     /// Get a deployment by ID
-    pub fn get_deployment(&self, id: &str) -> Option<Ref<'_, DeploymentId, Deployment>> {
-        self.deployments.get(id)
+    pub fn get_deployment(&self, id: &str) -> Option<Arc<Deployment>> {
+        self.routing_snapshot.load().deployments.get(id).cloned()
     }
 
     /// Set the complete list of deployments (batch operation)
     ///
-    /// Builds the new maps locally first, then swaps entry-by-entry so
-    /// concurrent readers never observe an empty deployment window.
+    /// Builds the new generation locally first, then installs it with a single
+    /// ArcSwap store so readers never observe mixed deployment/index state.
     pub fn set_model_list(&self, deployments: Vec<Deployment>) {
-        let new_deployments: DashMap<DeploymentId, Deployment> = DashMap::new();
-        let new_index: DashMap<String, Vec<DeploymentId>> = DashMap::new();
-
-        for deployment in deployments {
-            let model_name = deployment.model_name.clone();
-            let id = deployment.id.clone();
-            if let Some(old) = new_deployments.insert(id.clone(), deployment)
-                && old.model_name != model_name
-            {
-                let old_model_name = old.model_name;
-                let should_remove = if let Some(mut old_entry) = new_index.get_mut(&old_model_name)
-                {
-                    old_entry.retain(|did| did != &id);
-                    old_entry.is_empty()
-                } else {
-                    false
-                };
-
-                if should_remove {
-                    new_index.remove(&old_model_name);
-                }
-            }
-
-            let mut entry = new_index.entry(model_name).or_default();
-            if !entry.iter().any(|existing| existing == &id) {
-                entry.push(id);
-            }
-        }
-
-        self.deployments
-            .retain(|k, _| new_deployments.contains_key(k));
-        for (k, v) in new_deployments {
-            self.deployments.insert(k, v);
-        }
-
-        self.model_index.retain(|k, _| new_index.contains_key(k));
-        for (k, v) in new_index {
-            self.model_index.insert(k, v);
-        }
+        self.update_routing_snapshot(|snapshot| {
+            *snapshot = RoutingSnapshot::from_deployments_preserving_state(deployments, snapshot);
+        });
     }
 
     // ========== Model Aliases ==========
@@ -230,83 +292,45 @@ impl Router {
         alias: &str,
         model_name: &str,
     ) -> Result<(), super::error::RouterError> {
-        // Self-alias is always a cycle
-        if alias == model_name {
-            return Err(super::error::RouterError::AliasCycle(format!(
-                "'{alias}' -> '{model_name}' would create a cycle"
-            )));
-        }
-
-        // Walk the alias chain starting from model_name to detect cycles
-        let mut current = model_name.to_string();
-        let mut visited = std::collections::HashSet::new();
-        visited.insert(alias.to_string());
-
-        while let Some(next) = self.model_aliases.get(&current) {
-            let next_val = next.value().clone();
-            if !visited.insert(next_val.clone()) {
-                return Err(super::error::RouterError::AliasCycle(format!(
-                    "'{alias}' -> '{model_name}' would create a cycle"
-                )));
-            }
-            current = next_val;
-        }
-
-        self.model_aliases
-            .insert(alias.to_string(), model_name.to_string());
-        self.has_model_aliases.store(true, Relaxed);
+        let _guard = self.routing_snapshot_write_lock.lock();
+        let mut next = self.routing_snapshot.load_full().as_ref().clone();
+        next.add_model_alias(alias, model_name)?;
+        self.routing_snapshot.store(Arc::new(next));
         Ok(())
     }
 
     /// Resolve a model name (handles aliases)
     pub fn resolve_model_name(&self, name: &str) -> String {
-        if !self.has_model_aliases.load(Relaxed) {
-            return name.to_string();
-        }
-
-        let mut current = name.to_string();
-
-        for _ in 0..MAX_ALIAS_HOPS {
-            if let Some(next) = self.model_aliases.get(&current) {
-                current = next.value().clone();
-            } else {
-                return current;
-            }
-        }
-
-        tracing::debug!(
-            requested_model = %name,
-            resolved_model = %current,
-            max_alias_hops = MAX_ALIAS_HOPS,
-            "model alias resolution hit hop limit"
-        );
-        current
+        self.routing_snapshot.load().resolve_model_name(name)
     }
 
     // ========== Query Methods ==========
 
     /// Get all deployment IDs for a given model
     pub fn get_deployments_for_model(&self, model_name: &str) -> Vec<DeploymentId> {
-        let resolved_name = self.resolve_model_name(model_name);
+        let snapshot = self.routing_snapshot.load();
+        let resolved_name = snapshot.resolve_model_name(model_name);
 
-        self.model_index
+        snapshot
+            .model_index
             .get(&resolved_name)
-            .map(|v| v.clone())
+            .cloned()
             .unwrap_or_default()
     }
 
     /// Get healthy deployment IDs for a given model
     pub fn get_healthy_deployments(&self, model_name: &str) -> Vec<DeploymentId> {
-        let resolved_name = self.resolve_model_name(model_name);
+        let snapshot = self.routing_snapshot.load();
+        let resolved_name = snapshot.resolve_model_name(model_name);
 
-        let Some(deployment_ids) = self.model_index.get(&resolved_name) else {
+        let Some(deployment_ids) = snapshot.model_index.get(&resolved_name) else {
             return Vec::new();
         };
 
         let mut healthy = Vec::with_capacity(deployment_ids.len());
 
         for id in deployment_ids.iter() {
-            if let Some(deployment) = self.deployments.get(id.as_str())
+            if let Some(deployment) = snapshot.deployments.get(id.as_str())
                 && deployment.is_healthy()
                 && !deployment.is_in_cooldown()
             {
@@ -327,12 +351,13 @@ impl Router {
         model_name: &str,
         capability: &ProviderCapability,
     ) -> Option<CapabilityDeployment> {
-        let resolved_name = self.resolve_model_name(model_name);
+        let snapshot = self.routing_snapshot.load();
+        let resolved_name = snapshot.resolve_model_name(model_name);
 
-        let deployment_ids = self.model_index.get(&resolved_name)?;
+        let deployment_ids = snapshot.model_index.get(&resolved_name)?;
 
         for id in deployment_ids.iter() {
-            let Some(deployment) = self.deployments.get(id.as_str()) else {
+            let Some(deployment) = snapshot.deployments.get(id.as_str()) else {
                 continue;
             };
 
@@ -384,17 +409,21 @@ impl Router {
 
     /// List all model names
     pub fn list_models(&self) -> Vec<String> {
-        self.model_index
-            .iter()
-            .map(|entry| entry.key().clone())
+        self.routing_snapshot
+            .load()
+            .model_index
+            .keys()
+            .cloned()
             .collect()
     }
 
     /// List all deployment IDs
     pub fn list_deployments(&self) -> Vec<DeploymentId> {
-        self.deployments
-            .iter()
-            .map(|entry| entry.key().clone())
+        self.routing_snapshot
+            .load()
+            .deployments
+            .keys()
+            .cloned()
             .collect()
     }
 
@@ -405,19 +434,29 @@ impl Router {
     /// After recording, checks whether the deployment should be promoted from
     /// Degraded (half-open) back to Healthy based on `success_threshold`.
     pub fn record_success(&self, deployment_id: &str, tokens: u64, latency_us: u64) {
-        if let Some(deployment) = self.deployments.get(deployment_id) {
-            deployment.record_success(tokens, latency_us);
+        let snapshot = self.routing_snapshot.load();
+        if let Some(deployment) = snapshot.deployments.get(deployment_id) {
+            self.record_success_for_deployment(deployment, tokens, latency_us);
+        }
+    }
 
-            // Promote Degraded -> Healthy once enough consecutive successes
-            let current_health = deployment.state.health.load(Relaxed);
-            if current_health == super::deployment::HealthStatus::Degraded as u8 {
-                let consec = deployment.state.consecutive_successes.load(Relaxed);
-                if consec >= self.config.success_threshold {
-                    deployment
-                        .state
-                        .health
-                        .store(super::deployment::HealthStatus::Healthy as u8, Relaxed);
-                }
+    pub(crate) fn record_success_for_deployment(
+        &self,
+        deployment: &Deployment,
+        tokens: u64,
+        latency_us: u64,
+    ) {
+        deployment.record_success(tokens, latency_us);
+
+        // Promote Degraded -> Healthy once enough consecutive successes
+        let current_health = deployment.state.health.load(Relaxed);
+        if current_health == super::deployment::HealthStatus::Degraded as u8 {
+            let consec = deployment.state.consecutive_successes.load(Relaxed);
+            if consec >= self.config.success_threshold {
+                deployment
+                    .state
+                    .health
+                    .store(super::deployment::HealthStatus::Healthy as u8, Relaxed);
             }
         }
     }
@@ -428,65 +467,79 @@ impl Router {
     /// reaches `allowed_fails` **and** the total requests this minute meet the
     /// `min_requests` threshold.
     pub fn record_failure(&self, deployment_id: &str) {
-        if let Some(deployment) = self.deployments.get(deployment_id) {
-            deployment.record_failure();
+        let snapshot = self.routing_snapshot.load();
+        if let Some(deployment) = snapshot.deployments.get(deployment_id) {
+            self.record_failure_for_deployment(deployment);
+        }
+    }
 
-            let fails = deployment.state.fails_this_minute.load(Relaxed);
-            let successes_this_minute = deployment.state.rpm_current.load(Relaxed);
-            let total_this_minute = successes_this_minute + fails as u64;
-            if fails >= self.config.allowed_fails
-                && total_this_minute >= self.config.min_requests as u64
-            {
-                tracing::info!(
-                    deployment_id = %deployment_id,
-                    model = %deployment.model_name,
-                    reason = "consecutive_failures",
-                    cooldown_secs = self.config.cooldown_time_secs,
-                    fails_this_minute = fails,
-                    "deployment entering cooldown"
-                );
-                deployment.enter_cooldown(self.config.cooldown_time_secs);
-            }
+    pub(crate) fn record_failure_for_deployment(&self, deployment: &Deployment) {
+        deployment.record_failure();
+
+        let fails = deployment.state.fails_this_minute.load(Relaxed);
+        let successes_this_minute = deployment.state.rpm_current.load(Relaxed);
+        let total_this_minute = successes_this_minute + fails as u64;
+        if fails >= self.config.allowed_fails
+            && total_this_minute >= self.config.min_requests as u64
+        {
+            tracing::info!(
+                deployment_id = %deployment.id,
+                model = %deployment.model_name,
+                reason = "consecutive_failures",
+                cooldown_secs = self.config.cooldown_time_secs,
+                fails_this_minute = fails,
+                "deployment entering cooldown"
+            );
+            deployment.enter_cooldown(self.config.cooldown_time_secs);
         }
     }
 
     /// Record a failed request with a specific reason
     pub fn record_failure_with_reason(&self, deployment_id: &str, reason: CooldownReason) {
-        if let Some(d) = self.deployments.get(deployment_id) {
-            d.record_failure();
+        let snapshot = self.routing_snapshot.load();
+        if let Some(d) = snapshot.deployments.get(deployment_id) {
+            self.record_failure_with_reason_for_deployment(d, reason);
+        }
+    }
 
-            let should_cooldown = match reason {
-                CooldownReason::RateLimit
-                | CooldownReason::AuthError
-                | CooldownReason::NotFound
-                | CooldownReason::Timeout
-                | CooldownReason::Manual => true,
+    pub(crate) fn record_failure_with_reason_for_deployment(
+        &self,
+        deployment: &Deployment,
+        reason: CooldownReason,
+    ) {
+        deployment.record_failure();
 
-                CooldownReason::ConsecutiveFailures => {
-                    let fails = d.state.fails_this_minute.load(Relaxed);
-                    let successes_this_minute = d.state.rpm_current.load(Relaxed);
-                    let total_this_minute = successes_this_minute + fails as u64;
-                    fails >= self.config.allowed_fails
-                        && total_this_minute >= self.config.min_requests as u64
-                }
+        let should_cooldown = match reason {
+            CooldownReason::RateLimit
+            | CooldownReason::AuthError
+            | CooldownReason::NotFound
+            | CooldownReason::Timeout
+            | CooldownReason::Manual => true,
 
-                CooldownReason::HighFailureRate => {
-                    let total = d.state.total_requests.load(Relaxed);
-                    let fails = d.state.fail_requests.load(Relaxed);
-                    total >= self.config.min_requests as u64 && (fails * 100 / total) > 50
-                }
-            };
-
-            if should_cooldown {
-                tracing::info!(
-                    deployment_id = %deployment_id,
-                    model = %d.model_name,
-                    reason = ?reason,
-                    cooldown_secs = self.config.cooldown_time_secs,
-                    "deployment entering cooldown"
-                );
-                d.enter_cooldown(self.config.cooldown_time_secs);
+            CooldownReason::ConsecutiveFailures => {
+                let fails = deployment.state.fails_this_minute.load(Relaxed);
+                let successes_this_minute = deployment.state.rpm_current.load(Relaxed);
+                let total_this_minute = successes_this_minute + fails as u64;
+                fails >= self.config.allowed_fails
+                    && total_this_minute >= self.config.min_requests as u64
             }
+
+            CooldownReason::HighFailureRate => {
+                let total = deployment.state.total_requests.load(Relaxed);
+                let fails = deployment.state.fail_requests.load(Relaxed);
+                total >= self.config.min_requests as u64 && (fails * 100 / total) > 50
+            }
+        };
+
+        if should_cooldown {
+            tracing::info!(
+                deployment_id = %deployment.id,
+                model = %deployment.model_name,
+                reason = ?reason,
+                cooldown_secs = self.config.cooldown_time_secs,
+                "deployment entering cooldown"
+            );
+            deployment.enter_cooldown(self.config.cooldown_time_secs);
         }
     }
 
@@ -534,8 +587,9 @@ impl Router {
 
     /// Reset per-minute counters for all deployments
     pub fn reset_minute_counters(&self) {
-        for entry in self.deployments.iter() {
-            entry.value().state.reset_minute();
+        let snapshot = self.routing_snapshot.load();
+        for deployment in snapshot.deployments.values() {
+            deployment.state.reset_minute();
         }
     }
 

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -2,6 +2,7 @@
 
 use crate::core::providers::{Provider, ProviderError};
 use crate::core::router::UnifiedRouter;
+use crate::core::router::deployment::Deployment;
 use crate::core::router::execution::{
     calculate_retry_delay, infer_cooldown_reason, is_retryable_error,
     router_error_to_provider_error,
@@ -14,16 +15,16 @@ use std::time::Instant;
 /// Holds a selected deployment active for the lifetime of a streaming response.
 pub(super) struct StreamingDeploymentLease {
     router: Arc<UnifiedRouter>,
-    deployment_id: String,
+    deployment: Arc<Deployment>,
     started_at: Instant,
     finalized: bool,
 }
 
 impl StreamingDeploymentLease {
-    fn new(router: Arc<UnifiedRouter>, deployment_id: String, started_at: Instant) -> Self {
+    fn new(router: Arc<UnifiedRouter>, deployment: Arc<Deployment>, started_at: Instant) -> Self {
         Self {
             router,
-            deployment_id,
+            deployment,
             started_at,
             finalized: false,
         }
@@ -32,20 +33,20 @@ impl StreamingDeploymentLease {
     pub(super) fn finish_success(mut self, tokens_used: u64) {
         let latency_us = self.started_at.elapsed().as_micros() as u64;
         self.router
-            .record_success(&self.deployment_id, tokens_used, latency_us);
+            .record_success_for_deployment(&self.deployment, tokens_used, latency_us);
         self.release();
     }
 
     pub(super) fn finish_failure(mut self, error: &ProviderError) {
         let cooldown_reason = infer_cooldown_reason(error);
         self.router
-            .record_failure_with_reason(&self.deployment_id, cooldown_reason);
+            .record_failure_with_reason_for_deployment(&self.deployment, cooldown_reason);
         self.release();
     }
 
     fn release(&mut self) {
         if !self.finalized {
-            self.router.release_deployment(&self.deployment_id);
+            UnifiedRouter::release_selected_deployment(&self.deployment);
             self.finalized = true;
         }
     }
@@ -71,25 +72,73 @@ where
     F: Fn(Provider, String) -> Fut + Clone,
     Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
 {
-    let execution = router
-        .execute_with_capability_retry(requested_model, &capability, move |deployment_id| {
-            let operation = operation.clone();
-            async move {
-                let deployment = router.get_deployment(&deployment_id).ok_or_else(|| {
-                    ProviderError::other("router", "Selected deployment not found")
-                })?;
+    let max_attempts = router.config().num_retries + 1;
+    let mut last_error = None;
 
-                let provider = deployment.provider.clone();
-                let selected_model = deployment.model.clone();
-                drop(deployment);
+    for attempt in 1..=max_attempts {
+        let started_at = Instant::now();
 
-                operation(provider, selected_model).await
+        let deployment_lease =
+            match router.select_deployment_lease_for_capability(requested_model, &capability) {
+                Ok(lease) => lease,
+                Err(router_err) => {
+                    let provider_err = router_error_to_provider_error(router_err);
+
+                    if is_retryable_error(&provider_err) && attempt < max_attempts {
+                        let delay = calculate_retry_delay(router.config(), attempt);
+                        last_error = Some(provider_err);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+
+                    return Err(GatewayError::Provider(provider_err));
+                }
+            };
+
+        let provider = deployment_lease.deployment().provider.clone();
+        let selected_model = deployment_lease.deployment().model.clone();
+
+        match operation.clone()(provider, selected_model).await {
+            Ok((value, tokens_used)) => {
+                let latency_us = started_at.elapsed().as_micros() as u64;
+                router.record_success_for_deployment(
+                    deployment_lease.deployment(),
+                    tokens_used,
+                    latency_us,
+                );
+                drop(deployment_lease);
+                return Ok(value);
             }
-        })
-        .await
-        .map_err(|(e, _)| GatewayError::Provider(e))?;
+            Err(err) => {
+                if is_retryable_error(&err) && attempt < max_attempts {
+                    router.record_failure_with_reason_for_deployment(
+                        deployment_lease.deployment(),
+                        crate::core::router::CooldownReason::ConsecutiveFailures,
+                    );
+                    drop(deployment_lease);
+                    let delay = calculate_retry_delay(router.config(), attempt);
+                    last_error = Some(err);
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
 
-    Ok(execution.0)
+                let cooldown_reason = infer_cooldown_reason(&err);
+                router.record_failure_with_reason_for_deployment(
+                    deployment_lease.deployment(),
+                    cooldown_reason,
+                );
+                drop(deployment_lease);
+                return Err(GatewayError::Provider(err));
+            }
+        }
+    }
+
+    Err(GatewayError::Provider(last_error.unwrap_or_else(|| {
+        ProviderError::Other {
+            provider: "router",
+            message: "Unknown error during selected deployment retry".to_string(),
+        }
+    })))
 }
 
 /// Start a streaming operation while keeping the selected deployment active.
@@ -129,39 +178,23 @@ where
                     return Err(GatewayError::Provider(provider_err));
                 }
             };
-        let deployment_id = deployment_lease.clone_deployment_id();
-
-        let Some(deployment) = router.get_deployment(&deployment_id) else {
-            drop(deployment_lease);
-            let err = ProviderError::other("router", "Selected deployment not found");
-            if is_retryable_error(&err) && attempt < max_attempts {
-                let delay = calculate_retry_delay(router.config(), attempt);
-                last_error = Some(err);
-                tokio::time::sleep(delay).await;
-                continue;
-            }
-            return Err(GatewayError::Provider(err));
-        };
-
+        let deployment = deployment_lease.clone_deployment();
         let provider = deployment.provider.clone();
         let selected_model = deployment.model.clone();
-        drop(deployment);
 
         match operation.clone()(provider, selected_model).await {
             Ok(stream) => {
-                let deployment_id = deployment_lease.into_deployment_id();
-                let lease =
-                    StreamingDeploymentLease::new(router.clone(), deployment_id, started_at);
+                let _deployment_id = deployment_lease.into_deployment_id();
+                let lease = StreamingDeploymentLease::new(router.clone(), deployment, started_at);
                 return Ok((stream, lease));
             }
             Err(err) => {
-                drop(deployment_lease);
-
                 if is_retryable_error(&err) && attempt < max_attempts {
-                    router.record_failure_with_reason(
-                        &deployment_id,
+                    router.record_failure_with_reason_for_deployment(
+                        deployment_lease.deployment(),
                         crate::core::router::CooldownReason::ConsecutiveFailures,
                     );
+                    drop(deployment_lease);
                     let delay = calculate_retry_delay(router.config(), attempt);
                     last_error = Some(err);
                     tokio::time::sleep(delay).await;
@@ -169,7 +202,11 @@ where
                 }
 
                 let cooldown_reason = infer_cooldown_reason(&err);
-                router.record_failure_with_reason(&deployment_id, cooldown_reason);
+                router.record_failure_with_reason_for_deployment(
+                    deployment_lease.deployment(),
+                    cooldown_reason,
+                );
+                drop(deployment_lease);
                 return Err(GatewayError::Provider(err));
             }
         }

--- a/tests/integration/router_tests.rs
+++ b/tests/integration/router_tests.rs
@@ -4,6 +4,8 @@
 
 #[cfg(test)]
 mod tests {
+    #![allow(deprecated)]
+
     use litellm_rs::core::providers::Provider;
     use litellm_rs::core::providers::openai::OpenAIProvider;
     use litellm_rs::core::router::deployment::{


### PR DESCRIPTION
## Summary
- Add an immutable `RoutingSnapshot` behind `ArcSwap` so router metadata readers see one deployment/index/alias generation.
- Serialize snapshot writers and rebuild complete generations for add/remove/set-model-list/alias updates.
- Make `DeploymentState` clones share runtime counters, preserve existing runtime state on same-id deployment updates, and carry the selected `Arc<Deployment>` through leases, core execution, and server route helpers.
- Deprecate legacy ID-only selector/release/execution APIs where same-id snapshot swaps can rebind callers to the wrong deployment.
- Add regressions for complete snapshot generation, same-id snapshot swaps, shared state, release-mode lease release, selected-deployment execution, and concurrent selector stability.

## Notes
- `Router::get_deployment` now returns an `Arc<Deployment>` snapshot handle instead of a borrowed DashMap ref-shaped value, matching the new snapshot lifetime model.
- This PR is scoped to #710 only; #711/#713/#714/#715 remain separate follow-up slices.

Fixes #710

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --message-format=short`
- `FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo clippy --lib --tests --bins --features "$FEATURES" -- -D warnings --force-warn clippy::collapsible-if`
- `cargo test test_execute_once_with_selected_deployment_keeps_snapshot_after_same_id_swap --lib`
- `cargo test router --lib`
- `cargo test --lib -- --test-threads=1`
- `cargo test --release test_deployment_lease_releases_selected_snapshot_after_same_id_swap --lib`

## Threads review
- Native reviewer found and verified the release-build `debug_assert!` release blocker was fixed.
- GitHub review feedback on `release_deployment` and `set_model_list` was fixed and the two review threads were resolved.
- Final native reviewer found the remaining ID-only core execution callback hazard; this is fixed by selected-deployment execution APIs plus deprecating the legacy ID-only wrappers.
