### PR TITLE
Fix image edit and variation routes

### DIFF
--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -1,16 +1,55 @@
-//! Image generation endpoint
+//! Image API endpoints
 
+use crate::config::models::provider::ProviderConfig;
 use crate::core::models::openai::{ImageGenerationRequest, ImageGenerationResponse};
+use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::types::context::RequestContext;
 use crate::core::types::image::ImageGenerationRequest as CoreImageRequest;
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
-use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
-use tracing::info;
+use actix_web::{
+    HttpRequest, HttpResponse, Result as ActixResult, http::StatusCode, http::header, web,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::{Client, RequestBuilder, Url};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tracing::{error, info};
 
 use super::context::handle_ai_request;
 use super::execution::execute_with_selected_deployment;
+use super::{openai_errors, provider_config};
+
+const OPENAI_IMAGE_BASE_URL: &str = "https://api.openai.com/v1";
+const MAX_IMAGE_MULTIPART_BYTES: usize = 64 * 1024 * 1024;
+static IMAGE_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy)]
+enum ImageProxyEndpoint {
+    Edits,
+    Variations,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ImageProxyProvider {
+    provider_name: String,
+    pricing_provider: String,
+    base_url: String,
+    headers: Vec<(HeaderName, HeaderValue)>,
+    timeout: Duration,
+}
+
+#[derive(Debug, Clone)]
+struct ImageProxyFormFields {
+    model: Option<String>,
+    prompt: Option<String>,
+    size: Option<String>,
+    quality: Option<String>,
+    n: u32,
+}
 
 /// Image generation endpoint
 ///
@@ -29,6 +68,51 @@ pub async fn image_generations(
         |request, context| handle_image_generation_with_state(state.get_ref(), request, context),
     )
     .await
+}
+
+/// Image edit endpoint.
+///
+/// Proxies OpenAI-compatible multipart requests to an enabled OpenAI or
+/// OpenAI-compatible provider.
+pub async fn image_edits(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    payload: web::Payload,
+) -> ActixResult<HttpResponse> {
+    match proxy_image_multipart_endpoint(state.get_ref(), &req, payload, ImageProxyEndpoint::Edits)
+        .await
+    {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            error!("Image edit error: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
+}
+
+/// Image variation endpoint.
+///
+/// Proxies OpenAI-compatible multipart requests to an enabled OpenAI or
+/// OpenAI-compatible provider.
+pub async fn image_variations(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    payload: web::Payload,
+) -> ActixResult<HttpResponse> {
+    match proxy_image_multipart_endpoint(
+        state.get_ref(),
+        &req,
+        payload,
+        ImageProxyEndpoint::Variations,
+    )
+    .await
+    {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            error!("Image variation error: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
 }
 
 /// Handle image generation with app state (UnifiedRouter only)
@@ -99,4 +183,484 @@ async fn handle_image_generation_internal(
     };
 
     Ok(response)
+}
+
+async fn proxy_image_multipart_endpoint(
+    state: &AppState,
+    req: &HttpRequest,
+    payload: web::Payload,
+    endpoint: ImageProxyEndpoint,
+) -> Result<HttpResponse, GatewayError> {
+    ensure_image_route_authorized(state, req)?;
+    let content_type = image_multipart_content_type(req)?;
+    let body = read_image_multipart_payload(payload).await?;
+    let form_fields = extract_image_proxy_form_fields(&body, &content_type);
+    let requested_model = required_image_proxy_model(&form_fields)?;
+    let Some(provider) = select_image_proxy_provider(
+        state.config().gateway.providers.as_slice(),
+        Some(requested_model),
+    )?
+    else {
+        return Err(missing_image_proxy_provider_error());
+    };
+    let (usage, estimated_cost) =
+        price_image_proxy_request(state, &provider, requested_model, &form_fields)?;
+
+    super::spend::ensure_budget_available(
+        &state.budget_limits,
+        &provider.provider_name,
+        requested_model,
+    )?;
+    let url = image_proxy_url(&provider, endpoint)?;
+    let response = apply_image_proxy_headers(image_http_client().post(url), &provider)
+        .header(reqwest::header::CONTENT_TYPE, content_type)
+        .body(body)
+        .timeout(provider.timeout)
+        .send()
+        .await?;
+
+    if response.status().is_success() {
+        record_image_proxy_spend(
+            state,
+            &provider,
+            requested_model,
+            &usage,
+            estimated_cost,
+            req,
+        )
+        .await;
+    }
+
+    image_proxy_response_to_http_response(response).await
+}
+
+async fn record_image_proxy_spend(
+    state: &AppState,
+    provider: &ImageProxyProvider,
+    model: &str,
+    usage: &PricingUsage,
+    cost: f64,
+    req: &HttpRequest,
+) {
+    state
+        .budget_limits
+        .record_spend(&provider.provider_name, model, cost);
+    if let Some(api_key_id) =
+        super::context::get_authenticated_api_key(req).map(|key| key.metadata.id)
+    {
+        let total_tokens = u64::from(
+            usage
+                .total_tokens
+                .saturating_add(usage.image_tokens.unwrap_or(0)),
+        );
+        if let Err(error) = state
+            .key_manager
+            .record_usage(api_key_id, total_tokens, cost)
+            .await
+        {
+            error!("failed to record image proxy usage for key {api_key_id}: {error}");
+        }
+    }
+}
+
+fn price_image_proxy_request(
+    state: &AppState,
+    provider: &ImageProxyProvider,
+    model: &str,
+    form_fields: &ImageProxyFormFields,
+) -> Result<(PricingUsage, f64), GatewayError> {
+    let usage = estimated_image_proxy_usage(form_fields);
+    let cost = image_proxy_cost(
+        state.pricing.as_ref(),
+        &provider.pricing_provider,
+        model,
+        &usage,
+    )?;
+
+    if cost <= 0.0 {
+        return Err(GatewayError::Config(format!(
+            "Image model '{model}' has non-positive pricing"
+        )));
+    }
+
+    Ok((usage, cost))
+}
+
+fn required_image_proxy_model(form_fields: &ImageProxyFormFields) -> Result<&str, GatewayError> {
+    let model = form_fields
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .ok_or_else(|| GatewayError::validation("model is required"))?;
+    Ok(model)
+}
+
+fn image_proxy_cost(
+    pricing_service: &PricingService,
+    provider: &str,
+    model: &str,
+    usage: &PricingUsage,
+) -> Result<f64, GatewayError> {
+    pricing_service
+        .calculate_loaded_usage_cost_for_provider(provider, model, usage)
+        .map(|breakdown| breakdown.total_cost)
+}
+
+fn estimated_image_proxy_usage(form_fields: &ImageProxyFormFields) -> PricingUsage {
+    let prompt_tokens = form_fields
+        .prompt
+        .as_deref()
+        .map(estimated_text_tokens)
+        .unwrap_or(1);
+    let image_tokens = estimated_image_output_tokens(
+        form_fields.size.as_deref(),
+        form_fields.quality.as_deref(),
+        form_fields.n,
+    );
+    let mut usage = PricingUsage::new(prompt_tokens, image_tokens);
+    usage.image_tokens = Some(image_tokens);
+    usage
+}
+
+fn estimated_text_tokens(text: &str) -> u32 {
+    u32::try_from(text.chars().count().div_ceil(4))
+        .unwrap_or(u32::MAX)
+        .max(1)
+}
+
+fn estimated_image_output_tokens(size: Option<&str>, quality: Option<&str>, quantity: u32) -> u32 {
+    let base_tokens: u32 = match size.unwrap_or("1024x1024") {
+        "256x256" => 256,
+        "512x512" => 512,
+        "1024x1792" | "1792x1024" => 1_792,
+        "1024x1024" => 1_024,
+        _ => 1_024,
+    };
+    let quality_multiplier: u32 = match quality.map(str::to_ascii_lowercase).as_deref() {
+        Some("hd") | Some("high") => 2,
+        _ => 1,
+    };
+    base_tokens
+        .saturating_mul(quality_multiplier)
+        .saturating_mul(quantity.max(1))
+}
+
+fn extract_image_proxy_form_fields(body: &Bytes, content_type: &str) -> ImageProxyFormFields {
+    let n = extract_multipart_text_field(body, content_type, "n")
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(1);
+
+    ImageProxyFormFields {
+        model: extract_multipart_text_field(body, content_type, "model"),
+        prompt: extract_multipart_text_field(body, content_type, "prompt"),
+        size: extract_multipart_text_field(body, content_type, "size"),
+        quality: extract_multipart_text_field(body, content_type, "quality"),
+        n,
+    }
+}
+
+fn ensure_image_route_authorized(
+    state: &AppState,
+    req: &HttpRequest,
+) -> Result<RequestContext, GatewayError> {
+    let context = super::context::get_request_context(req)
+        .map_err(|_| GatewayError::Auth("Unauthorized".to_string()))?;
+    let auth = &state.config().gateway.auth;
+    if !auth.enable_jwt && !auth.enable_api_key && auth.allow_anonymous {
+        return Ok(context);
+    }
+
+    let user = super::context::get_authenticated_user(req);
+    let api_key = super::context::get_authenticated_api_key(req);
+    if super::context::check_permission(user.as_ref(), api_key.as_ref(), "images") {
+        Ok(context)
+    } else {
+        Err(GatewayError::Auth("Unauthorized".to_string()))
+    }
+}
+
+async fn read_image_multipart_payload(mut payload: web::Payload) -> Result<Bytes, GatewayError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = payload.next().await {
+        let chunk = chunk.map_err(|error| {
+            GatewayError::validation(format!("Invalid multipart data: {error}"))
+        })?;
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| GatewayError::validation("Image multipart payload too large"))?;
+        if next_len > MAX_IMAGE_MULTIPART_BYTES {
+            return Err(GatewayError::validation(
+                "Image multipart payload too large",
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(Bytes::from(body))
+}
+
+async fn image_proxy_response_to_http_response(
+    response: reqwest::Response,
+) -> Result<HttpResponse, GatewayError> {
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .map_err(|error| GatewayError::internal(format!("Invalid upstream status: {error}")))?;
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+    let body = response.bytes().await?;
+
+    Ok(HttpResponse::build(status)
+        .insert_header((header::CONTENT_TYPE, content_type))
+        .body(body))
+}
+
+fn select_image_proxy_provider(
+    providers: &[ProviderConfig],
+    requested_model: Option<&str>,
+) -> Result<Option<ImageProxyProvider>, GatewayError> {
+    let candidates = providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter(|provider| is_openai_image_provider(provider))
+        .collect::<Vec<_>>();
+
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let requested_model = requested_model.and_then(|model| {
+        let model = model.trim();
+        (!model.is_empty()).then_some(model)
+    });
+    let Some(provider) = candidates
+        .iter()
+        .copied()
+        .find(|provider| image_provider_supports_requested_model(provider, requested_model))
+    else {
+        let model = requested_model.unwrap_or("");
+        return Err(GatewayError::Config(format!(
+            "Image provider for model '{model}' is not configured"
+        )));
+    };
+
+    if provider.api_key.trim().is_empty() {
+        return Err(GatewayError::Config(format!(
+            "Image provider '{}' is missing api_key",
+            provider.name
+        )));
+    }
+
+    Ok(Some(ImageProxyProvider {
+        provider_name: provider.name.clone(),
+        pricing_provider: image_proxy_pricing_provider(provider),
+        base_url: image_proxy_base_url(provider)?,
+        headers: image_proxy_provider_headers(provider)?,
+        timeout: Duration::from_secs(provider.timeout),
+    }))
+}
+
+fn image_provider_supports_requested_model(
+    provider: &ProviderConfig,
+    requested_model: Option<&str>,
+) -> bool {
+    let Some(requested_model) = requested_model else {
+        return true;
+    };
+    provider.models.is_empty() || provider.models.iter().any(|model| model == requested_model)
+}
+
+fn image_proxy_pricing_provider(provider: &ProviderConfig) -> String {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+    if provider_type == "openai"
+        || provider_type == "openaicompatible"
+        || provider_name == "openai"
+        || provider_name == "openaicompatible"
+    {
+        "openai".to_string()
+    } else {
+        provider.name.clone()
+    }
+}
+
+fn image_proxy_base_url(provider: &ProviderConfig) -> Result<String, GatewayError> {
+    if let Some(base_url) = provider.base_url.as_deref() {
+        let trimmed = base_url.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if provider_config::normalize_provider_selector(&provider.provider_type) == "openai"
+        || provider_config::normalize_provider_selector(&provider.name) == "openai"
+    {
+        return Ok(OPENAI_IMAGE_BASE_URL.to_string());
+    }
+
+    Err(GatewayError::Config(format!(
+        "Image provider '{}' is missing base_url",
+        provider.name
+    )))
+}
+
+fn image_proxy_url(
+    provider: &ImageProxyProvider,
+    endpoint: ImageProxyEndpoint,
+) -> Result<Url, GatewayError> {
+    let mut url = Url::parse(&provider.base_url)
+        .map_err(|error| GatewayError::Config(format!("Invalid image provider URL: {error}")))?;
+    url.path_segments_mut()
+        .map_err(|_| GatewayError::Config("Invalid image provider URL".to_string()))?
+        .extend(["images", endpoint.path_segment()]);
+    Ok(url)
+}
+
+fn image_multipart_content_type(req: &HttpRequest) -> Result<String, GatewayError> {
+    let content_type = req
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .ok_or_else(|| GatewayError::validation("multipart/form-data content type is required"))?
+        .to_str()
+        .map_err(|_| GatewayError::validation("Invalid content type"))?
+        .trim()
+        .to_string();
+
+    if content_type
+        .to_ascii_lowercase()
+        .starts_with("multipart/form-data")
+    {
+        return Ok(content_type);
+    }
+
+    Err(GatewayError::validation(
+        "multipart/form-data content type is required",
+    ))
+}
+
+fn extract_multipart_text_field(
+    body: &Bytes,
+    content_type: &str,
+    field_name: &str,
+) -> Option<String> {
+    let boundary = multipart_boundary(content_type)?;
+    let marker = format!("--{boundary}");
+    let body = String::from_utf8_lossy(body);
+
+    for raw_part in body.split(&marker).skip(1) {
+        if raw_part.starts_with("--") {
+            continue;
+        }
+        let part = raw_part.trim_start_matches("\r\n");
+        let Some((headers, value)) = part.split_once("\r\n\r\n") else {
+            continue;
+        };
+        if !multipart_part_has_field_name(headers, field_name) {
+            continue;
+        }
+        return Some(value.trim_end_matches("\r\n").trim().to_string());
+    }
+
+    None
+}
+
+fn multipart_boundary(content_type: &str) -> Option<String> {
+    content_type.split(';').find_map(|segment| {
+        let segment = segment.trim();
+        let raw_boundary = segment.strip_prefix("boundary=")?;
+        let boundary = raw_boundary.trim_matches('"').trim();
+        (!boundary.is_empty()).then(|| boundary.to_string())
+    })
+}
+
+fn multipart_part_has_field_name(headers: &str, field_name: &str) -> bool {
+    headers.lines().any(|line| {
+        let line = line.trim();
+        line.to_ascii_lowercase()
+            .starts_with("content-disposition:")
+            && (line.contains(&format!("name=\"{field_name}\""))
+                || line.contains(&format!("name={field_name}")))
+    })
+}
+
+fn missing_image_proxy_provider_error() -> GatewayError {
+    GatewayError::Config(
+        "Image edits and variations API requires an enabled openai or openai_compatible provider"
+            .to_string(),
+    )
+}
+
+fn image_http_client() -> &'static Client {
+    IMAGE_HTTP_CLIENT.get_or_init(Client::new)
+}
+
+fn apply_image_proxy_headers(
+    mut request: RequestBuilder,
+    provider: &ImageProxyProvider,
+) -> RequestBuilder {
+    for (name, value) in &provider.headers {
+        request = request.header(name.clone(), value.clone());
+    }
+    request
+}
+
+fn image_proxy_provider_headers(
+    provider: &ProviderConfig,
+) -> Result<Vec<(HeaderName, HeaderValue)>, GatewayError> {
+    let mut headers = Vec::new();
+    push_image_proxy_header(
+        &mut headers,
+        "Authorization",
+        format!("Bearer {}", provider.api_key),
+    )?;
+    if let Some(organization) = provider.organization.as_deref() {
+        push_image_proxy_header(&mut headers, "OpenAI-Organization", organization)?;
+    }
+    if let Some(project) = provider.project.as_deref() {
+        push_image_proxy_header(&mut headers, "OpenAI-Project", project)?;
+    }
+    provider_config::append_string_header_map(provider, "headers", |key, value| {
+        push_image_proxy_header(&mut headers, key, value)
+    })?;
+    provider_config::append_string_header_map(provider, "custom_headers", |key, value| {
+        push_image_proxy_header(&mut headers, key, value)
+    })?;
+    Ok(headers)
+}
+
+fn push_image_proxy_header(
+    headers: &mut Vec<(HeaderName, HeaderValue)>,
+    name: impl AsRef<str>,
+    value: impl AsRef<str>,
+) -> Result<(), GatewayError> {
+    let name = HeaderName::from_bytes(name.as_ref().as_bytes())
+        .map_err(|error| GatewayError::Config(format!("Invalid image provider header: {error}")))?;
+    let value = HeaderValue::from_str(value.as_ref()).map_err(|error| {
+        GatewayError::Config(format!("Invalid image provider header value: {error}"))
+    })?;
+    headers.push((name, value));
+    Ok(())
+}
+
+fn is_openai_image_provider(provider: &ProviderConfig) -> bool {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+
+    provider_type == "openai"
+        || provider_type == "openaicompatible"
+        || provider_name == "openai"
+        || provider_name == "openaicompatible"
+}
+
+impl ImageProxyEndpoint {
+    fn path_segment(self) -> &'static str {
+        match self {
+            Self::Edits => "edits",
+            Self::Variations => "variations",
+        }
+    }
 }

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -35,7 +35,7 @@ pub use fine_tuning::{
     cancel_fine_tuning_job, create_fine_tuning_job, get_fine_tuning_job,
     list_fine_tuning_checkpoints, list_fine_tuning_events, list_fine_tuning_jobs,
 };
-pub use images::image_generations;
+pub use images::{image_edits, image_generations, image_variations};
 pub use models::{get_model, list_models};
 pub use responses::{
     cancel_response, create_response, delete_response, get_response, list_response_input_items,
@@ -104,6 +104,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/files/{file_id}/content", web::get().to(get_file_content))
             // Image generation
             .route("/images/generations", web::post().to(image_generations))
+            .route("/images/edits", web::post().to(image_edits))
+            .route("/images/variations", web::post().to(image_variations))
             // Models
             .route("/models", web::get().to(list_models))
             .route("/models/{model_id}", web::get().to(get_model))

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -1,0 +1,690 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone, Debug)]
+    struct CapturedImageRequest {
+        method: String,
+        path: String,
+        headers: HashMap<String, String>,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    struct MockImageState {
+        captured_requests: Arc<Mutex<Vec<CapturedImageRequest>>>,
+    }
+
+    struct MockImageServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedImageRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockImageServer {
+        async fn start_image_mock() -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockImageState {
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .route("/v1/images/edits", web::post().to(mock_image_edit))
+                    .route(
+                        "/v1/images/variations",
+                        web::post().to(mock_image_variation),
+                    )
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            wait_for_server(address).await;
+
+            Self {
+                base_url: format!("http://{address}/v1"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedImageRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn stop_image_mock(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
+    }
+
+    async fn mock_image_edit(
+        state: web::Data<MockImageState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({
+            "created": 1710000000,
+            "data": [{ "url": "https://images.example.test/edit.png" }]
+        }))
+    }
+
+    async fn mock_image_variation(
+        state: web::Data<MockImageState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({
+            "created": 1710000001,
+            "data": [{ "b64_json": "dmFyaWF0aW9u" }]
+        }))
+    }
+
+    fn capture_request(state: &MockImageState, request: &HttpRequest, body: Bytes) {
+        let headers = request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect();
+
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedImageRequest {
+                method: request.method().to_string(),
+                path: request.path().to_string(),
+                headers,
+                body: body.to_vec(),
+            });
+    }
+
+    async fn build_test_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    async fn build_auth_required_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn image_route_provider(base_url: &str) -> ProviderConfig {
+        image_route_provider_with_name_and_models("mock-openai-compatible", base_url, Vec::new())
+    }
+
+    fn image_route_provider_with_name_and_models(
+        name: &str,
+        base_url: &str,
+        models: Vec<String>,
+    ) -> ProviderConfig {
+        let mut provider = ProviderConfig {
+            name: name.to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            organization: Some("org-test".to_string()),
+            project: Some("proj-test".to_string()),
+            models,
+            ..ProviderConfig::default()
+        };
+        provider.settings = HashMap::from([
+            (
+                "headers".to_string(),
+                json!({
+                    "X-Base-Header": "base-value",
+                    "X-Ignored-Non-String": false
+                }),
+            ),
+            (
+                "custom_headers".to_string(),
+                json!({
+                    "X-Custom-Header": "custom-value"
+                }),
+            ),
+        ]);
+        provider
+    }
+
+    fn image_edit_multipart_body(boundary: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        add_text_field(&mut body, boundary, "model", "gpt-image-1-mini");
+        add_text_field(&mut body, boundary, "prompt", "make it lighter");
+        add_text_field(&mut body, boundary, "size", "1024x1024");
+        add_file_field(
+            &mut body,
+            boundary,
+            "image",
+            "input.png",
+            "image/png",
+            b"png-bytes",
+        );
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    fn image_variation_multipart_body(boundary: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        add_text_field(&mut body, boundary, "model", "gpt-image-1-mini");
+        add_text_field(&mut body, boundary, "n", "1");
+        add_file_field(
+            &mut body,
+            boundary,
+            "image",
+            "source.png",
+            "image/png",
+            b"source-png-bytes",
+        );
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    fn image_variation_without_model_multipart_body(boundary: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        add_text_field(&mut body, boundary, "n", "1");
+        add_file_field(
+            &mut body,
+            boundary,
+            "image",
+            "source.png",
+            "image/png",
+            b"source-png-bytes",
+        );
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    fn image_edit_unpriced_model_multipart_body(boundary: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        add_text_field(&mut body, boundary, "model", "unpriced-image-model");
+        add_text_field(&mut body, boundary, "prompt", "make it lighter");
+        add_file_field(
+            &mut body,
+            boundary,
+            "image",
+            "input.png",
+            "image/png",
+            b"png-bytes",
+        );
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    fn add_text_field(body: &mut Vec<u8>, boundary: &str, name: &str, value: &str) {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+        );
+        body.extend_from_slice(value.as_bytes());
+        body.extend_from_slice(b"\r\n");
+    }
+
+    fn add_file_field(
+        body: &mut Vec<u8>,
+        boundary: &str,
+        name: &str,
+        filename: &str,
+        content_type: &str,
+        content: &[u8],
+    ) {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+        body.extend_from_slice(content);
+        body.extend_from_slice(b"\r\n");
+    }
+
+    #[tokio::test]
+    async fn image_edit_and_variation_routes_without_provider_fail_closed() {
+        let state = build_test_state(Vec::new()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let edit_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(edit_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let edit_body: Value = test::read_body_json(edit_resp).await;
+        assert!(
+            edit_body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("Image edits and variations API requires")
+        );
+        assert_eq!(edit_body["error"]["type"], "server_error");
+
+        let variation_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/variations")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_variation_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(variation_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let variation_body: Value = test::read_body_json(variation_resp).await;
+        assert!(
+            variation_body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("Image edits and variations API requires")
+        );
+    }
+
+    #[tokio::test]
+    async fn image_edit_and_variation_routes_proxy_openai_compatible_provider() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![
+            image_route_provider_with_name_and_models(
+                "wrong-model-provider",
+                "http://127.0.0.1:9/v1",
+                vec!["other-image-model".to_string()],
+            ),
+            image_route_provider_with_name_and_models(
+                "mock-openai-compatible",
+                &mock.base_url,
+                vec!["gpt-image-1-mini".to_string()],
+            ),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-compatible",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            "gpt-image-1-mini",
+            ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let edit_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(edit_resp.status(), StatusCode::OK);
+        let edit_body: Value = test::read_body_json(edit_resp).await;
+        assert_eq!(
+            edit_body["data"][0]["url"],
+            "https://images.example.test/edit.png"
+        );
+
+        let variation_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/variations")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_variation_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(variation_resp.status(), StatusCode::OK);
+        let variation_body: Value = test::read_body_json(variation_resp).await;
+        assert_eq!(variation_body["data"][0]["b64_json"], "dmFyaWF0aW9u");
+
+        let captured = mock.requests();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].method, "POST");
+        assert_eq!(captured[0].path, "/v1/images/edits");
+        assert_eq!(captured[1].path, "/v1/images/variations");
+        for request in &captured {
+            assert!(
+                request
+                    .headers
+                    .get("content-type")
+                    .expect("multipart content type")
+                    .contains("multipart/form-data")
+            );
+            assert_eq!(request.headers["authorization"], "Bearer sk-test");
+            assert_eq!(request.headers["openai-organization"], "org-test");
+            assert_eq!(request.headers["openai-project"], "proj-test");
+            assert_eq!(request.headers["x-base-header"], "base-value");
+            assert_eq!(request.headers["x-custom-header"], "custom-value");
+            let multipart_body = String::from_utf8_lossy(&request.body);
+            assert!(multipart_body.contains("name=\"model\""));
+            assert!(multipart_body.contains("gpt-image-1-mini"));
+            assert!(multipart_body.contains("name=\"image\""));
+        }
+        let edit_multipart = String::from_utf8_lossy(&captured[0].body);
+        assert!(edit_multipart.contains("name=\"prompt\""));
+        assert!(edit_multipart.contains("make it lighter"));
+        assert!(edit_multipart.contains("filename=\"input.png\""));
+        let variation_multipart = String::from_utf8_lossy(&captured[1].body);
+        assert!(variation_multipart.contains("filename=\"source.png\""));
+        assert!(
+            budget_limits
+                .providers
+                .get_provider_usage("mock-openai-compatible")
+                .expect("provider spend should be recorded")
+                .current_spend
+                > 0.0
+        );
+        assert!(
+            budget_limits
+                .models
+                .get_model_usage("gpt-image-1-mini")
+                .expect("model spend should be recorded")
+                .current_spend
+                > 0.0
+        );
+
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn image_edit_rejects_unauthenticated_request_when_auth_is_enabled() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_auth_required_state(vec![image_route_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "authentication_error");
+        assert!(
+            mock.requests().is_empty(),
+            "unauthorized requests must not reach upstream"
+        );
+
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn image_variation_rejects_missing_model_before_upstream() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/variations")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_variation_without_model_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(
+            body["error"]["message"],
+            "Validation error: model is required"
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "missing model must fail before upstream call"
+        );
+
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn image_edit_rejects_unpriced_model_before_upstream() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_unpriced_model_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("unpriced-image-model")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "unpriced model must fail before upstream call"
+        );
+
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn image_edit_rejects_exhausted_provider_budget_before_upstream() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-compatible",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("mock-openai-compatible", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "insufficient_quota");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("provider 'mock-openai-compatible' budget exceeded")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "budget rejection must happen before upstream call"
+        );
+
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn image_edit_rejects_exhausted_model_budget_before_upstream() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;
+        state.budget_limits.models.set_model_limit(
+            "gpt-image-1-mini",
+            ModelLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .models
+            .record_model_spend("gpt-image-1-mini", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "insufficient_quota");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("model 'gpt-image-1-mini' budget exceeded")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "model budget rejection must happen before upstream call"
+        );
+
+        mock.stop_image_mock().await;
+    }
+}


### PR DESCRIPTION
Fixes #744

## Summary
- add /v1/images/edits and /v1/images/variations routes
- proxy OpenAI-compatible multipart image requests to enabled openai/openai_compatible providers
- preserve configured provider headers and reject exhausted provider budgets before upstream calls

## Tests
- cargo test --all-features --locked --test image_edit_variation_routes --quiet
- cargo check --all-features --locked
- cargo test --all-features --locked --quiet