### PR TITLE
fix: converge canonical chat/model type boundaries

### DIFF
--- a/specs/GH724/product.md
+++ b/specs/GH724/product.md
@@ -1,0 +1,67 @@
+# Product Spec
+
+## Linked Issue
+
+GH-724
+
+## User Problem
+
+The gateway still exposes overlapping internal and OpenAI-compatible chat/model
+types. That makes it hard to know which type owns provider execution data and
+which type only represents HTTP/OpenAI wire compatibility, increasing the risk
+that fields are dropped during conversion.
+
+## Goals
+
+- Make `core::types::chat::ChatRequest` the documented internal chat request.
+- Keep `core::models::openai::ChatCompletionRequest` as an OpenAI-compatible
+  transport DTO with one explicit conversion boundary.
+- Make `core::types::model::ModelInfo` the single internal model information
+  authority.
+- Add tests for OpenAI request fields that must survive transport-to-core
+  conversion.
+
+## Non-Goals
+
+- Do not rewrite provider dispatch, provider construction, or registry behavior.
+- Do not change SDK/HTTP provider parity beyond the type boundary.
+- Do not remove OpenAI-compatible DTOs that are still needed for API
+  compatibility.
+
+## Behavior Invariants
+
+1. Provider traits and provider implementations continue to receive
+   `core::types::chat::ChatRequest`.
+2. HTTP chat completion handlers continue to accept OpenAI-compatible JSON via
+   `ChatCompletionRequest`.
+3. Conversion from `ChatCompletionRequest` to `ChatRequest` preserves known
+   routing, sampling, tool, metadata, service tier, stream option, and
+   provider-specific extension fields.
+4. The `ModelInfo` name under `core::models` no longer defines a second
+   internal model-info shape.
+5. Existing OpenAI-compatible request serialization behavior remains compatible.
+
+## Acceptance Criteria
+
+- [ ] Chat request ownership is documented at both internal and OpenAI DTO
+      boundaries.
+- [ ] `core::models::ModelInfo` resolves to the canonical
+      `core::types::model::ModelInfo`, with any legacy shape renamed out of the
+      authority path.
+- [ ] Conversion tests cover currently risky request fields, including
+      `store`, `metadata`, `service_tier`, `stream_options`, provider extension
+      fields, tools, tool choice, functions, and function call.
+- [ ] `cargo fmt --all -- --check` and `cargo test --lib` pass.
+
+## Edge Cases
+
+- OpenAI `seed` stays range-checked because the internal type is narrower.
+- Route-level stream handling remains explicit: streaming and non-streaming
+  handlers decide the internal `stream` flag.
+- Unknown provider-specific request keys remain available through
+  `ChatRequest::extra_params`.
+
+## Rollout Notes
+
+This is an internal type-boundary cleanup. It should not require migration for
+HTTP clients because OpenAI-compatible DTOs remain in place.

--- a/specs/GH724/tasks.md
+++ b/specs/GH724/tasks.md
@@ -1,0 +1,39 @@
+# Task Plan
+
+## Linked Issue
+
+GitHub issue: `#724`
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP724-T001` Owner: `type-boundary-worker` | Done when: internal `ChatRequest` and OpenAI `ChatCompletionRequest` ownership is documented in code | Verify: `rg "Canonical internal chat request|OpenAI-compatible chat completion transport request" src/core/types/chat.rs src/core/models/openai/requests.rs`
+- [ ] `SP724-T002` Owner: `type-boundary-worker` | Done when: `core::models::ModelInfo` resolves to canonical `core::types::model::ModelInfo` and the old shape is renamed `LegacyModelSummary` | Verify: `cargo test --lib test_core_models_model_info_uses_canonical_shape --locked`
+- [ ] `SP724-T003` Owner: `route-boundary-worker` | Done when: `build_core_chat_request` preserves transport DTO fields at the internal request boundary | Verify: `cargo test --lib test_build_core_chat_request_preserves_transport_fields --locked`
+- [ ] `SP724-T004` Owner: `openai-transformer-worker` | Done when: typed OpenAI request transformation forwards unknown provider extras without overriding typed fields | Verify: `cargo test --lib test_transform_request_forwards_extra_params_without_overriding_typed_fields --locked`
+- [ ] `SP724-T005` Owner: `coordinator` | Done when: SpecRail, formatting, check, and full library tests pass | Verify: `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue724/specs/GH724 && cargo fmt --all -- --check && cargo check --all-features --locked && cargo test --lib --locked`
+
+## Parallelization
+
+This tranche stays single-writer because the main edits touch shared type
+definitions and route conversion tests. The threads explorer lane is read-only
+and owns no writable files.
+
+## Verification
+
+- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue724/specs/GH724`
+- `cargo fmt --all -- --check`
+- `cargo check --all-features --locked`
+- `cargo test --lib test_build_core_chat_request_preserves_transport_fields --locked`
+- `cargo test --lib test_core_models_model_info_uses_canonical_shape --locked`
+- `cargo test --lib test_transform_request_forwards_extra_params_without_overriding_typed_fields --locked`
+- `cargo test --lib --locked`
+
+## Handoff Notes
+
+Do not use this issue to rewrite provider dispatch, provider registry, pricing,
+or SDK/HTTP provider parity. Those are tracked by GH-725 through GH-729.

