### PR TITLE
fix: align provider contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ Providers are organised into two tiers (see [CLAUDE.md → Provider Tiers](./CLA
 - **Tier 1 — catalog-only**: OpenAI-compatible endpoints declared as data in [`src/core/providers/registry/catalog.rs`](./src/core/providers/registry/catalog.rs). Routed through `OpenAILikeProvider`. Always available (no cargo feature required). The current crate runtime exposes chat completions and chat streaming for these providers; embeddings, images, audio, and other non-chat endpoints are not forwarded yet.
 - **Tier 2 — code-based**: providers with custom request/response handling, auth signing, or streaming. Wired into the `Provider` enum and the factory. Some Tier 2 builders are feature-gated.
 
+Router deployments use the closed `Provider` enum. Implementing `LLMProvider`
+alone does not make a third-party provider routeable; use the generic
+OpenAI-compatible path for compatible endpoints, or wire a code-based provider
+into the enum, dispatch, registry metadata, and factory.
+
 > The matrix below is **hand-maintained** and reflects the runtime surface today. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 wiring lives in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Capability columns describe which endpoints this crate exposes for the provider — `passthrough` means an implemented crate endpoint forwards the call to the upstream OpenAI-compatible endpoint without per-provider transformation. A dynamically-generated matrix is tracked as a follow-up.
 
 ### Tier 2 — code-based providers

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -17,12 +17,13 @@ LiteLLM-RS implements a **Unified Provider Architecture** that combines the best
 - **Exhaustive pattern matching**: Compiler ensures all providers are handled
 
 ### 3. **Developer Experience**
-- **Uniform API**: All providers implement the same `LLMProvider` trait
+- **Uniform API**: Built-in providers implement the same `LLMProvider` trait
 - **Macro-driven dispatch**: No repetitive match statements in user code
 - **Clear error handling**: Unified error conversion with context preservation
 
 ### 4. **Extensibility**
-- **Trait-based interface**: New providers only need to implement `LLMProvider`
+- **Trait-based implementation**: new routed providers must implement `LLMProvider`
+  and be wired into the `Provider` enum, dispatch macros, and factory path
 - **Modular design**: Each provider is self-contained
 - **Configuration flexibility**: Provider-specific config types
 
@@ -132,6 +133,11 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
 - **Gradual feature adoption**: Optional methods have default "not supported" implementations
 - **Strong typing**: Associated types ensure type safety across provider implementations
 - **Future-proof**: New methods can be added with default implementations
+
+`LLMProvider` is not currently a standalone router plugin boundary. Router
+deployments store the closed `Provider` enum, so a third-party implementation
+must also be added to the enum, dispatch macros, and factory wiring before it can
+serve routed traffic.
 
 ### 3. Dispatch Macros (Boilerplate Elimination)
 
@@ -285,7 +291,7 @@ async fn try_providers(
 
 ## 🔧 Extending the Architecture
 
-### Adding a New Provider
+### Adding a New Routed Provider
 
 1. **Implement the Provider**:
 

--- a/docs/comparison/03-providers.md
+++ b/docs/comparison/03-providers.md
@@ -7,7 +7,7 @@
 | **Total Providers** | 16 | 100+ |
 | **Architecture** | Trait-based (compile-time) | Class-based (runtime) |
 | **Type Safety** | Compile-time verification | Runtime checks |
-| **Extensibility** | Implement `LLMProvider` trait | Inherit `BaseConfig` class |
+| **Extensibility** | Implement `LLMProvider` and wire into `Provider` enum/factory | Inherit `BaseConfig` class |
 | **Maturity** | Early stage | Production-ready |
 
 ---
@@ -95,6 +95,10 @@ TOTAL                      16      100+
 ## 2. Provider Implementation Architecture
 
 ### 2.1 Rust: Trait-Based Architecture
+
+In `litellm-rs`, `LLMProvider` is the implementation trait for built-in
+providers. Router deployments use the closed `Provider` enum, so implementing
+the trait alone does not make a third-party provider routeable.
 
 ```rust
 // Core LLMProvider trait definition
@@ -368,6 +372,9 @@ impl LLMProvider for NewProvider {
     // ... implement other required methods
 }
 ```
+
+The provider must also be added to the `Provider` enum, dispatch arms, provider
+type metadata, and factory wiring before router deployments can use it.
 
 **Step 4: Add to Provider Enum**
 ```rust

--- a/specs/GH713/product.md
+++ b/specs/GH713/product.md
@@ -1,0 +1,66 @@
+# Product Spec
+
+## Linked Issue
+
+GH-713
+
+## User Problem
+
+The public provider contract is ambiguous. `LLMProvider` is documented as the
+core provider abstraction, while router deployments store the closed
+`Provider` enum. A third-party `LLMProvider` implementation cannot be routed
+unless the crate also adds an enum variant and dispatch wiring.
+
+`ProviderHandle` makes the confusion worse because it is public and described as
+a type-erased routing wrapper, but its core methods return optimistic stub data:
+all models and tools are supported, health is healthy, cost is zero, latency is
+fixed, and success rate is 100%.
+
+## Goals
+
+- Make the router provider contract explicit: deployments route through the
+  built-in `Provider` enum.
+- Keep `LLMProvider` documented as the implementation trait for providers wired
+  into this crate, not as a standalone router plugin boundary.
+- Keep `ProviderHandle` compatible as a legacy wrapper, but stop presenting it
+  as a real routing abstraction.
+- Ensure `ProviderHandle` no longer returns optimistic capability, health, cost,
+  latency, or success-rate data.
+- Record the decision in SpecRail so #714 can focus on registry and declaration
+  source-of-truth work.
+
+## Non-Goals
+
+- Do not introduce a `dyn LLMProvider` router path in this issue.
+- Do not add `Provider::Custom` or external custom provider routing.
+- Do not solve the #714 provider registry/catalog drift in this PR.
+- Do not split provider retry/error/HTTP mapping responsibilities from #715.
+- Do not change provider factory feature gates or generated docs matrices.
+
+## User-Visible Behavior
+
+The router continues to use built-in provider deployments only. Public docs no
+longer imply that implementing `LLMProvider` alone makes a provider routeable.
+Any code still using `ProviderHandle` receives explicit unsupported/unknown
+results instead of fabricated healthy or successful routing data.
+
+## Acceptance Criteria
+
+- [x] `LLMProvider` docs state that router dispatch currently requires a
+  built-in `Provider` enum variant and dispatch wiring.
+- [x] `Provider`/`Deployment` docs identify the built-in enum as the router
+  deployment contract.
+- [x] `ProviderHandle` docs no longer advertise it as an active router dispatch
+  wrapper.
+- [x] `ProviderHandle::supports_model` and `supports_tools` do not return
+  optimistic `true` by default.
+- [x] `ProviderHandle::health_check` does not report `Healthy` without evidence.
+- [x] `ProviderHandle` cost, latency, and success-rate methods return explicit
+  errors instead of fabricated values.
+- [x] Tests cover the non-optimistic `ProviderHandle` behavior.
+
+## Follow-Up
+
+#714 should add registry/source-of-truth conformance around the built-in provider
+set. A future custom-provider issue can revisit an object-safe adapter or hybrid
+`Provider::Custom` design after the closed contract is stable.

--- a/specs/GH713/tasks.md
+++ b/specs/GH713/tasks.md
@@ -1,0 +1,43 @@
+# Task Plan
+
+## Linked Issue
+
+GH-713
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [x] `SP713-T1` Owner: coordinator. Done when: SpecRail product and tech specs record the closed built-in provider contract and #714 boundary. Verify: `check_workflow.py --spec-dir /private/tmp/litellm-rs-issue713/specs/GH713`.
+- [x] `SP713-T2` Owner: coordinator. Done when: `LLMProvider`, `Provider`, `Deployment`, and `ProviderHandle` docs no longer imply standalone custom-provider router support. Verify: targeted `rg` for provider-contract wording.
+- [x] `SP713-T3` Owner: coordinator. Done when: `ProviderHandle` stops returning optimistic support, health, cost, latency, and success-rate data. Verify: `cargo test provider_handle --lib`.
+- [x] `SP713-T4` Owner: coordinator. Done when: #713 remains separate from #714 registry/source-of-truth implementation. Verify: git diff contains no registry/catalog/provider matrix rewrite.
+- [ ] `SP713-T5` Owner: coordinator. Done when: PR body records SpecRail readiness/review/merge gates and threads closure audit. Verify: PR template checklist is completed with fresh CI/review evidence.
+
+## Parallel Split
+
+- Main coordinator owns writable files for `specs/GH713/**`,
+  `src/core/traits/provider/**`, `src/core/providers/mod.rs`, and
+  `src/core/router/deployment.rs`.
+- Threads lane #713 is read-only planning/review of the provider contract.
+- Threads lane #714 is read-only planning so registry/source-of-truth work stays
+  out of this PR.
+
+## Verification
+
+- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/route_gate.py --repo /Users/apple/Desktop/code/AI/tool/specrail --route write_spec --issue 713 --state ready_to_spec --mode advisory --json`
+- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue713/specs/GH713`
+- `cargo test provider_handle --lib`
+- `cargo test test_create_provider_reports_unknown_custom_provider --lib`
+- `cargo test provider_registry_contains_all_non_custom_provider_types --lib`
+- `cargo check --all-features --locked`
+- `cargo test --lib`
+
+## Handoff Notes
+
+SpecRail implementation is advisory until maintainer labels are applied on
+GitHub. The user has authorized continuing through PR and merge gates when
+threads, CI, reviewThreads, and SpecRail review evidence are clean.

--- a/specs/GH713/tasks.md
+++ b/specs/GH713/tasks.md
@@ -15,7 +15,7 @@ GH-713
 - [x] `SP713-T2` Owner: coordinator. Done when: `LLMProvider`, `Provider`, `Deployment`, and `ProviderHandle` docs no longer imply standalone custom-provider router support. Verify: targeted `rg` for provider-contract wording.
 - [x] `SP713-T3` Owner: coordinator. Done when: `ProviderHandle` stops returning optimistic support, health, cost, latency, and success-rate data. Verify: `cargo test provider_handle --lib`.
 - [x] `SP713-T4` Owner: coordinator. Done when: #713 remains separate from #714 registry/source-of-truth implementation. Verify: git diff contains no registry/catalog/provider matrix rewrite.
-- [ ] `SP713-T5` Owner: coordinator. Done when: PR body records SpecRail readiness/review/merge gates and threads closure audit. Verify: PR template checklist is completed with fresh CI/review evidence.
+- [x] `SP713-T5` Owner: coordinator. Done when: PR body records SpecRail readiness/review/merge gates and threads closure audit. Verify: PR #721 template checklist is completed with fresh CI/review evidence.
 
 ## Parallel Split
 

--- a/specs/GH713/tech.md
+++ b/specs/GH713/tech.md
@@ -1,0 +1,68 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-713
+
+## Product Spec
+
+Link to `product.md`.
+
+## Current System
+
+- `src/core/router/deployment.rs` stores `pub provider: Provider` in every
+  router deployment.
+- `src/core/providers/mod.rs` defines the closed `Provider` enum and dispatch
+  macro arms that call each concrete provider implementation.
+- `src/core/traits/provider/llm_provider/trait_definition.rs` documents
+  `LLMProvider` as the core abstraction, including routing-oriented language.
+- `src/core/traits/provider/handle.rs` stores an erased provider in
+  `ProviderHandle`, but does not downcast or call it.
+- `ProviderHandle` currently returns optimistic placeholder results for
+  capability, health, cost, latency, and success-rate methods.
+
+## Proposed Design
+
+Choose the closed built-in provider contract for this PR.
+
+1. Update module and type docs so they say the router deployment boundary is the
+   `Provider` enum.
+2. Update `LLMProvider` docs to describe it as the implementation interface for
+   providers compiled and wired into the crate. Third-party implementations
+   require crate integration before they can be routed.
+3. Keep `ProviderHandle` for source compatibility, but describe it as a legacy
+   metadata wrapper rather than a router dispatch path.
+4. Change `ProviderHandle` methods to avoid fabricated success:
+   - `supports_model` returns `false`.
+   - `supports_tools` returns `false`.
+   - `health_check` returns `HealthStatus::Unknown`.
+   - `calculate_cost`, `get_average_latency`, and `get_success_rate` return
+     `GatewayError::Internal` with a direct unsupported-contract message.
+   - `chat_completion` continues to return an explicit error, with wording tied
+     to the closed `Provider` enum route.
+5. Add tests in `handle.rs` that construct a module-local test handle and assert
+   the non-optimistic behavior.
+
+## Alternatives
+
+- Add `Provider::Custom(Arc<dyn DynProvider>)`: broader public API and routing
+  change; defer until a custom-provider design is accepted.
+- Replace `ProviderHandle` with a real object-safe adapter: useful long term,
+  but out of scope for the narrow #713 contract alignment.
+- Remove `ProviderHandle`: more breaking than necessary for this compatibility
+  cleanup.
+
+## Test Plan
+
+- [x] Unit tests: `ProviderHandle` capability methods return false.
+- [x] Unit tests: `ProviderHandle` health returns `Unknown`.
+- [x] Unit tests: `ProviderHandle` cost/latency/success methods return
+  explicit errors.
+- [x] Build check: `cargo test provider_handle --lib`.
+- [x] Build check: `cargo check --all-features --locked`.
+
+## Rollback Plan
+
+If the compatibility change breaks downstream users, keep the documentation
+clarification and restore the old method bodies only behind explicit follow-up
+review. No schema, feature, or persistent data migration is involved.

--- a/src/ARCHITECTURE_ENHANCEMENT.md
+++ b/src/ARCHITECTURE_ENHANCEMENT.md
@@ -32,6 +32,10 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
 }
 ```
 
+`LLMProvider` is the implementation interface for providers compiled into this
+crate. It is not a standalone router plugin boundary: routed providers must also
+be wired into the closed `Provider` enum and factory/dispatch paths.
+
 ### 2. Error Mapping Mechanism
 
 Implemented a unified error mapping system that supports converting HTTP errors to standardized provider errors:
@@ -173,14 +177,14 @@ impl LLMProvider for MyProvider {
 ### 3. 可扩展架构
 
 ```rust
-// 添加新 provider 只需实现 trait
+// 添加新的 routed provider 需要实现 trait
 pub struct NewProvider { /* ... */ }
 
 impl LLMProvider for NewProvider {
     // 实现所有必需方法
 }
 
-// 自动获得所有框架功能
+// 还必须接入 Provider enum、dispatch 和 factory 后才能进入 router
 ```
 
 ### 4. 完备的测试支持

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -1,6 +1,9 @@
-//! AI Provider implementations using Rust-idiomatic enum-based design
+//! AI Provider implementations using Rust-idiomatic enum-based design.
 //!
-//! This module contains the unified Provider enum and all provider implementations.
+//! This module contains the closed `Provider` enum used by router deployments
+//! plus the built-in provider implementations wired into that enum. Implementing
+//! `LLMProvider` alone does not make a provider routeable; new routed providers
+//! must be added to the enum, dispatch arms, and factory wiring.
 
 // Base infrastructure
 pub mod base;
@@ -387,10 +390,13 @@ macro_rules! dispatch_provider_selective {
     };
 }
 
-/// Unified Provider Enum (Rust-idiomatic design)
+/// Unified built-in Provider enum (Rust-idiomatic design).
 ///
 /// This enum provides zero-cost abstractions and type safety for all providers.
-/// Each variant contains a concrete provider implementation.
+/// Each variant contains a concrete provider implementation. Router
+/// deployments dispatch through this closed enum; third-party `LLMProvider`
+/// implementations are not routeable without crate changes that add enum,
+/// dispatch, and factory support.
 #[derive(Debug, Clone)]
 pub enum Provider {
     OpenAI(openai::OpenAIProvider),

--- a/src/core/router/deployment.rs
+++ b/src/core/router/deployment.rs
@@ -248,7 +248,11 @@ pub struct Deployment {
     /// Unique deployment ID
     pub id: DeploymentId,
 
-    /// Provider instance
+    /// Built-in provider enum instance.
+    ///
+    /// Router deployments dispatch through the closed `Provider` enum. A
+    /// third-party `LLMProvider` implementation is not routeable here unless it
+    /// is wired into that enum and its dispatch/factory paths.
     pub provider: Provider,
 
     /// Actual model name (e.g., "azure/gpt-4-turbo")
@@ -273,7 +277,7 @@ impl Deployment {
     /// # Arguments
     ///
     /// * `id` - Unique deployment identifier
-    /// * `provider` - Provider instance
+    /// * `provider` - Built-in provider enum instance
     /// * `model` - Actual model name (provider-specific)
     /// * `model_name` - User-facing model name (model group)
     pub fn new(id: DeploymentId, provider: Provider, model: String, model_name: String) -> Self {

--- a/src/core/traits/provider/handle.rs
+++ b/src/core/traits/provider/handle.rs
@@ -1,6 +1,8 @@
-//! Provider handle for routing system
+//! Legacy provider handle metadata wrapper
 //!
-//! Provides a type-erased wrapper for LLMProvider instances used by the router
+//! Router deployments dispatch through the closed `Provider` enum. This wrapper
+//! keeps source compatibility for older type-erased experiments, but it is not a
+//! router dispatch path.
 
 use crate::core::types::health::HealthStatus;
 use crate::core::types::{chat::ChatRequest, context::RequestContext, responses::ChatResponse};
@@ -8,23 +10,24 @@ use crate::utils::error::gateway_error::GatewayError;
 
 use super::llm_provider::trait_definition::LLMProvider;
 
-/// Provider handle for routing system
+/// Legacy provider handle metadata wrapper.
 ///
-/// This struct wraps a concrete provider implementation and provides
-/// a uniform interface for the routing system. It uses type erasure
-/// to allow heterogeneous provider collections.
+/// This struct stores a provider name, weight, and enabled flag alongside an
+/// erased provider value for compatibility with older APIs. It does not
+/// downcast the provider and cannot make an arbitrary `LLMProvider`
+/// implementation routeable. Router deployments currently use the built-in
+/// `Provider` enum and its dispatch arms.
 ///
 /// # Design Principles
-/// - Type erasure for flexible provider management
-/// - Weight-based routing support
-/// - Enable/disable functionality for health management
-/// - Simplified interface for routing decisions
+/// - Preserve source compatibility for legacy metadata usage
+/// - Avoid optimistic capability, health, cost, or success-rate data
+/// - Keep router dispatch explicit in the `Provider` enum
 ///
 /// # Example
 ///
-/// The `ProviderHandle` wraps any type implementing `LLMProvider` with type erasure
-/// for flexible provider management in routing systems. See the routing module
-/// for usage examples.
+/// `ProviderHandle::new` accepts any type implementing `LLMProvider`, but this
+/// only captures metadata. The provider is not automatically available to the
+/// router unless it is also wired into the `Provider` enum.
 pub struct ProviderHandle {
     name: String,
     _provider: std::sync::Arc<dyn std::any::Any + Send + Sync>,
@@ -33,14 +36,15 @@ pub struct ProviderHandle {
 }
 
 impl ProviderHandle {
-    /// Create a new provider handle
+    /// Create a new legacy provider handle.
     ///
     /// # Parameters
     /// * `provider` - The provider instance to wrap
     /// * `weight` - Routing weight (higher values = more traffic)
     ///
     /// # Returns
-    /// A new ProviderHandle with the provider enabled by default
+    /// A new `ProviderHandle` with the provider enabled by default. This does
+    /// not register the provider with the router.
     ///
     /// # Type Parameters
     /// * `P` - Any type implementing LLMProvider
@@ -94,7 +98,7 @@ impl ProviderHandle {
         self.enabled = enabled;
     }
 
-    /// Execute chat completion request
+    /// Execute chat completion request.
     ///
     /// # Parameters
     /// * `request` - Chat completion request
@@ -104,18 +108,14 @@ impl ProviderHandle {
     /// Chat completion response
     ///
     /// # Note
-    /// This is a simplified implementation. In a real system, you would need
-    /// to properly downcast the provider and call its chat_completion method.
+    /// `ProviderHandle` is not a router dispatch path. Use a `Deployment` with
+    /// a built-in `Provider` enum variant for routed chat completion.
     pub async fn chat_completion(
         &self,
         _request: ChatRequest,
         _context: RequestContext,
     ) -> Result<ChatResponse, GatewayError> {
-        // This is a simplified implementation - in a real system,
-        // you'd need to properly downcast and handle the provider
-        Err(GatewayError::Internal(
-            "Provider chat_completion not implemented".to_string(),
-        ))
+        Err(Self::unsupported_contract_error("chat_completion"))
     }
 
     /// Check if model is supported
@@ -124,37 +124,25 @@ impl ProviderHandle {
     /// * `model` - Model name to check
     ///
     /// # Returns
-    /// `true` if the model is supported
-    ///
-    /// # Note
-    /// Simplified implementation - returns true for all models
+    /// `false` because this wrapper has no verified model metadata.
     pub fn supports_model(&self, _model: &str) -> bool {
-        // Simplified implementation
-        true
+        false
     }
 
     /// Check if tools are supported
     ///
     /// # Returns
-    /// `true` if tool calling is supported
-    ///
-    /// # Note
-    /// Simplified implementation - returns true
+    /// `false` because this wrapper has no verified capability metadata.
     pub fn supports_tools(&self) -> bool {
-        // Simplified implementation
-        true
+        false
     }
 
     /// Check provider health status
     ///
     /// # Returns
-    /// Health status of the provider
-    ///
-    /// # Note
-    /// Simplified implementation - always returns Healthy
+    /// `Unknown` because this wrapper cannot call the provider health endpoint.
     pub async fn health_check(&self) -> HealthStatus {
-        // Simplified implementation
-        HealthStatus::Healthy
+        HealthStatus::Unknown
     }
 
     /// Calculate request cost
@@ -165,42 +153,36 @@ impl ProviderHandle {
     /// * `output` - Number of output tokens
     ///
     /// # Returns
-    /// Estimated cost in USD
-    ///
-    /// # Note
-    /// Simplified implementation - returns 0.0
+    /// Explicit error because this wrapper cannot calculate verified cost.
     pub async fn calculate_cost(
         &self,
         _model: &str,
         _input: u32,
         _output: u32,
     ) -> Result<f64, GatewayError> {
-        // Simplified implementation
-        Ok(0.0)
+        Err(Self::unsupported_contract_error("calculate_cost"))
     }
 
     /// Get average response latency
     ///
     /// # Returns
-    /// Average latency for this provider
-    ///
-    /// # Note
-    /// Simplified implementation - returns 100ms
+    /// Explicit error because this wrapper has no verified latency telemetry.
     pub async fn get_average_latency(&self) -> Result<std::time::Duration, GatewayError> {
-        // Simplified implementation
-        Ok(std::time::Duration::from_millis(100))
+        Err(Self::unsupported_contract_error("get_average_latency"))
     }
 
     /// Get success rate
     ///
     /// # Returns
-    /// Success rate between 0.0 and 1.0
-    ///
-    /// # Note
-    /// Simplified implementation - returns 1.0 (100%)
+    /// Explicit error because this wrapper has no verified success telemetry.
     pub async fn get_success_rate(&self) -> Result<f32, GatewayError> {
-        // Simplified implementation
-        Ok(1.0)
+        Err(Self::unsupported_contract_error("get_success_rate"))
+    }
+
+    fn unsupported_contract_error(method: &str) -> GatewayError {
+        GatewayError::Internal(format!(
+            "ProviderHandle::{method} is not a router dispatch path; router deployments use the built-in Provider enum"
+        ))
     }
 }
 
@@ -208,38 +190,49 @@ impl ProviderHandle {
 mod tests {
     use super::*;
 
-    // Test directly on the struct methods that don't require provider creation
-    // Since ProviderHandle::new requires a concrete LLMProvider implementation,
-    // we test the simpler functions that can be tested in isolation
+    fn test_handle() -> ProviderHandle {
+        ProviderHandle {
+            name: "legacy".to_string(),
+            _provider: std::sync::Arc::new(()),
+            weight: 1.0,
+            enabled: true,
+        }
+    }
 
     #[test]
-    fn test_provider_handle_struct_exists() {
-        // Test that ProviderHandle struct is properly defined
-        // and can be referenced (compilation test)
-        let _type_check: fn() -> bool = || {
-            // Just a compilation test to ensure the type exists
-            true
-        };
-        assert!(_type_check());
+    fn test_provider_handle_metadata_accessors() {
+        let mut handle = test_handle();
+
+        assert_eq!(handle.name(), "legacy");
+        assert_eq!(handle.weight(), 1.0);
+        assert!(handle.is_enabled());
+
+        handle.set_enabled(false);
+        assert!(!handle.is_enabled());
     }
 
     #[tokio::test]
-    async fn test_health_status_healthy() {
-        // Test HealthStatus enum
-        let status = HealthStatus::Healthy;
-        assert!(matches!(status, HealthStatus::Healthy));
-    }
+    async fn provider_handle_does_not_report_optimistic_routing_data() {
+        let handle = test_handle();
 
-    #[tokio::test]
-    async fn test_health_status_unhealthy() {
-        let status = HealthStatus::Unhealthy;
-        assert!(matches!(status, HealthStatus::Unhealthy));
-    }
+        assert!(!handle.supports_model("gpt-4"));
+        assert!(!handle.supports_tools());
+        assert_eq!(handle.health_check().await, HealthStatus::Unknown);
 
-    #[tokio::test]
-    async fn test_health_status_degraded() {
-        let status = HealthStatus::Degraded;
-        assert!(matches!(status, HealthStatus::Degraded));
+        let cost = handle.calculate_cost("gpt-4", 1, 1).await;
+        assert!(
+            matches!(cost, Err(GatewayError::Internal(message)) if message.contains("ProviderHandle::calculate_cost"))
+        );
+
+        let latency = handle.get_average_latency().await;
+        assert!(
+            matches!(latency, Err(GatewayError::Internal(message)) if message.contains("ProviderHandle::get_average_latency"))
+        );
+
+        let success_rate = handle.get_success_rate().await;
+        assert!(
+            matches!(success_rate, Err(GatewayError::Internal(message)) if message.contains("ProviderHandle::get_success_rate"))
+        );
     }
 
     #[test]
@@ -261,7 +254,21 @@ mod tests {
         assert!(request.messages.is_empty());
     }
 
-    // Note: Full ProviderHandle tests would require a mock LLMProvider implementation
-    // which is complex due to the trait bounds. These basic tests verify the
-    // foundational types work correctly.
+    #[tokio::test]
+    async fn provider_handle_chat_completion_returns_explicit_contract_error() {
+        let handle = test_handle();
+        let request = ChatRequest {
+            model: "test-model".to_string(),
+            messages: vec![],
+            ..Default::default()
+        };
+
+        let result = handle
+            .chat_completion(request, RequestContext::default())
+            .await;
+
+        assert!(
+            matches!(result, Err(GatewayError::Internal(message)) if message.contains("ProviderHandle::chat_completion"))
+        );
+    }
 }

--- a/src/core/traits/provider/llm_provider/trait_definition.rs
+++ b/src/core/traits/provider/llm_provider/trait_definition.rs
@@ -21,9 +21,12 @@ use crate::core::types::{
     responses::{ChatChunk, ChatResponse, EmbeddingResponse, ImageGenerationResponse},
 };
 
-/// Unified LLM Provider interface
+/// Unified interface implemented by providers wired into this crate.
 ///
-/// This is the core abstraction of LiteLLM, all AI providers must implement this trait
+/// `LLMProvider` defines the behavior expected from concrete provider
+/// implementations. Implementing this trait alone does not make a provider
+/// routeable: router deployments currently store the built-in `Provider` enum,
+/// so a provider must also be added to that enum and its dispatch/factory wiring.
 ///
 /// # Design Principles
 ///
@@ -36,9 +39,9 @@ use crate::core::types::{
 ///
 /// # Example
 ///
-/// The `LLMProvider` trait is the core abstraction for AI providers. All providers
-/// use `ProviderError` as the unified error type. See existing provider
-/// implementations in `src/core/providers/` for reference.
+/// The `LLMProvider` trait is the implementation interface for providers built
+/// into this crate. All providers use `ProviderError` as the unified error type.
+/// See existing provider implementations in `src/core/providers/` for reference.
 #[allow(async_fn_in_trait)]
 pub trait LLMProvider: Send + Sync + Debug + 'static {
     // ==================== Basic Metadata ====================
@@ -49,7 +52,8 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// String identifier for the provider, such as "openai", "anthropic", "v0", etc.
     ///
     /// # Note
-    /// This name is used for routing and logging, must be unique across the entire system.
+    /// This name is used by built-in routing and logging, and must be unique
+    /// among provider implementations wired into the crate.
     /// Implementations may return either a static literal or a value borrowed from `self`.
     fn name(&self) -> &str;
 

--- a/src/core/traits/provider/mod.rs
+++ b/src/core/traits/provider/mod.rs
@@ -1,13 +1,13 @@
 //! Core LLM Provider trait definitions
 //!
-//! Defines unified interface for all AI providers
+//! Defines the implementation interfaces for providers wired into this crate.
 //!
 //! # Module Organization
 //!
 //! This module is split into three main components:
 //! - `llm_provider` - The main LLMProvider trait definition
 //! - `config` - ProviderConfig trait for configuration management
-//! - `handle` - ProviderHandle struct for routing system integration
+//! - `handle` - legacy ProviderHandle metadata wrapper
 //!
 //! # Design Principles
 //!


### PR DESCRIPTION
## Linked Work

Closes #713.

## What

- Documents the accepted #713 contract: router deployments use the closed built-in `Provider` enum.
- Clarifies that implementing `LLMProvider` alone does not make a third-party provider routeable; routed providers must be wired into enum/dispatch/factory paths or use the OpenAI-compatible route where applicable.
- Keeps `ProviderHandle` source-compatible as a legacy metadata wrapper, but makes routing-like methods fail closed instead of returning optimistic stub data.
- Adds `specs/GH713/` product, tech, and task plan artifacts.

## Why

`ProviderHandle` was public and described as a type-erased routing wrapper, but it could not dispatch through `LLMProvider` and returned fabricated success data for model/tool support, health, cost, latency, and success rate. That made the public provider contract disagree with the actual router path.

## Readiness Gate

- SpecRail `write_spec` gate passed locally for GH-713.
- SpecRail `implement` gate passed locally for GH-713.
- SpecRail workflow packet validation passed for `specs/GH713`.
- Threads split was used: coordinator owned writable files; two read-only lanes reviewed #713 provider-contract scope and #714 registry boundary.

## Review Gate

- #713 scope intentionally chooses the closed built-in provider set.
- #714 registry/source-of-truth conformance is left untouched: no catalog, factory, provider matrix, or provider module rewiring in this PR.
- `ProviderHandle` is not removed, avoiding a hard public API break.

## Merge Gate

- [ ] CI green on this PR.
- [ ] GraphQL reviewThreads have no unresolved threads.
- [ ] SpecRail PR review gate passes with PR evidence.

## Test Plan

- [x] `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue713/specs/GH713`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test provider_handle --lib`
- [x] `cargo test test_create_provider_reports_unknown_custom_provider --lib`
- [x] `cargo test provider_registry_contains_all_non_custom_provider_types --lib`
- [x] `cargo check --all-features --locked`
- [x] `cargo test --lib` (8691 passed)

## Local Hook Note

The default VibeGuard pre-commit timeout is 10s, while this repo's plain `cargo check` took 35.9s locally. The commit used `VIBEGUARD_PRECOMMIT_TIMEOUT=120` so the hook could run normally instead of being skipped.