### PR TITLE
fix: converge provider instantiation registry

### DIFF
--- a/specs/GH725/product.md
+++ b/specs/GH725/product.md
@@ -1,0 +1,62 @@
+# Product Spec
+
+## Linked Issue
+
+GH-725 / #725
+
+## User Problem
+
+Provider identity is split across enum variants, factory branches, catalog metadata,
+and runtime registration. That makes provider additions easy to drift: a selector
+can parse, but the factory or runtime registry can disagree about whether it is
+constructible or how it is keyed.
+
+## Goals
+
+- Make `PROVIDER_TYPE_REGISTRY` the authoritative source for provider identity
+  and dispatchability checks.
+- Ensure catalog-backed provider construction follows registry dispatch metadata.
+- Ensure runtime `ProviderRegistry` keys providers by canonical provider identity
+  unless callers explicitly opt into a logical key.
+- Add mechanical tests that catch drift between registry metadata, factory support,
+  runtime registration, and selector support.
+
+## Non-Goals
+
+- Do not split provider capability traits; that belongs to GH-729.
+- Do not change SDK, `completion()`, or HTTP adapter parity; that belongs to GH-728.
+- Do not rewrite the closed `Provider` enum or all dispatch macro arms in this slice.
+
+## Behavior Invariants
+
+1. Every dispatchable non-custom `ProviderType` listed by `PROVIDER_TYPE_REGISTRY`
+   is advertised by `Provider::factory_supported_provider_types()`.
+2. Every unsupported registry entry is rejected by support-detection helpers and
+   falls through to `ProviderError::NotImplemented` during construction.
+3. Catalog-backed providers are constructed through entries marked
+   `CatalogOpenAiLike`; catalog definitions alone cannot make unsupported enum
+   entries appear constructible.
+4. `ProviderRegistry::register` stores providers under `Provider::name()`, and
+   typed lookup via `get_by_type` reflects the same provider identity.
+5. Explicit logical keys remain available through `register_with_key` for multiple
+   configured instances of the same provider type.
+
+## Acceptance Criteria
+
+- [ ] Registry dispatchability and factory support are mechanically checked.
+- [ ] Catalog provider factory construction uses registry dispatch metadata.
+- [ ] Runtime provider registration has tests for canonical key and explicit key behavior.
+- [ ] The focused provider registry/factory tests and full feature check pass locally.
+
+## Edge Cases
+
+- Feature-gated providers may be native only when the relevant feature is enabled.
+- `OpenAILike` catalog providers report runtime `ProviderType::OpenAICompatible`;
+  tests must not treat catalog provider type identity as a native enum identity.
+- Duplicate logical provider names remain caller-controlled via `register_with_key`.
+
+## Rollout Notes
+
+This is an internal convergence slice. There is no data migration or public API
+change expected, but provider additions should now fail tests earlier when a table
+is updated without the corresponding constructibility metadata.

--- a/specs/GH725/tasks.md
+++ b/specs/GH725/tasks.md
@@ -1,0 +1,39 @@
+# Task Plan
+
+## Linked Issue
+
+GH-725 / #725
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [x] `SP725-T001` Owner: registry-worker | Done when: registry exposes a catalog-dispatch helper and tests keep factory support equal to dispatchable registry entries. | Verify: cargo test provider_registry --lib
+- [x] `SP725-T002` Owner: factory-worker | Done when: catalog provider construction is gated by `ProviderDispatchKind::CatalogOpenAiLike` instead of catalog presence alone. | Verify: cargo test from_config_async --lib
+- [x] `SP725-T003` Owner: runtime-worker | Done when: `ProviderRegistry` tests prove canonical registration keys and explicit logical keys do not drift from provider identity. | Verify: cargo test provider_registry --lib
+- [x] `SP725-T004` Owner: router-worker | Done when: default router catalog startup registration uses one catalog-driven list without repeated per-provider blocks. | Verify: cargo test provider_registry --lib
+- [x] `SP725-T005` Owner: verifier | Done when: local SpecRail, format, targeted tests, and full feature compile pass. | Verify: cargo check --all-features --locked
+
+## Parallelization
+
+The coordinator owns all writable files for this tranche to avoid overlapping
+provider registry/factory edits. The read-only explorer lane inspected the same
+areas and returned a plan but did not edit files.
+
+## Verification
+
+- SpecRail: `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue725/specs/GH725`
+- Format: `cargo fmt --all -- --check`
+- Targeted: `cargo test provider_registry --lib`
+- Targeted: `cargo test from_config_async --lib`
+- Compile: `cargo check --all-features --locked`
+
+## Handoff Notes
+
+Do not claim GH-725 removes all manual enum dispatch. The accepted slice makes
+the existing manual surfaces mechanically guarded and moves catalog factory/runtime
+paths behind registry metadata. Full enum macro generation should be a separate
+refactor if still needed after GH-725.

