### PR TITLE
Fix OpenAI engine endpoint aliases

### DIFF
--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -34,7 +34,9 @@ pub use responses::{
     cancel_response, create_response, delete_response, get_response, list_response_input_items,
 };
 
-use actix_web::web;
+use crate::core::models::openai::EmbeddingRequest;
+use crate::server::state::AppState;
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 
 /// Configure AI API routes
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
@@ -59,6 +61,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             )
             // Embeddings
             .route("/embeddings", web::post().to(embeddings))
+            .route(
+                "/engines/{model_id}/embeddings",
+                web::post().to(engine_embeddings),
+            )
             // Batch processing
             .route("/batches", web::post().to(create_batch))
             .route("/batches", web::get().to(list_batches))
@@ -75,6 +81,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             // Models
             .route("/models", web::get().to(list_models))
             .route("/models/{model_id}", web::get().to(get_model))
+            .route("/engines", web::get().to(list_models))
+            .route("/engines/{model_id}", web::get().to(get_model))
             // Audio (future implementation)
             .route(
                 "/audio/transcriptions",
@@ -85,9 +93,34 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     );
 }
 
+async fn engine_embeddings(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    model_id: web::Path<String>,
+    request: web::Json<EmbeddingRequest>,
+) -> ActixResult<HttpResponse> {
+    embeddings_for_path_model(state, req, model_id.into_inner(), request).await
+}
+
+async fn embeddings_for_path_model(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    model: String,
+    request: web::Json<EmbeddingRequest>,
+) -> ActixResult<HttpResponse> {
+    let mut request = request.into_inner();
+    override_embedding_model(&mut request, model);
+    embeddings(state, req, web::Json(request)).await
+}
+
+fn override_embedding_model(request: &mut EmbeddingRequest, model: String) {
+    request.model = model;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Config;
+    use crate::core::models::openai::EmbeddingRequest;
     use crate::core::types::context::RequestContext;
     use crate::server::HttpServer as GatewayHttpServer;
     use actix_web::{App, http::StatusCode, test, web};
@@ -209,5 +242,73 @@ mod tests {
             .to_request();
         let input_items_resp = test::call_service(&app, input_items_req).await;
         assert_eq!(input_items_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_engine_alias_routes_are_mounted_with_expected_methods() {
+        let state = build_no_provider_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(super::configure_routes),
+        )
+        .await;
+
+        let list_req = test::TestRequest::get().uri("/v1/engines").to_request();
+        let list_resp = test::call_service(&app, list_req).await;
+        assert_eq!(list_resp.status(), StatusCode::OK);
+
+        let get_missing_req = test::TestRequest::get()
+            .uri("/v1/engines/missing-model")
+            .to_request();
+        let get_missing_resp = test::call_service(&app, get_missing_req).await;
+        assert_eq!(get_missing_resp.status(), StatusCode::NOT_FOUND);
+
+        let embeddings_req = test::TestRequest::post()
+            .uri("/v1/engines/text-embedding-3-small/embeddings")
+            .set_json(serde_json::json!({
+                "model": "body-model",
+                "input": "Hello"
+            }))
+            .to_request();
+        let embeddings_resp = test::call_service(&app, embeddings_req).await;
+        let embeddings_status = embeddings_resp.status();
+        let embeddings_body: Value = test::read_body_json(embeddings_resp).await;
+        assert_eq!(embeddings_status, StatusCode::NOT_FOUND);
+        assert!(
+            embeddings_body
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .is_some()
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_root_engine_aliases_remain_unmounted() {
+        let state = build_no_provider_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(super::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/engines").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_alias_embedding_model_overrides_body_model() {
+        let mut request = EmbeddingRequest {
+            model: "body-model".to_string(),
+            input: serde_json::json!("Hello"),
+            user: None,
+        };
+
+        super::override_embedding_model(&mut request, "path-model".to_string());
+
+        assert_eq!(request.model, "path-model");
     }
 }

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -99,28 +99,14 @@ async fn engine_embeddings(
     model_id: web::Path<String>,
     request: web::Json<EmbeddingRequest>,
 ) -> ActixResult<HttpResponse> {
-    embeddings_for_path_model(state, req, model_id.into_inner(), request).await
-}
-
-async fn embeddings_for_path_model(
-    state: web::Data<AppState>,
-    req: HttpRequest,
-    model: String,
-    request: web::Json<EmbeddingRequest>,
-) -> ActixResult<HttpResponse> {
     let mut request = request.into_inner();
-    override_embedding_model(&mut request, model);
+    request.model = model_id.into_inner();
     embeddings(state, req, web::Json(request)).await
-}
-
-fn override_embedding_model(request: &mut EmbeddingRequest, model: String) {
-    request.model = model;
 }
 
 #[cfg(test)]
 mod tests {
     use crate::Config;
-    use crate::core::models::openai::EmbeddingRequest;
     use crate::core::types::context::RequestContext;
     use crate::server::HttpServer as GatewayHttpServer;
     use actix_web::{App, http::StatusCode, test, web};
@@ -297,18 +283,5 @@ mod tests {
         let req = test::TestRequest::get().uri("/engines").to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[actix_web::test]
-    async fn test_alias_embedding_model_overrides_body_model() {
-        let mut request = EmbeddingRequest {
-            model: "body-model".to_string(),
-            input: serde_json::json!("Hello"),
-            user: None,
-        };
-
-        super::override_embedding_model(&mut request, "path-model".to_string());
-
-        assert_eq!(request.model, "path-model");
     }
 }

--- a/tests/integration/http_routes_tests.rs
+++ b/tests/integration/http_routes_tests.rs
@@ -6,7 +6,7 @@
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
     use actix_web::http::StatusCode;
-    use actix_web::{App, test, web};
+    use actix_web::{App, HttpResponse, HttpServer, test, web};
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
@@ -14,7 +14,8 @@ mod tests {
     use litellm_rs::server::routes;
     use litellm_rs::server::state::AppState;
     use serde_json::Value;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     async fn build_state_with_config(config: Config) -> AppState {
         let server = match GatewayHttpServer::new(&config).await {
@@ -52,6 +53,48 @@ mod tests {
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
 
         build_state_with_config(config).await
+    }
+
+    async fn build_openai_alias_state(base_url: &str) -> AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.providers = vec![ProviderConfig {
+            name: "mock-openai".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            models: vec!["text-embedding-3-small".to_string()],
+            ..ProviderConfig::default()
+        }];
+
+        build_state_with_config(config).await
+    }
+
+    async fn mock_embeddings(
+        captured_requests: web::Data<Arc<Mutex<Vec<Value>>>>,
+        payload: web::Json<Value>,
+    ) -> HttpResponse {
+        captured_requests.lock().unwrap().push(payload.into_inner());
+
+        HttpResponse::Ok().json(serde_json::json!({
+            "object": "list",
+            "data": [{
+                "object": "embedding",
+                "index": 0,
+                "embedding": [0.1, 0.2]
+            }],
+            "model": "text-embedding-3-small",
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 0,
+                "total_tokens": 1
+            }
+        }))
     }
 
     /// Construct an actix-web test app with AuthMiddleware and route
@@ -256,6 +299,48 @@ mod tests {
         let resp = test::call_service(&app, req).await;
 
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_engine_embedding_alias_uses_path_model() {
+        let captured_requests = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock server should have local address");
+        let captured_for_server = Arc::clone(&captured_requests);
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(Arc::clone(&captured_for_server)))
+                .route("/embeddings", web::post().to(mock_embeddings))
+        })
+        .listen(listener)
+        .expect("mock server should listen")
+        .run();
+        let handle = server.handle();
+        let task = tokio::spawn(server);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let state = build_openai_alias_state(&format!("http://{address}")).await;
+        let app = test::init_service(build_test_app(state)).await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/engines/text-embedding-3-small/embeddings")
+            .set_json(serde_json::json!({
+                "model": "body-model",
+                "input": "hello"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        handle.stop(true).await;
+        let _ = task.await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = captured_requests.lock().unwrap().clone();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["model"], "text-embedding-3-small");
+        assert_ne!(requests[0]["model"], "body-model");
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `/v1/engines` and `/v1/engines/{model_id}` aliases to the existing model list/get handlers.
- Add `/v1/engines/{model_id}/embeddings` and override the embedding request model from the path before provider execution.
- Add route-level and integration coverage proving the alias is mounted and the upstream provider receives the path model instead of the body model.

## Scope boundary
- This intentionally does not implement `/v1/completions` or `/v1/engines/{model_id}/completions`; that remains #746.
- This intentionally leaves root `/engines` unmounted because current OpenAI-compatible routes are mounted under `/v1`.

Fixes #741

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-features --locked test_engine_alias_routes_are_mounted_with_expected_methods --lib --quiet`
- `cargo test --all-features --locked test_root_engine_aliases_remain_unmounted --lib --quiet`
- `cargo test --all-features --locked --test lib test_engine_embedding_alias_uses_path_model --quiet`
- `cargo check --all-features --locked`
- `cargo test --all-features --locked`
