### PR TITLE
fix: converge pricing service spend authority

### DIFF
--- a/specs/GH726/product.md
+++ b/specs/GH726/product.md
@@ -1,0 +1,64 @@
+# Product Spec
+
+## Linked Issue
+
+GH-726 / #726
+
+## User Problem
+
+网关的价格、成本和 spend 记录现在走多条路径。`/v1/pricing/*`
+接口使用 `PricingService`，但 AI 请求预算预留和成功后的 spend 落账仍直接使用
+`core::cost` 的旧计算器和旧 DTO。这样会让同一个模型在价格 API、预算预留、
+预算结算和 provider-specific 计费中出现不一致，也会让缺失价格在用户可见
+成本场景中被错误地当作 0 美元处理。
+
+## Goals
+
+- 让 `PricingService` 成为用户可见 pricing、cost、spend 计算的权威入口。
+- 保留需要兼容的 `core::cost` API，但把它收敛为薄适配层，而不是第二套价格来源。
+- 让预算预留和完成后 spend 结算使用同一套 provider/model 价格匹配规则。
+- 对缺失或不完整价格保持 fail-closed，避免用户可见成本被静默低估。
+- 用测试覆盖 pricing route、AI spend/reservation 路径和至少一个 provider-specific
+  pricing 场景。
+
+## Non-Goals
+
+- 不刷新模型价格数据，除非测试夹具需要最小本地数据。
+- 不改变 provider registry 或 provider selector 语义。
+- 不拆分 U-16 超大 Rust 文件；该维护工作属于 GH-727。
+- 不移除所有 provider 内部的展示型或本地目录价格结构，除非它们已经参与用户可见 spend。
+
+## Behavior Invariants
+
+1. `/v1/pricing/calculate` 和 AI 请求 spend/reservation 对同一 provider/model/usage
+   使用同一个权威价格计算路径。
+2. 预算预留的估算成本和成功完成后的实际成本不能来自不同价格来源。
+3. 用户可见 spend 场景中，未知模型、未知 provider 或 chat/completion 缺一侧 token
+   价格时必须返回错误或跳过 budget spend 并记录错误，不能静默按 0 美元计费。
+4. 兼容 API 如 `generic_cost_per_token`、`estimate_cost` 和 `get_model_pricing`
+   可以继续存在，但必须通过 `PricingService` 的 authority 逻辑取得价格和成本结果。
+5. provider-specific 价格匹配行为必须保留，包括 Xiaomi MiMo 通过 Anthropic-compatible
+   路径计费、Gemini/Vertex AI alias、OpenAI-like provider-prefixed model 等既有场景。
+
+## Acceptance Criteria
+
+- [ ] pricing API cost calculation and AI spend/reservation use the same pricing authority.
+- [ ] Legacy `core::cost` calculation functions are thin adapters over `PricingService` authority logic.
+- [ ] Unknown or incomplete pricing remains fail-closed for user-visible spend.
+- [ ] Tests cover pricing route behavior, AI spend/reservation behavior, and one provider-specific pricing case.
+- [ ] SpecRail workflow check, focused pricing/spend tests, formatting, and all-features compile pass locally.
+
+## Edge Cases
+
+- Cached, reasoning, image, and audio token extras must keep their existing cost behavior.
+- Time-based pricing must still require duration input where applicable.
+- Provider aliases must not accidentally match unrelated provider rows.
+- Pricing refresh network failure is outside this issue; this slice should rely on the already loaded
+  pricing data source or bundled defaults.
+- Missing usage from an upstream provider should keep the existing reservation settlement behavior.
+
+## Rollout Notes
+
+This is an internal architecture convergence slice. No data migration or public endpoint shape change
+is expected. The main compatibility risk is callers that import `core::cost`; they should keep compiling
+while receiving results from the same PricingService-backed calculation path.

--- a/specs/GH726/tasks.md
+++ b/specs/GH726/tasks.md
@@ -1,0 +1,40 @@
+# Task Plan
+
+## Linked Issue
+
+GH-726 / #726
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [x] `SP726-T001` Owner: pricing-service-worker | Dependencies: none | Done when: `PricingService` exposes provider-aware lookup/calculation helpers for already-loaded pricing data and preserves fail-closed missing-pricing behavior. | Verify: `cargo test pricing_service --lib --locked`
+- [x] `SP726-T002` Owner: cost-adapter-worker | Dependencies: `SP726-T001` | Done when: `generic_cost_per_token`, `estimate_cost`, and `get_model_pricing` use the PricingService-backed authority and only map into legacy DTOs. | Verify: `cargo test estimate_cost --lib --locked`
+- [x] `SP726-T003` Owner: spend-worker | Dependencies: `SP726-T002` | Done when: AI spend reservation and completion settlement are covered by tests proving the same authority-backed cost values are used. | Verify: `cargo test spend --lib --locked`
+- [x] `SP726-T004` Owner: provider-pricing-worker | Dependencies: `SP726-T002` | Done when: at least one provider-specific alias/pricing case proves compatibility through the new authority path. | Verify: `cargo test runtime_pricing --lib --locked`
+- [x] `SP726-T005` Owner: verifier | Dependencies: `SP726-T001`, `SP726-T002`, `SP726-T003`, `SP726-T004` | Done when: SpecRail check, formatting, focused tests, and all-features compile pass. | Verify: `cargo check --all-features --locked`
+
+## Parallelization
+
+The coordinator owns writable files for this tranche because `PricingService`,
+the legacy cost facade, and AI spend tests share a dependency chain. The native
+threads lane for GH-726 is read-only architecture exploration only.
+
+## Verification
+
+- SpecRail: `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue726/specs/GH726`
+- Format: `cargo fmt --all -- --check`
+- Targeted: `cargo test pricing_service --lib --locked`
+- Targeted: `cargo test estimate_cost --lib --locked`
+- Targeted: `cargo test spend --lib --locked`
+- Targeted: `cargo test runtime_pricing --lib --locked`
+- Compile: `cargo check --all-features --locked`
+
+## Handoff Notes
+
+Do not overclaim that all pricing-like structs are removed. In this slice, legacy
+`core::cost` DTOs may remain as compatibility data shapes, but they must no longer
+own an independent user-visible pricing calculation source.

--- a/specs/GH726/tech.md
+++ b/specs/GH726/tech.md
@@ -1,0 +1,89 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-726 / #726
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Runtime pricing service | `src/core/pricing_service/service.rs`, `types.rs`, `loader.rs` | Owns loaded LiteLLM pricing data and powers `/v1/pricing/*`, but only supports model-key lookup for calculation. | This should become the authority for calculation and provider/model matching. |
+| Shared pricing DB | `src/core/pricing.rs` | Exposes `PricingDatabase`, model normalization, provider normalization, bundled defaults, and standalone `calculate_cost`. | Existing parsing and normalization should remain shared; duplicate runtime calculation should move behind PricingService-compatible logic. |
+| Legacy cost facade | `src/core/cost/calculator.rs`, `types.rs`, `utils.rs` | Owns `generic_cost_per_token`, `estimate_cost`, `get_model_pricing`, `CostBreakdown`, and provider-specific fallback logic. | Keep public compatibility, but convert calculation to a PricingService-backed adapter. |
+| AI spend path | `src/server/routes/ai/spend.rs` and spend tests | Budget reservation and settlement import `core::cost::calculator` directly. | User-visible spend must use the same pricing authority as the pricing route. |
+| Pricing route | `src/server/routes/pricing.rs` | `/v1/pricing/calculate` calls `AppState.pricing.calculate_completion_cost`. | This is the existing route that must stay behaviorally aligned with spend. |
+| Provider-specific tests | `src/core/cost/calculator/tests.rs`, `pricing_regression_tests.rs`, AI spend tests | Tests already cover provider aliases and strict missing pricing. | Reuse and extend these to prove compatibility after convergence. |
+
+## Proposed Design
+
+Keep `PricingService` as the canonical user-facing authority. Add synchronous, already-loaded-data
+helpers on `PricingService` so both HTTP pricing routes and legacy cost adapters can resolve and calculate
+without requiring a server `AppState`:
+
+- Add provider-aware lookup and calculation helpers to `PricingService`.
+- Add a default authority constructor for compatibility callers that need bundled pricing outside server state.
+- Convert `core::cost::calculator::{get_model_pricing, generic_cost_per_token, estimate_cost}` to call
+  the PricingService-backed helpers and then map results into legacy DTOs.
+- Keep `UsageTokens`, `CostBreakdown`, and `CostEstimate` as compatibility DTOs, not an independent
+  pricing authority.
+- Update `src/server/routes/ai/spend.rs` so live reservation and settlement helpers receive
+  `AppState.pricing` and calculate from the runtime `PricingService`; keep test-only wrapper names for
+  existing unit tests.
+
+Provider-specific hardcoded fallbacks may remain only inside the PricingService authority where the
+shared catalog cannot resolve a model and the existing behavior already used a provider catalog, such as
+Azure and Bedrock compatibility pricing. Unknown or incomplete shared catalog rows must not fall through
+to $0 billing.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | `pricing_service/service.rs`, `cost/calculator.rs`, `server/routes/pricing.rs`, `server/routes/ai/spend.rs` | `cargo test pricing --lib --locked`, `cargo test spend --lib --locked` |
+| P2 | `cost/calculator.rs` | `cargo test estimate_cost --lib --locked`, existing spend reservation tests |
+| P3 | `pricing_service/service.rs`, `cost/calculator.rs`, spend tests | missing-pricing focused tests and `cargo test spend --lib --locked` |
+| P4 | `cost/calculator.rs`, `cost/types.rs` | legacy cost calculator tests continue to pass |
+| P5 | provider alias helpers and existing provider-specific fixtures | `cargo test runtime_pricing --lib --locked` |
+
+## Data Flow
+
+Pricing data is loaded from LiteLLM JSON through the existing parser into `PricingService`.
+Cost inputs are provider, model, usage tokens, optional prompt/completion text, and optional duration.
+The authority resolves the best matching pricing row, validates required fields, calculates input/output
+and extra token costs, then returns either `CostResult` or a legacy DTO adapter. No new persistence,
+external network calls, or background services are added.
+
+## Alternatives Considered
+
+- Remove `core::cost` entirely. Deferred because many provider modules and tests import its DTOs and
+  facade functions.
+- Move spend signatures to accept `Arc<PricingService>`. Deferred for this slice because the existing
+  call graph can be converged by making the facade authoritative first.
+- Rewrite pricing provider catalogs. Deferred because the issue explicitly excludes price refresh and
+  provider registry semantics.
+
+## Risks
+
+- Security: no secret handling changes; do not add network calls to cost calculation.
+- Compatibility: legacy `core::cost` imports must continue compiling.
+- Performance: default authority should use already-loaded bundled pricing and avoid per-call JSON parsing.
+- Maintenance: provider alias matching must remain explicit so one provider does not borrow another provider's price row.
+
+## Test Plan
+
+- [ ] SpecRail: `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue726/specs/GH726`
+- [ ] Format: `cargo fmt --all -- --check`
+- [ ] Targeted: `cargo test pricing --lib --locked`
+- [ ] Targeted: `cargo test spend --lib --locked`
+- [ ] Targeted: `cargo test runtime_pricing --lib --locked`
+- [ ] Compile: `cargo check --all-features --locked`
+
+## Rollback Plan
+
+Revert the GH-726 PR. The slice should be limited to pricing service helpers, the legacy cost facade,
+AI spend tests, pricing service tests, and the SpecRail packet. No persisted state or migration rollback is needed.

--- a/specs/GH726/tech.md
+++ b/specs/GH726/tech.md
@@ -37,8 +37,9 @@ without requiring a server `AppState`:
 
 Provider-specific hardcoded fallbacks may remain only inside the PricingService authority where the
 shared catalog cannot resolve a model and the existing behavior already used a provider catalog, such as