--- a/specs/GH724/tech.md
+++ b/specs/GH724/tech.md
@@ -1,0 +1,83 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-724
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Internal chat request | `src/core/types/chat.rs` | Defines `ChatRequest` used by provider traits and providers. | This is the canonical provider execution request. |
+| OpenAI transport request | `src/core/models/openai/requests.rs` | Defines `ChatCompletionRequest` for OpenAI-compatible JSON. | This should stay a transport DTO, not an internal authority. |
+| HTTP conversion boundary | `src/server/routes/ai/chat.rs` | `build_core_chat_request` converts the DTO into `ChatRequest`. | This is where field preservation must be explicit and tested. |
+| Model information | `src/core/types/model.rs`, `src/core/models/mod.rs` | Both define a `ModelInfo` shape; providers use the one under `core::types`. | The duplicate authority named `ModelInfo` must be removed from `core::models`. |
+
+## Proposed Design
+
+Document the ownership boundary in the two request modules and in the HTTP
+conversion function. Keep `ChatCompletionRequest` as the HTTP/OpenAI DTO and
+`ChatRequest` as the provider-facing internal type.
+
+Rename the old `core::models::ModelInfo` struct to `LegacyModelSummary` because
+it is not used by provider traits and is not the canonical model-info authority.
+Then expose `pub type ModelInfo = crate::core::types::model::ModelInfo` from
+`core::models` so the public name resolves to the canonical shape.
+
+Expand the existing `build_core_chat_request` tests to cover the fields at risk
+of conversion loss. Keep seed overflow validation as the explicit lossy/narrow
+case.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | Provider-facing `ChatRequest` docs and route conversion | `cargo test --lib test_build_core_chat_request_minimal` |
+| P2 | OpenAI DTO docs and route conversion | `cargo test --lib test_build_core_chat_request_preserves_transport_fields` |
+| P3 | `core::models::ModelInfo` alias to canonical type | `cargo test --lib test_core_models_model_info_uses_canonical_shape` |
+| P4 | Legacy duplicate is renamed out of authority path | `cargo test --lib test_legacy_model_summary_structure` |
+
+## Data Flow
+
+HTTP JSON enters as `ChatCompletionRequest`, route validation runs on the DTO,
+and `build_core_chat_request` produces the internal `ChatRequest` used by
+routing/provider execution. Provider-specific extension fields flow into
+`ChatRequest::extra_params`; explicit fields stay on explicit internal fields.
+
+No persistence, network behavior, or external API behavior changes in this
+slice.
+
+## Alternatives Considered
+
+- Removing OpenAI request DTOs entirely: rejected because the HTTP API still
+  needs OpenAI-compatible serialization and deserialization.
+- Moving conversion into `core::models::openai`: rejected because it would make
+  OpenAI DTO modules depend on server-layer error types.
+- Deleting the legacy model summary struct outright: rejected to keep an
+  explicit compatibility type for any internal callers that still need that
+  summary shape later.
+
+## Risks
+
+- Security: No new secret, auth, SQL, or command execution surface.
+- Compatibility: The `core::models::ModelInfo` public name now points at the
+  canonical model-info shape; this is intentional for GH-724 but may affect
+  consumers of the duplicate legacy fields.
+- Performance: Conversion remains linear over messages/tools/functions.
+- Maintenance: The legacy summary type is clearly named so it cannot be
+  mistaken for the internal model-info authority.
+
+## Test Plan
+
+- [ ] Unit tests: focused model and chat conversion tests.
+- [ ] Integration tests: covered by `cargo test --lib` for this internal slice.
+- [ ] Manual verification: SpecRail packet validation and PR gate evidence.
+
+## Rollback Plan
+
+Revert the PR. The change is contained to type definitions, documentation, tests,
+and the explicit transport-to-core conversion boundary.

