### PR TITLE
Fix audio routes provider execution

### DIFF
--- a/src/core/providers/audio_dispatch.rs
+++ b/src/core/providers/audio_dispatch.rs
@@ -1,0 +1,54 @@
+use crate::core::audio::types::{
+    SpeechRequest, SpeechResponse, TranscriptionRequest, TranscriptionResponse, TranslationRequest,
+    TranslationResponse,
+};
+use crate::core::providers::{Provider, ProviderError};
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::context::RequestContext;
+
+impl Provider {
+    /// Transcribe audio to text.
+    ///
+    /// Route selection must confirm `ProviderCapability::AudioTranscription`
+    /// before calling this optional dispatch method.
+    pub async fn audio_transcription(
+        &self,
+        request: TranscriptionRequest,
+        context: RequestContext,
+    ) -> Result<TranscriptionResponse, ProviderError> {
+        match self {
+            Provider::OpenAI(provider) => provider.audio_transcription(request).await,
+            _ => dispatch_provider!(async_err, self, audio_transcription, request, context),
+        }
+    }
+
+    /// Translate audio to English text.
+    ///
+    /// Route selection must confirm `ProviderCapability::AudioTranslation`
+    /// before calling this optional dispatch method.
+    pub async fn audio_translation(
+        &self,
+        request: TranslationRequest,
+        context: RequestContext,
+    ) -> Result<TranslationResponse, ProviderError> {
+        match self {
+            Provider::OpenAI(provider) => provider.audio_translation(request).await,
+            _ => dispatch_provider!(async_err, self, audio_translation, request, context),
+        }
+    }
+
+    /// Generate speech audio from text.
+    ///
+    /// Route selection must confirm `ProviderCapability::TextToSpeech` before
+    /// calling this optional dispatch method.
+    pub async fn text_to_speech(
+        &self,
+        request: SpeechRequest,
+        context: RequestContext,
+    ) -> Result<SpeechResponse, ProviderError> {
+        match self {
+            Provider::OpenAI(provider) => provider.text_to_speech(request).await,
+            _ => dispatch_provider!(async_err, self, text_to_speech, request, context),
+        }
+    }
+}

--- a/src/core/providers/audio_dispatch.rs
+++ b/src/core/providers/audio_dispatch.rs
@@ -16,10 +16,7 @@ impl Provider {
         request: TranscriptionRequest,
         context: RequestContext,
     ) -> Result<TranscriptionResponse, ProviderError> {
-        match self {
-            Provider::OpenAI(provider) => provider.audio_transcription(request).await,
-            _ => dispatch_provider!(async_err, self, audio_transcription, request, context),
-        }
+        dispatch_provider!(async_err, self, audio_transcription, request, context)
     }
 
     /// Translate audio to English text.
@@ -31,10 +28,7 @@ impl Provider {
         request: TranslationRequest,
         context: RequestContext,
     ) -> Result<TranslationResponse, ProviderError> {
-        match self {
-            Provider::OpenAI(provider) => provider.audio_translation(request).await,
-            _ => dispatch_provider!(async_err, self, audio_translation, request, context),
-        }
+        dispatch_provider!(async_err, self, audio_translation, request, context)
     }
 
     /// Generate speech audio from text.
@@ -46,9 +40,6 @@ impl Provider {
         request: SpeechRequest,
         context: RequestContext,
     ) -> Result<SpeechResponse, ProviderError> {
-        match self {
-            Provider::OpenAI(provider) => provider.text_to_speech(request).await,
-            _ => dispatch_provider!(async_err, self, text_to_speech, request, context),
-        }
+        dispatch_provider!(async_err, self, text_to_speech, request, context)
     }
 }

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -1,0 +1,28 @@
+use crate::core::providers::Provider;
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::model::ProviderCapability;
+
+impl Provider {
+    /// Check whether a deployment's concrete model supports `capability`.
+    ///
+    /// Provider-level capabilities answer whether a provider family has an
+    /// implementation. When the provider has a registry entry for the concrete
+    /// deployment model, route selection also respects that model-specific
+    /// capability list.
+    pub fn supports_capability_for_model(
+        &self,
+        model: &str,
+        capability: &ProviderCapability,
+    ) -> bool {
+        match self {
+            Provider::OpenAI(provider) => {
+                if provider.get_model_config(model).is_some() {
+                    provider.model_supports_capability(model, capability)
+                } else {
+                    LLMProvider::supports_capability(provider, capability)
+                }
+            }
+            _ => self.supports_capability(capability),
+        }
+    }
+}

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -393,6 +393,7 @@ macro_rules! dispatch_provider_selective {
 }
 
 mod audio_dispatch;
+mod capability_dispatch;
 
 /// Unified built-in Provider enum (Rust-idiomatic design).
 ///

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -392,6 +392,8 @@ macro_rules! dispatch_provider_selective {
     };
 }
 
+mod audio_dispatch;
+
 /// Unified built-in Provider enum (Rust-idiomatic design).
 ///
 /// This enum provides zero-cost abstractions and type safety for all providers.
@@ -766,6 +768,6 @@ mod tests {
         assert!(provider.supports_capability(&ProviderCapability::ChatCompletion));
         assert!(provider.supports_capability(&ProviderCapability::ChatCompletionStream));
         assert!(provider.supports_capability(&ProviderCapability::Embeddings));
-        assert!(!provider.supports_capability(&ProviderCapability::TextToSpeech));
+        assert!(provider.supports_capability(&ProviderCapability::TextToSpeech));
     }
 }

--- a/src/core/providers/openai/api_methods.rs
+++ b/src/core/providers/openai/api_methods.rs
@@ -3,21 +3,31 @@
 //! Inherent methods called by the LLMProvider trait impl in `client.rs`:
 //! - `embeddings`
 //! - `generate_images`
+//! - `audio_transcription`
+//! - `audio_translation`
+//! - `text_to_speech`
 //!
-//! Other side-API methods (transcription, completions, fine-tuning,
-//! image edit / variations, vector stores, realtime, advanced chat)
-//! were declared but never reached from any live code path and have
-//! been removed.
+//! Other side-API methods (completions, fine-tuning, image edit / variations,
+//! vector stores, realtime, advanced chat) were declared but never reached from
+//! any live code path and have been removed.
 
+use reqwest::header::CONTENT_TYPE;
+use reqwest::multipart;
 use serde_json::Value;
 
-use crate::core::providers::base::HttpMethod;
+use crate::core::audio::types::{
+    SpeechRequest, SpeechResponse, TranscriptionRequest, TranscriptionResponse, TranslationRequest,
+    TranslationResponse, format_to_content_type,
+};
+use crate::core::providers::base::{HttpMethod, apply_headers, global_client};
+use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 use crate::core::types::embedding::EmbeddingRequest;
 use crate::core::types::responses::EmbeddingResponse;
 
 use super::client::OpenAIProvider;
 use super::config::OpenAIFeature;
 use super::error::OpenAIError;
+use super::error_mapper::OpenAIErrorMapper;
 
 /// Additional OpenAI-specific API methods
 impl OpenAIProvider {
@@ -127,4 +137,227 @@ impl OpenAIProvider {
             message: e.to_string(),
         })
     }