--- a/specs/GH725/tech.md
+++ b/specs/GH725/tech.md
@@ -1,0 +1,83 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-725 / #725
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Provider metadata | `src/core/providers/registry/types.rs` | `PROVIDER_TYPE_REGISTRY` records canonical names, aliases, dispatch kind, and catalog backing. | This is the intended authoritative matrix. |
+| Factory dispatch | `src/core/providers/factory/registry.rs` | Native and explicit OpenAI-like branches are handwritten; catalog fallback checks catalog definitions directly. | Catalog constructibility should be gated by registry dispatch metadata. |
+| Runtime registry | `src/core/providers/provider_registry.rs` | `register()` uses `provider.name()` but only empty-registry behavior is tested. | Runtime keying should be guarded against identity drift. |
+| Selector support | `src/core/providers/factory/resolver.rs` | Catalog definitions and factory-supported types decide support. | Unsupported registry entries must not be accepted accidentally. |
+| Default router boot | `src/core/completion/default_router/mod.rs` | Several catalog provider registrations are manually repeated. | Runtime catalog registration can be driven by the catalog/registry path. |
+
+## Proposed Design
+
+Keep the closed `Provider` enum intact for this issue. The high-risk enum and
+macro-generation refactor is deferred.
+
+Tighten the lower-risk convergence path:
+
+- Add a registry helper that returns only catalog-dispatch entries.
+- Use that helper in `Provider::from_config_async` so catalog fallback depends on
+  `ProviderDispatchKind::CatalogOpenAiLike`, not on catalog presence alone.
+- Use catalog iteration in `DefaultRouter::new` to register known environment-backed
+  OpenAI-like providers once, removing repeated hand-written blocks for the same
+  provider names.
+- Extend tests so registry dispatchability, selector support, factory construction,
+  and runtime registration are checked together.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | `registry/types.rs`, `providers/mod.rs` | `cargo test provider_registry --lib` |
+| P2 | `factory/resolver.rs`, `factory/registry.rs` | `cargo test from_config_async --lib` |
+| P3 | `factory/registry.rs` | `cargo test dispatch_kind_matches_runtime_variant --lib` |
+| P4 | `provider_registry.rs` | `cargo test provider_registry --lib` |
+| P5 | `provider_registry.rs` | `cargo test register_with_key --lib` |
+
+## Data Flow
+
+Input provider selectors parse into `ProviderType` or catalog names. Registry
+entries define whether that selector is constructible natively, explicitly as an
+OpenAI-like provider, via the catalog, or not at all. Factory construction returns
+a `Provider` enum instance, and runtime registries store that instance by canonical
+provider name unless an explicit logical key is supplied.
+
+No persistence or external calls are added.
+
+## Alternatives Considered
+
+- Generate the full `Provider` enum and four dispatch macro arms from one macro.
+  Deferred because feature-gated provider modules make this a broader refactor.
+- Remove the enum and use trait objects in runtime registries. Deferred because it
+  changes router dispatch semantics and is larger than GH-725.
+
+## Risks
+
+- Security: no secret handling changes; tests must avoid real API keys.
+- Compatibility: provider selector support should not expand or shrink except where
+  it already follows dispatch metadata.
+- Performance: registry iteration happens at startup/tests only and uses static data.
+- Maintenance: tests should describe the remaining enum/manual-match boundary rather
+  than overclaiming full generation.
+
+## Test Plan
+
+- [ ] Unit tests: `cargo test provider_registry --lib`
+- [ ] Unit tests: `cargo test from_config_async --lib`
+- [ ] Static check: `cargo fmt --all -- --check`
+- [ ] Full feature compile: `cargo check --all-features --locked`
+
+## Rollback Plan
+
+Revert the GH-725 commit or PR. The changes are limited to provider registry,
+factory dispatch, router startup catalog iteration, tests, and the SpecRail packet.

