### PR TITLE
refactor: split provider retry policy

### DIFF
--- a/specs/GH715/product.md
+++ b/specs/GH715/product.md
@@ -1,0 +1,57 @@
+# Product Spec
+
+## Linked Issue
+
+GH-715
+
+## User Problem
+
+Provider failures currently carry retry and HTTP response policy as convenience
+methods on `ProviderError`. That makes router behavior depend on an error
+variant without enough request context: retry budget, stream stage, idempotency,
+deadline, and provider retry hints.
+
+## Goals
+
+- Introduce fact-only provider failure data that can be derived from
+  `ProviderError` without owning retry or HTTP policy.
+- Add a router retry policy layer that receives request context before deciding
+  whether and when to retry.
+- Ensure streaming failures after client-visible output are not automatically
+  retried.
+- Ensure pre-output streaming failures can still retry when policy and budget
+  permit.
+- Keep HTTP status mapping at the OpenAI-compatible gateway adapter boundary.
+- Preserve existing provider implementations and `ProviderError` compatibility
+  helpers.
+
+## Non-Goals
+
+- Do not remove or rename `ProviderError` variants in this PR.
+- Do not migrate every provider-specific error test away from legacy helper
+  methods.
+- Do not change the broad `LLMProvider` trait shape; that remains #519 scope.
+- Do not rewrite retry/cooldown selection or budget fallback routing.
+
+## User-Visible Behavior
+
+Successful requests are unchanged. Retry behavior gains explicit policy inputs:
+`Retry-After` can control retry delay, and streaming errors after emitted chunks
+are classified as non-retryable by policy.
+
+## Acceptance Criteria
+
+- [x] SpecRail docs record the #715 migration slice.
+- [x] Provider failure facts can be derived from `ProviderError` without policy
+  decisions.
+- [x] Router selected-deployment helpers call `RetryPolicy` instead of deciding
+  only from the error variant.
+- [x] Tests cover post-output streaming no-retry and pre-output streaming retry.
+- [x] Tests cover provider `Retry-After` in delay calculation.
+- [x] HTTP mapping tests live in `server/routes/ai/openai_errors.rs`.
+
+## Follow-Up
+
+A later major-version cleanup can deprecate or remove `ProviderError`
+compatibility helpers once SDK/provider tests and external callers use the new
+fact and adapter surfaces.