+
+    /// Transcribe audio through OpenAI's `/audio/transcriptions` endpoint.
+    pub async fn audio_transcription(
+        &self,
+        request: TranscriptionRequest,
+    ) -> Result<TranscriptionResponse, OpenAIError> {
+        if !self
+            .config
+            .is_feature_enabled(OpenAIFeature::AudioTranscription)
+        {
+            return Err(OpenAIError::NotSupported {
+                provider: "openai",
+                feature: "Audio transcription is disabled in configuration".to_string(),
+            });
+        }
+
+        let response_format = request.response_format.clone();
+        let form = transcription_form(request);
+        let url = format!("{}/audio/transcriptions", self.config.get_api_base());
+        let response = apply_headers(
+            global_client().post(url).multipart(form),
+            self.get_request_headers(),
+        )
+        .send()
+        .await
+        .map_err(|e| OpenAIError::Network {
+            provider: "openai",
+            message: e.to_string(),
+        })?;
+
+        let response_bytes = read_success_response_bytes(response).await?;
+        if is_raw_audio_text_format(response_format.as_deref()) {
+            return Ok(TranscriptionResponse {
+                text: String::from_utf8_lossy(&response_bytes).into_owned(),
+                task: None,
+                language: None,
+                duration: None,
+                words: None,
+                segments: None,
+            });
+        }
+
+        serde_json::from_slice(&response_bytes).map_err(|e| OpenAIError::ResponseParsing {
+            provider: "openai",
+            message: e.to_string(),
+        })
+    }
+
+    /// Translate audio through OpenAI's `/audio/translations` endpoint.
+    pub async fn audio_translation(
+        &self,
+        request: TranslationRequest,
+    ) -> Result<TranslationResponse, OpenAIError> {
+        if !self.config.is_feature_enabled(OpenAIFeature::AudioModels) {
+            return Err(OpenAIError::NotSupported {
+                provider: "openai",
+                feature: "Audio models are disabled in configuration".to_string(),
+            });
+        }
+
+        let response_format = request.response_format.clone();
+        let form = translation_form(request);
+        let url = format!("{}/audio/translations", self.config.get_api_base());
+        let response = apply_headers(
+            global_client().post(url).multipart(form),
+            self.get_request_headers(),
+        )
+        .send()
+        .await
+        .map_err(|e| OpenAIError::Network {
+            provider: "openai",
+            message: e.to_string(),
+        })?;
+
+        let response_bytes = read_success_response_bytes(response).await?;
+        if is_raw_audio_text_format(response_format.as_deref()) {
+            return Ok(TranslationResponse {
+                text: String::from_utf8_lossy(&response_bytes).into_owned(),
+                task: None,
+                language: None,
+                duration: None,
+                segments: None,
+            });
+        }
+
+        serde_json::from_slice(&response_bytes).map_err(|e| OpenAIError::ResponseParsing {
+            provider: "openai",
+            message: e.to_string(),
+        })
+    }
+
+    /// Generate speech through OpenAI's `/audio/speech` endpoint.
+    pub async fn text_to_speech(
+        &self,
+        request: SpeechRequest,
+    ) -> Result<SpeechResponse, OpenAIError> {
+        if !self.config.is_feature_enabled(OpenAIFeature::AudioModels) {
+            return Err(OpenAIError::NotSupported {
+                provider: "openai",
+                feature: "Audio models are disabled in configuration".to_string(),
+            });
+        }
+
+        let response_format = request.response_format.clone();
+        let body = serde_json::json!({
+            "model": request.model,
+            "input": request.input,
+            "voice": request.voice,
+            "response_format": request.response_format,
+            "speed": request.speed,
+        });
+        let url = format!("{}/audio/speech", self.config.get_api_base());
+        let response = apply_headers(
+            global_client().post(url).json(&body),
+            self.get_request_headers(),
+        )
+        .send()
+        .await
+        .map_err(|e| OpenAIError::Network {
+            provider: "openai",
+            message: e.to_string(),
+        })?;
+
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                format_to_content_type(response_format.as_deref().unwrap_or("mp3")).to_string()
+            });
+        let response_bytes = response.bytes().await.map_err(|e| OpenAIError::Network {
+            provider: "openai",
+            message: e.to_string(),
+        })?;
+
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&response_bytes);
+            return Err(OpenAIErrorMapper.map_http_error(status.as_u16(), &body));
+        }
+
+        Ok(SpeechResponse {
+            audio: response_bytes.to_vec(),
+            content_type,
+        })
+    }
+}
+
+fn transcription_form(request: TranscriptionRequest) -> multipart::Form {
+    let form = audio_file_form(request.file, request.filename)
+        .text("model", request.model)
+        .optional_text("language", request.language)
+        .optional_text("prompt", request.prompt)
+        .optional_text("response_format", request.response_format)
+        .optional_text(
+            "temperature",
+            request.temperature.map(|value| value.to_string()),
+        );
+
+    if let Some(granularities) = request.timestamp_granularities {
+        granularities.into_iter().fold(form, |form, granularity| {
+            form.text("timestamp_granularities[]", granularity)
+        })
+    } else {
+        form
+    }
+}
+
+fn translation_form(request: TranslationRequest) -> multipart::Form {
+    audio_file_form(request.file, request.filename)
+        .text("model", request.model)
+        .optional_text("prompt", request.prompt)
+        .optional_text("response_format", request.response_format)
+        .optional_text(
+            "temperature",
+            request.temperature.map(|value| value.to_string()),
+        )
+}
+
+fn audio_file_form(file: Vec<u8>, filename: String) -> multipart::Form {
+    let filename = if filename.trim().is_empty() {
+        "audio.mp3".to_string()
+    } else {
+        filename
+    };
+
+    multipart::Form::new().part("file", multipart::Part::bytes(file).file_name(filename))
+}
+
+trait OptionalMultipartText {
+    fn optional_text(self, name: &'static str, value: Option<String>) -> Self;
+}
+
+impl OptionalMultipartText for multipart::Form {
+    fn optional_text(self, name: &'static str, value: Option<String>) -> Self {
+        match value {
+            Some(value) => self.text(name, value),
+            None => self,
+        }
+    }
+}
+
+async fn read_success_response_bytes(response: reqwest::Response) -> Result<Vec<u8>, OpenAIError> {
+    let status = response.status();
+    let response_bytes = response.bytes().await.map_err(|e| OpenAIError::Network {
+        provider: "openai",
+        message: e.to_string(),
+    })?;
+
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&response_bytes);
+        return Err(OpenAIErrorMapper.map_http_error(status.as_u16(), &body));
+    }
+
+    Ok(response_bytes.to_vec())
+}
+
+fn is_raw_audio_text_format(response_format: Option<&str>) -> bool {
+    matches!(
+        response_format.map(str::to_ascii_lowercase).as_deref(),
+        Some("text" | "srt" | "vtt")
+    )
 }

--- a/src/core/providers/openai/api_methods.rs
+++ b/src/core/providers/openai/api_methods.rs
@@ -153,7 +153,6 @@ impl OpenAIProvider {
             });
         }
 
-        let response_format = request.response_format.clone();
         let form = transcription_form(request);
         let url = format!("{}/audio/transcriptions", self.config.get_api_base());
         let response = apply_headers(
@@ -168,17 +167,6 @@ impl OpenAIProvider {
         })?;
 
         let response_bytes = read_success_response_bytes(response).await?;
