### PR TITLE
Fix moderation router fallback

### DIFF
--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -372,6 +372,7 @@ impl LLMProvider for OpenAIProvider {
             ProviderCapability::AudioTranscription,
             ProviderCapability::AudioTranslation,
             ProviderCapability::TextToSpeech,
+            ProviderCapability::Moderation,
             ProviderCapability::ToolCalling,
             ProviderCapability::FunctionCalling,
             // New capabilities

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -139,6 +139,10 @@ impl OpenAIModelRegistry {
             features.push(OpenAIModelFeature::AudioOutput);
         }
 
+        if model_id.starts_with("omni-moderation") {
+            features.push(OpenAIModelFeature::Moderation);
+        }
+
         if model_id.contains("embedding") {
             features.push(OpenAIModelFeature::Embeddings);
         }
@@ -242,6 +246,8 @@ impl OpenAIModelRegistry {
             OpenAIModelFamily::Whisper
         } else if model_id.starts_with("tts") {
             OpenAIModelFamily::TTS
+        } else if model_id.starts_with("omni-moderation") {
+            OpenAIModelFamily::Moderation
         } else if model_id.contains("embedding") {
             OpenAIModelFamily::Embedding
         } else {
@@ -308,7 +314,8 @@ impl OpenAIModelRegistry {
                 max_context_length: max_context,
                 max_output_length: max_output,
                 supports_streaming: family != OpenAIModelFamily::Embedding
-                    && family != OpenAIModelFamily::Whisper,
+                    && family != OpenAIModelFamily::Whisper
+                    && family != OpenAIModelFamily::Moderation,
                 supports_tools: matches!(
                     family,
                     OpenAIModelFamily::GPT4
@@ -648,6 +655,9 @@ mod tests {
         assert!(!registry.supports_feature("gpt-audio-1.5", &OpenAIModelFeature::VisionSupport));
         assert!(registry.supports_feature("whisper-1", &OpenAIModelFeature::AudioTranscription));
         assert!(registry.supports_feature("whisper-1", &OpenAIModelFeature::AudioTranslation));
+        assert!(
+            registry.supports_feature("omni-moderation-latest", &OpenAIModelFeature::Moderation)
+        );
     }
 
     #[test]

--- a/src/core/providers/openai/models/registry_types.rs
+++ b/src/core/providers/openai/models/registry_types.rs
@@ -49,6 +49,8 @@ pub enum OpenAIModelFeature {
     LargeContext,
     /// Real-time audio processing
     RealtimeAudio,
+    /// Moderation support
+    Moderation,
 }
 
 impl OpenAIModelFeature {
@@ -64,6 +66,7 @@ impl OpenAIModelFeature {
             OpenAIModelFeature::Embeddings => Some(ProviderCapability::Embeddings),
             OpenAIModelFeature::AudioOutput => Some(ProviderCapability::TextToSpeech),
             OpenAIModelFeature::ImageEditing => Some(ProviderCapability::ImageEdit),
+            OpenAIModelFeature::Moderation => Some(ProviderCapability::Moderation),
             // Features that don't map directly to provider capabilities
             OpenAIModelFeature::SystemMessages
             | OpenAIModelFeature::JsonMode

--- a/src/core/providers/openai/models/static_models.rs
+++ b/src/core/providers/openai/models/static_models.rs
@@ -557,6 +557,16 @@ pub(super) fn static_model_entries() -> Vec<StaticModelEntry> {
             0.005,
             0.032,
         ),
+        // ==================== Moderation Models ====================
+        (
+            "omni-moderation-latest",
+            "Omni Moderation Latest",
+            OpenAIModelFamily::Moderation,
+            32768,
+            None,
+            0.0,
+            0.0,
+        ),
         // Computer Use Preview
         (
             "computer-use-preview",

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -495,6 +495,7 @@ impl LLMProvider for OpenAILikeProvider {
             ProviderCapability::ChatCompletionStream,
             ProviderCapability::ImageEdit,
             ProviderCapability::ImageVariation,
+            ProviderCapability::Moderation,
             ProviderCapability::ToolCalling,
             ProviderCapability::FunctionCalling,
         ];

--- a/src/core/types/model.rs
+++ b/src/core/types/model.rs
@@ -26,6 +26,8 @@ pub enum ProviderCapability {
     AudioTranslation,
     /// Text to speech
     TextToSpeech,
+    /// Moderation
+    Moderation,
     /// Tool calling
     ToolCalling,
     /// Function calling (backward compatibility)
@@ -184,6 +186,7 @@ mod tests {
             ProviderCapability::AudioTranscription,
             ProviderCapability::AudioTranslation,
             ProviderCapability::TextToSpeech,
+            ProviderCapability::Moderation,
             ProviderCapability::ToolCalling,
             ProviderCapability::FunctionCalling,
             ProviderCapability::CodeExecution,

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -1,6 +1,8 @@
 //! OpenAI-compatible moderation API route.
 
 use crate::config::models::provider::ProviderConfig;
+use crate::core::providers::{Provider, ProviderError};
+use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
@@ -10,6 +12,7 @@ use serde_json::Value;
 use std::time::Duration;
 use tracing::error;
 
+use super::execution::execute_with_selected_deployment;
 use super::openai_errors;
 use super::provider_config;
 
@@ -69,30 +72,81 @@ async fn proxy_moderation(
 ) -> Result<HttpResponse, GatewayError> {
     let resolved_model = validate_moderation_request(&request)?;
     apply_resolved_moderation_model(&mut request, &resolved_model);
-    let Some(provider) = select_moderation_proxy_provider(
+    ensure_moderation_proxy_candidate_configured(
         state.config().gateway.providers.as_slice(),
         &resolved_model,
-    )?
-    else {
-        return Err(missing_moderation_provider_error());
-    };
-
-    super::spend::ensure_budget_available(
-        &state.budget_limits,
-        &provider.provider_name,
-        &resolved_model,
     )?;
+    let router_models =
+        moderation_router_models(state.config().gateway.providers.as_slice(), &resolved_model);
 
-    let response = provider_config::apply_proxy_headers(
-        provider_config::proxy_http_client().post(moderation_url(&provider)?),
-        &provider.headers,
-    )
-    .timeout(provider.timeout)
-    .json(&request)
-    .send()
-    .await?;
+    let mut last_router_error = None;
+    for router_model in router_models {
+        let result = execute_with_selected_deployment(
+            &state.unified_router,
+            &router_model,
+            ProviderCapability::Moderation,
+            {
+                let request = request.clone();
+                let resolved_model = resolved_model.clone();
+                move |selected_provider, selected_model| {
+                    let request = request.clone();
+                    let resolved_model = resolved_model.clone();
+                    async move {
+                        let provider = selected_moderation_proxy_provider(
+                            state.config().gateway.providers.as_slice(),
+                            &selected_provider,
+                            &selected_model,
+                            &resolved_model,
+                        )?;
+                        super::spend::ensure_budget_available(
+                            &state.budget_limits,
+                            &provider.provider_name,
+                            &resolved_model,
+                        )?;
 
-    provider_config::proxy_response_to_http_response(response).await
+                        let url = moderation_url(&provider)
+                            .map_err(moderation_gateway_error_to_provider_error)?;
+                        let response = provider_config::apply_proxy_headers(
+                            provider_config::proxy_http_client().post(url),
+                            &provider.headers,
+                        )
+                        .timeout(provider.timeout)
+                        .json(&request)
+                        .send()
+                        .await
+                        .map_err(|error| {
+                            ProviderError::network("moderation_proxy", error.to_string())
+                        })?;
+
+                        if !response.status().is_success() {
+                            return Err(moderation_upstream_error(response).await);
+                        }
+
+                        let response = provider_config::proxy_response_to_http_response(response)
+                            .await
+                            .map_err(moderation_gateway_error_to_provider_error)?;
+                        Ok((response, 0))
+                    }
+                }
+            },
+        )
+        .await;
+        match result {
+            Ok(response) => return Ok(response),
+            Err(GatewayError::Provider(ProviderError::QuotaExceeded {
+                provider: "budget",
+                message,
+            })) if message.starts_with("provider ") => {
+                last_router_error = Some(GatewayError::Provider(ProviderError::QuotaExceeded {
+                    provider: "budget",
+                    message,
+                }));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_router_error.unwrap_or_else(missing_moderation_provider_error))
 }
 
 fn validate_moderation_request(request: &Value) -> Result<String, GatewayError> {
@@ -138,29 +192,97 @@ fn apply_resolved_moderation_model(request: &mut Value, resolved_model: &str) {
     }
 }
 
-fn select_moderation_proxy_provider(
+fn ensure_moderation_proxy_candidate_configured(
     providers: &[ProviderConfig],
     requested_model: &str,
-) -> Result<Option<ModerationProxyProvider>, GatewayError> {
-    let candidates = providers
+) -> Result<(), GatewayError> {
+    let candidates = moderation_candidate_configs(providers);
+    if candidates.is_empty() {
+        return Err(missing_moderation_provider_error());
+    }
+
+    if candidates
+        .iter()
+        .any(|provider| moderation_provider_supports_requested_model(provider, requested_model))
+    {
+        Ok(())
+    } else {
+        Err(GatewayError::Config(format!(
+            "Moderation provider for model '{requested_model}' is not configured"
+        )))
+    }
+}
+
+fn moderation_router_models(providers: &[ProviderConfig], requested_model: &str) -> Vec<String> {
+    let candidates = moderation_candidate_configs(providers);
+    let mut router_models = Vec::new();
+
+    if candidates
+        .iter()
+        .any(|provider| provider.models.iter().any(|model| model == requested_model))
+    {
+        router_models.push(requested_model.to_string());
+    }
+
+    router_models.extend(
+        candidates
+            .iter()
+            .filter(|provider| provider.models.is_empty())
+            .map(|provider| provider.name.clone()),
+    );
+
+    if router_models.is_empty() {
+        router_models.push(requested_model.to_string());
+    }
+
+    router_models
+}
+
+fn selected_moderation_proxy_provider(
+    providers: &[ProviderConfig],
+    selected_provider: &Provider,
+    selected_model: &str,
+    requested_model: &str,
+) -> Result<ModerationProxyProvider, ProviderError> {
+    let provider_name = selected_provider.name();
+    let candidates = moderation_candidate_configs(providers);
+    let matching = candidates
+        .iter()
+        .copied()
+        .filter(|provider| moderation_provider_supports_requested_model(provider, requested_model))
+        .find(|provider| {
+            provider.name == provider_name
+                || provider
+                    .settings
+                    .get("provider_name")
+                    .and_then(|value| value.as_str())
+                    == Some(provider_name)
+                || (provider.models.is_empty() && provider.name == selected_model)
+        })
+        .ok_or_else(|| {
+            ProviderError::configuration(
+                "moderation_proxy",
+                format!(
+                    "selected moderation provider '{provider_name}' for model '{selected_model}' has no matching gateway provider config"
+                ),
+            )
+        })?;
+
+    moderation_proxy_provider_from_config(matching)
+        .map_err(moderation_gateway_error_to_provider_error)
+}
+
+fn moderation_candidate_configs(providers: &[ProviderConfig]) -> Vec<&ProviderConfig> {
+    providers
         .iter()
         .filter(|provider| provider.enabled)
         .filter(|provider| is_openai_moderation_provider(provider))
-        .collect::<Vec<_>>();
+        .collect()
+}
 
-    let Some(provider) = candidates
-        .iter()
-        .copied()
-        .find(|provider| moderation_provider_supports_requested_model(provider, requested_model))
-    else {
-        if candidates.is_empty() {
-            return Ok(None);
-        }
-        return Err(GatewayError::Config(format!(
-            "Moderation provider for model '{requested_model}' is not configured"
-        )));
-    };
-
+fn moderation_proxy_provider_from_config(
+    provider: &ProviderConfig,
+) -> Result<ModerationProxyProvider, GatewayError> {
     if provider.api_key.trim().is_empty() {
         return Err(GatewayError::Config(format!(
             "Moderation provider '{}' is missing api_key",
@@ -168,12 +290,12 @@ fn select_moderation_proxy_provider(
         )));
     }
 
-    Ok(Some(ModerationProxyProvider {
+    Ok(ModerationProxyProvider {
         provider_name: provider.name.clone(),
         base_url: moderation_base_url(provider)?,
         headers: moderation_provider_headers(provider)?,
         timeout: Duration::from_secs(provider.timeout),
-    }))
+    })
 }
 
 fn moderation_provider_supports_requested_model(
@@ -210,6 +332,52 @@ fn moderation_url(provider: &ModerationProxyProvider) -> Result<Url, GatewayErro
         .map_err(|_| GatewayError::Config("Invalid moderation URL".to_string()))?
         .extend(["moderations"]);
     Ok(url)
+}
+
+fn moderation_gateway_error_to_provider_error(error: GatewayError) -> ProviderError {
+    match error {
+        GatewayError::Provider(error) => error,
+        GatewayError::Validation(message) | GatewayError::BadRequest(message) => {
+            ProviderError::invalid_request("moderation_proxy", message)
+        }
+        GatewayError::Config(message) => ProviderError::configuration("moderation_proxy", message),
+        GatewayError::Auth(message) | GatewayError::Forbidden(message) => {
+            ProviderError::authentication("moderation_proxy", message)
+        }
+        GatewayError::Timeout(message) => ProviderError::timeout("moderation_proxy", message),
+        GatewayError::RateLimit {
+            message,
+            retry_after,
+            ..
+        } => ProviderError::rate_limit_with_retry("moderation_proxy", message, retry_after),
+        GatewayError::HttpClient(error) => {
+            ProviderError::network("moderation_proxy", error.to_string())
+        }
+        GatewayError::Network(message) => ProviderError::network("moderation_proxy", message),
+        GatewayError::Unavailable(message) => {
+            ProviderError::provider_unavailable("moderation_proxy", message)
+        }
+        other => ProviderError::api_error("moderation_proxy", 500, other.to_string()),
+    }
+}
+
+async fn moderation_upstream_error(response: reqwest::Response) -> ProviderError {
+    let status = response.status().as_u16();
+    let message = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("Failed to read moderation error body: {error}"));
+
+    match status {
+        400 => ProviderError::invalid_request("moderation_proxy", message),
+        401 | 403 => ProviderError::authentication("moderation_proxy", message),
+        402 => ProviderError::quota_exceeded("moderation_proxy", message),
+        404 => ProviderError::model_not_found("moderation_proxy", message),
+        408 | 504 => ProviderError::timeout("moderation_proxy", message),
+        429 => ProviderError::rate_limit_with_retry("moderation_proxy", message, None),
+        502 | 503 => ProviderError::provider_unavailable("moderation_proxy", message),
+        _ => ProviderError::api_error("moderation_proxy", status, message),
+    }
 }
 
 fn missing_moderation_provider_error() -> GatewayError {

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -311,7 +311,7 @@ fn moderation_provider_uses_registry_models(provider: &ProviderConfig) -> bool {
     let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
     let provider_name = provider_config::normalize_provider_selector(&provider.name);
 
-    provider_type == "openai" || provider_name == "openai"
+    provider_type == "openai" || (provider_type.is_empty() && provider_name == "openai")
 }
 
 fn moderation_base_url(provider: &ProviderConfig) -> Result<String, GatewayError> {

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -217,17 +217,19 @@ fn moderation_router_models(providers: &[ProviderConfig], requested_model: &str)
     let candidates = moderation_candidate_configs(providers);
     let mut router_models = Vec::new();
 
-    if candidates
-        .iter()
-        .any(|provider| provider.models.iter().any(|model| model == requested_model))
-    {
+    if candidates.iter().any(|provider| {
+        provider.models.iter().any(|model| model == requested_model)
+            || (provider.models.is_empty() && moderation_provider_uses_registry_models(provider))
+    }) {
         router_models.push(requested_model.to_string());
     }
 
     router_models.extend(
         candidates
             .iter()
-            .filter(|provider| provider.models.is_empty())
+            .filter(|provider| {
+                provider.models.is_empty() && !moderation_provider_uses_registry_models(provider)
+            })
             .map(|provider| provider.name.clone()),
     );
 
@@ -303,6 +305,13 @@ fn moderation_provider_supports_requested_model(
     requested_model: &str,
 ) -> bool {
     provider.models.is_empty() || provider.models.iter().any(|model| model == requested_model)
+}
+
+fn moderation_provider_uses_registry_models(provider: &ProviderConfig) -> bool {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = provider_config::normalize_provider_selector(&provider.name);
+
+    provider_type == "openai" || provider_name == "openai"
 }
 
 fn moderation_base_url(provider: &ProviderConfig) -> Result<String, GatewayError> {

--- a/tests/moderations_routes.rs
+++ b/tests/moderations_routes.rs
@@ -164,8 +164,16 @@ mod tests {
     }
 
     fn moderation_provider_with_models(base_url: &str, models: Vec<String>) -> ProviderConfig {
+        named_moderation_provider("mock-openai-compatible", base_url, models)
+    }
+
+    fn named_moderation_provider(
+        name: &str,
+        base_url: &str,
+        models: Vec<String>,
+    ) -> ProviderConfig {
         let mut provider = ProviderConfig {
-            name: "mock-openai-compatible".to_string(),
+            name: name.to_string(),
             provider_type: "openai_compatible".to_string(),
             api_key: "sk-test".to_string(),
             base_url: Some(base_url.to_string()),
@@ -547,6 +555,127 @@ mod tests {
         );
 
         mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_uses_router_budget_fallback_provider() {
+        let exhausted = MockModerationServer::start_moderation_mock().await;
+        let fallback = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![
+            named_moderation_provider(
+                "exhausted-moderation-provider",
+                &exhausted.base_url,
+                vec!["omni-moderation-latest".to_string()],
+            ),
+            named_moderation_provider(
+                "fallback-moderation-provider",
+                &fallback.base_url,
+                vec!["omni-moderation-latest".to_string()],
+            ),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "exhausted-moderation-provider",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("exhausted-moderation-provider", 2.0);
+        state.budget_limits.providers.set_provider_limit(
+            "fallback-moderation-provider",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({
+                    "model": "omni-moderation-latest",
+                    "input": "moderate this text"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            exhausted.requests().is_empty(),
+            "exhausted provider must be skipped before upstream call"
+        );
+        let requests = fallback.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+
+        exhausted.stop_moderation_mock().await;
+        fallback.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn moderation_route_uses_wildcard_provider_name_fallback() {
+        let exhausted = MockModerationServer::start_moderation_mock().await;
+        let fallback = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![
+            named_moderation_provider(
+                "wildcard-moderation-primary",
+                &exhausted.base_url,
+                Vec::new(),
+            ),
+            named_moderation_provider(
+                "wildcard-moderation-secondary",
+                &fallback.base_url,
+                Vec::new(),
+            ),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "wildcard-moderation-primary",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("wildcard-moderation-primary", 2.0);
+        state.budget_limits.providers.set_provider_limit(
+            "wildcard-moderation-secondary",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "moderate this text" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            exhausted.requests().is_empty(),
+            "exhausted wildcard provider must be skipped before upstream call"
+        );
+        let requests = fallback.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+
+        exhausted.stop_moderation_mock().await;
+        fallback.stop_moderation_mock().await;
     }
 
     #[tokio::test]

--- a/tests/moderations_routes.rs
+++ b/tests/moderations_routes.rs
@@ -164,7 +164,12 @@ mod tests {
     }
 
     fn moderation_provider_with_models(base_url: &str, models: Vec<String>) -> ProviderConfig {
-        named_moderation_provider("mock-openai-compatible", base_url, models)
+        named_moderation_provider_with_type(
+            "mock-openai-compatible",
+            "openai_compatible",
+            base_url,
+            models,
+        )
     }
 
     fn named_moderation_provider(
@@ -172,9 +177,18 @@ mod tests {
         base_url: &str,
         models: Vec<String>,
     ) -> ProviderConfig {
+        named_moderation_provider_with_type(name, "openai_compatible", base_url, models)
+    }
+
+    fn named_moderation_provider_with_type(
+        name: &str,
+        provider_type: &str,
+        base_url: &str,
+        models: Vec<String>,
+    ) -> ProviderConfig {
         let mut provider = ProviderConfig {
             name: name.to_string(),
-            provider_type: "openai_compatible".to_string(),
+            provider_type: provider_type.to_string(),
             api_key: "sk-test".to_string(),
             base_url: Some(base_url.to_string()),
             organization: Some("org-test".to_string()),
@@ -617,6 +631,41 @@ mod tests {
 
         exhausted.stop_moderation_mock().await;
         fallback.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
+    async fn native_openai_moderation_route_uses_default_model_with_empty_config_models() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![named_moderation_provider_with_type(
+            "mock-openai-native",
+            "openai",
+            &mock.base_url,
+            Vec::new(),
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "moderate this text" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+
+        mock.stop_moderation_mock().await;
     }
 
     #[tokio::test]

--- a/tests/moderations_routes.rs
+++ b/tests/moderations_routes.rs
@@ -669,6 +669,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_compatible_named_openai_uses_provider_name_wildcard_fallback() {
+        let mock = MockModerationServer::start_moderation_mock().await;
+        let state = build_test_app_state(vec![named_moderation_provider_with_type(
+            "openai",
+            "openai_compatible",
+            &mock.base_url,
+            Vec::new(),
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({ "input": "moderate this text" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/moderations");
+        assert_eq!(requests[0].body["model"], "omni-moderation-latest");
+
+        mock.stop_moderation_mock().await;
+    }
+
+    #[tokio::test]
     async fn moderation_route_uses_wildcard_provider_name_fallback() {
         let exhausted = MockModerationServer::start_moderation_mock().await;
         let fallback = MockModerationServer::start_moderation_mock().await;


### PR DESCRIPTION
Refs issue 749.

This is the moderation route slice only. Issue 749 remains open for the remaining rerank, Gemini SDK, batches, and fine-tuning route families.

Changes:
- add a Moderation provider capability for router selection
- route /moderations and /v1/moderations through execute_with_selected_deployment
- preserve request validation/auth/proxy header behavior
- add budget-fallback and wildcard provider-name fallback regression tests

Verification:
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked --message-format=short
- cargo test --all-features --locked --test moderations_routes -- --nocapture
- cargo test --all-features --locked provider_capability -- --nocapture
- cargo test --all-features --locked test_provider_capabilities -- --nocapture
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked