### PR TITLE
Add moderation route proxy

### DIFF
--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -15,6 +15,7 @@ mod fine_tuning;
 mod gemini;
 mod images;
 mod models;
+mod moderations;
 mod openai_errors;
 mod provider_config;
 #[cfg(test)]
@@ -44,6 +45,7 @@ pub use gemini::{
 };
 pub use images::{image_edits, image_generations, image_variations};
 pub use models::{get_model, list_models};
+pub use moderations::create_moderation;
 pub use responses::{
     cancel_response, create_response, delete_response, get_response, list_response_input_items,
 };
@@ -55,6 +57,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 /// Configure AI API routes
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/completions", web::post().to(completions))
+        .route("/moderations", web::post().to(create_moderation))
         .route(
             "/engines/{model_id}/completions",
             web::post().to(engine_completions),
@@ -128,6 +131,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/images/generations", web::post().to(image_generations))
             .route("/images/edits", web::post().to(image_edits))
             .route("/images/variations", web::post().to(image_variations))
+            // Moderations
+            .route("/moderations", web::post().to(create_moderation))
             // Models
             .route("/models", web::get().to(list_models))
             .route("/models/{model_id}", web::get().to(get_model))

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -1,0 +1,264 @@
+//! OpenAI-compatible moderation API route.
+
+use crate::config::models::provider::ProviderConfig;
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
+use reqwest::Url;
+use reqwest::header::{HeaderName, HeaderValue};
+use serde_json::Value;
+use std::time::Duration;
+use tracing::error;
+
+use super::openai_errors;
+use super::provider_config;
+
+const DEFAULT_MODERATION_MODEL: &str = "omni-moderation-latest";
+const OPENAI_MODERATION_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Clone, PartialEq)]
+struct ModerationProxyProvider {
+    provider_name: String,
+    base_url: String,
+    headers: Vec<(HeaderName, HeaderValue)>,
+    timeout: Duration,
+}
+
+/// Create a moderation request.
+pub async fn create_moderation(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    request: web::Json<Value>,
+) -> ActixResult<HttpResponse> {
+    if let Err(error) = ensure_moderation_route_authorized(state.get_ref(), &req) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match proxy_moderation(state.get_ref(), request.into_inner()).await {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            error!("Moderation route error: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
+}
+
+fn ensure_moderation_route_authorized(
+    state: &AppState,
+    req: &HttpRequest,
+) -> Result<(), GatewayError> {
+    let _context = super::context::get_request_context(req)
+        .map_err(|_| GatewayError::Auth("Unauthorized".to_string()))?;
+    let auth = &state.config().gateway.auth;
+    if !auth.enable_jwt && !auth.enable_api_key && auth.allow_anonymous {
+        return Ok(());
+    }
+
+    let user = super::context::get_authenticated_user(req);
+    let api_key = super::context::get_authenticated_api_key(req);
+    if super::context::check_permission(user.as_ref(), api_key.as_ref(), "moderations") {
+        Ok(())
+    } else {
+        Err(GatewayError::Auth("Unauthorized".to_string()))
+    }
+}
+
+async fn proxy_moderation(
+    state: &AppState,
+    mut request: Value,
+) -> Result<HttpResponse, GatewayError> {
+    let resolved_model = validate_moderation_request(&request)?;
+    apply_resolved_moderation_model(&mut request, &resolved_model);
+    let Some(provider) = select_moderation_proxy_provider(
+        state.config().gateway.providers.as_slice(),
+        &resolved_model,
+    )?
+    else {
+        return Err(missing_moderation_provider_error());
+    };
+
+    super::spend::ensure_budget_available(
+        &state.budget_limits,
+        &provider.provider_name,
+        &resolved_model,
+    )?;
+
+    let response = provider_config::apply_proxy_headers(
+        provider_config::proxy_http_client().post(moderation_url(&provider)?),
+        &provider.headers,
+    )
+    .timeout(provider.timeout)
+    .json(&request)
+    .send()
+    .await?;
+
+    provider_config::proxy_response_to_http_response(response).await
+}
+
+fn validate_moderation_request(request: &Value) -> Result<String, GatewayError> {
+    let object = request
+        .as_object()
+        .ok_or_else(|| GatewayError::validation("request body must be a JSON object"))?;
+
+    for key in object.keys() {
+        if key != "input" && key != "model" {
+            return Err(GatewayError::validation(format!(
+                "Unknown /v1/moderations field: {key}"
+            )));
+        }
+    }
+
+    match object.get("input") {
+        Some(Value::String(input)) if !input.trim().is_empty() => {}
+        Some(Value::Array(inputs)) if !inputs.is_empty() => {}
+        Some(Value::String(_)) => return Err(GatewayError::validation("input cannot be empty")),
+        Some(Value::Array(_)) => return Err(GatewayError::validation("input cannot be empty")),
+        Some(_) => {
+            return Err(GatewayError::validation(
+                "input must be a string or non-empty array",
+            ));
+        }
+        None => return Err(GatewayError::validation("input is required")),
+    }
+
+    match object.get("model") {
+        Some(Value::String(model)) if !model.trim().is_empty() => Ok(model.trim().to_string()),
+        Some(Value::String(_)) => Err(GatewayError::validation("model cannot be empty")),
+        Some(Value::Null) | None => Ok(DEFAULT_MODERATION_MODEL.to_string()),
+        Some(_) => Err(GatewayError::validation("model must be a string")),
+    }
+}
+
+fn apply_resolved_moderation_model(request: &mut Value, resolved_model: &str) {
+    if let Some(object) = request.as_object_mut() {
+        object.insert(
+            "model".to_string(),
+            Value::String(resolved_model.to_string()),
+        );
+    }
+}
+
+fn select_moderation_proxy_provider(
+    providers: &[ProviderConfig],
+    requested_model: &str,
+) -> Result<Option<ModerationProxyProvider>, GatewayError> {
+    let candidates = providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter(|provider| is_openai_moderation_provider(provider))
+        .collect::<Vec<_>>();
+
+    let Some(provider) = candidates
+        .iter()
+        .copied()
+        .find(|provider| moderation_provider_supports_requested_model(provider, requested_model))
+    else {
+        if candidates.is_empty() {
+            return Ok(None);
+        }
+        return Err(GatewayError::Config(format!(
+            "Moderation provider for model '{requested_model}' is not configured"
+        )));
+    };
+
+    if provider.api_key.trim().is_empty() {
+        return Err(GatewayError::Config(format!(
+            "Moderation provider '{}' is missing api_key",
+            provider.name
+        )));
+    }
+
+    Ok(Some(ModerationProxyProvider {
+        provider_name: provider.name.clone(),
+        base_url: moderation_base_url(provider)?,
+        headers: moderation_provider_headers(provider)?,
+        timeout: Duration::from_secs(provider.timeout),
+    }))
+}
+
+fn moderation_provider_supports_requested_model(
+    provider: &ProviderConfig,
+    requested_model: &str,
+) -> bool {
+    provider.models.is_empty() || provider.models.iter().any(|model| model == requested_model)
+}
+
+fn moderation_base_url(provider: &ProviderConfig) -> Result<String, GatewayError> {
+    if let Some(base_url) = provider.base_url.as_deref() {
+        let trimmed = base_url.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if provider_config::normalize_provider_selector(&provider.provider_type) == "openai"
+        || provider_config::normalize_provider_selector(&provider.name) == "openai"
+    {
+        return Ok(OPENAI_MODERATION_BASE_URL.to_string());
+    }
+
+    Err(GatewayError::Config(format!(
+        "Moderation provider '{}' is missing base_url",
+        provider.name
+    )))
+}
+
+fn moderation_url(provider: &ModerationProxyProvider) -> Result<Url, GatewayError> {
+    let mut url = Url::parse(&provider.base_url)
+        .map_err(|error| GatewayError::Config(format!("Invalid moderation URL: {error}")))?;
+    url.path_segments_mut()
+        .map_err(|_| GatewayError::Config("Invalid moderation URL".to_string()))?
+        .extend(["moderations"]);
+    Ok(url)
+}
+
+fn missing_moderation_provider_error() -> GatewayError {
+    GatewayError::Config(
+        "Moderation API requires an enabled openai or openai_compatible provider".to_string(),
+    )
+}
+
+fn moderation_provider_headers(
+    provider: &ProviderConfig,
+) -> Result<Vec<(HeaderName, HeaderValue)>, GatewayError> {
+    let mut headers = Vec::new();
+    provider_config::push_proxy_header(
+        &mut headers,
+        "moderation provider",
+        "Authorization",
+        format!("Bearer {}", provider.api_key),
+    )?;
+    if let Some(organization) = provider.organization.as_deref() {
+        provider_config::push_proxy_header(
+            &mut headers,
+            "moderation provider",
+            "OpenAI-Organization",
+            organization,
+        )?;
+    }
+    if let Some(project) = provider.project.as_deref() {
+        provider_config::push_proxy_header(
+            &mut headers,
+            "moderation provider",
+            "OpenAI-Project",
+            project,
+        )?;
+    }
+    provider_config::append_string_header_map(provider, "headers", |key, value| {
+        provider_config::push_proxy_header(&mut headers, "moderation provider", key, value)
+    })?;
+    provider_config::append_string_header_map(provider, "custom_headers", |key, value| {
+        provider_config::push_proxy_header(&mut headers, "moderation provider", key, value)
+    })?;
+    Ok(headers)
+}
+
+fn is_openai_moderation_provider(provider: &ProviderConfig) -> bool {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+
+    provider_type == "openai"
+        || provider_type == "openaicompatible"
+        || provider_name == "openai"
+        || provider_name == "openaicompatible"
+}

--- a/src/server/routes/ai/provider_config.rs
+++ b/src/server/routes/ai/provider_config.rs
@@ -2,6 +2,13 @@
 
 use crate::config::models::provider::ProviderConfig;
 use crate::utils::error::gateway_error::GatewayError;
+use actix_web::HttpResponse;
+use actix_web::http::{StatusCode, header};
+use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::{Client, RequestBuilder};
+use std::sync::OnceLock;
+
+static PROXY_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 
 pub(super) fn append_string_header_map(
     provider: &ProviderConfig,
@@ -26,4 +33,51 @@ pub(super) fn append_string_header_map(
 
 pub(super) fn normalize_provider_selector(value: &str) -> String {
     value.trim().to_ascii_lowercase().replace(['_', '-'], "")
+}
+
+pub(super) fn proxy_http_client() -> &'static Client {
+    PROXY_HTTP_CLIENT.get_or_init(Client::new)
+}
+
+pub(super) async fn proxy_response_to_http_response(
+    response: reqwest::Response,
+) -> Result<HttpResponse, GatewayError> {
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .map_err(|error| GatewayError::internal(format!("Invalid upstream status: {error}")))?;
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+    let body = response.bytes().await?;
+
+    Ok(HttpResponse::build(status)
+        .insert_header((header::CONTENT_TYPE, content_type))
+        .body(body))
+}
+
+pub(super) fn apply_proxy_headers(
+    mut request: RequestBuilder,
+    headers: &[(HeaderName, HeaderValue)],
+) -> RequestBuilder {
+    for (name, value) in headers {
+        request = request.header(name.clone(), value.clone());
+    }
+    request
+}
+
+pub(super) fn push_proxy_header(
+    headers: &mut Vec<(HeaderName, HeaderValue)>,
+    context: &str,
+    name: impl AsRef<str>,
+    value: impl AsRef<str>,
+) -> Result<(), GatewayError> {
+    let name = HeaderName::from_bytes(name.as_ref().as_bytes())
+        .map_err(|error| GatewayError::Config(format!("Invalid {context} header: {error}")))?;
+    let value = HeaderValue::from_str(value.as_ref()).map_err(|error| {
+        GatewayError::Config(format!("Invalid {context} header value: {error}"))
+    })?;
+    headers.push((name, value));
+    Ok(())
 }

--- a/tests/moderations_routes.rs
+++ b/tests/moderations_routes.rs
@@ -1,0 +1,596 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use actix_web::{HttpMessage, dev::Service};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone, Debug)]
+    struct CapturedModerationRequest {
+        method: String,
+        path: String,
+        headers: HashMap<String, String>,
+        body: Value,
+    }
+
+    #[derive(Clone)]
+    struct MockModerationState {
+        captured_requests: Arc<Mutex<Vec<CapturedModerationRequest>>>,
+    }
+
+    struct MockModerationServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedModerationRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockModerationServer {
+        async fn start_moderation_mock() -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockModerationState {
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .route("/v1/moderations", web::post().to(mock_moderation_create))
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            wait_for_server(address).await;
+
+            Self {
+                base_url: format!("http://{address}/v1"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedModerationRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn stop_moderation_mock(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
+    }
+
+    async fn mock_moderation_create(
+        state: web::Data<MockModerationState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        capture_request(&state, &request, body);
+        HttpResponse::Ok().json(json!({
+            "id": "modr_mock",
+            "model": "omni-moderation-latest",
+            "results": [{
+                "flagged": false,
+                "categories": { "violence": false },
+                "category_scores": { "violence": 0.0 }
+            }]
+        }))
+    }
+
+    fn capture_request(state: &MockModerationState, request: &HttpRequest, body: Bytes) {
+        let headers = request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect();
+        let body = if body.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&body).expect("mock moderation body should be json")
+        };
+
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedModerationRequest {
+                method: request.method().to_string(),
+                path: request.path().to_string(),
+                headers,
+                body,
+            });
+    }
+
+    async fn build_test_app_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        build_test_app_state_with_auth(providers, false, true).await
+    }
+
+    async fn build_test_app_state_with_auth(
+        providers: Vec<ProviderConfig>,
+        enable_api_key: bool,
+        allow_anonymous: bool,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = enable_api_key;
+        config.gateway.auth.allow_anonymous = allow_anonymous;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn moderation_provider(base_url: &str) -> ProviderConfig {
+        moderation_provider_with_models(base_url, Vec::new())
+    }
+
+    fn moderation_provider_with_models(base_url: &str, models: Vec<String>) -> ProviderConfig {
+        let mut provider = ProviderConfig {
+            name: "mock-openai-compatible".to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            organization: Some("org-test".to_string()),
+            project: Some("proj-test".to_string()),
+            models,
+            ..ProviderConfig::default()
+        };
+        provider.settings = HashMap::from([
+            (
+                "headers".to_string(),
+                json!({
+                    "X-Base-Header": "base-value",
+                    "X-Ignored-Non-String": false
+                }),
+            ),
+            (
+                "custom_headers".to_string(),
+                json!({
+                    "X-Custom-Header": "custom-value"
+                }),
+            ),
+        ]);
+        provider
+    }
+
+    fn authenticated_api_key() -> ApiKey {
+        ApiKey {
+            metadata: Metadata::new(),
+            name: "test-key".to_string(),
+            key_hash: "hash".to_string(),
+            key_prefix: "sk-test".to_string(),
+            user_id: None,
+            team_id: None,
+            permissions: Vec::new(),
+            rate_limits: None,
+            expires_at: None,
+            is_active: true,
+            last_used_at: None,
+            usage_stats: UsageStats::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn moderation_route_without_provider_fails_closed() {
+        let state = build_test_app_state(Vec::new()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "server_error");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("Moderation API requires")
+        );
+    }
+
+    #[tokio::test]
+    async fn moderation_route_proxies_request_with_provider_headers() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({
+                    "model": "omni-moderation-latest",
+                    "input": "moderate this text"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["id"], "modr_mock");
+        assert_eq!(body["results"][0]["flagged"], false);
+
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["input"], "moderate this text");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+        assert_eq!(requests[0].headers["authorization"], "Bearer sk-test");
+        assert_eq!(requests[0].headers["openai-organization"], "org-test");
+        assert_eq!(requests[0].headers["openai-project"], "proj-test");
+        assert_eq!(requests[0].headers["x-base-header"], "base-value");
+        assert_eq!(requests[0].headers["x-custom-header"], "custom-value");
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn root_moderation_alias_proxies_request() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/moderations")
+                .set_json(json!({
+                    "input": ["one", "two"]
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["input"][0], "one");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_uses_default_model_for_provider_selection_when_omitted() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![
+            moderation_provider_with_models(
+                "http://127.0.0.1:9/v1",
+                vec!["unrelated-moderation-model".to_string()],
+            ),
+            moderation_provider_with_models(
+                &mock.base_url,
+                vec!["omni-moderation-latest".to_string()],
+            ),
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "moderate this text" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_requires_auth_when_anonymous_is_disabled() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state =
+            build_test_app_state_with_auth(vec![moderation_provider(&mock.base_url)], true, false)
+                .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "authentication_error");
+        assert!(
+            mock.requests().is_empty(),
+            "unauthenticated requests must fail before upstream call"
+        );
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_allows_authenticated_api_key() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state =
+            build_test_app_state_with_auth(vec![moderation_provider(&mock.base_url)], true, false)
+                .await;
+        let api_key = authenticated_api_key();
+        let app = test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert::<ApiKey>(api_key.clone());
+                    srv.call(req)
+                })
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.requests().len(), 1);
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_rejects_invalid_request_before_upstream() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let cases = [
+            (json!({}), "input"),
+            (json!({ "input": "" }), "input"),
+            (json!({ "input": "hello", "model": 1 }), "model"),
+            (json!({ "input": "hello", "unknown": true }), "Unknown"),
+        ];
+
+        for (body, expected_message) in cases {
+            let resp = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri("/v1/moderations")
+                    .set_json(body)
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+            let body: Value = test::read_body_json(resp).await;
+            assert!(
+                body["error"]["message"]
+                    .as_str()
+                    .expect("error message")
+                    .contains(expected_message)
+            );
+        }
+
+        assert!(
+            mock.requests().is_empty(),
+            "invalid requests must fail before provider call"
+        );
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_rejects_unconfigured_model_before_upstream() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![moderation_provider_with_models(
+            &mock.base_url,
+            vec!["omni-moderation-latest".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({
+                    "model": "different-moderation-model",
+                    "input": "hello"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(resp).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("different-moderation-model")
+        );
+        assert!(mock.requests().is_empty());
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_rejects_exhausted_provider_budget_before_upstream() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-compatible",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("mock-openai-compatible", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "insufficient_quota");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("provider 'mock-openai-compatible' budget exceeded")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "budget rejection must happen before upstream call"
+        );
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_rejects_exhausted_default_model_budget_before_upstream() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
+        state.budget_limits.models.set_model_limit(
+            "omni-moderation-latest",
+            ModelLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .models
+            .record_model_spend("omni-moderation-latest", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "insufficient_quota");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("model 'omni-moderation-latest' budget exceeded")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "model budget rejection must happen before upstream call"
+        );
+
+        mock.stop_moderation_mock().await;
+    }
+}


### PR DESCRIPTION
Fixes #747

## Summary
- add OpenAI-compatible /v1/moderations and /moderations routes
- proxy moderation requests to enabled openai/openai_compatible providers with provider headers and model filtering
- fail closed on invalid input, missing provider, unconfigured model, and exhausted provider budget

## Tests
- cargo test --all-features --locked --test moderations_routes -- --nocapture
- cargo check --all-features --locked --message-format=short
- cargo clippy --all-features --locked --lib --tests --bins -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked --quiet