-Azure and Bedrock compatibility pricing. Unknown or incomplete shared catalog rows must not fall through
-to $0 billing.
+Azure, Bedrock, Amazon Nova, and xAI compatibility pricing. Authority adapters must preserve tiered
+pricing metadata when converting legacy provider catalog rows. Unknown or incomplete shared catalog rows
+must not fall through to $0 billing.
 
 ## Product-to-Test Mapping
 

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -4,13 +4,16 @@
 //! This eliminates code duplication and ensures consistent behavior.
 
 use async_trait::async_trait;
+use std::sync::LazyLock;
 
 use crate::core::cost::types::{
     CostBreakdown, CostError, CostEstimate, ModelCostComparison, ModelPricing, UsageTokens,
 };
 use crate::core::cost::utils::select_tiered_pricing;
+use crate::core::pricing_service::{PricingCostBreakdown, PricingService, PricingUsage};
+use crate::utils::error::gateway_error::GatewayError;
 
-mod pricing;
+pub(crate) mod pricing;
 
 use self::pricing::{
     get_anthropic_pricing, get_azure_pricing, get_deepseek_pricing, get_minimax_pricing,
@@ -54,54 +57,52 @@ pub fn generic_cost_per_token(
     usage: &UsageTokens,
     provider: &str,
 ) -> Result<CostBreakdown, CostError> {
-    // Get model pricing information
-    let pricing = get_model_pricing(model, provider)?;
-
-    // Initialize cost breakdown
-    let mut breakdown = CostBreakdown::new(model.to_string(), provider.to_string(), usage.clone());
-
-    // Calculate tiered pricing if applicable
-    let (input_cost_per_1k, output_cost_per_1k, cache_creation_cost_per_1k, cache_read_cost_per_1k) =
-        select_tiered_pricing(&pricing, usage);
-
-    // Calculate input cost
-    breakdown.input_cost = calculate_input_cost(usage, input_cost_per_1k);
-
-    // Calculate output cost
-    breakdown.output_cost = calculate_output_cost(usage, output_cost_per_1k);
-
-    // Calculate cache costs if applicable
-    if let Some(cached_tokens) = usage.cached_tokens {
-        breakdown.cache_cost = calculate_cache_cost(
-            cached_tokens,
-            cache_creation_cost_per_1k,
-            cache_read_cost_per_1k,
-        );
+    let pricing_usage = pricing_usage_from_cost_usage(usage);
+    match default_pricing_authority().calculate_loaded_usage_cost_for_provider(
+        provider,
+        model,
+        &pricing_usage,
+    ) {
+        Ok(breakdown) => {
+            return Ok(pricing_breakdown_to_cost_breakdown(
+                model, provider, usage, breakdown,
+            ));
+        }
+        Err(error) if !is_not_found(&error) => {
+            return Err(gateway_error_to_cost_error(error, model, provider));
+        }
+        Err(_) => {
+            // Fall through to legacy provider catalogs for models that are not in
+            // the shared pricing source but were already supported before GH-726.
+        }
     }
 
-    // Calculate audio costs if applicable
-    if let Some(audio_tokens) = usage.audio_tokens {
-        breakdown.audio_cost = calculate_audio_cost(&pricing, audio_tokens);
-    }
-
-    // Calculate image costs if applicable
-    if let Some(image_tokens) = usage.image_tokens {
-        breakdown.image_cost = calculate_image_cost(&pricing, image_tokens);
-    }
-
-    // Calculate reasoning tokens cost if applicable (for o1 models)
-    if let Some(reasoning_tokens) = usage.reasoning_tokens {
-        breakdown.reasoning_cost = calculate_reasoning_cost(&pricing, reasoning_tokens);
-    }
-
-    // Calculate total
-    breakdown.calculate_total();
-
-    Ok(breakdown)
+    let pricing = get_fallback_model_pricing(model, provider)?;
+    calculate_with_model_pricing(model, provider, usage, pricing)
 }
 
 /// Get model pricing information
 pub fn get_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, CostError> {
+    if let Some((resolved_model, info)) =
+        default_pricing_authority().get_model_info_for_provider(provider, model)
+    {
+        return litellm_to_cost_pricing(&resolved_model, &info);
+    }
+
+    get_fallback_model_pricing(model, provider)
+}
+
+fn default_pricing_authority() -> &'static PricingService {
+    static DEFAULT_PRICING_AUTHORITY: LazyLock<PricingService> = LazyLock::new(|| {
+        PricingService::with_embedded_default().unwrap_or_else(|error| {
+            tracing::error!("failed to initialize embedded PricingService authority: {error}");
+            PricingService::new(None)
+        })
+    });
+    &DEFAULT_PRICING_AUTHORITY
+}
+
+fn get_fallback_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, CostError> {
     let normalized_provider = crate::core::pricing::normalize_pricing_provider(provider);
 
     match normalized_provider.as_str() {
@@ -160,6 +161,123 @@ pub fn get_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, Co
             provider: provider.to_string(),
         }),
     }
