### PR TITLE
Add rerank HTTP route

### DIFF
--- a/src/core/rerank/providers/cohere.rs
+++ b/src/core/rerank/providers/cohere.rs
@@ -1,5 +1,6 @@
 //! Cohere rerank provider implementation
 
+use super::rerank_upstream_error;
 use crate::core::rerank::service::RerankProvider;
 use crate::core::rerank::types::{RerankRequest, RerankResponse, RerankResult, RerankUsage};
 use crate::utils::error::gateway_error::{GatewayError, Result};
@@ -82,10 +83,7 @@ impl RerankProvider for CohereRerankProvider {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(GatewayError::Network(format!(
-                "Cohere rerank error ({}): {}",
-                status, error_text
-            )));
+            return Err(rerank_upstream_error("cohere", status, error_text));
         }
 
         // Parse response

--- a/src/core/rerank/providers/jina.rs
+++ b/src/core/rerank/providers/jina.rs
@@ -1,5 +1,6 @@
 //! Jina AI rerank provider implementation
 
+use super::rerank_upstream_error;
 use crate::core::rerank::service::RerankProvider;
 use crate::core::rerank::types::{RerankRequest, RerankResponse, RerankResult, RerankUsage};
 use crate::utils::error::gateway_error::{GatewayError, Result};
@@ -24,6 +25,12 @@ impl JinaRerankProvider {
             base_url: "https://api.jina.ai/v1".to_string(),
             client: crate::core::http::outbound::default_outbound_client().clone(),
         }
+    }
+
+    /// Set custom base URL
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
     }
 }
 