-        if is_raw_audio_text_format(response_format.as_deref()) {
-            return Ok(TranscriptionResponse {
-                text: String::from_utf8_lossy(&response_bytes).into_owned(),
-                task: None,
-                language: None,
-                duration: None,
-                words: None,
-                segments: None,
-            });
-        }
-
         serde_json::from_slice(&response_bytes).map_err(|e| OpenAIError::ResponseParsing {
             provider: "openai",
             message: e.to_string(),
@@ -197,7 +185,6 @@ impl OpenAIProvider {
             });
         }
 
-        let response_format = request.response_format.clone();
         let form = translation_form(request);
         let url = format!("{}/audio/translations", self.config.get_api_base());
         let response = apply_headers(
@@ -212,16 +199,6 @@ impl OpenAIProvider {
         })?;
 
         let response_bytes = read_success_response_bytes(response).await?;
-        if is_raw_audio_text_format(response_format.as_deref()) {
-            return Ok(TranslationResponse {
-                text: String::from_utf8_lossy(&response_bytes).into_owned(),
-                task: None,
-                language: None,
-                duration: None,
-                segments: None,
-            });
-        }
-
         serde_json::from_slice(&response_bytes).map_err(|e| OpenAIError::ResponseParsing {
             provider: "openai",
             message: e.to_string(),
@@ -353,11 +330,4 @@ async fn read_success_response_bytes(response: reqwest::Response) -> Result<Vec<
     }
 
     Ok(response_bytes.to_vec())
-}
-
-fn is_raw_audio_text_format(response_format: Option<&str>) -> bool {
-    matches!(
-        response_format.map(str::to_ascii_lowercase).as_deref(),
-        Some("text" | "srt" | "vtt")
-    )
 }

--- a/src/core/providers/openai/api_methods.rs
+++ b/src/core/providers/openai/api_methods.rs
@@ -19,7 +19,7 @@ use crate::core::audio::types::{
     SpeechRequest, SpeechResponse, TranscriptionRequest, TranscriptionResponse, TranslationRequest,
     TranslationResponse, format_to_content_type,
 };
-use crate::core::providers::base::{HttpMethod, apply_headers, global_client};
+use crate::core::providers::base::{HttpMethod, apply_headers};
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 use crate::core::types::embedding::EmbeddingRequest;
 use crate::core::types::responses::EmbeddingResponse;
