### PR TITLE
Add Gemini SDK compatibility routes

### DIFF
--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -1,0 +1,545 @@
+//! Gemini SDK-compatible native generation routes.
+
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, http::StatusCode, web};
+use bytes::Bytes;
+use futures::StreamExt;
+use reqwest::{
+    Client, Url,
+    header::{CONTENT_TYPE, HeaderName, HeaderValue},
+};
+use serde_json::Value;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::error;
+
+use crate::config::models::provider::ProviderConfig;
+use crate::core::budget::UnifiedBudgetReservation;
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::{openai_errors, provider_config};
+
+mod spend;
+use spend::{
+    GeminiSpendState, extract_gemini_sse_usage, record_gemini_spend, reserve_gemini_budget,
+    settle_gemini_stream_spend,
+};
+
+const GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+const GEMINI_V1: &str = "v1";
+const GEMINI_V1BETA: &str = "v1beta";
+const GEMINI_MAX_JSON_BYTES: usize = 16 * 1024 * 1024;
+
+static GEMINI_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+struct GeminiRouteProvider {
+    provider_name: String,
+    pricing_provider: String,
+    model: String,
+    api_key: String,
+    base_url: String,
+    headers: Vec<(HeaderName, HeaderValue)>,
+    timeout: Duration,
+}
+
+macro_rules! gemini_route_handler {
+    ($name:ident, $version:expr, $method:literal, $stream:expr) => {
+        pub async fn $name(
+            state: web::Data<AppState>,
+            req: HttpRequest,
+            model: web::Path<String>,
+            request: web::Json<Value>,
+        ) -> ActixResult<HttpResponse> {
+            proxy_gemini_route(
+                state.get_ref(),
+                &req,
+                $version,
+                model.into_inner(),
+                $method,
+                $stream,
+                request.into_inner(),
+            )
+            .await
+        }
+    };
+}
+
+gemini_route_handler!(
+    gemini_generate_content_v1beta,
+    GEMINI_V1BETA,
+    "generateContent",
+    false
+);
+gemini_route_handler!(
+    gemini_stream_generate_content_v1beta,
+    GEMINI_V1BETA,
+    "streamGenerateContent",
+    true
+);
+gemini_route_handler!(
+    gemini_generate_content_v1,
+    GEMINI_V1,
+    "generateContent",
+    false
+);
+gemini_route_handler!(
+    gemini_stream_generate_content_v1,
+    GEMINI_V1,
+    "streamGenerateContent",
+    true
+);
+
+async fn proxy_gemini_route(
+    state: &AppState,
+    req: &HttpRequest,
+    api_version: &str,
+    requested_model: String,
+    method: &'static str,
+    stream: bool,
+    request: Value,
+) -> ActixResult<HttpResponse> {
+    match proxy_gemini_route_inner(
+        state,
+        req,
+        api_version,
+        requested_model,
+        method,
+        stream,
+        request,
+    )
+    .await
+    {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            error!("Gemini SDK route error: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
+}
+
+async fn proxy_gemini_route_inner(
+    state: &AppState,
+    req: &HttpRequest,
+    api_version: &str,
+    requested_model: String,
+    method: &'static str,
+    stream: bool,
+    request: Value,
+) -> Result<HttpResponse, GatewayError> {
+    let context = ensure_gemini_route_authorized(state, req)?;
+    validate_api_version(api_version)?;
+    validate_method(method)?;
+    validate_model_segment(&requested_model)?;
+    validate_gemini_request_size(&request)?;
+
+    let provider = select_gemini_provider(state.config().providers(), &requested_model)?;
+    super::spend::ensure_budget_available(
+        &state.budget_limits,
+        &provider.provider_name,
+        &provider.model,
+    )?;
+    let budget_reservation = reserve_gemini_budget(state, &provider, &request)?;
+
+    let url = gemini_url(&provider, api_version, method, stream)?;
+    let response = apply_gemini_headers(gemini_http_client().post(url), &provider)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&request)
+        .timeout(provider.timeout)
+        .send()
+        .await
+        .map_err(gemini_http_error)?;
+
+    gemini_upstream_response_to_http_response(
+        state,
+        context,
+        provider,
+        budget_reservation,
+        response,
+        stream,
+    )
+    .await
+}
+
+async fn gemini_upstream_response_to_http_response(
+    state: &AppState,
+    context: crate::core::types::context::RequestContext,
+    provider: GeminiRouteProvider,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    response: reqwest::Response,
+    stream: bool,
+) -> Result<HttpResponse, GatewayError> {
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .map_err(|error| GatewayError::internal(format!("Invalid upstream status: {error}")))?;
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or(if stream {
+            "text/event-stream"
+        } else {
+            "application/json"
+        })
+        .to_string();
+
+    if stream && !status.is_success() {
+        let body = response.bytes().await.map_err(gemini_http_error)?;
+        return Ok(HttpResponse::build(status)
+            .insert_header((actix_web::http::header::CONTENT_TYPE, content_type))
+            .body(sanitize_gemini_error_body(body, &provider)));
+    }
+
+    if stream {
+        return Ok(gemini_streaming_response(
+            state,
+            context,
+            provider,
+            budget_reservation,
+            response,
+            status,
+            content_type,
+        ));
+    }
+
+    let mut body = response.bytes().await.map_err(gemini_http_error)?;
+    if status.is_success() {
+        let spend_state = GeminiSpendState {
+            pricing: state.pricing.as_ref(),
+            budget_limits: &state.budget_limits,
+            key_manager: &state.key_manager,
+            api_key_id: context.api_key_id(),
+        };
+        record_gemini_spend(&spend_state, &provider, &body, budget_reservation, true).await;
+    } else {
+        body = sanitize_gemini_error_body(body, &provider);
+    }
+
+    Ok(HttpResponse::build(status)
+        .insert_header((actix_web::http::header::CONTENT_TYPE, content_type))
+        .body(body))
+}
+
+fn gemini_streaming_response(
+    state: &AppState,
+    context: crate::core::types::context::RequestContext,
+    provider: GeminiRouteProvider,
+    mut budget_reservation: Option<UnifiedBudgetReservation>,
+    response: reqwest::Response,
+    status: StatusCode,
+    content_type: String,
+) -> HttpResponse {
+    let (tx, rx) = mpsc::channel::<Bytes>(8);
+    let pricing = state.pricing.clone();
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let api_key_id = context.api_key_id();
+    let should_record_spend = status.is_success();
+
+    tokio::spawn(async move {
+        let mut upstream = response.bytes_stream();
+        let mut sse_buffer = String::new();
+        let mut final_usage = None;
+        let mut saw_upstream_output = false;
+
+        while let Some(chunk_result) = upstream.next().await {
+            let bytes = match chunk_result {
+                Ok(bytes) => bytes,
+                Err(_) => {
+                    error!("Gemini SDK upstream stream error; closing client stream");
+                    let spend_state = GeminiSpendState {
+                        pricing: pricing.as_ref(),
+                        budget_limits: &budget_limits,
+                        key_manager: &key_manager,
+                        api_key_id,
+                    };
+                    settle_gemini_stream_spend(
+                        &spend_state,
+                        &provider,
+                        should_record_spend.then(|| final_usage.take()).flatten(),
+                        budget_reservation.take(),
+                        false,
+                    )
+                    .await;
+                    if tx
+                        .send(Bytes::from_static(
+                            b"event: error\ndata: Gemini upstream stream error\n\n",
+                        ))
+                        .await
+                        .is_err()
+                    {
+                        error!("client disconnected before Gemini stream error could be sent");
+                    }
+                    return;
+                }
+            };
+            saw_upstream_output = true;
+            if let Some(usage) = extract_gemini_sse_usage(&bytes, &mut sse_buffer) {
+                final_usage = Some(usage);
+            }
+            if tx.send(bytes).await.is_err() {
+                let spend_state = GeminiSpendState {
+                    pricing: pricing.as_ref(),
+                    budget_limits: &budget_limits,
+                    key_manager: &key_manager,
+                    api_key_id,
+                };
+                settle_gemini_stream_spend(
+                    &spend_state,
+                    &provider,
+                    should_record_spend.then(|| final_usage.take()).flatten(),
+                    budget_reservation.take(),
+                    should_record_spend && saw_upstream_output,
+                )
+                .await;
+                return;
+            }
+        }
+
+        let spend_state = GeminiSpendState {
+            pricing: pricing.as_ref(),
+            budget_limits: &budget_limits,
+            key_manager: &key_manager,
+            api_key_id,
+        };
+        settle_gemini_stream_spend(
+            &spend_state,
+            &provider,
+            if should_record_spend {
+                final_usage
+            } else {
+                None
+            },
+            budget_reservation.take(),
+            should_record_spend && saw_upstream_output,
+        )
+        .await;
+    });
+
+    let upstream =
+        tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok::<_, actix_web::error::Error>);
+    HttpResponse::build(status)
+        .insert_header((actix_web::http::header::CONTENT_TYPE, content_type))
+        .streaming(upstream)
+}
+
+fn select_gemini_provider(
+    providers: &[ProviderConfig],
+    requested_model: &str,
+) -> Result<GeminiRouteProvider, GatewayError> {
+    let Some(provider) = providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter(|provider| is_gemini_provider(provider))
+        .find(|provider| provider_supports_requested_model(provider, requested_model))
+    else {
+        return Err(GatewayError::Config(format!(
+            "Gemini SDK route provider for model '{requested_model}' is not configured"
+        )));
+    };
+
+    if provider.api_key.trim().is_empty() {
+        return Err(GatewayError::Config(format!(
+            "Gemini provider '{}' is missing api_key",
+            provider.name
+        )));
+    }
+
+    Ok(GeminiRouteProvider {
+        provider_name: provider.name.clone(),
+        pricing_provider: "gemini".to_string(),
+        model: requested_model.to_string(),
+        api_key: provider.api_key.clone(),
+        base_url: gemini_base_url(provider),
+        headers: gemini_provider_headers(provider)?,
+        timeout: Duration::from_secs(provider.timeout),
+    })
+}
+
+fn provider_supports_requested_model(provider: &ProviderConfig, requested_model: &str) -> bool {
+    provider.models.is_empty() || provider.models.iter().any(|model| model == requested_model)
+}
+
+fn is_gemini_provider(provider: &ProviderConfig) -> bool {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+
+    matches!(
+        provider_type.as_str(),
+        "gemini" | "googleai" | "googleaistudio"
+    ) || matches!(
+        provider_name.as_str(),
+        "gemini" | "googleai" | "googleaistudio"
+    )
+}
+
+fn gemini_base_url(provider: &ProviderConfig) -> String {
+    provider
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .unwrap_or(GEMINI_BASE_URL)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn gemini_provider_headers(
+    provider: &ProviderConfig,
+) -> Result<Vec<(HeaderName, HeaderValue)>, GatewayError> {
+    let mut headers = Vec::new();
+    provider_config::append_string_header_map(provider, "headers", |key, value| {
+        push_gemini_header(&mut headers, key, value)
+    })?;
+    provider_config::append_string_header_map(provider, "custom_headers", |key, value| {
+        push_gemini_header(&mut headers, key, value)
+    })?;
+    Ok(headers)
+}
+
+fn push_gemini_header(
+    headers: &mut Vec<(HeaderName, HeaderValue)>,
+    name: impl AsRef<str>,
+    value: impl AsRef<str>,
+) -> Result<(), GatewayError> {
+    let name = HeaderName::from_bytes(name.as_ref().as_bytes()).map_err(|error| {
+        GatewayError::Config(format!("Invalid Gemini provider header: {error}"))
+    })?;
+    let value = HeaderValue::from_str(value.as_ref()).map_err(|error| {
+        GatewayError::Config(format!("Invalid Gemini provider header value: {error}"))
+    })?;
+    headers.push((name, value));
+    Ok(())
+}
+
+fn gemini_url(
+    provider: &GeminiRouteProvider,
+    api_version: &str,
+    method: &'static str,
+    stream: bool,
+) -> Result<Url, GatewayError> {
+    validate_api_version(api_version)?;
+    validate_model_segment(&provider.model)?;
+    validate_method(method)?;
+
+    let mut url = Url::parse(&format!(
+        "{}/{}/models/{}:{}",
+        provider.base_url.trim_end_matches('/'),
+        api_version,
+        provider.model,
+        method
+    ))
+    .map_err(|error| GatewayError::Config(format!("Invalid Gemini base URL: {error}")))?;
+
+    {
+        let mut query = url.query_pairs_mut();
+        if stream {
+            query.append_pair("alt", "sse");
+        }
+        query.append_pair("key", &provider.api_key);
+    }
+
+    Ok(url)
+}
+
+fn ensure_gemini_route_authorized(
+    state: &AppState,
+    req: &HttpRequest,
+) -> Result<crate::core::types::context::RequestContext, GatewayError> {
+    let context = super::context::get_request_context(req)
+        .map_err(|_| GatewayError::Auth("Unauthorized".to_string()))?;
+    let auth = &state.config().gateway.auth;
+    if !auth.enable_jwt && !auth.enable_api_key && auth.allow_anonymous {
+        return Ok(context);
+    }
+
+    let user = super::context::get_authenticated_user(req);
+    let api_key = super::context::get_authenticated_api_key(req);
+    if super::context::check_permission(user.as_ref(), api_key.as_ref(), "chat") {
+        Ok(context)
+    } else {
+        Err(GatewayError::Auth("Unauthorized".to_string()))
+    }
+}
+
+fn validate_api_version(api_version: &str) -> Result<(), GatewayError> {
+    if matches!(api_version, GEMINI_V1 | GEMINI_V1BETA) {
+        return Ok(());
+    }
+
+    Err(GatewayError::validation("Unsupported Gemini API version"))
+}
+
+fn validate_method(method: &str) -> Result<(), GatewayError> {
+    if matches!(method, "generateContent" | "streamGenerateContent") {
+        return Ok(());
+    }
+
+    Err(GatewayError::validation("Unsupported Gemini method"))
+}
+
+fn validate_model_segment(model: &str) -> Result<(), GatewayError> {
+    if model.trim().is_empty() {
+        return Err(GatewayError::validation("Gemini model is required"));
+    }
+
+    if model
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        return Ok(());
+    }
+
+    Err(GatewayError::validation(
+        "Gemini model must be a single safe path segment",
+    ))
+}
+
+fn validate_gemini_request_size(request: &Value) -> Result<(), GatewayError> {
+    let len = serde_json::to_vec(request)?.len();
+    if len > GEMINI_MAX_JSON_BYTES {
+        return Err(GatewayError::validation("Gemini request body too large"));
+    }
+    Ok(())
+}
+
+fn gemini_http_client() -> &'static Client {
+    GEMINI_HTTP_CLIENT.get_or_init(Client::new)
+}
+
+fn gemini_http_error(error: reqwest::Error) -> GatewayError {
+    if error.is_timeout() {
+        GatewayError::timeout("Gemini upstream request timed out")
+    } else {
+        GatewayError::network("Gemini upstream request failed")
+    }
+}
+
+fn apply_gemini_headers(
+    mut request: reqwest::RequestBuilder,
+    provider: &GeminiRouteProvider,
+) -> reqwest::RequestBuilder {
+    for (name, value) in &provider.headers {
+        request = request.header(name.clone(), value.clone());
+    }
+    request
+}
+
+fn sanitize_gemini_error_body(body: Bytes, provider: &GeminiRouteProvider) -> Bytes {
+    if provider.api_key.is_empty() || body.is_empty() {
+        return body;
+    }
+
+    let text = String::from_utf8_lossy(&body);
+    let encoded_key: String =
+        url::form_urlencoded::byte_serialize(provider.api_key.as_bytes()).collect();
+    if !text.contains(&provider.api_key) && !text.contains(&encoded_key) {
+        return body;
+    }
+
+    let mut sanitized = text.replace(&provider.api_key, "[REDACTED]");
+    if encoded_key != provider.api_key {
+        sanitized = sanitized.replace(&encoded_key, "[REDACTED]");
+    }
+    Bytes::from(sanitized)
+}