@@ -69,10 +76,7 @@ impl RerankProvider for JinaRerankProvider {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(GatewayError::Network(format!(
-                "Jina rerank error ({}): {}",
-                status, error_text
-            )));
+            return Err(rerank_upstream_error("jina", status, error_text));
         }
 
         let jina_response: serde_json::Value = response.json().await.map_err(|e| {

--- a/src/core/rerank/providers/mod.rs
+++ b/src/core/rerank/providers/mod.rs
@@ -3,5 +3,23 @@
 mod cohere;
 mod jina;
 
+use crate::core::providers::ProviderError;
+use crate::utils::error::gateway_error::GatewayError;
+use reqwest::StatusCode;
+
 pub use cohere::CohereRerankProvider;
 pub use jina::JinaRerankProvider;
+
+pub(crate) fn rerank_upstream_error(
+    provider: &'static str,
+    status: StatusCode,
+    body: String,
+) -> GatewayError {
+    let message = if body.trim().is_empty() {
+        format!("rerank error ({status})")
+    } else {
+        format!("rerank error ({status}): {body}")
+    };
+
+    GatewayError::Provider(ProviderError::api_error(provider, status.as_u16(), message))
+}

--- a/src/server/routes/ai/context.rs
+++ b/src/server/routes/ai/context.rs
@@ -52,8 +52,8 @@ pub fn get_authenticated_api_key(req: &HttpRequest) -> Option<ApiKey> {
 /// - Unauthenticated requests are always denied.
 /// - Admin roles (`SuperAdmin`, `Admin`) have full access to every operation.
 /// - API-usage operations (`chat`, `completions`, `models`, `embeddings`, `images`,
-///   `audio`, `moderations`, `assistants`, `files`, `fine_tuning`) are allowed for
-///   any authenticated user/key.
+///   `audio`, `moderations`, `rerank`, `assistants`, `files`, `fine_tuning`) are
+///   allowed for any authenticated user/key.
 /// - Management operations (`keys.list_all`, `users.manage`, `config.manage`,
 ///   `teams.manage`, `analytics.admin`) require an admin role.
 /// - API key `permissions` can grant admin-level access via `"*"` or `"system.admin"`,

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -20,6 +20,7 @@ mod openai_errors;
 mod provider_config;
 #[cfg(test)]
 mod provider_selection;
+mod rerank;
 mod responses;
 mod responses_stream;
 mod spend;
@@ -46,6 +47,7 @@ pub use gemini::{
 pub use images::{image_edits, image_generations, image_variations};
 pub use models::{get_model, list_models};
 pub use moderations::create_moderation;
+pub use rerank::rerank;
 pub use responses::{
     cancel_response, create_response, delete_response, get_response, list_response_input_items,
 };
@@ -58,6 +60,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/completions", web::post().to(completions))
         .route("/moderations", web::post().to(create_moderation))
+        .route("/rerank", web::post().to(rerank))
         .route(
             "/engines/{model_id}/completions",
             web::post().to(engine_completions),
@@ -133,6 +136,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .route("/images/variations", web::post().to(image_variations))
             // Moderations
             .route("/moderations", web::post().to(create_moderation))
+            // Rerank
+            .route("/rerank", web::post().to(rerank))
             // Models
             .route("/models", web::get().to(list_models))
             .route("/models/{model_id}", web::get().to(get_model))

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -1,0 +1,345 @@
+//! Rerank endpoint.
+
+use crate::config::models::provider::ProviderConfig;
+use crate::core::rerank::{
+    CohereRerankProvider, JinaRerankProvider, RerankRequest, RerankResponse, RerankService,
+};
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{error, info};
+
+use super::{openai_errors, provider_config};
+
+/// Rerank documents against a query.
+pub async fn rerank(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    request: web::Json<RerankRequest>,
+) -> ActixResult<HttpResponse> {
+    info!("Rerank request for model: {}", request.model);
+
+    if let Err(error) = ensure_rerank_route_authorized(state.get_ref(), &req) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
+    match handle_rerank_with_state(state.get_ref(), request.into_inner()).await {
+        Ok(response) => Ok(HttpResponse::Ok().json(response)),
+        Err(error) => {
+            error!("Rerank error: {}", error);
+            Ok(openai_errors::gateway_error_response(&error))
+        }
+    }
+}
+
+async fn handle_rerank_with_state(
+    state: &AppState,
+    request: RerankRequest,
+) -> Result<RerankResponse, GatewayError> {
+    let selected = select_rerank_provider(state.config().gateway.providers.as_slice(), &request)?;
+    let served_model = served_rerank_model(&request.model);
+
+    super::spend::ensure_budget_available(
+        &state.budget_limits,
+        &selected.provider_name,
+        served_model,
+    )?;
+
+    let service = build_rerank_service(&selected)?;
+    service.rerank(request).await
+}
+
+fn ensure_rerank_route_authorized(state: &AppState, req: &HttpRequest) -> Result<(), GatewayError> {
+    let _context = super::context::get_request_context(req)
+        .map_err(|_| GatewayError::Auth("Unauthorized".to_string()))?;
+    let auth = &state.config().gateway.auth;
+    if !auth.enable_jwt && !auth.enable_api_key && auth.allow_anonymous {
+        return Ok(());
+    }
+
+    let user = super::context::get_authenticated_user(req);
+    let api_key = super::context::get_authenticated_api_key(req);
+    if super::context::check_permission(user.as_ref(), api_key.as_ref(), "rerank") {
+        Ok(())
+    } else {
+        Err(GatewayError::Auth("Unauthorized".to_string()))
+    }
+}
+
+fn build_rerank_service(provider: &SelectedRerankProvider) -> Result<RerankService, GatewayError> {
+    let mut service = RerankService::new();
+    service
+        .set_default_provider(provider.kind.as_str())
+        .set_timeout(provider.timeout);
+
+    match provider.kind {
+        RerankProviderKind::Cohere => {
+            let mut rerank_provider = CohereRerankProvider::new(provider.api_key.clone());
+            if let Some(base_url) = provider.base_url.as_deref() {
+                rerank_provider = rerank_provider.with_base_url(base_url.trim_end_matches('/'));
+            }
+            service.register_provider("cohere", Arc::new(rerank_provider));
+        }
+        RerankProviderKind::Jina => {
+            let mut rerank_provider = JinaRerankProvider::new(provider.api_key.clone());
+            if let Some(base_url) = provider.base_url.as_deref() {
+                rerank_provider = rerank_provider.with_base_url(base_url.trim_end_matches('/'));
+            }
+            service.register_provider("jina", Arc::new(rerank_provider));
+        }
+    }
+
+    Ok(service)
+}
+
+fn select_rerank_provider(
+    providers: &[ProviderConfig],
+    request: &RerankRequest,
+) -> Result<SelectedRerankProvider, GatewayError> {
+    let candidates = providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter_map(|provider| rerank_provider_kind(provider).map(|kind| (provider, kind)))
+        .collect::<Vec<_>>();
+
+    if candidates.is_empty() {
+        return Err(GatewayError::NotFound(
+            "No configured rerank provider found; configure a cohere or jina provider".to_string(),
+        ));
+    }
+
+    let Some((provider, kind)) = candidates
+        .into_iter()
+        .find(|(provider, kind)| rerank_provider_supports_model(provider, *kind, &request.model))
+    else {
+        return Err(GatewayError::NotFound(format!(
+            "No configured rerank provider supports model '{}'",
+            request.model
+        )));
+    };
+
+    if provider.api_key.trim().is_empty() {
+        return Err(GatewayError::Config(format!(
+            "Rerank provider '{}' is missing api_key",
+            provider.name
+        )));
+    }
+
+    Ok(SelectedRerankProvider {
+        provider_name: provider.name.clone(),
+        kind,
+        api_key: provider.api_key.clone(),
+        base_url: provider.base_url.clone(),
+        timeout: Duration::from_secs(provider.timeout),
+    })
+}
+
+fn rerank_provider_supports_model(
+    provider: &ProviderConfig,
+    kind: RerankProviderKind,
+    requested_model: &str,
+) -> bool {
+    let (requested_provider, served_model) = split_rerank_model(requested_model);
+    if let Some(requested_provider) = requested_provider
+        && provider_config::normalize_provider_selector(requested_provider) != kind.as_str()
+    {
+        return false;
+    }
+
+    let explicitly_configured = provider
+        .models
+        .iter()
+        .any(|model| model == requested_model || model == served_model);
+
+    if !provider.models.is_empty() {
+        return explicitly_configured;
+    }
+
+    kind.supports_model(served_model)
+}
+
+fn rerank_provider_kind(provider: &ProviderConfig) -> Option<RerankProviderKind> {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+
+    if provider_type.contains("cohere") || provider_name.contains("cohere") {
+        return Some(RerankProviderKind::Cohere);
+    }
+
+    if provider_type.contains("jina") || provider_name.contains("jina") {
+        return Some(RerankProviderKind::Jina);
+    }
+
+    None
+}
+
+fn served_rerank_model(model: &str) -> &str {
+    split_rerank_model(model).1
+}
+
+fn split_rerank_model(model: &str) -> (Option<&str>, &str) {
+    match model.split_once('/') {
+        Some((provider, model)) if !provider.trim().is_empty() && !model.trim().is_empty() => {
+            (Some(provider), model)
+        }
+        _ => (None, model),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RerankProviderKind {
+    Cohere,
+    Jina,
+}
+
+impl RerankProviderKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cohere => "cohere",
+            Self::Jina => "jina",
+        }
+    }
+
+    fn supports_model(self, model: &str) -> bool {
+        match self {
+            Self::Cohere => matches!(
+                model,
+                "rerank-english-v3.0"
+                    | "rerank-multilingual-v3.0"
+                    | "rerank-english-v2.0"
+                    | "rerank-multilingual-v2.0"
+            ),
+            Self::Jina => matches!(
+                model,
+                "jina-reranker-v2-base-multilingual"
+                    | "jina-reranker-v1-base-en"
+                    | "jina-reranker-v1-turbo-en"
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SelectedRerankProvider {
+    provider_name: String,
+    kind: RerankProviderKind,
+    api_key: String,
+    base_url: Option<String>,
+    timeout: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_config(name: &str, provider_type: &str, models: Vec<&str>) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            provider_type: provider_type.to_string(),
+            api_key: "test-key".to_string(),
+            models: models.into_iter().map(ToString::to_string).collect(),
+            ..ProviderConfig::default()
+        }
+    }
+
+    #[test]
+    fn detects_provider_kind_from_type_or_name() {
+        let by_type = provider_config("primary", "cohere_rerank", Vec::new());
+        let by_name = provider_config("jina-reranker", "custom", Vec::new());
+        let unsupported = provider_config("voyage", "voyage", Vec::new());
+
+        assert_eq!(
+            rerank_provider_kind(&by_type),
+            Some(RerankProviderKind::Cohere)
+        );
+        assert_eq!(
+            rerank_provider_kind(&by_name),
+            Some(RerankProviderKind::Jina)
+        );
+        assert_eq!(rerank_provider_kind(&unsupported), None);
+    }
+
+    #[test]
+    fn provider_model_filter_accepts_prefixed_and_unprefixed_models() {
+        let provider = provider_config("cohere", "cohere", vec!["rerank-english-v3.0"]);
+
+        assert!(rerank_provider_supports_model(
+            &provider,
+            RerankProviderKind::Cohere,
+            "rerank-english-v3.0"
+        ));
+        assert!(rerank_provider_supports_model(
+            &provider,
+            RerankProviderKind::Cohere,
+            "cohere/rerank-english-v3.0"
+        ));
+        assert!(!rerank_provider_supports_model(
+            &provider,
+            RerankProviderKind::Cohere,
+            "jina/rerank-english-v3.0"
+        ));
+        assert!(!rerank_provider_supports_model(
+            &provider,
+            RerankProviderKind::Cohere,
+            "rerank-multilingual-v3.0"
+        ));
+    }
+
+    #[test]
+    fn provider_model_filter_allows_explicit_new_provider_models() {
+        let cohere = provider_config("cohere", "cohere", vec!["rerank-v4.0-pro"]);
+        let jina = provider_config("jina", "jina", vec!["jina-colbert-v2"]);
+
+        assert!(rerank_provider_supports_model(
+            &cohere,
+            RerankProviderKind::Cohere,
+            "rerank-v4.0-pro"
+        ));
+        assert!(rerank_provider_supports_model(
+            &cohere,
+            RerankProviderKind::Cohere,
+            "cohere/rerank-v4.0-pro"
+        ));
+        assert!(rerank_provider_supports_model(
+            &jina,
+            RerankProviderKind::Jina,
+            "jina-colbert-v2"
+        ));
+        assert!(rerank_provider_supports_model(
+            &jina,
+            RerankProviderKind::Jina,
+            "jina/jina-colbert-v2"
+        ));
+    }
+
+    #[test]
+    fn provider_model_filter_rejects_unconfigured_unknown_models() {
+        let cohere = provider_config("cohere", "cohere", Vec::new());
+
+        assert!(!rerank_provider_supports_model(
+            &cohere,
+            RerankProviderKind::Cohere,
+            "rerank-v4.0-pro"
+        ));
+    }
+
+    #[test]
+    fn selects_matching_enabled_provider() {
+        let wrong = provider_config("wrong-cohere", "cohere", vec!["rerank-multilingual-v3.0"]);
+        let selected = provider_config("right-cohere", "cohere", vec!["rerank-english-v3.0"]);
+        let request = RerankRequest {
+            model: "rerank-english-v3.0".to_string(),
+            query: "hello".to_string(),
+            documents: vec!["doc".into()],
+            ..RerankRequest::default()
+        };
+
+        let selected = select_rerank_provider(&[wrong, selected], &request)
+            .expect("matching provider should be selected");
+
+        assert_eq!(selected.provider_name, "right-cohere");
+        assert_eq!(selected.kind, RerankProviderKind::Cohere);
+    }
+}

--- a/tests/rerank_routes.rs
+++ b/tests/rerank_routes.rs
@@ -1,0 +1,659 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use actix_web::{HttpMessage, dev::Service};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone, Debug)]
+    struct CapturedRerankRequest {
+        method: String,
+        path: String,
+        headers: HashMap<String, String>,
+        body: Value,
+    }
+
+    #[derive(Clone)]
+    struct MockRerankState {
+        captured_requests: Arc<Mutex<Vec<CapturedRerankRequest>>>,
+    }
+
+    struct MockRerankServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedRerankRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockRerankServer {
+        async fn start_rerank_mock() -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockRerankState {
+                captured_requests: Arc::clone(&captured_requests),
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .route("/v1/rerank", web::post().to(mock_rerank_create))
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            wait_for_server(address).await;
+
+            Self {
+                base_url: format!("http://{address}/v1"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedRerankRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn stop_rerank_mock(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
+    }
+
+    async fn mock_rerank_create(
+        state: web::Data<MockRerankState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        let body = capture_request(&state, &request, body);
+        match body.get("query").and_then(Value::as_str) {
+            Some("force bad request") => {
+                return HttpResponse::BadRequest()
+                    .json(json!({ "message": "invalid rerank payload" }));
+            }
+            Some("force unauthorized") => {
+                return HttpResponse::Unauthorized().json(json!({ "message": "invalid api key" }));
+            }
+            Some("force forbidden") => {
+                return HttpResponse::Forbidden().json(json!({ "message": "access denied" }));
+            }
+            Some("force rate limit") => {
+                return HttpResponse::TooManyRequests().json(json!({ "message": "slow down" }));
+            }
+            _ => {}
+        }
+
+        HttpResponse::Ok().json(json!({
+            "id": "rerank_mock",
+            "results": [
+                { "index": 1, "relevance_score": 0.91 },
+                { "index": 0, "relevance_score": 0.12 }
+            ],
+            "meta": {
+                "billed_units": { "search_units": 1 }
+            }
+        }))
+    }
+
+    fn capture_request(state: &MockRerankState, request: &HttpRequest, body: Bytes) -> Value {
+        let headers = request
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect();
+        let body = if body.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&body).expect("mock rerank body should be json")
+        };
+
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedRerankRequest {
+                method: request.method().to_string(),
+                path: request.path().to_string(),
+                headers,
+                body: body.clone(),
+            });
+
+        body
+    }
+
+    async fn build_test_app_state(
+        providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        build_test_app_state_with_auth(providers, false, true).await
+    }
+
+    async fn build_test_app_state_with_auth(
+        providers: Vec<ProviderConfig>,
+        enable_api_key: bool,
+        allow_anonymous: bool,
+    ) -> litellm_rs::server::state::AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = enable_api_key;
+        config.gateway.auth.allow_anonymous = allow_anonymous;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn cohere_rerank_provider(base_url: &str) -> ProviderConfig {
+        cohere_rerank_provider_with_name_and_models(
+            "mock-cohere",
+            base_url,
+            vec!["rerank-english-v3.0".to_string()],
+        )
+    }
+
+    fn cohere_rerank_provider_with_name_and_models(
+        name: &str,
+        base_url: &str,
+        models: Vec<String>,
+    ) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            models,
+            ..ProviderConfig::default()
+        }
+    }
+
+    fn jina_rerank_provider_with_models(base_url: &str, models: Vec<String>) -> ProviderConfig {
+        ProviderConfig {
+            name: "mock-jina-rerank".to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            models,
+            ..ProviderConfig::default()
+        }
+    }
+
+    fn authenticated_api_key() -> ApiKey {
+        ApiKey {
+            metadata: Metadata::new(),
+            name: "test-key".to_string(),
+            key_hash: "hash".to_string(),
+            key_prefix: "sk-test".to_string(),
+            user_id: None,
+            team_id: None,
+            permissions: Vec::new(),
+            rate_limits: None,
+            expires_at: None,
+            is_active: true,
+            last_used_at: None,
+            usage_stats: UsageStats::default(),
+        }
+    }
+
+    fn rerank_body() -> Value {
+        json!({
+            "model": "rerank-english-v3.0",
+            "query": "What is machine learning?",
+            "documents": [
+                "A database migration guide",
+                "Machine learning models learn patterns"
+            ],
+            "top_n": 2,
+            "return_documents": true
+        })
+    }
+
+    #[tokio::test]
+    async fn rerank_route_without_provider_fails_closed() {
+        let state = build_test_app_state(Vec::new()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["code"], "not_found");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("No configured rerank provider")
+        );
+    }
+
+    #[tokio::test]
+    async fn rerank_route_proxies_cohere_provider() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["id"], "rerank_mock");
+        assert_eq!(body["model"], "rerank-english-v3.0");
+        assert_eq!(body["results"][0]["index"], 1);
+        assert_eq!(
+            body["results"][0]["document"],
+            "Machine learning models learn patterns"
+        );
+        assert_eq!(body["usage"]["search_units"], 1);
+
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].path, "/v1/rerank");
+        assert_eq!(requests[0].headers["authorization"], "Bearer sk-test");
+        assert_eq!(requests[0].body["model"], "rerank-english-v3.0");
+        assert_eq!(requests[0].body["query"], "What is machine learning?");
+        assert_eq!(
+            requests[0].body["documents"][1],
+            "Machine learning models learn patterns"
+        );
+        assert_eq!(requests[0].body["top_n"], 2);
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_allows_explicit_configured_cohere_model() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider_with_name_and_models(
+            "cohere-v4-provider",
+            &mock.base_url,
+            vec!["rerank-v4.0-pro".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let mut body = rerank_body();
+        body["model"] = json!("rerank-v4.0-pro");
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(body)
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].body["model"], "rerank-v4.0-pro");
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_proxies_jina_provider() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![jina_rerank_provider_with_models(
+            &mock.base_url,
+            vec!["jina-reranker-v3".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let mut body = rerank_body();
+        body["model"] = json!("jina-reranker-v3");
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(body)
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/rerank");
+        assert_eq!(requests[0].headers["authorization"], "Bearer sk-test");
+        assert_eq!(requests[0].body["model"], "jina-reranker-v3");
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn root_rerank_alias_proxies_request() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.requests().len(), 1);
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_requires_auth_when_anonymous_is_disabled() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state_with_auth(
+            vec![cohere_rerank_provider(&mock.base_url)],
+            true,
+            false,
+        )
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            mock.requests().is_empty(),
+            "unauthenticated requests must fail before upstream call"
+        );
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_allows_authenticated_api_key() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state_with_auth(
+            vec![cohere_rerank_provider(&mock.base_url)],
+            true,
+            false,
+        )
+        .await;
+        let api_key = authenticated_api_key();
+        let app = test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert::<ApiKey>(api_key.clone());
+                    srv.call(req)
+                })
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.requests().len(), 1);
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_preserves_upstream_error_statuses() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let cases = [
+            (
+                "force bad request",
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                "invalid_request",
+            ),
+            (
+                "force unauthorized",
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "authentication_error",
+            ),
+            (
+                "force forbidden",
+                StatusCode::FORBIDDEN,
+                "permission_error",
+                "permission_denied",
+            ),
+            (
+                "force rate limit",
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate_limit_error",
+                "rate_limit_exceeded",
+            ),
+        ];
+
+        for (query, expected_status, expected_type, expected_code) in cases {
+            let mut body = rerank_body();
+            body["query"] = json!(query);
+
+            let resp = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri("/v1/rerank")
+                    .set_json(body)
+                    .to_request(),
+            )
+            .await;
+
+            assert_eq!(resp.status(), expected_status, "query: {query}");
+            let body: Value = test::read_body_json(resp).await;
+            assert_eq!(body["error"]["type"], expected_type, "query: {query}");
+            assert_eq!(body["error"]["code"], expected_code, "query: {query}");
+        }
+
+        assert_eq!(mock.requests().len(), cases.len());
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_rejects_unconfigured_model_before_upstream() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider_with_name_and_models(
+            "wrong-model-provider",
+            &mock.base_url,
+            vec!["rerank-multilingual-v3.0".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(
+            mock.requests().is_empty(),
+            "model filtering must happen before upstream call"
+        );
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_rejects_exhausted_provider_budget_before_upstream() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-cohere",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("mock-cohere", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            mock.requests().is_empty(),
+            "budget rejection must happen before upstream call"
+        );
+
+        mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_rejects_exhausted_model_budget_before_upstream() {
+        let mock = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
+        state.budget_limits.models.set_model_limit(
+            "rerank-english-v3.0",
+            ModelLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .models
+            .record_model_spend("rerank-english-v3.0", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            mock.requests().is_empty(),
+            "model budget rejection must happen before upstream call"
+        );
+
+        mock.stop_rerank_mock().await;
+    }
+}


### PR DESCRIPTION
Fixes #748

## Summary
- add `/rerank` and `/v1/rerank` HTTP routes backed by configured Cohere/Jina rerank providers
- enforce route auth and provider/model budget checks before upstream I/O
- add rerank route tests for no-provider, proxy, root alias, auth, provider model filtering, and budget rejection

## Tests
- `cargo test --all-features --locked --test rerank_routes -- --nocapture`
- `cargo test --all-features --locked server::routes::ai::rerank --lib --quiet`
- `cargo check --all-features --locked --message-format=short`
- `cargo clippy --all-features --locked --lib --tests --bins -- -D warnings --force-warn clippy::collapsible-if`
- `cargo test --all-features --locked --quiet`

Note: the first full-suite run hit a transient DNS-dependent SSRF test failure for `api.anthropic.com`; the isolated test and the subsequent full-suite rerun passed.