--- a/src/core/models/mod.rs
+++ b/src/core/models/mod.rs
@@ -14,6 +14,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
+/// Canonical internal model information.
+///
+/// The model-info authority lives under `core::types::model`. This re-export
+/// keeps the historical `core::models::ModelInfo` path from defining a second
+/// internal shape.
+pub use crate::core::types::model::ModelInfo;
+
 /// Common metadata for all models
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
@@ -130,17 +137,20 @@ pub struct UsageStats {
     pub last_reset: chrono::DateTime<chrono::Utc>,
 }
 
-/// Model information
+/// Legacy gateway/admin model summary.
+///
+/// This is intentionally not named `ModelInfo`: the internal provider-facing
+/// model-info authority is `crate::core::types::model::ModelInfo`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelInfo {
+pub struct LegacyModelSummary {
     /// Model ID
     pub id: String,
     /// Model name
     pub name: String,
     /// Provider
     pub provider: String,
-    /// Model type (chat, completion, embedding, etc.)
-    pub model_type: ModelType,
+    /// Legacy model category (chat, completion, embedding, etc.)
+    pub model_type: LegacyModelType,
     /// Context window size
     pub context_window: Option<u32>,
     /// Maximum output tokens
@@ -157,10 +167,10 @@ pub struct ModelInfo {
     pub is_available: bool,
 }
 
-/// Model types
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Legacy model categories used by `LegacyModelSummary`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ModelType {
+pub enum LegacyModelType {
     /// Chat completion models
     Chat,
     /// Text completion models
@@ -180,6 +190,11 @@ pub enum ModelType {
     /// Document reranking models
     Rerank,
 }
+
+#[deprecated(
+    note = "use LegacyModelType for legacy summaries or core::types::model::ProviderCapability for internal model capabilities"
+)]
+pub type ModelType = LegacyModelType;
 
 /// Canonical request context type used across the gateway.
 pub type RequestContext = crate::core::types::context::RequestContext;
@@ -282,5 +297,34 @@ mod tests {
         assert_eq!(context.team_id(), Some(team_id));
         assert_eq!(context.client_ip, Some("127.0.0.1".to_string()));
         assert_eq!(context.headers.get("X-Custom"), Some(&"value".to_string()));
+    }
+
+    #[test]
+    fn test_core_models_model_info_uses_canonical_shape() {
+        let info = ModelInfo::default();
+        assert_eq!(info.max_context_length, 4096);
+        assert_eq!(info.currency, "USD");
+        assert!(info.capabilities.is_empty());
+    }
+
+    #[test]
+    fn test_legacy_model_summary_structure() {
+        let summary = LegacyModelSummary {
+            id: "gpt-4".to_string(),
+            name: "GPT-4".to_string(),
+            provider: "openai".to_string(),
+            model_type: LegacyModelType::Chat,
+            context_window: Some(128000),
+            max_output_tokens: Some(4096),
+            input_cost_per_token: Some(0.00003),
+            output_cost_per_token: Some(0.00006),
+            features: vec!["tools".to_string()],
+            description: Some("legacy admin summary".to_string()),
+            is_available: true,
+        };
+
+        assert_eq!(summary.model_type, LegacyModelType::Chat);
+        assert_eq!(summary.context_window, Some(128000));
+        assert!(summary.is_available);
     }
 }

--- a/src/core/models/openai/requests.rs
+++ b/src/core/models/openai/requests.rs
@@ -10,7 +10,11 @@ use super::audio::AudioParams;
 use super::messages::ChatMessage;
 use super::tools::{Function, FunctionCall, Tool, ToolChoice};
 
