### PR TITLE
Fix fine-tuning HTTP API

### DIFF
--- a/src/core/fine_tuning/providers/openai.rs
+++ b/src/core/fine_tuning/providers/openai.rs
@@ -3,8 +3,11 @@
 //! Implementation of fine-tuning for OpenAI API.
 
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest::{Client, Method, Url, header::RETRY_AFTER};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use tracing::{debug, warn};
 
@@ -16,28 +19,38 @@ use crate::core::fine_tuning::types::{
 };
 use crate::utils::net::http::create_custom_client;
 
+static CLIENTS_BY_TIMEOUT: OnceLock<Mutex<HashMap<u64, Client>>> = OnceLock::new();
+
 /// OpenAI fine-tuning provider
 pub struct OpenAIFineTuningProvider {
     config: ProviderFineTuningConfig,
     client: Client,
     api_base: String,
+    provider_name: String,
 }
 
 impl OpenAIFineTuningProvider {
     /// Create a new OpenAI fine-tuning provider
     pub fn new(config: ProviderFineTuningConfig) -> Self {
-        let client =
-            create_custom_client(Duration::from_secs(config.timeout_seconds)).unwrap_or_default();
+        Self::new_named(config, "openai")
+    }
+
+    /// Create a new OpenAI-compatible fine-tuning provider with a gateway provider name.
+    pub fn new_named(config: ProviderFineTuningConfig, provider_name: impl Into<String>) -> Self {
+        let client = shared_client(config.timeout_seconds);
 
         let api_base = config
             .api_base
             .clone()
-            .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+            .unwrap_or_else(|| "https://api.openai.com/v1".to_string())
+            .trim_end_matches('/')
+            .to_string();
 
         Self {
             config,
             client,
             api_base,
+            provider_name: provider_name.into(),
         }
     }
 
@@ -60,19 +73,35 @@ impl OpenAIFineTuningProvider {
             .ok_or_else(|| FineTuningError::auth("No API key configured"))
     }
 
+    /// Build a provider endpoint URL without concatenating untrusted path segments.
+    fn endpoint_url(&self, segments: &[&str]) -> FineTuningResult<Url> {
+        let mut url = Url::parse(&self.api_base)
+            .map_err(|e| FineTuningError::provider(format!("Invalid API base URL: {}", e)))?;
+        {
+            let mut path_segments = url.path_segments_mut().map_err(|_| {
+                FineTuningError::provider("API base URL cannot accept path segments")
+            })?;
+            for segment in segments {
+                path_segments.push(segment);
+            }
+        }
+        Ok(url)
+    }
+
     /// Make an authenticated request
-    async fn request<T: for<'de> Deserialize<'de>>(
+    async fn request<T: DeserializeOwned>(
         &self,
-        method: reqwest::Method,
-        path: &str,
-        body: Option<impl Serialize>,
+        method: Method,
+        url: Url,
+        body: Option<serde_json::Value>,
+        not_found_job_id: Option<&str>,
     ) -> FineTuningResult<T> {
-        let url = format!("{}{}", self.api_base, path);
         let auth = self.auth_header()?;
+        let request_url = url.to_string();
 
         let mut request = self
             .client
-            .request(method, &url)
+            .request(method, url)
             .header("Authorization", auth);
 
         // Add organization header if configured
@@ -90,7 +119,7 @@ impl OpenAIFineTuningProvider {
             request = request.json(&body);
         }
 
-        debug!("OpenAI fine-tuning request: {}", url);
+        debug!("OpenAI fine-tuning request: {}", request_url);
 
         let response = request
             .send()
@@ -105,6 +134,12 @@ impl OpenAIFineTuningProvider {
                 .await
                 .map_err(|e| FineTuningError::other(format!("Failed to parse response: {}", e)))
         } else {
+            let retry_after_seconds = response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(60);
             let error_text = response.text().await.unwrap_or_else(|e| {
                 warn!(
                     "Failed to read OpenAI fine-tuning error response payload: {}",
@@ -122,16 +157,12 @@ impl OpenAIFineTuningProvider {
 
             match status.as_u16() {
                 401 => Err(FineTuningError::auth("Invalid API key")),
-                404 => {
-                    // Try to extract job ID from error
-                    Err(FineTuningError::job_not_found("unknown"))
-                }
-                429 => {
-                    // Try to parse retry-after
-                    Err(FineTuningError::RateLimited {
-                        retry_after_seconds: 60,
-                    })
-                }
+                404 => Err(FineTuningError::job_not_found(
+                    not_found_job_id.unwrap_or("unknown"),
+                )),
+                429 => Err(FineTuningError::RateLimited {
+                    retry_after_seconds,
+                }),
                 _ => Err(FineTuningError::provider(format!(
                     "API error {}: {}",
                     status,
@@ -143,6 +174,31 @@ impl OpenAIFineTuningProvider {
             }
         }
     }
+
+    fn annotate_job(&self, mut job: FineTuningJob) -> FineTuningJob {
+        job.provider = Some(self.provider_name.clone());
+        job
+    }
+}
+
+fn shared_client(timeout_seconds: u64) -> Client {
+    let clients = CLIENTS_BY_TIMEOUT.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut clients = clients
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    clients
+        .entry(timeout_seconds)
+        .or_insert_with(|| {
+            create_custom_client(Duration::from_secs(timeout_seconds)).unwrap_or_else(|error| {
+                warn!(
+                    "Failed to create custom fine-tuning HTTP client, using default client: {}",
+                    error
+                );
+                Client::new()
+            })
+        })
+        .clone()
 }
 
 fn extract_openai_error_message(error_text: &str) -> Option<String> {
@@ -171,6 +227,8 @@ struct OpenAICreateJobRequest {
     suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     seed: Option<u64>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    metadata: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -205,6 +263,7 @@ impl From<&CreateJobRequest> for OpenAICreateJobRequest {
             hyperparameters,
             suffix: req.suffix.clone(),
             seed: req.seed,
+            metadata: req.metadata.clone(),
         }
     }
 }
@@ -217,17 +276,14 @@ impl FineTuningProvider for OpenAIFineTuningProvider {
 
     async fn create_job(&self, request: CreateJobRequest) -> FineTuningResult<FineTuningJob> {
         let openai_request = OpenAICreateJobRequest::from(&request);
+        let url = self.endpoint_url(&["fine_tuning", "jobs"])?;
+        let body = serde_json::to_value(&openai_request)
+            .map_err(|e| FineTuningError::other(format!("Failed to serialize request: {}", e)))?;
 
-        let mut job: FineTuningJob = self
-            .request(
-                reqwest::Method::POST,
-                "/fine_tuning/jobs",
-                Some(&openai_request),
-            )
-            .await?;
+        let mut job: FineTuningJob = self.request(Method::POST, url, Some(body), None).await?;
 
         // Add provider info
-        job.provider = Some("openai".to_string());
+        job.provider = Some(self.provider_name.clone());
 
         // Copy metadata from request
         job.metadata = request.metadata;
@@ -236,54 +292,41 @@ impl FineTuningProvider for OpenAIFineTuningProvider {
     }
 
     async fn list_jobs(&self, params: ListJobsParams) -> FineTuningResult<ListJobsResponse> {
-        let mut query = Vec::new();
-        if let Some(after) = &params.after {
-            query.push(format!("after={}", after));
-        }
-        if let Some(limit) = params.limit {
-            query.push(format!("limit={}", limit));
+        let mut url = self.endpoint_url(&["fine_tuning", "jobs"])?;
+        {
+            let mut query = url.query_pairs_mut();
+            if let Some(after) = &params.after {
+                query.append_pair("after", after);
+            }
+            if let Some(limit) = params.limit {
+                query.append_pair("limit", &limit.to_string());
+            }
         }
 
-        let path = if query.is_empty() {
-            "/fine_tuning/jobs".to_string()
-        } else {
-            format!("/fine_tuning/jobs?{}", query.join("&"))
-        };
-
-        let mut response: ListJobsResponse = self
-            .request::<ListJobsResponse>(reqwest::Method::GET, &path, None::<()>)
-            .await?;
+        let mut response: ListJobsResponse = self.request(Method::GET, url, None, None).await?;
 
         // Add provider info to all jobs
         for job in &mut response.data {
-            job.provider = Some("openai".to_string());
+            job.provider = Some(self.provider_name.clone());
         }
 
         Ok(response)
     }
 
     async fn get_job(&self, job_id: &str) -> FineTuningResult<FineTuningJob> {
-        let path = format!("/fine_tuning/jobs/{}", job_id);
+        let url = self.endpoint_url(&["fine_tuning", "jobs", job_id])?;
 
-        let mut job: FineTuningJob = self
-            .request::<FineTuningJob>(reqwest::Method::GET, &path, None::<()>)
-            .await?;
+        let job: FineTuningJob = self.request(Method::GET, url, None, Some(job_id)).await?;
 
-        job.provider = Some("openai".to_string());
-
-        Ok(job)
+        Ok(self.annotate_job(job))
     }
 
     async fn cancel_job(&self, job_id: &str) -> FineTuningResult<FineTuningJob> {
-        let path = format!("/fine_tuning/jobs/{}/cancel", job_id);
+        let url = self.endpoint_url(&["fine_tuning", "jobs", job_id, "cancel"])?;
 
-        let mut job: FineTuningJob = self
-            .request::<FineTuningJob>(reqwest::Method::POST, &path, None::<()>)
-            .await?;
+        let job: FineTuningJob = self.request(Method::POST, url, None, Some(job_id)).await?;
 
-        job.provider = Some("openai".to_string());
-
-        Ok(job)
+        Ok(self.annotate_job(job))
     }
 
     async fn list_events(
@@ -291,35 +334,30 @@ impl FineTuningProvider for OpenAIFineTuningProvider {
         job_id: &str,
         params: ListEventsParams,
     ) -> FineTuningResult<ListEventsResponse> {
-        let mut query = Vec::new();
-        if let Some(after) = &params.after {
-            query.push(format!("after={}", after));
-        }
-        if let Some(limit) = params.limit {
-            query.push(format!("limit={}", limit));
+        let mut url = self.endpoint_url(&["fine_tuning", "jobs", job_id, "events"])?;
+        {
+            let mut query = url.query_pairs_mut();
+            if let Some(after) = &params.after {
+                query.append_pair("after", after);
+            }
+            if let Some(limit) = params.limit {
+                query.append_pair("limit", &limit.to_string());
+            }
         }
 
-        let path = if query.is_empty() {
-            format!("/fine_tuning/jobs/{}/events", job_id)
-        } else {
-            format!("/fine_tuning/jobs/{}/events?{}", job_id, query.join("&"))
-        };
-
-        self.request::<ListEventsResponse>(reqwest::Method::GET, &path, None::<()>)
-            .await
+        self.request(Method::GET, url, None, Some(job_id)).await
     }
 
     async fn list_checkpoints(&self, job_id: &str) -> FineTuningResult<Vec<FineTuningCheckpoint>> {
-        let path = format!("/fine_tuning/jobs/{}/checkpoints", job_id);
+        let url = self.endpoint_url(&["fine_tuning", "jobs", job_id, "checkpoints"])?;
 
         #[derive(Deserialize)]
         struct CheckpointsResponse {
             data: Vec<FineTuningCheckpoint>,
         }
 
-        let response: CheckpointsResponse = self
-            .request::<CheckpointsResponse>(reqwest::Method::GET, &path, None::<()>)
-            .await?;
+        let response: CheckpointsResponse =
+            self.request(Method::GET, url, None, Some(job_id)).await?;
 
         Ok(response.data)
     }

--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -15,6 +15,7 @@ use std::sync::OnceLock;
 use tracing::error;
 
 use super::openai_errors;
+use super::provider_config;
 
 const OPENAI_BATCH_BASE_URL: &str = "https://api.openai.com/v1";
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
@@ -221,8 +222,8 @@ fn batch_base_url(provider: &ProviderConfig) -> Result<String, GatewayError> {
         }
     }
 
-    if normalize_provider_selector(&provider.provider_type) == "openai"
-        || normalize_provider_selector(&provider.name) == "openai"
+    if provider_config::normalize_provider_selector(&provider.provider_type) == "openai"
+        || provider_config::normalize_provider_selector(&provider.name) == "openai"
     {
         return Ok(OPENAI_BATCH_BASE_URL.to_string());
     }
@@ -295,30 +296,13 @@ fn batch_provider_headers(
     if let Some(project) = provider.project.as_deref() {
         push_header(&mut headers, "OpenAI-Project", project)?;
     }
-    append_string_header_map(&mut headers, provider, "headers")?;
-    append_string_header_map(&mut headers, provider, "custom_headers")?;
+    provider_config::append_string_header_map(provider, "headers", |key, value| {
+        push_header(&mut headers, key, value)
+    })?;
+    provider_config::append_string_header_map(provider, "custom_headers", |key, value| {
+        push_header(&mut headers, key, value)
+    })?;
     Ok(headers)
-}
-
-fn append_string_header_map(
-    headers: &mut Vec<(HeaderName, HeaderValue)>,
-    provider: &ProviderConfig,
-    settings_key: &str,
-) -> Result<(), GatewayError> {
-    let Some(header_map) = provider
-        .settings
-        .get(settings_key)
-        .and_then(serde_json::Value::as_object)
-    else {
-        return Ok(());
-    };
-
-    for (key, value) in header_map {
-        if let Some(value) = value.as_str() {
-            push_header(headers, key, value)?;
-        }
-    }
-    Ok(())
 }
 
 fn push_header(
@@ -366,17 +350,13 @@ fn validate_batch_id(batch_id: &str) -> Result<(), GatewayError> {
 }
 
 fn is_openai_batch_provider(provider: &ProviderConfig) -> bool {
-    let provider_type = normalize_provider_selector(&provider.provider_type);
-    let provider_name = normalize_provider_selector(&provider.name);
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
 
     provider_type == "openai"
         || provider_type == "openaicompatible"
         || provider_name == "openai"
         || provider_name == "openaicompatible"
-}
-
-fn normalize_provider_selector(value: &str) -> String {
-    value.trim().to_ascii_lowercase().replace(['_', '-'], "")
 }
 
 #[cfg(test)]

--- a/src/server/routes/ai/fine_tuning.rs
+++ b/src/server/routes/ai/fine_tuning.rs
@@ -1,0 +1,565 @@
+//! Fine-tuning API route handlers.
+//!
+//! These endpoints expose OpenAI-compatible fine-tuning lifecycle routes and
+//! proxy them to an enabled OpenAI or OpenAI-compatible provider.
+
+use crate::config::models::provider::ProviderConfig;
+use crate::core::fine_tuning::FineTuningManager;
+use crate::core::fine_tuning::config::{FineTuningConfig, ProviderFineTuningConfig};
+use crate::core::fine_tuning::providers::{FineTuningError, OpenAIFineTuningProvider};
+use crate::core::fine_tuning::types::{
+    CreateJobRequest, FineTuningCheckpoint, ListEventsParams, ListJobsParams,
+};
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::{HttpResponse, Result as ActixResult, web};
+use reqwest::header::{HeaderName, HeaderValue};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::error;
+
+use super::openai_errors;
+use super::provider_config;
+
+const OPENAI_FINE_TUNING_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Clone)]
+struct FineTuningRouteProvider {
+    name: String,
+    config: ProviderFineTuningConfig,
+}
+
+struct FineTuningRouteManager {
+    manager: FineTuningManager,
+    default_provider: String,
+}
+
+#[derive(Serialize)]
+struct ListCheckpointsResponse {
+    object: &'static str,
+    data: Vec<FineTuningCheckpoint>,
+}
+
+/// Create a fine-tuning job.
+pub async fn create_fine_tuning_job(
+    state: web::Data<AppState>,
+    request: web::Json<CreateJobRequest>,
+) -> ActixResult<HttpResponse> {
+    let request = request.into_inner();
+    if let Err(error) = validate_create_job_request(&request) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
+        Ok(route_manager) => route_manager,
+        Err(error) => {
+            error!("Fine-tuning create route configuration error: {}", error);
+            return Ok(openai_errors::gateway_error_response(&error));
+        }
+    };
+    if let Err(error) = ensure_fine_tuning_budget(
+        state.get_ref(),
+        &route_manager.default_provider,
+        &request.model,
+    ) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match route_manager.manager.create_job(None, request).await {
+        Ok(job) => Ok(HttpResponse::Ok().json(job)),
+        Err(error) => {
+            error!("Fine-tuning create error: {}", error);
+            Ok(fine_tuning_error_response(error))
+        }
+    }
+}
+
+/// List fine-tuning jobs.
+pub async fn list_fine_tuning_jobs(
+    state: web::Data<AppState>,
+    query: web::Query<ListJobsParams>,
+) -> ActixResult<HttpResponse> {
+    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
+        Ok(route_manager) => route_manager,
+        Err(error) => {
+            error!("Fine-tuning list route configuration error: {}", error);
+            return Ok(openai_errors::gateway_error_response(&error));
+        }
+    };
+    if let Err(error) =
+        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match route_manager
+        .manager
+        .list_jobs(None, query.into_inner())
+        .await
+    {
+        Ok(response) => Ok(HttpResponse::Ok().json(response)),
+        Err(error) => {
+            error!("Fine-tuning list error: {}", error);
+            Ok(fine_tuning_error_response(error))
+        }
+    }
+}
+
+/// Get a fine-tuning job by ID.
+pub async fn get_fine_tuning_job(
+    state: web::Data<AppState>,
+    job_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let job_id = job_id.into_inner();
+    if let Err(error) = validate_fine_tuning_job_id(&job_id) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
+        Ok(route_manager) => route_manager,
+        Err(error) => {
+            error!("Fine-tuning retrieve route configuration error: {}", error);
+            return Ok(openai_errors::gateway_error_response(&error));
+        }
+    };
+    if let Err(error) =
+        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match route_manager.manager.get_job(None, &job_id).await {
+        Ok(job) => Ok(HttpResponse::Ok().json(job)),
+        Err(error) => {
+            error!("Fine-tuning retrieve error: {}", error);
+            Ok(fine_tuning_error_response(error))
+        }
+    }
+}
+
+/// Cancel a fine-tuning job by ID.
+pub async fn cancel_fine_tuning_job(
+    state: web::Data<AppState>,
+    job_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let job_id = job_id.into_inner();
+    if let Err(error) = validate_fine_tuning_job_id(&job_id) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
+        Ok(route_manager) => route_manager,
+        Err(error) => {
+            error!("Fine-tuning cancel route configuration error: {}", error);
+            return Ok(openai_errors::gateway_error_response(&error));
+        }
+    };
+    if let Err(error) =
+        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match route_manager.manager.cancel_job(None, &job_id).await {
+        Ok(job) => Ok(HttpResponse::Ok().json(job)),
+        Err(error) => {
+            error!("Fine-tuning cancel error: {}", error);
+            Ok(fine_tuning_error_response(error))
+        }
+    }
+}
+
+/// List events for a fine-tuning job.
+pub async fn list_fine_tuning_events(
+    state: web::Data<AppState>,
+    job_id: web::Path<String>,
+    query: web::Query<ListEventsParams>,
+) -> ActixResult<HttpResponse> {
+    let job_id = job_id.into_inner();
+    if let Err(error) = validate_fine_tuning_job_id(&job_id) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
+        Ok(route_manager) => route_manager,
+        Err(error) => {
+            error!("Fine-tuning events route configuration error: {}", error);
+            return Ok(openai_errors::gateway_error_response(&error));
+        }
+    };
+    if let Err(error) =
+        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match route_manager
+        .manager
+        .list_events(None, &job_id, query.into_inner())
+        .await
+    {
+        Ok(response) => Ok(HttpResponse::Ok().json(response)),
+        Err(error) => {
+            error!("Fine-tuning events error: {}", error);
+            Ok(fine_tuning_error_response(error))
+        }
+    }
+}
+
+/// List checkpoints for a fine-tuning job.
+pub async fn list_fine_tuning_checkpoints(
+    state: web::Data<AppState>,
+    job_id: web::Path<String>,
+) -> ActixResult<HttpResponse> {
+    let job_id = job_id.into_inner();
+    if let Err(error) = validate_fine_tuning_job_id(&job_id) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
+        Ok(route_manager) => route_manager,
+        Err(error) => {
+            error!(
+                "Fine-tuning checkpoints route configuration error: {}",
+                error
+            );
+            return Ok(openai_errors::gateway_error_response(&error));
+        }
+    };
+    if let Err(error) =
+        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match route_manager.manager.list_checkpoints(None, &job_id).await {
+        Ok(data) => Ok(HttpResponse::Ok().json(ListCheckpointsResponse {
+            object: "list",
+            data,
+        })),
+        Err(error) => {
+            error!("Fine-tuning checkpoints error: {}", error);
+            Ok(fine_tuning_error_response(error))
+        }
+    }
+}
+
+async fn build_fine_tuning_manager(
+    state: &AppState,
+) -> Result<FineTuningRouteManager, GatewayError> {
+    let providers =
+        select_fine_tuning_route_providers(state.config().gateway.providers.as_slice())?;
+    let Some(default_provider) = providers.first().map(|provider| provider.name.clone()) else {
+        return Err(missing_fine_tuning_provider_error());
+    };
+
+    let provider_configs = providers
+        .iter()
+        .map(|provider| (provider.name.clone(), provider.config.clone()))
+        .collect();
+    let manager = FineTuningManager::new(FineTuningConfig {
+        enabled: true,
+        default_provider: Some(default_provider.clone()),
+        providers: provider_configs,
+        ..FineTuningConfig::default()
+    });
+
+    for provider in providers {
+        manager
+            .register_provider(
+                provider.name.clone(),
+                Arc::new(OpenAIFineTuningProvider::new_named(
+                    provider.config,
+                    provider.name,
+                )),
+            )
+            .await;
+    }
+
+    Ok(FineTuningRouteManager {
+        manager,
+        default_provider,
+    })
+}
+
+fn ensure_fine_tuning_budget(
+    state: &AppState,
+    provider: &str,
+    model: &str,
+) -> Result<(), GatewayError> {
+    super::spend::ensure_budget_available(&state.budget_limits, provider, model)
+        .map_err(GatewayError::from)
+}
+
+fn select_fine_tuning_route_providers(
+    providers: &[ProviderConfig],
+) -> Result<Vec<FineTuningRouteProvider>, GatewayError> {
+    providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter(|provider| is_openai_fine_tuning_provider(provider))
+        .map(fine_tuning_route_provider)
+        .collect()
+}
+
+fn fine_tuning_route_provider(
+    provider: &ProviderConfig,
+) -> Result<FineTuningRouteProvider, GatewayError> {
+    if provider.api_key.trim().is_empty() {
+        return Err(GatewayError::Config(format!(
+            "Fine-tuning provider '{}' is missing api_key",
+            provider.name
+        )));
+    }
+
+    Ok(FineTuningRouteProvider {
+        name: provider.name.clone(),
+        config: ProviderFineTuningConfig {
+            enabled: true,
+            api_key: Some(provider.api_key.clone()),
+            api_base: Some(fine_tuning_api_base(provider)?),
+            organization_id: provider.organization.clone(),
+            supported_models: provider.models.clone(),
+            timeout_seconds: provider.timeout,
+            headers: fine_tuning_provider_headers(provider)?,
+        },
+    })
+}
+
+fn fine_tuning_api_base(provider: &ProviderConfig) -> Result<String, GatewayError> {
+    if let Some(base_url) = provider.base_url.as_deref() {
+        let trimmed = base_url.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if provider_config::normalize_provider_selector(&provider.provider_type) == "openai"
+        || provider_config::normalize_provider_selector(&provider.name) == "openai"
+    {
+        return Ok(OPENAI_FINE_TUNING_BASE_URL.to_string());
+    }
+
+    Err(GatewayError::Config(format!(
+        "Fine-tuning provider '{}' is missing base_url",
+        provider.name
+    )))
+}
+
+fn fine_tuning_provider_headers(
+    provider: &ProviderConfig,
+) -> Result<HashMap<String, String>, GatewayError> {
+    let mut headers = HashMap::new();
+    if let Some(project) = provider.project.as_deref() {
+        push_config_header(&mut headers, "OpenAI-Project", project)?;
+    }
+    provider_config::append_string_header_map(provider, "headers", |key, value| {
+        push_config_header(&mut headers, key, value)
+    })?;
+    provider_config::append_string_header_map(provider, "custom_headers", |key, value| {
+        push_config_header(&mut headers, key, value)
+    })?;
+    Ok(headers)
+}
+
+fn push_config_header(
+    headers: &mut HashMap<String, String>,
+    name: impl AsRef<str>,
+    value: impl AsRef<str>,
+) -> Result<(), GatewayError> {
+    HeaderName::from_bytes(name.as_ref().as_bytes()).map_err(|error| {
+        GatewayError::Config(format!("Invalid fine-tuning provider header: {error}"))
+    })?;
+    HeaderValue::from_str(value.as_ref()).map_err(|error| {
+        GatewayError::Config(format!(
+            "Invalid fine-tuning provider header value: {error}"
+        ))
+    })?;
+    headers.insert(name.as_ref().to_string(), value.as_ref().to_string());
+    Ok(())
+}
+
+fn validate_create_job_request(request: &CreateJobRequest) -> Result<(), GatewayError> {
+    if request.model.trim().is_empty() {
+        return Err(GatewayError::validation("model is required"));
+    }
+    if request.training_file.trim().is_empty() {
+        return Err(GatewayError::validation("training_file is required"));
+    }
+    Ok(())
+}
+
+fn validate_fine_tuning_job_id(job_id: &str) -> Result<(), GatewayError> {
+    if job_id.trim().is_empty() {
+        return Err(GatewayError::validation("fine_tuning_job_id is required"));
+    }
+
+    if job_id
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return Ok(());
+    }
+
+    Err(GatewayError::validation(
+        "fine_tuning_job_id must be a single safe path segment",
+    ))
+}
+
+fn missing_fine_tuning_provider_error() -> GatewayError {
+    GatewayError::Config(
+        "Fine-tuning API requires an enabled openai or openai_compatible provider".to_string(),
+    )
+}
+
+fn fine_tuning_error_response(error: FineTuningError) -> HttpResponse {
+    match error {
+        FineTuningError::Authentication { message } => openai_errors::unauthorized_error(message),
+        FineTuningError::InvalidRequest { message } => openai_errors::validation_error(message),
+        FineTuningError::JobNotFound { job_id } => {
+            let gateway_error =
+                GatewayError::NotFound(format!("Fine-tuning job not found: {job_id}"));
+            openai_errors::gateway_error_response(&gateway_error)
+        }
+        FineTuningError::ProviderNotFound { provider } => {
+            let gateway_error =
+                GatewayError::Config(format!("Fine-tuning provider not found: {provider}"));
+            openai_errors::gateway_error_response(&gateway_error)
+        }
+        FineTuningError::RateLimited {
+            retry_after_seconds,
+        } => {
+            let gateway_error = GatewayError::RateLimit {
+                message: "Fine-tuning provider rate limit exceeded".to_string(),
+                retry_after: Some(retry_after_seconds),
+                rpm_limit: None,
+                tpm_limit: None,
+            };
+            openai_errors::gateway_error_response(&gateway_error)
+        }
+        FineTuningError::Network { message } => {
+            let gateway_error = GatewayError::Network(message);
+            openai_errors::gateway_error_response(&gateway_error)
+        }
+        FineTuningError::Provider { message } | FineTuningError::Other { message } => {
+            let gateway_error = GatewayError::Unavailable(message);
+            openai_errors::gateway_error_response(&gateway_error)
+        }
+    }
+}
+
+fn is_openai_fine_tuning_provider(provider: &ProviderConfig) -> bool {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+
+    provider_type == "openai"
+        || provider_type == "openaicompatible"
+        || provider_name == "openai"
+        || provider_name == "openaicompatible"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn provider(name: &str, provider_type: &str) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            provider_type: provider_type.to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some("https://fine-tuning.example.test/v1/".to_string()),
+            ..ProviderConfig::default()
+        }
+    }
+
+    #[test]
+    fn selects_openai_compatible_fine_tuning_provider() {
+        let selected =
+            select_fine_tuning_route_providers(&[provider("primary", "openai_compatible")])
+                .expect("provider selection should succeed");
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].name, "primary");
+        assert_eq!(
+            selected[0].config.api_base.as_deref(),
+            Some("https://fine-tuning.example.test/v1")
+        );
+        assert_eq!(selected[0].config.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn selected_provider_preserves_project_and_custom_headers() {
+        let mut provider = provider("mock-openai-compatible", "openai_compatible");
+        provider.organization = Some("org-test".to_string());
+        provider.project = Some("proj-test".to_string());
+        provider.settings = HashMap::from([
+            (
+                "headers".to_string(),
+                json!({
+                    "X-Base-Header": "base-value",
+                    "X-Ignored-Non-String": false
+                }),
+            ),
+            (
+                "custom_headers".to_string(),
+                json!({
+                    "X-Custom-Header": "custom-value"
+                }),
+            ),
+        ]);
+
+        let selected = select_fine_tuning_route_providers(&[provider])
+            .expect("provider selection should succeed");
+
+        assert_eq!(
+            selected[0].config.organization_id.as_deref(),
+            Some("org-test")
+        );
+        assert_eq!(selected[0].config.headers["OpenAI-Project"], "proj-test");
+        assert_eq!(selected[0].config.headers["X-Base-Header"], "base-value");
+        assert_eq!(
+            selected[0].config.headers["X-Custom-Header"],
+            "custom-value"
+        );
+        assert!(
+            !selected[0]
+                .config
+                .headers
+                .contains_key("X-Ignored-Non-String")
+        );
+    }
+
+    #[test]
+    fn compatible_provider_requires_base_url() {
+        let mut provider = provider("local", "openai_compatible");
+        provider.base_url = None;
+
+        let error = select_fine_tuning_route_providers(&[provider]).unwrap_err();
+
+        assert!(error.to_string().contains("missing base_url"));
+    }
+
+    #[test]
+    fn validates_create_job_required_fields() {
+        validate_create_job_request(&CreateJobRequest::new("gpt-4o-mini", "file-train"))
+            .expect("request should validate");
+
+        let mut request = CreateJobRequest::new("", "file-train");
+        let error = validate_create_job_request(&request).unwrap_err();
+        assert!(error.to_string().contains("model is required"));
+
+        request.model = "gpt-4o-mini".to_string();
+        request.training_file = " ".to_string();
+        let error = validate_create_job_request(&request).unwrap_err();
+        assert!(error.to_string().contains("training_file is required"));
+    }
+
+    #[test]
+    fn rejects_unsafe_fine_tuning_job_id() {
+        let error = validate_fine_tuning_job_id("../ftjob_123").unwrap_err();
+
+        assert!(error.to_string().contains("safe path segment"));
+    }
+}

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -10,9 +10,11 @@ mod context;
 mod embeddings;
 mod execution;
 mod files;
+mod fine_tuning;
 mod images;
 mod models;
 mod openai_errors;
+mod provider_config;
 #[cfg(test)]
 mod provider_selection;
 mod responses;
@@ -29,6 +31,10 @@ pub use context::{
 };
 pub use embeddings::embeddings;
 pub use files::{create_file, delete_file, get_file, get_file_content, list_files};
+pub use fine_tuning::{
+    cancel_fine_tuning_job, create_fine_tuning_job, get_fine_tuning_job,
+    list_fine_tuning_checkpoints, list_fine_tuning_events, list_fine_tuning_jobs,
+};
 pub use images::image_generations;
 pub use models::{get_model, list_models};
 pub use responses::{
@@ -71,6 +77,25 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/batches", web::get().to(list_batches))
             .route("/batches/{batch_id}", web::get().to(get_batch))
             .route("/batches/{batch_id}/cancel", web::post().to(cancel_batch))
+            // Fine-tuning
+            .route("/fine_tuning/jobs", web::post().to(create_fine_tuning_job))
+            .route("/fine_tuning/jobs", web::get().to(list_fine_tuning_jobs))
+            .route(
+                "/fine_tuning/jobs/{job_id}",
+                web::get().to(get_fine_tuning_job),
+            )
+            .route(
+                "/fine_tuning/jobs/{job_id}/cancel",
+                web::post().to(cancel_fine_tuning_job),
+            )
+            .route(
+                "/fine_tuning/jobs/{job_id}/events",
+                web::get().to(list_fine_tuning_events),
+            )
+            .route(
+                "/fine_tuning/jobs/{job_id}/checkpoints",
+                web::get().to(list_fine_tuning_checkpoints),
+            )
             // Files
             .route("/files", web::post().to(create_file))
             .route("/files", web::get().to(list_files))

--- a/src/server/routes/ai/provider_config.rs
+++ b/src/server/routes/ai/provider_config.rs
@@ -1,0 +1,29 @@
+//! Shared helpers for OpenAI-compatible provider route configuration.
+
+use crate::config::models::provider::ProviderConfig;
+use crate::utils::error::gateway_error::GatewayError;
+
+pub(super) fn append_string_header_map(
+    provider: &ProviderConfig,
+    settings_key: &str,
+    mut append: impl FnMut(&str, &str) -> Result<(), GatewayError>,
+) -> Result<(), GatewayError> {
+    let Some(header_map) = provider
+        .settings
+        .get(settings_key)
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Ok(());
+    };
+
+    for (key, value) in header_map {
+        if let Some(value) = value.as_str() {
+            append(key, value)?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn normalize_provider_selector(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace(['_', '-'], "")
+}

--- a/tests/fine_tuning_routes.rs
+++ b/tests/fine_tuning_routes.rs
@@ -1,0 +1,468 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone, Debug)]
+    struct CapturedFineTuningRequest {
+        method: String,
+        path: String,
+        query: String,
+        headers: HashMap<String, String>,
+        body: Value,
+    }
+
+    #[derive(Clone)]
+    struct MockFineTuningState {
+        captured_requests: Arc<Mutex<Vec<CapturedFineTuningRequest>>>,
+    }
+
+    struct MockFineTuningServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedFineTuningRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockFineTuningServer {
+        async fn start() -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockFineTuningState {
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .route("/v1/fine_tuning/jobs", web::post().to(mock_create_job))
+                    .route("/v1/fine_tuning/jobs", web::get().to(mock_list_jobs))
+                    .route("/v1/fine_tuning/jobs/{job_id}", web::get().to(mock_get_job))
+                    .route(
+                        "/v1/fine_tuning/jobs/{job_id}/cancel",
+                        web::post().to(mock_cancel_job),
+                    )
+                    .route(
+                        "/v1/fine_tuning/jobs/{job_id}/events",
+                        web::get().to(mock_list_events),
+                    )
+                    .route(
+                        "/v1/fine_tuning/jobs/{job_id}/checkpoints",
+                        web::get().to(mock_list_checkpoints),
+                    )
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            wait_for_server(address).await;
+
+            Self {
+                base_url: format!("http://{address}/v1"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedFineTuningRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn shutdown(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
+    }
+
+    async fn mock_create_job(
+        state: web::Data<MockFineTuningState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(job_json("ftjob_mock", "queued"))
+    }
+
+    async fn mock_list_jobs(
+        state: web::Data<MockFineTuningState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({
+            "object": "list",
+            "data": [job_json("ftjob_mock", "running")],
+            "has_more": false
+        }))
+    }
+
+    async fn mock_get_job(
+        state: web::Data<MockFineTuningState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(job_json("ftjob_mock", "running"))
+    }
+
+    async fn mock_cancel_job(
+        state: web::Data<MockFineTuningState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(job_json("ftjob_mock", "cancelled"))
+    }
+
+    async fn mock_list_events(
+        state: web::Data<MockFineTuningState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({
+            "object": "list",
+            "data": [{
+                "id": "ftevent_mock",
+                "object": "fine_tuning.job.event",
+                "level": "info",
+                "message": "Job started",
+                "created_at": 1710000001
+            }],
+            "has_more": false
+        }))
+    }
+
+    async fn mock_list_checkpoints(
+        state: web::Data<MockFineTuningState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({
+            "object": "list",
+            "data": [{
+                "id": "ftckpt_mock",
+                "object": "fine_tuning.job.checkpoint",
+                "fine_tuning_job_id": "ftjob_mock",
+                "step_number": 1,
+                "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:mock",
+                "created_at": 1710000002
+            }]
+        }))
+    }
+
+    fn job_json(id: &str, status: &str) -> Value {
+        json!({
+            "id": id,
+            "object": "fine_tuning.job",
+            "model": "gpt-4o-mini",
+            "status": status,
+            "training_file": "file-train",
+            "created_at": 1710000000
+        })
+    }
+
+    fn capture_request(state: &MockFineTuningState, request: &HttpRequest, body: Bytes) {
+        let headers = request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect();
+        let body = if body.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&body).expect("mock fine-tuning body should be json")
+        };
+
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedFineTuningRequest {
+                method: request.method().to_string(),
+                path: request.path().to_string(),
+                query: request.query_string().to_string(),
+                headers,
+                body,
+            });
+    }
+
+    async fn build_test_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn fine_tuning_provider(base_url: &str) -> ProviderConfig {
+        let mut provider = ProviderConfig {
+            name: "mock-openai-compatible".to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            organization: Some("org-test".to_string()),
+            project: Some("proj-test".to_string()),
+            models: vec!["gpt-4o-mini".to_string()],
+            ..ProviderConfig::default()
+        };
+        provider.settings = HashMap::from([
+            (
+                "headers".to_string(),
+                json!({
+                    "X-Base-Header": "base-value",
+                    "X-Ignored-Non-String": false
+                }),
+            ),
+            (
+                "custom_headers".to_string(),
+                json!({
+                    "X-Custom-Header": "custom-value"
+                }),
+            ),
+        ]);
+        provider
+    }
+
+    #[tokio::test]
+    async fn fine_tuning_route_without_provider_fails_closed() {
+        let state = build_test_state(Vec::new()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/fine_tuning/jobs")
+            .set_json(json!({
+                "model": "gpt-4o-mini",
+                "training_file": "file-train"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(resp).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("Fine-tuning API requires")
+        );
+        assert_eq!(body["error"]["type"], "server_error");
+    }
+
+    #[tokio::test]
+    async fn fine_tuning_routes_proxy_provider_lifecycle() {
+        let mock = MockFineTuningServer::start().await;
+        let state = build_test_state(vec![fine_tuning_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let create_req = test::TestRequest::post()
+            .uri("/v1/fine_tuning/jobs")
+            .set_json(json!({
+                "model": "gpt-4o-mini",
+                "training_file": "file-train",
+                "hyperparameters": { "n_epochs": 2 },
+                "metadata": { "owner": "route-test" }
+            }))
+            .to_request();
+        let create_resp = test::call_service(&app, create_req).await;
+        assert_eq!(create_resp.status(), StatusCode::OK);
+        let create_body: Value = test::read_body_json(create_resp).await;
+        assert_eq!(create_body["id"], "ftjob_mock");
+        assert_eq!(create_body["provider"], "mock-openai-compatible");
+
+        let list_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/v1/fine_tuning/jobs?after=ftjob_prev&limit=1")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(list_resp.status(), StatusCode::OK);
+
+        let get_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/v1/fine_tuning/jobs/ftjob_mock")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+
+        let cancel_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/fine_tuning/jobs/ftjob_mock/cancel")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(cancel_resp.status(), StatusCode::OK);
+
+        let events_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/v1/fine_tuning/jobs/ftjob_mock/events?after=ftevent_prev&limit=2")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(events_resp.status(), StatusCode::OK);
+
+        let checkpoints_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/v1/fine_tuning/jobs/ftjob_mock/checkpoints")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(checkpoints_resp.status(), StatusCode::OK);
+        let checkpoints_body: Value = test::read_body_json(checkpoints_resp).await;
+        assert_eq!(checkpoints_body["object"], "list");
+        assert_eq!(checkpoints_body["data"][0]["id"], "ftckpt_mock");
+
+        let captured = mock.requests();
+        assert_eq!(captured.len(), 6);
+        assert_eq!(captured[0].method, "POST");
+        assert_eq!(captured[0].path, "/v1/fine_tuning/jobs");
+        assert_eq!(captured[0].body["model"], "gpt-4o-mini");
+        assert_eq!(captured[0].body["training_file"], "file-train");
+        assert_eq!(captured[0].body["hyperparameters"]["n_epochs"], 2);
+        assert_eq!(captured[0].body["metadata"]["owner"], "route-test");
+        assert_eq!(
+            captured[0].headers.get("authorization").map(String::as_str),
+            Some("Bearer sk-test")
+        );
+        assert_eq!(
+            captured[0]
+                .headers
+                .get("openai-organization")
+                .map(String::as_str),
+            Some("org-test")
+        );
+        assert_eq!(
+            captured[0]
+                .headers
+                .get("openai-project")
+                .map(String::as_str),
+            Some("proj-test")
+        );
+        assert_eq!(
+            captured[0].headers.get("x-base-header").map(String::as_str),
+            Some("base-value")
+        );
+        assert_eq!(
+            captured[0]
+                .headers
+                .get("x-custom-header")
+                .map(String::as_str),
+            Some("custom-value")
+        );
+        assert_eq!(captured[1].path, "/v1/fine_tuning/jobs");
+        assert_eq!(captured[1].query, "after=ftjob_prev&limit=1");
+        assert_eq!(captured[2].path, "/v1/fine_tuning/jobs/ftjob_mock");
+        assert_eq!(captured[3].path, "/v1/fine_tuning/jobs/ftjob_mock/cancel");
+        assert_eq!(captured[4].path, "/v1/fine_tuning/jobs/ftjob_mock/events");
+        assert_eq!(captured[4].query, "after=ftevent_prev&limit=2");
+        assert_eq!(
+            captured[5].path,
+            "/v1/fine_tuning/jobs/ftjob_mock/checkpoints"
+        );
+
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn fine_tuning_create_rejects_exhausted_provider_budget_before_upstream() {
+        let mock = MockFineTuningServer::start().await;
+        let state = build_test_state(vec![fine_tuning_provider(&mock.base_url)]).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-compatible",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("mock-openai-compatible", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let create_req = test::TestRequest::post()
+            .uri("/v1/fine_tuning/jobs")
+            .set_json(json!({
+                "model": "gpt-4o-mini",
+                "training_file": "file-train"
+            }))
+            .to_request();
+        let create_resp = test::call_service(&app, create_req).await;
+
+        assert_eq!(create_resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(create_resp).await;
+        assert_eq!(body["error"]["type"], "insufficient_quota");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("provider 'mock-openai-compatible' budget exceeded")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "budget rejection must happen before upstream call"
+        );
+
+        mock.shutdown().await;
+    }
+}


### PR DESCRIPTION
Fixes #743

## Summary
- expose OpenAI-compatible fine-tuning job, event, cancel, and checkpoint routes
- wire enabled openai/openai_compatible providers into the fine-tuning manager for HTTP requests
- preserve provider headers, metadata, provider identity, query parameters, and safe path handling
- share OpenAI-compatible provider config helpers with batch routes

## Verification
- cargo test --all-features --locked --test fine_tuning_routes --quiet
- cargo test --all-features --locked routes::ai::batches --lib --quiet
- cargo test --all-features --locked fine_tuning --lib --quiet
- cargo check --all-features --locked
- cargo test --all-features --locked