### PR TITLE
fix(provider): enforce capability dispatch contract

### DIFF
--- a/specs/GH729/product.md
+++ b/specs/GH729/product.md
@@ -1,0 +1,52 @@
+# Product Spec
+
+## Linked Issue
+
+GH-729 / #729
+
+## 用户问题
+
+provider 能力契约现在有两套表述：实际 HTTP/router 路径通过 `ProviderCapability`
+选择部署，但 `sub_traits.rs` 仍暴露 `LLMChat`、`LLMEmbed`、`LLMStream`
+这组未接入 call site 的旧 carve-out。维护者和下游用户无法判断 optional
+capabilities 应该通过 trait object、sub-trait，还是能力枚举来分发。
+
+## 目标
+
+- 明确 `ProviderCapability` 是当前 runtime dispatch 的唯一能力契约。
+- 保留 deprecated sub-traits 作为 library compatibility adapters，但不再把它们描述成未来主架构。
+- optional capabilities（streaming、embeddings、image generation）必须有稳定的 supports/error 语义。
+- 用测试覆盖 chat-only provider 和 optional-capability provider 的判断行为。
+
+## 非目标
+
+- 不收敛 provider factory、registry 或 runtime enum。
+- 不新增 provider 实现。
+- 不把 `LLMProvider` 拆成新的 object-safe trait 栈。
+- 不删除 public deprecated sub-traits，避免 minor release 破坏下游编译。
+
+## Behavior Invariants
+
+1. `LLMProvider::supports_capability(capability)` 必须只由 `capabilities()` 返回值决定。
+2. `supports_streaming()`、`supports_embeddings()`、`supports_image_generation()` 必须与对应 `ProviderCapability` 保持一致。
+3. 未声明 optional capability 的 provider 调用对应 optional method 时必须返回稳定的 `ProviderError::NotSupported`，不能静默 fallback。
+4. deprecated `LLMChat`、`LLMEmbed`、`LLMStream` 只能作为 `LLMProvider` 的 compatibility adapters；新路由不得依赖它们。
+5. router/gateway 的 capability 选择必须使用同一套 capability predicate，不能复制新的判断逻辑。
+
+## 验收标准
+
+- [ ] `sub_traits.rs` 明确说明 removal/migration guidance，并避免暗示它会成为 runtime dispatch path。
+- [ ] `LLMProvider` 或 provider wrapper 暴露统一 capability predicate。
+- [ ] optional capabilities 的 dispatch contract 在代码注释和测试中可见。
+- [ ] 测试覆盖 chat-only provider 和至少一个 optional capability provider。
+- [ ] 通过 `cargo fmt --all -- --check`、focused provider/capability tests、`cargo check --all-features --locked`。
+
+## 边界情况
+
+- 下游代码仍可能 import deprecated sub-traits；本变更不得删除这些 symbols。
+- 有些 provider 支持 embeddings 但不支持 chat；capability predicate 必须允许这种组合。
+- 路由层可能遇到健康不可用和能力不支持两类错误；两者不能混淆。
+
+## 发布说明
+
+这是 provider architecture clarification。用户可见行为应保持不变，但开发者文档和测试会明确：新增/修改 provider 时必须声明 `ProviderCapability`，router 按 capability 选择部署。