+}
+
+fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
+    PricingUsage {
+        prompt_tokens: usage.prompt_tokens,
+        completion_tokens: usage.completion_tokens,
+        total_tokens: usage.total_tokens,
+        cached_tokens: usage.cached_tokens,
+        audio_tokens: usage.audio_tokens,
+        image_tokens: usage.image_tokens,
+        reasoning_tokens: usage.reasoning_tokens,
+    }
+}
+
+fn pricing_breakdown_to_cost_breakdown(
+    model: &str,
+    provider: &str,
+    usage: &UsageTokens,
+    pricing: PricingCostBreakdown,
+) -> CostBreakdown {
+    CostBreakdown {
+        total_cost: pricing.total_cost,
+        input_cost: pricing.input_cost,
+        output_cost: pricing.output_cost,
+        cache_cost: pricing.cache_cost,
+        audio_cost: pricing.audio_cost,
+        image_cost: pricing.image_cost,
+        reasoning_cost: pricing.reasoning_cost,
+        usage: usage.clone(),
+        currency: pricing.currency,
+        model: model.to_string(),
+        provider: provider.to_string(),
+    }
+}
+
+fn calculate_with_model_pricing(
+    model: &str,
+    provider: &str,
+    usage: &UsageTokens,
+    pricing: ModelPricing,
+) -> Result<CostBreakdown, CostError> {
+    let mut breakdown = CostBreakdown::new(model.to_string(), provider.to_string(), usage.clone());
+    let (_, _, cache_creation_cost_per_1k, cache_read_cost_per_1k) =
+        select_tiered_pricing(&pricing, usage);
+    let (input_cost_per_1k, output_cost_per_1k, _, _) = select_tiered_pricing(&pricing, usage);
+
+    breakdown.input_cost = calculate_input_cost(usage, input_cost_per_1k);
+    breakdown.output_cost = calculate_output_cost(usage, output_cost_per_1k);
+
+    if let Some(cached_tokens) = usage.cached_tokens {
+        breakdown.cache_cost = calculate_cache_cost(
+            cached_tokens,
+            cache_creation_cost_per_1k,
+            cache_read_cost_per_1k,
+        );
+    }
+    if let Some(audio_tokens) = usage.audio_tokens {
+        breakdown.audio_cost = calculate_audio_cost(&pricing, audio_tokens);
+    }
+    if let Some(image_tokens) = usage.image_tokens {
+        breakdown.image_cost = calculate_image_cost(&pricing, image_tokens);
+    }
+    if let Some(reasoning_tokens) = usage.reasoning_tokens {
+        breakdown.reasoning_cost = calculate_reasoning_cost(&pricing, reasoning_tokens);
+    }
+
+    breakdown.calculate_total();
+    Ok(breakdown)
+}
+
+fn gateway_error_to_cost_error(error: GatewayError, model: &str, provider: &str) -> CostError {
+    match error {
+        GatewayError::NotFound(_) if provider_is_supported(provider) => {
+            CostError::ModelNotSupported {
+                model: model.to_string(),
+                provider: provider.to_string(),
+            }
+        }
+        GatewayError::NotFound(_) => CostError::ProviderNotSupported {
+            provider: provider.to_string(),
+        },
+        GatewayError::Config(message) if message.contains("Missing") => CostError::MissingPricing {
+            model: model.to_string(),
+        },
+        GatewayError::Validation(message) => CostError::InvalidUsage { message },
+        GatewayError::Config(message) => CostError::ConfigError { message },
+        other => CostError::CalculationError {
+            message: other.to_string(),
+        },
+    }
+}
+
+fn is_not_found(error: &GatewayError) -> bool {
+    matches!(error, GatewayError::NotFound(_))
+}
+
+fn provider_is_supported(provider: &str) -> bool {
+    matches!(
+        crate::core::pricing::normalize_pricing_provider(provider).as_str(),
+        "openai"
+            | "anthropic"
+            | "azure"
+            | "azure_ai"
+            | "vertex_ai"
+            | "gemini"
+            | "bedrock"
+            | "amazon_nova"
+            | "openai_like"
+            | "xai"
+            | "groq"
+            | "cohere"
+            | "deepseek"
+            | "xiaomi_mimo"
+            | "moonshot"
+            | "minimax"
+            | "zhipuai"
+    )
 }
 
 fn is_xiaomi_mimo_model(model: &str) -> bool {
@@ -529,6 +647,30 @@ pub fn estimate_cost(
     input_tokens: u32,
     max_output_tokens: Option<u32>,
 ) -> Result<CostEstimate, CostError> {
+    match default_pricing_authority().estimate_loaded_completion_cost_for_provider(
+        provider,
+        model,
+        input_tokens,
+        max_output_tokens,
+    ) {
+        Ok(estimate) => {
+            return Ok(CostEstimate {
+                min_cost: estimate.min_cost,
+                max_cost: estimate.max_cost,
+                input_cost: estimate.input_cost,
+                estimated_output_cost: estimate.estimated_output_cost,
+                currency: estimate.currency,
+            });
+        }
+        Err(error) if !is_not_found(&error) => {
+            return Err(gateway_error_to_cost_error(error, model, provider));
+        }
+        Err(_) => {
+            // Fall through to legacy provider catalogs for compatibility models
+            // absent from the shared pricing authority.
+        }
+    }
+
     let pricing = get_model_pricing(model, provider)?;
     let estimated_output_tokens = max_output_tokens.unwrap_or(100); // Default estimate
     let usage = UsageTokens::new(input_tokens, estimated_output_tokens);

--- a/src/core/cost/calculator/pricing.rs
+++ b/src/core/cost/calculator/pricing.rs
@@ -473,7 +473,7 @@ pub(super) fn get_anthropic_pricing(model: &str) -> Result<ModelPricing, CostErr
     Ok(pricing)
 }
 
-pub(super) fn get_azure_pricing(model: &str) -> Result<ModelPricing, CostError> {
+pub(crate) fn get_azure_pricing(model: &str) -> Result<ModelPricing, CostError> {
     // Azure pricing is typically the same as OpenAI but may have regional differences
     get_openai_pricing(model).map(|mut pricing| {
         pricing.model = model.to_string();

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -1,0 +1,566 @@
+//! Provider-aware pricing authority helpers.
+
+use super::service::PricingService;
+use super::types::{
+    CostResult, CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingCostEstimate, PricingUsage,
+};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+impl PricingService {
+    /// Create a pricing service preloaded with the bundled default pricing data.
+    ///
+    /// Compatibility adapters use this when they cannot access `AppState.pricing`.
+    /// Live request paths should use the runtime service in `AppState`.
+    pub fn with_embedded_default() -> Result<Self> {
+        let service = Self::new(Some(super::DEFAULT_PRICING_SOURCE.to_string()));
+        let models = service.load_from_embedded_default()?;
+        {
+            let mut data = service.pricing_data.write();
+            data.models = models;
+            data.last_updated = SystemTime::now();
+        }
+        Ok(service)
+    }
+
+    /// Resolve pricing metadata for a provider/model pair using provider aliases
+    /// and provider-prefixed model rules.
+    pub fn get_model_info_for_provider(
+        &self,
+        provider: &str,
+        model: &str,
+    ) -> Option<(String, LiteLLMModelInfo)> {
+        let data = self.pricing_data.read();
+        resolve_model_info_for_provider(&data.models, provider, model)
+    }
+
+    /// Calculate a completion cost from already-loaded pricing data.
+    ///
+    /// This method does not refresh pricing data, so it is safe for live spend
+    /// reservation and settlement paths that must not perform network I/O.
+    pub fn calculate_loaded_completion_cost_for_provider(
+        &self,
+        provider: &str,
+        model: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+        prompt: Option<&str>,
+        completion: Option<&str>,
+        total_time_seconds: Option<f64>,
+    ) -> Result<CostResult> {
+        let (resolved_model, model_info) = self
+            .get_model_info_for_provider(provider, model)
+            .ok_or_else(|| model_not_found(provider, model))?;
+
+        if model_info.cost_per_second.is_some() {
+            let total_time_seconds =
+                super::service::require_total_time_seconds(&resolved_model, total_time_seconds)?;
+            return self.calculate_time_based_cost(
+                &resolved_model,
+                &model_info,
+                total_time_seconds,
+            );
+        }
+
+        match crate::core::pricing::normalize_pricing_provider(&model_info.litellm_provider)
+            .as_str()
+        {
+            "vertex_ai" => self.calculate_google_cost(
+                &resolved_model,
+                &model_info,
+                input_tokens,
+                output_tokens,
+                prompt,
+                completion,
+            ),
+            _ => self.calculate_token_based_cost(
+                &resolved_model,
+                &model_info,
+                input_tokens,
+                output_tokens,
+            ),
+        }
+    }
+
+    /// Calculate detailed token usage cost for spend settlement and legacy cost
+    /// adapters from already-loaded pricing data.
+    pub fn calculate_loaded_usage_cost_for_provider(
+        &self,
+        provider: &str,
+        model: &str,
+        usage: &PricingUsage,
+    ) -> Result<PricingCostBreakdown> {
+        let (resolved_model, model_info) = self
+            .get_model_info_for_provider(provider, model)
+            .ok_or_else(|| model_not_found(provider, model))?;
+
+        calculate_usage_cost_with_pricing(provider, &resolved_model, &model_info, usage)
+    }
+
+    /// Estimate reservation cost from the same authority used for completed
+    /// spend settlement.
+    pub fn estimate_loaded_completion_cost_for_provider(
+        &self,
+        provider: &str,
+        model: &str,
+        input_tokens: u32,
+        max_output_tokens: Option<u32>,
+    ) -> Result<PricingCostEstimate> {
+        let estimated_output_tokens = max_output_tokens.unwrap_or(100);
+        let input_only = PricingUsage::new(input_tokens, 0);
+        let full_usage = PricingUsage::new(input_tokens, estimated_output_tokens);
+        let input = self.calculate_loaded_usage_cost_for_provider(provider, model, &input_only)?;
+        let full = self.calculate_loaded_usage_cost_for_provider(provider, model, &full_usage)?;
+
+        Ok(PricingCostEstimate {
+            min_cost: input.total_cost,
+            max_cost: full.total_cost,
+            input_cost: input.input_cost,
+            estimated_output_cost: full.output_cost,
+            currency: full.currency,
+        })
+    }
+
+    /// Get provider-aware max output tokens from the loaded pricing catalog.
+    pub fn max_output_tokens_for_provider(&self, provider: &str, model: &str) -> Option<u32> {
+        self.get_model_info_for_provider(provider, model)
+            .and_then(|(_, info)| info.max_output_tokens)
+    }
+}
+
+fn resolve_model_info_for_provider(
+    models: &HashMap<String, LiteLLMModelInfo>,
+    provider: &str,
+    model: &str,
+) -> Option<(String, LiteLLMModelInfo)> {
+    let normalized_provider = crate::core::pricing::normalize_pricing_provider(provider);
+    if normalized_provider == "openai_like" {
+        let (prefixed_provider, stripped_model) = provider_prefixed_model(model)?;
+        let prefixed_provider = crate::core::pricing::normalize_pricing_provider(prefixed_provider);
+        if prefixed_provider == "openai_like" {
+            return None;
+        }
+        return resolve_model_info_for_provider(models, &prefixed_provider, stripped_model)
+            .or_else(|| resolve_model_info_for_provider(models, &prefixed_provider, model));
+    }
+
+    let provider_aliases = pricing_provider_aliases(provider, model);
+
+    if let Some(info) = models
+        .get(model)
+        .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+    {
+        return Some((model.to_string(), info.clone()));
+    }
+
+    let normalized_model = crate::core::pricing::normalize_model_key(model);
+    if normalized_model != model
+        && let Some(info) = models
+            .get(normalized_model)
+            .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+    {
+        return Some((normalized_model.to_string(), info.clone()));
+    }
+
+    let requested = normalized_model.to_lowercase();
+    models
+        .iter()
+        .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
+        .filter(|(candidate, _)| is_shared_model_match(&candidate.to_lowercase(), &requested))
+        .max_by_key(|(candidate, _)| candidate.len())
+        .map(|(candidate, info)| (candidate.clone(), info.clone()))
+        .or_else(|| provider_catalog_model_info(&normalized_provider, model))
+}
+
+fn provider_catalog_model_info(
+    normalized_provider: &str,
+    model: &str,
+) -> Option<(String, LiteLLMModelInfo)> {
+    match normalized_provider {
+        "azure" | "azure_ai" => crate::core::cost::calculator::pricing::get_azure_pricing(model)
+            .ok()
+            .map(|pricing| {
+                let resolved_model = pricing.model.clone();
+                (
+                    resolved_model,
+                    core_pricing_to_litellm_model_info(normalized_provider, pricing),
+                )
+            }),
+        "bedrock" => crate::core::providers::bedrock::CostCalculator::get_core_model_pricing(model)
+            .map(|pricing| {
+                let resolved_model = pricing.model.clone();
+                (
+                    resolved_model,
+                    core_pricing_to_litellm_model_info("bedrock", pricing),
+                )
+            }),
+        _ => None,
+    }
+}
+
+fn core_pricing_to_litellm_model_info(
+    provider: &str,
+    pricing: crate::core::cost::types::ModelPricing,
+) -> LiteLLMModelInfo {
+    let mut extra = HashMap::new();
+    insert_optional_token_cost(
+        &mut extra,
+        "cache_read_input_token_cost",
+        pricing.cache_read_input_token_cost,
+    );
+    insert_optional_token_cost(
+        &mut extra,
+        "cache_creation_input_token_cost",
+        pricing.cache_creation_input_token_cost,
+    );
+    insert_optional_cost(
+        &mut extra,
+        "input_cost_per_audio_token",
+        pricing.input_cost_per_audio_token,
+    );
+    insert_optional_cost(
+        &mut extra,
+        "output_cost_per_audio_token",
+        pricing.output_cost_per_audio_token,
+    );
+    insert_optional_cost(
+        &mut extra,
+        "image_cost_per_token",
+        pricing.image_cost_per_token,
+    );
+    insert_optional_cost(
+        &mut extra,
+        "output_cost_per_reasoning_token",
+        pricing.reasoning_cost_per_token,
+    );
+
+    LiteLLMModelInfo {
+        max_tokens: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        input_cost_per_token: Some(pricing.input_cost_per_1k_tokens / 1000.0),
+        output_cost_per_token: Some(pricing.output_cost_per_1k_tokens / 1000.0),
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: pricing.cost_per_second,
+        litellm_provider: provider.to_string(),
+        mode: "chat".to_string(),
+        supports_function_calling: None,
+        supports_vision: None,
+        supports_streaming: None,
+        supports_parallel_function_calling: None,
+        supports_system_message: None,
+        extra,
+    }
+}
+
+fn insert_optional_token_cost(
+    extra: &mut HashMap<String, serde_json::Value>,
+    key: &str,
+    cost_per_1k_tokens: Option<f64>,
+) {
+    if let Some(cost_per_1k_tokens) = cost_per_1k_tokens {
+        insert_optional_cost(extra, key, Some(cost_per_1k_tokens / 1000.0));
+    }
+}
+
+fn insert_optional_cost(
+    extra: &mut HashMap<String, serde_json::Value>,
+    key: &str,
+    value: Option<f64>,
+) {
+    if let Some(value) = value {
+        extra.insert(key.to_string(), serde_json::json!(value));
+    }
+}
+
+fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
+    let normalized = crate::core::pricing::normalize_pricing_provider(provider);
+    let aliases = match normalized.as_str() {
+        "anthropic" if is_xiaomi_mimo_model(model) => vec!["xiaomi_mimo", "xiaomi", "mimo"],
+        "gemini" => vec!["gemini", "vertex_ai"],
+        "vertex_ai" => vec!["vertex_ai", "google"],
+        "xiaomi_mimo" => vec!["xiaomi_mimo", "xiaomi", "mimo"],
+        "zhipuai" => vec!["zhipuai", "glm", "zai"],
+        "amazon_nova" => vec!["amazon_nova", "bedrock"],
+        _ => return vec![normalized],
+    };
+    aliases
+        .into_iter()
+        .map(crate::core::pricing::normalize_pricing_provider)
+        .fold(Vec::new(), |mut unique, alias| {
+            if !unique.contains(&alias) {
+                unique.push(alias);
+            }
+            unique
+        })
+}
+
+fn provider_prefixed_model(model: &str) -> Option<(&str, &str)> {
+    let (provider, stripped_model) = model.split_once('/')?;
+    if provider.is_empty() || stripped_model.is_empty() {
+        return None;
+    }
+    Some((provider, stripped_model))
+}
+
+fn is_xiaomi_mimo_model(model: &str) -> bool {
+    crate::core::pricing::normalize_model_key(model).starts_with("mimo-")
+}
+
+fn provider_name_matches(provider: &str, aliases: &[String]) -> bool {
+    let provider = crate::core::pricing::normalize_pricing_provider(provider);
+    aliases
+        .iter()
+        .any(|alias| crate::core::pricing::normalize_pricing_provider(alias) == provider)
+}
+
+fn is_shared_model_match(candidate: &str, requested: &str) -> bool {
+    fn model_id_matches(candidate: &str, requested: &str) -> bool {
+        if candidate == requested {
+            return true;
+        }
+
+        candidate
+            .strip_prefix(requested)
+            .and_then(|suffix| suffix.strip_prefix('-'))
+            .is_some_and(alias_suffix_matches)
+    }
+
+    if candidate == requested {
+        return true;
+    }
+
+    model_id_matches(candidate, requested)
+        || model_id_matches(requested, candidate)
+        || candidate
+            .rsplit_once('/')
+            .map(|(_, model_id)| {
+                model_id_matches(model_id, requested) || model_id_matches(requested, model_id)
+            })
+            .unwrap_or(false)
+}
+
+fn alias_suffix_matches(suffix: &str) -> bool {
+    if suffix == "latest" {
+        return true;
+    }
+
+    let digit_prefix_len = suffix.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    digit_prefix_len >= 4
+        && suffix
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn calculate_usage_cost_with_pricing(
+    requested_provider: &str,
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+) -> Result<PricingCostBreakdown> {
+    let input_cost_per_token = super::service::require_pricing_field(
+        model_info.input_cost_per_token,
+        model,
+        "token pricing",
+        "input_cost_per_token",
+    )?;
+    let output_cost_per_token = super::service::require_pricing_field(
+        model_info.output_cost_per_token,
+        model,
+        "token pricing",
+        "output_cost_per_token",
+    )?;
+
+    let input_cost_per_token = tiered_cost_per_token(
+        model_info,
+        input_cost_per_token,
+        "input_cost_per_token_above_",
+        usage.prompt_tokens,
+    );
+    let output_cost_per_token = tiered_cost_per_token(
+        model_info,
+        output_cost_per_token,
+        "output_cost_per_token_above_",
+        usage.prompt_tokens,
+    );
+    let cache_read_cost_per_token = tiered_cost_per_token(
+        model_info,
+        extra_f64(model_info, "cache_read_input_token_cost"),
+        "cache_read_input_token_cost_above_",
+        usage.prompt_tokens,
+    );
+
+    let non_cached_tokens = usage
+        .cached_tokens
+        .map(|cached| usage.prompt_tokens.saturating_sub(cached))
+        .unwrap_or(usage.prompt_tokens);
+    let input_cost = non_cached_tokens as f64 * input_cost_per_token;
+    let output_cost = usage.completion_tokens as f64 * output_cost_per_token;
+    let cache_cost = usage.cached_tokens.unwrap_or(0) as f64 * cache_read_cost_per_token;
+    let audio_cost = usage.audio_tokens.unwrap_or(0) as f64
+        * extra_f64(model_info, "input_cost_per_audio_token");
+    let image_cost =
+        usage.image_tokens.unwrap_or(0) as f64 * extra_f64(model_info, "image_cost_per_token");
+    let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64
+        * extra_f64(model_info, "output_cost_per_reasoning_token");
+    let total_cost =
+        input_cost + output_cost + cache_cost + audio_cost + image_cost + reasoning_cost;
+
+    Ok(PricingCostBreakdown {
+        total_cost,
+        input_cost,
+        output_cost,
+        cache_cost,
+        audio_cost,
+        image_cost,
+        reasoning_cost,
+        usage: usage.clone(),
+        currency: "USD".to_string(),
+        model: model.to_string(),
+        provider: requested_provider.to_string(),
+        cost_type: CostType::TokenBased,
+    })
+}
+
+fn model_not_found(provider: &str, model: &str) -> GatewayError {
+    GatewayError::not_found(format!(
+        "Model not found for provider {}: {}",
+        provider, model
+    ))
+}
+
+fn extra_f64(pricing: &LiteLLMModelInfo, key: &str) -> f64 {
+    pricing
+        .extra
+        .get(key)
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0)
+}
+
+fn tiered_cost_per_token(
+    pricing: &LiteLLMModelInfo,
+    base_cost: f64,
+    key_prefix: &str,
+    prompt_tokens: u32,
+) -> f64 {
+    pricing
+        .extra
+        .iter()
+        .filter_map(|(key, value)| {
+            if !key.starts_with(key_prefix) {
+                return None;
+            }
+            let threshold = extract_tier_threshold(key)?;
+            if prompt_tokens > threshold {
+                value.as_f64().map(|cost| (threshold, cost))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|(threshold, _)| *threshold)
+        .map(|(_, cost)| cost)
+        .unwrap_or(base_cost)
+}
+
+fn extract_tier_threshold(key: &str) -> Option<u32> {
+    let threshold = key.split("_above_").nth(1)?.split("_tokens").next()?;
+    if let Some(number) = threshold.strip_suffix('k') {
+        number.parse::<u32>().ok().map(|value| value * 1000)
+    } else {
+        threshold.parse::<u32>().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_model_info(provider: &str) -> LiteLLMModelInfo {
+        LiteLLMModelInfo {
+            max_tokens: Some(4096),
+            max_input_tokens: Some(4096),
+            max_output_tokens: Some(4096),
+            input_cost_per_token: Some(0.00001),
+            output_cost_per_token: Some(0.00003),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: provider.to_string(),
+            mode: "chat".to_string(),
+            supports_function_calling: Some(true),
+            supports_vision: Some(false),
+            supports_streaming: Some(true),
+            supports_parallel_function_calling: Some(true),
+            supports_system_message: Some(true),
+            extra: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn provider_aware_authority_uses_loaded_custom_model() {
+        let service = PricingService::new(None);
+        service.add_custom_model(
+            "runtime-only-priced-model".to_string(),
+            test_model_info("runtime_provider"),
+        );
+
+        let cost = match service.calculate_loaded_usage_cost_for_provider(
+            "runtime_provider",
+            "runtime-only-priced-model",
+            &PricingUsage::new(1000, 500),
+        ) {
+            Ok(cost) => cost,
+            Err(error) => panic!("runtime-loaded pricing should calculate cost: {error}"),
+        };
+
+        assert_eq!(cost.model, "runtime-only-priced-model");
+        assert_eq!(cost.provider, "runtime_provider");
+        assert_eq!(cost.input_cost, 0.01);
+        assert!((cost.output_cost - 0.015).abs() < f64::EPSILON);
+        assert!((cost.total_cost - 0.025).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provider_aware_authority_resolves_anthropic_mimo_alias() {
+        let service = match PricingService::with_embedded_default() {
+            Ok(service) => service,
+            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+        };
+
+        let cost = match service.calculate_loaded_usage_cost_for_provider(
+            "anthropic",
+            "mimo-v2.5-pro",
+            &PricingUsage::new(1000, 500),
+        ) {
+            Ok(cost) => cost,
+            Err(error) => {
+                panic!("Anthropic-compatible MiMo should resolve through Xiaomi pricing: {error}")
+            }
+        };
+
+        assert_eq!(cost.model, "mimo-v2.5-pro");
+        assert_eq!(cost.provider, "anthropic");
+        assert!(cost.total_cost > 0.0);
+    }
+
+    #[test]
+    fn provider_aware_authority_rejects_missing_token_pricing() {
+        let service = PricingService::new(None);
+        let mut model_info = test_model_info("runtime_provider");
+        model_info.output_cost_per_token = None;
+        service.add_custom_model("partial-priced-model".to_string(), model_info);
+
+        let error = match service.calculate_loaded_usage_cost_for_provider(
+            "runtime_provider",
+            "partial-priced-model",
+            &PricingUsage::new(1000, 500),
+        ) {
+            Ok(_) => panic!("incomplete pricing must fail closed"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("output_cost_per_token"));
+    }
+}

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -136,14 +136,17 @@ fn resolve_model_info_for_provider(
     model: &str,
 ) -> Option<(String, LiteLLMModelInfo)> {
     let normalized_provider = crate::core::pricing::normalize_pricing_provider(provider);
-    if normalized_provider == "openai_like" {
-        let (prefixed_provider, stripped_model) = provider_prefixed_model(model)?;
+    if normalized_provider == "openai_like"
+        && let Some((prefixed_provider, stripped_model)) = provider_prefixed_model(model)
+    {
         let prefixed_provider = crate::core::pricing::normalize_pricing_provider(prefixed_provider);
-        if prefixed_provider == "openai_like" {
-            return None;
+        if prefixed_provider != "openai_like"
+            && let Some(resolved) =
+                resolve_model_info_for_provider(models, &prefixed_provider, stripped_model)
+                    .or_else(|| resolve_model_info_for_provider(models, &prefixed_provider, model))
+        {
+            return Some(resolved);
         }
-        return resolve_model_info_for_provider(models, &prefixed_provider, stripped_model)
-            .or_else(|| resolve_model_info_for_provider(models, &prefixed_provider, model));
     }
 
     let provider_aliases = pricing_provider_aliases(provider, model);
@@ -196,9 +199,44 @@ fn provider_catalog_model_info(
                     core_pricing_to_litellm_model_info("bedrock", pricing),
                 )
             }),
+        "amazon_nova" => amazon_nova_pricing_model_info(model),
         "xai" => xai_pricing_model_info(model),
         _ => None,
     }
+}
+
+#[cfg(feature = "providers-extended")]
+fn amazon_nova_pricing_model_info(model: &str) -> Option<(String, LiteLLMModelInfo)> {
+    let registry = crate::core::providers::amazon_nova::AmazonNovaModelRegistry::new();
+    let model = registry.get(model)?;
+    let resolved_model = model.id.clone();
+
+    Some((
+        resolved_model,
+        LiteLLMModelInfo {
+            max_tokens: Some(model.context_length),
+            max_input_tokens: Some(model.context_length),
+            max_output_tokens: Some(model.max_output_tokens),
+            input_cost_per_token: Some(model.input_cost_per_1k / 1000.0),
+            output_cost_per_token: Some(model.output_cost_per_1k / 1000.0),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: "amazon_nova".to_string(),
+            mode: "chat".to_string(),
+            supports_function_calling: Some(model.supports_tools),
+            supports_vision: Some(model.supports_vision),
+            supports_streaming: Some(model.supports_streaming),
+            supports_parallel_function_calling: Some(model.supports_tools),
+            supports_system_message: Some(true),
+            extra: HashMap::new(),
+        },
+    ))
+}
+
+#[cfg(not(feature = "providers-extended"))]
+fn amazon_nova_pricing_model_info(_model: &str) -> Option<(String, LiteLLMModelInfo)> {
+    None
 }
 
 fn xai_pricing_model_info(model: &str) -> Option<(String, LiteLLMModelInfo)> {
@@ -282,6 +320,7 @@ fn core_pricing_to_litellm_model_info(
         "output_cost_per_reasoning_token",
         pricing.reasoning_cost_per_token,
     );
+    insert_tiered_pricing(&mut extra, pricing.tiered_pricing.as_ref());
 
     LiteLLMModelInfo {
         max_tokens: None,
@@ -300,6 +339,19 @@ fn core_pricing_to_litellm_model_info(
         supports_parallel_function_calling: None,
         supports_system_message: None,
         extra,
+    }
+}
+
+fn insert_tiered_pricing(
+    extra: &mut HashMap<String, serde_json::Value>,
+    tiered_pricing: Option<&HashMap<String, f64>>,
+) {
+    let Some(tiered_pricing) = tiered_pricing else {
+        return;
+    };
+
+    for (key, cost_per_1k_tokens) in tiered_pricing {
+        insert_optional_cost(extra, key, Some(cost_per_1k_tokens / 1000.0));
     }
 }
 
@@ -594,6 +646,28 @@ mod tests {
     }
 
     #[test]
+    fn provider_aware_authority_resolves_loaded_openai_like_model_without_prefix() {
+        let service = PricingService::new(None);
+        service.add_custom_model(
+            "runtime-openai-like-model".to_string(),
+            test_model_info("openai_like"),
+        );
+
+        let cost = match service.calculate_loaded_usage_cost_for_provider(
+            "openai_like",
+            "runtime-openai-like-model",
+            &PricingUsage::new(1000, 500),
+        ) {
+            Ok(cost) => cost,
+            Err(error) => panic!("loaded OpenAI-like pricing should calculate cost: {error}"),
+        };
+
+        assert_eq!(cost.model, "runtime-openai-like-model");
+        assert_eq!(cost.provider, "openai_like");
+        assert!((cost.total_cost - 0.025).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn provider_aware_authority_resolves_xai_openai_like_prefix() {
         let service = match PricingService::with_embedded_default() {
             Ok(service) => service,
@@ -612,6 +686,63 @@ mod tests {
         assert_eq!(cost.model, "grok-4.3");
         assert_eq!(cost.provider, "openai_like");
         assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[test]
+    fn provider_aware_authority_resolves_amazon_nova_short_alias() {
+        let service = match PricingService::with_embedded_default() {
+            Ok(service) => service,
+            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+        };
+
+        let cost = match service.calculate_loaded_usage_cost_for_provider(
+            "amazon_nova",
+            "nova-2-lite",
+            &PricingUsage::new(1000, 500),
+        ) {
+            Ok(cost) => cost,
+            Err(error) => panic!("Amazon Nova short alias should resolve: {error}"),
+        };
+
+        assert_eq!(cost.model, "amazon.nova-2-lite-v1:0");
+        assert_eq!(cost.provider, "amazon_nova");
+        assert!((cost.total_cost - 0.00155).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provider_aware_authority_preserves_core_pricing_tiers() {
+        let service = match PricingService::with_embedded_default() {
+            Ok(service) => service,
+            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+        };
+
+        let cost = match service.calculate_loaded_usage_cost_for_provider(
+            "azure",
+            "gpt-5.5",
+            &PricingUsage::new(300_000, 1_000),
+        ) {
+            Ok(cost) => cost,
+            Err(error) => panic!("Azure tiered fallback pricing should resolve: {error}"),
+        };
+
+        assert_eq!(cost.model, "gpt-5.5");
+        assert_eq!(cost.provider, "azure");
+        assert!(
+            (cost.input_cost - 3.0).abs() < 1e-12,
+            "unexpected input cost: {}",
+            cost.input_cost
+        );
+        assert!(
+            (cost.output_cost - 0.045).abs() < 1e-12,
+            "unexpected output cost: {}",
+            cost.output_cost
+        );
+        assert!(
+            (cost.total_cost - 3.045).abs() < 1e-12,
+            "unexpected total cost: {}",
+            cost.total_cost
+        );
     }
 
     #[test]

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -75,12 +75,25 @@ impl PricingService {
                 prompt,
                 completion,
             ),
-            _ => self.calculate_token_based_cost(
-                &resolved_model,
-                &model_info,
-                input_tokens,
-                output_tokens,
-            ),
+            _ => {
+                let usage = PricingUsage::new(input_tokens, output_tokens);
+                let breakdown = calculate_usage_cost_with_pricing(
+                    &model_info.litellm_provider,
+                    &resolved_model,
+                    &model_info,
+                    &usage,
+                )?;
+                Ok(CostResult {
+                    input_cost: breakdown.input_cost,
+                    output_cost: breakdown.output_cost,
+                    total_cost: breakdown.total_cost,
+                    input_tokens,
+                    output_tokens,
+                    model: resolved_model,
+                    provider: model_info.litellm_provider,
+                    cost_type: CostType::TokenBased,
+                })
+            }
         }
     }
 

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -39,6 +39,7 @@ impl PricingService {
     ///
     /// This method does not refresh pricing data, so it is safe for live spend
     /// reservation and settlement paths that must not perform network I/O.
+    #[allow(clippy::too_many_arguments)]
     pub fn calculate_loaded_completion_cost_for_provider(
         &self,
         provider: &str,
@@ -195,7 +196,54 @@ fn provider_catalog_model_info(
                     core_pricing_to_litellm_model_info("bedrock", pricing),
                 )
             }),
+        "xai" => xai_pricing_model_info(model),
         _ => None,
+    }
+}
+
+fn xai_pricing_model_info(model: &str) -> Option<(String, LiteLLMModelInfo)> {
+    let models = crate::core::providers::openai_like::models::get_openai_like_registry();
+    if !crate::core::providers::openai_like::models::is_xai_priced_model(model) {
+        return None;
+    }
+
+    let info = models.get_model_info(model);
+    if info.input_cost_per_1k_tokens.is_none() || info.output_cost_per_1k_tokens.is_none() {
+        return None;
+    }
+    let resolved_model = info.id.clone();
+
+    Some((
+        resolved_model,
+        model_info_to_litellm_model_info("xai", info),
+    ))
+}
+
+fn model_info_to_litellm_model_info(
+    provider: &str,
+    info: crate::core::types::model::ModelInfo,
+) -> LiteLLMModelInfo {
+    LiteLLMModelInfo {
+        max_tokens: Some(info.max_context_length),
+        max_input_tokens: Some(info.max_context_length),
+        max_output_tokens: info.max_output_length,
+        input_cost_per_token: info
+            .input_cost_per_1k_tokens
+            .map(|cost_per_1k| cost_per_1k / 1000.0),
+        output_cost_per_token: info
+            .output_cost_per_1k_tokens
+            .map(|cost_per_1k| cost_per_1k / 1000.0),
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: None,
+        litellm_provider: provider.to_string(),
+        mode: "chat".to_string(),
+        supports_function_calling: Some(info.supports_tools),
+        supports_vision: Some(info.supports_multimodal),
+        supports_streaming: Some(info.supports_streaming),
+        supports_parallel_function_calling: Some(info.supports_tools),
+        supports_system_message: Some(true),
+        extra: info.metadata,
     }
 }
 
@@ -543,6 +591,27 @@ mod tests {
         assert_eq!(cost.model, "mimo-v2.5-pro");
         assert_eq!(cost.provider, "anthropic");
         assert!(cost.total_cost > 0.0);
+    }
+
+    #[test]
+    fn provider_aware_authority_resolves_xai_openai_like_prefix() {
+        let service = match PricingService::with_embedded_default() {
+            Ok(service) => service,
+            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+        };
+
+        let cost = match service.calculate_loaded_usage_cost_for_provider(
+            "openai_like",
+            "xai/grok-4.3",
+            &PricingUsage::new(1000, 500),
+        ) {
+            Ok(cost) => cost,
+            Err(error) => panic!("xAI OpenAI-like prefixed model should resolve: {error}"),
+        };
+
+        assert_eq!(cost.model, "grok-4.3");
+        assert_eq!(cost.provider, "openai_like");
+        assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -3,6 +3,7 @@
 //! This service loads pricing data from LiteLLM's JSON format and provides
 //! unified cost calculation for all AI providers.
 
+mod authority;
 mod cache;
 mod events;
 mod loader;
@@ -24,6 +25,6 @@ pub(super) const REMOTE_LITELLM_PRICING_SOURCE: &str =
 // Re-export public types
 pub use service::PricingService;
 pub use types::{
-    CostRange, CostResult, CostType, LiteLLMModelInfo, PricingEventType, PricingStatistics,
-    PricingUpdateEvent,
+    CostRange, CostResult, CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingCostEstimate,
+    PricingEventType, PricingStatistics, PricingUpdateEvent, PricingUsage,
 };

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, SystemTime};
 use tokio::sync::broadcast;
 use tracing::{info, warn};
 
-fn require_pricing_field(
+pub(super) fn require_pricing_field(
     value: Option<f64>,
     model: &str,
     pricing_type: &str,
@@ -34,7 +34,10 @@ fn require_pricing_field(
     Ok(value)
 }
 
-fn require_total_time_seconds(model: &str, total_time_seconds: Option<f64>) -> Result<f64> {
+pub(super) fn require_total_time_seconds(
+    model: &str,
+    total_time_seconds: Option<f64>,
+) -> Result<f64> {
     let total_time_seconds = total_time_seconds.ok_or_else(|| {
         GatewayError::validation(format!(
             "Missing total_time_seconds for time-based pricing model {}",
@@ -190,7 +193,7 @@ impl PricingService {
     }
 
     /// Calculate Google/Vertex AI cost (character or token based)
-    fn calculate_google_cost(
+    pub(super) fn calculate_google_cost(
         &self,
         model: &str,
         model_info: &LiteLLMModelInfo,
@@ -239,7 +242,7 @@ impl PricingService {
     }
 
     /// Calculate time-based cost (for deployment providers)
-    fn calculate_time_based_cost(
+    pub(super) fn calculate_time_based_cost(
         &self,
         model: &str,
         model_info: &LiteLLMModelInfo,

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -71,6 +71,82 @@ pub struct CostResult {
     pub cost_type: CostType,
 }
 
+/// Usage information for authority-backed pricing calculations.
+#[derive(Debug, Clone, Default)]
+pub struct PricingUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+    pub cached_tokens: Option<u32>,
+    pub audio_tokens: Option<u32>,
+    pub image_tokens: Option<u32>,
+    pub reasoning_tokens: Option<u32>,
+}
+
+impl PricingUsage {
+    pub fn new(prompt_tokens: u32, completion_tokens: u32) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens.saturating_add(completion_tokens),
+            cached_tokens: None,
+            audio_tokens: None,
+            image_tokens: None,
+            reasoning_tokens: None,
+        }
+    }
+}
+
+impl From<&crate::core::types::responses::Usage> for PricingUsage {
+    fn from(usage: &crate::core::types::responses::Usage) -> Self {
+        Self {
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens,
+            total_tokens: usage.total_tokens,
+            cached_tokens: usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.cached_tokens),
+            audio_tokens: usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.audio_tokens),
+            image_tokens: None,
+            reasoning_tokens: usage
+                .completion_tokens_details
+                .as_ref()
+                .and_then(|details| details.reasoning_tokens),
+        }
+    }
+}
+
+/// Detailed cost calculation result used by spend and legacy cost adapters.
+#[derive(Debug, Clone)]
+pub struct PricingCostBreakdown {
+    pub total_cost: f64,
+    pub input_cost: f64,
+    pub output_cost: f64,
+    pub cache_cost: f64,
+    pub audio_cost: f64,
+    pub image_cost: f64,
+    pub reasoning_cost: f64,
+    pub usage: PricingUsage,
+    pub currency: String,
+    pub model: String,
+    pub provider: String,
+    pub cost_type: CostType,
+}
+
+/// Reservation estimate from the same authority used for completed spend.
+#[derive(Debug, Clone)]
+pub struct PricingCostEstimate {
+    pub min_cost: f64,
+    pub max_cost: f64,
+    pub input_cost: f64,
+    pub estimated_output_cost: f64,
+    pub currency: String,
+}
+
 /// Type of cost calculation method
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum CostType {

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -95,7 +95,7 @@ async fn handle_streaming_chat_completion(
 
     let requested_model = core_request.model.clone();
     let context_for_execution = context.clone();
-    let budget_limits = state.budget_limits.clone();
+    let (budget_limits, pricing_service) = (state.budget_limits.clone(), state.pricing.clone());
     let api_key_id = context.api_key_id();
     match execute_stream_with_selected_deployment(
         state.unified_router.clone(),
@@ -104,7 +104,7 @@ async fn handle_streaming_chat_completion(
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
-            let budget_limits = budget_limits.clone();
+            let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());
             let request_for_budget = request_for_budget.clone();
             async move {
                 super::spend::ensure_budget_available(
@@ -112,7 +112,8 @@ async fn handle_streaming_chat_completion(
                     provider.name(),
                     &selected_model,
                 )?;
-                let budget_reservation = super::spend::reserve_chat_completion_budget(
+                let budget_reservation = super::spend::reserve_chat_completion_budget_with_pricing(
+                    pricing_service.as_ref(),
                     &budget_limits,
                     provider.name(),
                     &selected_model,
@@ -139,7 +140,7 @@ async fn handle_streaming_chat_completion(
 
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let budget_limits = state.budget_limits.clone();
-            let key_manager = state.key_manager.clone();
+            let (key_manager, pricing_service) = (state.key_manager.clone(), state.pricing.clone());
 
             tokio::spawn(async move {
                 let mut lease = Some(lease);
@@ -149,8 +150,8 @@ async fn handle_streaming_chat_completion(
                 macro_rules! settle_after_upstream_output {
                     () => {
                         if final_usage.is_some() || saw_upstream_output {
-                            super::spend::record_stream_disconnect_spend_with_reservation(
-                                &budget_limits,
+                            super::spend::record_stream_disconnect_spend_with_reservation_with_pricing(
+                                pricing_service.as_ref(), &budget_limits,
                                 &key_manager,
                                 api_key_id,
                                 &served_provider,
@@ -283,7 +284,8 @@ async fn handle_streaming_chat_completion(
 
                     if tx.send(bytes).await.is_err() {
                         info!("Client disconnected during streaming, cancelling upstream");
-                        super::spend::record_stream_disconnect_spend_with_reservation(
+                        super::spend::record_stream_disconnect_spend_with_reservation_with_pricing(
+                            pricing_service.as_ref(),
                             &budget_limits,
                             &key_manager,
                             api_key_id,
@@ -302,7 +304,8 @@ async fn handle_streaming_chat_completion(
                 if tx.send(done_event.to_bytes()).await.is_err() {
                     info!("Client disconnected before [DONE] event could be sent");
                 }
-                super::spend::record_finished_stream_spend_with_reservation(
+                super::spend::record_finished_stream_spend_with_reservation_with_pricing(
+                    pricing_service.as_ref(),
                     super::spend::StreamSpendSettlement {
                         budget_limits: &budget_limits,
                         key_manager: &key_manager,
@@ -360,7 +363,7 @@ async fn handle_chat_completion_internal(
 
     // Owned handles captured into the (retryable) execution closure so that the
     // successful attempt records budget spend and per-key usage.
-    let budget_limits = state.budget_limits.clone();
+    let (budget_limits, pricing_service) = (state.budget_limits.clone(), state.pricing.clone());
     let key_manager = state.key_manager.clone();
     let api_key_id = context.api_key_id();
 
@@ -371,7 +374,7 @@ async fn handle_chat_completion_internal(
         move |provider, selected_model| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
-            let budget_limits = budget_limits.clone();
+            let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());
             let key_manager = key_manager.clone();
             let request_for_budget = request_for_budget.clone();
             async move {
@@ -382,7 +385,8 @@ async fn handle_chat_completion_internal(
                     provider.name(),
                     &selected_model,
                 )?;
-                let budget_reservation = super::spend::reserve_chat_completion_budget(
+                let budget_reservation = super::spend::reserve_chat_completion_budget_with_pricing(
+                    pricing_service.as_ref(),
                     &budget_limits,
                     provider.name(),
                     &selected_model,
@@ -398,7 +402,8 @@ async fn handle_chat_completion_internal(
                     .as_ref()
                     .map(|usage| u64::from(usage.total_tokens))
                     .unwrap_or_default();
-                super::spend::record_completion_spend_with_reservation(
+                super::spend::record_completion_spend_with_reservation_with_pricing(
+                    pricing_service.as_ref(),
                     &budget_limits,
                     &key_manager,
                     api_key_id,

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -11,6 +11,7 @@ use crate::core::models::openai::responses_api::{
     ResponseOutputMessage, ResponseOutputTokensDetails, ResponseReasoningItem, ResponseStreamEvent,
     ResponseUsage, ResponsesApiRequest, ResponsesApiResponse,
 };
+use crate::core::pricing_service::PricingService;
 use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
 use crate::core::types::responses::Usage as ChatUsage;
@@ -45,6 +46,7 @@ struct ToolCallAccum {
 }
 
 struct StreamBudgetSettlement {
+    pricing_service: Arc<PricingService>,
     budget_limits: Arc<UnifiedBudgetLimits>,
     key_manager: KeyManager,
     api_key_id: Option<Uuid>,
@@ -55,21 +57,25 @@ struct StreamBudgetSettlement {
 
 impl StreamBudgetSettlement {
     async fn record_completion(mut self, usage: Option<&ChatUsage>, saw_upstream_output: bool) {
-        spend::record_finished_stream_spend_with_reservation(spend::StreamSpendSettlement {
-            budget_limits: self.budget_limits.as_ref(),
-            key_manager: &self.key_manager,
-            api_key_id: self.api_key_id,
-            provider: &self.provider,
-            model: &self.model,
-            usage,
-            saw_upstream_output,
-            budget_reservation: self.reservation.take(),
-        })
+        spend::record_finished_stream_spend_with_reservation_with_pricing(
+            self.pricing_service.as_ref(),
+            spend::StreamSpendSettlement {
+                budget_limits: self.budget_limits.as_ref(),
+                key_manager: &self.key_manager,
+                api_key_id: self.api_key_id,
+                provider: &self.provider,
+                model: &self.model,
+                usage,
+                saw_upstream_output,
+                budget_reservation: self.reservation.take(),
+            },
+        )
         .await;
     }
 
     async fn record_disconnect(&mut self, usage: Option<&ChatUsage>) {
-        spend::record_stream_disconnect_spend_with_reservation(
+        spend::record_stream_disconnect_spend_with_reservation_with_pricing(
+            self.pricing_service.as_ref(),
             self.budget_limits.as_ref(),
             &self.key_manager,
             self.api_key_id,
@@ -113,6 +119,7 @@ pub(crate) async fn handle_streaming_response(
     let requested_model = core_request.model.clone();
     let context_clone = context.clone();
     let budget_limits = state.budget_limits.clone();
+    let pricing_service = state.pricing.clone();
     let api_key_id = context.api_key_id();
 
     match execute_stream_with_selected_deployment(
@@ -123,10 +130,12 @@ pub(crate) async fn handle_streaming_response(
             let core_request = core_request.clone();
             let ctx = context_clone.clone();
             let budget_limits = budget_limits.clone();
+            let pricing_service = pricing_service.clone();
             let request_for_budget = request_for_budget.clone();
             async move {
                 spend::ensure_budget_available(&budget_limits, provider.name(), &selected_model)?;
-                let budget_reservation = spend::reserve_chat_completion_budget(
+                let budget_reservation = spend::reserve_chat_completion_budget_with_pricing(
+                    pricing_service.as_ref(),
                     &budget_limits,
                     provider.name(),
                     &selected_model,
@@ -146,6 +155,7 @@ pub(crate) async fn handle_streaming_response(
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout = state.config.load().gateway.server.stream_idle_timeout;
             let settlement = StreamBudgetSettlement {
+                pricing_service: state.pricing.clone(),
                 budget_limits: state.budget_limits.clone(),
                 key_manager: state.key_manager.clone(),
                 api_key_id,

--- a/src/server/routes/ai/responses_stream_tests.rs
+++ b/src/server/routes/ai/responses_stream_tests.rs
@@ -3,7 +3,15 @@ use crate::core::budget::{
     ModelLimitConfig, ProviderLimitConfig, ResetPeriod, UnifiedBudgetLimits,
 };
 use crate::core::keys::{InMemoryKeyRepository, KeyManager};
+use crate::core::pricing_service::PricingService;
 use std::sync::Arc;
+
+fn test_pricing_service() -> Arc<PricingService> {
+    match PricingService::with_embedded_default() {
+        Ok(service) => Arc::new(service),
+        Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+    }
+}
 
 #[test]
 fn test_sse_error_contains_done() {
@@ -151,6 +159,7 @@ async fn disconnect_after_upstream_output_settles_reserved_budget() {
             .unwrap();
     let reserved = reservation.reserved_amount();
     let mut settlement = StreamBudgetSettlement {
+        pricing_service: test_pricing_service(),
         budget_limits: Arc::clone(&budget),
         key_manager: KeyManager::new(InMemoryKeyRepository::new()),
         api_key_id: None,
@@ -196,6 +205,7 @@ async fn completed_stream_without_usage_after_output_settles_reserved_budget() {
             .unwrap();
     let reserved = reservation.reserved_amount();
     let settlement = StreamBudgetSettlement {
+        pricing_service: test_pricing_service(),
         budget_limits: Arc::clone(&budget),
         key_manager: KeyManager::new(InMemoryKeyRepository::new()),
         api_key_id: None,

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -464,6 +464,7 @@ pub(super) async fn record_completion_spend_with_reservation(
     .await;
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn record_completion_spend_with_reservation_with_pricing(
     pricing_service: &PricingService,
     budget_limits: &UnifiedBudgetLimits,
@@ -578,6 +579,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation(
     .await;
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing(
     pricing_service: &PricingService,
     budget_limits: &UnifiedBudgetLimits,

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -7,16 +7,17 @@
 use uuid::Uuid;
 
 use crate::core::budget::{BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation};
-use crate::core::cost::calculator::{estimate_cost, generic_cost_per_token};
-use crate::core::cost::types::UsageTokens;
 use crate::core::keys::KeyManager;
 use crate::core::models::openai::requests::ChatCompletionRequest;
 use crate::core::models::openai::{
     ChatMessage, ContentPart, Function, FunctionCall, MessageContent, ResponseFormat, Tool,
 };
+use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::responses::Usage;
 use crate::utils::ai::counter::token_counter::TokenCounter;
+#[cfg(test)]
+use std::sync::LazyLock;
 
 const IMAGE_PROMPT_BASE_TOKENS: u32 = 85;
 const IMAGE_HIGH_DETAIL_PROMPT_TOKENS: u32 = 1_105;
@@ -51,6 +52,7 @@ pub(super) fn ensure_budget_available(
     Ok(())
 }
 
+#[cfg(test)]
 pub(super) fn reserve_completion_budget(
     budget_limits: &UnifiedBudgetLimits,
     provider: &str,
@@ -58,14 +60,44 @@ pub(super) fn reserve_completion_budget(
     estimated_prompt_tokens: u32,
     max_output_tokens: Option<u32>,
 ) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
-    let estimate = match estimate_cost(model, provider, estimated_prompt_tokens, max_output_tokens)
-    {
+    reserve_completion_budget_with_pricing(
+        default_spend_pricing_service(),
+        budget_limits,
+        provider,
+        model,
+        estimated_prompt_tokens,
+        max_output_tokens,
+    )
+}
+
+pub(super) fn reserve_completion_budget_with_pricing(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    provider: &str,
+    model: &str,
+    estimated_prompt_tokens: u32,
+    max_output_tokens: Option<u32>,
+) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
+    let estimate = match pricing_service.estimate_loaded_completion_cost_for_provider(
+        provider,
+        model,
+        estimated_prompt_tokens,
+        max_output_tokens,
+    ) {
         Ok(estimate) => estimate,
         Err(e) => {
             tracing::error!(
                 "cost estimation failed for '{provider}'/'{model}': {e}; \
                  checking exhausted status without reservation"
             );
+            if pricing_required_for_budget(budget_limits, provider, model) {
+                return Err(ProviderError::invalid_request(
+                    "pricing",
+                    format!(
+                        "pricing is required for budget reservation for '{provider}'/'{model}': {e}"
+                    ),
+                ));
+            }
             ensure_budget_available(budget_limits, provider, model)?;
             return Ok(None);
         }
@@ -82,7 +114,24 @@ pub(super) fn reserve_completion_budget(
         .map_err(|error| reservation_error_to_provider_error(error, provider, model))
 }
 
+#[cfg(test)]
 pub(super) fn reserve_chat_completion_budget(
+    budget_limits: &UnifiedBudgetLimits,
+    provider: &str,
+    model: &str,
+    request: &ChatCompletionRequest,
+) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
+    reserve_chat_completion_budget_with_pricing(
+        default_spend_pricing_service(),
+        budget_limits,
+        provider,
+        model,
+        request,
+    )
+}
+
+pub(super) fn reserve_chat_completion_budget_with_pricing(
+    pricing_service: &PricingService,
     budget_limits: &UnifiedBudgetLimits,
     provider: &str,
     model: &str,
@@ -96,12 +145,14 @@ pub(super) fn reserve_chat_completion_budget(
         request.function_call.as_ref(),
         request.response_format.as_ref(),
     );
-    reserve_completion_budget(
+    reserve_completion_budget_with_pricing(
+        pricing_service,
         budget_limits,
         provider,
         model,
         prompt_tokens,
         reservation_output_tokens(
+            pricing_service,
             provider,
             model,
             prompt_tokens,
@@ -178,6 +229,7 @@ pub(super) fn estimate_chat_prompt_tokens(
 }
 
 fn reservation_output_tokens(
+    pricing_service: &PricingService,
     provider: &str,
     model: &str,
     prompt_tokens: u32,
@@ -189,7 +241,7 @@ fn reservation_output_tokens(
     let output_tokens = if let Some(requested) = requested_max_output_tokens {
         Some(requested)
     } else {
-        catalog_max_output_tokens(provider, model).or_else(|| {
+        catalog_max_output_tokens_with_pricing(pricing_service, provider, model).or_else(|| {
             counter
                 .estimate_output_tokens(None, prompt_tokens, model)
                 .ok()
@@ -199,35 +251,17 @@ fn reservation_output_tokens(
     output_tokens.map(|tokens| tokens.saturating_mul(choice_count))
 }
 
+#[cfg(test)]
 fn catalog_max_output_tokens(provider: &str, model: &str) -> Option<u32> {
-    let db = crate::core::pricing::get_pricing_db();
-    let provider_aliases = pricing_provider_aliases(provider, model);
-    if let Some(tokens) = db
-        .get_model_info(model)
-        .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-        .and_then(|info| info.max_output_tokens)
-    {
-        return Some(tokens);
-    }
+    catalog_max_output_tokens_with_pricing(default_spend_pricing_service(), provider, model)
+}
 
-    let normalized_model = crate::core::pricing::normalize_model_key(model);
-    if normalized_model != model
-        && let Some(tokens) = db
-            .get_model_info(normalized_model)
-            .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-            .and_then(|info| info.max_output_tokens)
-    {
-        return Some(tokens);
-    }
-
-    provider_aliases
-        .iter()
-        .flat_map(|provider| db.get_provider_models(provider))
-        .filter(|candidate| model_id_matches(&candidate.to_lowercase(), normalized_model))
-        .filter_map(|candidate| db.get_model_info(&candidate))
-        .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-        .filter_map(|info| info.max_output_tokens)
-        .max()
+fn catalog_max_output_tokens_with_pricing(
+    pricing_service: &PricingService,
+    provider: &str,
+    model: &str,
+) -> Option<u32> {
+    pricing_service.max_output_tokens_for_provider(provider, model)
 }
 
 fn provider_effective_max_output_tokens(
@@ -263,51 +297,6 @@ fn bedrock_effective_max_output_tokens(
         }
         BedrockApiType::Invoke | BedrockApiType::InvokeStream => request.max_tokens,
     }
-}
-
-fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
-    let normalized = crate::core::pricing::normalize_pricing_provider(provider);
-    let aliases = match normalized.as_str() {
-        "anthropic" if is_xiaomi_mimo_model(model) => vec!["xiaomi_mimo", "xiaomi", "mimo"],
-        "gemini" => vec!["gemini", "vertex_ai"],
-        "vertex_ai" => vec!["vertex_ai", "google"],
-        "xiaomi_mimo" => vec!["xiaomi_mimo", "xiaomi", "mimo"],
-        "zhipuai" => vec!["zhipuai", "glm", "zai"],
-        _ => return vec![normalized],
-    };
-    aliases
-        .into_iter()
-        .map(crate::core::pricing::normalize_pricing_provider)
-        .fold(Vec::new(), |mut unique, alias| {
-            if !unique.contains(&alias) {
-                unique.push(alias);
-            }
-            unique
-        })
-}
-
-fn is_xiaomi_mimo_model(model: &str) -> bool {
-    crate::core::pricing::normalize_model_key(model).starts_with("mimo-")
-}
-
-fn provider_name_matches(provider: &str, aliases: &[String]) -> bool {
-    let provider = crate::core::pricing::normalize_pricing_provider(provider);
-    aliases
-        .iter()
-        .any(|alias| crate::core::pricing::normalize_pricing_provider(alias) == provider)
-}
-
-fn model_id_matches(candidate: &str, requested: &str) -> bool {
-    candidate == requested
-        || has_dash_suffix(candidate, requested)
-        || has_dash_suffix(requested, candidate)
-}
-
-fn has_dash_suffix(value: &str, prefix: &str) -> bool {
-    value
-        .strip_prefix(prefix)
-        .and_then(|suffix| suffix.strip_prefix('-'))
-        .is_some()
 }
 
 fn conservative_multimodal_prompt_extra(messages: &[ChatMessage]) -> u32 {
@@ -452,7 +441,31 @@ fn reservation_error_to_provider_error(
 /// response. When the cost cannot be priced, token usage is still recorded but
 /// budget spend is skipped rather than booked at $0 — under-counting a budget is
 /// worse than leaving it unchanged with a loud error.
+#[cfg(test)]
 pub(super) async fn record_completion_spend_with_reservation(
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+) {
+    record_completion_spend_with_reservation_with_pricing(
+        default_spend_pricing_service(),
+        budget_limits,
+        key_manager,
+        api_key_id,
+        provider,
+        model,
+        usage,
+        budget_reservation,
+    )
+    .await;
+}
+
+pub(super) async fn record_completion_spend_with_reservation_with_pricing(
+    pricing_service: &PricingService,
     budget_limits: &UnifiedBudgetLimits,
     key_manager: &KeyManager,
     api_key_id: Option<Uuid>,
@@ -475,9 +488,13 @@ pub(super) async fn record_completion_spend_with_reservation(
     };
 
     let total_tokens = u64::from(usage.total_tokens);
-    let usage_tokens: UsageTokens = usage.clone().into();
+    let usage_tokens = PricingUsage::from(usage);
 
-    let cost = match generic_cost_per_token(model, &usage_tokens, provider) {
+    let cost = match pricing_service.calculate_loaded_usage_cost_for_provider(
+        provider,
+        model,
+        &usage_tokens,
+    ) {
         Ok(breakdown) => Some(breakdown.total_cost),
         Err(e) => {
             tracing::error!(
@@ -538,6 +555,7 @@ async fn record_reserved_spend_without_usage(
     }
 }
 
+#[cfg(test)]
 pub(super) async fn record_stream_disconnect_spend_with_reservation(
     budget_limits: &UnifiedBudgetLimits,
     key_manager: &KeyManager,
@@ -547,8 +565,32 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation(
     usage: Option<&Usage>,
     budget_reservation: Option<UnifiedBudgetReservation>,
 ) {
+    record_stream_disconnect_spend_with_reservation_with_pricing(
+        default_spend_pricing_service(),
+        budget_limits,
+        key_manager,
+        api_key_id,
+        provider,
+        model,
+        usage,
+        budget_reservation,
+    )
+    .await;
+}
+
+pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+) {
     if let Some(usage) = usage {
-        record_completion_spend_with_reservation(
+        record_completion_spend_with_reservation_with_pricing(
+            pricing_service,
             budget_limits,
             key_manager,
             api_key_id,
@@ -583,7 +625,19 @@ pub(super) struct StreamSpendSettlement<'a> {
     pub(super) budget_reservation: Option<UnifiedBudgetReservation>,
 }
 
+#[cfg(test)]
 pub(super) async fn record_finished_stream_spend_with_reservation(
+    settlement: StreamSpendSettlement<'_>,
+) {
+    record_finished_stream_spend_with_reservation_with_pricing(
+        default_spend_pricing_service(),
+        settlement,
+    )
+    .await;
+}
+
+pub(super) async fn record_finished_stream_spend_with_reservation_with_pricing(
+    pricing_service: &PricingService,
     settlement: StreamSpendSettlement<'_>,
 ) {
     let StreamSpendSettlement {
@@ -598,7 +652,8 @@ pub(super) async fn record_finished_stream_spend_with_reservation(
     } = settlement;
 
     if usage.is_some() || saw_upstream_output {
-        record_stream_disconnect_spend_with_reservation(
+        record_stream_disconnect_spend_with_reservation_with_pricing(
+            pricing_service,
             budget_limits,
             key_manager,
             api_key_id,
@@ -611,7 +666,8 @@ pub(super) async fn record_finished_stream_spend_with_reservation(
         return;
     }
 
-    record_completion_spend_with_reservation(
+    record_completion_spend_with_reservation_with_pricing(
+        pricing_service,
         budget_limits,
         key_manager,
         api_key_id,
@@ -621,6 +677,26 @@ pub(super) async fn record_finished_stream_spend_with_reservation(
         budget_reservation,
     )
     .await;
+}
+
+fn pricing_required_for_budget(
+    budget_limits: &UnifiedBudgetLimits,
+    provider: &str,
+    model: &str,
+) -> bool {
+    budget_limits.providers.has_provider_limit(provider)
+        || budget_limits.models.has_model_limit(model)
+}
+
+#[cfg(test)]
+fn default_spend_pricing_service() -> &'static PricingService {
+    static DEFAULT_SPEND_PRICING_SERVICE: LazyLock<PricingService> = LazyLock::new(|| {
+        PricingService::with_embedded_default().unwrap_or_else(|error| {
+            tracing::error!("failed to initialize embedded spend PricingService: {error}");
+            PricingService::new(None)
+        })
+    });
+    &DEFAULT_SPEND_PRICING_SERVICE
 }
 
 #[cfg(test)]
@@ -642,3 +718,7 @@ mod stream_disconnect_tests;
 #[cfg(test)]
 #[path = "spend_no_usage_tests.rs"]
 mod no_usage_tests;
+
+#[cfg(test)]
+#[path = "spend_runtime_pricing_tests.rs"]
+mod runtime_pricing_tests;

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -686,8 +686,20 @@ fn pricing_required_for_budget(
     provider: &str,
     model: &str,
 ) -> bool {
-    budget_limits.providers.has_provider_limit(provider)
-        || budget_limits.models.has_model_limit(model)
+    let provider_limit_enabled = budget_limits.providers.is_enabled()
+        && budget_limits
+            .providers
+            .list_provider_budgets()
+            .into_iter()
+            .any(|budget| budget.provider_name == provider && budget.enabled);
+    let model_limit_enabled = budget_limits.models.is_enabled()
+        && budget_limits
+            .models
+            .list_model_budgets()
+            .into_iter()
+            .any(|budget| budget.model_name == model && budget.enabled);
+
+    provider_limit_enabled || model_limit_enabled
 }
 
 #[cfg(test)]

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -116,6 +116,37 @@ fn reserve_completion_budget_prices_xai_openai_like_prefix() {
     reservation.cancel();
 }
 
+#[cfg(feature = "providers-extended")]
+#[test]
+fn reserve_completion_budget_prices_amazon_nova_short_alias() {
+    let pricing = default_spend_pricing_service();
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "amazon_nova",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.models.set_model_limit(
+        "nova-2-lite",
+        ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+
+    let reservation = match reserve_completion_budget_with_pricing(
+        pricing,
+        &budget,
+        "amazon_nova",
+        "nova-2-lite",
+        1000,
+        Some(500),
+    ) {
+        Ok(Some(reservation)) => reservation,
+        Ok(None) => panic!("priced Amazon Nova short alias should create a budget reservation"),
+        Err(error) => panic!("Amazon Nova short alias reservation should succeed: {error}"),
+    };
+
+    assert!((reservation.reserved_amount() - 0.00155).abs() < f64::EPSILON);
+    reservation.cancel();
+}
+
 #[tokio::test]
 async fn record_completion_spend_uses_runtime_pricing_service() {
     let pricing = runtime_test_pricing_service("runtime_provider");
@@ -230,4 +261,59 @@ fn reserve_completion_budget_rejects_missing_pricing_when_budget_requires_cost()
             .unwrap_or(0.0),
         0.0
     );
+}
+
+#[test]
+fn reserve_completion_budget_allows_missing_pricing_when_limits_are_disabled() {
+    let pricing = PricingService::new(None);
+    let budget = UnifiedBudgetLimits::new();
+    let mut provider_config = ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly);
+    provider_config.enabled = false;
+    budget
+        .providers
+        .set_provider_limit("runtime_provider", provider_config);
+    let mut model_config = ModelLimitConfig::new(1000.0, ResetPeriod::Monthly);
+    model_config.enabled = false;
+    budget
+        .models
+        .set_model_limit("missing-priced-model", model_config);
+
+    let reservation = match reserve_completion_budget_with_pricing(
+        &pricing,
+        &budget,
+        "runtime_provider",
+        "missing-priced-model",
+        1000,
+        Some(500),
+    ) {
+        Ok(reservation) => reservation,
+        Err(error) => panic!("disabled budget limits should not require pricing: {error}"),
+    };
+
+    assert!(reservation.is_none());
+}
+
+#[test]
+fn reserve_completion_budget_allows_missing_pricing_when_budget_manager_disabled() {
+    let pricing = PricingService::new(None);
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "runtime_provider",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.providers.set_enabled(false);
+
+    let reservation = match reserve_completion_budget_with_pricing(
+        &pricing,
+        &budget,
+        "runtime_provider",
+        "missing-priced-model",
+        1000,
+        Some(500),
+    ) {
+        Ok(reservation) => reservation,
+        Err(error) => panic!("disabled budget manager should not require pricing: {error}"),
+    };
+
+    assert!(reservation.is_none());
 }

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -79,6 +79,43 @@ fn reserve_completion_budget_uses_runtime_pricing_service() {
     reservation.cancel();
 }
 
+#[test]
+fn reserve_completion_budget_prices_xai_openai_like_prefix() {
+    let pricing = default_spend_pricing_service();
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "openai_like",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.models.set_model_limit(
+        "xai/grok-4.3",
+        ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+
+    let reservation = match reserve_completion_budget_with_pricing(
+        pricing,
+        &budget,
+        "openai_like",
+        "xai/grok-4.3",
+        1000,
+        Some(500),
+    ) {
+        Ok(Some(reservation)) => reservation,
+        Ok(None) => panic!("priced xAI OpenAI-like model should create a budget reservation"),
+        Err(error) => panic!("xAI OpenAI-like budget reservation should succeed: {error}"),
+    };
+
+    assert!((reservation.reserved_amount() - 0.0025).abs() < f64::EPSILON);
+    assert_eq!(
+        budget
+            .providers
+            .get_provider_usage("openai_like")
+            .map(|usage| usage.current_spend),
+        Some(0.0025)
+    );
+    reservation.cancel();
+}
+
 #[tokio::test]
 async fn record_completion_spend_uses_runtime_pricing_service() {
     let pricing = runtime_test_pricing_service("runtime_provider");
@@ -118,6 +155,48 @@ async fn record_completion_spend_uses_runtime_pricing_service() {
             .get_model_usage("runtime-only-priced-model")
             .map(|usage| usage.current_spend),
         Some(0.025)
+    );
+}
+
+#[tokio::test]
+async fn record_completion_spend_prices_xai_openai_like_prefix() {
+    let pricing = default_spend_pricing_service();
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "openai_like",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.models.set_model_limit(
+        "xai/grok-4.3",
+        ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    let keys = KeyManager::new(InMemoryKeyRepository::new());
+
+    record_completion_spend_with_reservation_with_pricing(
+        pricing,
+        &budget,
+        &keys,
+        None,
+        "openai_like",
+        "xai/grok-4.3",
+        Some(&response_usage(1000, 500)),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        budget
+            .providers
+            .get_provider_usage("openai_like")
+            .map(|usage| usage.current_spend),
+        Some(0.0025)
+    );
+    assert_eq!(
+        budget
+            .models
+            .get_model_usage("xai/grok-4.3")
+            .map(|usage| usage.current_spend),
+        Some(0.0025)
     );
 }
 

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -1,0 +1,154 @@
+use super::*;
+use crate::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+use crate::core::keys::InMemoryKeyRepository;
+use crate::core::pricing_service::LiteLLMModelInfo;
+use crate::core::types::responses::Usage;
+use std::collections::HashMap;
+
+fn response_usage(prompt: u32, completion: u32) -> Usage {
+    Usage {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: prompt + completion,
+        prompt_tokens_details: None,
+        completion_tokens_details: None,
+        thinking_usage: None,
+    }
+}
+
+fn runtime_test_pricing_service(provider: &str) -> PricingService {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "runtime-only-priced-model".to_string(),
+        LiteLLMModelInfo {
+            max_tokens: Some(8192),
+            max_input_tokens: Some(8192),
+            max_output_tokens: Some(2048),
+            input_cost_per_token: Some(0.00001),
+            output_cost_per_token: Some(0.00003),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: provider.to_string(),
+            mode: "chat".to_string(),
+            supports_function_calling: Some(true),
+            supports_vision: Some(false),
+            supports_streaming: Some(true),
+            supports_parallel_function_calling: Some(true),
+            supports_system_message: Some(true),
+            extra: HashMap::new(),
+        },
+    );
+    service
+}
+
+#[test]
+fn reserve_completion_budget_uses_runtime_pricing_service() {
+    let pricing = runtime_test_pricing_service("runtime_provider");
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "runtime_provider",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.models.set_model_limit(
+        "runtime-only-priced-model",
+        ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+
+    let reservation = match reserve_completion_budget_with_pricing(
+        &pricing,
+        &budget,
+        "runtime_provider",
+        "runtime-only-priced-model",
+        1000,
+        Some(500),
+    ) {
+        Ok(Some(reservation)) => reservation,
+        Ok(None) => panic!("priced runtime model should create a budget reservation"),
+        Err(error) => panic!("runtime pricing reservation should succeed: {error}"),
+    };
+
+    assert_eq!(reservation.reserved_amount(), 0.025);
+    assert_eq!(
+        budget
+            .providers
+            .get_provider_usage("runtime_provider")
+            .map(|usage| usage.current_spend),
+        Some(0.025)
+    );
+    reservation.cancel();
+}
+
+#[tokio::test]
+async fn record_completion_spend_uses_runtime_pricing_service() {
+    let pricing = runtime_test_pricing_service("runtime_provider");
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "runtime_provider",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.models.set_model_limit(
+        "runtime-only-priced-model",
+        ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    let keys = KeyManager::new(InMemoryKeyRepository::new());
+
+    record_completion_spend_with_reservation_with_pricing(
+        &pricing,
+        &budget,
+        &keys,
+        None,
+        "runtime_provider",
+        "runtime-only-priced-model",
+        Some(&response_usage(1000, 500)),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        budget
+            .providers
+            .get_provider_usage("runtime_provider")
+            .map(|usage| usage.current_spend),
+        Some(0.025)
+    );
+    assert_eq!(
+        budget
+            .models
+            .get_model_usage("runtime-only-priced-model")
+            .map(|usage| usage.current_spend),
+        Some(0.025)
+    );
+}
+
+#[test]
+fn reserve_completion_budget_rejects_missing_pricing_when_budget_requires_cost() {
+    let pricing = PricingService::new(None);
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "runtime_provider",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+
+    let error = match reserve_completion_budget_with_pricing(
+        &pricing,
+        &budget,
+        "runtime_provider",
+        "missing-priced-model",
+        1000,
+        Some(500),
+    ) {
+        Ok(_) => panic!("budgeted requests without pricing should fail closed"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+    assert_eq!(
+        budget
+            .providers
+            .get_provider_usage("runtime_provider")
+            .map(|usage| usage.current_spend)
+            .unwrap_or(0.0),
+        0.0
+    );
+}

--- a/src/server/routes/ai/spend_tests.rs
+++ b/src/server/routes/ai/spend_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+use crate::core::cost::{UsageTokens, estimate_cost, generic_cost_per_token};
 use crate::core::keys::InMemoryKeyRepository;
 use crate::core::models::openai::requests::ChatCompletionRequest;
 use crate::core::models::openai::{

--- a/src/server/routes/pricing.rs
+++ b/src/server/routes/pricing.rs
@@ -142,6 +142,8 @@ pub async fn get_model_pricing(
 pub struct CostCalculationRequest {
     /// Model name to calculate cost for
     pub model: String,
+    /// Optional provider name for provider-aware pricing
+    pub provider: Option<String>,
     /// Number of input tokens
     pub input_tokens: u32,
     /// Number of output tokens
@@ -161,8 +163,14 @@ pub async fn calculate_cost(
 ) -> Result<HttpResponse> {
     let pricing_service = &data.pricing;
 
-    match pricing_service
-        .calculate_completion_cost(
+    let result = if let Some(provider) = payload.provider.as_deref() {
+        if pricing_service.needs_refresh()
+            && let Err(e) = pricing_service.refresh_pricing_data().await
+        {
+            warn!("Failed to refresh pricing data: {}", e);
+        }
+        pricing_service.calculate_loaded_completion_cost_for_provider(
+            provider,
             &payload.model,
             payload.input_tokens,
             payload.output_tokens,
@@ -170,8 +178,20 @@ pub async fn calculate_cost(
             payload.completion.as_deref(),
             payload.duration_seconds,
         )
-        .await
-    {
+    } else {
+        pricing_service
+            .calculate_completion_cost(
+                &payload.model,
+                payload.input_tokens,
+                payload.output_tokens,
+                payload.prompt.as_deref(),
+                payload.completion.as_deref(),
+                payload.duration_seconds,
+            )
+            .await
+    };
+
+    match result {
         Ok(cost_result) => Ok(HttpResponse::Ok().json(cost_result)),
         Err(e) => Ok(HttpResponse::BadRequest().json(serde_json::json!({
             "error": "Cost calculation failed",
@@ -189,4 +209,87 @@ pub fn configure_pricing_routes(cfg: &mut web::ServiceConfig) {
             .route("/model/{model_name}", web::get().to(get_model_pricing))
             .route("/calculate", web::post().to(calculate_cost)),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Config;
+    use crate::core::pricing_service::LiteLLMModelInfo;
+    use crate::server::HttpServer as GatewayHttpServer;
+    use actix_web::http::StatusCode;
+    use actix_web::{App, test};
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+
+    fn runtime_model_info(provider: &str) -> LiteLLMModelInfo {
+        LiteLLMModelInfo {
+            max_tokens: Some(8192),
+            max_input_tokens: Some(8192),
+            max_output_tokens: Some(2048),
+            input_cost_per_token: Some(0.00001),
+            output_cost_per_token: Some(0.00003),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: provider.to_string(),
+            mode: "chat".to_string(),
+            supports_function_calling: Some(true),
+            supports_vision: Some(false),
+            supports_streaming: Some(true),
+            supports_parallel_function_calling: Some(true),
+            supports_system_message: Some(true),
+            extra: HashMap::new(),
+        }
+    }
+
+    async fn build_pricing_route_state() -> AppState {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+
+        let server = match GatewayHttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => {
+                panic!("gateway server should initialize for pricing route tests: {error}")
+            }
+        };
+        server.state().clone()
+    }
+
+    #[tokio::test]
+    async fn calculate_cost_route_uses_provider_aware_runtime_pricing() {
+        let state = build_pricing_route_state().await;
+        state.pricing.add_custom_model(
+            "runtime-route-priced-model".to_string(),
+            runtime_model_info("runtime_provider"),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(configure_pricing_routes),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/v1/pricing/calculate")
+            .set_json(json!({
+                "provider": "runtime_provider",
+                "model": "runtime-route-priced-model",
+                "input_tokens": 1000,
+                "output_tokens": 500
+            }))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["model"], "runtime-route-priced-model");
+        assert_eq!(body["provider"], "runtime_provider");
+        let total_cost = match body["total_cost"].as_f64() {
+            Some(total_cost) => total_cost,
+            None => panic!("pricing response should include numeric total_cost: {body}"),
+        };
+        assert!((total_cost - 0.025).abs() < f64::EPSILON);
+    }
 }

--- a/src/server/routes/pricing.rs
+++ b/src/server/routes/pricing.rs
@@ -292,4 +292,36 @@ mod tests {
         };
         assert!((total_cost - 0.025).abs() < f64::EPSILON);
     }
+
+    #[tokio::test]
+    async fn calculate_cost_route_resolves_xai_openai_like_prefix() {
+        let state = build_pricing_route_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(configure_pricing_routes),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/v1/pricing/calculate")
+            .set_json(json!({
+                "provider": "openai_like",
+                "model": "xai/grok-4.3",
+                "input_tokens": 1000,
+                "output_tokens": 500
+            }))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["model"], "grok-4.3");
+        assert_eq!(body["provider"], "xai");
+        let total_cost = match body["total_cost"].as_f64() {
+            Some(total_cost) => total_cost,
+            None => panic!("pricing response should include numeric total_cost: {body}"),
+        };
+        assert!((total_cost - 0.0025).abs() < f64::EPSILON);
+    }
 }

--- a/src/server/routes/pricing.rs
+++ b/src/server/routes/pricing.rs
@@ -324,4 +324,36 @@ mod tests {
         };
         assert!((total_cost - 0.0025).abs() < f64::EPSILON);
     }
+
+    #[tokio::test]
+    async fn calculate_cost_route_applies_provider_aware_tiered_pricing() {
+        let state = build_pricing_route_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(configure_pricing_routes),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/v1/pricing/calculate")
+            .set_json(json!({
+                "provider": "azure",
+                "model": "gpt-5.5",
+                "input_tokens": 300000,
+                "output_tokens": 1000
+            }))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["provider"], "azure");
+        let total_cost = match body["total_cost"].as_f64() {
+            Some(total_cost) => total_cost,
+            None => panic!("pricing response should include numeric total_cost: {body}"),
+        };
+        assert!((total_cost - 3.045).abs() < 1e-12);
+    }
 }


### PR DESCRIPTION
## Summary

- 增加 `PricingService` provider-aware authority，统一 already-loaded pricing lookup、cost、reservation estimate，并保留 Azure/Bedrock 兼容 catalog fallback
- 将 AI spend reservation/settlement live path 改为使用 `AppState.pricing`，legacy `core::cost` 保留为 PricingService-backed facade
- 给 `/v1/pricing/calculate` 增加可选 `provider` 字段，并补充 SpecRail GH726 packet 与 runtime pricing/spend/route 测试

Fixes #726

## Verification

- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /private/tmp/litellm-rs-issue726/specs/GH726`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test pricing_service --lib --locked`
- `cargo test estimate_cost --lib --locked`
- `cargo test spend --lib --locked`
- `cargo test runtime_pricing --lib --locked`
- `cargo test pricing --lib --locked`
- `cargo check --all-features --locked`