--- a/specs/GH715/tasks.md
+++ b/specs/GH715/tasks.md
@@ -1,0 +1,43 @@
+# Task Plan
+
+## Linked Issue
+
+GH-715
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [x] `SP715-T1` Owner: coordinator. Done when: SpecRail product and tech docs record the failure/retry/HTTP split and #519 boundary. Verify: `check_workflow.py --spec-dir /private/tmp/litellm-rs-issue715/specs/GH715`.
+- [x] `SP715-T2` Owner: coordinator. Done when: `ProviderFailureFacts` exposes provider failure facts and retry hints without policy methods. Verify: `cargo test failure --lib`.
+- [x] `SP715-T3` Owner: coordinator. Done when: `RetryPolicy` decides from context and preserves selected-deployment budget fallback behavior. Verify: `cargo test retry_policy --lib` and `cargo test budget_retry_fallbacks_skip_retry_delay --lib`.
+- [x] `SP715-T4` Owner: coordinator. Done when: server/router execution uses `RetryPolicy` for unary and pre-output streaming retries. Verify: `cargo test execute_with_selected_deployment --lib`.
+- [x] `SP715-T5` Owner: coordinator. Done when: OpenAI HTTP mapping remains at adapter boundary. Verify: `cargo test provider_timeout_http_mapping_lives_at_openai_adapter_boundary --lib`.
+
+## Parallel Split
+
+- Main coordinator owns writable files for `specs/GH715/**`, provider failure
+  facts, router retry policy, and selected-deployment execution.
+- Threads planner lane is read-only and may inspect retry/error/HTTP surfaces.
+- Merge-reviewer lane is read-only after PR creation.
+- No writable lane may touch #519 trait/type-tree refactors.
+
+## Verification
+
+- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue715/specs/GH715`
+- `cargo test failure --lib`
+- `cargo test retry_policy --lib`
+- `cargo test budget_retry_fallbacks_skip_retry_delay --lib`
+- `cargo test execute_with_selected_deployment --lib`
+- `cargo test core::router::tests::execution_tests --lib`
+- `cargo test provider_timeout_http_mapping_lives_at_openai_adapter_boundary --lib`
+- `cargo check --all-features --locked`
+
+## Handoff Notes
+
+This is a migration slice. Removing `ProviderError` compatibility helpers is
+deliberately deferred until callers have switched to policy and adapter
+surfaces.

--- a/specs/GH715/tech.md
+++ b/specs/GH715/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-715
+
+## Product Spec
+
+Link to `product.md`.
+
+## Current System
+
+- `src/core/providers/unified_provider.rs` defines `ProviderError` and legacy
+  helpers for retryability, retry delay, and HTTP status.
+- `src/server/routes/ai/execution.rs` retries selected deployments from
+  `is_retryable_error` plus backoff delay.
+- `src/core/router/execute_impl.rs` has the older router retry loops with the
+  same context-free retry decisions.
+- `src/server/routes/ai/openai_errors.rs` already maps `GatewayError` and
+  `ProviderError` to OpenAI-compatible HTTP responses.
+- Streaming route bodies emit SSE error events after stream creation; the
+  selected-deployment retry loop only runs before a stream is returned.
+
+## Proposed Design
+
+1. Add `src/core/providers/failure.rs`:
+   - `ProviderFailureKind`
+   - `ProviderRetryHint`
+   - `ProviderFailureFacts::from_error(&ProviderError)`
+   These types expose provider name, failure kind, upstream status, and retry
+   hints without owning policy decisions.
+2. Add `src/core/router/retry_policy.rs`:
+   - `RetryContext` with operation, stream stage, idempotency, attempt budget,
+     and optional remaining deadline.
+   - `RetryPolicy::decide(config, error, context)` returning a structured
+     `RetryDecision`.
+   - Provider `Retry-After` controls rate-limit retry delay when present.
+   - `StreamRetryStage::AfterChunksEmitted` always stops automatic retry.
+3. Update router and server execution:
+   - Keep existing budget-fallback special case.
+   - Replace direct retryability decisions with `RetryPolicy` for unary and
+     pre-output streaming selected-deployment execution.
+4. Keep HTTP mapping in `openai_errors.rs` and add adapter-boundary coverage.
+
+## Compatibility
+
+`ProviderError` variants and helper methods remain available. This PR changes
+the runtime retry paths first, then leaves broad helper migration for a future
+compatibility pass.
+
+## Test Plan
+
+- [x] `cargo test failure --lib`.
+- [x] `cargo test retry_policy --lib`.
+- [x] `cargo test budget_retry_fallbacks_skip_retry_delay --lib`.
+- [x] `cargo test provider_timeout_http_mapping_lives_at_openai_adapter_boundary --lib`.
+- [x] `cargo test execute_with_selected_deployment --lib`.
+- [x] `cargo test core::router::tests::execution_tests --lib`.
+- [x] `cargo check --all-features --locked`.
+
+## Rollback Plan
+
+Revert the new `failure` and `retry_policy` modules plus execution wiring. The
+legacy `ProviderError` helper behavior remains intact, so rollback does not
+require provider implementation changes.

--- a/src/core/providers/failure.rs
+++ b/src/core/providers/failure.rs
@@ -1,0 +1,134 @@
+//! Fact-only provider failure view.
+//!
+//! `ProviderError` remains the compatibility error type used by provider
+//! implementations. This module exposes a smaller view for retry policy and
+//! gateway adapters so those layers can reason from facts.
+
+use super::ProviderError;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderFailureKind {
+    Authentication,
+    RateLimit,
+    QuotaExceeded,
+    ModelNotFound,
+    InvalidRequest,
+    Network,
+    ProviderUnavailable,
+    NotSupported,
+    NotImplemented,
+    Configuration,
+    Serialization,
+    Timeout,
+    ContextLengthExceeded,
+    ContentFiltered,
+    ApiError,
+    TokenLimitExceeded,
+    FeatureDisabled,
+    DeploymentError,
+    ResponseParsing,
+    RoutingError,
+    TransformationError,
+    Cancelled,
+    Streaming,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ProviderRetryHint {
+    pub retry_after: Option<Duration>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderFailureFacts {
+    pub provider: &'static str,
+    pub kind: ProviderFailureKind,
+    pub upstream_status: Option<u16>,
+    pub retry_hint: ProviderRetryHint,
+}
+
+impl ProviderFailureFacts {
+    pub fn from_error(error: &ProviderError) -> Self {
+        Self::from(error)
+    }
+}
+
+impl From<&ProviderError> for ProviderFailureFacts {
+    fn from(error: &ProviderError) -> Self {
+        Self {
+            provider: error.provider(),
+            kind: ProviderFailureKind::from(error),
+            upstream_status: match error {
+                ProviderError::ApiError { status, .. } => Some(*status),
+                _ => None,
+            },
+            retry_hint: match error {
+                ProviderError::RateLimit { retry_after, .. } => ProviderRetryHint {
+                    retry_after: retry_after.map(Duration::from_secs),
+                },
+                _ => ProviderRetryHint::default(),
+            },
+        }
+    }
+}
+
+impl From<&ProviderError> for ProviderFailureKind {
+    fn from(error: &ProviderError) -> Self {
+        match error {
+            ProviderError::Authentication { .. } => Self::Authentication,
+            ProviderError::RateLimit { .. } => Self::RateLimit,
+            ProviderError::QuotaExceeded { .. } => Self::QuotaExceeded,
+            ProviderError::ModelNotFound { .. } => Self::ModelNotFound,
+            ProviderError::InvalidRequest { .. } => Self::InvalidRequest,
+            ProviderError::Network { .. } => Self::Network,
+            ProviderError::ProviderUnavailable { .. } => Self::ProviderUnavailable,
+            ProviderError::NotSupported { .. } => Self::NotSupported,
+            ProviderError::NotImplemented { .. } => Self::NotImplemented,
+            ProviderError::Configuration { .. } => Self::Configuration,
+            ProviderError::Serialization { .. } => Self::Serialization,
+            ProviderError::Timeout { .. } => Self::Timeout,
+            ProviderError::ContextLengthExceeded { .. } => Self::ContextLengthExceeded,
+            ProviderError::ContentFiltered { .. } => Self::ContentFiltered,
+            ProviderError::ApiError { .. } => Self::ApiError,
+            ProviderError::TokenLimitExceeded { .. } => Self::TokenLimitExceeded,
+            ProviderError::FeatureDisabled { .. } => Self::FeatureDisabled,
+            ProviderError::DeploymentError { .. } => Self::DeploymentError,
+            ProviderError::ResponseParsing { .. } => Self::ResponseParsing,
+            ProviderError::RoutingError { .. } => Self::RoutingError,
+            ProviderError::TransformationError { .. } => Self::TransformationError,
+            ProviderError::Cancelled { .. } => Self::Cancelled,
+            ProviderError::Streaming { .. } => Self::Streaming,
+            ProviderError::Other { .. } => Self::Other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn facts_capture_rate_limit_retry_after_without_policy() {
+        let facts = ProviderFailureFacts::from_error(&ProviderError::rate_limit("openai", Some(7)));
+
+        assert_eq!(facts.provider, "openai");
+        assert_eq!(facts.kind, ProviderFailureKind::RateLimit);
+        assert_eq!(facts.upstream_status, None);
+        assert_eq!(facts.retry_hint.retry_after, Some(Duration::from_secs(7)));
+    }
+
+    #[test]
+    fn facts_capture_upstream_api_status() {
+        let facts = ProviderFailureFacts::from_error(&ProviderError::api_error(
+            "anthropic",
+            503,
+            "upstream overloaded",
+        ));
+
+        assert_eq!(facts.provider, "anthropic");
+        assert_eq!(facts.kind, ProviderFailureKind::ApiError);
+        assert_eq!(facts.upstream_status, Some(503));
+        assert_eq!(facts.retry_hint.retry_after, None);
+    }
+}

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -193,6 +193,7 @@ pub use factory::{create_provider, is_provider_selector_supported};
 
 // Registry and unified provider
 pub mod contextual_error;
+pub mod failure;
 pub mod provider_error_conversions;
 pub mod provider_registry;
 pub mod registry; // Data-driven Tier 1 provider catalog
@@ -212,6 +213,7 @@ use crate::core::types::{
 };
 use crate::core::types::{context::RequestContext, model::ProviderCapability};
 pub use contextual_error::ContextualError;
+pub use failure::{ProviderFailureFacts, ProviderFailureKind, ProviderRetryHint};
 pub use provider_registry::ProviderRegistry;
 pub use unified_provider::ProviderError;
 

--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -5,10 +5,11 @@
 use super::deployment::{Deployment, DeploymentId};
 use super::error::{CooldownReason, RouterError};
 use super::execution::{
-    build_execution_result, calculate_retry_delay, infer_cooldown_reason, is_retryable_error,
-    provider_error_to_router_error, retryable_budget_scope, router_error_to_provider_error,
+    build_execution_result, infer_cooldown_reason, provider_error_to_router_error,
+    retryable_budget_scope, router_error_to_provider_error,
 };
 use super::fallback::{ExecutionResult, FallbackType};
+use super::retry_policy::{RetryContext, RetryPolicy};
 use super::unified::Router;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::model::ProviderCapability;
@@ -92,11 +93,17 @@ impl Router {
 
                     let provider_err = router_error_to_provider_error(router_err);
 
-                    if is_retryable_error(&provider_err) && attempt < max_attempts {
-                        let delay = calculate_retry_delay(&self.config, attempt);
+                    let retry_decision = RetryPolicy.decide(
+                        &self.config,
+                        &provider_err,
+                        RetryContext::unary(attempt, max_attempts),
+                    );
+                    if retry_decision.should_retry {
                         last_error = Some(provider_err);
                         attempt += 1;
-                        tokio::time::sleep(delay).await;
+                        if let Some(delay) = retry_decision.delay {
+                            tokio::time::sleep(delay).await;
+                        }
                         continue;
                     } else {
                         return Err((provider_err, attempt));
@@ -130,7 +137,12 @@ impl Router {
                         continue;
                     }
 
-                    if is_retryable_error(&err) && attempt < max_attempts {
+                    let retry_decision = RetryPolicy.decide(
+                        &self.config,
+                        &err,
+                        RetryContext::unary(attempt, max_attempts),
+                    );
+                    if retry_decision.should_retry {
                         // Use ConsecutiveFailures so the deployment only enters
                         // cooldown after exceeding allowed_fails threshold,
                         // giving retries a chance to succeed.
@@ -139,10 +151,11 @@ impl Router {
                             CooldownReason::ConsecutiveFailures,
                         );
                         drop(deployment_lease);
-                        let delay = calculate_retry_delay(&self.config, attempt);
                         last_error = Some(err);
                         attempt += 1;
-                        tokio::time::sleep(delay).await;
+                        if let Some(delay) = retry_decision.delay {
+                            tokio::time::sleep(delay).await;
+                        }
                         continue;
                     } else {
                         let cooldown_reason = infer_cooldown_reason(&err);
@@ -201,11 +214,17 @@ impl Router {
 
                     let provider_err = router_error_to_provider_error(router_err);
 
-                    if is_retryable_error(&provider_err) && attempt < max_attempts {
-                        let delay = calculate_retry_delay(&self.config, attempt);
+                    let retry_decision = RetryPolicy.decide(
+                        &self.config,
+                        &provider_err,
+                        RetryContext::unary(attempt, max_attempts),
+                    );
+                    if retry_decision.should_retry {
                         last_error = Some(provider_err);
                         attempt += 1;
-                        tokio::time::sleep(delay).await;
+                        if let Some(delay) = retry_decision.delay {
+                            tokio::time::sleep(delay).await;
+                        }
                         continue;
                     } else {
                         return Err((provider_err, attempt));
@@ -236,16 +255,22 @@ impl Router {
                         continue;
                     }
 
-                    if is_retryable_error(&err) && attempt < max_attempts {
+                    let retry_decision = RetryPolicy.decide(
+                        &self.config,
+                        &err,
+                        RetryContext::unary(attempt, max_attempts),
+                    );
+                    if retry_decision.should_retry {
                         self.record_failure_with_reason_for_deployment(
                             deployment_lease.deployment(),
                             CooldownReason::ConsecutiveFailures,
                         );
                         drop(deployment_lease);
-                        let delay = calculate_retry_delay(&self.config, attempt);
                         last_error = Some(err);
                         attempt += 1;
-                        tokio::time::sleep(delay).await;
+                        if let Some(delay) = retry_decision.delay {
+                            tokio::time::sleep(delay).await;
+                        }
                         continue;
                     } else {
                         let cooldown_reason = infer_cooldown_reason(&err);

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -27,6 +27,7 @@ pub mod execute_impl;
 pub mod execution;
 pub mod fallback;
 pub mod gateway_config;
+pub mod retry_policy;
 pub mod selection;
 pub mod strategy_impl;
 pub mod unified;

--- a/src/core/router/retry_policy.rs
+++ b/src/core/router/retry_policy.rs
@@ -1,0 +1,265 @@
+//! Contextual retry policy for router execution.
+
+use super::config::RouterConfig;
+use super::execution::calculate_retry_delay;
+use crate::core::providers::ProviderError;
+use crate::core::providers::failure::{ProviderFailureFacts, ProviderFailureKind};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryOperation {
+    Unary,
+    Streaming,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamRetryStage {
+    NotStreaming,
+    BeforeFirstChunk,
+    AfterChunksEmitted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestIdempotency {
+    Idempotent,
+    NonIdempotent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryContext {
+    pub operation: RetryOperation,
+    pub stream_stage: StreamRetryStage,
+    pub idempotency: RequestIdempotency,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    pub retry_budget_remaining: u32,
+    pub deadline_remaining: Option<Duration>,
+}
+
+impl RetryContext {
+    pub fn unary(attempt: u32, max_attempts: u32) -> Self {
+        Self::new(
+            RetryOperation::Unary,
+            StreamRetryStage::NotStreaming,
+            RequestIdempotency::Idempotent,
+            attempt,
+            max_attempts,
+        )
+    }
+
+    pub fn stream_pre_output(attempt: u32, max_attempts: u32) -> Self {
+        Self::new(
+            RetryOperation::Streaming,
+            StreamRetryStage::BeforeFirstChunk,
+            RequestIdempotency::Idempotent,
+            attempt,
+            max_attempts,
+        )
+    }
+
+    pub fn stream_after_chunks(attempt: u32, max_attempts: u32) -> Self {
+        Self::new(
+            RetryOperation::Streaming,
+            StreamRetryStage::AfterChunksEmitted,
+            RequestIdempotency::NonIdempotent,
+            attempt,
+            max_attempts,
+        )
+    }
+
+    pub fn with_deadline_remaining(mut self, deadline_remaining: Duration) -> Self {
+        self.deadline_remaining = Some(deadline_remaining);
+        self
+    }
+
+    fn new(
+        operation: RetryOperation,
+        stream_stage: StreamRetryStage,
+        idempotency: RequestIdempotency,
+        attempt: u32,
+        max_attempts: u32,
+    ) -> Self {
+        Self {
+            operation,
+            stream_stage,
+            idempotency,
+            attempt,
+            max_attempts,
+            retry_budget_remaining: max_attempts.saturating_sub(attempt),
+            deadline_remaining: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDecisionReason {
+    RetryableFailure,
+    AttemptsExhausted,
+    RetryBudgetExhausted,
+    NonIdempotentRequest,
+    StreamAlreadyEmitted,
+    DeadlineWouldExpire,
+    NonRetryableFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryDecision {
+    pub should_retry: bool,
+    pub delay: Option<Duration>,
+    pub reason: RetryDecisionReason,
+}
+
+impl RetryDecision {
+    fn retry(delay: Duration) -> Self {
+        Self {
+            should_retry: true,
+            delay: Some(delay),
+            reason: RetryDecisionReason::RetryableFailure,
+        }
+    }
+
+    fn stop(reason: RetryDecisionReason) -> Self {
+        Self {
+            should_retry: false,
+            delay: None,
+            reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RetryPolicy;
+
+impl RetryPolicy {
+    pub fn decide(
+        &self,
+        config: &RouterConfig,
+        error: &ProviderError,
+        context: RetryContext,
+    ) -> RetryDecision {
+        let facts = ProviderFailureFacts::from_error(error);
+
+        if context.attempt >= context.max_attempts {
+            return RetryDecision::stop(RetryDecisionReason::AttemptsExhausted);
+        }
+
+        if context.retry_budget_remaining == 0 {
+            return RetryDecision::stop(RetryDecisionReason::RetryBudgetExhausted);
+        }
+
+        if context.stream_stage == StreamRetryStage::AfterChunksEmitted {
+            return RetryDecision::stop(RetryDecisionReason::StreamAlreadyEmitted);
+        }
+
+        if context.idempotency == RequestIdempotency::NonIdempotent {
+            return RetryDecision::stop(RetryDecisionReason::NonIdempotentRequest);
+        }
+
+        if !failure_is_retryable(facts, context) {
+            return RetryDecision::stop(RetryDecisionReason::NonRetryableFailure);
+        }
+
+        let delay = facts
+            .retry_hint
+            .retry_after
+            .unwrap_or_else(|| calculate_retry_delay(config, context.attempt));
+
+        if let Some(deadline_remaining) = context.deadline_remaining
+            && delay > deadline_remaining
+        {
+            return RetryDecision::stop(RetryDecisionReason::DeadlineWouldExpire);
+        }
+
+        RetryDecision::retry(delay)
+    }
+}
+
+fn failure_is_retryable(facts: ProviderFailureFacts, context: RetryContext) -> bool {
+    match facts.kind {
+        ProviderFailureKind::RateLimit
+        | ProviderFailureKind::Timeout
+        | ProviderFailureKind::ProviderUnavailable
+        | ProviderFailureKind::Network
+        | ProviderFailureKind::DeploymentError => true,
+        ProviderFailureKind::ApiError => facts
+            .upstream_status
+            .is_some_and(|status| status == 429 || (500..=599).contains(&status)),
+        ProviderFailureKind::Streaming => {
+            context.operation == RetryOperation::Streaming
+                && context.stream_stage == StreamRetryStage::BeforeFirstChunk
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn streaming_error_after_emitted_chunks_is_not_retried() {
+        let error = ProviderError::streaming_error("openai", "chat", Some(1), None, "broken");
+        let decision = RetryPolicy.decide(
+            &RouterConfig::default(),
+            &error,
+            RetryContext::stream_after_chunks(1, 2),
+        );
+
+        assert!(!decision.should_retry);
+        assert_eq!(decision.reason, RetryDecisionReason::StreamAlreadyEmitted);
+    }
+
+    #[test]
+    fn pre_output_streaming_error_may_retry_when_budget_permits() {
+        let error = ProviderError::streaming_error("openai", "chat", None, None, "connect reset");
+        let decision = RetryPolicy.decide(
+            &RouterConfig::default(),
+            &error,
+            RetryContext::stream_pre_output(1, 2),
+        );
+
+        assert!(decision.should_retry);
+        assert_eq!(decision.delay, Some(Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn retry_after_hint_controls_rate_limit_delay() {
+        let config = RouterConfig {
+            retry_after_secs: 5,
+            ..Default::default()
+        };
+        let error = ProviderError::rate_limit("openai", Some(60));
+        let decision = RetryPolicy.decide(&config, &error, RetryContext::unary(1, 2));
+
+        assert!(decision.should_retry);
+        assert_eq!(decision.delay, Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn deadline_blocks_retry_delay_that_cannot_fit() {
+        let error = ProviderError::rate_limit("openai", Some(60));
+        let context = RetryContext::unary(1, 2).with_deadline_remaining(Duration::from_secs(10));
+        let decision = RetryPolicy.decide(&RouterConfig::default(), &error, context);
+
+        assert!(!decision.should_retry);
+        assert_eq!(decision.reason, RetryDecisionReason::DeadlineWouldExpire);
+    }
+
+    #[test]
+    fn upstream_5xx_api_error_is_retryable_fact_for_policy() {
+        let error = ProviderError::api_error("anthropic", 503, "overloaded");
+        let decision =
+            RetryPolicy.decide(&RouterConfig::default(), &error, RetryContext::unary(1, 2));
+
+        assert!(decision.should_retry);
+    }
+
+    #[test]
+    fn deployment_error_remains_retryable_for_provider_parity() {
+        let error = ProviderError::deployment_error("azure", "deployment not ready");
+        let decision =
+            RetryPolicy.decide(&RouterConfig::default(), &error, RetryContext::unary(1, 2));
+
+        assert!(decision.should_retry);
+    }
+}

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -4,13 +4,14 @@ use crate::core::providers::{Provider, ProviderError};
 use crate::core::router::UnifiedRouter;
 use crate::core::router::deployment::Deployment;
 use crate::core::router::execution::{
-    calculate_retry_delay, infer_cooldown_reason, is_retryable_error, retryable_budget_scope,
-    router_error_to_provider_error,
+    infer_cooldown_reason, retryable_budget_scope, router_error_to_provider_error,
 };
+use crate::core::router::retry_policy::{RetryContext, RetryPolicy};
 use crate::core::types::model::ProviderCapability;
 use crate::utils::error::gateway_error::GatewayError;
 use std::collections::HashSet;
 use std::sync::Arc;
+#[cfg(test)]
 use std::time::Duration;
 use std::time::Instant;
 
@@ -97,11 +98,17 @@ where
 
                 let provider_err = router_error_to_provider_error(router_err);
 
-                if is_retryable_error(&provider_err) && attempt < max_attempts {
-                    let delay = calculate_retry_delay(router.config(), attempt);
+                let retry_decision = RetryPolicy.decide(
+                    router.config(),
+                    &provider_err,
+                    RetryContext::unary(attempt, max_attempts),
+                );
+                if retry_decision.should_retry {
                     last_error = Some(provider_err);
                     attempt += 1;
-                    tokio::time::sleep(delay).await;
+                    if let Some(delay) = retry_decision.delay {
+                        tokio::time::sleep(delay).await;
+                    }
                     continue;
                 }
 
@@ -131,16 +138,20 @@ where
                     continue;
                 }
 
-                if is_retryable_error(&err) && attempt < max_attempts {
+                let retry_decision = RetryPolicy.decide(
+                    router.config(),
+                    &err,
+                    RetryContext::unary(attempt, max_attempts),
+                );
+                if retry_decision.should_retry {
                     router.record_failure_with_reason_for_deployment(
                         deployment_lease.deployment(),
                         crate::core::router::CooldownReason::ConsecutiveFailures,
                     );
                     drop(deployment_lease);
-                    let retry_delay = retry_delay_for_error(router.config(), attempt, &err);
                     last_error = Some(err);
                     attempt += 1;
-                    if let Some(delay) = retry_delay {
+                    if let Some(delay) = retry_decision.delay {
                         tokio::time::sleep(delay).await;
                     }
                     continue;
@@ -165,14 +176,22 @@ where
     })))
 }
 
+#[cfg(test)]
 fn retry_delay_for_error(
     config: &crate::core::router::config::RouterConfig,
     attempt: u32,
     error: &ProviderError,
 ) -> Option<Duration> {
-    retryable_budget_scope(error)
-        .is_none()
-        .then(|| calculate_retry_delay(config, attempt))
+    if retryable_budget_scope(error).is_some() {
+        return None;
+    }
+
+    let decision = RetryPolicy.decide(config, error, RetryContext::unary(attempt, attempt + 1));
+    if decision.should_retry {
+        decision.delay
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -217,11 +236,17 @@ where
 
                 let provider_err = router_error_to_provider_error(router_err);
 
-                if is_retryable_error(&provider_err) && attempt < max_attempts {
-                    let delay = calculate_retry_delay(router.config(), attempt);
+                let retry_decision = RetryPolicy.decide(
+                    router.config(),
+                    &provider_err,
+                    RetryContext::stream_pre_output(attempt, max_attempts),
+                );
+                if retry_decision.should_retry {
                     last_error = Some(provider_err);
                     attempt += 1;
-                    tokio::time::sleep(delay).await;
+                    if let Some(delay) = retry_decision.delay {
+                        tokio::time::sleep(delay).await;
+                    }
                     continue;
                 }
 
@@ -246,16 +271,20 @@ where
                     continue;
                 }
 
-                if is_retryable_error(&err) && attempt < max_attempts {
+                let retry_decision = RetryPolicy.decide(
+                    router.config(),
+                    &err,
+                    RetryContext::stream_pre_output(attempt, max_attempts),
+                );
+                if retry_decision.should_retry {
                     router.record_failure_with_reason_for_deployment(
                         deployment_lease.deployment(),
                         crate::core::router::CooldownReason::ConsecutiveFailures,
                     );
                     drop(deployment_lease);
-                    let retry_delay = retry_delay_for_error(router.config(), attempt, &err);
                     last_error = Some(err);
                     attempt += 1;
-                    if let Some(delay) = retry_delay {
+                    if let Some(delay) = retry_decision.delay {
                         tokio::time::sleep(delay).await;
                     }
                     continue;

--- a/src/server/routes/ai/execution_retry_delay_tests.rs
+++ b/src/server/routes/ai/execution_retry_delay_tests.rs
@@ -22,7 +22,7 @@ fn budget_retry_fallbacks_skip_retry_delay() {
     assert_eq!(retry_delay_for_error(&config, 1, &model_budget), None);
     assert_eq!(
         retry_delay_for_error(&config, 1, &rate_limit),
-        Some(std::time::Duration::from_secs(5))
+        Some(std::time::Duration::from_secs(60))
     );
 }
 

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -390,6 +390,18 @@ mod tests {
         assert!(body["error"]["retryable"].is_null());
     }
 
+    #[actix_web::test]
+    async fn provider_timeout_http_mapping_lives_at_openai_adapter_boundary() {
+        let error = GatewayError::Provider(ProviderError::timeout("openai", "upstream timed out"));
+
+        let response = gateway_error_response(&error);
+
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        let body = to_json(response).await;
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["code"], "timeout");
+    }
+
     async fn to_json(response: HttpResponse) -> Value {
         let body = to_bytes(response.into_body()).await.unwrap();
         serde_json::from_slice(&body).unwrap()


### PR DESCRIPTION
## Summary
- add provider failure fact wrappers separate from retry behavior
- add router `RetryPolicy` with request context for unary vs streaming retries, idempotency, retry budget, deadline, and provider Retry-After hints
- wire router/server retry loops through the policy while keeping HTTP mapping at adapter boundaries
- add SpecRail GH715 product/tech/tasks evidence

Fixes #715

## Threads / SpecRail
- mode: `execute_direct`
- tranche: issue #715 after #714 merged
- planner lane: read-only native subagent inspected provider facts, retry loops, and HTTP adapters
- merge policy: merge after fresh CI, GraphQL reviewThreads, independent merge-reviewer, and SpecRail gate
- SpecRail spec: `specs/GH715/`

## Local Verification
- `cargo test retry_policy --lib`
- `cargo test failure --lib`
- `cargo test budget_retry_fallbacks_skip_retry_delay --lib`
- `cargo test execute_with_selected_deployment --lib`
- `cargo test provider_timeout_http_mapping_lives_at_openai_adapter_boundary --lib`
- `cargo test core::router::tests::execution_tests --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue715/specs/GH715`
- `cargo check --all-features --locked`
- `cargo test --lib`