-/// Chat completion request (OpenAI compatible)
+/// OpenAI-compatible chat completion transport request.
+///
+/// This DTO preserves OpenAI wire compatibility for HTTP/API boundaries. It is
+/// not the provider-facing internal request; route adapters convert it into
+/// `crate::core::types::chat::ChatRequest` before provider execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatCompletionRequest {
     /// Model to use for completion

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -24,6 +24,9 @@ pub struct OpenAIChatRequest {
     pub stop: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
+    /// Stream options, such as final usage inclusion for streaming responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<crate::core::types::chat::StreamOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<OpenAITool>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -56,6 +56,9 @@ pub struct OpenAIChatRequest {
     /// Service tier for the request ("default" or "flex")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
+    /// Provider-specific request fields that are not modeled explicitly.
+    #[serde(default, flatten, skip_serializing_if = "HashMap::is_empty")]
+    pub extra_params: HashMap<String, serde_json::Value>,
 }
 
 /// OpenAI Message

--- a/src/core/providers/openai/transformer/request.rs
+++ b/src/core/providers/openai/transformer/request.rs
@@ -46,6 +46,7 @@ impl OpenAIRequestTransformer {
             top_p: request.top_p,
             n: request.n,
             stream: None, // Set by caller
+            stream_options: request.stream_options,
             stop: request.stop,
             max_tokens: request.max_tokens,
             max_completion_tokens: request.max_completion_tokens,
@@ -177,6 +178,7 @@ fn is_openai_chat_request_field(key: &str) -> bool {
             | "presence_penalty"
             | "stop"
             | "stream"
+            | "stream_options"
             | "tools"
             | "tool_choice"
             | "parallel_tool_calls"
@@ -615,11 +617,18 @@ mod tests {
                 ..Default::default()
             }],
             temperature: Some(0.5),
+            stream_options: Some(crate::core::types::chat::StreamOptions {
+                include_usage: Some(true),
+            }),
             extra_params: HashMap::from([
                 ("provider_flag".to_string(), serde_json::json!("kept")),
                 ("model".to_string(), serde_json::json!("wrong-model")),
                 ("messages".to_string(), serde_json::json!("wrong-messages")),
                 ("temperature".to_string(), serde_json::json!(1.9)),
+                (
+                    "stream_options".to_string(),
+                    serde_json::json!("wrong-options"),
+                ),
             ]),
             ..Default::default()
         };
@@ -631,6 +640,7 @@ mod tests {
         assert_eq!(json["model"], "gpt-4");
         assert!(json["messages"].is_array());
         assert_eq!(json["temperature"], serde_json::json!(0.5_f32));
+        assert_eq!(json["stream_options"]["include_usage"], true);
     }
 
     #[test]

--- a/src/core/providers/openai/transformer/request.rs
+++ b/src/core/providers/openai/transformer/request.rs
@@ -7,6 +7,7 @@ use crate::core::types::{
     tools::ResponseFormat, tools::Tool, tools::ToolChoice,
 };
 use serde_json;
+use std::collections::HashMap;
 
 use super::super::error::OpenAIError;
 use super::super::models::*;
@@ -20,6 +21,7 @@ pub struct OpenAIRequestTransformer;
 impl OpenAIRequestTransformer {
     /// Transform ChatRequest to OpenAIChatRequest
     pub fn transform(request: ChatRequest) -> Result<OpenAIChatRequest, OpenAIError> {
+        let extra_params = retain_openai_extra_params(request.extra_params);
         let messages = request
             .messages
             .into_iter()
@@ -62,6 +64,7 @@ impl OpenAIRequestTransformer {
             store: request.store,
             metadata: request.metadata,
             service_tier: request.service_tier,
+            extra_params,
         })
     }
 
@@ -150,6 +153,45 @@ impl OpenAIRequestTransformer {
             json_schema: format.json_schema,
         }
     }
+}
+
+fn retain_openai_extra_params(
+    extra_params: HashMap<String, serde_json::Value>,
+) -> HashMap<String, serde_json::Value> {
+    extra_params
+        .into_iter()
+        .filter(|(key, _)| !is_openai_chat_request_field(key))
+        .collect()
+}
+
+fn is_openai_chat_request_field(key: &str) -> bool {
+    matches!(
+        key,
+        "model"
+            | "messages"
+            | "temperature"
+            | "max_tokens"
+            | "max_completion_tokens"
+            | "top_p"
+            | "frequency_penalty"
+            | "presence_penalty"
+            | "stop"
+            | "stream"
+            | "tools"
+            | "tool_choice"
+            | "parallel_tool_calls"
+            | "response_format"
+            | "user"
+            | "seed"
+            | "n"
+            | "logit_bias"
+            | "logprobs"
+            | "top_logprobs"
+            | "reasoning_effort"
+            | "store"
+            | "metadata"
+            | "service_tier"
+    )
 }
 
 #[cfg(test)]