--- a/specs/GH729/tasks.md
+++ b/specs/GH729/tasks.md
@@ -1,0 +1,43 @@
+# Task Plan
+
+## Linked Issue
+
+GH-729 / #729
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP729-T1` Owner: coordinator. Done when: `specs/GH729/product.md`, `tech.md`, and `tasks.md` exist and pass SpecRail packet validation. Verify: `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /tmp/litellm-rs-issue729/specs/GH729`.
+- [x] `SP729-T2` Owner: coordinator. Done when: `LLMProvider` exposes the canonical `supports_capability()` predicate and optional helper methods delegate to it. Verify: focused provider trait tests.
+- [x] `SP729-T3` Owner: coordinator. Done when: `Provider` and router/server capability scans use the shared predicate instead of duplicated slice scans. Verify: focused router/provider tests.
+- [x] `SP729-T4` Owner: coordinator. Done when: `sub_traits.rs` clearly documents legacy compatibility/migration guidance while keeping deprecated symbols available. Verify: focused sub-trait tests compile and pass.
+- [x] `SP729-T5` Owner: verification owner. Done when: formatting, focused tests, SpecRail packet validation, and all-features check pass from this session. Verify: `cargo fmt --all -- --check`; `cargo test provider --lib`; `cargo check --all-features --locked`.
+
+## 并行拆分
+
+#729 is a serial writable lane. `#728` may plan read-only in parallel but must not edit SDK/support-matrix files until this branch is merged or rebased. `#727` may plan read-only in parallel and should choose files outside provider trait/router capability ownership.
+
+Writable ownership for this lane:
+
+- `specs/GH729/`
+- `src/core/traits/provider/llm_provider/`
+- `src/core/providers/mod.rs`
+- `src/core/router/selection.rs`
+- `src/core/router/unified.rs`
+- `src/server/routes/ai/provider_selection.rs`
+
+## 验证
+
+- SpecRail packet validation.
+- `cargo fmt --all -- --check`
+- `cargo test provider --lib`
+- `cargo check --all-features --locked`
+- PR head SHA, CI, merge state, and GraphQL review threads checked before merge.
+
+## Handoff Notes
+
+This issue intentionally chooses `ProviderCapability` as the runtime dispatch contract. Do not reopen the sub-trait carve-out in `#728`; the support matrix should consume this capability predicate and provider registry truth.

--- a/specs/GH729/tech.md
+++ b/specs/GH729/tech.md
@@ -1,0 +1,67 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-729 / #729
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Provider trait | `src/core/traits/provider/llm_provider/trait_definition.rs` | `LLMProvider` exposes `capabilities()` plus per-capability helper methods. Optional methods return `NotSupported` by default. | This is the canonical provider behavior API. |
+| Legacy sub-traits | `src/core/traits/provider/llm_provider/sub_traits.rs` | Deprecated blanket adapters over `LLMProvider`, but wording still says future roadmap may finish the carve-out. | This is the unused architecture surface called out by #729. |
+| Provider enum | `src/core/providers/mod.rs` | Router deployments store `Provider`; optional calls dispatch to `LLMProvider` methods through enum arms. | This is the current runtime dispatch boundary. |
+| Router capability selection | `src/core/router/selection.rs`, `src/core/router/unified.rs`, `src/server/routes/ai/provider_selection.rs` | These paths scan `provider.capabilities()` directly. | These should share one capability predicate. |
+
+## 设计方案
+
+Use `ProviderCapability` as the enforced runtime capability model for this issue.
+
+1. Add `LLMProvider::supports_capability(&ProviderCapability)` as the canonical predicate over `capabilities()`.
+2. Rewrite `supports_streaming()`, `supports_embeddings()`, and `supports_image_generation()` to delegate to `supports_capability()`.
+3. Add `Provider::supports_capability(&ProviderCapability)` and use it in router/server capability scans.
+4. Update `sub_traits.rs` top-level guidance and deprecation notes to say these traits are legacy compatibility adapters, not routing contracts.
+5. Add tests with a local chat-only mock and optional-capability mock so the contract is independent of concrete provider catalog drift.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | `LLMProvider::supports_capability` | Unit test checks chat-only and embeddings-capable mocks. |
+| P2 | helper methods delegate to canonical predicate | Unit test asserts stream/embed/image helpers mirror capability list. |
+| P3 | optional method failure remains explicit | Existing provider enum tests plus focused sub-trait/trait tests. |
+| P4 | sub-traits remain compatibility-only | Documentation update and deprecated adapter tests continue passing. |
+| P5 | router/gateway uses one predicate | Compile check plus focused router/provider tests. |
+
+## 数据流
+
+Provider implementations return a static `&[ProviderCapability]`. Runtime router selection asks the selected `Provider` enum whether it supports a requested capability. Optional execution methods are called only after routing selects a capable deployment; if called directly on an unsupported provider, the `LLMProvider` default returns `ProviderError::NotSupported`.
+
+No persistence, config format, or external API payload changes are required.
+
+## 备选方案
+
+- Real sub-trait carve-out: rejected for this issue because router deployments still use the closed `Provider` enum and a full carve-out would overlap factory/registry work.
+- Delete `sub_traits.rs`: rejected for compatibility; this can wait for a future major release.
+
+## 风险
+
+- Security: No auth, secret, or request execution changes.
+- Compatibility: Adding default trait methods is source-compatible for existing provider implementations; deleting symbols is avoided.
+- Performance: Capability checks remain a small slice scan over static arrays.
+- Maintenance: This makes future provider work less ambiguous by naming one predicate.
+
+## 测试计划
+
+- [ ] Unit tests: focused trait/provider/router capability tests.
+- [ ] Integration tests: existing router capability selection tests.
+- [ ] Manual verification: inspect diff to confirm no factory/registry/provider implementation churn.
+- [ ] Full check: `cargo check --all-features --locked`.
+
+## 回滚方案
+
+Revert the trait helper, provider helper, router predicate call-site changes, documentation updates, and `specs/GH729` packet. Because no data migration or config change is introduced, rollback is a normal code revert.

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -502,6 +502,12 @@ impl Provider {
         dispatch_provider!(sync, self, capabilities)
     }
 
