### PR TITLE
fix: unify provider route support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,23 @@ alone does not make a third-party provider routeable; use the generic
 OpenAI-compatible path for compatible endpoints, or wire a code-based provider
 into the enum, dispatch, registry metadata, and factory.
 
-> The matrix below is validated against the provider registry and Tier 1 catalog. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 identity and dispatch metadata lives in [`src/core/providers/registry/types.rs`](./src/core/providers/registry/types.rs), with construction branches in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Capability columns describe which endpoints this crate exposes for the provider — `passthrough` means an implemented crate endpoint forwards the call to the upstream OpenAI-compatible endpoint without per-provider transformation. A generated matrix is tracked as a follow-up.
+> The provider and route-surface matrices below are validated against the provider registry and Tier 1 catalog. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 identity and dispatch metadata lives in [`src/core/providers/registry/types.rs`](./src/core/providers/registry/types.rs), with construction branches in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Cross-surface support lives in [`src/core/providers/registry/support_matrix.rs`](./src/core/providers/registry/support_matrix.rs). Capability columns describe which endpoints this crate exposes for the provider — `passthrough` means an implemented crate endpoint forwards the call to the upstream OpenAI-compatible endpoint without per-provider transformation.
+
+### Route-surface matrix
+
+| Selector class | HTTP chat / stream | HTTP embeddings / image | SDK chat / stream / embeddings | `completion()` chat / stream | Notes |
+|----------------|--------------------|--------------------------|--------------------------------|-------------------------------|-------|
+| `openai` | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ / ✅ | ✅ / ✅ | Reference provider across all current surfaces. |
+| `anthropic` | ✅ / ✅ | – / – | ✅ / ✅ / – | ✅ / ✅ | Native chat and streaming only. |
+| `azure` | passthrough / passthrough | `providers-extra` / `providers-extra` | – / – / ✅ | passthrough / passthrough | SDK exposes Azure embeddings; SDK chat is not implemented. |
+| `azure_ai` | passthrough / passthrough | `providers-extra` / `providers-extra` | – / – / – | `providers-extra` / `providers-extra` | `completion()` supports `azure_ai/` and `azure-ai/` routes when the native feature is enabled. |
+| `bedrock` | ✅ / ✅ | ✅ / – | – / – / – | – / – | SDK Bedrock and public `completion()` routing are not implemented. |
+| `mistral`, `cloudflare`, `cohere`, `vertex_ai`, `gemini`, `fal_ai`, `replicate` | provider-specific | provider-specific | – / – / – | – / – | See `support_matrix.rs` for feature-gated HTTP support. |
+| `google` / SDK `Google` | – / – | – / – | – / – / – | – / – | Google/Gemini SDK chat is intentionally unsupported until a real adapter exists. |
+| Default catalog dynamic routes: `openrouter`, `deepseek`, `moonshot`, `minimax`, `zhipu`, `groq`, `xiaomi_mimo`, `xai` | passthrough / passthrough | – / – | – / – / – | ✅ / ✅ | OpenAI-compatible routes wired into default `completion()` routing. |
+| Other Tier 1 catalog providers | passthrough / passthrough | – / – | – / – / – | – / – | HTTP gateway chat/stream only unless routed through explicit OpenAI-compatible config. |
+| SDK `Custom` | – / – | – / – | – / – / ✅ | – / – | SDK custom providers support embeddings when `base_url` is configured. |
+| SDK `Ollama` | – / – | – / – | – / ✅ / – | – / – | SDK streaming uses the OpenAI-compatible stream parser; SDK chat is not implemented. |
 
 ### Tier 2 — code-based providers
 

--- a/specs/GH728/product.md
+++ b/specs/GH728/product.md
@@ -1,0 +1,59 @@
+# Product Spec
+
+## Linked Issue
+
+GH-728 / #728
+
+## 用户问题
+
+provider 支持状态现在分散在多条路径：HTTP gateway/router 看
+`ProviderCapability`，SDK routing 用本地 `matches!` 判断，`completion()` 又维护一组
+provider prefix 和动态 provider 分支。结果是同一个 provider 在不同入口的状态不一致：
+例如 SDK 把 Google 选为 chat-capable，但实际执行只返回 "not implemented"。
+
+## 目标
+
+- 建立一个 registry 侧的 route-surface support matrix，覆盖 HTTP、SDK 和
+  `completion()` 的主要入口。
+- SDK chat/stream/embeddings routing 使用同一套 matrix，未实现 provider 必须稳定返回
+  `NotSupported`。
+- `completion()` 对 matrix 中明确 unsupported 的 provider prefix 返回明确错误，而不是模糊的
+  "No suitable provider found"。
+- README 提供一张面向维护者的跨入口支持矩阵。
+
+## 非目标
+
+- 不实现 Google/Gemini SDK chat adapter。
+- 不实现所有缺失的 SDK provider。
+- 不改变 provider factory、auth、HTTP payload 结构或 core provider 构造逻辑。
+- 不把完整 SpecRail workflow vendoring 到本 repo。
+
+## Behavior Invariants
+
+1. SDK provider selection 只能选择 matrix 标记为当前 build 可用的 SDK surface。
+2. SDK Google/Gemini chat 在 adapter 实现前必须返回 `SDKError::NotSupported`。
+3. SDK default provider 不能绕过 surface support 判断。
+4. Embeddings 仍只支持 OpenAI、Azure 和 SDK Custom，并继续保留现有 model/base_url 校验。
+5. `completion()` 已知 unsupported provider prefix 必须返回明确 bad request。
+6. HTTP provider capability dispatch 继续由 #729 的 `ProviderCapability` predicate 负责；matrix 不替代 execution-time capability checks。
+
+## 验收标准
+
+- [ ] 有一个代码级 canonical support matrix，并从 registry module 导出。
+- [ ] README 中有一张跨 HTTP/SDK/completion 的 provider support matrix。
+- [ ] SDK chat routing 不再选择 Google/Gemini。
+- [ ] SDK direct execution 对 Google chat 返回 `NotSupported`。
+- [ ] `completion()` 对 Google/Gemini prefix 给出明确 unsupported 错误。
+- [ ] 通过 SpecRail packet validation、`cargo fmt --all -- --check`、focused tests、`cargo check --all-features --locked`。
+
+## 边界情况
+
+- Tier 1 catalog providers默认只承诺 HTTP chat/stream；只有已接入 default
+  `completion()` dynamic route 的 provider 才在 matrix 中标记 completion 支持。
+- Feature-gated HTTP provider surface 必须按当前 cargo feature 判断是否可选。
+- `api_base` 的 generic OpenAI-compatible 用法不能被未列入 matrix 的 provider-like model prefix 误拦截。
+
+## 发布说明
+
+这是 provider support contract 收敛。Google/Gemini SDK chat 的行为会从运行期
+`ProviderError("not implemented")` 收敛为稳定的 `NotSupported`，并在 README 中明确当前支持边界。