@@ -561,6 +603,34 @@ mod tests {
         assert_eq!(result.n, Some(2));
         assert_eq!(result.seed, Some(42));
         assert_eq!(result.user, Some("user123".to_string()));
+    }
+
+    #[test]
+    fn test_transform_request_forwards_extra_params_without_overriding_typed_fields() {
+        let request = ChatRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![ChatMessage {
+                role: MessageRole::User,
+                content: Some(MessageContent::Text("test".to_string())),
+                ..Default::default()
+            }],
+            temperature: Some(0.5),
+            extra_params: HashMap::from([
+                ("provider_flag".to_string(), serde_json::json!("kept")),
+                ("model".to_string(), serde_json::json!("wrong-model")),
+                ("messages".to_string(), serde_json::json!("wrong-messages")),
+                ("temperature".to_string(), serde_json::json!(1.9)),
+            ]),
+            ..Default::default()
+        };
+
+        let result = OpenAIRequestTransformer::transform(request).unwrap();
+        let json = serde_json::to_value(result).unwrap();
+
+        assert_eq!(json["provider_flag"], "kept");
+        assert_eq!(json["model"], "gpt-4");
+        assert!(json["messages"].is_array());
+        assert_eq!(json["temperature"], serde_json::json!(0.5_f32));
     }
 
     #[test]

--- a/src/core/types/chat.rs
+++ b/src/core/types/chat.rs
@@ -79,7 +79,11 @@ impl ChatMessage {
     }
 }
 
