### PR TITLE
Fix rerank router fallback

### DIFF
--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -22,7 +22,20 @@ impl Provider {
                     LLMProvider::supports_capability(provider, capability)
                 }
             }
+            Provider::OpenAILike(provider) if capability == &ProviderCapability::Rerank => {
+                openai_like_provider_supports_rerank(provider.name())
+            }
             _ => self.supports_capability(capability),
         }
     }
+}
+
+fn openai_like_provider_supports_rerank(provider_name: &str) -> bool {
+    let normalized = provider_name
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(|ch| ch.to_lowercase())
+        .collect::<String>();
+
+    normalized.contains("cohere") || normalized.contains("jina")
 }

--- a/src/core/providers/cohere/provider.rs
+++ b/src/core/providers/cohere/provider.rs
@@ -42,6 +42,7 @@ const COHERE_CAPABILITIES: &[ProviderCapability] = &[
     ProviderCapability::ChatCompletionStream,
     ProviderCapability::ToolCalling,
     ProviderCapability::Embeddings,
+    ProviderCapability::Rerank,
 ];
 
 /// Cohere error mapper
@@ -424,6 +425,7 @@ mod tests {
         assert!(caps.contains(&ProviderCapability::ChatCompletion));
         assert!(caps.contains(&ProviderCapability::ChatCompletionStream));
         assert!(caps.contains(&ProviderCapability::Embeddings));
+        assert!(caps.contains(&ProviderCapability::Rerank));
         assert!(caps.contains(&ProviderCapability::ToolCalling));
     }
 

--- a/src/core/providers/cohere/tests.rs
+++ b/src/core/providers/cohere/tests.rs
@@ -135,6 +135,7 @@ async fn test_provider_capabilities() {
     assert!(caps.contains(&ProviderCapability::ChatCompletion));
     assert!(caps.contains(&ProviderCapability::ChatCompletionStream));
     assert!(caps.contains(&ProviderCapability::Embeddings));
+    assert!(caps.contains(&ProviderCapability::Rerank));
     assert!(caps.contains(&ProviderCapability::ToolCalling));
 }
 