--- a/specs/GH728/tasks.md
+++ b/specs/GH728/tasks.md
@@ -1,0 +1,49 @@
+# Task Plan
+
+## Linked Issue
+
+GH-728 / #728
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP728-T1` Owner: coordinator. Done when: `specs/GH728/product.md`, `tech.md`, and `tasks.md` exist and pass SpecRail packet validation. Verify: `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /tmp/litellm-rs-issue728/specs/GH728`.
+- [x] `SP728-T2` Owner: coordinator. Done when: registry exports a canonical support matrix for HTTP, SDK, and completion route surfaces. Verify: `cargo test support_matrix --lib`.
+- [x] `SP728-T3` Owner: coordinator. Done when: SDK chat/stream/embeddings routing and direct execution use matrix-backed support checks. Verify: focused SDK routing/execution tests.
+- [x] `SP728-T4` Owner: coordinator. Done when: `completion()` reports explicit unsupported errors for known unsupported provider prefixes. Verify: focused completion router test.
+- [x] `SP728-T5` Owner: docs. Done when: README documents the cross-surface support matrix. Verify: registry README tests and manual diff review.
+- [ ] `SP728-T6` Owner: verification owner. Done when: formatting, focused tests, SpecRail packet validation, all-features check, PR CI, and review-thread gate pass from this session. Verify: `cargo fmt --all -- --check`; focused cargo tests; `cargo check --all-features --locked`; GitHub PR CI and review-thread query.
+
+## 并行拆分
+
+#728 is a serial writable lane after #729. Do not edit #727 U-16 split files from this lane except where a focused #728 test touches an already oversized file. #727 remains the dedicated file-size tranche.
+
+Writable ownership for this lane:
+
+- `specs/GH728/`
+- `src/core/providers/registry/support_matrix.rs`
+- `src/core/providers/registry/mod.rs`
+- `src/sdk/client/routing.rs`
+- `src/sdk/client/completions.rs`
+- `src/sdk/client/embeddings.rs`
+- `src/sdk/client/tests.rs`
+- `src/core/completion/default_router/router_impl.rs`
+- `README.md`
+
+## 验证
+
+- SpecRail packet validation.
+- `cargo fmt --all -- --check`
+- Focused SDK, support matrix, and completion router tests.
+- `cargo check --all-features --locked`
+- PR head SHA, CI, merge state, and GraphQL review threads checked before merge.
+
+## Handoff Notes
+
+This issue intentionally marks SDK Google/Gemini chat unsupported instead of
+implementing it. A future adapter PR can flip the matrix row only after adding
+real Google request/response handling and tests.

--- a/specs/GH728/tech.md
+++ b/specs/GH728/tech.md
@@ -1,0 +1,93 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-728 / #728
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Provider registry | `src/core/providers/registry/*` | Registry knows provider identity, aliases, catalog entries, and factory dispatch. | Best home for a cross-surface support matrix. |
+| SDK routing | `src/sdk/client/routing.rs` | Local `supports_chat` marks Google chat-capable even though execution is not implemented. | Main bug called out by #728. |
+| SDK execution | `src/sdk/client/completions.rs`, `src/sdk/client/embeddings.rs` | Execution has provider-specific branches and mixed unsupported errors. | Direct calls must match routing support state. |
+| completion() router | `src/core/completion/default_router/*` | Dynamic/static prefixes are separate from provider registry support documentation. | Needs explicit unsupported behavior for known unsupported prefixes. |
+| Docs | `README.md` | Provider matrix covers provider runtime capabilities but not SDK/completion surfaces. | Acceptance requires one documented matrix across public surfaces. |
+
+## 设计方案
+
+1. Add `src/core/providers/registry/support_matrix.rs`.
+   - Define `ProviderRouteSurface` for HTTP chat/stream/embeddings/images, SDK chat/stream/embeddings, and `completion()` chat/stream.
+   - Define `SurfaceSupport` with `Supported`, `Passthrough`, `FeatureGated`, and `Unsupported`.
+   - Provide `supports_provider_surface(provider, surface)` and canonical selector normalization.
+2. Export support matrix helpers from `registry/mod.rs`.
+3. Replace SDK routing's local chat/stream provider lists with matrix-backed checks.
+   - Default provider path also checks matrix support.
+   - If a model matches only unsupported providers, return `SDKError::NotSupported` instead of `ModelNotFound`.
+4. Guard SDK direct execution with the same matrix helpers.
+   - Google chat returns `NotSupported`.
+   - Embeddings still use existing prefix/base_url validation after matrix support passes.
+5. Add a minimal `completion()` prefix guard for explicit matrix rows that are unsupported.
+   - `google/...` and `gemini/...` become explicit bad requests.
+   - Unlisted catalog-like prefixes remain available to generic `api_base` passthrough.
+6. Update README with a route-surface matrix.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | `support_matrix.rs` | Unit tests cover registry/catalog selectors and default completion routes. |
+| P2 | SDK routing | Tests reject Google SDK chat and unsupported default provider. |
+| P3 | SDK direct execution | Test asserts `execute_chat_request("google", ...)` returns `NotSupported`. |
+| P4 | Embeddings support | Existing embeddings tests continue to pass; matrix adds a pre-check only. |
+| P5 | completion() explicit unsupported | Unit test checks Google/Gemini prefixes and does not block unlisted catalog prefixes. |
+| P6 | Docs | README updated and registry README tests remain valid. |
+
+## 数据流
+
+Callers pass a provider selector and a `ProviderRouteSurface` into the support
+matrix. The selector is normalized through registry aliases where possible.
+Explicit rows win; otherwise Tier 1 catalog providers get a conservative HTTP
+chat/stream fallback. SDK code maps its `ProviderType` enum to these canonical
+selectors before routing or execution.
+
+## 备选方案
+
+- Generate the matrix from every concrete provider's runtime `capabilities()`:
+  rejected for this slice because SDK and `completion()` support are adapter
+  availability questions, not only core provider capability questions.
+- Implement Google SDK chat now: rejected because it requires request/response
+  payload work and auth behavior outside #728's matrix contract.
+- Document only README state: rejected because SDK routing would continue to
+  drift.
+
+## 风险
+
+- Compatibility: Google SDK chat changes error class from `ProviderError` to
+  `NotSupported`; this is intentional and more stable.
+- Feature flags: feature-gated HTTP rows use `cfg!(feature = ...)` so SDK
+  selection does not accidentally choose unavailable adapters.
+- False negatives: explicit `completion()` prefix guard is limited to matrix
+  rows, so generic custom `api_base` routes for unlisted names remain possible.
+- Security: no auth, secret, or request signing changes.
+
+## 测试计划
+
+- [ ] SpecRail packet validation.
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo test support_matrix --lib`
+- [ ] `cargo test sdk_chat_routing --lib`
+- [ ] `cargo test google_returns_not_supported --lib`
+- [ ] `cargo test unsupported_completion_prefixes_are_explicit --lib`
+- [ ] `cargo test sdk_provider_support --lib`
+- [ ] `cargo check --all-features --locked`
+
+## 回滚方案
+
+Revert the support matrix module, SDK matrix wiring, completion prefix guard,
+README matrix, and `specs/GH728`. No data migration or config rewrite is
+introduced.

--- a/src/core/completion/default_router/router_impl.rs
+++ b/src/core/completion/default_router/router_impl.rs
@@ -1,12 +1,33 @@
 // Router trait implementation for DefaultRouter.
 
 use super::*;
+use crate::core::providers::registry::{
+    ProviderRouteSurface, canonical_selector, provider_surface_matrix,
+};
 
 fn bedrock_execution_model_id(model: &str) -> String {
     crate::core::providers::bedrock::parse_bedrock_model_id(model).execution_model_id
 }
 
 impl DefaultRouter {
+    fn unsupported_explicit_completion_selector(
+        model: &str,
+        surface: ProviderRouteSurface,
+        has_custom_api_base: bool,
+    ) -> Option<&'static str> {
+        if has_custom_api_base {
+            return None;
+        }
+
+        let (selector, _) = model.split_once('/')?;
+        let canonical = canonical_selector(selector);
+        provider_surface_matrix()
+            .iter()
+            .find(|entry| entry.selector == canonical)
+            .filter(|entry| !entry.support_for(surface).is_available_in_current_build())
+            .map(|entry| entry.selector)
+    }
+
     fn select_static_provider<'a>(
         providers: &'a [&'a Provider],
         model: &str,
@@ -107,6 +128,17 @@ impl Router for DefaultRouter {
         let chat_messages = convert_messages_to_chat_messages(messages);
         let chat_request =
             convert_to_chat_completion_request(model, chat_messages, options.clone())?;
+
+        if let Some(selector) = Self::unsupported_explicit_completion_selector(
+            model,
+            ProviderRouteSurface::CompletionChat,
+            options.api_base.is_some(),
+        ) {
+            return Err(GatewayError::invalid_request(format!(
+                "completion() chat is not supported for provider route '{}'",
+                selector
+            )));
+        }
 
         // Create request context with override parameters from options
         let mut context = RequestContext::new();
@@ -267,6 +299,17 @@ impl Router for DefaultRouter {
             convert_to_chat_completion_request(model, chat_messages, options.clone())?;
         chat_request.stream = true;
 
+        if let Some(selector) = Self::unsupported_explicit_completion_selector(
+            model,
+            ProviderRouteSurface::CompletionChatStream,
+            options.api_base.is_some(),
+        ) {
+            return Err(GatewayError::invalid_request(format!(
+                "completion() streaming is not supported for provider route '{}'",
+                selector
+            )));
+        }
+
         // Create request context
         let context = RequestContext::new();
 
@@ -309,6 +352,58 @@ impl Router for DefaultRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unsupported_completion_prefixes_are_explicit() {
+        assert_eq!(
+            DefaultRouter::unsupported_explicit_completion_selector(
+                "google/gemini-pro",
+                ProviderRouteSurface::CompletionChat,
+                false
+            ),
+            Some("google")
+        );
+        assert_eq!(
+            DefaultRouter::unsupported_explicit_completion_selector(
+                "gemini/gemini-pro",
+                ProviderRouteSurface::CompletionChatStream,
+                false
+            ),
+            Some("gemini")
+        );
+        assert_eq!(
+            DefaultRouter::unsupported_explicit_completion_selector(
+                "google/gemini-pro",
+                ProviderRouteSurface::CompletionChat,
+                true
+            ),
+            None
+        );
+        assert_eq!(
+            DefaultRouter::unsupported_explicit_completion_selector(
+                "azure/gpt-4",
+                ProviderRouteSurface::CompletionChat,
+                false
+            ),
+            None
+        );
+        assert_eq!(
+            DefaultRouter::unsupported_explicit_completion_selector(
+                "openrouter/deepseek-chat",
+                ProviderRouteSurface::CompletionChat,
+                false
+            ),
+            None
+        );
+        assert_eq!(
+            DefaultRouter::unsupported_explicit_completion_selector(
+                "together/meta-llama",
+                ProviderRouteSurface::CompletionChat,
+                false
+            ),
+            None
+        );
+    }
 
     async fn tier1_provider(name: &str) -> Result<Provider> {
         let Some(def) = crate::core::providers::registry::get_definition(name) else {

--- a/src/core/providers/registry/mod.rs
+++ b/src/core/providers/registry/mod.rs
@@ -9,16 +9,24 @@
 pub mod catalog;
 pub mod definition;
 pub mod lifecycle;
+pub mod support_matrix;
 pub mod types;
 
 #[cfg(test)]
 mod readme_tests;
+#[cfg(test)]
+mod support_matrix_tests;
 
 pub use catalog::{PROVIDER_CATALOG, get_definition, is_tier1_provider};
 pub use definition::{AuthType, ProviderDefinition};
 pub use lifecycle::{
     PROVIDER_MODULE_LIFECYCLE, ProviderModuleLifecycle, ProviderModuleLifecycleEntry,
     provider_module_lifecycle,
+};
+pub use support_matrix::{
+    ProviderRouteSurface, ProviderSurfaceSupport, SurfaceSupport, canonical_selector,
+    provider_surface_matrix, selector_has_matrix_entry, support_state_for_surface,
+    supports_provider_surface,
 };
 pub use types::{
     DEFAULT_CATALOG_RUNTIME_PROVIDERS, PROVIDER_TYPE_REGISTRY, ProviderDispatchKind,

--- a/src/core/providers/registry/support_matrix.rs
+++ b/src/core/providers/registry/support_matrix.rs
@@ -1,0 +1,302 @@
+//! Cross-surface provider support matrix.
+//!
+//! This matrix answers which provider selectors are usable through each public
+//! routing surface. Runtime capability checks still use `ProviderCapability`;
+//! this file keeps SDK and `completion()` support from drifting away from the
+//! core provider registry.
+
+use super::{entry_for_name, get_definition};
+
+/// Public route surfaces covered by the support matrix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderRouteSurface {
+    HttpChat,
+    HttpChatStream,
+    HttpEmbeddings,
+    HttpImageGeneration,
+    SdkChat,
+    SdkChatStream,
+    SdkEmbeddings,
+    CompletionChat,
+    CompletionChatStream,
+}
+
+/// Support state for one provider/surface pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceSupport {
+    Supported,
+    Passthrough,
+    FeatureGated(&'static str),
+    Unsupported,
+}
+
+impl SurfaceSupport {
+    /// True when the surface should be selected in the current binary.
+    pub fn is_available_in_current_build(self) -> bool {
+        match self {
+            Self::Supported | Self::Passthrough => true,
+            Self::FeatureGated("providers-extra") => cfg!(feature = "providers-extra"),
+            Self::FeatureGated("providers-extended") => cfg!(feature = "providers-extended"),
+            Self::FeatureGated(_) | Self::Unsupported => false,
+        }
+    }
+
+    pub fn markdown_cell(self) -> &'static str {
+        match self {
+            Self::Supported => "yes",
+            Self::Passthrough => "passthrough",
+            Self::FeatureGated(feature) => feature,
+            Self::Unsupported => "-",
+        }
+    }
+}
+
+/// One documented support row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderSurfaceSupport {
+    pub selector: &'static str,
+    pub http_chat: SurfaceSupport,
+    pub http_chat_stream: SurfaceSupport,
+    pub http_embeddings: SurfaceSupport,
+    pub http_image_generation: SurfaceSupport,
+    pub sdk_chat: SurfaceSupport,
+    pub sdk_chat_stream: SurfaceSupport,
+    pub sdk_embeddings: SurfaceSupport,
+    pub completion_chat: SurfaceSupport,
+    pub completion_chat_stream: SurfaceSupport,
+    pub notes: &'static str,
+}
+
+impl ProviderSurfaceSupport {
+    pub fn support_for(self, surface: ProviderRouteSurface) -> SurfaceSupport {
+        match surface {
+            ProviderRouteSurface::HttpChat => self.http_chat,
+            ProviderRouteSurface::HttpChatStream => self.http_chat_stream,
+            ProviderRouteSurface::HttpEmbeddings => self.http_embeddings,
+            ProviderRouteSurface::HttpImageGeneration => self.http_image_generation,
+            ProviderRouteSurface::SdkChat => self.sdk_chat,
+            ProviderRouteSurface::SdkChatStream => self.sdk_chat_stream,
+            ProviderRouteSurface::SdkEmbeddings => self.sdk_embeddings,
+            ProviderRouteSurface::CompletionChat => self.completion_chat,
+            ProviderRouteSurface::CompletionChatStream => self.completion_chat_stream,
+        }
+    }
+}
+
+const S: SurfaceSupport = SurfaceSupport::Supported;
+const P: SurfaceSupport = SurfaceSupport::Passthrough;
+const U: SurfaceSupport = SurfaceSupport::Unsupported;
+const EXTRA: SurfaceSupport = SurfaceSupport::FeatureGated("providers-extra");
+const EXTENDED: SurfaceSupport = SurfaceSupport::FeatureGated("providers-extended");
+
+const CATALOG_HTTP_SUPPORT: ProviderSurfaceSupport = row(
+    "catalog_openai_like",
+    [P, P, U, U, U, U, U, U, U],
+    "Generic Tier 1 catalog providers route through OpenAILike for HTTP chat/stream only.",
+);
+
+/// Explicit rows for non-catalog providers and catalog providers with
+/// additional completion() routing.
+pub static PROVIDER_SURFACE_MATRIX: &[ProviderSurfaceSupport] = &[
+    row(
+        "openai",
+        [S, S, S, S, S, S, S, S, S],
+        "Reference provider across HTTP, SDK, and completion().",
+    ),
+    row(
+        "anthropic",
+        [S, S, U, U, S, S, U, S, S],
+        "Native Anthropic chat/stream adapter.",
+    ),
+    row(
+        "azure",
+        [P, P, EXTRA, EXTRA, U, U, S, P, P],
+        "SDK currently exposes Azure embeddings only.",
+    ),
+    row(
+        "azure_ai",
+        [P, P, EXTRA, EXTRA, U, U, U, EXTRA, EXTRA],
+        "completion() supports azure_ai/ and azure-ai/ dynamic routes with providers-extra.",
+    ),
+    row(
+        "bedrock",
+        [S, S, S, U, U, U, U, U, U],
+        "Core Bedrock runtime supports chat, stream, and embeddings; public completion() routing is not registered.",
+    ),
+    row(
+        "mistral",
+        [S, S, P, U, U, U, U, U, U],
+        "Native HTTP provider; SDK/completion adapters are not implemented.",
+    ),
+    row(
+        "cloudflare",
+        [S, U, U, U, U, U, U, U, U],
+        "Workers AI chat only.",
+    ),
+    row(
+        "cohere",
+        [EXTENDED, EXTENDED, EXTENDED, U, U, U, U, U, U],
+        "Native provider is behind providers-extended.",
+    ),
+    row(
+        "vertex_ai",
+        [EXTRA, EXTRA, EXTRA, EXTRA, U, U, U, U, U],
+        "Native provider is behind providers-extra; SDK GoogleVertex is not implemented.",
+    ),
+    row(
+        "gemini",
+        [EXTENDED, EXTENDED, U, U, U, U, U, U, U],
+        "Native provider is behind providers-extended; SDK Google chat is not implemented.",
+    ),
+    row(
+        "github_copilot",
+        [EXTENDED, EXTENDED, U, U, U, U, U, U, U],
+        "Native provider is behind providers-extended; SDK adapter is not implemented.",
+    ),
+    row(
+        "google",
+        [U, U, U, U, U, U, U, U, U],
+        "SDK Google selector is intentionally unsupported until a real adapter exists.",
+    ),
+    row(
+        "fal_ai",
+        [U, U, U, EXTENDED, U, U, U, U, U],
+        "Image-generation provider behind providers-extended.",
+    ),
+    row(
+        "replicate",
+        [EXTENDED, EXTENDED, U, EXTENDED, U, U, U, U, U],
+        "Prediction lifecycle provider behind providers-extended.",
+    ),
+    row(
+        "pydantic_ai",
+        [U, U, U, U, U, U, U, U, U],
+        "ProviderType registry entry is not currently dispatchable.",
+    ),
+    row(
+        "openai_compatible",
+        [P, P, U, U, U, U, U, S, S],
+        "HTTP and completion() OpenAI-compatible passthrough.",
+    ),
+    row(
+        "sdk_custom",
+        [U, U, U, U, U, U, S, U, U],
+        "SDK custom providers support embeddings when a base_url is configured.",
+    ),
+    row(
+        "ollama",
+        [U, U, U, U, U, S, U, U, U],
+        "SDK streaming reuses the OpenAI-compatible stream parser; chat is not implemented.",
+    ),
+    row(
+        "openrouter",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with completion() dynamic route.",
+    ),
+    row(
+        "deepseek",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with completion() dynamic route.",
+    ),
+    row(
+        "moonshot",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with completion() dynamic route.",
+    ),
+    row(
+        "minimax",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with completion() dynamic route.",
+    ),
+    row(
+        "zhipu",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with zhipu/, glm/, and zai/ completion() routes.",
+    ),
+    row(
+        "groq",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with completion() dynamic route.",
+    ),
+    row(
+        "xiaomi_mimo",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with xiaomi_mimo/ and mimo/ completion() routes.",
+    ),
+    row(
+        "xai",
+        [P, P, U, U, U, U, U, S, S],
+        "Tier 1 catalog provider with completion() dynamic route.",
+    ),
+];
+
+pub fn provider_surface_matrix() -> &'static [ProviderSurfaceSupport] {
+    PROVIDER_SURFACE_MATRIX
+}
+
+pub fn support_state_for_surface(
+    provider_name: &str,
+    surface: ProviderRouteSurface,
+) -> Option<SurfaceSupport> {
+    let selector = canonical_selector(provider_name);
+
+    PROVIDER_SURFACE_MATRIX
+        .iter()
+        .find(|entry| entry.selector == selector)
+        .map(|entry| entry.support_for(surface))
+        .or_else(|| get_definition(&selector).map(|_| CATALOG_HTTP_SUPPORT.support_for(surface)))
+}
+
+pub fn supports_provider_surface(provider_name: &str, surface: ProviderRouteSurface) -> bool {
+    support_state_for_surface(provider_name, surface)
+        .map(SurfaceSupport::is_available_in_current_build)
+        .unwrap_or(false)
+}
+
+pub fn selector_has_matrix_entry(provider_name: &str) -> bool {
+    let selector = canonical_selector(provider_name);
+    PROVIDER_SURFACE_MATRIX
+        .iter()
+        .any(|entry| entry.selector == selector)
+        || get_definition(&selector).is_some()
+}
+
+pub fn canonical_selector(provider_name: &str) -> String {
+    let lowered = provider_name.trim().to_ascii_lowercase();
+    if let Some(entry) = entry_for_name(&lowered) {
+        return entry.canonical_name.to_string();
+    }
+
+    let normalized = lowered.replace('-', "_");
+
+    match normalized.as_str() {
+        "aws_bedrock" => "bedrock".to_string(),
+        "google_vertex" => "vertex_ai".to_string(),
+        "openai_like" => "openai_compatible".to_string(),
+        "custom" => "sdk_custom".to_string(),
+        "huggingface" | "hugging_face" => "huggingface".to_string(),
+        other => entry_for_name(other)
+            .map(|entry| entry.canonical_name.to_string())
+            .unwrap_or_else(|| other.to_string()),
+    }
+}
+
+const fn row(
+    selector: &'static str,
+    support: [SurfaceSupport; 9],
+    notes: &'static str,
+) -> ProviderSurfaceSupport {
+    ProviderSurfaceSupport {
+        selector,
+        http_chat: support[0],
+        http_chat_stream: support[1],
+        http_embeddings: support[2],
+        http_image_generation: support[3],
+        sdk_chat: support[4],
+        sdk_chat_stream: support[5],
+        sdk_embeddings: support[6],
+        completion_chat: support[7],
+        completion_chat_stream: support[8],
+        notes,
+    }
+}

--- a/src/core/providers/registry/support_matrix_tests.rs
+++ b/src/core/providers/registry/support_matrix_tests.rs
@@ -1,0 +1,99 @@
+use super::{
+    DEFAULT_CATALOG_RUNTIME_PROVIDERS, PROVIDER_CATALOG, ProviderRouteSurface, canonical_selector,
+    provider_type_registry, selector_has_matrix_entry, supports_provider_surface,
+};
+
+#[test]
+fn support_matrix_covers_registry_and_catalog_selectors() {
+    for entry in provider_type_registry() {
+        assert!(
+            selector_has_matrix_entry(entry.canonical_name),
+            "missing support matrix row for {}",
+            entry.canonical_name
+        );
+    }
+
+    for selector in PROVIDER_CATALOG.keys() {
+        assert!(
+            selector_has_matrix_entry(selector),
+            "missing support matrix fallback for catalog selector {selector}"
+        );
+    }
+}
+
+#[test]
+fn default_completion_catalog_routes_are_marked_supported() {
+    for selector in DEFAULT_CATALOG_RUNTIME_PROVIDERS {
+        assert!(
+            supports_provider_surface(selector, ProviderRouteSurface::CompletionChat),
+            "{selector} should support completion() chat"
+        );
+        assert!(
+            supports_provider_surface(selector, ProviderRouteSurface::CompletionChatStream),
+            "{selector} should support completion() streaming"
+        );
+    }
+}
+
+#[test]
+fn sdk_matrix_rejects_google_chat_until_adapter_exists() {
+    assert!(supports_provider_surface(
+        "openai",
+        ProviderRouteSurface::SdkChat
+    ));
+    assert!(supports_provider_surface(
+        "anthropic",
+        ProviderRouteSurface::SdkChatStream
+    ));
+    assert!(!supports_provider_surface(
+        "google",
+        ProviderRouteSurface::SdkChat
+    ));
+    assert!(!supports_provider_surface(
+        "gemini",
+        ProviderRouteSurface::SdkChat
+    ));
+}
+
+#[test]
+fn completion_matrix_matches_default_router_support() {
+    for surface in [
+        ProviderRouteSurface::CompletionChat,
+        ProviderRouteSurface::CompletionChatStream,
+    ] {
+        assert!(supports_provider_surface("azure", surface));
+        assert!(!supports_provider_surface("bedrock", surface));
+    }
+    assert_eq!(
+        supports_provider_surface("azure_ai", ProviderRouteSurface::CompletionChat),
+        cfg!(feature = "providers-extra")
+    );
+}
+
+#[test]
+fn catalog_fallback_is_http_chat_only() {
+    assert!(supports_provider_surface(
+        "together",
+        ProviderRouteSurface::HttpChat
+    ));
+    assert!(supports_provider_surface(
+        "together",
+        ProviderRouteSurface::HttpChatStream
+    ));
+    assert!(!supports_provider_surface(
+        "together",
+        ProviderRouteSurface::CompletionChat
+    ));
+    assert!(!supports_provider_surface(
+        "together",
+        ProviderRouteSurface::SdkChat
+    ));
+}
+
+#[test]
+fn selector_aliases_resolve_to_canonical_matrix_entries() {
+    assert_eq!(canonical_selector("azure-openai"), "azure");
+    assert_eq!(canonical_selector("google_vertex"), "vertex_ai");
+    assert_eq!(canonical_selector("aws_bedrock"), "bedrock");
+    assert_eq!(canonical_selector("openai-like"), "openai_compatible");
+}

--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -5,6 +5,8 @@ use super::provider_payloads::{
     build_anthropic_request_body, build_openai_request_body, convert_anthropic_response,
     convert_messages_to_anthropic,
 };
+use super::routing::{sdk_provider_supports_surface, unsupported_sdk_surface_error};
+use crate::core::providers::registry::ProviderRouteSurface;
 use crate::sdk::{errors::*, types::*};
 use futures::StreamExt;
 use serde::de::DeserializeOwned;
@@ -96,6 +98,13 @@ impl LLMClient {
 
         debug!("Executing chat request with provider: {}", provider_id);
 
+        if !sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChat) {
+            return Err(unsupported_sdk_surface_error(
+                provider,
+                ProviderRouteSurface::SdkChat,
+            ));
+        }
+
         match provider.provider_type {
             crate::sdk::config::ProviderType::Anthropic => {
                 self.call_anthropic_api(provider, request).await
@@ -120,6 +129,13 @@ impl LLMClient {
         messages: Vec<Message>,
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let provider = self.provider_config(provider_id)?;
+
+        if !sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChatStream) {
+            return Err(unsupported_sdk_surface_error(
+                provider,
+                ProviderRouteSurface::SdkChatStream,
+            ));
+        }
 
         match provider.provider_type {
             crate::sdk::config::ProviderType::OpenAI | crate::sdk::config::ProviderType::Ollama => {
@@ -482,10 +498,10 @@ impl LLMClient {
         provider: &crate::sdk::config::SdkProviderConfig,
         _request: SdkChatRequest,
     ) -> Result<ChatResponse> {
-        Err(SDKError::ProviderError(format!(
-            "Provider '{}' (Google) is not implemented in SDK client",
-            provider.id
-        )))
+        Err(unsupported_sdk_surface_error(
+            provider,
+            ProviderRouteSurface::SdkChat,
+        ))
     }
 }
 

--- a/src/sdk/client/embeddings.rs
+++ b/src/sdk/client/embeddings.rs
@@ -1,9 +1,11 @@
 //! Embedding methods backed by core embedding capabilities.
 
 use super::llm_client::LLMClient;
+use super::routing::{sdk_provider_supports_surface, unsupported_sdk_surface_error};
 use crate::core::embedding::{
     EmbeddingOptions as CoreEmbeddingOptions, embedding as core_embedding,
 };
+use crate::core::providers::registry::ProviderRouteSurface;
 use crate::sdk::config::{ProviderType, SdkProviderConfig};
 use crate::sdk::errors::*;
 use crate::utils::net::ClientUtils;
@@ -138,6 +140,13 @@ impl LLMClient {
     }
 
     fn ensure_embedding_supported(&self, provider: &SdkProviderConfig) -> Result<()> {
+        if !sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkEmbeddings) {
+            return Err(unsupported_sdk_surface_error(
+                provider,
+                ProviderRouteSurface::SdkEmbeddings,
+            ));
+        }
+
         self.embedding_provider_prefix(provider).map(|_| ())
     }
 

--- a/src/sdk/client/routing.rs
+++ b/src/sdk/client/routing.rs
@@ -2,6 +2,7 @@
 
 use super::llm_client::LLMClient;
 use super::types::{LoadBalancingStrategy, ProviderStats};
+use crate::core::providers::registry::{ProviderRouteSurface, supports_provider_surface};
 use crate::core::router::UnifiedRouter;
 use crate::core::router::UnifiedRoutingStrategy;
 use crate::core::router::deployment::DeploymentId;
@@ -31,7 +32,14 @@ impl LLMClient {
         }
 
         if let Some(provider) = self.default_enabled_provider() {
-            return Ok(provider);
+            return if sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChat) {
+                Ok(provider)
+            } else {
+                Err(unsupported_sdk_surface_error(
+                    provider,
+                    ProviderRouteSurface::SdkChat,
+                ))
+            };
         }
 
         self.load_balancer
@@ -45,7 +53,14 @@ impl LLMClient {
         _messages: &[Message],
     ) -> Result<&crate::sdk::config::SdkProviderConfig> {
         if let Some(provider) = self.default_enabled_provider() {
-            return Ok(provider);
+            return if sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChatStream) {
+                Ok(provider)
+            } else {
+                Err(unsupported_sdk_surface_error(
+                    provider,
+                    ProviderRouteSurface::SdkChatStream,
+                ))
+            };
         }
 
         self.load_balancer
@@ -65,8 +80,14 @@ impl LoadBalancer {
         stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
         model: Option<&str>,
     ) -> Result<&'a SdkProviderConfig> {
-        self.select_provider_with_capability(providers, stats, model, supports_chat)
-            .await
+        self.select_provider_with_capability(
+            providers,
+            stats,
+            model,
+            ProviderRouteSurface::SdkChat,
+            supports_chat,
+        )
+        .await
     }
 
     /// Select a streaming-capable provider using the configured load balancing strategy.
@@ -75,8 +96,14 @@ impl LoadBalancer {
         providers: &'a [SdkProviderConfig],
         stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
     ) -> Result<&'a SdkProviderConfig> {
-        self.select_provider_with_capability(providers, stats, None, supports_stream)
-            .await
+        self.select_provider_with_capability(
+            providers,
+            stats,
+            None,
+            ProviderRouteSurface::SdkChatStream,
+            supports_stream,
+        )
+        .await
     }
 
     async fn select_provider_with_capability<'a>(
@@ -84,20 +111,30 @@ impl LoadBalancer {
         providers: &'a [SdkProviderConfig],
         stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
         model: Option<&str>,
+        surface: ProviderRouteSurface,
         supports_capability: impl Fn(&SdkProviderConfig) -> bool,
     ) -> Result<&'a SdkProviderConfig> {
-        let enabled_providers: Vec<&SdkProviderConfig> = providers
+        let model_candidates: Vec<&SdkProviderConfig> = providers
             .iter()
             .filter(|provider| {
                 provider.enabled
-                    && supports_capability(provider)
                     && model.is_none_or(|model| {
                         provider.models.iter().any(|candidate| candidate == model)
                     })
             })
             .collect();
 
+        let enabled_providers: Vec<&SdkProviderConfig> = model_candidates
+            .iter()
+            .copied()
+            .filter(|provider| supports_capability(provider))
+            .collect();
+
         if enabled_providers.is_empty() {
+            if let Some(provider) = model_candidates.first() {
+                return Err(unsupported_sdk_surface_error(provider, surface));
+            }
+
             return match model {
                 Some(model) => Err(SDKError::ModelNotFound(format!(
                     "Model '{}' not supported by any provider",
@@ -168,17 +205,56 @@ impl LoadBalancer {
 }
 
 fn supports_chat(provider: &SdkProviderConfig) -> bool {
-    matches!(
-        provider.provider_type,
-        ProviderType::Anthropic | ProviderType::OpenAI | ProviderType::Google
-    )
+    sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChat)
 }
 
 fn supports_stream(provider: &SdkProviderConfig) -> bool {
-    matches!(
-        provider.provider_type,
-        ProviderType::Anthropic | ProviderType::OpenAI | ProviderType::Ollama
-    )
+    sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChatStream)
+}
+
+pub(crate) fn sdk_provider_supports_surface(
+    provider: &SdkProviderConfig,
+    surface: ProviderRouteSurface,
+) -> bool {
+    supports_provider_surface(&sdk_provider_matrix_selector(provider), surface)
+}
+
+pub(crate) fn sdk_provider_matrix_selector(provider: &SdkProviderConfig) -> String {
+    match &provider.provider_type {
+        ProviderType::OpenAI => "openai",
+        ProviderType::Anthropic => "anthropic",
+        ProviderType::Azure => "azure",
+        ProviderType::Google => "google",
+        ProviderType::Cohere => "cohere",
+        ProviderType::HuggingFace => "huggingface",
+        ProviderType::Ollama => "ollama",
+        ProviderType::AwsBedrock => "bedrock",
+        ProviderType::GoogleVertex => "vertex_ai",
+        ProviderType::Mistral => "mistral",
+        ProviderType::Custom(_) => "sdk_custom",
+    }
+    .to_string()
+}
+
+pub(crate) fn unsupported_sdk_surface_error(
+    provider: &SdkProviderConfig,
+    surface: ProviderRouteSurface,
+) -> SDKError {
+    SDKError::NotSupported(format!(
+        "SDK {} is not supported for provider '{}' ({:?})",
+        sdk_surface_name(surface),
+        provider.id,
+        provider.provider_type
+    ))
+}
+
+fn sdk_surface_name(surface: ProviderRouteSurface) -> &'static str {
+    match surface {
+        ProviderRouteSurface::SdkChat => "chat",
+        ProviderRouteSurface::SdkChatStream => "chat streaming",
+        ProviderRouteSurface::SdkEmbeddings => "embeddings",
+        _ => "surface",
+    }
 }
 
 fn sdk_weight_to_router_weight(weight: f32) -> u32 {

--- a/src/sdk/client/tests.rs
+++ b/src/sdk/client/tests.rs
@@ -220,6 +220,27 @@ async fn test_sdk_chat_routing_skips_non_chat_provider_with_matching_model() {
 }
 
 #[tokio::test]
+async fn test_sdk_chat_routing_rejects_google_as_unsupported() {
+    let providers = vec![test_provider_config(
+        "google",
+        ProviderType::Google,
+        "gemini-pro",
+    )];
+    let stats = Arc::new(RwLock::new(HashMap::<String, ProviderStats>::new()));
+    let load_balancer = LoadBalancer::new(LoadBalancingStrategy::RoundRobin);
+
+    let err = load_balancer
+        .select_chat_provider(&providers, &stats, Some("gemini-pro"))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, SDKError::NotSupported(ref message) if message.contains("google")),
+        "expected Google SDK chat to be explicitly unsupported, got {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_sdk_stream_routing_skips_non_stream_provider() {
     let providers = vec![
         test_provider_config("google", ProviderType::Google, "gemini-pro"),
@@ -234,6 +255,33 @@ async fn test_sdk_stream_routing_skips_non_stream_provider() {
         .unwrap();
 
     assert_eq!(selected.id, "openai");
+}
+
+#[tokio::test]
+async fn test_provider_selection_rejects_unsupported_default_provider() {
+    let config = ConfigBuilder::new()
+        .default_provider("google")
+        .add_provider(test_provider_config(
+            "google",
+            ProviderType::Google,
+            "gemini-pro",
+        ))
+        .build();
+
+    let client = LLMClient::new(config).unwrap();
+    let err = client
+        .select_provider(&SdkChatRequest {
+            model: String::new(),
+            messages: Vec::new(),
+            options: ChatOptions::default(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, SDKError::NotSupported(ref message) if message.contains("google")),
+        "expected unsupported default provider error, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -462,6 +510,33 @@ async fn test_execute_chat_request_anthropic_malformed_data_uri_returns_invalid_
     assert!(
         matches!(err, SDKError::InvalidRequest(_)),
         "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_chat_request_google_returns_not_supported() {
+    let config = ConfigBuilder::new()
+        .add_provider(test_provider_config(
+            "google",
+            ProviderType::Google,
+            "gemini-pro",
+        ))
+        .build();
+
+    let client = LLMClient::new(config).unwrap();
+    let request = SdkChatRequest {
+        model: "gemini-pro".to_string(),
+        messages: vec![],
+        options: ChatOptions::default(),
+    };
+
+    let err = client
+        .execute_chat_request("google", request)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SDKError::NotSupported(ref message) if message.contains("google")),
+        "expected Google SDK chat to be NotSupported, got {err:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add `specs/GH728` SpecRail packet for the support-matrix contract
- add registry-backed provider route-surface matrix for HTTP, SDK, and `completion()` surfaces
- wire SDK chat/stream/embeddings selection and direct execution to the matrix so Google/Gemini SDK chat returns `NotSupported`
- document the cross-surface matrix in README and add focused coverage for SDK and `completion()` unsupported routes

Closes #728.

## Verification
- `python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir /tmp/litellm-rs-issue728/specs/GH728`
- `cargo fmt --all -- --check`
- `cargo test support_matrix --lib`
- `cargo test sdk::client --lib`
- `cargo test core::completion::default_router --lib`
- `cargo check --all-features --locked`