### PR TITLE
Fix OpenAI-compatible Files API routes

### DIFF
--- a/src/server/routes/ai/files.rs
+++ b/src/server/routes/ai/files.rs
@@ -1,0 +1,400 @@
+//! OpenAI-compatible local Files API routes.
+
+use actix_multipart::Multipart;
+use actix_web::{HttpResponse, Result as ActixResult, web};
+use futures::StreamExt;
+use serde::Serialize;
+use tracing::error;
+
+use crate::server::state::AppState;
+use crate::storage::files::FileMetadata;
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::openai_errors;
+
+const DEFAULT_FILENAME: &str = "upload";
+const FILE_READ_ERROR_MESSAGE: &str = "Error reading file";
+const FIELD_READ_ERROR_MESSAGE: &str = "Error reading multipart field";
+const MAX_FILE_UPLOAD_BYTES: usize = 512 * 1024 * 1024;
+const MAX_BATCH_FILE_UPLOAD_BYTES: usize = 200 * 1024 * 1024;
+const MAX_TEXT_FIELD_BYTES: usize = 8 * 1024;
+const MAX_DISCARDED_FIELD_BYTES: usize = 1024 * 1024;
+const SUPPORTED_UPLOAD_PURPOSES: &[&str] = &[
+    "assistants",
+    "batch",
+    "evals",
+    "fine-tune",
+    "user_data",
+    "vision",
+];
+
+#[derive(Debug, Serialize)]
+struct OpenAiFileObject {
+    id: String,
+    object: &'static str,
+    bytes: u64,
+    created_at: i64,
+    filename: String,
+    purpose: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiFileList {
+    object: &'static str,
+    data: Vec<OpenAiFileObject>,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiFileDelete {
+    id: String,
+    object: &'static str,
+    deleted: bool,
+}
+
+struct ParsedFileUpload {
+    filename: String,
+    content: Vec<u8>,
+    purpose: String,
+}
+
+/// Upload a file to the configured gateway-local file storage backend.
+pub async fn create_file(
+    state: web::Data<AppState>,
+    payload: Multipart,
+) -> ActixResult<HttpResponse> {
+    let upload = match parse_upload(payload).await {
+        Ok(upload) => upload,
+        Err(response) => return Ok(response),
+    };
+
+    let file_id = match state
+        .storage
+        .files
+        .store_with_purpose(&upload.filename, &upload.content, Some(&upload.purpose))
+        .await
+    {
+        Ok(file_id) => file_id,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+
+    let metadata = match state.storage.files.metadata(&file_id).await {
+        Ok(metadata) => metadata,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+
+    match file_object(&metadata) {
+        Ok(object) => Ok(HttpResponse::Ok().json(object)),
+        Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+    }
+}
+
+/// List files known by the configured file storage backend.
+pub async fn list_files(state: web::Data<AppState>) -> ActixResult<HttpResponse> {
+    let file_ids = match state.storage.files.list(None, None).await {
+        Ok(file_ids) => file_ids,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+
+    let mut data = Vec::with_capacity(file_ids.len());
+    for file_id in file_ids {
+        let metadata = match state.storage.files.metadata(&file_id).await {
+            Ok(metadata) => metadata,
+            Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+        };
+        let object = match file_object(&metadata) {
+            Ok(object) => object,
+            Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+        };
+        data.push(object);
+    }
+
+    Ok(HttpResponse::Ok().json(OpenAiFileList {
+        object: "list",
+        data,
+    }))
+}
+
+/// Retrieve metadata for one file.
+pub async fn get_file(
+    state: web::Data<AppState>,
+    file_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let metadata = match state.storage.files.metadata(&file_id).await {
+        Ok(metadata) => metadata,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+
+    match file_object(&metadata) {
+        Ok(object) => Ok(HttpResponse::Ok().json(object)),
+        Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+    }
+}
+
+/// Delete one file.
+pub async fn delete_file(
+    state: web::Data<AppState>,
+    file_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let file_id = file_id.into_inner();
+    if let Err(error) = state.storage.files.metadata(&file_id).await {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+    if let Err(error) = state.storage.files.delete(&file_id).await {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    Ok(HttpResponse::Ok().json(OpenAiFileDelete {
+        id: file_id,
+        object: "file",
+        deleted: true,
+    }))
+}
+
+/// Return raw file content using the stored metadata content type.
+pub async fn get_file_content(
+    state: web::Data<AppState>,
+    file_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let file_id = file_id.into_inner();
+    let metadata = match state.storage.files.metadata(&file_id).await {
+        Ok(metadata) => metadata,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+    let content = match state.storage.files.get(&file_id).await {
+        Ok(content) => content,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+
+    Ok(HttpResponse::Ok()
+        .content_type(metadata.content_type)
+        .body(content))
+}
+
+async fn parse_upload(mut payload: Multipart) -> Result<ParsedFileUpload, HttpResponse> {
+    let mut filename = DEFAULT_FILENAME.to_string();
+    let mut content: Option<Vec<u8>> = None;
+    let mut purpose: Option<String> = None;
+
+    while let Some(item) = payload.next().await {
+        let mut field = item.map_err(|error| {
+            error!("Error reading multipart field: {}", error);
+            openai_errors::validation_error(format!("Invalid multipart data: {}", error))
+        })?;
+
+        let field_name = match field.name() {
+            Some(name) => name.to_string(),
+            None => {
+                drain_field(&mut field).await?;
+                continue;
+            }
+        };
+
+        match field_name.as_str() {
+            "file" => {
+                if let Some(disposition) = field.content_disposition()
+                    && let Some(name) = disposition.get_filename()
+                    && !name.is_empty()
+                {
+                    filename = name.to_string();
+                }
+                content = Some(
+                    read_field_bytes(&mut field, FILE_READ_ERROR_MESSAGE, MAX_FILE_UPLOAD_BYTES)
+                        .await?,
+                );
+            }
+            "purpose" => {
+                let value = read_text_field(&mut field).await?;
+                if !value.trim().is_empty() {
+                    purpose = Some(validate_upload_purpose(&value)?);
+                }
+            }
+            _ => drain_field(&mut field).await?,
+        }
+    }
+
+    let content = match content {
+        Some(content) if !content.is_empty() => content,
+        _ => return Err(openai_errors::validation_error("No file provided")),
+    };
+    let purpose = purpose.ok_or_else(|| openai_errors::validation_error("purpose is required"))?;
+    validate_purpose_size_limit(&purpose, content.len())?;
+
+    Ok(ParsedFileUpload {
+        filename,
+        content,
+        purpose,
+    })
+}
+
+async fn read_text_field(field: &mut actix_multipart::Field) -> Result<String, HttpResponse> {
+    let data = read_field_bytes(field, FIELD_READ_ERROR_MESSAGE, MAX_TEXT_FIELD_BYTES).await?;
+    Ok(String::from_utf8(data)
+        .unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned()))
+}
+
+async fn drain_field(field: &mut actix_multipart::Field) -> Result<(), HttpResponse> {
+    let mut total = 0usize;
+    while let Some(chunk) = field.next().await {
+        let bytes = chunk.map_err(|error| {
+            error!("Error draining multipart chunk: {}", error);
+            openai_errors::validation_error(FIELD_READ_ERROR_MESSAGE)
+        })?;
+        total = checked_field_size(
+            total,
+            bytes.len(),
+            MAX_DISCARDED_FIELD_BYTES,
+            "Multipart field too large",
+        )?;
+    }
+    Ok(())
+}
+
+async fn read_field_bytes(
+    field: &mut actix_multipart::Field,
+    user_message: &'static str,
+    max_bytes: usize,
+) -> Result<Vec<u8>, HttpResponse> {
+    let mut data = Vec::new();
+    while let Some(chunk) = field.next().await {
+        let bytes = chunk.map_err(|error| {
+            error!("Error reading multipart chunk: {}", error);
+            openai_errors::validation_error(user_message)
+        })?;
+        checked_field_size(
+            data.len(),
+            bytes.len(),
+            max_bytes,
+            "File size limit exceeded",
+        )?;
+        data.extend_from_slice(&bytes);
+    }
+    Ok(data)
+}
+
+fn checked_field_size(
+    current: usize,
+    additional: usize,
+    max_bytes: usize,
+    user_message: &'static str,
+) -> Result<usize, HttpResponse> {
+    let total = current
+        .checked_add(additional)
+        .ok_or_else(|| openai_errors::validation_error(user_message))?;
+    if total > max_bytes {
+        return Err(openai_errors::validation_error(user_message));
+    }
+    Ok(total)
+}
+
+fn validate_upload_purpose(value: &str) -> Result<String, HttpResponse> {
+    let purpose = value.trim();
+    if SUPPORTED_UPLOAD_PURPOSES.contains(&purpose) {
+        return Ok(purpose.to_string());
+    }
+
+    Err(openai_errors::validation_error(format!(
+        "Unsupported file purpose: {purpose}"
+    )))
+}
+
+fn validate_purpose_size_limit(purpose: &str, bytes: usize) -> Result<(), HttpResponse> {
+    let max_bytes = if purpose == "batch" {
+        MAX_BATCH_FILE_UPLOAD_BYTES
+    } else {
+        MAX_FILE_UPLOAD_BYTES
+    };
+    checked_field_size(0, bytes, max_bytes, "File size limit exceeded").map(|_| ())
+}
+
+fn file_object(metadata: &FileMetadata) -> Result<OpenAiFileObject, GatewayError> {
+    let purpose = metadata
+        .purpose
+        .as_deref()
+        .filter(|purpose| SUPPORTED_UPLOAD_PURPOSES.contains(purpose))
+        .ok_or_else(|| GatewayError::validation("File metadata purpose is missing or invalid"))?;
+
+    Ok(OpenAiFileObject {
+        id: metadata.id.clone(),
+        object: "file",
+        bytes: metadata.size,
+        created_at: metadata.created_at.timestamp(),
+        filename: metadata.filename.clone(),
+        purpose: purpose.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::body::to_bytes;
+    use chrono::{TimeZone, Utc};
+    use serde_json::Value;
+
+    fn metadata() -> FileMetadata {
+        FileMetadata {
+            id: "file_test".to_string(),
+            filename: "batch.jsonl".to_string(),
+            content_type: "application/json".to_string(),
+            size: 42,
+            created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            purpose: Some("batch".to_string()),
+            checksum: "checksum".to_string(),
+        }
+    }
+
+    #[test]
+    fn file_object_uses_metadata_purpose() {
+        let object = serde_json::to_value(file_object(&metadata()).unwrap()).unwrap();
+
+        assert_eq!(object["id"], "file_test");
+        assert_eq!(object["object"], "file");
+        assert_eq!(object["bytes"], 42);
+        assert_eq!(object["created_at"], 1_700_000_000);
+        assert_eq!(object["filename"], "batch.jsonl");
+        assert_eq!(object["purpose"], "batch");
+        assert!(object.get("content_type").is_none());
+        assert!(object.get("checksum").is_none());
+    }
+
+    #[test]
+    fn file_object_rejects_missing_purpose() {
+        let metadata = FileMetadata {
+            purpose: None,
+            ..metadata()
+        };
+
+        let error = file_object(&metadata).unwrap_err();
+
+        assert!(error.to_string().contains("purpose"));
+    }
+
+    #[test]
+    fn validates_supported_upload_purpose() {
+        assert_eq!(validate_upload_purpose(" batch ").unwrap(), "batch");
+
+        let response = validate_upload_purpose("invalid-purpose").unwrap_err();
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn enforces_upload_size_limit() {
+        assert!(validate_purpose_size_limit("batch", MAX_BATCH_FILE_UPLOAD_BYTES).is_ok());
+
+        let response =
+            validate_purpose_size_limit("batch", MAX_BATCH_FILE_UPLOAD_BYTES + 1).unwrap_err();
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn validation_error_for_missing_file_uses_openai_shape() {
+        let response = openai_errors::validation_error("No file provided");
+        let status = response.status();
+        let body = to_bytes(response.into_body()).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(status, actix_web::http::StatusCode::BAD_REQUEST);
+        assert_eq!(json["error"]["message"], "No file provided");
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+        assert_eq!(json["error"]["code"], "invalid_request");
+    }
+}

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -9,6 +9,7 @@ mod chat;
 mod context;
 mod embeddings;
 mod execution;
+mod files;
 mod images;
 mod models;
 mod openai_errors;
@@ -26,6 +27,7 @@ pub use context::{
     handle_ai_request, log_api_usage,
 };
 pub use embeddings::embeddings;
+pub use files::{create_file, delete_file, get_file, get_file_content, list_files};
 pub use images::image_generations;
 pub use models::{get_model, list_models};
 pub use responses::create_response;
@@ -47,6 +49,12 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/batches", web::get().to(list_batches))
             .route("/batches/{batch_id}", web::get().to(get_batch))
             .route("/batches/{batch_id}/cancel", web::post().to(cancel_batch))
+            // Files
+            .route("/files", web::post().to(create_file))
+            .route("/files", web::get().to(list_files))
+            .route("/files/{file_id}", web::get().to(get_file))
+            .route("/files/{file_id}", web::delete().to(delete_file))
+            .route("/files/{file_id}/content", web::get().to(get_file_content))
             // Image generation
             .route("/images/generations", web::post().to(image_generations))
             // Models

--- a/src/storage/files/local.rs
+++ b/src/storage/files/local.rs
@@ -33,6 +33,16 @@ impl LocalStorage {
 
     /// Store a file
     pub async fn store(&self, filename: &str, content: &[u8]) -> Result<String> {
+        self.store_with_purpose(filename, content, None).await
+    }
+
+    /// Store a file with optional OpenAI purpose metadata.
+    pub async fn store_with_purpose(
+        &self,
+        filename: &str,
+        content: &[u8],
+        purpose: Option<&str>,
+    ) -> Result<String> {
         let file_id = Uuid::new_v4().to_string();
         let file_path = self.get_file_path(&file_id);
 
@@ -59,6 +69,7 @@ impl LocalStorage {
             content_type: Self::detect_content_type(filename),
             size: content.len() as u64,
             created_at: chrono::Utc::now(),
+            purpose: Self::normalize_purpose(purpose),
             checksum: Self::calculate_checksum(content),
         };
 
@@ -148,36 +159,66 @@ impl LocalStorage {
     /// List files
     pub async fn list(&self, prefix: Option<&str>, limit: Option<usize>) -> Result<Vec<String>> {
         let mut files = Vec::new();
-        let mut entries = fs::read_dir(&self.base_path)
+        let mut subdirs = fs::read_dir(&self.base_path)
             .await
             .map_err(|e| GatewayError::Internal(format!("Failed to read directory: {}", e)))?;
 
-        while let Some(entry) = entries
+        while let Some(subdir) = subdirs
             .next_entry()
             .await
             .map_err(|e| GatewayError::Internal(format!("Failed to read entry: {}", e)))?
         {
-            let file_name = entry.file_name().to_string_lossy().to_string();
-
-            // Skip metadata files
-            if file_name.ends_with(".meta") {
+            let subdir_name = subdir.file_name().to_string_lossy().to_string();
+            if subdir_name.len() != 2 || !subdir_name.chars().all(|c| c.is_ascii_alphanumeric()) {
                 continue;
             }
 
-            // Apply prefix filter
-            if let Some(prefix) = prefix
-                && !file_name.starts_with(prefix)
-            {
+            let file_type = subdir
+                .file_type()
+                .await
+                .map_err(|e| GatewayError::Internal(format!("Failed to read entry type: {}", e)))?;
+            if !file_type.is_dir() {
                 continue;
             }
 
-            files.push(file_name);
+            let mut entries = fs::read_dir(subdir.path())
+                .await
+                .map_err(|e| GatewayError::Internal(format!("Failed to read directory: {}", e)))?;
 
-            // Apply limit
-            if let Some(limit) = limit
-                && files.len() >= limit
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(|e| GatewayError::Internal(format!("Failed to read entry: {}", e)))?
             {
-                break;
+                let file_type = entry.file_type().await.map_err(|e| {
+                    GatewayError::Internal(format!("Failed to read entry type: {}", e))
+                })?;
+                if !file_type.is_file() {
+                    continue;
+                }
+
+                let file_name = entry.file_name().to_string_lossy().to_string();
+
+                // Skip metadata files
+                if file_name.ends_with(".meta") {
+                    continue;
+                }
+
+                // Apply prefix filter to the stored file id, not to shard paths.
+                if let Some(prefix) = prefix
+                    && !file_name.starts_with(prefix)
+                {
+                    continue;
+                }
+
+                files.push(file_name);
+
+                // Apply limit
+                if let Some(limit) = limit
+                    && files.len() >= limit
+                {
+                    return Ok(files);
+                }
             }
         }
 
@@ -293,6 +334,13 @@ impl LocalStorage {
         let mut hasher = Sha256::new();
         hasher.update(content);
         hex::encode(hasher.finalize())
+    }
+
+    fn normalize_purpose(purpose: Option<&str>) -> Option<String> {
+        purpose
+            .map(str::trim)
+            .filter(|purpose| !purpose.is_empty())
+            .map(ToOwned::to_owned)
     }
 }
 

--- a/src/storage/files/s3.rs
+++ b/src/storage/files/s3.rs
@@ -104,18 +104,36 @@ impl S3Storage {
     /// Store a file to S3
     #[allow(unused_variables)]
     pub async fn store(&self, filename: &str, content: &[u8]) -> Result<String> {
+        self.store_with_purpose(filename, content, None).await
+    }
+
+    /// Store a file to S3 with optional OpenAI purpose metadata.
+    #[allow(unused_variables)]
+    pub async fn store_with_purpose(
+        &self,
+        filename: &str,
+        content: &[u8],
+        purpose: Option<&str>,
+    ) -> Result<String> {
         #[cfg(feature = "s3")]
         {
             if let Some(client) = &self.client {
                 use aws_s3::primitives::ByteStream;
 
                 let file_id = Self::file_id_for_object(&Uuid::new_v4().to_string(), filename);
-
-                client
+                let mut request = client
                     .put_object()
                     .bucket(&self.bucket)
                     .key(&file_id)
-                    .body(ByteStream::from(content.to_vec()))
+                    .content_type(Self::detect_content_type(filename))
+                    .metadata("filename", filename)
+                    .body(ByteStream::from(content.to_vec()));
+
+                if let Some(purpose) = Self::normalize_purpose(purpose) {
+                    request = request.metadata("purpose", purpose);
+                }
+
+                request
                     .send()
                     .await
                     .map_err(|e| GatewayError::Internal(format!("S3 upload failed: {}", e)))?;
@@ -261,9 +279,15 @@ impl S3Storage {
                     .and_then(|t| chrono::DateTime::from_timestamp(t.secs(), t.subsec_nanos()))
                     .unwrap_or_else(chrono::Utc::now);
 
-                let filename = Self::filename_from_file_id(file_id);
+                let filename = head
+                    .metadata()
+                    .and_then(|metadata| metadata.get("filename").cloned())
+                    .unwrap_or_else(|| Self::filename_from_file_id(file_id));
 
                 let checksum = head.e_tag().unwrap_or("").trim_matches('"').to_string();
+                let purpose = head
+                    .metadata()
+                    .and_then(|metadata| metadata.get("purpose").cloned());
 
                 Ok(FileMetadata {
                     id: file_id.to_string(),
@@ -271,6 +295,7 @@ impl S3Storage {
                     content_type,
                     size,
                     created_at,
+                    purpose,
                     checksum,
                 })
             } else {
@@ -361,13 +386,26 @@ impl S3Storage {
     }
 
     #[cfg_attr(not(feature = "s3"), allow(dead_code))]
-    fn file_id_for_object(object_id: &str, filename: &str) -> String {
-        format!("{}/{}", object_id, filename)
+    fn file_id_for_object(object_id: &str, _filename: &str) -> String {
+        object_id.to_string()
     }
 
     #[cfg_attr(not(feature = "s3"), allow(dead_code))]
     fn filename_from_file_id(file_id: &str) -> String {
         file_id.rsplit('/').next().unwrap_or(file_id).to_string()
+    }
+
+    #[cfg_attr(not(feature = "s3"), allow(dead_code))]
+    fn detect_content_type(filename: &str) -> String {
+        super::local::LocalStorage::detect_content_type(filename)
+    }
+
+    #[cfg_attr(not(feature = "s3"), allow(dead_code))]
+    fn normalize_purpose(purpose: Option<&str>) -> Option<String> {
+        purpose
+            .map(str::trim)
+            .filter(|purpose| !purpose.is_empty())
+            .map(ToOwned::to_owned)
     }
 }
 
@@ -376,11 +414,12 @@ mod tests {
     use super::S3Storage;
 
     #[test]
-    fn store_identifier_matches_s3_object_key() {
+    fn store_identifier_is_route_safe() {
         let object_id = "550e8400-e29b-41d4-a716-446655440000";
         let file_id = S3Storage::file_id_for_object(object_id, "batch.jsonl");
 
-        assert_eq!(file_id, "550e8400-e29b-41d4-a716-446655440000/batch.jsonl");
+        assert_eq!(file_id, "550e8400-e29b-41d4-a716-446655440000");
+        assert!(!file_id.contains('/'));
     }
 
     #[test]

--- a/src/storage/files/storage.rs
+++ b/src/storage/files/storage.rs
@@ -40,9 +40,23 @@ impl FileStorage {
 
     /// Store a file and return its ID
     pub async fn store(&self, filename: &str, content: &[u8]) -> Result<String> {
+        self.store_with_purpose(filename, content, None).await
+    }
+
+    /// Store a file with optional OpenAI purpose metadata and return its ID
+    pub async fn store_with_purpose(
+        &self,
+        filename: &str,
+        content: &[u8],
+        purpose: Option<&str>,
+    ) -> Result<String> {
         match self {
-            FileStorage::Local(storage) => storage.store(filename, content).await,
-            FileStorage::S3(storage) => storage.store(filename, content).await,
+            FileStorage::Local(storage) => {
+                storage.store_with_purpose(filename, content, purpose).await
+            }
+            FileStorage::S3(storage) => {
+                storage.store_with_purpose(filename, content, purpose).await
+            }
         }
     }
 

--- a/src/storage/files/tests.rs
+++ b/src/storage/files/tests.rs
@@ -47,10 +47,67 @@ async fn test_local_storage() {
     let metadata = storage.metadata(&file_id).await.unwrap();
     assert_eq!(metadata.filename, "test.txt");
     assert_eq!(metadata.size, content.len() as u64);
+    assert_eq!(metadata.purpose, None);
 
     // Test delete
     storage.delete(&file_id).await.unwrap();
     assert!(!storage.exists(&file_id).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_local_storage_persists_purpose_metadata() {
+    let temp_dir = TempDir::new().unwrap();
+    let storage = LocalStorage::new(temp_dir.path().to_str().unwrap())
+        .await
+        .unwrap();
+
+    let file_id = storage
+        .store_with_purpose("batch.jsonl", b"{\"custom_id\":\"1\"}\n", Some("batch"))
+        .await
+        .unwrap();
+
+    let metadata = storage.metadata(&file_id).await.unwrap();
+    assert_eq!(metadata.filename, "batch.jsonl");
+    assert_eq!(metadata.purpose.as_deref(), Some("batch"));
+}
+
+#[tokio::test]
+async fn test_local_storage_list_returns_stored_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let storage = LocalStorage::new(temp_dir.path().to_str().unwrap())
+        .await
+        .unwrap();
+
+    let first_id = storage
+        .store("first.jsonl", b"{\"index\":1}\n")
+        .await
+        .unwrap();
+    let second_id = storage
+        .store("second.jsonl", b"{\"index\":2}\n")
+        .await
+        .unwrap();
+
+    let mut listed = storage.list(None, None).await.unwrap();
+    listed.sort();
+
+    let mut expected = vec![first_id.clone(), second_id.clone()];
+    expected.sort();
+    assert_eq!(listed, expected);
+
+    assert_eq!(
+        storage.list(Some(&first_id), None).await.unwrap(),
+        vec![first_id]
+    );
+
+    let limited = storage.list(None, Some(1)).await.unwrap();
+    assert_eq!(limited.len(), 1);
+    assert!(expected.contains(&limited[0]));
+
+    for file_id in listed {
+        let metadata = storage.metadata(&file_id).await.unwrap();
+        assert_eq!(metadata.id, file_id);
+        assert!(metadata.filename.ends_with(".jsonl"));
+    }
 }
 
 #[test]

--- a/src/storage/files/types.rs
+++ b/src/storage/files/types.rs
@@ -24,6 +24,9 @@ pub struct FileMetadata {
     pub size: u64,
     /// Creation timestamp
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// OpenAI file purpose, when supplied at upload time
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
     /// File checksum
     pub checksum: String,
 }
@@ -41,6 +44,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             size: 1024,
             created_at: Utc::now(),
+            purpose: Some("assistants".to_string()),
             checksum: "abc123".to_string(),
         };
 
@@ -48,6 +52,7 @@ mod tests {
         assert_eq!(metadata.filename, "test.txt");
         assert_eq!(metadata.content_type, "text/plain");
         assert_eq!(metadata.size, 1024);
+        assert_eq!(metadata.purpose.as_deref(), Some("assistants"));
         assert_eq!(metadata.checksum, "abc123");
     }
 
@@ -59,6 +64,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             size: 1024,
             created_at: Utc::now(),
+            purpose: None,
             checksum: "abc123".to_string(),
         };
 
@@ -76,6 +82,7 @@ mod tests {
             content_type: "application/pdf".to_string(),
             size: 2048,
             created_at: Utc::now(),
+            purpose: Some("batch".to_string()),
             checksum: "def456".to_string(),
         };
 
@@ -84,6 +91,7 @@ mod tests {
         assert_eq!(json["filename"], "document.pdf");
         assert_eq!(json["content_type"], "application/pdf");
         assert_eq!(json["size"], 2048);
+        assert_eq!(json["purpose"], "batch");
     }
 
     #[test]
@@ -94,6 +102,7 @@ mod tests {
             "content_type": "image/png",
             "size": 4096,
             "created_at": "2024-01-01T00:00:00Z",
+            "purpose": "fine-tune",
             "checksum": "ghi789"
         }"#;
 
@@ -102,7 +111,24 @@ mod tests {
         assert_eq!(metadata.filename, "image.png");
         assert_eq!(metadata.content_type, "image/png");
         assert_eq!(metadata.size, 4096);
+        assert_eq!(metadata.purpose.as_deref(), Some("fine-tune"));
         assert_eq!(metadata.checksum, "ghi789");
+    }
+
+    #[test]
+    fn test_file_metadata_deserializes_legacy_without_purpose() {
+        let json = r#"{
+            "id": "file-legacy",
+            "filename": "legacy.jsonl",
+            "content_type": "application/json",
+            "size": 128,
+            "created_at": "2024-01-01T00:00:00Z",
+            "checksum": "legacy"
+        }"#;
+
+        let metadata: FileMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(metadata.id, "file-legacy");
+        assert_eq!(metadata.purpose, None);
     }
 
     #[test]
@@ -113,6 +139,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             size: 0,
             created_at: Utc::now(),
+            purpose: None,
             checksum: "empty".to_string(),
         };
 
@@ -127,6 +154,7 @@ mod tests {
             content_type: "application/octet-stream".to_string(),
             size: u64::MAX,
             created_at: Utc::now(),
+            purpose: None,
             checksum: "large".to_string(),
         };
 

--- a/tests/files_routes.rs
+++ b/tests/files_routes.rs
@@ -1,0 +1,198 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::http::{StatusCode, header};
+    use actix_web::{App, test, web};
+    use litellm_rs::Config;
+    use litellm_rs::server::http::HttpServer;
+    use serde_json::Value;
+
+    async fn build_files_state(local_path: String) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.storage.files.local_path = Some(local_path);
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+
+        let server = HttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize for files route test");
+        let state = server.state().clone();
+        state
+            .storage
+            .migrate()
+            .await
+            .expect("in-memory database migrations should run");
+        state
+    }
+
+    fn multipart_body(boundary: &str, purpose: Option<&str>, file_content: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        if let Some(purpose) = purpose {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(b"Content-Disposition: form-data; name=\"purpose\"\r\n\r\n");
+            body.extend_from_slice(purpose.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"batch.jsonl\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: application/jsonl\r\n\r\n");
+        body.extend_from_slice(file_content);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    #[tokio::test]
+    async fn upload_list_retrieve_content_and_delete_file() {
+        let tempdir = tempfile::tempdir().expect("temp dir should be created");
+        let local_path = tempdir.path().join("files").to_string_lossy().into_owned();
+        let state = build_files_state(local_path).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-files-boundary";
+        let content = br#"{"custom_id":"1"}"#;
+
+        let upload_req = test::TestRequest::post()
+            .uri("/v1/files")
+            .insert_header((
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(multipart_body(boundary, Some("batch"), content))
+            .to_request();
+        let upload_resp = test::call_service(&app, upload_req).await;
+
+        assert_eq!(upload_resp.status(), StatusCode::OK);
+        let uploaded: Value = test::read_body_json(upload_resp).await;
+        let file_id = uploaded["id"].as_str().expect("file id").to_string();
+        assert_eq!(uploaded["object"], "file");
+        assert_eq!(uploaded["filename"], "batch.jsonl");
+        assert_eq!(uploaded["purpose"], "batch");
+        assert_eq!(uploaded["bytes"], content.len() as u64);
+
+        let get_req = test::TestRequest::get()
+            .uri(&format!("/v1/files/{file_id}"))
+            .to_request();
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+        let fetched: Value = test::read_body_json(get_resp).await;
+        assert_eq!(fetched["id"], file_id);
+        assert_eq!(fetched["purpose"], "batch");
+
+        let list_req = test::TestRequest::get().uri("/v1/files").to_request();
+        let list_resp = test::call_service(&app, list_req).await;
+        assert_eq!(list_resp.status(), StatusCode::OK);
+        let listed: Value = test::read_body_json(list_resp).await;
+        assert!(
+            listed["data"]
+                .as_array()
+                .expect("files list")
+                .iter()
+                .any(|file| file["id"] == file_id)
+        );
+
+        let content_req = test::TestRequest::get()
+            .uri(&format!("/v1/files/{file_id}/content"))
+            .to_request();
+        let content_resp = test::call_service(&app, content_req).await;
+        assert_eq!(content_resp.status(), StatusCode::OK);
+        let body = test::read_body(content_resp).await;
+        assert_eq!(body.as_ref(), content);
+
+        let delete_req = test::TestRequest::delete()
+            .uri(&format!("/v1/files/{file_id}"))
+            .to_request();
+        let delete_resp = test::call_service(&app, delete_req).await;
+        assert_eq!(delete_resp.status(), StatusCode::OK);
+        let deleted: Value = test::read_body_json(delete_resp).await;
+        assert_eq!(deleted["id"], file_id);
+        assert_eq!(deleted["deleted"], true);
+
+        let get_deleted_req = test::TestRequest::get()
+            .uri(&format!("/v1/files/{file_id}"))
+            .to_request();
+        let get_deleted_resp = test::call_service(&app, get_deleted_req).await;
+        assert_eq!(get_deleted_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn upload_requires_supported_purpose() {
+        let tempdir = tempfile::tempdir().expect("temp dir should be created");
+        let local_path = tempdir.path().join("files").to_string_lossy().into_owned();
+        let state = build_files_state(local_path).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-files-boundary";
+
+        let missing_req = test::TestRequest::post()
+            .uri("/v1/files")
+            .insert_header((
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(multipart_body(boundary, None, b"content"))
+            .to_request();
+        let missing_resp = test::call_service(&app, missing_req).await;
+        assert_eq!(missing_resp.status(), StatusCode::BAD_REQUEST);
+        let missing_body: Value = test::read_body_json(missing_resp).await;
+        assert_eq!(missing_body["error"]["message"], "purpose is required");
+
+        let invalid_req = test::TestRequest::post()
+            .uri("/v1/files")
+            .insert_header((
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(multipart_body(
+                boundary,
+                Some("invalid-purpose"),
+                b"content",
+            ))
+            .to_request();
+        let invalid_resp = test::call_service(&app, invalid_req).await;
+        assert_eq!(invalid_resp.status(), StatusCode::BAD_REQUEST);
+        let invalid_body: Value = test::read_body_json(invalid_resp).await;
+        assert!(
+            invalid_body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("Unsupported file purpose")
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_missing_file_returns_404() {
+        let tempdir = tempfile::tempdir().expect("temp dir should be created");
+        let local_path = tempdir.path().join("files").to_string_lossy().into_owned();
+        let state = build_files_state(local_path).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::delete()
+            .uri("/v1/files/550e8400-e29b-41d4-a716-446655440000")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+}


### PR DESCRIPTION
## Summary
- add OpenAI-compatible `/v1/files` upload/list/retrieve/delete/content routes
- persist OpenAI file `purpose` metadata in local/S3 file storage
- fix local file listing to traverse sharded storage paths

## Scope
Issues: fixes #738

Writable files:
- `src/server/routes/ai/files.rs`
- `src/server/routes/ai/mod.rs`
- `src/storage/files/local.rs`
- `src/storage/files/s3.rs`
- `src/storage/files/storage.rs`
- `src/storage/files/tests.rs`
- `src/storage/files/types.rs`
- `tests/files_routes.rs`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-features --locked --test files_routes --quiet`
- `cargo test --all-features --locked storage::files --lib --quiet`
- `cargo test --all-features --locked server::routes::ai::files --lib --quiet`
- `cargo check --all-features --locked`

Note: VibeGuard pre-commit hook timed out on its internal 10s `cargo check`; the explicit full-feature check above passed in this session before commit.