--- a/src/server/routes/ai/gemini/spend.rs
+++ b/src/server/routes/ai/gemini/spend.rs
@@ -1,0 +1,304 @@
+use bytes::Bytes;
+use serde_json::Value;
+use tracing::error;
+
+use crate::core::budget::{BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::keys::KeyManager;
+use crate::core::pricing_service::{PricingService, PricingUsage};
+use crate::core::providers::ProviderError;
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::GeminiRouteProvider;
+
+pub(super) struct GeminiSpendState<'a> {
+    pub(super) pricing: &'a PricingService,
+    pub(super) budget_limits: &'a UnifiedBudgetLimits,
+    pub(super) key_manager: &'a KeyManager,
+    pub(super) api_key_id: Option<uuid::Uuid>,
+}
+
+pub(super) async fn settle_gemini_stream_spend(
+    spend_state: &GeminiSpendState<'_>,
+    provider: &GeminiRouteProvider,
+    usage: Option<PricingUsage>,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    saw_upstream_output: bool,
+) {
+    if let Some(usage) = usage {
+        record_gemini_usage(spend_state, provider, usage, budget_reservation).await;
+    } else if saw_upstream_output {
+        settle_gemini_reserved_spend_without_usage(
+            spend_state,
+            provider,
+            budget_reservation,
+            "Gemini SDK stream ended without usageMetadata",
+        )
+        .await;
+    }
+}
+
+pub(super) fn extract_gemini_sse_usage(bytes: &Bytes, buffer: &mut String) -> Option<PricingUsage> {
+    buffer.push_str(&String::from_utf8_lossy(bytes));
+    let mut usage = None;
+    while let Some(event_end) = buffer.find("\n\n") {
+        let event = buffer[..event_end].to_string();
+        buffer.drain(..event_end + 2);
+        if let Some(next_usage) = parse_gemini_sse_event_usage(&event) {
+            usage = Some(next_usage);
+        }
+    }
+    usage
+}
+
+pub(super) async fn record_gemini_spend(
+    spend_state: &GeminiSpendState<'_>,
+    provider: &GeminiRouteProvider,
+    body: &[u8],
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    settle_without_usage: bool,
+) {
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        settle_gemini_reserved_spend_without_usage(
+            spend_state,
+            provider,
+            budget_reservation,
+            "Gemini SDK response was not valid JSON",
+        )
+        .await;
+        return;
+    };
+    let Some(usage) = gemini_usage_metadata(&value) else {
+        if settle_without_usage {
+            settle_gemini_reserved_spend_without_usage(
+                spend_state,
+                provider,
+                budget_reservation,
+                "Gemini SDK response had no usageMetadata",
+            )
+            .await;
+        }
+        return;
+    };
+    record_gemini_usage(spend_state, provider, usage, budget_reservation).await;
+}
+
+pub(super) fn reserve_gemini_budget(
+    state: &AppState,
+    provider: &GeminiRouteProvider,
+    request: &Value,
+) -> Result<Option<UnifiedBudgetReservation>, GatewayError> {
+    let usage = estimated_gemini_request_usage(request);
+    let estimate = state.pricing.estimate_loaded_completion_cost_for_provider(
+        &provider.pricing_provider,
+        &provider.model,
+        usage.prompt_tokens,
+        Some(usage.completion_tokens),
+    )?;
+    if estimate.max_cost <= 0.0 {
+        super::super::spend::ensure_budget_available(
+            &state.budget_limits,
+            &provider.provider_name,
+            &provider.model,
+        )?;
+        return Ok(None);
+    }
+    state
+        .budget_limits
+        .reserve_spend(&provider.provider_name, &provider.model, estimate.max_cost)
+        .map(Some)
+        .map_err(|error| reservation_error_to_gateway_error(error, provider))
+}
+
+async fn record_gemini_usage(
+    spend_state: &GeminiSpendState<'_>,
+    provider: &GeminiRouteProvider,
+    usage: PricingUsage,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+) {
+    let cost = match spend_state
+        .pricing
+        .calculate_loaded_usage_cost_for_provider(
+            &provider.pricing_provider,
+            &provider.model,
+            &usage,
+        ) {
+        Ok(breakdown) => breakdown.total_cost,
+        Err(error) => {
+            settle_gemini_reserved_spend_without_usage(
+                spend_state,
+                provider,
+                budget_reservation,
+                &format!("Gemini SDK cost calculation failed: {error}"),
+            )
+            .await;
+            return;
+        }
+    };
+
+    if let Some(reservation) = budget_reservation {
+        if let Err(error) = reservation.settle(cost) {
+            error!(
+                "failed to settle Gemini SDK budget for provider '{}' model '{}': {error:?}",
+                provider.provider_name, provider.model
+            );
+        }
+    } else {
+        spend_state
+            .budget_limits
+            .record_spend(&provider.provider_name, &provider.model, cost);
+    }
+
+    if let Some(key_id) = spend_state.api_key_id
+        && let Err(error) = spend_state
+            .key_manager
+            .record_usage(key_id, u64::from(usage.total_tokens), cost)
+            .await
+    {
+        error!("failed to record Gemini SDK usage for key {key_id}: {error}");
+    }
+}
+
+async fn settle_gemini_reserved_spend_without_usage(
+    spend_state: &GeminiSpendState<'_>,
+    provider: &GeminiRouteProvider,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    context: &str,
+) {
+    let Some(reservation) = budget_reservation else {
+        error!(
+            "{context} for provider '{}' model '{}'; spend not recorded",
+            provider.provider_name, provider.model
+        );
+        return;
+    };
+    let reserved = reservation.reserved_amount();
+    if let Err(error) = reservation.settle(reserved) {
+        error!(
+            "failed to settle reserved Gemini SDK budget for provider '{}' model '{}': {error:?}",
+            provider.provider_name, provider.model
+        );
+    }
+    if let Some(key_id) = spend_state.api_key_id
+        && let Err(error) = spend_state
+            .key_manager
+            .record_usage(key_id, 0, reserved)
+            .await
+    {
+        error!("failed to record reserved Gemini SDK usage for key {key_id}: {error}");
+    }
+    error!(
+        "{context} for provider '{}' model '{}'; charged reserved amount",
+        provider.provider_name, provider.model
+    );
+}
+
+fn reservation_error_to_gateway_error(
+    error: BudgetReservationError,
+    provider: &GeminiRouteProvider,
+) -> GatewayError {
+    let message = match error {
+        BudgetReservationError::BudgetExceeded => "budget exceeded".to_string(),
+        BudgetReservationError::ProviderBudgetExceeded => {
+            format!("provider '{}' budget exceeded", provider.provider_name)
+        }
+        BudgetReservationError::ModelBudgetExceeded => {
+            format!("model '{}' budget exceeded", provider.model)
+        }
+        BudgetReservationError::InvalidAmount(error) => format!("invalid budget amount: {error}"),
+        BudgetReservationError::ActualExceedsReservation => format!(
+            "actual spend exceeded reserved budget for '{}/{}'",
+            provider.provider_name, provider.model
+        ),
+    };
+    match error {
+        BudgetReservationError::BudgetExceeded
+        | BudgetReservationError::ProviderBudgetExceeded
+        | BudgetReservationError::ModelBudgetExceeded => {
+            GatewayError::from(ProviderError::quota_exceeded("budget", message))
+        }
+        BudgetReservationError::InvalidAmount(_)
+        | BudgetReservationError::ActualExceedsReservation => {
+            GatewayError::from(ProviderError::invalid_request("budget", message))
+        }
+    }
+}
+
+fn parse_gemini_sse_event_usage(event: &str) -> Option<PricingUsage> {
+    for line in event.lines() {
+        let Some(data) = line.trim_start().strip_prefix("data:").map(str::trim) else {
+            continue;
+        };
+        if data == "[DONE]" || data.is_empty() {
+            continue;
+        }
+        let value = serde_json::from_str::<Value>(data).ok()?;
+        if let Some(usage) = gemini_usage_metadata(&value) {
+            return Some(usage);
+        }
+    }
+    None
+}
+
+fn estimated_gemini_request_usage(request: &Value) -> PricingUsage {
+    let prompt_tokens = estimate_gemini_prompt_tokens(request);
+    let completion_tokens = request
+        .pointer("/generationConfig/maxOutputTokens")
+        .and_then(Value::as_u64)
+        .and_then(|tokens| u32::try_from(tokens).ok())
+        .unwrap_or(0);
+    PricingUsage::new(prompt_tokens, completion_tokens)
+}
+
+fn gemini_usage_metadata(value: &Value) -> Option<PricingUsage> {
+    let metadata = value.get("usageMetadata")?;
+    let prompt_tokens = u32_field(metadata, "promptTokenCount").unwrap_or(0);
+    let completion_tokens = u32_field(metadata, "candidatesTokenCount").unwrap_or(0);
+    let mut usage = PricingUsage::new(prompt_tokens, completion_tokens);
+    usage.total_tokens = u32_field(metadata, "totalTokenCount")
+        .unwrap_or_else(|| prompt_tokens.saturating_add(completion_tokens));
+    usage.cached_tokens = u32_field(metadata, "cachedContentTokenCount");
+    usage.reasoning_tokens = u32_field(metadata, "thoughtsTokenCount");
+    Some(usage)
+}
+
+fn u32_field(value: &Value, key: &str) -> Option<u32> {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|tokens| u32::try_from(tokens).ok())
+}
+
+fn estimate_gemini_prompt_tokens(request: &Value) -> u32 {
+    let mut chars = 0_usize;
+    collect_text_chars(request.get("contents"), &mut chars);
+    collect_text_chars(request.get("systemInstruction"), &mut chars);
+    if chars == 0 {
+        chars = serde_json::to_string(request)
+            .map(|serialized| serialized.chars().count())
+            .unwrap_or(0);
+    }
+    u32::try_from(chars.div_ceil(4).max(1)).unwrap_or(u32::MAX)
+}
+
+fn collect_text_chars(value: Option<&Value>, chars: &mut usize) {
+    let Some(value) = value else {
+        return;
+    };
+    match value {
+        Value::Object(map) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                *chars = chars.saturating_add(text.chars().count());
+            }
+            for child in map.values() {
+                collect_text_chars(Some(child), chars);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_text_chars(Some(item), chars);
+            }
+        }
+        _ => {}
+    }
+}