+    /// Check if this provider declares a runtime capability.
+    pub fn supports_capability(&self, capability: &ProviderCapability) -> bool {
+        use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+        dispatch_provider!(value, self, supports_capability, capability)
+    }
+
     /// Execute chat completion
     pub async fn chat_completion(
         &self,
@@ -550,7 +556,10 @@ impl Provider {
             .unwrap_or(model)
     }
 
-    /// Execute streaming chat completion
+    /// Execute streaming chat completion.
+    ///
+    /// Route selection must confirm `ProviderCapability::ChatCompletionStream`
+    /// before calling this optional dispatch method.
     pub async fn chat_completion_stream(
         &self,
         request: ChatRequest,
@@ -565,7 +574,10 @@ impl Provider {
         dispatch_provider!(async_err, self, chat_completion_stream, request, context)
     }
 
-    /// Create embeddings
+    /// Create embeddings.
+    ///
+    /// Route selection must confirm `ProviderCapability::Embeddings` before
+    /// calling this optional dispatch method.
     pub async fn create_embeddings(
         &self,
         request: EmbeddingRequest,
@@ -575,7 +587,10 @@ impl Provider {
         dispatch_provider!(async_err, self, embeddings, request, context)
     }
 
-    /// Create images
+    /// Create images.
+    ///
+    /// Route selection must confirm `ProviderCapability::ImageGeneration`
+    /// before calling this optional dispatch method.
     pub async fn create_images(
         &self,
         request: ImageGenerationRequest,
@@ -618,6 +633,8 @@ mod tests {
             anthropic::AnthropicProvider::new(anthropic::AnthropicConfig::new_test("test-key"))
                 .unwrap(),
         );
+
+        assert!(!provider.supports_capability(&ProviderCapability::Embeddings));
 
         let err = provider
             .create_embeddings(
@@ -706,6 +723,8 @@ mod tests {
                 .unwrap(),
         );
 
+        assert!(!provider.supports_capability(&ProviderCapability::ImageGeneration));
+
         let err = provider
             .create_images(
                 crate::core::types::image::ImageGenerationRequest {
@@ -733,5 +752,20 @@ mod tests {
             ),
             "expected provider-specific NotSupported, got {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_provider_supports_capability_for_optional_provider() {
+        let mut config = openai::OpenAIConfig::default();
+        config.base.api_key = Some("sk-test123456789012345678901234567890123456".to_string());
+        let Ok(openai_provider) = openai::OpenAIProvider::new(config).await else {
+            panic!("OpenAI provider should initialize with a test API key");
+        };
+        let provider = Provider::OpenAI(openai_provider);
+
+        assert!(provider.supports_capability(&ProviderCapability::ChatCompletion));
+        assert!(provider.supports_capability(&ProviderCapability::ChatCompletionStream));
+        assert!(provider.supports_capability(&ProviderCapability::Embeddings));
+        assert!(!provider.supports_capability(&ProviderCapability::TextToSpeech));
     }
 }

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -155,12 +155,7 @@ impl Router {
         self.select_deployment_matching(
             model_name,
             |deployment| {
-                deployment
-                    .provider
-                    .capabilities()
-                    .iter()
-                    .any(|cap| cap == capability)
-                    && is_candidate(deployment)
+                deployment.provider.supports_capability(capability) && is_candidate(deployment)
             },
             Some(no_matching_candidate_error),
         )

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -390,12 +390,7 @@ impl Router {
                 continue;
             }
 
-            if deployment
-                .provider
-                .capabilities()
-                .iter()
-                .any(|cap| cap == capability)
-            {
+            if deployment.provider.supports_capability(capability) {
                 return Some(CapabilityDeployment {
                     deployment_id: id.clone(),
                     provider: deployment.provider.clone(),

--- a/src/core/traits/provider/llm_provider/mod.rs
+++ b/src/core/traits/provider/llm_provider/mod.rs
@@ -1,6 +1,10 @@
 //! LLM Provider module
 //!
 //! This module provides the unified interface for all AI providers.
+//!
+//! `trait_definition::LLMProvider` plus `ProviderCapability` is the runtime
+//! dispatch contract. `sub_traits` is exported only for deprecated library API
+//! compatibility and must not be used by new router or gateway call sites.
 //! The original `llm_provider.rs` has been split into smaller modules for better maintainability.
 
 pub mod sub_traits;

--- a/src/core/traits/provider/llm_provider/sub_traits.rs
+++ b/src/core/traits/provider/llm_provider/sub_traits.rs
@@ -1,11 +1,16 @@
-//! LLM Provider sub-traits (deprecated, kept for library API compatibility)
+//! LLM Provider sub-traits (deprecated compatibility adapters)
 //!
-//! These capability traits were drafted as a proposed carve-out of the
-//! monolithic `LLMProvider` trait but were never wired into any call site.
-//! They remain visible at `litellm_rs::core::traits::provider::llm_provider::sub_traits`
-//! to avoid breaking downstream library consumers; new code should accept
-//! `LLMProvider` directly. The traits will be removed in a future major
-//! release once the architecture roadmap (#519) finishes the trait carve-out.
+//! These traits were drafted as a proposed carve-out of the monolithic
+//! `LLMProvider` trait but were never wired into router or gateway call sites.
+//! Runtime dispatch now uses `LLMProvider::supports_capability` and
+//! `ProviderCapability`; this module is not a dispatch contract.
+//!
+//! The traits remain visible at
+//! `litellm_rs::core::traits::provider::llm_provider::sub_traits` to avoid
+//! breaking downstream library consumers. New code should accept `LLMProvider`
+//! directly and use `ProviderCapability` for optional feature routing. These
+//! adapters are scheduled for removal in a future major release after a
+//! migration window.
 
 use futures::Stream;
 use serde_json::Value;
@@ -33,7 +38,7 @@ use super::trait_definition::LLMProvider;
 #[allow(async_fn_in_trait)]
 #[deprecated(
     since = "0.5.1",
-    note = "sub-trait carve-out was never wired; use LLMProvider directly. Tracked under #519 architecture roadmap."
+    note = "legacy adapter only; use LLMProvider plus ProviderCapability for runtime dispatch. Tracked under #729."
 )]
 pub trait LLMChat: Send + Sync {
     /// Execute chat completion request.
@@ -69,7 +74,7 @@ pub trait LLMChat: Send + Sync {
     fn get_supported_openai_params(&self, model: &str) -> &'static [&'static str];
 }
 
-/// Blanket implementation: every `LLMProvider` is automatically an `LLMChat`.
+/// Compatibility adapter: every `LLMProvider` is automatically an `LLMChat`.
 #[allow(deprecated)]
 impl<T: LLMProvider> LLMChat for T {
     async fn chat_completion(
@@ -120,7 +125,7 @@ impl<T: LLMProvider> LLMChat for T {
 #[allow(async_fn_in_trait)]
 #[deprecated(
     since = "0.5.1",
-    note = "sub-trait carve-out was never wired; use LLMProvider directly. Tracked under #519 architecture roadmap."
+    note = "legacy adapter only; use LLMProvider plus ProviderCapability for runtime dispatch. Tracked under #729."
 )]
 pub trait LLMEmbed: Send + Sync {
     /// Generate text embeddings.
@@ -131,7 +136,7 @@ pub trait LLMEmbed: Send + Sync {
     ) -> Result<EmbeddingResponse, ProviderError>;
 }
 
-/// Blanket implementation: every `LLMProvider` is automatically an `LLMEmbed`.
+/// Compatibility adapter: every `LLMProvider` is automatically an `LLMEmbed`.
 #[allow(deprecated)]
 impl<T: LLMProvider> LLMEmbed for T {
     async fn embeddings(
@@ -153,7 +158,7 @@ impl<T: LLMProvider> LLMEmbed for T {
 #[allow(async_fn_in_trait)]
 #[deprecated(
     since = "0.5.1",
-    note = "sub-trait carve-out was never wired; use LLMProvider directly. Tracked under #519 architecture roadmap."
+    note = "legacy adapter only; use LLMProvider plus ProviderCapability for runtime dispatch. Tracked under #729."
 )]
 pub trait LLMStream: Send + Sync {
     /// Execute streaming chat completion request.
@@ -164,7 +169,7 @@ pub trait LLMStream: Send + Sync {
     ) -> Result<Pin<Box<dyn Stream<Item = Result<ChatChunk, ProviderError>> + Send>>, ProviderError>;
 }
 
-/// Blanket implementation: every `LLMProvider` is automatically an `LLMStream`.
+/// Compatibility adapter: every `LLMProvider` is automatically an `LLMStream`.
 #[allow(deprecated)]
 impl<T: LLMProvider> LLMStream for T {
     async fn chat_completion_stream(

--- a/src/core/traits/provider/llm_provider/trait_definition.rs
+++ b/src/core/traits/provider/llm_provider/trait_definition.rs
@@ -76,6 +76,16 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// - UI display: Show provider feature characteristics
     fn capabilities(&self) -> &'static [ProviderCapability];
 
+    /// Check if this provider declares a runtime capability.
+    ///
+    /// `ProviderCapability` is the current dispatch contract for router and
+    /// gateway execution. Optional methods such as streaming, embeddings, and
+    /// image generation are callable through `LLMProvider`, but route selection
+    /// must first confirm the corresponding capability here.
+    fn supports_capability(&self, capability: &ProviderCapability) -> bool {
+        self.capabilities().contains(capability)
+    }
+
     /// Get supported model list
     ///
     /// # Returns
@@ -111,8 +121,7 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// # Default Implementation
     /// Checks if capabilities contain ToolCalling
     fn supports_tools(&self) -> bool {
-        self.capabilities()
-            .contains(&ProviderCapability::ToolCalling)
+        self.supports_capability(&ProviderCapability::ToolCalling)
     }
 
     /// Check if streaming is supported
@@ -123,8 +132,7 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// # Default Implementation
     /// Checks if capabilities contain ChatCompletionStream
     fn supports_streaming(&self) -> bool {
-        self.capabilities()
-            .contains(&ProviderCapability::ChatCompletionStream)
+        self.supports_capability(&ProviderCapability::ChatCompletionStream)
     }
 
     /// Check if image generation is supported
@@ -132,8 +140,7 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// # Returns
     /// True if image generation (like DALL-E) is supported
     fn supports_image_generation(&self) -> bool {
-        self.capabilities()
-            .contains(&ProviderCapability::ImageGeneration)
+        self.supports_capability(&ProviderCapability::ImageGeneration)
     }
 
     /// Check if embeddings are supported
@@ -141,8 +148,7 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
     /// # Returns
     /// True if text embedding generation is supported
     fn supports_embeddings(&self) -> bool {
-        self.capabilities()
-            .contains(&ProviderCapability::Embeddings)
+        self.supports_capability(&ProviderCapability::Embeddings)
     }
 
     /// Check if vision capabilities are supported
@@ -480,5 +486,124 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
         // Simple estimation: 4 characters approximately equals 1 token
         // Subclasses should implement more accurate tokenization
         Ok((text.len() as f64 / 4.0).ceil() as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::traits::error_mapper::DefaultErrorMapper;
+    use crate::core::types::health::HealthStatus;
+
+    #[derive(Debug)]
+    struct CapabilityProvider {
+        capabilities: &'static [ProviderCapability],
+    }
+
+    #[allow(async_fn_in_trait)]
+    impl LLMProvider for CapabilityProvider {
+        fn name(&self) -> &'static str {
+            "capability-test"
+        }
+
+        fn capabilities(&self) -> &'static [ProviderCapability] {
+            self.capabilities
+        }
+
+        fn models(&self) -> &[ModelInfo] {
+            &[]
+        }
+
+        fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
+            &[]
+        }
+
+        async fn map_openai_params(
+            &self,
+            params: HashMap<String, Value>,
+            _model: &str,
+        ) -> Result<HashMap<String, Value>, ProviderError> {
+            Ok(params)
+        }
+
+        async fn transform_request(
+            &self,
+            _request: ChatRequest,
+            _context: RequestContext,
+        ) -> Result<Value, ProviderError> {
+            Ok(Value::Null)
+        }
+
+        async fn transform_response(
+            &self,
+            _raw_response: &[u8],
+            _model: &str,
+            _request_id: &str,
+        ) -> Result<ChatResponse, ProviderError> {
+            Err(ProviderError::not_supported(
+                "capability-test",
+                "transform_response",
+            ))
+        }
+
+        fn get_error_mapper(&self) -> Box<dyn ErrorMapper<ProviderError>> {
+            Box::new(DefaultErrorMapper)
+        }
+
+        async fn chat_completion(
+            &self,
+            _request: ChatRequest,
+            _context: RequestContext,
+        ) -> Result<ChatResponse, ProviderError> {
+            Err(ProviderError::not_supported(
+                "capability-test",
+                "chat_completion",
+            ))
+        }
+
+        async fn health_check(&self) -> HealthStatus {
+            HealthStatus::Healthy
+        }
+
+        async fn calculate_cost(
+            &self,
+            _model: &str,
+            _input_tokens: u32,
+            _output_tokens: u32,
+        ) -> Result<f64, ProviderError> {
+            Ok(0.0)
+        }
+    }
+
+    #[test]
+    fn test_supports_capability_for_chat_only_provider() {
+        static CHAT_ONLY: &[ProviderCapability] = &[ProviderCapability::ChatCompletion];
+        let provider = CapabilityProvider {
+            capabilities: CHAT_ONLY,
+        };
+
+        assert!(provider.supports_capability(&ProviderCapability::ChatCompletion));
+        assert!(!provider.supports_capability(&ProviderCapability::Embeddings));
+        assert!(!provider.supports_embeddings());
+        assert!(!provider.supports_streaming());
+        assert!(!provider.supports_image_generation());
+    }
+
+    #[test]
+    fn test_optional_helpers_delegate_to_provider_capability() {
+        static OPTIONAL: &[ProviderCapability] = &[
+            ProviderCapability::ChatCompletion,
+            ProviderCapability::ChatCompletionStream,
+            ProviderCapability::Embeddings,
+            ProviderCapability::ImageGeneration,
+        ];
+        let provider = CapabilityProvider {
+            capabilities: OPTIONAL,
+        };
+
+        assert!(provider.supports_streaming());
+        assert!(provider.supports_embeddings());
+        assert!(provider.supports_image_generation());
+        assert!(!provider.supports_tools());
     }
 }

--- a/src/server/routes/ai/provider_selection.rs
+++ b/src/server/routes/ai/provider_selection.rs
@@ -19,13 +19,7 @@ pub fn select_provider_for_model(
     let supports_capability = deployments.iter().any(|deployment_id| {
         router
             .get_deployment(deployment_id)
-            .map(|deployment| {
-                deployment
-                    .provider
-                    .capabilities()
-                    .iter()
-                    .any(|cap| cap == &capability)
-            })
+            .map(|deployment| deployment.provider.supports_capability(&capability))
             .unwrap_or(false)
     });
 


### PR DESCRIPTION
## Summary

Clarifies and enforces the provider capability dispatch contract for #729. `ProviderCapability` is now the runtime predicate used by provider/router/gateway selection, while deprecated `sub_traits` remain compatibility adapters only.

## Linked Work

- Fixes #729
- Parent roadmap: #519
- Spec packet: `specs/GH729/`

## Changes

- Added SpecRail product/tech/tasks packet for #729.
- Added `LLMProvider::supports_capability()` and made optional helper methods delegate to it.
- Added `Provider::supports_capability()` and routed capability scans through the shared predicate.
- Updated `sub_traits.rs` guidance to mark it as legacy compatibility only, not a dispatch contract.
- Added tests for chat-only and optional-capability provider behavior.

## Verification

- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /tmp/litellm-rs-issue729/specs/GH729`
- `cargo fmt --all -- --check`
- `cargo test test_supports_capability_for_chat_only_provider --lib`
- `cargo test test_optional_helpers_delegate_to_provider_capability --lib`
- `cargo test test_provider_supports_capability_for_optional_provider --lib`
- `cargo test test_execute_with_selected_deployment_uses_capability_selected_deployment --lib`
- `cargo test test_provider_capabilities_embeddings_error_names_real_provider --lib`
- `cargo test test_provider_capabilities_image_error_names_real_provider --lib`
- `cargo test provider --lib`
- `cargo check --all-features --locked`

## Merge Gate

- [x] PR head SHA will be checked before merge.
- [ ] CI/check rollup complete and passing.
- [ ] GraphQL reviewThreads checked and resolved.
- [x] Human merge authorization exists in this conversation, pending fresh gates.
