### PR TITLE
Add legacy completions route

### DIFF
--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -670,7 +670,7 @@ fn convert_usage(usage: types::responses::Usage) -> Usage {
 }
 
 /// Format a provider error into SSE error type and code for OpenAI-compatible responses.
-fn sse_error_classification(error: &ProviderError) -> (&'static str, &'static str) {
+pub(super) fn sse_error_classification(error: &ProviderError) -> (&'static str, &'static str) {
     match error {
         ProviderError::Authentication { .. } => ("invalid_request_error", "authentication_error"),
         ProviderError::RateLimit { .. } => ("rate_limit_error", "rate_limit_exceeded"),

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -441,9 +441,20 @@ fn completion_request_from_value(
     };
     let prompt = prompt_field(object.get("prompt"))?;
     let stream = bool_field(object, "stream")?.unwrap_or(false);
-    let include_usage = include_usage_field(object.get("stream_options"))?.unwrap_or(false);
+    let stream_options = object.get("stream_options");
+    let include_usage = include_usage_field(stream_options)?.unwrap_or(false);
+    if stream_options.is_some() && !stream {
+        return Err(GatewayError::validation(
+            "stream_options is only supported when stream is true",
+        ));
+    }
     let echo = bool_field(object, "echo")?.unwrap_or(false);
     let logprobs = u32_field(object, "logprobs")?;
+    if logprobs.is_some() {
+        return Err(GatewayError::validation(
+            "logprobs is not supported for /v1/completions compatibility",
+        ));
+    }
 
     Ok(CompletionAdapterRequest {
         prompt: prompt.clone(),
@@ -466,7 +477,7 @@ fn completion_request_from_value(
             top_p: f32_field(object, "top_p")?,
             n: u32_field(object, "n")?,
             stream: Some(stream),
-            stream_options: Some(StreamOptions {
+            stream_options: stream.then_some(StreamOptions {
                 include_usage: Some(include_usage),
             }),
             stop: stop_field(object.get("stop"))?,
@@ -474,8 +485,6 @@ fn completion_request_from_value(
             frequency_penalty: f32_field(object, "frequency_penalty")?,
             logit_bias: logit_bias_field(object.get("logit_bias"))?,
             user: optional_string_field(object, "user")?,
-            logprobs: logprobs.map(|_| true),
-            top_logprobs: logprobs.filter(|value| *value > 0),
             ..ChatCompletionRequest::default()
         },
     })
@@ -691,7 +700,7 @@ fn completion_chunk_from_core(
 ) -> CompletionSseChunk {
     CompletionSseChunk {
         id: chunk.id,
-        object: "text_completion.chunk",
+        object: "text_completion",
         created: chunk.created as u64,
         model: chunk.model,
         choices: chunk

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -179,7 +179,7 @@ async fn handle_streaming_completion(
             let key_manager = state.key_manager.clone();
             let pricing_service = state.pricing.clone();
             let include_usage = adapter_request.include_usage;
-            let echo_prefix = adapter_request.echo.then_some(adapter_request.prompt);
+            let mut echo_prefix = adapter_request.echo.then_some(adapter_request.prompt);
 
             tokio::spawn(async move {
                 let mut lease = Some(lease);
@@ -217,7 +217,7 @@ async fn handle_streaming_completion(
                                     );
                                     lease.finish_failure(&error);
                                 }
-                                settle_stream_spend(
+                                settle_stream_spend_if_chargeable(
                                     pricing_service.as_ref(),
                                     &budget_limits,
                                     &key_manager,
@@ -245,9 +245,14 @@ async fn handle_streaming_completion(
                                 tokens_used = u64::from(usage.total_tokens);
                                 final_usage = Some(usage.clone());
                             }
+                            let prefix_for_chunk = if chunk_has_text_delta(&chunk) {
+                                echo_prefix.take()
+                            } else {
+                                None
+                            };
                             let completion_chunk = completion_chunk_from_core(
                                 chunk,
-                                echo_prefix.as_deref(),
+                                prefix_for_chunk.as_deref(),
                                 include_usage,
                             );
                             if !include_usage && completion_chunk.choices.is_empty() {
@@ -271,7 +276,7 @@ async fn handle_streaming_completion(
                                         );
                                         lease.finish_failure(&error);
                                     }
-                                    settle_stream_spend(
+                                    settle_stream_spend_if_chargeable(
                                         pricing_service.as_ref(),
                                         &budget_limits,
                                         &key_manager,
@@ -296,7 +301,7 @@ async fn handle_streaming_completion(
                             if let Some(lease) = lease.take() {
                                 lease.finish_failure(&error);
                             }
-                            settle_stream_spend(
+                            settle_stream_spend_if_chargeable(
                                 pricing_service.as_ref(),
                                 &budget_limits,
                                 &key_manager,
@@ -313,7 +318,7 @@ async fn handle_streaming_completion(
                     };
 
                     if tx.send(bytes).await.is_err() {
-                        settle_stream_spend(
+                        settle_stream_spend_if_chargeable(
                             pricing_service.as_ref(),
                             &budget_limits,
                             &key_manager,
@@ -393,6 +398,34 @@ async fn settle_stream_spend(
     .await;
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn settle_stream_spend_if_chargeable(
+    pricing_service: &crate::core::pricing_service::PricingService,
+    budget_limits: &crate::core::budget::UnifiedBudgetLimits,
+    key_manager: &crate::core::keys::KeyManager,
+    api_key_id: Option<uuid::Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    budget_reservation: Option<crate::core::budget::UnifiedBudgetReservation>,
+    saw_upstream_output: bool,
+) {
+    if usage.is_some() || saw_upstream_output {
+        settle_stream_spend(
+            pricing_service,
+            budget_limits,
+            key_manager,
+            api_key_id,
+            provider,
+            model,
+            usage,
+            budget_reservation,
+            saw_upstream_output,
+        )
+        .await;
+    }
+}
+
 fn completion_request_from_value(
     body: Value,
     path_model: Option<String>,
@@ -402,18 +435,15 @@ fn completion_request_from_value(
         .ok_or_else(|| GatewayError::validation("request body must be a JSON object"))?;
     reject_unsupported_fields(object)?;
 
-    let model = path_model
-        .or_else(|| string_field(object, "model").map(str::to_string))
-        .ok_or_else(|| GatewayError::validation("Model is required"))?;
+    let model = match path_model {
+        Some(model) => model,
+        None => required_string_field(object, "model", "Model is required")?,
+    };
     let prompt = prompt_field(object.get("prompt"))?;
-    let stream = bool_field(object, "stream").unwrap_or(false);
-    let include_usage = object
-        .get("stream_options")
-        .and_then(|value| value.get("include_usage"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let echo = bool_field(object, "echo").unwrap_or(false);
-    let logprobs = u32_field(object, "logprobs");
+    let stream = bool_field(object, "stream")?.unwrap_or(false);
+    let include_usage = include_usage_field(object.get("stream_options"))?.unwrap_or(false);
+    let echo = bool_field(object, "echo")?.unwrap_or(false);
+    let logprobs = u32_field(object, "logprobs")?;
 
     Ok(CompletionAdapterRequest {
         prompt: prompt.clone(),
@@ -431,10 +461,10 @@ fn completion_request_from_value(
                 tool_call_id: None,
                 audio: None,
             }],
-            max_tokens: u32_field(object, "max_tokens"),
+            max_tokens: u32_field(object, "max_tokens")?,
             temperature: f32_field(object, "temperature")?,
             top_p: f32_field(object, "top_p")?,
-            n: u32_field(object, "n"),
+            n: u32_field(object, "n")?,
             stream: Some(stream),
             stream_options: Some(StreamOptions {
                 include_usage: Some(include_usage),
@@ -443,7 +473,7 @@ fn completion_request_from_value(
             presence_penalty: f32_field(object, "presence_penalty")?,
             frequency_penalty: f32_field(object, "frequency_penalty")?,
             logit_bias: logit_bias_field(object.get("logit_bias"))?,
-            user: string_field(object, "user").map(str::to_string),
+            user: optional_string_field(object, "user")?,
             logprobs: logprobs.map(|_| true),
             top_logprobs: logprobs.filter(|value| *value > 0),
             ..ChatCompletionRequest::default()
@@ -543,19 +573,74 @@ fn logit_bias_field(value: Option<&Value>) -> Result<Option<HashMap<String, f32>
     Ok(Some(result))
 }
 
-fn string_field<'a>(object: &'a serde_json::Map<String, Value>, key: &str) -> Option<&'a str> {
-    object.get(key).and_then(Value::as_str).map(str::trim)
+fn required_string_field(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+    missing_message: &'static str,
+) -> Result<String, GatewayError> {
+    match object.get(key) {
+        Some(Value::String(value)) => Ok(value.trim().to_string()),
+        Some(_) => Err(GatewayError::validation(format!("{key} must be a string"))),
+        None => Err(GatewayError::validation(missing_message)),
+    }
 }
 
-fn bool_field(object: &serde_json::Map<String, Value>, key: &str) -> Option<bool> {
-    object.get(key).and_then(Value::as_bool)
+fn optional_string_field(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>, GatewayError> {
+    match object.get(key) {
+        Some(Value::String(value)) => Ok(Some(value.trim().to_string())),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(GatewayError::validation(format!("{key} must be a string"))),
+    }
 }
 
-fn u32_field(object: &serde_json::Map<String, Value>, key: &str) -> Option<u32> {
-    object
-        .get(key)
-        .and_then(Value::as_u64)
-        .and_then(|value| u32::try_from(value).ok())
+fn bool_field(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<bool>, GatewayError> {
+    match object.get(key) {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(GatewayError::validation(format!("{key} must be a boolean"))),
+    }
+}
+
+fn u32_field(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<u32>, GatewayError> {
+    match object.get(key) {
+        Some(Value::Number(value)) => {
+            let Some(value) = value.as_u64() else {
+                return Err(GatewayError::validation(format!(
+                    "{key} must be a non-negative integer"
+                )));
+            };
+            u32::try_from(value).map(Some).map_err(|_| {
+                GatewayError::validation(format!("{key} must fit in an unsigned 32-bit integer"))
+            })
+        }
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(GatewayError::validation(format!(
+            "{key} must be an integer"
+        ))),
+    }
+}
+
+fn include_usage_field(value: Option<&Value>) -> Result<Option<bool>, GatewayError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Object(map)) => match map.get("include_usage") {
+            Some(Value::Bool(value)) => Ok(Some(*value)),
+            Some(Value::Null) | None => Ok(None),
+            Some(_) => Err(GatewayError::validation(
+                "stream_options.include_usage must be a boolean",
+            )),
+        },
+        Some(_) => Err(GatewayError::validation("stream_options must be an object")),
+    }
 }
 
 fn f32_field(
@@ -624,6 +709,16 @@ fn completion_chunk_from_core(
             .collect(),
         usage: include_usage.then_some(chunk.usage).flatten(),
     }
+}
+
+fn chunk_has_text_delta(chunk: &types::responses::ChatChunk) -> bool {
+    chunk.choices.iter().any(|choice| {
+        choice
+            .delta
+            .content
+            .as_deref()
+            .is_some_and(|text| !text.is_empty())
+    })
 }
 
 fn completion_text_from_message(

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -1,0 +1,689 @@
+//! Legacy OpenAI text completions compatibility route.
+
+use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
+use bytes::Bytes;
+use futures::StreamExt;
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::collections::{BTreeSet, HashMap};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+
+use crate::core::models::openai::{
+    ChatCompletionRequest, ChatMessage, CompletionChoice, CompletionResponse, MessageContent,
+    MessageRole, StreamOptions, Usage,
+};
+use crate::core::providers::ProviderError;
+use crate::core::streaming::types::Event;
+use crate::core::types::{self, context::RequestContext, model::ProviderCapability};
+use crate::server::state::AppState;
+use crate::utils::data::validation::RequestValidator;
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::context::get_request_context;
+use super::execution::execute_stream_with_selected_deployment;
+use super::openai_errors;
+
+#[derive(Debug, Clone)]
+struct CompletionAdapterRequest {
+    chat_request: ChatCompletionRequest,
+    prompt: String,
+    echo: bool,
+    stream: bool,
+    include_usage: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CompletionSseChunk {
+    id: String,
+    object: &'static str,
+    created: u64,
+    model: String,
+    choices: Vec<CompletionChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usage: Option<Usage>,
+}
+
+pub async fn completions(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    request: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
+    completions_inner(state, req, None, request.into_inner()).await
+}
+
+pub async fn engine_completions(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    model: web::Path<String>,
+    request: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
+    completions_inner(state, req, Some(model.into_inner()), request.into_inner()).await
+}
+
+async fn completions_inner(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    path_model: Option<String>,
+    request: Value,
+) -> ActixResult<HttpResponse> {
+    let context = get_request_context(&req)?;
+    let adapter_request = match completion_request_from_value(request, path_model) {
+        Ok(request) => request,
+        Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+    };
+
+    if let Err(error) = RequestValidator::validate_chat_completion_request(
+        &adapter_request.chat_request.model,
+        &adapter_request.chat_request.messages,
+        adapter_request.chat_request.max_tokens,
+        adapter_request.chat_request.temperature,
+    ) {
+        warn!("Invalid completions request: {}", error);
+        return Ok(openai_errors::validation_error(error.to_string()));
+    }
+
+    if adapter_request.stream {
+        return handle_streaming_completion(state.get_ref(), adapter_request, context).await;
+    }
+
+    match super::chat::handle_chat_completion_with_state(
+        state.get_ref(),
+        adapter_request.chat_request,
+        context,
+    )
+    .await
+    {
+        Ok(response) => Ok(HttpResponse::Ok().json(completion_response_from_chat(
+            response,
+            &adapter_request.prompt,
+            adapter_request.echo,
+        ))),
+        Err(error) => {
+            error!("Completion error: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
+}
+
+async fn handle_streaming_completion(
+    state: &AppState,
+    adapter_request: CompletionAdapterRequest,
+    context: RequestContext,
+) -> ActixResult<HttpResponse> {
+    info!(
+        "Handling streaming text completion for model: {}",
+        adapter_request.chat_request.model
+    );
+
+    let mut request = adapter_request.chat_request;
+    let requested_model = request.model.clone();
+    let request_for_budget = request.clone();
+    request
+        .stream_options
+        .get_or_insert(StreamOptions {
+            include_usage: None,
+        })
+        .include_usage = Some(true);
+
+    let core_request =
+        match super::chat::build_core_chat_request(request, requested_model.clone(), true) {
+            Ok(request) => request,
+            Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
+        };
+
+    let context_for_execution = context.clone();
+    let (budget_limits, pricing_service) = (state.budget_limits.clone(), state.pricing.clone());
+    let api_key_id = context.api_key_id();
+
+    match execute_stream_with_selected_deployment(
+        state.unified_router.clone(),
+        &requested_model,
+        ProviderCapability::ChatCompletionStream,
+        move |provider, selected_model| {
+            let core_request = core_request.clone();
+            let context = context_for_execution.clone();
+            let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());
+            let request_for_budget = request_for_budget.clone();
+            async move {
+                super::spend::ensure_budget_available(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                )?;
+                let budget_reservation = super::spend::reserve_chat_completion_budget_with_pricing(
+                    pricing_service.as_ref(),
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                    &request_for_budget,
+                )?;
+                let provider_name = provider.name().to_string();
+                let mut request_for_provider = core_request.clone();
+                request_for_provider.model = selected_model.clone();
+                let stream = provider
+                    .chat_completion_stream(request_for_provider, context)
+                    .await?;
+                Ok((stream, provider_name, selected_model, budget_reservation))
+            }
+        },
+    )
+    .await
+    {
+        Ok(((mut stream, served_provider, served_model, mut budget_reservation), lease)) => {
+            let (tx, rx) = mpsc::channel::<Bytes>(8);
+            let idle_timeout_secs = state.config().gateway.server.stream_idle_timeout;
+            let budget_limits = state.budget_limits.clone();
+            let key_manager = state.key_manager.clone();
+            let pricing_service = state.pricing.clone();
+            let include_usage = adapter_request.include_usage;
+            let echo_prefix = adapter_request.echo.then_some(adapter_request.prompt);
+
+            tokio::spawn(async move {
+                let mut lease = Some(lease);
+                let mut tokens_used = 0_u64;
+                let mut final_usage = None;
+                let mut saw_upstream_output = false;
+
+                loop {
+                    let chunk_result = if idle_timeout_secs == 0 {
+                        stream.next().await
+                    } else {
+                        match tokio::time::timeout(
+                            Duration::from_secs(idle_timeout_secs),
+                            stream.next(),
+                        )
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(_) => {
+                                warn!(
+                                    "Completion SSE stream idle timeout after {}s",
+                                    idle_timeout_secs
+                                );
+                                send_stream_error(
+                                    &tx,
+                                    "Stream idle timeout",
+                                    "server_error",
+                                    "timeout",
+                                )
+                                .await;
+                                if let Some(lease) = lease.take() {
+                                    let error = ProviderError::timeout(
+                                        "router",
+                                        format!("stream idle timeout after {}s", idle_timeout_secs),
+                                    );
+                                    lease.finish_failure(&error);
+                                }
+                                settle_stream_spend(
+                                    pricing_service.as_ref(),
+                                    &budget_limits,
+                                    &key_manager,
+                                    api_key_id,
+                                    &served_provider,
+                                    &served_model,
+                                    final_usage.as_ref(),
+                                    budget_reservation.take(),
+                                    saw_upstream_output,
+                                )
+                                .await;
+                                return;
+                            }
+                        }
+                    };
+
+                    let Some(chunk_result) = chunk_result else {
+                        break;
+                    };
+
+                    let bytes = match chunk_result {
+                        Ok(chunk) => {
+                            saw_upstream_output = true;
+                            if let Some(usage) = &chunk.usage {
+                                tokens_used = u64::from(usage.total_tokens);
+                                final_usage = Some(usage.clone());
+                            }
+                            let completion_chunk = completion_chunk_from_core(
+                                chunk,
+                                echo_prefix.as_deref(),
+                                include_usage,
+                            );
+                            if !include_usage && completion_chunk.choices.is_empty() {
+                                continue;
+                            }
+                            match serde_json::to_string(&completion_chunk) {
+                                Ok(json) => Event::default().data(&json).to_bytes(),
+                                Err(error) => {
+                                    error!("Completion stream serialization error: {}", error);
+                                    send_stream_error(
+                                        &tx,
+                                        &format!("Serialization error: {}", error),
+                                        "server_error",
+                                        "internal_error",
+                                    )
+                                    .await;
+                                    if let Some(lease) = lease.take() {
+                                        let error = ProviderError::serialization(
+                                            "router",
+                                            format!("Serialization error: {}", error),
+                                        );
+                                        lease.finish_failure(&error);
+                                    }
+                                    settle_stream_spend(
+                                        pricing_service.as_ref(),
+                                        &budget_limits,
+                                        &key_manager,
+                                        api_key_id,
+                                        &served_provider,
+                                        &served_model,
+                                        final_usage.as_ref(),
+                                        budget_reservation.take(),
+                                        saw_upstream_output,
+                                    )
+                                    .await;
+                                    return;
+                                }
+                            }
+                        }
+                        Err(error) => {
+                            error!("Completion stream chunk error: {}", error);
+                            let (error_type, error_code) =
+                                super::chat::sse_error_classification(&error);
+                            send_stream_error(&tx, &error.to_string(), error_type, error_code)
+                                .await;
+                            if let Some(lease) = lease.take() {
+                                lease.finish_failure(&error);
+                            }
+                            settle_stream_spend(
+                                pricing_service.as_ref(),
+                                &budget_limits,
+                                &key_manager,
+                                api_key_id,
+                                &served_provider,
+                                &served_model,
+                                final_usage.as_ref(),
+                                budget_reservation.take(),
+                                saw_upstream_output,
+                            )
+                            .await;
+                            return;
+                        }
+                    };
+
+                    if tx.send(bytes).await.is_err() {
+                        settle_stream_spend(
+                            pricing_service.as_ref(),
+                            &budget_limits,
+                            &key_manager,
+                            api_key_id,
+                            &served_provider,
+                            &served_model,
+                            final_usage.as_ref(),
+                            budget_reservation.take(),
+                            saw_upstream_output,
+                        )
+                        .await;
+                        return;
+                    }
+                }
+
+                let _ = tx.send(Event::default().data("[DONE]").to_bytes()).await;
+                super::spend::record_finished_stream_spend_with_reservation_with_pricing(
+                    pricing_service.as_ref(),
+                    super::spend::StreamSpendSettlement {
+                        budget_limits: &budget_limits,
+                        key_manager: &key_manager,
+                        api_key_id,
+                        provider: &served_provider,
+                        model: &served_model,
+                        usage: final_usage.as_ref(),
+                        saw_upstream_output,
+                        budget_reservation: budget_reservation.take(),
+                    },
+                )
+                .await;
+                if let Some(lease) = lease.take() {
+                    lease.finish_success(tokens_used);
+                }
+            });
+
+            let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx)
+                .map(Ok::<_, actix_web::error::Error>);
+            Ok(HttpResponse::Ok()
+                .insert_header((CONTENT_TYPE, "text/event-stream"))
+                .insert_header((CACHE_CONTROL, "no-cache"))
+                .insert_header(("Connection", "keep-alive"))
+                .insert_header(("X-Request-ID", context.request_id.as_str()))
+                .streaming(sse_stream))
+        }
+        Err(error) => {
+            error!("Failed to create streaming completion response: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn settle_stream_spend(
+    pricing_service: &crate::core::pricing_service::PricingService,
+    budget_limits: &crate::core::budget::UnifiedBudgetLimits,
+    key_manager: &crate::core::keys::KeyManager,
+    api_key_id: Option<uuid::Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    budget_reservation: Option<crate::core::budget::UnifiedBudgetReservation>,
+    saw_upstream_output: bool,
+) {
+    super::spend::record_finished_stream_spend_with_reservation_with_pricing(
+        pricing_service,
+        super::spend::StreamSpendSettlement {
+            budget_limits,
+            key_manager,
+            api_key_id,
+            provider,
+            model,
+            usage,
+            saw_upstream_output,
+            budget_reservation,
+        },
+    )
+    .await;
+}
+
+fn completion_request_from_value(
+    body: Value,
+    path_model: Option<String>,
+) -> Result<CompletionAdapterRequest, GatewayError> {
+    let object = body
+        .as_object()
+        .ok_or_else(|| GatewayError::validation("request body must be a JSON object"))?;
+    reject_unsupported_fields(object)?;
+
+    let model = path_model
+        .or_else(|| string_field(object, "model").map(str::to_string))
+        .ok_or_else(|| GatewayError::validation("Model is required"))?;
+    let prompt = prompt_field(object.get("prompt"))?;
+    let stream = bool_field(object, "stream").unwrap_or(false);
+    let include_usage = object
+        .get("stream_options")
+        .and_then(|value| value.get("include_usage"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let echo = bool_field(object, "echo").unwrap_or(false);
+    let logprobs = u32_field(object, "logprobs");
+
+    Ok(CompletionAdapterRequest {
+        prompt: prompt.clone(),
+        echo,
+        stream,
+        include_usage,
+        chat_request: ChatCompletionRequest {
+            model,
+            messages: vec![ChatMessage {
+                role: MessageRole::User,
+                content: Some(MessageContent::Text(prompt)),
+                name: None,
+                function_call: None,
+                tool_calls: None,
+                tool_call_id: None,
+                audio: None,
+            }],
+            max_tokens: u32_field(object, "max_tokens"),
+            temperature: f32_field(object, "temperature")?,
+            top_p: f32_field(object, "top_p")?,
+            n: u32_field(object, "n"),
+            stream: Some(stream),
+            stream_options: Some(StreamOptions {
+                include_usage: Some(include_usage),
+            }),
+            stop: stop_field(object.get("stop"))?,
+            presence_penalty: f32_field(object, "presence_penalty")?,
+            frequency_penalty: f32_field(object, "frequency_penalty")?,
+            logit_bias: logit_bias_field(object.get("logit_bias"))?,
+            user: string_field(object, "user").map(str::to_string),
+            logprobs: logprobs.map(|_| true),
+            top_logprobs: logprobs.filter(|value| *value > 0),
+            ..ChatCompletionRequest::default()
+        },
+    })
+}
+
+fn reject_unsupported_fields(object: &serde_json::Map<String, Value>) -> Result<(), GatewayError> {
+    let allowed = [
+        "model",
+        "prompt",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "n",
+        "stream",
+        "stream_options",
+        "stop",
+        "presence_penalty",
+        "frequency_penalty",
+        "logit_bias",
+        "user",
+        "logprobs",
+        "echo",
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    let unsupported = ["best_of", "suffix"];
+    for key in object.keys() {
+        if unsupported.contains(&key.as_str()) {
+            return Err(GatewayError::validation(format!(
+                "Unsupported /v1/completions field: {key}"
+            )));
+        }
+        if !allowed.contains(key.as_str()) {
+            return Err(GatewayError::validation(format!(
+                "Unknown /v1/completions field: {key}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn prompt_field(value: Option<&Value>) -> Result<String, GatewayError> {
+    match value {
+        Some(Value::String(prompt)) => Ok(prompt.clone()),
+        Some(Value::Array(items)) if items.len() == 1 => items[0]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| GatewayError::validation("prompt array must contain strings")),
+        Some(Value::Array(_)) => Err(GatewayError::validation(
+            "prompt arrays with multiple entries are not supported",
+        )),
+        Some(_) => Err(GatewayError::validation("prompt must be a string")),
+        None => Err(GatewayError::validation("prompt is required")),
+    }
+}
+
+fn stop_field(value: Option<&Value>) -> Result<Option<Vec<String>>, GatewayError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(stop)) => Ok(Some(vec![stop.clone()])),
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| GatewayError::validation("stop entries must be strings"))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(_) => Err(GatewayError::validation(
+            "stop must be a string or string array",
+        )),
+    }
+}
+
+fn logit_bias_field(value: Option<&Value>) -> Result<Option<HashMap<String, f32>>, GatewayError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let map = value
+        .as_object()
+        .ok_or_else(|| GatewayError::validation("logit_bias must be an object"))?;
+    let mut result = HashMap::with_capacity(map.len());
+    for (key, value) in map {
+        let Some(value) = value.as_f64() else {
+            return Err(GatewayError::validation(
+                "logit_bias values must be numbers",
+            ));
+        };
+        if !value.is_finite() || value < f32::MIN as f64 || value > f32::MAX as f64 {
+            return Err(GatewayError::validation("logit_bias value is out of range"));
+        }
+        result.insert(key.clone(), value as f32);
+    }
+    Ok(Some(result))
+}
+
+fn string_field<'a>(object: &'a serde_json::Map<String, Value>, key: &str) -> Option<&'a str> {
+    object.get(key).and_then(Value::as_str).map(str::trim)
+}
+
+fn bool_field(object: &serde_json::Map<String, Value>, key: &str) -> Option<bool> {
+    object.get(key).and_then(Value::as_bool)
+}
+
+fn u32_field(object: &serde_json::Map<String, Value>, key: &str) -> Option<u32> {
+    object
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn f32_field(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<f32>, GatewayError> {
+    let Some(value) = object.get(key) else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_f64() else {
+        return Err(GatewayError::validation(format!("{key} must be a number")));
+    };
+    if !value.is_finite() || value < f32::MIN as f64 || value > f32::MAX as f64 {
+        return Err(GatewayError::validation(format!("{key} is out of range")));
+    }
+    Ok(Some(value as f32))
+}
+
+fn completion_response_from_chat(
+    response: crate::core::models::openai::ChatCompletionResponse,
+    prompt: &str,
+    echo: bool,
+) -> CompletionResponse {
+    CompletionResponse {
+        id: response.id,
+        object: "text_completion".to_string(),
+        created: response.created,
+        model: response.model,
+        choices: response
+            .choices
+            .into_iter()
+            .map(|choice| CompletionChoice {
+                text: completion_text_from_message(choice.message.content.as_ref(), prompt, echo),
+                index: choice.index,
+                logprobs: choice
+                    .logprobs
+                    .and_then(|logprobs| serde_json::to_value(logprobs).ok()),
+                finish_reason: choice.finish_reason,
+            })
+            .collect(),
+        usage: response.usage,
+    }
+}
+
+fn completion_chunk_from_core(
+    chunk: types::responses::ChatChunk,
+    echo_prefix: Option<&str>,
+    include_usage: bool,
+) -> CompletionSseChunk {
+    CompletionSseChunk {
+        id: chunk.id,
+        object: "text_completion.chunk",
+        created: chunk.created as u64,
+        model: chunk.model,
+        choices: chunk
+            .choices
+            .into_iter()
+            .map(|choice| CompletionChoice {
+                text: completion_text_from_delta(choice.delta.content, echo_prefix),
+                index: choice.index,
+                logprobs: choice
+                    .logprobs
+                    .and_then(|logprobs| serde_json::to_value(logprobs).ok()),
+                finish_reason: choice.finish_reason.map(finish_reason_to_string),
+            })
+            .collect(),
+        usage: include_usage.then_some(chunk.usage).flatten(),
+    }
+}
+
+fn completion_text_from_message(
+    content: Option<&MessageContent>,
+    prompt: &str,
+    echo: bool,
+) -> String {
+    let completion = match content {
+        Some(MessageContent::Text(text)) => text.clone(),
+        Some(MessageContent::Parts(parts)) => parts
+            .iter()
+            .filter_map(|part| match part {
+                crate::core::models::openai::ContentPart::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+        None => String::new(),
+    };
+    if echo {
+        format!("{prompt}{completion}")
+    } else {
+        completion
+    }
+}
+
+fn completion_text_from_delta(content: Option<String>, echo_prefix: Option<&str>) -> String {
+    let content = content.unwrap_or_default();
+    match echo_prefix {
+        Some(prefix) => format!("{prefix}{content}"),
+        None => content,
+    }
+}
+
+fn finish_reason_to_string(reason: types::responses::FinishReason) -> String {
+    match reason {
+        types::responses::FinishReason::Stop => "stop",
+        types::responses::FinishReason::Length => "length",
+        types::responses::FinishReason::ToolCalls => "tool_calls",
+        types::responses::FinishReason::ContentFilter => "content_filter",
+        types::responses::FinishReason::FunctionCall => "function_call",
+        types::responses::FinishReason::StopSequence => "stop_sequence",
+        types::responses::FinishReason::Refusal => "refusal",
+        types::responses::FinishReason::PauseTurn => "pause_turn",
+    }
+    .to_string()
+}
+
+async fn send_stream_error(tx: &mpsc::Sender<Bytes>, message: &str, error_type: &str, code: &str) {
+    let error_json = json!({
+        "error": {
+            "message": message,
+            "type": error_type,
+            "code": code,
+        }
+    });
+    let mut bytes = Event::default()
+        .data(&error_json.to_string())
+        .to_bytes()
+        .to_vec();
+    bytes.extend_from_slice(&Event::default().data("[DONE]").to_bytes());
+    let _ = tx.send(Bytes::from(bytes)).await;
+}

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use serde::Serialize;
 use serde_json::{Value, json};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -174,7 +174,7 @@ async fn handle_streaming_completion(
     {
         Ok(((mut stream, served_provider, served_model, mut budget_reservation), lease)) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
-            let idle_timeout_secs = state.config().gateway.server.stream_idle_timeout;
+            let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let budget_limits = state.budget_limits.clone();
             let key_manager = state.key_manager.clone();
             let pricing_service = state.pricing.clone();
@@ -482,7 +482,7 @@ fn completion_request_from_value(
 }
 
 fn reject_unsupported_fields(object: &serde_json::Map<String, Value>) -> Result<(), GatewayError> {
-    let allowed = [
+    const ALLOWED: &[&str] = &[
         "model",
         "prompt",
         "max_tokens",
@@ -498,17 +498,16 @@ fn reject_unsupported_fields(object: &serde_json::Map<String, Value>) -> Result<
         "user",
         "logprobs",
         "echo",
-    ]
-    .into_iter()
-    .collect::<BTreeSet<_>>();
-    let unsupported = ["best_of", "suffix"];
+    ];
+    const UNSUPPORTED: &[&str] = &["best_of", "suffix"];
     for key in object.keys() {
-        if unsupported.contains(&key.as_str()) {
+        let key_str = key.as_str();
+        if UNSUPPORTED.contains(&key_str) {
             return Err(GatewayError::validation(format!(
                 "Unsupported /v1/completions field: {key}"
             )));
         }
-        if !allowed.contains(key.as_str()) {
+        if !ALLOWED.contains(&key_str) {
             return Err(GatewayError::validation(format!(
                 "Unknown /v1/completions field: {key}"
             )));

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -6,6 +6,7 @@
 mod audio;
 mod batches;
 mod chat;
+mod completions;
 mod context;
 mod embeddings;
 mod execution;
@@ -26,6 +27,7 @@ mod spend;
 pub use audio::{audio_speech, audio_transcriptions, audio_translations};
 pub use batches::{cancel_batch, create_batch, get_batch, list_batches};
 pub use chat::chat_completions;
+pub use completions::{completions, engine_completions};
 pub use context::{
     check_permission, get_authenticated_api_key, get_authenticated_user, get_request_context,
     handle_ai_request, log_api_usage,
@@ -52,8 +54,23 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 
 /// Configure AI API routes
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/completions", web::post().to(completions))
+        .route(
+            "/engines/{model_id}/completions",
+            web::post().to(engine_completions),
+        )
+        .route(
+            "/openai/deployments/{model_id}/completions",
+            web::post().to(engine_completions),
+        );
     cfg.service(
         web::scope("/v1")
+            // Legacy text completions
+            .route("/completions", web::post().to(completions))
+            .route(
+                "/engines/{model_id}/completions",
+                web::post().to(engine_completions),
+            )
             // Chat completions
             .route("/chat/completions", web::post().to(chat_completions))
             // Responses API

--- a/tests/integration/completions_route_tests.rs
+++ b/tests/integration/completions_route_tests.rs
@@ -1,7 +1,4 @@
 //! Completions route integration tests
-//!
-//! Note: `src/server/routes/ai/completions.rs` does not exist in this repo.
-//! These tests map FUT-60 scope to the existing `/v1/chat/completions` route.
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
@@ -10,6 +7,7 @@ mod tests {
     use futures::stream;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use litellm_rs::server::state::AppState;
     use serde_json::{Value, json};
@@ -98,7 +96,7 @@ mod tests {
                 "id": "chatcmpl-success-1",
                 "object": "chat.completion",
                 "created": 1_707_000_000_i64,
-                "model": "gpt-4o-mini",
+                "model": "gpt-4o",
                 "choices": [{
                     "index": 0,
                     "message": {
@@ -117,13 +115,13 @@ mod tests {
                 "error": {
                     "type": "rate_limit_error",
                     "code": "rate_limit_exceeded",
-                    "message": "Rate limit exceeded",
+                    "message": "Rate limit exceeded for sk-completion-secret",
                     "retry_after": 2
                 }
             })),
             MockScenario::StreamingSuccess => {
-                let chunk_1 = r#"data: {"id":"chatcmpl-stream-1","object":"chat.completion.chunk","created":1707000001,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}"#;
-                let chunk_2 = r#"data: {"id":"chatcmpl-stream-1","object":"chat.completion.chunk","created":1707000001,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}]}"#;
+                let chunk_1 = r#"data: {"id":"chatcmpl-stream-1","object":"chat.completion.chunk","created":1707000001,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}"#;
+                let chunk_2 = r#"data: {"id":"chatcmpl-stream-1","object":"chat.completion.chunk","created":1707000001,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"#;
 
                 let stream = stream::iter(vec![
                     Ok::<Bytes, actix_web::Error>(Bytes::from(format!("{chunk_1}\n\n"))),
@@ -140,12 +138,18 @@ mod tests {
 
     fn build_provider_config(base_url: &str) -> ProviderConfig {
         ProviderConfig {
-            name: "mock-openai-compatible".to_string(),
+            name: "openai".to_string(),
             provider_type: "openai_compatible".to_string(),
-            api_key: "test-key".to_string(),
+            api_key: "sk-completion-secret".to_string(),
             base_url: Some(base_url.to_string()),
-            settings: HashMap::from([("skip_api_key".to_string(), serde_json::Value::Bool(true))]),
-            models: vec!["gpt-4o-mini".to_string()],
+            settings: HashMap::from([
+                ("skip_api_key".to_string(), serde_json::Value::Bool(true)),
+                (
+                    "provider_name".to_string(),
+                    serde_json::Value::String("openai".to_string()),
+                ),
+            ]),
+            models: vec!["gpt-4o".to_string()],
             ..ProviderConfig::default()
         }
     }
@@ -162,15 +166,11 @@ mod tests {
         server.state().clone()
     }
 
-    fn chat_request(stream: Option<bool>) -> Value {
+    fn completion_request(stream: Option<bool>) -> Value {
         json!({
-            "model": "gpt-4o-mini",
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Hello"
-                }
-            ],
+            "model": "gpt-4o",
+            "prompt": "Hello",
+            "max_tokens": 16,
             "stream": stream
         })
     }
@@ -188,8 +188,8 @@ mod tests {
         .await;
 
         let req = test::TestRequest::post()
-            .uri("/v1/chat/completions")
-            .set_json(chat_request(None))
+            .uri("/v1/completions")
+            .set_json(completion_request(None))
             .to_request();
 
         let resp = test::call_service(&app, req).await;
@@ -198,14 +198,15 @@ mod tests {
         let body: Value = test::read_body_json(resp).await;
         assert!(body.get("success").is_none());
         assert_eq!(body["id"], "chatcmpl-success-1");
-        assert_eq!(body["object"], "chat.completion");
-        assert_eq!(body["model"], "gpt-4o-mini");
-        assert_eq!(body["choices"][0]["message"]["role"], "assistant");
-        assert_eq!(body["choices"][0]["message"]["content"], "mocked response");
+        assert_eq!(body["object"], "text_completion");
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["choices"][0]["text"], "mocked response");
         assert_eq!(body["usage"]["total_tokens"], 16);
 
         let requests = mock_server.requests();
         assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["messages"][0]["role"], "user");
+        assert_eq!(requests[0]["messages"][0]["content"], "Hello");
         assert!(requests[0].get("stream").is_none());
 
         mock_server.shutdown().await;
@@ -224,13 +225,10 @@ mod tests {
         .await;
 
         let req = test::TestRequest::post()
-            .uri("/v1/chat/completions")
+            .uri("/v1/completions")
             .set_json(json!({
                 "model": "",
-                "messages": [{
-                    "role": "user",
-                    "content": "Hello"
-                }]
+                "prompt": "Hello"
             }))
             .to_request();
 
@@ -266,8 +264,8 @@ mod tests {
         .await;
 
         let req = test::TestRequest::post()
-            .uri("/v1/chat/completions")
-            .set_json(chat_request(Some(false)))
+            .uri("/v1/completions")
+            .set_json(completion_request(Some(false)))
             .to_request();
 
         let resp = test::call_service(&app, req).await;
@@ -283,14 +281,11 @@ mod tests {
             .as_str()
             .expect("provider error body should have OpenAI error message");
         assert!(message.to_lowercase().contains("rate limit"));
+        assert!(!message.contains("sk-completion-secret"));
 
         let requests = mock_server.requests();
         assert!(!requests.is_empty());
-        assert!(
-            requests
-                .iter()
-                .all(|request| request["model"] == "gpt-4o-mini")
-        );
+        assert!(requests.iter().all(|request| request["model"] == "gpt-4o"));
 
         mock_server.shutdown().await;
     }
@@ -308,8 +303,8 @@ mod tests {
         .await;
 
         let req = test::TestRequest::post()
-            .uri("/v1/chat/completions")
-            .set_json(chat_request(Some(true)))
+            .uri("/v1/completions")
+            .set_json(completion_request(Some(true)))
             .to_request();
 
         let resp = test::call_service(&app, req).await;
@@ -324,14 +319,64 @@ mod tests {
         let body = test::read_body(resp).await;
         let body_text = String::from_utf8(body.to_vec()).expect("streaming body should be utf8");
         assert!(body_text.contains("data: {"));
-        assert!(body_text.contains("\"object\":\"chat.completion.chunk\""));
-        assert!(body_text.contains("\"content\":\"Hel\""));
-        assert!(body_text.contains("\"content\":\"lo\""));
+        assert!(body_text.contains("\"object\":\"text_completion.chunk\""));
+        assert!(body_text.contains("\"text\":\"Hel\""));
+        assert!(body_text.contains("\"text\":\"lo\""));
         assert!(body_text.contains("[DONE]"));
 
         let requests = mock_server.requests();
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0]["stream"], true);
+
+        mock_server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_completions_success_records_budget_spend() {
+        let mock_server = MockOpenAIServer::start(MockScenario::NonStreamingSuccess).await;
+        let state = build_test_app_state(&mock_server.base_url).await;
+        state.budget_limits.providers.set_provider_limit(
+            "openai",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .models
+            .set_model_limit("gpt-4o", ModelLimitConfig::new(100.0, ResetPeriod::Monthly));
+        let budget_limits = state.budget_limits.clone();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/completions")
+            .set_json(completion_request(None))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        let status = resp.status();
+        let body = test::read_body(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unexpected completions budget response: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let provider_usage = budget_limits
+            .providers
+            .get_provider_usage("openai")
+            .expect("provider spend should be recorded");
+        assert!(provider_usage.current_spend > 0.0);
+        let model_usage = budget_limits
+            .models
+            .get_model_usage("gpt-4o")
+            .expect("model spend should be recorded");
+        assert!(model_usage.current_spend > 0.0);
 
         mock_server.shutdown().await;
     }

--- a/tests/integration/completions_route_tests.rs
+++ b/tests/integration/completions_route_tests.rs
@@ -232,6 +232,7 @@ mod tests {
         assert_eq!(requests[0]["messages"][0]["role"], "user");
         assert_eq!(requests[0]["messages"][0]["content"], "Hello");
         assert!(requests[0].get("stream").is_none());
+        assert!(requests[0].get("stream_options").is_none());
 
         mock_server.shutdown().await;
     }
@@ -361,6 +362,14 @@ mod tests {
             (
                 json!({"model":"gpt-4o","prompt":"Hello","logprobs":"1"}),
                 "logprobs",
+            ),
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","logprobs":1}),
+                "logprobs",
+            ),
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","stream_options":{"include_usage":true}}),
+                "stream_options",
             ),
             (
                 json!({"model":"gpt-4o","prompt":"Hello","stream_options":{"include_usage":"true"}}),
@@ -544,7 +553,7 @@ mod tests {
         let body = test::read_body(resp).await;
         let body_text = String::from_utf8(body.to_vec()).expect("streaming body should be utf8");
         assert!(body_text.contains("data: {"));
-        assert!(body_text.contains("\"object\":\"text_completion.chunk\""));
+        assert!(body_text.contains("\"object\":\"text_completion\""));
         assert!(body_text.contains("\"text\":\"Hel\""));
         assert!(body_text.contains("\"text\":\"lo\""));
         assert!(body_text.contains("[DONE]"));

--- a/tests/integration/completions_route_tests.rs
+++ b/tests/integration/completions_route_tests.rs
@@ -20,6 +20,7 @@ mod tests {
         NonStreamingSuccess,
         RateLimitFailure,
         StreamingSuccess,
+        StreamingIdle,
     }
 
     #[derive(Clone)]
@@ -133,6 +134,12 @@ mod tests {
                     .insert_header(("Content-Type", "text/event-stream"))
                     .streaming(stream)
             }
+            MockScenario::StreamingIdle => {
+                let stream = stream::pending::<Result<Bytes, actix_web::Error>>();
+                HttpResponse::Ok()
+                    .insert_header(("Content-Type", "text/event-stream"))
+                    .streaming(stream)
+            }
         }
     }
 
@@ -155,9 +162,19 @@ mod tests {
     }
 
     async fn build_test_app_state(base_url: &str) -> AppState {
+        build_test_app_state_with_idle_timeout(base_url, None).await
+    }
+
+    async fn build_test_app_state_with_idle_timeout(
+        base_url: &str,
+        stream_idle_timeout: Option<u64>,
+    ) -> AppState {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
+        if let Some(stream_idle_timeout) = stream_idle_timeout {
+            config.gateway.server.stream_idle_timeout = stream_idle_timeout;
+        }
         config.gateway.providers = vec![build_provider_config(base_url)];
 
         let server = GatewayHttpServer::new(&config)
@@ -172,6 +189,13 @@ mod tests {
             "prompt": "Hello",
             "max_tokens": 16,
             "stream": stream
+        })
+    }
+
+    fn completion_request_without_model() -> Value {
+        json!({
+            "prompt": "Hello",
+            "max_tokens": 16
         })
     }
 
@@ -208,6 +232,63 @@ mod tests {
         assert_eq!(requests[0]["messages"][0]["role"], "user");
         assert_eq!(requests[0]["messages"][0]["content"], "Hello");
         assert!(requests[0].get("stream").is_none());
+
+        mock_server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_completions_alias_routes_and_path_model_override() {
+        let mock_server = MockOpenAIServer::start(MockScenario::NonStreamingSuccess).await;
+        let state = build_test_app_state(&mock_server.base_url).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let cases = [
+            ("/completions", completion_request(None)),
+            (
+                "/engines/gpt-4o/completions",
+                completion_request_without_model(),
+            ),
+            (
+                "/v1/engines/gpt-4o/completions",
+                json!({
+                    "model": "wrong-model",
+                    "prompt": "Hello",
+                    "max_tokens": 16
+                }),
+            ),
+            (
+                "/openai/deployments/gpt-4o/completions",
+                json!({
+                    "model": "wrong-model",
+                    "prompt": "Hello",
+                    "max_tokens": 16
+                }),
+            ),
+        ];
+
+        for (uri, body) in cases {
+            let resp = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri(uri)
+                    .set_json(body)
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(resp.status(), StatusCode::OK, "route should work: {uri}");
+            let body: Value = test::read_body_json(resp).await;
+            assert_eq!(body["object"], "text_completion");
+        }
+
+        let requests = mock_server.requests();
+        assert_eq!(requests.len(), 4);
+        assert!(requests.iter().all(|request| request["model"] == "gpt-4o"));
 
         mock_server.shutdown().await;
     }
@@ -252,6 +333,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_completions_rejects_invalid_scalar_fields() {
+        let mock_server = MockOpenAIServer::start(MockScenario::NonStreamingSuccess).await;
+        let state = build_test_app_state(&mock_server.base_url).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let cases = [
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","max_tokens":-1}),
+                "max_tokens",
+            ),
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","stream":"true"}),
+                "stream",
+            ),
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","echo":"false"}),
+                "echo",
+            ),
+            (json!({"model":"gpt-4o","prompt":"Hello","n":-1}), "n"),
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","logprobs":"1"}),
+                "logprobs",
+            ),
+            (
+                json!({"model":"gpt-4o","prompt":"Hello","stream_options":{"include_usage":"true"}}),
+                "include_usage",
+            ),
+        ];
+
+        for (body, expected_message) in cases {
+            let resp = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri("/v1/completions")
+                    .set_json(body)
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+            let body: Value = test::read_body_json(resp).await;
+            let message = body["error"]["message"]
+                .as_str()
+                .expect("invalid scalar response should have message");
+            assert!(
+                message.contains(expected_message),
+                "message '{message}' should mention '{expected_message}'"
+            );
+        }
+
+        assert!(mock_server.requests().is_empty());
+        mock_server.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn test_completions_provider_failure_maps_to_rate_limit() {
         let mock_server = MockOpenAIServer::start(MockScenario::RateLimitFailure).await;
         let state = build_test_app_state(&mock_server.base_url).await;
@@ -286,6 +427,90 @@ mod tests {
         let requests = mock_server.requests();
         assert!(!requests.is_empty());
         assert!(requests.iter().all(|request| request["model"] == "gpt-4o"));
+
+        mock_server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_completions_streaming_echo_prefixes_prompt_once() {
+        let mock_server = MockOpenAIServer::start(MockScenario::StreamingSuccess).await;
+        let state = build_test_app_state(&mock_server.base_url).await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let mut body = completion_request(Some(true));
+        body["echo"] = Value::Bool(true);
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/completions")
+                .set_json(body)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = test::read_body(resp).await;
+        let body_text = String::from_utf8(body.to_vec()).expect("streaming body should be utf8");
+        assert!(body_text.contains("\"text\":\"HelloHel\""));
+        assert!(body_text.contains("\"text\":\"lo\""));
+        assert_eq!(body_text.matches("Hello").count(), 1);
+
+        mock_server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_completions_stream_timeout_before_output_does_not_record_spend() {
+        let mock_server = MockOpenAIServer::start(MockScenario::StreamingIdle).await;
+        let state = build_test_app_state_with_idle_timeout(&mock_server.base_url, Some(1)).await;
+        state.budget_limits.providers.set_provider_limit(
+            "openai",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .models
+            .set_model_limit("gpt-4o", ModelLimitConfig::new(100.0, ResetPeriod::Monthly));
+        let budget_limits = state.budget_limits.clone();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/completions")
+                .set_json(completion_request(Some(true)))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test::read_body(resp).await;
+        let body_text = String::from_utf8(body.to_vec()).expect("streaming body should be utf8");
+        assert!(body_text.contains("Stream idle timeout"));
+
+        let provider_spend = budget_limits
+            .providers
+            .get_provider_usage("openai")
+            .map(|usage| usage.current_spend)
+            .unwrap_or(0.0);
+        let model_spend = budget_limits
+            .models
+            .get_model_usage("gpt-4o")
+            .map(|usage| usage.current_spend)
+            .unwrap_or(0.0);
+        assert_eq!(provider_spend, 0.0);
+        assert_eq!(model_spend, 0.0);
 
         mock_server.shutdown().await;
     }


### PR DESCRIPTION
## Summary
- Add a legacy OpenAI-compatible `/v1/completions` adapter plus root, engines, and deployment aliases
- Convert legacy completion requests onto the existing chat execution, routing, streaming, and spend path
- Return `text_completion` / `text_completion.chunk` envelopes with OpenAI-shaped validation and provider errors
- Update completions integration tests to hit the real route and verify provider forwarding, streaming, errors, and budget spend

Fixes #746

## Verification
- `cargo test --all-features --locked --test lib completions_route_tests --quiet`
- `cargo check --all-features --locked --message-format=short`
- `cargo test --all-features --locked --quiet`
- `cargo clippy --all-features --locked --lib --tests --bins -- -D warnings --force-warn clippy::collapsible-if`