--- a/src/server/routes/ai/gemini/spend.rs
+++ b/src/server/routes/ai/gemini/spend.rs
@@ -41,14 +41,24 @@ pub(super) async fn settle_gemini_stream_spend(
 pub(super) fn extract_gemini_sse_usage(bytes: &Bytes, buffer: &mut String) -> Option<PricingUsage> {
     buffer.push_str(&String::from_utf8_lossy(bytes));
     let mut usage = None;
-    while let Some(event_end) = buffer.find("\n\n") {
+    while let Some((event_end, separator_len)) = next_sse_event_boundary(buffer) {
         let event = buffer[..event_end].to_string();
-        buffer.drain(..event_end + 2);
+        buffer.drain(..event_end + separator_len);
         if let Some(next_usage) = parse_gemini_sse_event_usage(&event) {
             usage = Some(next_usage);
         }
     }
     usage
+}
+
+fn next_sse_event_boundary(buffer: &str) -> Option<(usize, usize)> {
+    match (buffer.find("\n\n"), buffer.find("\r\n\r\n")) {
+        (Some(lf), Some(crlf)) if lf < crlf => Some((lf, 2)),
+        (Some(_), Some(crlf)) => Some((crlf, 4)),
+        (Some(lf), None) => Some((lf, 2)),
+        (None, Some(crlf)) => Some((crlf, 4)),
+        (None, None) => None,
+    }
 }
 
 pub(super) async fn record_gemini_spend(
@@ -271,8 +281,12 @@ fn u32_field(value: &Value, key: &str) -> Option<u32> {
 
 fn estimate_gemini_prompt_tokens(request: &Value) -> u32 {
     let mut chars = 0_usize;
-    collect_text_chars(request.get("contents"), &mut chars);
-    collect_text_chars(request.get("systemInstruction"), &mut chars);
+    if let Some(contents) = request.get("contents") {
+        collect_text_chars(contents, &mut chars);
+    }
+    if let Some(system_instruction) = request.get("systemInstruction") {
+        collect_text_chars(system_instruction, &mut chars);
+    }
     if chars == 0 {
         chars = serde_json::to_string(request)
             .map(|serialized| serialized.chars().count())
@@ -281,24 +295,45 @@ fn estimate_gemini_prompt_tokens(request: &Value) -> u32 {
     u32::try_from(chars.div_ceil(4).max(1)).unwrap_or(u32::MAX)
 }
 
-fn collect_text_chars(value: Option<&Value>, chars: &mut usize) {
-    let Some(value) = value else {
-        return;
-    };
+fn collect_text_chars(value: &Value, chars: &mut usize) {
     match value {
         Value::Object(map) => {
             if let Some(text) = map.get("text").and_then(Value::as_str) {
                 *chars = chars.saturating_add(text.chars().count());
             }
             for child in map.values() {
-                collect_text_chars(Some(child), chars);
+                collect_text_chars(child, chars);
             }
         }
         Value::Array(items) => {
             for item in items {
-                collect_text_chars(Some(item), chars);
+                collect_text_chars(item, chars);
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_usage_from_crlf_sse_event_boundaries() {
+        let mut buffer = String::new();
+        let usage = extract_gemini_sse_usage(
+            &Bytes::from_static(
+                b"event: message\r\n\
+                  data: {\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":2,\"totalTokenCount\":3}}\r\n\r\n",
+            ),
+            &mut buffer,
+        );
+        assert!(usage.is_some(), "usage should be parsed");
+        let usage = usage.unwrap_or_default();
+
+        assert_eq!(usage.prompt_tokens, 1);
+        assert_eq!(usage.completion_tokens, 2);
+        assert_eq!(usage.total_tokens, 3);
+        assert!(buffer.is_empty());
     }
 }

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -11,6 +11,7 @@ mod embeddings;
 mod execution;
 mod files;
 mod fine_tuning;
+mod gemini;
 mod images;
 mod models;
 mod openai_errors;
@@ -34,6 +35,10 @@ pub use files::{create_file, delete_file, get_file, get_file_content, list_files
 pub use fine_tuning::{
     cancel_fine_tuning_job, create_fine_tuning_job, get_fine_tuning_job,
     list_fine_tuning_checkpoints, list_fine_tuning_events, list_fine_tuning_jobs,
+};
+pub use gemini::{
+    gemini_generate_content_v1, gemini_generate_content_v1beta, gemini_stream_generate_content_v1,
+    gemini_stream_generate_content_v1beta,
 };
 pub use images::{image_edits, image_generations, image_variations};
 pub use models::{get_model, list_models};
@@ -109,6 +114,14 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             // Models
             .route("/models", web::get().to(list_models))
             .route("/models/{model_id}", web::get().to(get_model))
+            .route(
+                "/models/{model}:generateContent",
+                web::post().to(gemini_generate_content_v1),
+            )
+            .route(
+                "/models/{model}:streamGenerateContent",
+                web::post().to(gemini_stream_generate_content_v1),
+            )
             .route("/engines", web::get().to(list_models))
             .route("/engines/{model_id}", web::get().to(get_model))
             // Audio (future implementation)
@@ -118,6 +131,39 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             )
             .route("/audio/translations", web::post().to(audio_translations))
             .route("/audio/speech", web::post().to(audio_speech)),
+    );
+    cfg.service(
+        web::scope("/v1beta")
+            .route(
+                "/models/{model}:generateContent",
+                web::post().to(gemini_generate_content_v1beta),
+            )
+            .route(
+                "/models/{model}:streamGenerateContent",
+                web::post().to(gemini_stream_generate_content_v1beta),
+            ),
+    );
+    cfg.service(
+        web::scope("/gemini/v1beta")
+            .route(
+                "/models/{model}:generateContent",
+                web::post().to(gemini_generate_content_v1beta),
+            )
+            .route(
+                "/models/{model}:streamGenerateContent",
+                web::post().to(gemini_stream_generate_content_v1beta),
+            ),
+    );
+    cfg.service(
+        web::scope("/gemini/v1")
+            .route(
+                "/models/{model}:generateContent",
+                web::post().to(gemini_generate_content_v1),
+            )
+            .route(
+                "/models/{model}:streamGenerateContent",
+                web::post().to(gemini_stream_generate_content_v1),
+            ),
     );
 }
 

--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -6,6 +6,7 @@ mod tests {
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use litellm_rs::server::state::AppState;
     use serde_json::{Value, json};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -211,9 +212,7 @@ mod tests {
         }))
     }
 
-    async fn build_test_state(
-        providers: Vec<ProviderConfig>,
-    ) -> litellm_rs::server::state::AppState {
+    async fn build_test_state(providers: Vec<ProviderConfig>) -> AppState {
         let mut config = Config::default();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
@@ -229,9 +228,7 @@ mod tests {
             .clone()
     }
 
-    async fn build_auth_required_state(
-        providers: Vec<ProviderConfig>,
-    ) -> litellm_rs::server::state::AppState {
+    async fn build_auth_required_state(providers: Vec<ProviderConfig>) -> AppState {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
@@ -247,7 +244,7 @@ mod tests {
     fn gemini_provider(name: &str, base_url: &str, models: Vec<String>) -> ProviderConfig {
         let mut provider = ProviderConfig {
             name: name.to_string(),
-            provider_type: "gemini".to_string(),
+            provider_type: "openai_compatible".to_string(),
             api_key: "test-api-key-12345678901234567890".to_string(),
             base_url: Some(base_url.to_string()),
             models,
@@ -321,19 +318,19 @@ mod tests {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![
             gemini_provider(
-                "wrong-gemini",
+                "googleai",
                 "http://127.0.0.1:9",
                 vec!["other-model".to_string()],
             ),
             gemini_provider(
-                "mock-gemini",
+                "gemini",
                 &mock.base_url,
                 vec!["gemini-3.1-flash-lite".to_string()],
             ),
         ])
         .await;
         state.budget_limits.providers.set_provider_limit(
-            "mock-gemini",
+            "gemini",
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
         state.budget_limits.models.set_model_limit(
@@ -378,7 +375,7 @@ mod tests {
 
         let provider_usage = budget_limits
             .providers
-            .get_provider_usage("mock-gemini")
+            .get_provider_usage("gemini")
             .expect("provider spend should be recorded");
         assert!(provider_usage.current_spend > 0.0);
         let model_usage = budget_limits
@@ -394,13 +391,13 @@ mod tests {
     async fn gemini_sdk_stream_route_uses_sse_alt_query() {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
         .await;
         state.budget_limits.providers.set_provider_limit(
-            "mock-gemini",
+            "gemini",
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
         state.budget_limits.models.set_model_limit(
@@ -442,7 +439,7 @@ mod tests {
         );
         let provider_usage = budget_limits
             .providers
-            .get_provider_usage("mock-gemini")
+            .get_provider_usage("gemini")
             .expect("provider stream spend should be recorded");
         assert!(provider_usage.current_spend > 0.0);
         let model_usage = budget_limits
@@ -458,7 +455,7 @@ mod tests {
     async fn gemini_prefixed_sdk_route_is_supported() {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
@@ -493,7 +490,7 @@ mod tests {
     async fn gemini_sdk_route_rejects_unauthenticated_when_auth_enabled() {
         let mock = MockGeminiServer::start().await;
         let state = build_auth_required_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
@@ -522,12 +519,8 @@ mod tests {
     #[tokio::test]
     async fn gemini_sdk_route_rejects_unsafe_model_segment_before_upstream() {
         let mock = MockGeminiServer::start().await;
-        let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
-            &mock.base_url,
-            Vec::new(),
-        )])
-        .await;
+        let state =
+            build_test_state(vec![gemini_provider("gemini", &mock.base_url, Vec::new())]).await;
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(state))
@@ -553,18 +546,18 @@ mod tests {
     async fn gemini_sdk_route_rejects_exhausted_provider_budget_before_upstream() {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
         .await;
         state.budget_limits.providers.set_provider_limit(
-            "mock-gemini",
+            "gemini",
             ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
         );
         state
             .budget_limits
-            .record_spend("mock-gemini", "gemini-3.1-flash-lite", 0.01);
+            .record_spend("gemini", "gemini-3.1-flash-lite", 0.01);
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(state))
@@ -590,13 +583,13 @@ mod tests {
     async fn gemini_sdk_route_reserves_budget_before_upstream() {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
         .await;
         state.budget_limits.providers.set_provider_limit(
-            "mock-gemini",
+            "gemini",
             ProviderLimitConfig::new(0.000001, ResetPeriod::Monthly),
         );
         state.budget_limits.models.set_model_limit(
@@ -627,7 +620,7 @@ mod tests {
     #[tokio::test]
     async fn gemini_sdk_route_network_error_does_not_leak_provider_key() {
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             "http://127.0.0.1:9",
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
@@ -659,7 +652,7 @@ mod tests {
     async fn gemini_sdk_route_redacts_key_from_upstream_error_body() {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
@@ -694,13 +687,13 @@ mod tests {
     async fn gemini_sdk_stream_route_does_not_charge_upstream_error_body() {
         let mock = MockGeminiServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &mock.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
         .await;
         state.budget_limits.providers.set_provider_limit(
-            "mock-gemini",
+            "gemini",
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
         state.budget_limits.models.set_model_limit(
@@ -732,7 +725,7 @@ mod tests {
         assert!(!stream_text.contains("test-api-key-12345678901234567890"));
         let provider_usage = budget_limits
             .providers
-            .get_provider_usage("mock-gemini")
+            .get_provider_usage("gemini")
             .expect("provider budget should exist");
         assert_eq!(provider_usage.current_spend, 0.0);
         let model_usage = budget_limits
@@ -748,13 +741,13 @@ mod tests {
     async fn gemini_sdk_stream_route_releases_budget_on_midstream_read_error() {
         let broken = BrokenGeminiStreamServer::start().await;
         let state = build_test_state(vec![gemini_provider(
-            "mock-gemini",
+            "gemini",
             &broken.base_url,
             vec!["gemini-3.1-flash-lite".to_string()],
         )])
         .await;
         state.budget_limits.providers.set_provider_limit(
-            "mock-gemini",
+            "gemini",
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
         state.budget_limits.models.set_model_limit(
@@ -785,7 +778,7 @@ mod tests {
         assert!(stream_text.contains("Gemini upstream stream error"));
         let provider_usage = budget_limits
             .providers
-            .get_provider_usage("mock-gemini")
+            .get_provider_usage("gemini")
             .expect("provider budget should exist");
         assert_eq!(provider_usage.current_spend, 0.0);
         let model_usage = budget_limits

--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -1,0 +1,799 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[derive(Clone, Debug)]
+    struct CapturedGeminiRequest {
+        path_and_query: String,
+        headers: HashMap<String, String>,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    struct MockGeminiState {
+        captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
+    }
+
+    struct MockGeminiServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockGeminiServer {
+        async fn start() -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockGeminiState {
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .default_service(web::post().to(mock_gemini))
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            wait_for_server(address).await;
+
+            Self {
+                base_url: format!("http://{address}"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedGeminiRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn stop(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    struct BrokenGeminiStreamServer {
+        base_url: String,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl BrokenGeminiStreamServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("broken stream server should bind");
+            let address = listener
+                .local_addr()
+                .expect("broken stream server should have address");
+            let task = tokio::spawn(async move {
+                let (mut socket, _) = listener
+                    .accept()
+                    .await
+                    .expect("broken stream server should accept");
+                let mut buffer = [0_u8; 4096];
+                let _ = socket.read(&mut buffer).await;
+                let response = concat!(
+                    "HTTP/1.1 200 OK\r\n",
+                    "content-type: text/event-stream\r\n",
+                    "content-length: 4096\r\n",
+                    "connection: close\r\n",
+                    "\r\n",
+                    "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"partial\"}]}}]}\n\n"
+                );
+                socket
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("broken stream server should write partial response");
+                let _ = socket.shutdown().await;
+            });
+
+            Self {
+                base_url: format!("http://{address}"),
+                task,
+            }
+        }
+
+        async fn stop(self) {
+            self.task
+                .await
+                .expect("broken stream server task should join");
+        }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
+    }
+
+    async fn mock_gemini(
+        state: web::Data<MockGeminiState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        let headers = request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect();
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedGeminiRequest {
+                path_and_query: request
+                    .uri()
+                    .path_and_query()
+                    .expect("request should have path")
+                    .as_str()
+                    .to_string(),
+                headers,
+                body: body.to_vec(),
+            });
+
+        if request.path().ends_with(":streamGenerateContent") {
+            let should_fail_stream = serde_json::from_slice::<Value>(&body)
+                .ok()
+                .and_then(|value| value.get("forceUpstreamError").and_then(Value::as_bool))
+                .unwrap_or(false);
+            if should_fail_stream {
+                return HttpResponse::BadGateway()
+                    .insert_header(("content-type", "text/event-stream"))
+                    .body(format!(
+                        "event: error\n\
+                         data: {{\"error\":{{\"message\":\"upstream failed at {}\"}}}}\n\n",
+                        request.uri()
+                    ));
+            }
+            return HttpResponse::Ok()
+                .insert_header(("content-type", "text/event-stream"))
+                .body(
+                    "event: message\n\
+                     data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n\
+                     event: message\n\
+                     data: {\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n\n",
+                );
+        }
+
+        let should_fail = serde_json::from_slice::<Value>(&body)
+            .ok()
+            .and_then(|value| value.get("forceUpstreamError").and_then(Value::as_bool))
+            .unwrap_or(false);
+        if should_fail {
+            return HttpResponse::BadGateway().json(json!({
+                "error": {
+                    "message": format!("upstream failed at {}", request.uri())
+                }
+            }));
+        }
+
+        HttpResponse::Ok().json(json!({
+            "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15,
+                "cachedContentTokenCount": 2,
+                "thoughtsTokenCount": 1
+            }
+        }))
+    }
+
+    async fn build_test_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    async fn build_auth_required_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn gemini_provider(name: &str, base_url: &str, models: Vec<String>) -> ProviderConfig {
+        let mut provider = ProviderConfig {
+            name: name.to_string(),
+            provider_type: "gemini".to_string(),
+            api_key: "test-api-key-12345678901234567890".to_string(),
+            base_url: Some(base_url.to_string()),
+            models,
+            ..ProviderConfig::default()
+        };
+        provider.settings = HashMap::from([
+            (
+                "headers".to_string(),
+                json!({
+                    "X-Base-Header": "base-value",
+                    "X-Ignored-Non-String": false
+                }),
+            ),
+            (
+                "custom_headers".to_string(),
+                json!({
+                    "X-Custom-Header": "custom-value"
+                }),
+            ),
+        ]);
+        provider
+    }
+
+    fn gemini_body() -> Value {
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "hello from the Gemini SDK"}]
+            }],
+            "generationConfig": {"maxOutputTokens": 8}
+        })
+    }
+
+    fn gemini_upstream_error_body() -> Value {
+        let mut body = gemini_body();
+        body["forceUpstreamError"] = json!(true);
+        body
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_routes_without_provider_fail_closed() {
+        let state = build_test_state(Vec::new()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(response).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("Gemini SDK route provider")
+        );
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_proxies_native_body_and_records_spend() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![
+            gemini_provider(
+                "wrong-gemini",
+                "http://127.0.0.1:9",
+                vec!["other-model".to_string()],
+            ),
+            gemini_provider(
+                "mock-gemini",
+                &mock.base_url,
+                vec!["gemini-3.1-flash-lite".to_string()],
+            ),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-gemini",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            "gemini-3.1-flash-lite",
+            ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["candidates"][0]["content"]["parts"][0]["text"], "ok");
+
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].path_and_query,
+            "/v1beta/models/gemini-3.1-flash-lite:generateContent?key=test-api-key-12345678901234567890"
+        );
+        assert_eq!(requests[0].headers["x-base-header"], "base-value");
+        assert_eq!(requests[0].headers["x-custom-header"], "custom-value");
+        let upstream_body: Value =
+            serde_json::from_slice(&requests[0].body).expect("body should be json");
+        assert_eq!(
+            upstream_body["contents"][0]["parts"][0]["text"],
+            "hello from the Gemini SDK"
+        );
+
+        let provider_usage = budget_limits
+            .providers
+            .get_provider_usage("mock-gemini")
+            .expect("provider spend should be recorded");
+        assert!(provider_usage.current_spend > 0.0);
+        let model_usage = budget_limits
+            .models
+            .get_model_usage("gemini-3.1-flash-lite")
+            .expect("model spend should be recorded");
+        assert!(model_usage.current_spend > 0.0);
+
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_stream_route_uses_sse_alt_query() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-gemini",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            "gemini-3.1-flash-lite",
+            ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/models/gemini-3.1-flash-lite:streamGenerateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream")
+        );
+        let stream_body = test::read_body(response).await;
+        let stream_text = String::from_utf8(stream_body.to_vec()).expect("stream should be utf8");
+        assert!(stream_text.contains("\"usageMetadata\""));
+        let requests = mock.requests();
+        assert_eq!(
+            requests[0].path_and_query,
+            "/v1/models/gemini-3.1-flash-lite:streamGenerateContent?alt=sse&key=test-api-key-12345678901234567890"
+        );
+        let provider_usage = budget_limits
+            .providers
+            .get_provider_usage("mock-gemini")
+            .expect("provider stream spend should be recorded");
+        assert!(provider_usage.current_spend > 0.0);
+        let model_usage = budget_limits
+            .models
+            .get_model_usage("gemini-3.1-flash-lite")
+            .expect("model stream spend should be recorded");
+        assert!(model_usage.current_spend > 0.0);
+
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_prefixed_sdk_route_is_supported() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/gemini/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(
+            requests[0].path_and_query,
+            "/v1beta/models/gemini-3.1-flash-lite:generateContent?key=test-api-key-12345678901234567890"
+        );
+
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_rejects_unauthenticated_when_auth_enabled() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_auth_required_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(mock.requests().is_empty());
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_rejects_unsafe_model_segment_before_upstream() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            Vec::new(),
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/..%2Fgemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(mock.requests().is_empty());
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_rejects_exhausted_provider_budget_before_upstream() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-gemini",
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .record_spend("mock-gemini", "gemini-3.1-flash-lite", 0.01);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(mock.requests().is_empty());
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_reserves_budget_before_upstream() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-gemini",
+            ProviderLimitConfig::new(0.000001, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            "gemini-3.1-flash-lite",
+            ModelLimitConfig::new(0.000001, ResetPeriod::Monthly),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(mock.requests().is_empty());
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_network_error_does_not_leak_provider_key() {
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            "http://127.0.0.1:9",
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body: Value = test::read_body_json(response).await;
+        let message = body["error"]["message"].as_str().expect("error message");
+        assert!(message.contains("Gemini upstream request failed"));
+        assert!(!message.contains("test-api-key-12345678901234567890"));
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_redacts_key_from_upstream_error_body() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_upstream_error_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = test::read_body(response).await;
+        let text = String::from_utf8(body.to_vec()).expect("body should be utf8");
+        assert!(text.contains("upstream failed"));
+        assert!(text.contains("key=[REDACTED]"));
+        assert!(!text.contains("test-api-key-12345678901234567890"));
+
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_stream_route_does_not_charge_upstream_error_body() {
+        let mock = MockGeminiServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-gemini",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            "gemini-3.1-flash-lite",
+            ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:streamGenerateContent")
+                .set_json(gemini_upstream_error_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let stream_body = test::read_body(response).await;
+        let stream_text = String::from_utf8(stream_body.to_vec()).expect("stream should be utf8");
+        assert!(stream_text.contains("upstream failed"));
+        assert!(stream_text.contains("key=[REDACTED]"));
+        assert!(!stream_text.contains("test-api-key-12345678901234567890"));
+        let provider_usage = budget_limits
+            .providers
+            .get_provider_usage("mock-gemini")
+            .expect("provider budget should exist");
+        assert_eq!(provider_usage.current_spend, 0.0);
+        let model_usage = budget_limits
+            .models
+            .get_model_usage("gemini-3.1-flash-lite")
+            .expect("model budget should exist");
+        assert_eq!(model_usage.current_spend, 0.0);
+
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_stream_route_releases_budget_on_midstream_read_error() {
+        let broken = BrokenGeminiStreamServer::start().await;
+        let state = build_test_state(vec![gemini_provider(
+            "mock-gemini",
+            &broken.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-gemini",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            "gemini-3.1-flash-lite",
+            ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:streamGenerateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let stream_body = test::read_body(response).await;
+        let stream_text = String::from_utf8(stream_body.to_vec()).expect("stream should be utf8");
+        assert!(stream_text.contains("partial"));
+        assert!(stream_text.contains("Gemini upstream stream error"));
+        let provider_usage = budget_limits
+            .providers
+            .get_provider_usage("mock-gemini")
+            .expect("provider budget should exist");
+        assert_eq!(provider_usage.current_spend, 0.0);
+        let model_usage = budget_limits
+            .models
+            .get_model_usage("gemini-3.1-flash-lite")
+            .expect("model budget should exist");
+        assert_eq!(model_usage.current_spend, 0.0);
+
+        broken.stop().await;
+    }
+}


### PR DESCRIPTION
Fixes #745

## Summary
- add explicit Gemini SDK-compatible generateContent and streamGenerateContent routes for /v1, /v1beta, /gemini/v1, and /gemini/v1beta
- proxy native Gemini JSON/SSE without OpenAI response conversion while preserving gateway auth, provider selection, budget reservation, spend settlement, and key-usage accounting
- sanitize upstream error bodies so configured Gemini provider keys are not returned to callers

## Verification
- cargo fmt --all
- cargo test --all-features --locked --test gemini_sdk_routes --quiet
- cargo check --all-features --locked --message-format=short
- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo clippy --lib --tests --bins --features "$FEATURES" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked --quiet

## Threads Review
- xhigh read-only reviewer: 019f149d-e765-7e81-957b-93526840395d
- final result: no issues found after P1 fixes