--- a/src/core/completion/default_router/mod.rs
+++ b/src/core/completion/default_router/mod.rs
@@ -60,7 +60,6 @@ impl DefaultRouter {
     async fn register_openai_like_provider_from_env(
         provider_registry: &mut ProviderRegistry,
         provider_name: &str,
-        _env_var: &str,
     ) {
         let Some(def) = crate::core::providers::registry::get_definition(provider_name) else {
             return;
@@ -74,6 +73,16 @@ impl DefaultRouter {
             crate::core::providers::openai_like::OpenAILikeProvider::new(config).await
         {
             provider_registry.register(Provider::OpenAILike(provider));
+        }
+    }
+
+    async fn register_default_openai_like_providers_from_env(
+        provider_registry: &mut ProviderRegistry,
+    ) {
+        for provider_name in
+            crate::core::providers::registry::default_catalog_runtime_provider_names()
+        {
+            Self::register_openai_like_provider_from_env(provider_registry, provider_name).await;
         }
     }
 
@@ -107,13 +116,7 @@ impl DefaultRouter {
             }
         }
 
-        // Add OpenRouter provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "openrouter",
-            "OPENROUTER_API_KEY",
-        )
-        .await;
+        Self::register_default_openai_like_providers_from_env(&mut provider_registry).await;
 
         // Add Anthropic provider if API key is available
         if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
@@ -126,94 +129,6 @@ impl DefaultRouter {
             let anthropic_provider = AnthropicProvider::new(config)?;
             provider_registry.register(Provider::Anthropic(anthropic_provider));
         }
-
-        // Add DeepSeek provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "deepseek",
-            "DEEPSEEK_API_KEY",
-        )
-        .await;
-
-        // Add Moonshot provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "moonshot",
-            "MOONSHOT_API_KEY",
-        )
-        .await;
-
-        // Add MiniMax provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "minimax",
-            "MINIMAX_API_KEY",
-        )
-        .await;
-
-        // Add Zhipu provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "zhipu",
-            "ZHIPU_API_KEY",
-        )
-        .await;
-
-        // Add Moonshot provider if API key is available
-        if let Ok(api_key) = std::env::var("MOONSHOT_API_KEY")
-            && let Some(def) = crate::core::providers::registry::get_definition("moonshot")
-        {
-            let config = def.to_openai_like_config(Some(&api_key), None);
-            if let Ok(provider) =
-                crate::core::providers::openai_like::OpenAILikeProvider::new(config).await
-            {
-                provider_registry.register(Provider::OpenAILike(provider));
-            }
-        }
-
-        // Add MiniMax provider if API key is available
-        if let Ok(api_key) = std::env::var("MINIMAX_API_KEY")
-            && let Some(def) = crate::core::providers::registry::get_definition("minimax")
-        {
-            let config = def.to_openai_like_config(Some(&api_key), None);
-            if let Ok(provider) =
-                crate::core::providers::openai_like::OpenAILikeProvider::new(config).await
-            {
-                provider_registry.register(Provider::OpenAILike(provider));
-            }
-        }
-
-        // Add Zhipu provider if API key is available
-        if let Ok(api_key) = std::env::var("ZHIPU_API_KEY")
-            && let Some(def) = crate::core::providers::registry::get_definition("zhipu")
-        {
-            let config = def.to_openai_like_config(Some(&api_key), None);
-            if let Ok(provider) =
-                crate::core::providers::openai_like::OpenAILikeProvider::new(config).await
-            {
-                provider_registry.register(Provider::OpenAILike(provider));
-            }
-        }
-
-        // Add Groq provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "groq",
-            "GROQ_API_KEY",
-        )
-        .await;
-
-        // Add Xiaomi MiMo provider if API key is available
-        Self::register_openai_like_provider_from_env(
-            &mut provider_registry,
-            "xiaomi_mimo",
-            "MIMO_API_KEY",
-        )
-        .await;
-
-        // Add xAI provider if API key is available
-        Self::register_openai_like_provider_from_env(&mut provider_registry, "xai", "XAI_API_KEY")
-            .await;
 
         Ok(Self {
             provider_registry: Arc::new(provider_registry),

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -32,6 +32,23 @@ fn provider_diagnostic_name(provider_type: &ProviderType) -> &'static str {
         .unwrap_or("custom")
 }
 
+fn catalog_definition_for_supported_selector(
+    selector: &str,
+) -> Option<&'static provider_registry::ProviderDefinition> {
+    let normalized = selector.trim().to_ascii_lowercase();
+    let def = provider_registry::get_definition(&normalized)?;
+    match provider_registry::entry_for_name(&normalized) {
+        Some(entry)
+            if entry.dispatch_kind
+                == provider_registry::ProviderDispatchKind::CatalogOpenAiLike =>
+        {
+            Some(def)
+        }
+        Some(_) => None,
+        None => Some(def),
+    }
+}
+
 /// Create a provider from configuration
 ///
 /// This is the main factory function for creating providers