@@ -156,7 +156,7 @@ impl OpenAIProvider {
         let form = transcription_form(request);
         let url = format!("{}/audio/transcriptions", self.config.get_api_base());
         let response = apply_headers(
-            global_client().post(url).multipart(form),
+            self.pool_manager.client().post(url).multipart(form),
             self.get_request_headers(),
         )
         .send()
@@ -188,7 +188,7 @@ impl OpenAIProvider {
         let form = translation_form(request);
         let url = format!("{}/audio/translations", self.config.get_api_base());
         let response = apply_headers(
-            global_client().post(url).multipart(form),
+            self.pool_manager.client().post(url).multipart(form),
             self.get_request_headers(),
         )
         .send()
@@ -226,18 +226,20 @@ impl OpenAIProvider {
             "speed": request.speed,
         });
         let url = format!("{}/audio/speech", self.config.get_api_base());
-        let response = apply_headers(
-            global_client().post(url).json(&body),
-            self.get_request_headers(),
-        )
-        .send()
-        .await
-        .map_err(|e| OpenAIError::Network {
-            provider: "openai",
-            message: e.to_string(),
-        })?;
+        let response = self
+            .pool_manager
+            .execute_request(
+                &url,
+                HttpMethod::POST,
+                self.get_request_headers(),
+                Some(body),
+            )
+            .await
+            .map_err(|e| OpenAIError::Network {
+                provider: "openai",
+                message: e.to_string(),
+            })?;
 
-        let status = response.status();
         let content_type = response
             .headers()
             .get(CONTENT_TYPE)
@@ -246,15 +248,7 @@ impl OpenAIProvider {
             .unwrap_or_else(|| {
                 format_to_content_type(response_format.as_deref().unwrap_or("mp3")).to_string()
             });
-        let response_bytes = response.bytes().await.map_err(|e| OpenAIError::Network {
-            provider: "openai",
-            message: e.to_string(),
-        })?;
-
-        if !status.is_success() {
-            let body = String::from_utf8_lossy(&response_bytes);
-            return Err(OpenAIErrorMapper.map_http_error(status.as_u16(), &body));
-        }
+        let response_bytes = read_success_response_bytes(response).await?;
 
         Ok(SpeechResponse {
             audio: response_bytes.to_vec(),

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use crate::core::audio::types::{
+    SpeechRequest, SpeechResponse, TranscriptionRequest, TranscriptionResponse, TranslationRequest,
+    TranslationResponse,
+};
 use crate::core::providers::base::{
     GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
     read_streaming_error_body, send_streaming_request, streaming_unbounded_client,
@@ -27,7 +31,7 @@ use crate::core::types::{
 
 use super::{
     config::OpenAIConfig,
-    models::{OpenAIModelFeature, OpenAIModelRegistry, OpenAIUseCase, get_openai_registry},
+    models::{OpenAIModelRegistry, get_openai_registry},
 };
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
@@ -441,6 +445,30 @@ impl LLMProvider for OpenAIProvider {
         })
     }
 
+    async fn audio_transcription(
+        &self,
+        request: TranscriptionRequest,
+        _context: RequestContext,
+    ) -> Result<TranscriptionResponse, ProviderError> {
+        self.audio_transcription(request).await
+    }
+
+    async fn audio_translation(
+        &self,
+        request: TranslationRequest,
+        _context: RequestContext,
+    ) -> Result<TranslationResponse, ProviderError> {
+        self.audio_translation(request).await
+    }
+
+    async fn text_to_speech(
+        &self,
+        request: SpeechRequest,
+        _context: RequestContext,
+    ) -> Result<SpeechResponse, ProviderError> {
+        self.text_to_speech(request).await
+    }
+
     async fn health_check(&self) -> HealthStatus {
         let url = format!("{}/models?limit=1", self.config.get_api_base());
         let client = crate::core::http::outbound::default_outbound_client().clone();
@@ -677,108 +705,5 @@ impl LLMProvider for OpenAIProvider {
 }
 
 // Re-export error mapper from dedicated module
+pub use super::client_convenience::OpenAITask;
 pub use super::error_mapper::OpenAIErrorMapper;
-
-// ==================== Convenience Methods ====================
-
-impl OpenAIProvider {
-    /// Get model recommendations for specific use cases
-    pub fn get_recommended_model(&self, use_case: OpenAIUseCase) -> Option<String> {
-        get_openai_registry().get_recommended_model(use_case)
-    }
-
-    /// Check if a model supports a specific feature
-    pub fn model_supports_feature(&self, model_id: &str, feature: &OpenAIModelFeature) -> bool {
-        get_openai_registry().supports_feature(model_id, feature)
-    }
-
-    /// Get models by family (e.g., all GPT-4 variants)
-    pub fn get_models_by_family(&self, family: &super::models::OpenAIModelFamily) -> Vec<String> {
-        get_openai_registry().get_models_by_family(family)
-    }
-
-    /// Get models supporting specific feature
-    pub fn get_models_with_feature(&self, feature: &OpenAIModelFeature) -> Vec<String> {
-        get_openai_registry().get_models_with_feature(feature)
-    }
-
-    /// List available models from static registry
-    pub fn list_available_models(&self) -> Vec<String> {
-        self.models().iter().map(|m| m.id.clone()).collect()
-    }
-
-    /// Get model pricing information
-    pub fn get_model_pricing(&self, model_id: &str) -> Option<(f64, f64)> {
-        if let Ok(pricing) = crate::core::cost::calculator::get_model_pricing(model_id, "openai") {
-            return Some((
-                pricing.input_cost_per_1k_tokens,
-                pricing.output_cost_per_1k_tokens,
-            ));
-        }
-
-        if let Some(model_info) = self
-            .model_registry
-            .get_model_spec(model_id)
-            .map(|spec| &spec.model_info)
-            && let (Some(input_cost), Some(output_cost)) = (
-                model_info.input_cost_per_1k_tokens,
-                model_info.output_cost_per_1k_tokens,
-            )
-        {
-            return Some((input_cost, output_cost));
-        }
-        None
-    }
-
-    /// Get model context window information
-    pub fn get_model_context_window(&self, model_id: &str) -> Result<u32, ProviderError> {
-        let model_info = self.get_model_info(model_id)?;
-        Ok(model_info.max_context_length)
-    }
-
-    /// Check if model supports vision/multimodal input
-    pub fn model_supports_vision(&self, model_id: &str) -> bool {
-        self.model_supports_feature(model_id, &OpenAIModelFeature::VisionSupport)
-    }
-
-    /// Check if model supports function/tool calling
-    pub fn model_supports_tools(&self, model_id: &str) -> bool {
-        self.model_supports_feature(model_id, &OpenAIModelFeature::FunctionCalling)
-    }
-
-    /// Check if model supports streaming
-    pub fn model_supports_streaming(&self, model_id: &str) -> bool {
-        self.model_supports_feature(model_id, &OpenAIModelFeature::StreamingSupport)
-    }
-
-    /// Get best model for specific task
-    pub fn get_best_model_for_task(&self, task: OpenAITask) -> Option<String> {
-        match task {
-            OpenAITask::GeneralChat => self.get_recommended_model(OpenAIUseCase::GeneralChat),
-            OpenAITask::CodeGeneration => self.get_recommended_model(OpenAIUseCase::CodeGeneration),
-            OpenAITask::ComplexReasoning => self.get_recommended_model(OpenAIUseCase::Reasoning),
-            OpenAITask::VisionAnalysis => self.get_recommended_model(OpenAIUseCase::Vision),
-            OpenAITask::ImageGeneration => {
-                self.get_recommended_model(OpenAIUseCase::ImageGeneration)
-            }
-            OpenAITask::AudioTranscription => {
-                self.get_recommended_model(OpenAIUseCase::AudioTranscription)
-            }
-            OpenAITask::Embeddings => self.get_recommended_model(OpenAIUseCase::Embeddings),
-            OpenAITask::CostSensitive => self.get_recommended_model(OpenAIUseCase::CostOptimized),
-        }
-    }
-}
-
-/// OpenAI task categories for model selection
-#[derive(Debug, Clone)]
-pub enum OpenAITask {
-    GeneralChat,
-    CodeGeneration,
-    ComplexReasoning,
-    VisionAnalysis,
-    ImageGeneration,
-    AudioTranscription,
-    Embeddings,
-    CostSensitive,
-}

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -366,6 +366,8 @@ impl LLMProvider for OpenAIProvider {
             ProviderCapability::Embeddings,
             ProviderCapability::ImageGeneration,
             ProviderCapability::AudioTranscription,
+            ProviderCapability::AudioTranslation,
+            ProviderCapability::TextToSpeech,
             ProviderCapability::ToolCalling,
             ProviderCapability::FunctionCalling,
             // New capabilities

--- a/src/core/providers/openai/client_convenience.rs
+++ b/src/core/providers/openai/client_convenience.rs
@@ -1,0 +1,107 @@
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+use super::client::OpenAIProvider;
+use super::models::{OpenAIModelFamily, OpenAIModelFeature, OpenAIUseCase, get_openai_registry};
+
+impl OpenAIProvider {
+    /// Get model recommendations for specific use cases
+    pub fn get_recommended_model(&self, use_case: OpenAIUseCase) -> Option<String> {
+        get_openai_registry().get_recommended_model(use_case)
+    }
+
+    /// Check if a model supports a specific feature
+    pub fn model_supports_feature(&self, model_id: &str, feature: &OpenAIModelFeature) -> bool {
+        get_openai_registry().supports_feature(model_id, feature)
+    }
+
+    /// Get models by family (e.g., all GPT-4 variants)
+    pub fn get_models_by_family(&self, family: &OpenAIModelFamily) -> Vec<String> {
+        get_openai_registry().get_models_by_family(family)
+    }
+
+    /// Get models supporting specific feature
+    pub fn get_models_with_feature(&self, feature: &OpenAIModelFeature) -> Vec<String> {
+        get_openai_registry().get_models_with_feature(feature)
+    }
+
+    /// List available models from static registry
+    pub fn list_available_models(&self) -> Vec<String> {
+        self.models().iter().map(|m| m.id.clone()).collect()
+    }
+
+    /// Get model pricing information
+    pub fn get_model_pricing(&self, model_id: &str) -> Option<(f64, f64)> {
+        if let Ok(pricing) = crate::core::cost::calculator::get_model_pricing(model_id, "openai") {
+            return Some((
+                pricing.input_cost_per_1k_tokens,
+                pricing.output_cost_per_1k_tokens,
+            ));
+        }
+
+        if let Some(model_info) = self
+            .model_registry
+            .get_model_spec(model_id)
+            .map(|spec| &spec.model_info)
+            && let (Some(input_cost), Some(output_cost)) = (
+                model_info.input_cost_per_1k_tokens,
+                model_info.output_cost_per_1k_tokens,
+            )
+        {
+            return Some((input_cost, output_cost));
+        }
+        None
+    }
+
+    /// Get model context window information
+    pub fn get_model_context_window(&self, model_id: &str) -> Result<u32, ProviderError> {
+        let model_info = self.get_model_info(model_id)?;
+        Ok(model_info.max_context_length)
+    }
+
+    /// Check if model supports vision/multimodal input
+    pub fn model_supports_vision(&self, model_id: &str) -> bool {
+        self.model_supports_feature(model_id, &OpenAIModelFeature::VisionSupport)
+    }
+
+    /// Check if model supports function/tool calling
+    pub fn model_supports_tools(&self, model_id: &str) -> bool {
+        self.model_supports_feature(model_id, &OpenAIModelFeature::FunctionCalling)
+    }
+
+    /// Check if model supports streaming
+    pub fn model_supports_streaming(&self, model_id: &str) -> bool {
+        self.model_supports_feature(model_id, &OpenAIModelFeature::StreamingSupport)
+    }
+
+    /// Get best model for specific task
+    pub fn get_best_model_for_task(&self, task: OpenAITask) -> Option<String> {
+        match task {
+            OpenAITask::GeneralChat => self.get_recommended_model(OpenAIUseCase::GeneralChat),
+            OpenAITask::CodeGeneration => self.get_recommended_model(OpenAIUseCase::CodeGeneration),
+            OpenAITask::ComplexReasoning => self.get_recommended_model(OpenAIUseCase::Reasoning),
+            OpenAITask::VisionAnalysis => self.get_recommended_model(OpenAIUseCase::Vision),
+            OpenAITask::ImageGeneration => {
+                self.get_recommended_model(OpenAIUseCase::ImageGeneration)
+            }
+            OpenAITask::AudioTranscription => {
+                self.get_recommended_model(OpenAIUseCase::AudioTranscription)
+            }
+            OpenAITask::Embeddings => self.get_recommended_model(OpenAIUseCase::Embeddings),
+            OpenAITask::CostSensitive => self.get_recommended_model(OpenAIUseCase::CostOptimized),
+        }
+    }
+}
+
+/// OpenAI task categories for model selection
+#[derive(Debug, Clone)]
+pub enum OpenAITask {
+    GeneralChat,
+    CodeGeneration,
+    ComplexReasoning,
+    VisionAnalysis,
+    ImageGeneration,
+    AudioTranscription,
+    Embeddings,
+    CostSensitive,
+}

--- a/src/core/providers/openai/mod.rs
+++ b/src/core/providers/openai/mod.rs
@@ -8,6 +8,7 @@
 
 mod api_methods;
 pub mod client;
+mod client_convenience;
 #[cfg(test)]
 mod client_tests;
 pub mod config;

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -132,6 +132,7 @@ impl OpenAIModelRegistry {
 
         if model_id.starts_with("whisper") {
             features.push(OpenAIModelFeature::AudioTranscription);
+            features.push(OpenAIModelFeature::AudioTranslation);
         }
 
         if model_id.starts_with("tts") {
@@ -645,6 +646,8 @@ mod tests {
         assert!(registry.supports_feature("gpt-audio-1.5", &OpenAIModelFeature::AudioInput));
         assert!(registry.supports_feature("gpt-audio-1.5", &OpenAIModelFeature::AudioOutput));
         assert!(!registry.supports_feature("gpt-audio-1.5", &OpenAIModelFeature::VisionSupport));
+        assert!(registry.supports_feature("whisper-1", &OpenAIModelFeature::AudioTranscription));
+        assert!(registry.supports_feature("whisper-1", &OpenAIModelFeature::AudioTranslation));
     }
 
     #[test]

--- a/src/core/providers/openai/models/registry_types.rs
+++ b/src/core/providers/openai/models/registry_types.rs
@@ -37,6 +37,8 @@ pub enum OpenAIModelFeature {
     ImageEditing,
     /// Audio transcription
     AudioTranscription,
+    /// Audio translation
+    AudioTranslation,
     /// Fine-tuning support
     FineTuning,
     /// Embeddings generation
@@ -58,6 +60,7 @@ impl OpenAIModelFeature {
             OpenAIModelFeature::FunctionCalling => Some(ProviderCapability::ToolCalling),
             OpenAIModelFeature::ImageGeneration => Some(ProviderCapability::ImageGeneration),
             OpenAIModelFeature::AudioTranscription => Some(ProviderCapability::AudioTranscription),
+            OpenAIModelFeature::AudioTranslation => Some(ProviderCapability::AudioTranslation),
             OpenAIModelFeature::Embeddings => Some(ProviderCapability::Embeddings),
             OpenAIModelFeature::AudioOutput => Some(ProviderCapability::TextToSpeech),
             OpenAIModelFeature::ImageEditing => Some(ProviderCapability::ImageEdit),

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -155,7 +155,10 @@ impl Router {
         self.select_deployment_matching(
             model_name,
             |deployment| {
-                deployment.provider.supports_capability(capability) && is_candidate(deployment)
+                deployment
+                    .provider
+                    .supports_capability_for_model(&deployment.model, capability)
+                    && is_candidate(deployment)
             },
             Some(no_matching_candidate_error),
         )

--- a/src/core/router/tests/selection_tests.rs
+++ b/src/core/router/tests/selection_tests.rs
@@ -146,13 +146,13 @@ async fn test_capability_selection_reports_unsupported_capability() {
     router.add_deployment(d);
 
     let err = router
-        .select_deployment_for_capability("shared-model", &ProviderCapability::TextToSpeech)
+        .select_deployment_for_capability("shared-model", &ProviderCapability::CodeExecution)
         .expect_err("unsupported capability should not look unavailable");
 
     assert!(matches!(
         err,
         RouterError::UnsupportedCapability { model, capability }
-            if model == "shared-model" && capability == "TextToSpeech"
+            if model == "shared-model" && capability == "CodeExecution"
     ));
 }
 

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -390,7 +390,10 @@ impl Router {
                 continue;
             }
 
-            if deployment.provider.supports_capability(capability) {
+            if deployment
+                .provider
+                .supports_capability_for_model(&deployment.model, capability)
+            {
                 return Some(CapabilityDeployment {
                     deployment_id: id.clone(),
                     provider: deployment.provider.clone(),

--- a/src/core/traits/provider/llm_provider/trait_definition.rs
+++ b/src/core/traits/provider/llm_provider/trait_definition.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::pin::Pin;
 
+use crate::core::audio::types::{
+    SpeechRequest, SpeechResponse, TranscriptionRequest, TranscriptionResponse, TranslationRequest,
+    TranslationResponse,
+};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 use crate::core::types::{
@@ -376,6 +380,51 @@ pub trait LLMProvider: Send + Sync + Debug + 'static {
         Err(ProviderError::not_supported(
             self.error_provider_name(),
             "image_generation",
+        ))
+    }
+
+    /// Transcribe audio to text.
+    ///
+    /// Route selection must confirm `ProviderCapability::AudioTranscription`
+    /// before calling this optional dispatch method.
+    async fn audio_transcription(
+        &self,
+        _request: TranscriptionRequest,
+        _context: RequestContext,
+    ) -> Result<TranscriptionResponse, ProviderError> {
+        Err(ProviderError::not_supported(
+            self.error_provider_name(),
+            "audio_transcription",
+        ))
+    }
+
+    /// Translate audio to English text.
+    ///
+    /// Route selection must confirm `ProviderCapability::AudioTranslation`
+    /// before calling this optional dispatch method.
+    async fn audio_translation(
+        &self,
+        _request: TranslationRequest,
+        _context: RequestContext,
+    ) -> Result<TranslationResponse, ProviderError> {
+        Err(ProviderError::not_supported(
+            self.error_provider_name(),
+            "audio_translation",
+        ))
+    }
+
+    /// Generate speech audio from text.
+    ///
+    /// Route selection must confirm `ProviderCapability::TextToSpeech` before
+    /// calling this optional dispatch method.
+    async fn text_to_speech(
+        &self,
+        _request: SpeechRequest,
+        _context: RequestContext,
+    ) -> Result<SpeechResponse, ProviderError> {
+        Err(ProviderError::not_supported(
+            self.error_provider_name(),
+            "text_to_speech",
         ))
     }
 

--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -1,6 +1,5 @@
 //! Audio speech endpoint (text-to-speech)
 
-use crate::core::audio::AudioService;
 use crate::core::audio::types::SpeechRequest;
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
@@ -8,9 +7,9 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde::Deserialize;
 use tracing::{error, info};
 
+use super::super::execution::execute_with_selected_deployment;
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
-use crate::server::routes::ai::provider_selection::select_provider_for_model;
 
 /// Audio speech generation request
 #[derive(Debug, Deserialize)]
@@ -48,35 +47,46 @@ pub async fn audio_speech(
     );
 
     // Get request context (validates auth)
-    let _context = match get_request_context(&req) {
+    let context = match get_request_context(&req) {
         Ok(ctx) => ctx,
         Err(_) => {
             return Ok(openai_errors::unauthorized_error("Unauthorized"));
         }
     };
 
-    let unified_router = &state.unified_router;
-
-    let selected_model = match select_provider_for_model(
-        unified_router,
-        &request.model,
-        ProviderCapability::TextToSpeech,
-    ) {
-        Ok(selection) => selection,
-        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
-    };
+    if request.input.len() > 4096 {
+        return Ok(openai_errors::validation_error(
+            "Input text too long (max 4096 characters)",
+        ));
+    }
 
     let speech_request = SpeechRequest {
         input: request.input.clone(),
-        model: selected_model,
+        model: request.model.clone(),
         voice: request.voice.clone(),
         response_format: request.response_format.clone(),
         speed: request.speed,
     };
 
-    let audio_service = AudioService::new();
+    let requested_model = request.model.clone();
+    let context_for_execution = context.clone();
 
-    match audio_service.speech(speech_request).await {
+    match execute_with_selected_deployment(
+        &state.unified_router,
+        &requested_model,
+        ProviderCapability::TextToSpeech,
+        move |provider, selected_model| {
+            let mut request = speech_request.clone();
+            let context = context_for_execution.clone();
+            async move {
+                request.model = selected_model;
+                let response = provider.text_to_speech(request, context).await?;
+                Ok((response, 0))
+            }
+        },
+    )
+    .await
+    {
         Ok(response) => Ok(HttpResponse::Ok()
             .content_type(response.content_type)
             .body(response.audio)),

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -1,6 +1,5 @@
 //! Audio transcriptions endpoint
 
-use crate::core::audio::AudioService;
 use crate::core::audio::types::TranscriptionRequest;
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
@@ -9,10 +8,12 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
-use super::upload::{drain_field, read_audio_file, read_text_field, upload_error_response};
+use super::super::execution::execute_with_selected_deployment;
+use super::upload::{
+    drain_field, raw_response_format_error, read_audio_file, read_text_field, upload_error_response,
+};
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
-use crate::server::routes::ai::provider_selection::select_provider_for_model;
 
 /// Audio transcriptions endpoint
 ///
@@ -26,7 +27,7 @@ pub async fn audio_transcriptions(
     info!("Audio transcriptions request");
 
     // Get request context (validates auth)
-    let _context = match get_request_context(&req) {
+    let context = match get_request_context(&req) {
         Ok(ctx) => ctx,
         Err(_) => {
             return Ok(openai_errors::unauthorized_error("Unauthorized"));
@@ -123,22 +124,15 @@ pub async fn audio_transcriptions(
         }
     };
 
-    let unified_router = &state.unified_router;
-
-    let selected_model = match select_provider_for_model(
-        unified_router,
-        &model,
-        ProviderCapability::AudioTranscription,
-    ) {
-        Ok(selection) => selection,
-        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
-    };
+    if let Some(error_response) = raw_response_format_error(response_format.as_deref()) {
+        return Ok(error_response);
+    }
 
     // Create transcription request
     let transcription_request = TranscriptionRequest {
         file,
         filename,
-        model: selected_model,
+        model: model.clone(),
         language,
         prompt,
         response_format,
@@ -146,10 +140,25 @@ pub async fn audio_transcriptions(
         timestamp_granularities: None,
     };
 
-    // Create audio service and process request
-    let audio_service = AudioService::new();
+    let requested_model = model;
+    let context_for_execution = context.clone();
 
-    match audio_service.transcribe(transcription_request).await {
+    match execute_with_selected_deployment(
+        &state.unified_router,
+        &requested_model,
+        ProviderCapability::AudioTranscription,
+        move |provider, selected_model| {
+            let mut request = transcription_request.clone();
+            let context = context_for_execution.clone();
+            async move {
+                request.model = selected_model;
+                let response = provider.audio_transcription(request, context).await?;
+                Ok((response, 0))
+            }
+        },
+    )
+    .await
+    {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(e) => {
             error!("Transcription error: {}", e);

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -10,7 +10,8 @@ use tracing::{error, info};
 
 use super::super::execution::execute_with_selected_deployment;
 use super::upload::{
-    drain_field, raw_response_format_error, read_audio_file, read_text_field, upload_error_response,
+    drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
+    read_text_field, upload_error_response,
 };
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
@@ -101,11 +102,10 @@ pub async fn audio_transcriptions(
                 Err(e) => return Ok(upload_error_response(e)),
             },
             "temperature" => match read_text_field(&mut field).await {
-                Ok(value) => {
-                    if let Ok(temp) = value.parse::<f32>() {
-                        temperature = Some(temp);
-                    }
-                }
+                Ok(value) => match parse_optional_f32_field("temperature", &value) {
+                    Ok(parsed) => temperature = parsed,
+                    Err(response) => return Ok(response),
+                },
                 Err(e) => return Ok(upload_error_response(e)),
             },
             _ => {

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -10,7 +10,8 @@ use tracing::{error, info};
 
 use super::super::execution::execute_with_selected_deployment;
 use super::upload::{
-    drain_field, raw_response_format_error, read_audio_file, read_text_field, upload_error_response,
+    drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
+    read_text_field, upload_error_response,
 };
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
@@ -93,11 +94,10 @@ pub async fn audio_translations(
                 Err(e) => return Ok(upload_error_response(e)),
             },
             "temperature" => match read_text_field(&mut field).await {
-                Ok(value) => {
-                    if let Ok(temp) = value.parse::<f32>() {
-                        temperature = Some(temp);
-                    }
-                }
+                Ok(value) => match parse_optional_f32_field("temperature", &value) {
+                    Ok(parsed) => temperature = parsed,
+                    Err(response) => return Ok(response),
+                },
                 Err(e) => return Ok(upload_error_response(e)),
             },
             _ => {

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -1,6 +1,5 @@
 //! Audio translations endpoint
 
-use crate::core::audio::AudioService;
 use crate::core::audio::types::TranslationRequest;
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
@@ -9,10 +8,12 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
-use super::upload::{drain_field, read_audio_file, read_text_field, upload_error_response};
+use super::super::execution::execute_with_selected_deployment;
+use super::upload::{
+    drain_field, raw_response_format_error, read_audio_file, read_text_field, upload_error_response,
+};
 use crate::server::routes::ai::context::get_request_context;
 use crate::server::routes::ai::openai_errors;
-use crate::server::routes::ai::provider_selection::select_provider_for_model;
 
 /// Audio translations endpoint
 ///
@@ -26,7 +27,7 @@ pub async fn audio_translations(
     info!("Audio translations request");
 
     // Get request context (validates auth)
-    let _context = match get_request_context(&req) {
+    let context = match get_request_context(&req) {
         Ok(ctx) => ctx,
         Err(_) => {
             return Ok(openai_errors::unauthorized_error("Unauthorized"));
@@ -114,29 +115,38 @@ pub async fn audio_translations(
         }
     };
 
-    let unified_router = &state.unified_router;
-
-    let selected_model = match select_provider_for_model(
-        unified_router,
-        &model,
-        ProviderCapability::AudioTranslation,
-    ) {
-        Ok(selection) => selection,
-        Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
-    };
+    if let Some(error_response) = raw_response_format_error(response_format.as_deref()) {
+        return Ok(error_response);
+    }
 
     let translation_request = TranslationRequest {
         file,
         filename,
-        model: selected_model,
+        model: model.clone(),
         prompt,
         response_format,
         temperature,
     };
 
-    let audio_service = AudioService::new();
+    let requested_model = model;
+    let context_for_execution = context.clone();
 
-    match audio_service.translate(translation_request).await {
+    match execute_with_selected_deployment(
+        &state.unified_router,
+        &requested_model,
+        ProviderCapability::AudioTranslation,
+        move |provider, selected_model| {
+            let mut request = translation_request.clone();
+            let context = context_for_execution.clone();
+            async move {
+                request.model = selected_model;
+                let response = provider.audio_translation(request, context).await?;
+                Ok((response, 0))
+            }
+        },
+    )
+    .await
+    {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(e) => {
             error!("Translation error: {}", e);

--- a/src/server/routes/ai/audio/upload.rs
+++ b/src/server/routes/ai/audio/upload.rs
@@ -32,6 +32,17 @@ pub(super) fn upload_error_response(error: AudioUploadError) -> HttpResponse {
     }
 }
 
+pub(super) fn raw_response_format_error(response_format: Option<&str>) -> Option<HttpResponse> {
+    let response_format = response_format?;
+    match response_format.to_ascii_lowercase().as_str() {
+        "text" | "srt" | "vtt" => Some(openai_errors::validation_error(format!(
+            "response_format '{}' requires raw response passthrough, which is not supported yet",
+            response_format
+        ))),
+        _ => None,
+    }
+}
+
 fn ensure_field_within_limit(
     current_size: usize,
     chunk_size: usize,

--- a/src/server/routes/ai/audio/upload.rs
+++ b/src/server/routes/ai/audio/upload.rs
@@ -43,6 +43,19 @@ pub(super) fn raw_response_format_error(response_format: Option<&str>) -> Option
     }
 }
 
+pub(super) fn parse_optional_f32_field(
+    field_name: &str,
+    value: &str,
+) -> Result<Option<f32>, HttpResponse> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    value.parse::<f32>().map(Some).map_err(|_| {
+        openai_errors::validation_error(format!("{field_name} must be a valid number"))
+    })
+}
+
 fn ensure_field_within_limit(
     current_size: usize,
     chunk_size: usize,

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -499,7 +499,7 @@ mod tests {
         let err = execute_with_selected_deployment(
             &router,
             "shared-model",
-            ProviderCapability::TextToSpeech,
+            ProviderCapability::CodeExecution,
             |_provider, _model| async { Ok::<_, ProviderError>(("should not run", 0)) },
         )
         .await

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -13,6 +13,7 @@ mod files;
 mod images;
 mod models;
 mod openai_errors;
+#[cfg(test)]
 mod provider_selection;
 mod responses;
 mod responses_stream;

--- a/src/server/routes/ai/provider_selection.rs
+++ b/src/server/routes/ai/provider_selection.rs
@@ -13,8 +13,6 @@ pub fn select_provider_for_model(
         return Err(GatewayError::validation("Model is required"));
     }
 
-    reject_unimplemented_route_capability(&capability)?;
-
     let deployments = router.get_deployments_for_model(model);
     let supports_capability = deployments.iter().any(|deployment_id| {
         router
@@ -42,19 +40,6 @@ pub fn select_provider_for_model(
     Ok(deployment.model)
 }
 
-fn reject_unimplemented_route_capability(
-    capability: &ProviderCapability,
-) -> Result<(), GatewayError> {
-    match capability {
-        ProviderCapability::AudioTranscription
-        | ProviderCapability::AudioTranslation
-        | ProviderCapability::TextToSpeech => Err(GatewayError::not_implemented(
-            "Audio routes are not wired to provider execution yet",
-        )),
-        _ => Ok(()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,6 +61,30 @@ mod tests {
             provider,
             "text-embedding-3-small".to_string(),
             "embedding-model".to_string(),
+        ));
+
+        router
+    }
+
+    async fn build_audio_router() -> UnifiedRouter {
+        let router = UnifiedRouter::default();
+        let provider = Provider::OpenAI(
+            OpenAIProvider::with_api_key("sk-test-key")
+                .await
+                .expect("test provider should build"),
+        );
+
+        router.add_deployment(Deployment::new(
+            "whisper-1".to_string(),
+            provider.clone(),
+            "whisper-1".to_string(),
+            "whisper-1".to_string(),
+        ));
+        router.add_deployment(Deployment::new(
+            "tts-1".to_string(),
+            provider,
+            "tts-1".to_string(),
+            "tts-1".to_string(),
         ));
 
         router
@@ -115,16 +124,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_provider_for_model_rejects_audio_capability_before_selection() {
-        let router = build_embeddings_router().await;
+    async fn select_provider_for_model_routes_audio_capabilities() {
+        let router = build_audio_router().await;
 
-        let err = select_provider_for_model(
-            &router,
-            "embedding-model",
-            ProviderCapability::AudioTranscription,
-        )
-        .expect_err("audio capabilities should fail closed until provider execution is wired");
+        let transcription =
+            select_provider_for_model(&router, "whisper-1", ProviderCapability::AudioTranscription)
+                .expect("audio transcription should route through a capable provider");
+        let translation =
+            select_provider_for_model(&router, "whisper-1", ProviderCapability::AudioTranslation)
+                .expect("audio translation should route through a capable provider");
+        let speech = select_provider_for_model(&router, "tts-1", ProviderCapability::TextToSpeech)
+            .expect("text-to-speech should route through a capable provider");
 
-        assert!(matches!(err, GatewayError::NotImplemented(_)));
+        assert_eq!(transcription, "whisper-1");
+        assert_eq!(translation, "whisper-1");
+        assert_eq!(speech, "tts-1");
     }
 }

--- a/src/server/routes/ai/provider_selection.rs
+++ b/src/server/routes/ai/provider_selection.rs
@@ -17,7 +17,11 @@ pub fn select_provider_for_model(
     let supports_capability = deployments.iter().any(|deployment_id| {
         router
             .get_deployment(deployment_id)
-            .map(|deployment| deployment.provider.supports_capability(&capability))
+            .map(|deployment| {
+                deployment
+                    .provider
+                    .supports_capability_for_model(&deployment.model, &capability)
+            })
             .unwrap_or(false)
     });
 

--- a/tests/audio_routes.rs
+++ b/tests/audio_routes.rs
@@ -136,6 +136,14 @@ mod tests {
     }
 
     async fn build_audio_state(base_url: &str) -> litellm_rs::server::state::AppState {
+        build_audio_state_with_models(base_url, vec!["whisper-1".to_string(), "tts-1".to_string()])
+            .await
+    }
+
+    async fn build_audio_state_with_models(
+        base_url: &str,
+        models: Vec<String>,
+    ) -> litellm_rs::server::state::AppState {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
@@ -148,7 +156,7 @@ mod tests {
             provider_type: "openai".to_string(),
             api_key: "sk-test".to_string(),
             base_url: Some(base_url.to_string()),
-            models: vec!["whisper-1".to_string(), "tts-1".to_string()],
+            models,
             ..ProviderConfig::default()
         }];
 
@@ -165,11 +173,29 @@ mod tests {
         filename: &str,
         file_content: &[u8],
     ) -> Vec<u8> {
+        audio_multipart_body_with_fields(boundary, model, filename, file_content, &[])
+    }
+
+    fn audio_multipart_body_with_fields(
+        boundary: &str,
+        model: &str,
+        filename: &str,
+        file_content: &[u8],
+        fields: &[(&str, &str)],
+    ) -> Vec<u8> {
         let mut body = Vec::new();
         body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
         body.extend_from_slice(b"Content-Disposition: form-data; name=\"model\"\r\n\r\n");
         body.extend_from_slice(model.as_bytes());
         body.extend_from_slice(b"\r\n");
+        for (name, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
         body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
         body.extend_from_slice(
             format!("Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n")
@@ -312,6 +338,81 @@ mod tests {
         assert_eq!(forwarded["model"], "tts-1");
         assert_eq!(forwarded["input"], "hello from litellm rs");
         assert_eq!(forwarded["voice"], "alloy");
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn audio_speech_rejects_non_tts_openai_model_before_provider_call() {
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state_with_models(&mock.base_url, vec!["gpt-4".to_string()]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/audio/speech")
+            .set_json(json!({
+                "model": "gpt-4",
+                "input": "hello from litellm rs",
+                "voice": "alloy"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            mock.requests().is_empty(),
+            "unsupported model must fail before provider execution"
+        );
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn audio_routes_reject_invalid_temperature_before_provider_call() {
+        assert_invalid_temperature_rejected("/v1/audio/transcriptions").await;
+        assert_invalid_temperature_rejected("/v1/audio/translations").await;
+    }
+
+    async fn assert_invalid_temperature_rejected(uri: &str) {
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state(&mock.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-audio-boundary";
+
+        let req = test::TestRequest::post()
+            .uri(uri)
+            .insert_header((
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(audio_multipart_body_with_fields(
+                boundary,
+                "whisper-1",
+                "sample.mp3",
+                b"audio-bytes",
+                &[("temperature", "not-a-number")],
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["error"]["message"],
+            "temperature must be a valid number"
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "invalid temperature must fail before provider execution"
+        );
         mock.shutdown().await;
     }
 }

--- a/tests/audio_routes.rs
+++ b/tests/audio_routes.rs
@@ -59,7 +59,7 @@ mod tests {
             .run();
             let handle = server.handle();
             let task = tokio::spawn(server);
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            wait_for_server(address).await;
 
             Self {
                 base_url: format!("http://{address}"),
@@ -80,6 +80,16 @@ mod tests {
                 panic!("mock server should stop cleanly: {error}");
             }
         }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
     }
 
     async fn mock_audio_transcriptions(

--- a/tests/audio_routes.rs
+++ b/tests/audio_routes.rs
@@ -1,0 +1,317 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone, Debug)]
+    struct CapturedAudioRequest {
+        method: String,
+        path: String,
+        headers: HashMap<String, String>,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    struct MockAudioState {
+        captured_requests: Arc<Mutex<Vec<CapturedAudioRequest>>>,
+    }
+
+    struct MockAudioServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedAudioRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockAudioServer {
+        async fn start() -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockAudioState {
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .route(
+                        "/audio/transcriptions",
+                        web::post().to(mock_audio_transcriptions),
+                    )
+                    .route(
+                        "/audio/translations",
+                        web::post().to(mock_audio_translations),
+                    )
+                    .route("/audio/speech", web::post().to(mock_audio_speech))
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            tokio::time::sleep(Duration::from_millis(20)).await;
+
+            Self {
+                base_url: format!("http://{address}"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedAudioRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn shutdown(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn mock_audio_transcriptions(
+        state: web::Data<MockAudioState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({ "text": "mock transcript" }))
+    }
+
+    async fn mock_audio_translations(
+        state: web::Data<MockAudioState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({ "text": "mock translation" }))
+    }
+
+    async fn mock_audio_speech(
+        state: web::Data<MockAudioState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok()
+            .insert_header(("Content-Type", "audio/mpeg"))
+            .body(Bytes::from_static(b"mock-audio"))
+    }
+
+    fn capture_request(state: &MockAudioState, request: &HttpRequest, body: Bytes) {
+        let headers = request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect();
+
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedAudioRequest {
+                method: request.method().to_string(),
+                path: request.path().to_string(),
+                headers,
+                body: body.to_vec(),
+            });
+    }
+
+    async fn build_audio_state(base_url: &str) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.providers = vec![ProviderConfig {
+            name: "mock-openai-audio".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            models: vec!["whisper-1".to_string(), "tts-1".to_string()],
+            ..ProviderConfig::default()
+        }];
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn audio_multipart_body(
+        boundary: &str,
+        model: &str,
+        filename: &str,
+        file_content: &[u8],
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"model\"\r\n\r\n");
+        body.extend_from_slice(model.as_bytes());
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: audio/mpeg\r\n\r\n");
+        body.extend_from_slice(file_content);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    #[tokio::test]
+    async fn audio_transcriptions_route_executes_openai_provider() {
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state(&mock.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-audio-boundary";
+
+        let req = test::TestRequest::post()
+            .uri("/v1/audio/transcriptions")
+            .insert_header((
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(audio_multipart_body(
+                boundary,
+                "whisper-1",
+                "sample.mp3",
+                b"audio-bytes",
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["text"], "mock transcript");
+
+        let captured = mock.requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].method, "POST");
+        assert_eq!(captured[0].path, "/audio/transcriptions");
+        assert!(
+            captured[0]
+                .headers
+                .get("content-type")
+                .expect("multipart content type")
+                .contains("multipart/form-data")
+        );
+        let multipart_body = String::from_utf8_lossy(&captured[0].body);
+        assert!(multipart_body.contains("name=\"model\""));
+        assert!(multipart_body.contains("whisper-1"));
+        assert!(multipart_body.contains("filename=\"sample.mp3\""));
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn audio_translations_route_executes_openai_provider() {
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state(&mock.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-audio-boundary";
+
+        let req = test::TestRequest::post()
+            .uri("/v1/audio/translations")
+            .insert_header((
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(audio_multipart_body(
+                boundary,
+                "whisper-1",
+                "sample.mp3",
+                b"audio-bytes",
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["text"], "mock translation");
+
+        let captured = mock.requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].path, "/audio/translations");
+        let multipart_body = String::from_utf8_lossy(&captured[0].body);
+        assert!(multipart_body.contains("whisper-1"));
+        assert!(multipart_body.contains("filename=\"sample.mp3\""));
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn audio_speech_route_executes_openai_provider() {
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state(&mock.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/audio/speech")
+            .set_json(json!({
+                "model": "tts-1",
+                "input": "hello from litellm rs",
+                "voice": "alloy",
+                "response_format": "mp3"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("audio/mpeg")
+        );
+        let body = test::read_body(resp).await;
+        assert_eq!(body.as_ref(), b"mock-audio");
+
+        let captured = mock.requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].method, "POST");
+        assert_eq!(captured[0].path, "/audio/speech");
+        let forwarded: Value =
+            serde_json::from_slice(&captured[0].body).expect("speech request should be json");
+        assert_eq!(forwarded["model"], "tts-1");
+        assert_eq!(forwarded["input"], "hello from litellm rs");
+        assert_eq!(forwarded["voice"], "alloy");
+        mock.shutdown().await;
+    }
+}


### PR DESCRIPTION
## Summary
- wire audio transcription, translation, and speech routes through router-selected provider execution
- add OpenAI audio transcription/translation/speech provider calls
- add audio route integration tests with a mock OpenAI server

## Verification
- cargo fmt --all -- --check
- cargo test --all-features --locked provider_selection --lib --quiet
- cargo test --all-features --locked --test audio_routes --quiet
- cargo test --all-features --locked test_realtime_and_audio_capabilities --lib --quiet
- cargo check --all-features --locked
- cargo test --all-features --locked

Fixes #742