-/// Chat request
+/// Canonical internal chat request.
+///
+/// Provider traits and provider implementations consume this type. External
+/// wire-compatible request DTOs, such as OpenAI chat completions, must be
+/// converted into this shape at adapter boundaries before routing.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ChatRequest {
     /// Model name

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -422,6 +422,9 @@ pub(crate) fn build_core_chat_request(
     model: String,
     stream: bool,
 ) -> Result<CoreChatRequest, GatewayError> {
+    // This is the OpenAI transport DTO -> internal provider request boundary.
+    // Keep field forwarding explicit so new OpenAI-compatible parameters cannot
+    // disappear silently while routing through the canonical ChatRequest tree.
     let tools = match request.tools {
         Some(tools) => {
             let mut converted = Vec::with_capacity(tools.len());

--- a/src/server/routes/ai/chat_tests.rs
+++ b/src/server/routes/ai/chat_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::core::models::openai::{ChatMessage, MessageContent, MessageRole};
+use crate::core::models::openai::{
+    ChatMessage, Function, FunctionCall, MessageContent, MessageRole, ToolChoiceFunction,
+    ToolChoiceFunctionSpec,
+};
 use crate::core::types::responses::{
     ChatChunk, ChatDelta, ChatStreamChoice, LogProbs, TokenLogProb,
 };
@@ -294,9 +297,10 @@ fn test_build_core_chat_request_minimal() {
 }
 
 #[test]
-fn test_build_core_chat_request_preserves_boundary_fields() {
+fn test_build_core_chat_request_preserves_transport_fields() {
     let mut extra_body = std::collections::HashMap::new();
     extra_body.insert("provider_knob".to_string(), serde_json::json!("kept"));
+    extra_body.insert("modalities".to_string(), serde_json::json!("wrong"));
     let request = ChatCompletionRequest {
         model: "gpt-4".to_string(),
         messages: vec![ChatMessage {
@@ -308,6 +312,32 @@ fn test_build_core_chat_request_preserves_boundary_fields() {
             tool_call_id: None,
             audio: None,
         }],
+        stream_options: Some(crate::core::models::openai::StreamOptions {
+            include_usage: Some(true),
+        }),
+        tools: Some(vec![Tool {
+            tool_type: "function".to_string(),
+            function: Function {
+                name: "lookup".to_string(),
+                description: Some("Look up a record".to_string()),
+                parameters: Some(serde_json::json!({"type": "object"})),
+            },
+        }]),
+        tool_choice: Some(ToolChoice::Specific(ToolChoiceFunction {
+            tool_type: "function".to_string(),
+            function: ToolChoiceFunctionSpec {
+                name: "lookup".to_string(),
+            },
+        })),
+        functions: Some(vec![Function {
+            name: "legacy_lookup".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({"type": "object"})),
+        }]),
+        function_call: Some(FunctionCall {
+            name: "legacy_lookup".to_string(),
+            arguments: "{}".to_string(),
+        }),
         parallel_tool_calls: Some(false),
         response_format: Some(crate::core::models::openai::ResponseFormat {
             format_type: "json_schema".to_string(),
@@ -315,9 +345,20 @@ fn test_build_core_chat_request_preserves_boundary_fields() {
             response_type: Some("json_schema".to_string()),
         }),
         seed: Some(123),
+        modalities: Some(vec!["text".to_string(), "audio".to_string()]),
+        audio: Some(crate::core::models::openai::AudioParams {
+            voice: "alloy".to_string(),
+            format: "wav".to_string(),
+        }),
         prediction: Some(serde_json::json!({"type": "content", "content": "expected"})),
         safety_settings: Some(serde_json::json!([{"category": "test"}])),
         cache_control: Some(serde_json::json!({"type": "ephemeral"})),
+        store: Some(true),
+        metadata: Some(std::collections::HashMap::from([(
+            "trace_id".to_string(),
+            "trace-123".to_string(),
+        )])),
+        service_tier: Some("flex".to_string()),
         extra_body,
         ..Default::default()
     };
@@ -327,12 +368,54 @@ fn test_build_core_chat_request_preserves_boundary_fields() {
     assert_eq!(core_request.seed, Some(123));
     assert_eq!(
         core_request
+            .stream_options
+            .as_ref()
+            .and_then(|options| options.include_usage),
+        Some(true)
+    );
+    assert_eq!(
+        core_request
+            .tools
+            .as_ref()
+            .and_then(|tools| tools.first())
+            .map(|tool| tool.function.name.as_str()),
+        Some("lookup")
+    );
+    match core_request.tool_choice.as_ref().expect("tool choice") {
+        crate::core::types::tools::ToolChoice::Specific {
+            choice_type,
+            function,
+        } => {
+            assert_eq!(choice_type, "function");
+            assert_eq!(function.as_ref().map(|f| f.name.as_str()), Some("lookup"));
+        }
+        _ => panic!("expected specific tool choice"),
+    }
+    assert_eq!(
+        core_request
+            .functions
+            .as_ref()
+            .and_then(|functions| functions.first())
+            .and_then(|function| function.get("name")),
+        Some(&serde_json::json!("legacy_lookup"))
+    );
+    assert_eq!(
+        core_request
+            .function_call
+            .as_ref()
+            .and_then(|call| call.get("name")),
+        Some(&serde_json::json!("legacy_lookup"))
+    );
+    assert_eq!(
+        core_request
             .response_format
             .as_ref()
             .and_then(|format| format.response_type.as_deref()),
         Some("json_schema")
     );
     assert_eq!(core_request.extra_params["provider_knob"], "kept");
+    assert_eq!(core_request.extra_params["modalities"][0], "text");
+    assert_eq!(core_request.extra_params["audio"]["voice"], "alloy");
     assert_eq!(
         core_request.extra_params["prediction"]["content"],
         "expected"
@@ -345,6 +428,15 @@ fn test_build_core_chat_request_preserves_boundary_fields() {
         core_request.extra_params["cache_control"]["type"],
         "ephemeral"
     );
+    assert_eq!(core_request.store, Some(true));
+    assert_eq!(
+        core_request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("trace_id")),
+        Some(&"trace-123".to_string())
+    );
+    assert_eq!(core_request.service_tier.as_deref(), Some("flex"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add SpecRail packet for GH-724 and scope the slice to canonical chat/model type boundaries.
- Document `ChatRequest` as the internal provider-facing request and `ChatCompletionRequest` as the OpenAI transport DTO.
- Repoint `core::models::ModelInfo` to the canonical `core::types::model::ModelInfo`, rename the duplicate legacy shape to `LegacyModelSummary`, and preserve a deprecated `ModelType` alias.
- Expand transport-to-core field preservation tests and keep OpenAI typed transformer extras from overriding typed fields.

## Verification
- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue724/specs/GH724`
- `cargo fmt --all -- --check`
- `cargo test --lib test_build_core_chat_request_preserves_transport_fields --locked`
- `cargo test --lib test_core_models_model_info_uses_canonical_shape --locked`
- `cargo test --lib test_transform_request_forwards_extra_params_without_overriding_typed_fields --locked`
- `cargo check --all-features --locked`
- `cargo test --lib --locked`

Fixes #724