--- a/src/core/types/model.rs
+++ b/src/core/types/model.rs
@@ -28,6 +28,8 @@ pub enum ProviderCapability {
     TextToSpeech,
     /// Moderation
     Moderation,
+    /// Reranking
+    Rerank,
     /// Tool calling
     ToolCalling,
     /// Function calling (backward compatibility)
@@ -136,6 +138,13 @@ mod tests {
     }
 
     #[test]
+    fn test_provider_capability_rerank() {
+        let cap = ProviderCapability::Rerank;
+        let json = serde_json::to_string(&cap).unwrap();
+        assert_eq!(json, "\"rerank\"");
+    }
+
+    #[test]
     fn test_provider_capability_audio_transcription() {
         let cap = ProviderCapability::AudioTranscription;
         let json = serde_json::to_string(&cap).unwrap();
@@ -187,6 +196,7 @@ mod tests {
             ProviderCapability::AudioTranslation,
             ProviderCapability::TextToSpeech,
             ProviderCapability::Moderation,
+            ProviderCapability::Rerank,
             ProviderCapability::ToolCalling,
             ProviderCapability::FunctionCalling,
             ProviderCapability::CodeExecution,

--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -75,7 +75,7 @@ pub async fn audio_speech(
         &state.unified_router,
         &requested_model,
         ProviderCapability::TextToSpeech,
-        move |provider, selected_model| {
+        move |provider, selected_model, _deployment_id| {
             let mut request = speech_request.clone();
             let context = context_for_execution.clone();
             async move {

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -147,7 +147,7 @@ pub async fn audio_transcriptions(
         &state.unified_router,
         &requested_model,
         ProviderCapability::AudioTranscription,
-        move |provider, selected_model| {
+        move |provider, selected_model, _deployment_id| {
             let mut request = transcription_request.clone();
             let context = context_for_execution.clone();
             async move {

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -135,7 +135,7 @@ pub async fn audio_translations(
         &state.unified_router,
         &requested_model,
         ProviderCapability::AudioTranslation,
-        move |provider, selected_model| {
+        move |provider, selected_model, _deployment_id| {
             let mut request = translation_request.clone();
             let context = context_for_execution.clone();
             async move {

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -371,7 +371,7 @@ async fn handle_chat_completion_internal(
         unified_router,
         &requested_model,
         ProviderCapability::ChatCompletion,
-        move |provider, selected_model| {
+        move |provider, selected_model, _deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -104,7 +104,7 @@ async fn handle_embedding_internal(
         unified_router,
         &requested_model,
         ProviderCapability::Embeddings,
-        move |provider, selected_model| {
+        move |provider, selected_model, _deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             async move {

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -72,7 +72,7 @@ pub(super) async fn execute_with_selected_deployment<T, F, Fut>(
     operation: F,
 ) -> Result<T, GatewayError>
 where
-    F: Fn(Provider, String) -> Fut + Clone,
+    F: Fn(Provider, String, String) -> Fut + Clone,
     Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
 {
     let max_attempts = router.config().num_retries + 1;
@@ -116,10 +116,11 @@ where
             }
         };
 
+        let selected_deployment_id = deployment_lease.clone_deployment_id();
         let provider = deployment_lease.deployment().provider.clone();
         let selected_model = deployment_lease.deployment().model.clone();
 
-        match operation.clone()(provider, selected_model).await {
+        match operation.clone()(provider, selected_model, selected_deployment_id).await {
             Ok((value, tokens_used)) => {
                 let latency_us = started_at.elapsed().as_micros() as u64;
                 router.record_success_for_deployment(
@@ -440,7 +441,7 @@ mod tests {
             &router,
             "gpt-4",
             ProviderCapability::ChatCompletion,
-            |_provider, model| async { Ok((model, 0)) },
+            |_provider, model, _deployment_id| async { Ok((model, 0)) },
         )
         .await
         .expect("execution should succeed");
@@ -456,7 +457,9 @@ mod tests {
             &router,
             "shared-model",
             ProviderCapability::Embeddings,
-            |provider, model| async move { Ok(((provider.name().to_string(), model), 0)) },
+            |provider, model, _deployment_id| async move {
+                Ok(((provider.name().to_string(), model), 0))
+            },
         )
         .await
         .expect("execution should use an embeddings-capable deployment");
@@ -481,7 +484,9 @@ mod tests {
             &router,
             "shared-model",
             ProviderCapability::Embeddings,
-            |_provider, _model| async { Ok::<_, ProviderError>(("should not run", 0)) },
+            |_provider, _model, _deployment_id| async {
+                Ok::<_, ProviderError>(("should not run", 0))
+            },
         )
         .await
         .expect_err("unavailable capability should fail before execution");
@@ -500,7 +505,9 @@ mod tests {
             &router,
             "shared-model",
             ProviderCapability::CodeExecution,
-            |_provider, _model| async { Ok::<_, ProviderError>(("should not run", 0)) },
+            |_provider, _model, _deployment_id| async {
+                Ok::<_, ProviderError>(("should not run", 0))
+            },
         )
         .await
         .expect_err("unsupported capability should fail before execution");
@@ -519,7 +526,7 @@ mod tests {
             &router,
             "gpt-4",
             ProviderCapability::ChatCompletion,
-            |_provider, _model| async {
+            |_provider, _model, _deployment_id| async {
                 Err::<(String, u64), _>(ProviderError::timeout("test", "timed out"))
             },
         )
@@ -543,7 +550,7 @@ mod tests {
             ProviderCapability::ChatCompletion,
             {
                 let attempts = attempts.clone();
-                move |provider, model| {
+                move |provider, model, _deployment_id| {
                     let attempts = attempts.clone();
                     async move {
                         let provider_name = provider.name().to_string();
@@ -582,7 +589,7 @@ mod tests {
             ProviderCapability::ChatCompletion,
             {
                 let attempts = attempts.clone();
-                move |provider, model| {
+                move |provider, model, _deployment_id| {
                     let attempts = attempts.clone();
                     async move {
                         attempts.lock().unwrap().push(model.clone());

--- a/src/server/routes/ai/execution_retry_delay_tests.rs
+++ b/src/server/routes/ai/execution_retry_delay_tests.rs
@@ -82,7 +82,7 @@ async fn budget_fallback_ignores_retry_limit_and_keeps_same_provider_candidates(
         ProviderCapability::ChatCompletion,
         {
             let attempts = attempts.clone();
-            move |provider, model| {
+            move |provider, model, _deployment_id| {
                 let attempts = attempts.clone();
                 async move {
                     attempts

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -146,7 +146,7 @@ async fn handle_image_generation_internal(
         unified_router,
         &requested_model,
         ProviderCapability::ImageGeneration,
-        move |provider, selected_model| {
+        move |provider, selected_model, _deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             async move {
@@ -214,7 +214,7 @@ async fn proxy_image_multipart_endpoint(
                 let body = body.clone();
                 let content_type = content_type.clone();
                 let usage = usage.clone();
-                move |selected_provider, selected_model| {
+                move |selected_provider, selected_model, _deployment_id| {
                     let body = body.clone();
                     let content_type = content_type.clone();
                     let usage = usage.clone();

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -88,7 +88,7 @@ async fn proxy_moderation(
             {
                 let request = request.clone();
                 let resolved_model = resolved_model.clone();
-                move |selected_provider, selected_model| {
+                move |selected_provider, selected_model, _deployment_id| {
                     let request = request.clone();
                     let resolved_model = resolved_model.clone();
                     async move {

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -1,9 +1,11 @@
 //! Rerank endpoint.
 
 use crate::config::models::provider::ProviderConfig;
+use crate::core::providers::{Provider, ProviderError};
 use crate::core::rerank::{
     CohereRerankProvider, JinaRerankProvider, RerankRequest, RerankResponse, RerankService,
 };
+use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
@@ -11,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info};
 
-use super::{openai_errors, provider_config};
+use super::{execution::execute_with_selected_deployment, openai_errors, provider_config};
 
 /// Rerank documents against a query.
 pub async fn rerank(
@@ -38,17 +40,72 @@ async fn handle_rerank_with_state(
     state: &AppState,
     request: RerankRequest,
 ) -> Result<RerankResponse, GatewayError> {
-    let selected = select_rerank_provider(state.config().gateway.providers.as_slice(), &request)?;
-    let served_model = served_rerank_model(&request.model);
-
-    super::spend::ensure_budget_available(
-        &state.budget_limits,
-        &selected.provider_name,
-        served_model,
+    let requested_model = request.model.clone();
+    ensure_rerank_provider_candidate_configured(
+        state.config().gateway.providers.as_slice(),
+        &requested_model,
     )?;
+    let router_models = rerank_router_models(
+        state.config().gateway.providers.as_slice(),
+        &requested_model,
+    );
 
-    let service = build_rerank_service(&selected)?;
-    service.rerank(request).await
+    let mut last_router_error = None;
+    for router_model in router_models {
+        let result = execute_with_selected_deployment(
+            &state.unified_router,
+            &router_model,
+            ProviderCapability::Rerank,
+            {
+                let request = request.clone();
+                let requested_model = requested_model.clone();
+                move |selected_provider, selected_model| {
+                    let request = request.clone();
+                    let requested_model = requested_model.clone();
+                    async move {
+                        let selected = selected_rerank_provider(
+                            state.config().gateway.providers.as_slice(),
+                            &selected_provider,
+                            &selected_model,
+                            &requested_model,
+                        )?;
+                        let served_model = served_rerank_model(&requested_model);
+
+                        super::spend::ensure_budget_available(
+                            &state.budget_limits,
+                            &selected.provider_name,
+                            served_model,
+                        )?;
+
+                        let service = build_rerank_service(&selected)
+                            .map_err(rerank_gateway_error_to_provider_error)?;
+                        let response = service
+                            .rerank(request)
+                            .await
+                            .map_err(rerank_gateway_error_to_provider_error)?;
+                        Ok((response, 0))
+                    }
+                }
+            },
+        )
+        .await;
+
+        match result {
+            Ok(response) => return Ok(response),
+            Err(GatewayError::Provider(ProviderError::QuotaExceeded {
+                provider: "budget",
+                message,
+            })) if message.starts_with("provider ") => {
+                last_router_error = Some(GatewayError::Provider(ProviderError::QuotaExceeded {
+                    provider: "budget",
+                    message,
+                }));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_router_error.unwrap_or_else(missing_rerank_provider_error))
 }
 
 fn ensure_rerank_route_authorized(state: &AppState, req: &HttpRequest) -> Result<(), GatewayError> {
@@ -94,32 +151,48 @@ fn build_rerank_service(provider: &SelectedRerankProvider) -> Result<RerankServi
     Ok(service)
 }
 
+#[cfg(test)]
 fn select_rerank_provider(
     providers: &[ProviderConfig],
     request: &RerankRequest,
 ) -> Result<SelectedRerankProvider, GatewayError> {
-    let candidates = providers
-        .iter()
-        .filter(|provider| provider.enabled)
-        .filter_map(|provider| rerank_provider_kind(provider).map(|kind| (provider, kind)))
-        .collect::<Vec<_>>();
+    ensure_rerank_provider_candidate_configured(providers, &request.model)?;
 
-    if candidates.is_empty() {
-        return Err(GatewayError::NotFound(
-            "No configured rerank provider found; configure a cohere or jina provider".to_string(),
-        ));
-    }
-
-    let Some((provider, kind)) = candidates
+    let Some((provider, kind)) = rerank_candidate_configs(providers)
         .into_iter()
         .find(|(provider, kind)| rerank_provider_supports_model(provider, *kind, &request.model))
     else {
-        return Err(GatewayError::NotFound(format!(
-            "No configured rerank provider supports model '{}'",
-            request.model
-        )));
+        return Err(missing_rerank_provider_error());
     };
 
+    selected_rerank_provider_from_config(provider, kind)
+}
+
+fn ensure_rerank_provider_candidate_configured(
+    providers: &[ProviderConfig],
+    requested_model: &str,
+) -> Result<(), GatewayError> {
+    let candidates = rerank_candidate_configs(providers);
+    if candidates.is_empty() {
+        return Err(missing_rerank_provider_error());
+    }
+
+    if candidates
+        .iter()
+        .any(|(provider, kind)| rerank_provider_supports_model(provider, *kind, requested_model))
+    {
+        Ok(())
+    } else {
+        Err(GatewayError::NotFound(format!(
+            "No configured rerank provider supports model '{requested_model}'"
+        )))
+    }
+}
+
+fn selected_rerank_provider_from_config(
+    provider: &ProviderConfig,
+    kind: RerankProviderKind,
+) -> Result<SelectedRerankProvider, GatewayError> {
     if provider.api_key.trim().is_empty() {
         return Err(GatewayError::Config(format!(
             "Rerank provider '{}' is missing api_key",
@@ -134,6 +207,93 @@ fn select_rerank_provider(
         base_url: provider.base_url.clone(),
         timeout: Duration::from_secs(provider.timeout),
     })
+}
+
+fn selected_rerank_provider(
+    providers: &[ProviderConfig],
+    selected_provider: &Provider,
+    selected_model: &str,
+    requested_model: &str,
+) -> Result<SelectedRerankProvider, ProviderError> {
+    let selected_provider_name = selected_provider.name();
+    let candidates = rerank_candidate_configs(providers);
+    let matching = candidates
+        .iter()
+        .copied()
+        .filter(|(provider, kind)| {
+            rerank_provider_supports_model(provider, *kind, requested_model)
+        })
+        .find(|(provider, kind)| {
+            provider.name == selected_provider_name
+                || provider
+                    .settings
+                    .get("provider_name")
+                    .and_then(|value| value.as_str())
+                    == Some(selected_provider_name)
+                || (provider.models.is_empty() && provider.name == selected_model)
+                || (provider.models.iter().any(|model| model == selected_model)
+                    && kind.as_str() == selected_provider_name)
+        })
+        .ok_or_else(|| {
+            ProviderError::configuration(
+                "rerank_proxy",
+                format!(
+                    "selected rerank provider '{selected_provider_name}' for model '{selected_model}' has no matching gateway provider config"
+                ),
+            )
+        })?;
+
+    selected_rerank_provider_from_config(matching.0, matching.1)
+        .map_err(rerank_gateway_error_to_provider_error)
+}
+
+fn rerank_router_models(providers: &[ProviderConfig], requested_model: &str) -> Vec<String> {
+    let (_, served_model) = split_rerank_model(requested_model);
+    let mut router_models = Vec::new();
+
+    for (provider, kind) in rerank_candidate_configs(providers) {
+        if !rerank_provider_supports_model(provider, kind, requested_model) {
+            continue;
+        }
+
+        if provider.models.is_empty() {
+            if rerank_provider_uses_registry_models(provider) {
+                push_unique_model(&mut router_models, served_model);
+                push_unique_model(&mut router_models, requested_model);
+            } else {
+                push_unique_model(&mut router_models, &provider.name);
+            }
+            continue;
+        }
+
+        for model in &provider.models {
+            if model == requested_model || model == served_model {
+                push_unique_model(&mut router_models, model);
+            }
+        }
+    }
+
+    if router_models.is_empty() {
+        push_unique_model(&mut router_models, served_model);
+    }
+
+    router_models
+}
+
+fn push_unique_model(router_models: &mut Vec<String>, model: &str) {
+    if !router_models.iter().any(|existing| existing == model) {
+        router_models.push(model.to_string());
+    }
+}
+
+fn rerank_candidate_configs(
+    providers: &[ProviderConfig],
+) -> Vec<(&ProviderConfig, RerankProviderKind)> {
+    providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter_map(|provider| rerank_provider_kind(provider).map(|kind| (provider, kind)))
+        .collect()
 }
 
 fn rerank_provider_supports_model(
@@ -175,8 +335,45 @@ fn rerank_provider_kind(provider: &ProviderConfig) -> Option<RerankProviderKind>
     None
 }
 
+fn rerank_provider_uses_registry_models(provider: &ProviderConfig) -> bool {
+    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
+    provider_type == "cohere"
+}
+
 fn served_rerank_model(model: &str) -> &str {
     split_rerank_model(model).1
+}
+
+fn rerank_gateway_error_to_provider_error(error: GatewayError) -> ProviderError {
+    match error {
+        GatewayError::Provider(error) => error,
+        GatewayError::Validation(message) | GatewayError::BadRequest(message) => {
+            ProviderError::invalid_request("rerank_proxy", message)
+        }
+        GatewayError::Config(message) => ProviderError::configuration("rerank_proxy", message),
+        GatewayError::Auth(message) => ProviderError::authentication("rerank_proxy", message),
+        GatewayError::Forbidden(message) => ProviderError::api_error("rerank_proxy", 403, message),
+        GatewayError::Timeout(message) => ProviderError::timeout("rerank_proxy", message),
+        GatewayError::RateLimit {
+            message,
+            retry_after,
+            ..
+        } => ProviderError::rate_limit_with_retry("rerank_proxy", message, retry_after),
+        GatewayError::HttpClient(error) => {
+            ProviderError::network("rerank_proxy", error.to_string())
+        }
+        GatewayError::Network(message) => ProviderError::network("rerank_proxy", message),
+        GatewayError::Unavailable(message) => {
+            ProviderError::provider_unavailable("rerank_proxy", message)
+        }
+        other => ProviderError::api_error("rerank_proxy", 500, other.to_string()),
+    }
+}
+
+fn missing_rerank_provider_error() -> GatewayError {
+    GatewayError::NotFound(
+        "No configured rerank provider found; configure a cohere or jina provider".to_string(),
+    )
 }
 
 fn split_rerank_model(model: &str) -> (Option<&str>, &str) {

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -59,12 +59,13 @@ async fn handle_rerank_with_state(
             {
                 let request = request.clone();
                 let requested_model = requested_model.clone();
-                move |selected_provider, selected_model| {
+                move |selected_provider, selected_model, selected_deployment_id| {
                     let request = request.clone();
                     let requested_model = requested_model.clone();
                     async move {
                         let selected = selected_rerank_provider(
                             state.config().gateway.providers.as_slice(),
+                            &selected_deployment_id,
                             &selected_provider,
                             &selected_model,
                             &requested_model,
@@ -211,20 +212,31 @@ fn selected_rerank_provider_from_config(
 
 fn selected_rerank_provider(
     providers: &[ProviderConfig],
+    selected_deployment_id: &str,
     selected_provider: &Provider,
     selected_model: &str,
     requested_model: &str,
 ) -> Result<SelectedRerankProvider, ProviderError> {
     let selected_provider_name = selected_provider.name();
     let candidates = rerank_candidate_configs(providers);
-    let matching = candidates
+    let supported_candidates = candidates
         .iter()
         .copied()
-        .filter(|(provider, kind)| {
-            rerank_provider_supports_model(provider, *kind, requested_model)
+        .filter(|(provider, kind)| rerank_provider_supports_model(provider, *kind, requested_model))
+        .collect::<Vec<_>>();
+    let matching = supported_candidates
+        .iter()
+        .copied()
+        .find(|(provider, _)| {
+            selected_deployment_matches_provider_config(
+                selected_deployment_id,
+                provider,
+                selected_model,
+            )
         })
-        .find(|(provider, kind)| {
-            provider.name == selected_provider_name
+        .or_else(|| {
+            supported_candidates.iter().copied().find(|(provider, kind)| {
+                provider.name == selected_provider_name
                 || provider
                     .settings
                     .get("provider_name")
@@ -233,6 +245,7 @@ fn selected_rerank_provider(
                 || (provider.models.is_empty() && provider.name == selected_model)
                 || (provider.models.iter().any(|model| model == selected_model)
                     && kind.as_str() == selected_provider_name)
+            })
         })
         .ok_or_else(|| {
             ProviderError::configuration(
@@ -245,6 +258,18 @@ fn selected_rerank_provider(
 
     selected_rerank_provider_from_config(matching.0, matching.1)
         .map_err(rerank_gateway_error_to_provider_error)
+}
+
+fn selected_deployment_matches_provider_config(
+    selected_deployment_id: &str,
+    provider: &ProviderConfig,
+    selected_model: &str,
+) -> bool {
+    selected_deployment_id == provider.name
+        || selected_deployment_id
+            .strip_prefix(provider.name.as_str())
+            .and_then(|suffix| suffix.strip_prefix('-'))
+            == Some(selected_model)
 }
 
 fn rerank_router_models(providers: &[ProviderConfig], requested_model: &str) -> Vec<String> {
@@ -537,6 +562,35 @@ mod tests {
             .expect("matching provider should be selected");
 
         assert_eq!(selected.provider_name, "right-cohere");
+        assert_eq!(selected.kind, RerankProviderKind::Cohere);
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[tokio::test]
+    async fn selected_provider_uses_deployment_id_for_native_cohere_duplicate_model() {
+        let primary = provider_config("cohere-a", "cohere", vec!["rerank-english-v3.0"]);
+        let fallback = provider_config("cohere-b", "cohere", vec!["rerank-english-v3.0"]);
+        let cohere =
+            match crate::core::providers::cohere::CohereProvider::with_api_key("test-key").await {
+                Ok(provider) => provider,
+                Err(error) => panic!("native cohere provider should build: {error}"),
+            };
+        let provider = Provider::Cohere(cohere);
+
+        let selected = match selected_rerank_provider(
+            &[primary, fallback],
+            "cohere-b-rerank-english-v3.0",
+            &provider,
+            "rerank-english-v3.0",
+            "rerank-english-v3.0",
+        ) {
+            Ok(selected) => selected,
+            Err(error) => {
+                panic!("selected deployment id should identify the fallback config: {error}")
+            }
+        };
+
+        assert_eq!(selected.provider_name, "cohere-b");
         assert_eq!(selected.kind, RerankProviderKind::Cohere);
     }
 }

--- a/tests/rerank_routes.rs
+++ b/tests/rerank_routes.rs
@@ -5,6 +5,7 @@ mod tests {
     use bytes::Bytes;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::config::models::router::RoutingStrategyConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
@@ -170,6 +171,7 @@ mod tests {
         config.gateway.auth.allow_anonymous = allow_anonymous;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
+        config.gateway.router.strategy = RoutingStrategyConfig::RoundRobin;
         config.gateway.providers = providers;
 
         GatewayHttpServer::new(&config)
@@ -489,15 +491,6 @@ mod tests {
 
     #[tokio::test]
     async fn rerank_route_preserves_upstream_error_statuses() {
-        let mock = MockRerankServer::start_rerank_mock().await;
-        let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(state))
-                .configure(litellm_rs::server::routes::ai::configure_routes),
-        )
-        .await;
-
         let cases = [
             (
                 "force bad request",
@@ -526,6 +519,14 @@ mod tests {
         ];
 
         for (query, expected_status, expected_type, expected_code) in cases {
+            let mock = MockRerankServer::start_rerank_mock().await;
+            let state = build_test_app_state(vec![cohere_rerank_provider(&mock.base_url)]).await;
+            let app = test::init_service(
+                App::new()
+                    .app_data(web::Data::new(state))
+                    .configure(litellm_rs::server::routes::ai::configure_routes),
+            )
+            .await;
             let mut body = rerank_body();
             body["query"] = json!(query);
 
@@ -542,11 +543,18 @@ mod tests {
             let body: Value = test::read_body_json(resp).await;
             assert_eq!(body["error"]["type"], expected_type, "query: {query}");
             assert_eq!(body["error"]["code"], expected_code, "query: {query}");
+
+            let request_count = mock.requests().len();
+            if expected_status == StatusCode::TOO_MANY_REQUESTS {
+                assert_eq!(
+                    request_count, 4,
+                    "router retry policy should retry pre-output 429 responses"
+                );
+            } else {
+                assert_eq!(request_count, 1, "query: {query}");
+            }
+            mock.stop_rerank_mock().await;
         }
-
-        assert_eq!(mock.requests().len(), cases.len());
-
-        mock.stop_rerank_mock().await;
     }
 
     #[tokio::test]
@@ -618,6 +626,124 @@ mod tests {
         );
 
         mock.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn rerank_route_uses_router_budget_fallback_provider() {
+        let exhausted = MockRerankServer::start_rerank_mock().await;
+        let fallback = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![
+            cohere_rerank_provider_with_name_and_models(
+                "exhausted-cohere",
+                &exhausted.base_url,
+                vec!["rerank-english-v3.0".to_string()],
+            ),
+            cohere_rerank_provider_with_name_and_models(
+                "fallback-cohere",
+                &fallback.base_url,
+                vec!["rerank-english-v3.0".to_string()],
+            ),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "exhausted-cohere",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("exhausted-cohere", 2.0);
+        state.budget_limits.providers.set_provider_limit(
+            "fallback-cohere",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            exhausted.requests().is_empty(),
+            "exhausted provider must be skipped before upstream call"
+        );
+        let requests = fallback.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/rerank");
+        assert_eq!(requests[0].body["model"], "rerank-english-v3.0");
+
+        exhausted.stop_rerank_mock().await;
+        fallback.stop_rerank_mock().await;
+    }
+
+    #[tokio::test]
+    async fn wildcard_rerank_provider_tries_next_provider_name_key() {
+        let exhausted = MockRerankServer::start_rerank_mock().await;
+        let fallback = MockRerankServer::start_rerank_mock().await;
+        let state = build_test_app_state(vec![
+            cohere_rerank_provider_with_name_and_models(
+                "wild-primary-cohere",
+                &exhausted.base_url,
+                Vec::new(),
+            ),
+            cohere_rerank_provider_with_name_and_models(
+                "wild-secondary-cohere",
+                &fallback.base_url,
+                Vec::new(),
+            ),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "wild-primary-cohere",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("wild-primary-cohere", 2.0);
+        state.budget_limits.providers.set_provider_limit(
+            "wild-secondary-cohere",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/rerank")
+                .set_json(rerank_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            exhausted.requests().is_empty(),
+            "wildcard exhausted provider must be skipped before upstream call"
+        );
+        let requests = fallback.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/v1/rerank");
+        assert_eq!(requests[0].body["model"], "rerank-english-v3.0");
+
+        exhausted.stop_rerank_mock().await;
+        fallback.stop_rerank_mock().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Refs issue 749.

This is the rerank route fallback slice for the broader active-route fallback issue; issue 749 remains open for the remaining route families.

Summary:
- route `/rerank` and `/v1/rerank` through `UnifiedRouter` deployment selection with a rerank capability
- keep existing Cohere/Jina rerank proxy execution while allowing provider-budget and wildcard fallback
- add rerank capability metadata and regression coverage for explicit and wildcard fallback

Verification:
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/litellm-rs-pr749-rerank-target cargo test --all-features --locked --test rerank_routes -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/litellm-rs-pr749-rerank-target cargo check --all-features --locked --message-format=short`
- `CARGO_TARGET_DIR=/tmp/litellm-rs-pr749-rerank-target cargo test --all-features --locked`
- `CARGO_TARGET_DIR=/tmp/litellm-rs-pr749-rerank-target cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
