### PR TITLE
Fix Responses API lifecycle routes

### DIFF
--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -30,7 +30,9 @@ pub use embeddings::embeddings;
 pub use files::{create_file, delete_file, get_file, get_file_content, list_files};
 pub use images::image_generations;
 pub use models::{get_model, list_models};
-pub use responses::create_response;
+pub use responses::{
+    cancel_response, create_response, delete_response, get_response, list_response_input_items,
+};
 
 use actix_web::web;
 
@@ -42,6 +44,19 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/chat/completions", web::post().to(chat_completions))
             // Responses API
             .route("/responses", web::post().to(create_response))
+            .route("/responses/{response_id}", web::get().to(get_response))
+            .route(
+                "/responses/{response_id}",
+                web::delete().to(delete_response),
+            )
+            .route(
+                "/responses/{response_id}/cancel",
+                web::post().to(cancel_response),
+            )
+            .route(
+                "/responses/{response_id}/input_items",
+                web::get().to(list_response_input_items),
+            )
             // Embeddings
             .route("/embeddings", web::post().to(embeddings))
             // Batch processing
@@ -142,5 +157,57 @@ mod tests {
             .to_request();
         let cancel_resp = test::call_service(&app, cancel_req).await;
         assert_eq!(cancel_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[actix_web::test]
+    async fn test_response_lifecycle_routes_mounted_with_expected_methods() {
+        let state = build_no_provider_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(super::configure_routes),
+        )
+        .await;
+
+        let create_req = test::TestRequest::post()
+            .uri("/v1/responses")
+            .set_json(serde_json::json!({
+                "model": "gpt-4o",
+                "input": "hello"
+            }))
+            .to_request();
+        let create_resp = test::call_service(&app, create_req).await;
+        assert_eq!(create_resp.status(), StatusCode::BAD_REQUEST);
+        let create_body: Value = test::read_body_json(create_resp).await;
+        assert!(
+            create_body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("store=false")
+        );
+
+        let get_req = test::TestRequest::get()
+            .uri("/v1/responses/resp_missing")
+            .to_request();
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::NOT_FOUND);
+
+        let delete_req = test::TestRequest::delete()
+            .uri("/v1/responses/resp_missing")
+            .to_request();
+        let delete_resp = test::call_service(&app, delete_req).await;
+        assert_eq!(delete_resp.status(), StatusCode::NOT_FOUND);
+
+        let cancel_req = test::TestRequest::post()
+            .uri("/v1/responses/resp_missing/cancel")
+            .to_request();
+        let cancel_resp = test::call_service(&app, cancel_req).await;
+        assert_eq!(cancel_resp.status(), StatusCode::NOT_FOUND);
+
+        let input_items_req = test::TestRequest::get()
+            .uri("/v1/responses/resp_missing/input_items?limit=1&order=asc")
+            .to_request();
+        let input_items_resp = test::call_service(&app, input_items_req).await;
+        assert_eq!(input_items_resp.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/src/server/routes/ai/responses.rs
+++ b/src/server/routes/ai/responses.rs
@@ -19,6 +19,9 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use tracing::{error, info};
 
 use super::openai_errors;
+mod lifecycle;
+pub(crate) use lifecycle::{ResponseOwner, store_response_if_requested};
+pub use lifecycle::{cancel_response, delete_response, get_response, list_response_input_items};
 
 /// POST /v1/responses handler
 pub async fn create_response(
@@ -29,6 +32,7 @@ pub async fn create_response(
     info!("Responses API request for model: {}", payload.model);
 
     let context = super::context::get_request_context(&req)?;
+    let owner = lifecycle::response_owner(&context);
     let request = payload.into_inner();
 
     if request.model.trim().is_empty() {
@@ -49,34 +53,44 @@ pub async fn create_response(
         _ => {}
     }
 
-    if request.background.unwrap_or(false) {
-        return Ok(openai_errors::validation_error(
-            "background (async) execution is not supported; omit background or set it to false",
-        ));
+    if let Err(error) = lifecycle::validate_storage_owner(&request, &owner) {
+        return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    if request.previous_response_id.is_some() {
-        return Ok(openai_errors::validation_error(
-            "previous_response_id (stateful chaining) is not supported; \
-             omit previous_response_id to make a fresh request",
-        ));
-    }
+    let request = match lifecycle::resolve_previous_response_context(request, &owner) {
+        Ok(request) => request,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
 
     let chat_request = match build_chat_request(&request) {
         Ok(r) => r,
         Err(e) => return Ok(openai_errors::validation_error(e)),
     };
 
-    if request.stream.unwrap_or(false) {
+    if request.background.unwrap_or(false) {
+        if request.stream.unwrap_or(false) {
+            return Ok(openai_errors::validation_error(
+                "background responses do not support stream=true",
+            ));
+        }
+        Ok(lifecycle::handle_background_response(
+            state.get_ref().clone(),
+            chat_request,
+            request,
+            context,
+            owner,
+        ))
+    } else if request.stream.unwrap_or(false) {
         super::responses_stream::handle_streaming_response(
             state.get_ref(),
             chat_request,
             request,
             context,
+            owner,
         )
         .await
     } else {
-        handle_sync_response(state.get_ref(), chat_request, request, context).await
+        handle_sync_response(state.get_ref(), chat_request, request, context, owner).await
     }
 }
 
@@ -87,10 +101,12 @@ async fn handle_sync_response(
     chat_request: ChatCompletionRequest,
     original: ResponsesApiRequest,
     context: crate::core::types::context::RequestContext,
+    owner: Option<lifecycle::ResponseOwner>,
 ) -> ActixResult<HttpResponse> {
     match handle_chat_completion_with_state(state, chat_request, context).await {
         Ok(chat_resp) => {
             let resp = convert_to_responses_api(chat_resp, &original);
+            lifecycle::store_response_if_requested(&original, &resp, owner);
             Ok(HttpResponse::Ok().json(resp))
         }
         Err(e) => {

--- a/src/server/routes/ai/responses/lifecycle.rs
+++ b/src/server/routes/ai/responses/lifecycle.rs
@@ -1,0 +1,498 @@
+use crate::core::models::openai::requests::ChatCompletionRequest;
+use crate::core::models::openai::responses_api::{
+    ResponseInput, ResponseInputContent, ResponseInputItem, ResponseInputMessage,
+    ResponseOutputContent, ResponseOutputItem, ResponsesApiRequest, ResponsesApiResponse,
+};
+use crate::server::routes::ai::chat::handle_chat_completion_with_state;
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use tokio::task::JoinHandle;
+use tracing::error;
+
+use super::{convert_to_responses_api, current_unix_ts, uuid_v4_hex};
+use crate::server::routes::ai::openai_errors;
+
+static RESPONSE_STORE: LazyLock<DashMap<String, StoredResponse>> = LazyLock::new(DashMap::new);
+static BACKGROUND_TASKS: LazyLock<DashMap<String, JoinHandle<()>>> = LazyLock::new(DashMap::new);
+const RESPONSE_STORE_LIMIT: usize = 1024;
+const RESPONSE_STORE_TTL_SECS: i64 = 86_400;
+
+#[derive(Clone)]
+pub(super) struct StoredResponse {
+    response: ResponsesApiResponse,
+    input: ResponseInput,
+    background: bool,
+    owner: ResponseOwner,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResponseOwner(String);
+
+#[derive(Serialize)]
+struct DeletedResponse {
+    id: String,
+    object: &'static str,
+    deleted: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ResponseInputItemsList {
+    object: &'static str,
+    data: Vec<ResponseInputListItem>,
+    first_id: Option<String>,
+    last_id: Option<String>,
+    has_more: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ResponseInputListItem {
+    id: String,
+    #[serde(flatten)]
+    item: ResponseInputItem,
+}
+
+#[derive(Deserialize)]
+pub struct InputItemsQuery {
+    after: Option<String>,
+    include: Option<Vec<String>>,
+    limit: Option<usize>,
+    order: Option<String>,
+}
+
+struct BackgroundTaskCleanup {
+    response_id: String,
+}
+
+impl Drop for BackgroundTaskCleanup {
+    fn drop(&mut self) {
+        BACKGROUND_TASKS.remove(&self.response_id);
+    }
+}
+
+pub async fn get_response(
+    req: HttpRequest,
+    response_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let owner = response_owner(&super::super::context::get_request_context(&req)?);
+    match get_owned_response(response_id.as_str(), &owner) {
+        Ok(stored) => Ok(HttpResponse::Ok().json(stored.response)),
+        Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+    }
+}
+
+pub async fn delete_response(
+    req: HttpRequest,
+    response_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let owner = response_owner(&super::super::context::get_request_context(&req)?);
+    let response_id = response_id.into_inner();
+    match get_owned_response(&response_id, &owner) {
+        Ok(_) => {
+            RESPONSE_STORE.remove(&response_id);
+            if let Some((_, task)) = BACKGROUND_TASKS.remove(&response_id) {
+                task.abort();
+            }
+            Ok(HttpResponse::Ok().json(DeletedResponse {
+                id: response_id,
+                object: "response",
+                deleted: true,
+            }))
+        }
+        Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+    }
+}
+
+pub async fn cancel_response(
+    req: HttpRequest,
+    response_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let owner = response_owner(&super::super::context::get_request_context(&req)?);
+    match cancel_stored_background_response(response_id.as_str(), &owner) {
+        Ok(response) => Ok(HttpResponse::Ok().json(response)),
+        Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+    }
+}
+
+pub async fn list_response_input_items(
+    req: HttpRequest,
+    response_id: web::Path<String>,
+    query: web::Query<InputItemsQuery>,
+) -> ActixResult<HttpResponse> {
+    let owner = response_owner(&super::super::context::get_request_context(&req)?);
+    match get_owned_response(response_id.as_str(), &owner) {
+        Ok(stored) => match input_items_page(&stored.input, &query) {
+            Ok(page) => Ok(HttpResponse::Ok().json(page)),
+            Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+        },
+        Err(error) => Ok(openai_errors::gateway_error_response(&error)),
+    }
+}
+
+pub(super) fn handle_background_response(
+    state: AppState,
+    chat_request: ChatCompletionRequest,
+    original: ResponsesApiRequest,
+    context: crate::core::types::context::RequestContext,
+    owner: Option<ResponseOwner>,
+) -> HttpResponse {
+    let Some(owner) = owner else {
+        return openai_errors::validation_error(
+            "background responses require an authenticated owner",
+        );
+    };
+    let response = queued_background_response(&original);
+    let response_id = response.id.clone();
+    insert_stored_response(
+        response_id.clone(),
+        StoredResponse {
+            response: response.clone(),
+            input: original.input.clone(),
+            background: true,
+            owner,
+        },
+    );
+    let task_response_id = response_id.clone();
+    let handle = tokio::spawn(async move {
+        let _cleanup = BackgroundTaskCleanup {
+            response_id: response_id.clone(),
+        };
+        set_background_status(&response_id, "in_progress");
+        match handle_chat_completion_with_state(&state, chat_request, context).await {
+            Ok(chat_resp) => {
+                let mut response = convert_to_responses_api(chat_resp, &original);
+                response.id = response_id.clone();
+                finish_background_response(&response_id, original.input.clone(), response);
+            }
+            Err(error) => {
+                error!("Background Responses API error: {}", error);
+                set_background_status(&response_id, "failed");
+            }
+        }
+    });
+    BACKGROUND_TASKS.insert(task_response_id, handle);
+    HttpResponse::Ok().json(response)
+}
+
+pub(crate) fn store_response_if_requested(
+    original: &ResponsesApiRequest,
+    response: &ResponsesApiResponse,
+    owner: Option<ResponseOwner>,
+) {
+    if original.store.unwrap_or(true)
+        && let Some(owner) = owner
+    {
+        insert_stored_response(
+            response.id.clone(),
+            StoredResponse {
+                response: response.clone(),
+                input: original.input.clone(),
+                background: false,
+                owner,
+            },
+        );
+    }
+}
+
+pub(super) fn resolve_previous_response_context(
+    mut request: ResponsesApiRequest,
+    owner: &Option<ResponseOwner>,
+) -> Result<ResponsesApiRequest, GatewayError> {
+    let Some(previous_response_id) = request.previous_response_id.as_deref() else {
+        return Ok(request);
+    };
+    let stored = get_owned_response(previous_response_id, owner)?;
+    request.input = append_previous_context(&stored, &request.input);
+    Ok(request)
+}
+
+pub(super) fn response_owner(
+    context: &crate::core::types::context::RequestContext,
+) -> Option<ResponseOwner> {
+    if let Some(api_key_id) = context.api_key_id() {
+        return Some(ResponseOwner(format!("api_key:{api_key_id}")));
+    }
+    if let Some(user_id) = context
+        .user_id
+        .as_deref()
+        .filter(|user_id| !user_id.is_empty())
+    {
+        return Some(ResponseOwner(format!("user:{user_id}")));
+    }
+    None
+}
+
+pub(super) fn validate_storage_owner(
+    request: &ResponsesApiRequest,
+    owner: &Option<ResponseOwner>,
+) -> Result<(), GatewayError> {
+    if owner.is_none() && request.store != Some(false) {
+        return Err(GatewayError::validation(
+            "Responses lifecycle storage requires authentication; set store=false for anonymous requests",
+        ));
+    }
+    Ok(())
+}
+
+fn queued_background_response(original: &ResponsesApiRequest) -> ResponsesApiResponse {
+    ResponsesApiResponse {
+        id: format!("resp_bg_{}", uuid_v4_hex()),
+        object: "response".to_string(),
+        created_at: current_unix_ts(),
+        status: "queued".to_string(),
+        model: original.model.clone(),
+        output: vec![],
+        usage: None,
+        error: None,
+        previous_response_id: original.previous_response_id.clone(),
+        metadata: original.metadata.clone(),
+    }
+}
+
+fn set_background_status(response_id: &str, status: &str) {
+    if let Some(mut stored) = RESPONSE_STORE.get_mut(response_id)
+        && stored.background
+        && stored.response.status != "cancelled"
+    {
+        stored.response.status = status.to_string();
+    }
+}
+
+fn finish_background_response(
+    response_id: &str,
+    input: ResponseInput,
+    response: ResponsesApiResponse,
+) {
+    if let Some(mut stored) = RESPONSE_STORE.get_mut(response_id)
+        && stored.response.status != "cancelled"
+    {
+        stored.response = response;
+        stored.input = input;
+    }
+}
+
+fn cancel_stored_background_response(
+    response_id: &str,
+    owner: &Option<ResponseOwner>,
+) -> Result<ResponsesApiResponse, GatewayError> {
+    let Some(mut stored) = RESPONSE_STORE.get_mut(response_id) else {
+        return Err(response_not_found(response_id));
+    };
+    let Some(owner) = owner else {
+        return Err(response_not_found(response_id));
+    };
+    if &stored.owner != owner {
+        return Err(response_not_found(response_id));
+    }
+    if !stored.background {
+        return Err(GatewayError::conflict(
+            "Only background Responses tasks can be canceled",
+        ));
+    }
+    match stored.response.status.as_str() {
+        "queued" | "in_progress" | "cancelled" => {
+            if let Some((_, task)) = BACKGROUND_TASKS.remove(response_id) {
+                task.abort();
+            }
+            stored.response.status = "cancelled".to_string();
+            Ok(stored.response.clone())
+        }
+        status => Err(GatewayError::conflict(format!(
+            "Cannot cancel background response with status {status}"
+        ))),
+    }
+}
+
+fn get_owned_response(
+    response_id: &str,
+    owner: &Option<ResponseOwner>,
+) -> Result<StoredResponse, GatewayError> {
+    let stored = RESPONSE_STORE
+        .get(response_id)
+        .ok_or_else(|| response_not_found(response_id))?;
+    let Some(owner) = owner else {
+        return Err(response_not_found(response_id));
+    };
+    if &stored.owner != owner {
+        return Err(response_not_found(response_id));
+    }
+    Ok(stored.clone())
+}
+
+fn insert_stored_response(response_id: String, stored: StoredResponse) {
+    cleanup_response_store();
+    RESPONSE_STORE.insert(response_id, stored);
+}
+
+fn cleanup_response_store() {
+    let now = current_unix_ts();
+    let mut entries = RESPONSE_STORE
+        .iter()
+        .map(|entry| (entry.key().clone(), entry.value().response.created_at))
+        .collect::<Vec<_>>();
+
+    for (response_id, created_at) in &entries {
+        if now.saturating_sub(*created_at) > RESPONSE_STORE_TTL_SECS {
+            remove_response_and_task(response_id);
+        }
+    }
+
+    entries.retain(|(_, created_at)| now.saturating_sub(*created_at) <= RESPONSE_STORE_TTL_SECS);
+    let overflow = entries
+        .len()
+        .saturating_add(1)
+        .saturating_sub(RESPONSE_STORE_LIMIT);
+    if overflow == 0 {
+        return;
+    }
+
+    entries.sort_by_key(|(_, created_at)| *created_at);
+    for (response_id, _) in entries.into_iter().take(overflow) {
+        remove_response_and_task(&response_id);
+    }
+}
+
+fn remove_response_and_task(response_id: &str) {
+    RESPONSE_STORE.remove(response_id);
+    if let Some((_, task)) = BACKGROUND_TASKS.remove(response_id) {
+        task.abort();
+    }
+}
+
+fn append_previous_context(
+    stored: &StoredResponse,
+    current_input: &ResponseInput,
+) -> ResponseInput {
+    let mut items = input_items_from_response_input(&stored.input);
+    items.extend(output_items_as_input_context(&stored.response.output));
+    items.extend(non_empty_input_items(current_input));
+    ResponseInput::Items(items)
+}
+
+fn non_empty_input_items(input: &ResponseInput) -> Vec<ResponseInputItem> {
+    match input {
+        ResponseInput::Text(text) if text.trim().is_empty() => vec![],
+        ResponseInput::Text(_) | ResponseInput::Items(_) => input_items_from_response_input(input),
+    }
+}
+
+fn input_items_from_response_input(input: &ResponseInput) -> Vec<ResponseInputItem> {
+    match input {
+        ResponseInput::Text(text) => vec![ResponseInputItem::Message(ResponseInputMessage {
+            role: "user".to_string(),
+            content: ResponseInputContent::Text(text.clone()),
+        })],
+        ResponseInput::Items(items) => items.clone(),
+    }
+}
+
+fn input_items_page(
+    input: &ResponseInput,
+    query: &InputItemsQuery,
+) -> Result<ResponseInputItemsList, GatewayError> {
+    if let Some(include) = &query.include
+        && !include.is_empty()
+    {
+        return Err(GatewayError::validation(
+            "input_items include is not supported",
+        ));
+    }
+
+    let mut items = input_items_from_response_input(input)
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| (stable_input_item_id(index, &item), item))
+        .collect::<Vec<_>>();
+    match query.order.as_deref().unwrap_or("desc") {
+        "asc" => {}
+        "desc" => items.reverse(),
+        other => {
+            return Err(GatewayError::validation(format!(
+                "Unsupported input_items order: {other}"
+            )));
+        }
+    }
+
+    let mut start = 0;
+    if let Some(after) = &query.after {
+        let index = items
+            .iter()
+            .position(|(id, _)| id == after)
+            .ok_or_else(|| {
+                GatewayError::validation(format!("Unknown input_items cursor: {after}"))
+            })?;
+        start = index + 1;
+    }
+
+    let limit = query.limit.unwrap_or(20).clamp(1, 100);
+    let has_more = start + limit < items.len();
+    let data = items
+        .into_iter()
+        .skip(start)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let first_id = data.first().map(|(id, _)| id.clone());
+    let last_id = data.last().map(|(id, _)| id.clone());
+    let data = data
+        .into_iter()
+        .map(|(id, item)| ResponseInputListItem { id, item })
+        .collect();
+
+    Ok(ResponseInputItemsList {
+        object: "list",
+        data,
+        first_id,
+        last_id,
+        has_more,
+    })
+}
+
+fn stable_input_item_id(index: usize, item: &ResponseInputItem) -> String {
+    use sha2::{Digest, Sha256};
+
+    let value = serde_json::to_string(&(index, item)).unwrap_or_else(|_| index.to_string());
+    let digest = Sha256::digest(value.as_bytes());
+    format!("item_{}", hex::encode(&digest[..8]))
+}
+
+fn output_items_as_input_context(output: &[ResponseOutputItem]) -> Vec<ResponseInputItem> {
+    output
+        .iter()
+        .filter_map(|item| {
+            let ResponseOutputItem::Message(message) = item else {
+                return None;
+            };
+            let text = output_text_content(&message.content);
+            if text.trim().is_empty() {
+                return None;
+            }
+            Some(ResponseInputItem::Message(ResponseInputMessage {
+                role: "assistant".to_string(),
+                content: ResponseInputContent::Text(text),
+            }))
+        })
+        .collect()
+}
+
+fn output_text_content(content: &[ResponseOutputContent]) -> String {
+    content
+        .iter()
+        .map(|part| match part {
+            ResponseOutputContent::OutputText { text, .. } => text.as_str(),
+            ResponseOutputContent::Refusal { refusal } => refusal.as_str(),
+        })
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(super) fn response_not_found(response_id: &str) -> GatewayError {
+    GatewayError::not_found(format!("Response not found: {response_id}"))
+}
+
+#[cfg(test)]
+#[path = "lifecycle_tests.rs"]
+mod tests;

--- a/src/server/routes/ai/responses/lifecycle_tests.rs
+++ b/src/server/routes/ai/responses/lifecycle_tests.rs
@@ -1,0 +1,350 @@
+use super::*;
+use crate::core::models::openai::responses_api::{
+    ResponseInputContent, ResponseInputItem, ResponseInputMessage, ResponseOutputMessage,
+    ResponsesApiRequest,
+};
+use actix_web::{HttpMessage, body::to_bytes, http::StatusCode, test as actix_test};
+use serde_json::Value;
+
+fn owner(label: &str) -> ResponseOwner {
+    ResponseOwner(format!("test:{label}"))
+}
+
+fn user_owner(user_id: &str) -> ResponseOwner {
+    ResponseOwner(format!("user:{user_id}"))
+}
+
+fn req(input: &str) -> ResponsesApiRequest {
+    ResponsesApiRequest {
+        model: "gpt-4o".into(),
+        input: ResponseInput::Text(input.into()),
+        instructions: None,
+        previous_response_id: None,
+        store: None,
+        tools: None,
+        stream: None,
+        background: None,
+        max_output_tokens: None,
+        temperature: None,
+        top_p: None,
+        user: None,
+        reasoning: None,
+        metadata: None,
+        truncation: None,
+    }
+}
+
+fn resp(id: &str, request: &ResponsesApiRequest, text: &str) -> ResponsesApiResponse {
+    ResponsesApiResponse {
+        id: id.into(),
+        object: "response".into(),
+        created_at: current_unix_ts(),
+        status: "completed".into(),
+        model: request.model.clone(),
+        output: vec![ResponseOutputItem::Message(ResponseOutputMessage {
+            id: format!("msg_test_{}", uuid_v4_hex()),
+            role: "assistant".into(),
+            status: "completed".into(),
+            content: vec![ResponseOutputContent::OutputText {
+                text: text.into(),
+                annotations: None,
+                logprobs: None,
+            }],
+        })],
+        usage: None,
+        error: None,
+        previous_response_id: None,
+        metadata: None,
+    }
+}
+
+fn request_for_user(user_id: &str) -> HttpRequest {
+    let req = actix_test::TestRequest::default().to_http_request();
+    req.extensions_mut()
+        .insert(crate::core::types::context::RequestContext::new().with_user_id(user_id));
+    req
+}
+
+async fn read_json(response: HttpResponse) -> Value {
+    let body = to_bytes(response.into_body())
+        .await
+        .expect("response body should be readable");
+    serde_json::from_slice(&body).expect("response body should be json")
+}
+
+#[test]
+fn store_respects_owner_and_store_false() {
+    let owner_a = Some(owner("a"));
+    let owner_b = Some(owner("b"));
+    let request = req("hello");
+    let response = resp(&format!("resp_test_{}", uuid_v4_hex()), &request, "world");
+    store_response_if_requested(&request, &response, owner_a.clone());
+
+    assert!(get_owned_response(&response.id, &owner_a).is_ok());
+    assert!(get_owned_response(&response.id, &owner_b).is_err());
+    RESPONSE_STORE.remove(&response.id);
+
+    let mut unstored_request = req("hello");
+    unstored_request.store = Some(false);
+    let unstored = resp(
+        &format!("resp_test_{}", uuid_v4_hex()),
+        &unstored_request,
+        "world",
+    );
+    store_response_if_requested(&unstored_request, &unstored, owner_a);
+    assert!(get_owned_response(&unstored.id, &Some(owner("a"))).is_err());
+}
+
+#[test]
+fn storage_requires_authenticated_owner_unless_store_false() {
+    let request = req("hello");
+    assert!(validate_storage_owner(&request, &None).is_err());
+
+    let mut unstored = req("hello");
+    unstored.store = Some(false);
+    assert!(validate_storage_owner(&unstored, &None).is_ok());
+}
+
+#[test]
+fn previous_context_prepends_prior_input_output_and_current_input() {
+    let owner = Some(owner("chain"));
+    let previous_id = format!("resp_test_{}", uuid_v4_hex());
+    let previous_req = req("first question");
+    let previous_resp = resp(&previous_id, &previous_req, "first answer");
+    store_response_if_requested(&previous_req, &previous_resp, owner.clone());
+
+    let mut follow_up = req("follow up");
+    follow_up.previous_response_id = Some(previous_id.clone());
+    let resolved = resolve_previous_response_context(follow_up, &owner).unwrap();
+    let ResponseInput::Items(items) = resolved.input else {
+        panic!("previous context should produce item input");
+    };
+    assert_eq!(items.len(), 3);
+
+    RESPONSE_STORE.remove(&previous_id);
+    let mut missing = req("follow up");
+    missing.previous_response_id = Some(previous_id);
+    assert!(resolve_previous_response_context(missing, &owner).is_err());
+}
+
+#[test]
+fn background_cancel_is_owner_scoped() {
+    let background_owner = owner("background");
+    let other_owner = Some(owner("other"));
+    let request = req("run later");
+    let queued = queued_background_response(&request);
+    let id = queued.id.clone();
+    insert_stored_response(
+        id.clone(),
+        StoredResponse {
+            response: queued,
+            input: request.input.clone(),
+            background: true,
+            owner: background_owner.clone(),
+        },
+    );
+
+    assert!(cancel_stored_background_response(&id, &other_owner).is_err());
+    assert_eq!(
+        cancel_stored_background_response(&id, &Some(background_owner))
+            .unwrap()
+            .status,
+        "cancelled"
+    );
+    finish_background_response(&id, request.input.clone(), resp(&id, &request, "done"));
+    assert_eq!(
+        RESPONSE_STORE
+            .get(&id)
+            .map(|stored| stored.response.status.clone()),
+        Some("cancelled".to_string())
+    );
+    remove_response_and_task(&id);
+}
+
+#[actix_web::test]
+async fn lifecycle_handlers_enforce_owner_delete_and_input_items_shape() {
+    let route_owner = Some(user_owner("route-owner"));
+    let other = request_for_user("other-owner");
+    let request = req("hello");
+    let response = resp(&format!("resp_test_{}", uuid_v4_hex()), &request, "world");
+    let id = response.id.clone();
+    store_response_if_requested(&request, &response, route_owner);
+
+    let cross_owner = get_response(other, web::Path::from(id.clone()))
+        .await
+        .unwrap();
+    assert_eq!(cross_owner.status(), StatusCode::NOT_FOUND);
+
+    let list = list_response_input_items(
+        request_for_user("route-owner"),
+        web::Path::from(id.clone()),
+        web::Query(InputItemsQuery {
+            after: None,
+            include: None,
+            limit: Some(1),
+            order: Some("asc".to_string()),
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let list_body = read_json(list).await;
+    assert_eq!(list_body["object"], "list");
+    assert_eq!(list_body["data"].as_array().unwrap().len(), 1);
+    assert!(list_body["first_id"].as_str().unwrap().starts_with("item_"));
+    assert_eq!(list_body["first_id"], list_body["last_id"]);
+    assert_eq!(list_body["first_id"], list_body["data"][0]["id"]);
+    assert_eq!(list_body["data"][0]["type"], "message");
+    assert_eq!(list_body["has_more"], false);
+
+    let deleted = delete_response(request_for_user("route-owner"), web::Path::from(id.clone()))
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), StatusCode::OK);
+    let deleted_body = read_json(deleted).await;
+    assert_eq!(deleted_body["object"], "response");
+    assert_eq!(deleted_body["deleted"], true);
+    assert!(get_owned_response(&id, &Some(user_owner("route-owner"))).is_err());
+}
+
+#[test]
+fn input_items_page_defaults_desc_and_rejects_unsupported_include() {
+    let input = ResponseInput::Items(vec![
+        ResponseInputItem::Message(ResponseInputMessage {
+            role: "user".to_string(),
+            content: ResponseInputContent::Text("first".to_string()),
+        }),
+        ResponseInputItem::Message(ResponseInputMessage {
+            role: "user".to_string(),
+            content: ResponseInputContent::Text("second".to_string()),
+        }),
+    ]);
+
+    let first_page = input_items_page(
+        &input,
+        &InputItemsQuery {
+            after: None,
+            include: None,
+            limit: Some(1),
+            order: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(first_page.data.len(), 1);
+    assert_eq!(
+        serde_json::to_value(&first_page.data[0].item).unwrap(),
+        serde_json::to_value(&input_items_from_response_input(&input)[1]).unwrap()
+    );
+    assert_eq!(first_page.first_id, first_page.last_id);
+    assert!(first_page.has_more);
+
+    let second_page = input_items_page(
+        &input,
+        &InputItemsQuery {
+            after: first_page.last_id,
+            include: None,
+            limit: Some(1),
+            order: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(second_page.data.len(), 1);
+    assert_eq!(
+        serde_json::to_value(&second_page.data[0].item).unwrap(),
+        serde_json::to_value(&input_items_from_response_input(&input)[0]).unwrap()
+    );
+    assert!(!second_page.has_more);
+
+    let include_error = input_items_page(
+        &input,
+        &InputItemsQuery {
+            after: None,
+            include: Some(vec!["file_search_call.results".to_string()]),
+            limit: None,
+            order: None,
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(include_error, GatewayError::Validation(_)));
+}
+
+#[actix_web::test]
+async fn response_store_cleanup_removes_expired_entries_and_tasks() {
+    let cleanup_owner = owner("cleanup");
+    let mut request = req("old");
+    let mut response = resp(&format!("resp_test_{}", uuid_v4_hex()), &request, "old");
+    response.created_at = current_unix_ts() - RESPONSE_STORE_TTL_SECS - 1;
+    let id = response.id.clone();
+    request.input = ResponseInput::Text("old".to_string());
+    insert_stored_response(
+        id.clone(),
+        StoredResponse {
+            response,
+            input: request.input.clone(),
+            background: true,
+            owner: cleanup_owner,
+        },
+    );
+    let handle = tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    });
+    BACKGROUND_TASKS.insert(id.clone(), handle);
+
+    let fresh_request = req("fresh");
+    let fresh_response = resp(
+        &format!("resp_test_{}", uuid_v4_hex()),
+        &fresh_request,
+        "fresh",
+    );
+    insert_stored_response(
+        fresh_response.id.clone(),
+        StoredResponse {
+            response: fresh_response.clone(),
+            input: fresh_request.input.clone(),
+            background: false,
+            owner: owner("cleanup-fresh"),
+        },
+    );
+
+    assert!(RESPONSE_STORE.get(&id).is_none());
+    assert!(BACKGROUND_TASKS.get(&id).is_none());
+    remove_response_and_task(&fresh_response.id);
+}
+
+#[actix_web::test]
+async fn cancel_aborts_background_task_and_non_background_conflicts() {
+    let background_owner = owner("abort-owner");
+    let request = req("run later");
+    let queued = queued_background_response(&request);
+    let id = queued.id.clone();
+    insert_stored_response(
+        id.clone(),
+        StoredResponse {
+            response: queued,
+            input: request.input.clone(),
+            background: true,
+            owner: background_owner.clone(),
+        },
+    );
+    let handle = tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    });
+    BACKGROUND_TASKS.insert(id.clone(), handle);
+
+    let cancelled = cancel_stored_background_response(&id, &Some(background_owner)).unwrap();
+    assert_eq!(cancelled.status, "cancelled");
+    assert!(BACKGROUND_TASKS.get(&id).is_none());
+    remove_response_and_task(&id);
+
+    let owner = Some(owner("sync-owner"));
+    let sync_request = req("hello");
+    let sync_response = resp(
+        &format!("resp_test_{}", uuid_v4_hex()),
+        &sync_request,
+        "world",
+    );
+    store_response_if_requested(&sync_request, &sync_response, owner.clone());
+    let err = cancel_stored_background_response(&sync_response.id, &owner).unwrap_err();
+    assert!(matches!(err, GatewayError::Conflict(_)));
+    remove_response_and_task(&sync_response.id);
+}

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -19,7 +19,8 @@ use crate::core::types::{context::RequestContext, model::ProviderCapability};
 use crate::server::routes::ai::chat::build_core_chat_request;
 use crate::server::routes::ai::execution::execute_stream_with_selected_deployment;
 use crate::server::routes::ai::responses::{
-    current_unix_ts, finish_reason_enum_to_status, uuid_v4_hex,
+    ResponseOwner, current_unix_ts, finish_reason_enum_to_status, store_response_if_requested,
+    uuid_v4_hex,
 };
 use crate::server::state::AppState;
 use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
@@ -94,6 +95,7 @@ pub(crate) async fn handle_streaming_response(
     mut chat_request: ChatCompletionRequest,
     original: ResponsesApiRequest,
     context: RequestContext,
+    owner: Option<ResponseOwner>,
 ) -> ActixResult<HttpResponse> {
     info!(
         "Streaming Responses API request for model: {}",
@@ -650,9 +652,10 @@ pub(crate) async fn handle_streaming_response(
                     output: output_items,
                     usage,
                     error: None,
-                    previous_response_id: original.previous_response_id,
-                    metadata: original.metadata,
+                    previous_response_id: original.previous_response_id.clone(),
+                    metadata: original.metadata.clone(),
                 };
+                store_response_if_requested(&original, &completed, owner);
                 let _ = emit(
                     &tx,
                     &ResponseStreamEvent::ResponseCompleted {

--- a/tests/responses_routes.rs
+++ b/tests/responses_routes.rs
@@ -1,0 +1,315 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpMessage, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use futures::stream;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::types::context::RequestContext;
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use litellm_rs::server::state::AppState;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone, Copy)]
+    enum MockScenario {
+        NonStreaming,
+        Streaming,
+    }
+
+    #[derive(Clone)]
+    struct MockServerState {
+        scenario: MockScenario,
+        captured_requests: Arc<Mutex<Vec<Value>>>,
+    }
+
+    struct MockOpenAiServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<Value>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockOpenAiServer {
+        async fn start(scenario: MockScenario) -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockServerState {
+                scenario,
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .route("/chat/completions", web::post().to(mock_chat_completions))
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            tokio::time::sleep(Duration::from_millis(20)).await;
+
+            Self {
+                base_url: format!("http://{address}"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<Value> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn shutdown(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn mock_chat_completions(
+        state: web::Data<MockServerState>,
+        payload: web::Json<Value>,
+    ) -> HttpResponse {
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(payload.into_inner());
+
+        match state.scenario {
+            MockScenario::NonStreaming => HttpResponse::Ok().json(json!({
+                "id": "chatcmpl-response-route",
+                "object": "chat.completion",
+                "created": 4_102_444_800_i64,
+                "model": "gpt-4o-mini",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "mocked response"
+                    },
+                    "finish_reason": "stop"
+                }],
+                "usage": {
+                    "prompt_tokens": 4,
+                    "completion_tokens": 3,
+                    "total_tokens": 7
+                }
+            })),
+            MockScenario::Streaming => {
+                let chunk_1 = r#"data: {"id":"chatcmpl-response-stream","object":"chat.completion.chunk","created":1707000001,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}"#;
+                let chunk_2 = r#"data: {"id":"chatcmpl-response-stream","object":"chat.completion.chunk","created":1707000001,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}]}"#;
+                let stream = stream::iter(vec![
+                    Ok::<Bytes, actix_web::Error>(Bytes::from(format!("{chunk_1}\n\n"))),
+                    Ok::<Bytes, actix_web::Error>(Bytes::from(format!("{chunk_2}\n\n"))),
+                    Ok::<Bytes, actix_web::Error>(Bytes::from("data: [DONE]\n\n")),
+                ]);
+                HttpResponse::Ok()
+                    .insert_header(("Content-Type", "text/event-stream"))
+                    .streaming(stream)
+            }
+        }
+    }
+
+    fn provider_config(base_url: &str) -> ProviderConfig {
+        ProviderConfig {
+            name: "mock-openai-compatible".to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "test-key".to_string(),
+            base_url: Some(base_url.to_string()),
+            settings: HashMap::from([("skip_api_key".to_string(), Value::Bool(true))]),
+            models: vec!["gpt-4o-mini".to_string()],
+            ..ProviderConfig::default()
+        }
+    }
+
+    async fn app_state(base_url: &str) -> AppState {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = vec![provider_config(base_url)];
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    macro_rules! with_user {
+        ($req:expr, $user_id:expr) => {{
+            let req = $req;
+            req.extensions_mut()
+                .insert(RequestContext::new().with_user_id($user_id));
+            req
+        }};
+    }
+
+    fn response_request(stream: Option<bool>) -> Value {
+        json!({
+            "model": "gpt-4o-mini",
+            "input": "Hello",
+            "stream": stream
+        })
+    }
+
+    #[tokio::test]
+    async fn create_retrieve_input_items_and_delete_response() {
+        let mock = MockOpenAiServer::start(MockScenario::NonStreaming).await;
+        let state = app_state(&mock.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let create_req = with_user!(
+            test::TestRequest::post()
+                .uri("/v1/responses")
+                .set_json(response_request(None))
+                .to_request(),
+            "owner-a"
+        );
+        let create_resp = test::call_service(&app, create_req).await;
+        assert_eq!(create_resp.status(), StatusCode::OK);
+        let created: Value = test::read_body_json(create_resp).await;
+        let response_id = created["id"].as_str().expect("response id").to_string();
+        assert_eq!(created["object"], "response");
+
+        let get_req = with_user!(
+            test::TestRequest::get()
+                .uri(&format!("/v1/responses/{response_id}"))
+                .to_request(),
+            "owner-a"
+        );
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+        let fetched: Value = test::read_body_json(get_resp).await;
+        assert_eq!(fetched["id"], response_id);
+
+        let cross_owner_req = with_user!(
+            test::TestRequest::get()
+                .uri(&format!("/v1/responses/{response_id}"))
+                .to_request(),
+            "owner-b"
+        );
+        let cross_owner_resp = test::call_service(&app, cross_owner_req).await;
+        assert_eq!(cross_owner_resp.status(), StatusCode::NOT_FOUND);
+
+        let items_req = with_user!(
+            test::TestRequest::get()
+                .uri(&format!("/v1/responses/{response_id}/input_items?limit=1"))
+                .to_request(),
+            "owner-a"
+        );
+        let items_resp = test::call_service(&app, items_req).await;
+        assert_eq!(items_resp.status(), StatusCode::OK);
+        let items: Value = test::read_body_json(items_resp).await;
+        assert_eq!(items["object"], "list");
+        assert!(
+            items["data"][0]["id"]
+                .as_str()
+                .unwrap()
+                .starts_with("item_")
+        );
+        assert_eq!(items["data"][0]["type"], "message");
+        assert_eq!(items["first_id"], items["data"][0]["id"]);
+        assert_eq!(items["last_id"], items["data"][0]["id"]);
+
+        let include_req = with_user!(
+            test::TestRequest::get()
+                .uri(&format!(
+                    "/v1/responses/{response_id}/input_items?include=file_search_call.results"
+                ))
+                .to_request(),
+            "owner-a"
+        );
+        let include_resp = test::call_service(&app, include_req).await;
+        assert_eq!(include_resp.status(), StatusCode::BAD_REQUEST);
+
+        let delete_req = with_user!(
+            test::TestRequest::delete()
+                .uri(&format!("/v1/responses/{response_id}"))
+                .to_request(),
+            "owner-a"
+        );
+        let delete_resp = test::call_service(&app, delete_req).await;
+        assert_eq!(delete_resp.status(), StatusCode::OK);
+        let deleted: Value = test::read_body_json(delete_resp).await;
+        assert_eq!(deleted["id"], response_id);
+        assert_eq!(deleted["object"], "response");
+        assert_eq!(deleted["deleted"], true);
+
+        assert_eq!(mock.requests().len(), 1);
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn streamed_response_is_stored_after_completion_event() {
+        let mock = MockOpenAiServer::start(MockScenario::Streaming).await;
+        let state = app_state(&mock.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let stream_req = with_user!(
+            test::TestRequest::post()
+                .uri("/v1/responses")
+                .set_json(response_request(Some(true)))
+                .to_request(),
+            "stream-owner"
+        );
+        let stream_resp = test::call_service(&app, stream_req).await;
+        assert_eq!(stream_resp.status(), StatusCode::OK);
+        let body = test::read_body(stream_resp).await;
+        let response_id = response_id_from_sse(&String::from_utf8_lossy(&body));
+
+        let get_req = with_user!(
+            test::TestRequest::get()
+                .uri(&format!("/v1/responses/{response_id}"))
+                .to_request(),
+            "stream-owner"
+        );
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+        let fetched: Value = test::read_body_json(get_resp).await;
+        assert_eq!(fetched["id"], response_id);
+        assert_eq!(fetched["output"][0]["content"][0]["text"], "Hello");
+
+        mock.shutdown().await;
+    }
+
+    fn response_id_from_sse(body: &str) -> String {
+        for line in body.lines() {
+            let Some(payload) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            if payload == "[DONE]" {
+                continue;
+            }
+            let event: Value = serde_json::from_str(payload).expect("SSE payload should be json");
+            if event["type"] == "response.completed" {
+                return event["response"]["id"]
+                    .as_str()
+                    .expect("completed response should have id")
+                    .to_string();
+            }
+        }
+        panic!("response.completed event not found");
+    }
+}


### PR DESCRIPTION
## Summary
- add Responses API retrieve/delete/cancel/input_items lifecycle routes
- scope stored responses by API key or user owner and return 404 across owners
- support previous_response_id context replay, sync and stream storage, background task cancellation, bounded TTL/size cleanup, and input_items pagination metadata

## Tests
- cargo fmt --all -- --check
- cargo test --all-features --locked server::routes::ai::responses --lib --quiet
- cargo test --all-features --locked test_response_lifecycle_routes_mounted_with_expected_methods --lib --quiet
- cargo test --all-features --locked responses_stream --lib --quiet
- cargo test --all-features --locked --test responses_routes --quiet
- cargo check --all-features --locked
- GitHub CI: Compile-check all features, Lint, Feature Matrix, Test, Security Audit

Fixes #740