@@ -60,9 +77,7 @@ pub async fn create_provider(
     } else {
         provider_type.as_str()
     };
-    // --- Tier 1: check the data-driven catalog first ---
-    let provider_name_lower = provider_selector.to_lowercase();
-    if let Some(def) = provider_registry::get_definition(&provider_name_lower) {
+    if let Some(def) = catalog_definition_for_supported_selector(provider_selector) {
         let effective_key = if api_key.is_empty() {
             def.resolve_api_key(None)
         } else {
@@ -164,6 +179,31 @@ pub async fn create_provider(
 mod tests {
     use super::*;
     use crate::core::providers::registry as provider_registry;
+
+    #[test]
+    fn test_catalog_factory_shortcut_is_registry_dispatch_gated_for_enum_selectors() {
+        for name in provider_registry::PROVIDER_CATALOG.keys() {
+            let shortcut = catalog_definition_for_supported_selector(name);
+            if let Some(entry) = provider_registry::entry_for_name(name) {
+                assert_eq!(
+                    shortcut.is_some(),
+                    entry.dispatch_kind
+                        == provider_registry::ProviderDispatchKind::CatalogOpenAiLike,
+                    "{name} must not use the catalog factory shortcut unless registry dispatch says CatalogOpenAiLike"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_catalog_factory_shortcut_keeps_pure_catalog_only_selectors() {
+        let selector = "together";
+        assert!(
+            provider_registry::entry_for_name(selector).is_none(),
+            "{selector} should remain a pure catalog-only selector for this guard"
+        );
+        assert!(catalog_definition_for_supported_selector(selector).is_some());
+    }
 
     #[tokio::test]
     async fn test_catalog_entries_are_creatable_via_factory() {

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -227,21 +227,14 @@ impl Provider {
                     ))
                 }
             }
-            ref pt if provider_registry::catalog_dispatch_entry_for_type(pt).is_some() => {
-                let entry =
-                    provider_registry::catalog_dispatch_entry_for_type(pt).ok_or_else(|| {
-                        ProviderError::not_implemented(
-                            super::provider_diagnostic_name(pt),
-                            "Catalog dispatch entry disappeared",
-                        )
-                    })?;
-                let name = entry.canonical_name;
-                let Some(def) = provider_registry::get_definition(name) else {
+            pt => {
+                let Some(def) = provider_registry::catalog_definition_for_provider_type(&pt) else {
                     return Err(ProviderError::not_implemented(
-                        name,
-                        format!("Catalog definition for '{}' disappeared unexpectedly", name),
+                        super::provider_diagnostic_name(&pt),
+                        format!("Factory for {:?} not yet implemented", pt),
                     ));
                 };
+                let name = def.name;
                 let api_key = config_str(&config, "api_key")
                     .map(|s| s.to_string())
                     .or_else(|| def.resolve_api_key(None));
@@ -262,10 +255,6 @@ impl Provider {
                     .map_err(|e| ProviderError::initialization(name, e.to_string()))?;
                 Ok(Provider::OpenAILike(provider))
             }
-            _ => Err(ProviderError::not_implemented(
-                super::provider_diagnostic_name(&provider_type),
-                format!("Factory for {:?} not yet implemented", provider_type),
-            )),
         }
     }
 }
@@ -777,6 +766,7 @@ mod tests {
             ProviderType::V0,
             ProviderType::AmazonNova,
             ProviderType::GitHub,
+            ProviderType::Custom("together".to_string()),
         ] {
             let provider = Provider::from_config_async(
                 provider_type.clone(),

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -227,19 +227,20 @@ impl Provider {
                     ))
                 }
             }
-            // Catalog-covered provider types: delegate to the Tier 1 registry after
-            // all explicit branches, so catalog metadata cannot shadow provider-specific builders.
-            ref pt if provider_registry::get_definition(&pt.to_string()).is_some() => {
-                let name = pt.to_string();
-                // Safety: guard guarantees the definition exists
-                let def = match provider_registry::get_definition(&name) {
-                    Some(d) => d,
-                    None => {
-                        return Err(ProviderError::not_implemented(
+            ref pt if provider_registry::catalog_dispatch_entry_for_type(pt).is_some() => {
+                let entry =
+                    provider_registry::catalog_dispatch_entry_for_type(pt).ok_or_else(|| {
+                        ProviderError::not_implemented(
                             super::provider_diagnostic_name(pt),
-                            format!("Catalog definition for '{}' disappeared unexpectedly", name),
-                        ));
-                    }
+                            "Catalog dispatch entry disappeared",
+                        )
+                    })?;
+                let name = entry.canonical_name;
+                let Some(def) = provider_registry::get_definition(name) else {
+                    return Err(ProviderError::not_implemented(
+                        name,
+                        format!("Catalog definition for '{}' disappeared unexpectedly", name),
+                    ));
                 };
                 let api_key = config_str(&config, "api_key")
                     .map(|s| s.to_string())
@@ -258,7 +259,7 @@ impl Provider {
                 }
                 let provider = openai_like::OpenAILikeProvider::new(oai_config)
                     .await
-                    .map_err(|e| ProviderError::initialization(def.name, e.to_string()))?;
+                    .map_err(|e| ProviderError::initialization(name, e.to_string()))?;
                 Ok(Provider::OpenAILike(provider))
             }
             _ => Err(ProviderError::not_implemented(
@@ -416,6 +417,9 @@ mod tests {
                     "{:?} is not dispatchable and should have been skipped",
                     entry.provider_type
                 ),
+            }
+            if entry.dispatch_kind == ProviderDispatchKind::CatalogOpenAiLike {
+                assert_eq!(provider.name(), entry.canonical_name);
             }
         }
     }

--- a/src/core/providers/factory/resolver.rs
+++ b/src/core/providers/factory/resolver.rs
@@ -4,12 +4,11 @@
 
 use crate::core::providers::Provider;
 use crate::core::providers::provider_type::ProviderType;
-use crate::core::providers::registry;
 
 /// Returns true if a provider selector can be instantiated by the current runtime.
 ///
 /// The selector is resolved using the same precedence as `create_provider`:
-/// 1. Tier-1 data-driven catalog names
+/// 1. Registry-gated Tier-1 data-driven catalog names
 /// 2. Built-in factory provider types
 pub fn is_provider_selector_supported(selector: &str) -> bool {
     let normalized = selector.trim().to_lowercase();
@@ -17,11 +16,10 @@ pub fn is_provider_selector_supported(selector: &str) -> bool {
         return false;
     }
 
-    if registry::get_definition(&normalized).is_some() {
+    if super::catalog_definition_for_supported_selector(&normalized).is_some() {
         return true;
     }
 
-    // Catalog selectors are already handled above; use strict FromStr for enum variants.
     match normalized.parse::<ProviderType>() {
         Ok(t) => Provider::factory_supported_provider_types().contains(&t),
         Err(_) => false,
@@ -44,9 +42,13 @@ mod tests {
     #[test]
     fn test_catalog_entries_are_supported_selectors() {
         for name in registry::PROVIDER_CATALOG.keys() {
-            assert!(
+            let expected = registry::entry_for_name(name)
+                .map(|entry| entry.dispatch_kind.is_dispatchable())
+                .unwrap_or(true);
+            assert_eq!(
                 is_provider_selector_supported(name),
-                "Catalog provider '{}' must be a supported selector",
+                expected,
+                "Catalog provider '{}' support must follow registry dispatchability",
                 name
             );
         }

--- a/src/core/providers/provider_registry.rs
+++ b/src/core/providers/provider_registry.rs
@@ -118,6 +118,16 @@ impl std::fmt::Debug for ProviderRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::providers::anthropic::{AnthropicConfig, AnthropicProvider};
+    use crate::core::providers::registry::entry_for_type;
+
+    fn test_anthropic_provider() -> Provider {
+        let provider = match AnthropicProvider::new(AnthropicConfig::new_test("test-key")) {
+            Ok(provider) => provider,
+            Err(err) => panic!("test Anthropic provider should be constructible: {err}"),
+        };
+        Provider::Anthropic(provider)
+    }
 
     // ==================== Creation Tests ====================
 
@@ -346,5 +356,36 @@ mod tests {
         assert!(registry.get("provider-with-dash").is_none());
         assert!(registry.get("provider_with_underscore").is_none());
         assert!(registry.get("provider.with.dots").is_none());
+    }
+
+    #[test]
+    fn test_register_uses_provider_canonical_name() {
+        let mut registry = ProviderRegistry::new();
+        let entry = match entry_for_type(&ProviderType::Anthropic) {
+            Some(entry) => entry,
+            None => panic!("anthropic registry entry should exist"),
+        };
+
+        registry.register(test_anthropic_provider());
+
+        assert!(registry.contains(entry.canonical_name));
+        assert!(registry.get("anthropic").is_some());
+        let typed = registry.get_by_type(ProviderType::Anthropic);
+        assert_eq!(typed.len(), 1);
+        assert_eq!(typed[0].name(), entry.canonical_name);
+    }
+
+    #[test]
+    fn test_register_with_key_preserves_logical_key_and_provider_identity() {
+        let mut registry = ProviderRegistry::new();
+
+        registry.register_with_key("anthropic-primary", test_anthropic_provider());
+
+        assert!(registry.contains("anthropic-primary"));
+        assert!(!registry.contains("anthropic"));
+        let typed = registry.get_by_type(ProviderType::Anthropic);
+        assert_eq!(typed.len(), 1);
+        assert_eq!(typed[0].provider_type(), ProviderType::Anthropic);
+        assert_eq!(typed[0].name(), "anthropic");
     }
 }

--- a/src/core/providers/registry/mod.rs
+++ b/src/core/providers/registry/mod.rs
@@ -21,7 +21,8 @@ pub use lifecycle::{
     provider_module_lifecycle,
 };
 pub use types::{
-    PROVIDER_TYPE_REGISTRY, ProviderDispatchKind, ProviderRegistryEntry,
-    dispatchable_provider_types, dispatchable_provider_types_slice, entry_for_name, entry_for_type,
-    provider_type_registry,
+    DEFAULT_CATALOG_RUNTIME_PROVIDERS, PROVIDER_TYPE_REGISTRY, ProviderDispatchKind,
+    ProviderRegistryEntry, catalog_dispatch_entries, catalog_dispatch_entry_for_type,
+    default_catalog_runtime_provider_names, dispatchable_provider_types,
+    dispatchable_provider_types_slice, entry_for_name, entry_for_type, provider_type_registry,
 };

--- a/src/core/providers/registry/mod.rs
+++ b/src/core/providers/registry/mod.rs
@@ -26,3 +26,13 @@ pub use types::{
     default_catalog_runtime_provider_names, dispatchable_provider_types,
     dispatchable_provider_types_slice, entry_for_name, entry_for_type, provider_type_registry,
 };
+
+pub fn catalog_definition_for_provider_type(
+    provider_type: &super::provider_type::ProviderType,
+) -> Option<&'static ProviderDefinition> {
+    match provider_type {
+        super::provider_type::ProviderType::Custom(name) => get_definition(name),
+        _ => catalog_dispatch_entry_for_type(provider_type)
+            .and_then(|entry| get_definition(entry.canonical_name)),
+    }
+}

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -293,6 +293,22 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
     ),
 ];
 
+/// Catalog providers registered by the default router when their configured
+/// environment credentials are available.
+///
+/// Keep this list in registry metadata instead of router startup code so runtime
+/// registration and catalog definitions drift together.
+pub static DEFAULT_CATALOG_RUNTIME_PROVIDERS: &[&str] = &[
+    "openrouter",
+    "deepseek",
+    "moonshot",
+    "minimax",
+    "zhipu",
+    "groq",
+    "xiaomi_mimo",
+    "xai",
+];
+
 static DISPATCHABLE_PROVIDER_TYPES: LazyLock<Vec<ProviderType>> = LazyLock::new(|| {
     PROVIDER_TYPE_REGISTRY
         .iter()
@@ -311,6 +327,19 @@ pub fn entry_for_type(provider_type: &ProviderType) -> Option<&'static ProviderR
         .find(|entry| &entry.provider_type == provider_type)
 }
 
+pub fn catalog_dispatch_entry_for_type(
+    provider_type: &ProviderType,
+) -> Option<&'static ProviderRegistryEntry> {
+    entry_for_type(provider_type)
+        .filter(|entry| entry.dispatch_kind == ProviderDispatchKind::CatalogOpenAiLike)
+}
+
+pub fn catalog_dispatch_entries() -> impl Iterator<Item = &'static ProviderRegistryEntry> {
+    PROVIDER_TYPE_REGISTRY
+        .iter()
+        .filter(|entry| entry.dispatch_kind == ProviderDispatchKind::CatalogOpenAiLike)
+}
+
 pub fn entry_for_name(name: &str) -> Option<&'static ProviderRegistryEntry> {
     PROVIDER_TYPE_REGISTRY
         .iter()
@@ -323,6 +352,10 @@ pub fn dispatchable_provider_types() -> Vec<ProviderType> {
 
 pub fn dispatchable_provider_types_slice() -> &'static [ProviderType] {
     DISPATCHABLE_PROVIDER_TYPES.as_slice()
+}
+
+pub fn default_catalog_runtime_provider_names() -> &'static [&'static str] {
+    DEFAULT_CATALOG_RUNTIME_PROVIDERS
 }
 
 const fn entry(
@@ -536,6 +569,40 @@ mod tests {
                 "{} catalog flag drifted",
                 entry.canonical_name
             );
+        }
+    }
+
+    #[test]
+    fn provider_registry_catalog_dispatch_entries_have_catalog_definitions() {
+        for entry in catalog_dispatch_entries() {
+            assert!(
+                entry.catalog_backed,
+                "{} catalog dispatch entry must be marked catalog-backed",
+                entry.canonical_name
+            );
+            assert!(
+                super::super::catalog::get_definition(entry.canonical_name).is_some(),
+                "{} catalog dispatch entry must have a provider definition",
+                entry.canonical_name
+            );
+        }
+    }
+
+    #[test]
+    fn provider_registry_default_runtime_catalog_providers_are_known_catalog_names() {
+        for provider_name in default_catalog_runtime_provider_names() {
+            assert!(
+                super::super::catalog::get_definition(provider_name).is_some(),
+                "{provider_name} default runtime provider must exist in the catalog"
+            );
+
+            if let Some(entry) = entry_for_name(provider_name) {
+                assert_eq!(
+                    entry.dispatch_kind,
+                    ProviderDispatchKind::CatalogOpenAiLike,
+                    "{provider_name} default runtime ProviderType entry must be catalog dispatchable"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Linked Work

Fixes #725
Parent roadmap: #519
SpecRail packet: `specs/GH725/`

## Readiness Gate

- [x] Issue-scoped implementation for GH-725
- [x] SpecRail packet added and validated
- [x] No high-context files modified

## Review Gate

This PR makes provider instantiation metadata converge around registry-owned facts:

- Adds registry helpers for catalog-dispatched provider entries and default runtime catalog registration names.
- Gates `Provider::from_config_async` catalog fallback through `ProviderDispatchKind::CatalogOpenAiLike` instead of catalog presence alone.
- Moves default router OpenAI-like env registration to one registry-driven loop and removes duplicated Moonshot/MiniMax/Zhipu registration blocks.
- Adds runtime `ProviderRegistry` tests for canonical registration keys and explicit logical keys.

Non-goals: no provider capability trait split, no SDK/HTTP adapter support-matrix changes, no full enum macro rewrite.

## Merge Gate

- [ ] CI green on this PR head
- [ ] Review threads resolved
- [ ] Maintainer merge authorization present

## Verification

- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue725/specs/GH725`
- `cargo fmt --all -- --check`
- `cargo test provider_registry --lib`
- `cargo test from_config_async --lib`
- `cargo test dispatch_kind_matches_runtime_variant --lib`
- `cargo check --all-features --locked`
- `cargo test --lib --locked`
