### PR TITLE
Fix Gemini SDK router fallback

### DIFF
--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -101,7 +101,7 @@ async fn handle_streaming_chat_completion(
         state.unified_router.clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,
-        move |provider, selected_model| {
+        move |provider, selected_model, _selected_deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -142,7 +142,7 @@ async fn handle_streaming_completion(
         state.unified_router.clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,
-        move |provider, selected_model| {
+        move |provider, selected_model, _selected_deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -211,7 +211,7 @@ pub(super) async fn execute_stream_with_selected_deployment<T, F, Fut>(
     operation: F,
 ) -> Result<(T, StreamingDeploymentLease), GatewayError>
 where
-    F: Fn(Provider, String) -> Fut + Clone,
+    F: Fn(Provider, String, String) -> Fut + Clone,
     Fut: std::future::Future<Output = Result<T, ProviderError>>,
 {
     let max_attempts = router.config().num_retries + 1;
@@ -255,10 +255,11 @@ where
             }
         };
         let deployment = deployment_lease.clone_deployment();
+        let selected_deployment_id = deployment_lease.clone_deployment_id();
         let provider = deployment.provider.clone();
         let selected_model = deployment.model.clone();
 
-        match operation.clone()(provider, selected_model).await {
+        match operation.clone()(provider, selected_model, selected_deployment_id).await {
             Ok(stream) => {
                 let _deployment_id = deployment_lease.into_deployment_id();
                 let lease = StreamingDeploymentLease::new(router.clone(), deployment, started_at);
@@ -628,7 +629,7 @@ mod tests {
             router.clone(),
             "gpt-4",
             ProviderCapability::ChatCompletionStream,
-            |_provider, model| async move { Ok(model) },
+            |_provider, model, _selected_deployment_id| async move { Ok(model) },
         )
         .await
         .expect("stream creation should succeed");
@@ -658,7 +659,7 @@ mod tests {
             router.clone(),
             "gpt-4",
             ProviderCapability::ChatCompletionStream,
-            |_provider, model| async move { Ok(model) },
+            |_provider, model, _selected_deployment_id| async move { Ok(model) },
         )
         .await
         .expect("stream creation should succeed");
@@ -680,7 +681,7 @@ mod tests {
             router.clone(),
             "gpt-4",
             ProviderCapability::ChatCompletionStream,
-            |_provider, model| async move { Ok(model) },
+            |_provider, model, _selected_deployment_id| async move { Ok(model) },
         )
         .await
         .expect("stream creation should succeed");
@@ -706,7 +707,7 @@ mod tests {
             ProviderCapability::ChatCompletionStream,
             {
                 let attempts = attempts.clone();
-                move |provider, model| {
+                move |provider, model, _selected_deployment_id| {
                     let attempts = attempts.clone();
                     async move {
                         let provider_name = provider.name().to_string();
@@ -765,7 +766,7 @@ mod tests {
                     router,
                     "gpt-4",
                     ProviderCapability::ChatCompletionStream,
-                    move |_provider, _model| {
+                    move |_provider, _model, _selected_deployment_id| {
                         let operation_entered = operation_entered.clone();
                         async move {
                             operation_entered.notify_one();

--- a/src/server/routes/ai/execution_retry_delay_tests.rs
+++ b/src/server/routes/ai/execution_retry_delay_tests.rs
@@ -132,7 +132,7 @@ async fn stream_budget_fallback_ignores_retry_limit() {
         ProviderCapability::ChatCompletionStream,
         {
             let attempts = attempts.clone();
-            move |provider, model| {
+            move |provider, model, _selected_deployment_id| {
                 let attempts = attempts.clone();
                 async move {
                     attempts

--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -3,46 +3,37 @@
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, http::StatusCode, web};
 use bytes::Bytes;
 use futures::StreamExt;
-use reqwest::{
-    Client, Url,
-    header::{CONTENT_TYPE, HeaderName, HeaderValue},
-};
+use reqwest::header::CONTENT_TYPE;
 use serde_json::Value;
-use std::sync::OnceLock;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::error;
 
-use crate::config::models::provider::ProviderConfig;
 use crate::core::budget::UnifiedBudgetReservation;
+use crate::core::providers::ProviderError;
+use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
-use super::{openai_errors, provider_config};
+use super::execution::{
+    StreamingDeploymentLease, execute_stream_with_selected_deployment,
+    execute_with_selected_deployment,
+};
+use super::openai_errors;
 
+mod provider;
 mod spend;
+use provider::{
+    GeminiRouteProvider, ensure_gemini_provider_candidate_configured,
+    gemini_gateway_error_to_provider_error, gemini_http_error, gemini_router_models,
+    missing_gemini_provider_error, selected_gemini_provider, send_gemini_request,
+};
 use spend::{
-    GeminiSpendState, extract_gemini_sse_usage, record_gemini_spend, reserve_gemini_budget,
-    settle_gemini_stream_spend,
+    GeminiSpendState, extract_gemini_sse_usage, record_gemini_spend, settle_gemini_stream_spend,
 };
 
-const GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com";
 const GEMINI_V1: &str = "v1";
 const GEMINI_V1BETA: &str = "v1beta";
 const GEMINI_MAX_JSON_BYTES: usize = 16 * 1024 * 1024;
-
-static GEMINI_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
-
-#[derive(Debug, Clone)]
-struct GeminiRouteProvider {
-    provider_name: String,
-    pricing_provider: String,
-    model: String,
-    api_key: String,
-    base_url: String,
-    headers: Vec<(HeaderName, HeaderValue)>,
-    timeout: Duration,
-}
 
 macro_rules! gemini_route_handler {
     ($name:ident, $version:expr, $method:literal, $stream:expr) => {
@@ -134,32 +125,161 @@ async fn proxy_gemini_route_inner(
     validate_model_segment(&requested_model)?;
     validate_gemini_request_size(&request)?;
 
-    let provider = select_gemini_provider(state.config().providers(), &requested_model)?;
-    super::spend::ensure_budget_available(
-        &state.budget_limits,
-        &provider.provider_name,
-        &provider.model,
-    )?;
-    let budget_reservation = reserve_gemini_budget(state, &provider, &request)?;
+    ensure_gemini_provider_candidate_configured(state.config().providers(), &requested_model)?;
+    if stream {
+        return proxy_gemini_stream_route_inner(
+            state,
+            context,
+            api_version,
+            requested_model,
+            method,
+            request,
+        )
+        .await;
+    }
 
-    let url = gemini_url(&provider, api_version, method, stream)?;
-    let response = apply_gemini_headers(gemini_http_client().post(url), &provider)
-        .header(CONTENT_TYPE, "application/json")
-        .json(&request)
-        .timeout(provider.timeout)
-        .send()
-        .await
-        .map_err(gemini_http_error)?;
+    let router_models = gemini_router_models(state.config().providers(), &requested_model);
 
-    gemini_upstream_response_to_http_response(
-        state,
-        context,
-        provider,
-        budget_reservation,
-        response,
-        stream,
-    )
-    .await
+    let mut last_router_error = None;
+    for router_model in router_models {
+        let result = execute_with_selected_deployment(
+            &state.unified_router,
+            &router_model,
+            gemini_route_capability(stream),
+            {
+                let context = context.clone();
+                let request = request.clone();
+                let requested_model = requested_model.clone();
+                move |selected_provider, selected_model, selected_deployment_id| {
+                    let context = context.clone();
+                    let request = request.clone();
+                    let requested_model = requested_model.clone();
+                    async move {
+                        let provider = selected_gemini_provider(
+                            state.config().providers(),
+                            &selected_deployment_id,
+                            &selected_provider,
+                            &selected_model,
+                            &requested_model,
+                        )?;
+                        let (budget_reservation, response) = send_gemini_request(
+                            state,
+                            &provider,
+                            api_version,
+                            method,
+                            false,
+                            &request,
+                        )
+                        .await?;
+
+                        let response = gemini_upstream_response_to_http_response(
+                            state,
+                            context,
+                            provider,
+                            budget_reservation,
+                            response,
+                            stream,
+                            None,
+                        )
+                        .await
+                        .map_err(gemini_gateway_error_to_provider_error)?;
+                        Ok((response, 0))
+                    }
+                }
+            },
+        )
+        .await;
+
+        match result {
+            Ok(response) => return Ok(response),
+            Err(GatewayError::Provider(ProviderError::QuotaExceeded {
+                provider: "budget",
+                message,
+            })) if message.starts_with("provider ") => {
+                last_router_error = Some(GatewayError::Provider(ProviderError::QuotaExceeded {
+                    provider: "budget",
+                    message,
+                }));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_router_error.unwrap_or_else(|| missing_gemini_provider_error(&requested_model)))
+}
+
+async fn proxy_gemini_stream_route_inner(
+    state: &AppState,
+    context: crate::core::types::context::RequestContext,
+    api_version: &str,
+    requested_model: String,
+    method: &'static str,
+    request: Value,
+) -> Result<HttpResponse, GatewayError> {
+    let router_models = gemini_router_models(state.config().providers(), &requested_model);
+    let mut last_router_error = None;
+    for router_model in router_models {
+        let result = execute_stream_with_selected_deployment(
+            state.unified_router.clone(),
+            &router_model,
+            gemini_route_capability(true),
+            {
+                let request = request.clone();
+                let requested_model = requested_model.clone();
+                move |selected_provider, selected_model, selected_deployment_id| {
+                    let request = request.clone();
+                    let requested_model = requested_model.clone();
+                    async move {
+                        let provider = selected_gemini_provider(
+                            state.config().providers(),
+                            &selected_deployment_id,
+                            &selected_provider,
+                            &selected_model,
+                            &requested_model,
+                        )?;
+                        let (budget_reservation, response) = send_gemini_request(
+                            state,
+                            &provider,
+                            api_version,
+                            method,
+                            true,
+                            &request,
+                        )
+                        .await?;
+                        Ok((provider, budget_reservation, response))
+                    }
+                }
+            },
+        )
+        .await;
+
+        match result {
+            Ok(((provider, budget_reservation, response), lease)) => {
+                return gemini_upstream_response_to_http_response(
+                    state,
+                    context,
+                    provider,
+                    budget_reservation,
+                    response,
+                    true,
+                    Some(lease),
+                )
+                .await;
+            }
+            Err(GatewayError::Provider(ProviderError::QuotaExceeded {
+                provider: "budget",
+                message,
+            })) if message.starts_with("provider ") => {
+                last_router_error = Some(GatewayError::Provider(ProviderError::QuotaExceeded {
+                    provider: "budget",
+                    message,
+                }));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_router_error.unwrap_or_else(|| missing_gemini_provider_error(&requested_model)))
 }
 
 async fn gemini_upstream_response_to_http_response(
@@ -169,6 +289,7 @@ async fn gemini_upstream_response_to_http_response(
     budget_reservation: Option<UnifiedBudgetReservation>,
     response: reqwest::Response,
     stream: bool,
+    stream_lease: Option<StreamingDeploymentLease>,
 ) -> Result<HttpResponse, GatewayError> {
     let status = StatusCode::from_u16(response.status().as_u16())
         .map_err(|error| GatewayError::internal(format!("Invalid upstream status: {error}")))?;
@@ -183,26 +304,24 @@ async fn gemini_upstream_response_to_http_response(
         })
         .to_string();
 
-    if stream && !status.is_success() {
-        let body = response.bytes().await.map_err(gemini_http_error)?;
-        return Ok(HttpResponse::build(status)
-            .insert_header((actix_web::http::header::CONTENT_TYPE, content_type))
-            .body(sanitize_gemini_error_body(body, &provider)));
-    }
-
     if stream {
+        let stream_lease = stream_lease
+            .ok_or_else(|| GatewayError::internal("Gemini stream missing deployment lease"))?;
         return Ok(gemini_streaming_response(
             state,
-            context,
-            provider,
-            budget_reservation,
-            response,
-            status,
-            content_type,
+            GeminiStreamResponseParts {
+                context,
+                provider,
+                budget_reservation,
+                response,
+                status,
+                content_type,
+                stream_lease,
+            },
         ));
     }
 
-    let mut body = response.bytes().await.map_err(gemini_http_error)?;
+    let body = response.bytes().await.map_err(gemini_http_error)?;
     if status.is_success() {
         let spend_state = GeminiSpendState {
             pricing: state.pricing.as_ref(),
@@ -211,8 +330,6 @@ async fn gemini_upstream_response_to_http_response(
             api_key_id: context.api_key_id(),
         };
         record_gemini_spend(&spend_state, &provider, &body, budget_reservation, true).await;
-    } else {
-        body = sanitize_gemini_error_body(body, &provider);
     }
 
     Ok(HttpResponse::build(status)
@@ -220,15 +337,26 @@ async fn gemini_upstream_response_to_http_response(
         .body(body))
 }
 
-fn gemini_streaming_response(
-    state: &AppState,
+struct GeminiStreamResponseParts {
     context: crate::core::types::context::RequestContext,
     provider: GeminiRouteProvider,
-    mut budget_reservation: Option<UnifiedBudgetReservation>,
+    budget_reservation: Option<UnifiedBudgetReservation>,
     response: reqwest::Response,
     status: StatusCode,
     content_type: String,
-) -> HttpResponse {
+    stream_lease: StreamingDeploymentLease,
+}
+
+fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts) -> HttpResponse {
+    let GeminiStreamResponseParts {
+        context,
+        provider,
+        mut budget_reservation,
+        response,
+        status,
+        content_type,
+        stream_lease,
+    } = parts;
     let (tx, rx) = mpsc::channel::<Bytes>(8);
     let pricing = state.pricing.clone();
     let budget_limits = state.budget_limits.clone();
@@ -237,6 +365,7 @@ fn gemini_streaming_response(
     let should_record_spend = status.is_success();
 
     tokio::spawn(async move {
+        let mut stream_lease = Some(stream_lease);
         let mut upstream = response.bytes_stream();
         let mut sse_buffer = String::new();
         let mut final_usage = None;
@@ -247,6 +376,16 @@ fn gemini_streaming_response(
                 Ok(bytes) => bytes,
                 Err(_) => {
                     error!("Gemini SDK upstream stream error; closing client stream");
+                    if let Some(lease) = stream_lease.take() {
+                        let error = ProviderError::streaming_error(
+                            "gemini_proxy",
+                            "streamGenerateContent",
+                            None,
+                            None,
+                            "Gemini upstream stream error",
+                        );
+                        lease.finish_failure(&error);
+                    }
                     let spend_state = GeminiSpendState {
                         pricing: pricing.as_ref(),
                         budget_limits: &budget_limits,
@@ -302,6 +441,10 @@ fn gemini_streaming_response(
             key_manager: &key_manager,
             api_key_id,
         };
+        let tokens_used = final_usage
+            .as_ref()
+            .map(|usage| u64::from(usage.total_tokens))
+            .unwrap_or(0);
         settle_gemini_stream_spend(
             &spend_state,
             &provider,
@@ -314,6 +457,9 @@ fn gemini_streaming_response(
             should_record_spend && saw_upstream_output,
         )
         .await;
+        if let Some(lease) = stream_lease.take() {
+            lease.finish_success(tokens_used);
+        }
     });
 
     let upstream =
@@ -323,123 +469,12 @@ fn gemini_streaming_response(
         .streaming(upstream)
 }
 
-fn select_gemini_provider(
-    providers: &[ProviderConfig],
-    requested_model: &str,
-) -> Result<GeminiRouteProvider, GatewayError> {
-    let Some(provider) = providers
-        .iter()
-        .filter(|provider| provider.enabled)
-        .filter(|provider| is_gemini_provider(provider))
-        .find(|provider| provider_supports_requested_model(provider, requested_model))
-    else {
-        return Err(GatewayError::Config(format!(
-            "Gemini SDK route provider for model '{requested_model}' is not configured"
-        )));
-    };
-
-    if provider.api_key.trim().is_empty() {
-        return Err(GatewayError::Config(format!(
-            "Gemini provider '{}' is missing api_key",
-            provider.name
-        )));
+fn gemini_route_capability(stream: bool) -> ProviderCapability {
+    if stream {
+        ProviderCapability::ChatCompletionStream
+    } else {
+        ProviderCapability::ChatCompletion
     }
-
-    Ok(GeminiRouteProvider {
-        provider_name: provider.name.clone(),
-        pricing_provider: "gemini".to_string(),
-        model: requested_model.to_string(),
-        api_key: provider.api_key.clone(),
-        base_url: gemini_base_url(provider),
-        headers: gemini_provider_headers(provider)?,
-        timeout: Duration::from_secs(provider.timeout),
-    })
-}
-
-fn provider_supports_requested_model(provider: &ProviderConfig, requested_model: &str) -> bool {
-    provider.models.is_empty() || provider.models.iter().any(|model| model == requested_model)
-}
-
-fn is_gemini_provider(provider: &ProviderConfig) -> bool {
-    let provider_type = provider_config::normalize_provider_selector(&provider.provider_type);
-    let provider_name = provider_config::normalize_provider_selector(&provider.name);
-
-    matches!(
-        provider_type.as_str(),
-        "gemini" | "googleai" | "googleaistudio"
-    ) || matches!(
-        provider_name.as_str(),
-        "gemini" | "googleai" | "googleaistudio"
-    )
-}
-
-fn gemini_base_url(provider: &ProviderConfig) -> String {
-    provider
-        .base_url
-        .as_deref()
-        .map(str::trim)
-        .filter(|base_url| !base_url.is_empty())
-        .unwrap_or(GEMINI_BASE_URL)
-        .trim_end_matches('/')
-        .to_string()
-}
-
-fn gemini_provider_headers(
-    provider: &ProviderConfig,
-) -> Result<Vec<(HeaderName, HeaderValue)>, GatewayError> {
-    let mut headers = Vec::new();
-    provider_config::append_string_header_map(provider, "headers", |key, value| {
-        push_gemini_header(&mut headers, key, value)
-    })?;
-    provider_config::append_string_header_map(provider, "custom_headers", |key, value| {
-        push_gemini_header(&mut headers, key, value)
-    })?;
-    Ok(headers)
-}
-
-fn push_gemini_header(
-    headers: &mut Vec<(HeaderName, HeaderValue)>,
-    name: impl AsRef<str>,
-    value: impl AsRef<str>,
-) -> Result<(), GatewayError> {
-    let name = HeaderName::from_bytes(name.as_ref().as_bytes()).map_err(|error| {
-        GatewayError::Config(format!("Invalid Gemini provider header: {error}"))
-    })?;
-    let value = HeaderValue::from_str(value.as_ref()).map_err(|error| {
-        GatewayError::Config(format!("Invalid Gemini provider header value: {error}"))
-    })?;
-    headers.push((name, value));
-    Ok(())
-}
-
-fn gemini_url(
-    provider: &GeminiRouteProvider,
-    api_version: &str,
-    method: &'static str,
-    stream: bool,
-) -> Result<Url, GatewayError> {
-    validate_api_version(api_version)?;
-    validate_model_segment(&provider.model)?;
-    validate_method(method)?;
-
-    let mut url = Url::parse(&format!(
-        "{}/{}/models/{}:{}",
-        provider.base_url.trim_end_matches('/'),
-        api_version,
-        provider.model,
-        method
-    ))
-    .map_err(|error| GatewayError::Config(format!("Invalid Gemini base URL: {error}")))?;
-
-    {
-        let mut query = url.query_pairs_mut();
-        if stream {
-            query.append_pair("alt", "sse");
-        }
-        query.append_pair("key", &provider.api_key);
-    }
-
-    Ok(url)
 }
 
 fn ensure_gemini_route_authorized(
@@ -501,45 +536,4 @@ fn validate_gemini_request_size(request: &Value) -> Result<(), GatewayError> {
         return Err(GatewayError::validation("Gemini request body too large"));
     }
     Ok(())
-}
-
-fn gemini_http_client() -> &'static Client {
-    GEMINI_HTTP_CLIENT.get_or_init(Client::new)
-}
-
-fn gemini_http_error(error: reqwest::Error) -> GatewayError {
-    if error.is_timeout() {
-        GatewayError::timeout("Gemini upstream request timed out")
-    } else {
-        GatewayError::network("Gemini upstream request failed")
-    }
-}
-
-fn apply_gemini_headers(
-    mut request: reqwest::RequestBuilder,
-    provider: &GeminiRouteProvider,
-) -> reqwest::RequestBuilder {
-    for (name, value) in &provider.headers {
-        request = request.header(name.clone(), value.clone());
-    }
-    request
-}
-
-fn sanitize_gemini_error_body(body: Bytes, provider: &GeminiRouteProvider) -> Bytes {
-    if provider.api_key.is_empty() || body.is_empty() {
-        return body;
-    }
-
-    let text = String::from_utf8_lossy(&body);
-    let encoded_key: String =
-        url::form_urlencoded::byte_serialize(provider.api_key.as_bytes()).collect();
-    if !text.contains(&provider.api_key) && !text.contains(&encoded_key) {
-        return body;
-    }
-
-    let mut sanitized = text.replace(&provider.api_key, "[REDACTED]");
-    if encoded_key != provider.api_key {
-        sanitized = sanitized.replace(&encoded_key, "[REDACTED]");
-    }
-    Bytes::from(sanitized)
 }

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -1,0 +1,446 @@
+use bytes::Bytes;
+use reqwest::{
+    Client, Url,
+    header::{CONTENT_TYPE, HeaderName, HeaderValue, RETRY_AFTER},
+};
+use serde_json::Value;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use crate::config::models::provider::ProviderConfig;
+use crate::core::budget::UnifiedBudgetReservation;
+use crate::core::providers::shared::parse_retry_after_from_body;
+use crate::core::providers::{Provider, ProviderError};
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::{validate_api_version, validate_method, validate_model_segment};
+
+const GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+
+static GEMINI_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+pub(super) struct GeminiRouteProvider {
+    pub(super) provider_name: String,
+    pub(super) pricing_provider: String,
+    pub(super) model: String,
+    api_key: String,
+    base_url: String,
+    headers: Vec<(HeaderName, HeaderValue)>,
+    timeout: Duration,
+}
+
+pub(super) fn ensure_gemini_provider_candidate_configured(
+    providers: &[ProviderConfig],
+    requested_model: &str,
+) -> Result<(), GatewayError> {
+    let candidates = gemini_candidate_configs(providers);
+    if candidates.is_empty() {
+        return Err(missing_gemini_provider_error(requested_model));
+    }
+
+    if candidates
+        .iter()
+        .any(|provider| gemini_provider_supports_requested_model(provider, requested_model))
+    {
+        Ok(())
+    } else {
+        Err(missing_gemini_provider_error(requested_model))
+    }
+}
+
+pub(super) fn gemini_router_models(
+    providers: &[ProviderConfig],
+    requested_model: &str,
+) -> Vec<String> {
+    let mut router_models = Vec::new();
+
+    for provider in gemini_candidate_configs(providers) {
+        if !gemini_provider_supports_requested_model(provider, requested_model) {
+            continue;
+        }
+
+        if provider.models.is_empty() {
+            if gemini_provider_uses_registry_models(provider) {
+                push_unique_gemini_router_model(&mut router_models, requested_model);
+            } else {
+                push_unique_gemini_router_model(&mut router_models, &provider.name);
+            }
+            continue;
+        }
+
+        if provider.models.iter().any(|model| model == requested_model) {
+            push_unique_gemini_router_model(&mut router_models, requested_model);
+        }
+    }
+
+    if router_models.is_empty() {
+        router_models.push(requested_model.to_string());
+    }
+
+    router_models
+}
+
+fn push_unique_gemini_router_model(router_models: &mut Vec<String>, model: &str) {
+    if !router_models.iter().any(|existing| existing == model) {
+        router_models.push(model.to_string());
+    }
+}
+
+pub(super) fn selected_gemini_provider(
+    providers: &[ProviderConfig],
+    selected_deployment_id: &str,
+    selected_provider: &Provider,
+    selected_model: &str,
+    requested_model: &str,
+) -> Result<GeminiRouteProvider, ProviderError> {
+    let selected_provider_name = selected_provider.name();
+    let candidates = gemini_candidate_configs(providers);
+    let supported_candidates = candidates
+        .iter()
+        .copied()
+        .filter(|provider| gemini_provider_supports_requested_model(provider, requested_model))
+        .collect::<Vec<_>>();
+    let matching = supported_candidates
+        .iter()
+        .copied()
+        .find(|provider| {
+            selected_deployment_matches_gemini_config(
+                selected_deployment_id,
+                provider,
+                selected_model,
+            )
+        })
+        .or_else(|| {
+            supported_candidates.iter().copied().find(|provider| {
+                provider.name == selected_provider_name
+                    || provider
+                        .settings
+                        .get("provider_name")
+                        .and_then(|value| value.as_str())
+                        == Some(selected_provider_name)
+                    || (provider.models.is_empty() && provider.name == selected_model)
+            })
+        })
+        .ok_or_else(|| {
+            ProviderError::configuration(
+                "gemini_proxy",
+                format!(
+                    "selected Gemini provider '{selected_provider_name}' for model '{selected_model}' has no matching gateway provider config"
+                ),
+            )
+        })?;
+
+    gemini_route_provider_from_config(matching, requested_model)
+        .map_err(gemini_gateway_error_to_provider_error)
+}
+
+fn selected_deployment_matches_gemini_config(
+    selected_deployment_id: &str,
+    provider: &ProviderConfig,
+    selected_model: &str,
+) -> bool {
+    selected_deployment_id == provider.name
+        || selected_deployment_id
+            .strip_prefix(provider.name.as_str())
+            .and_then(|suffix| suffix.strip_prefix('-'))
+            == Some(selected_model)
+}
+
+fn gemini_route_provider_from_config(
+    provider: &ProviderConfig,
+    requested_model: &str,
+) -> Result<GeminiRouteProvider, GatewayError> {
+    if provider.api_key.trim().is_empty() {
+        return Err(GatewayError::Config(format!(
+            "Gemini provider '{}' is missing api_key",
+            provider.name
+        )));
+    }
+
+    Ok(GeminiRouteProvider {
+        provider_name: provider.name.clone(),
+        pricing_provider: "gemini".to_string(),
+        model: requested_model.to_string(),
+        api_key: provider.api_key.clone(),
+        base_url: gemini_base_url(provider),
+        headers: gemini_provider_headers(provider)?,
+        timeout: Duration::from_secs(provider.timeout),
+    })
+}
+
+fn gemini_candidate_configs(providers: &[ProviderConfig]) -> Vec<&ProviderConfig> {
+    providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .filter(|provider| is_gemini_provider(provider))
+        .collect()
+}
+
+fn gemini_provider_supports_requested_model(
+    provider: &ProviderConfig,
+    requested_model: &str,
+) -> bool {
+    provider.models.is_empty() || provider.models.iter().any(|model| model == requested_model)
+}
+
+fn gemini_provider_uses_registry_models(provider: &ProviderConfig) -> bool {
+    matches!(
+        super::super::provider_config::normalize_provider_selector(&provider.provider_type)
+            .as_str(),
+        "gemini" | "googlegemini" | "googleai"
+    )
+}
+
+fn is_gemini_provider(provider: &ProviderConfig) -> bool {
+    let provider_type =
+        super::super::provider_config::normalize_provider_selector(&provider.provider_type);
+    let provider_name = super::super::provider_config::normalize_provider_selector(&provider.name);
+
+    matches!(
+        provider_type.as_str(),
+        "gemini" | "googleai" | "googleaistudio"
+    ) || matches!(
+        provider_name.as_str(),
+        "gemini" | "googleai" | "googleaistudio"
+    )
+}
+
+fn gemini_base_url(provider: &ProviderConfig) -> String {
+    provider
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .unwrap_or(GEMINI_BASE_URL)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn gemini_provider_headers(
+    provider: &ProviderConfig,
+) -> Result<Vec<(HeaderName, HeaderValue)>, GatewayError> {
+    let mut headers = Vec::new();
+    super::super::provider_config::append_string_header_map(provider, "headers", |key, value| {
+        push_gemini_header(&mut headers, key, value)
+    })?;
+    super::super::provider_config::append_string_header_map(
+        provider,
+        "custom_headers",
+        |key, value| push_gemini_header(&mut headers, key, value),
+    )?;
+    Ok(headers)
+}
+
+fn push_gemini_header(
+    headers: &mut Vec<(HeaderName, HeaderValue)>,
+    name: impl AsRef<str>,
+    value: impl AsRef<str>,
+) -> Result<(), GatewayError> {
+    let name = HeaderName::from_bytes(name.as_ref().as_bytes()).map_err(|error| {
+        GatewayError::Config(format!("Invalid Gemini provider header: {error}"))
+    })?;
+    let value = HeaderValue::from_str(value.as_ref()).map_err(|error| {
+        GatewayError::Config(format!("Invalid Gemini provider header value: {error}"))
+    })?;
+    headers.push((name, value));
+    Ok(())
+}
+
+fn gemini_url(
+    provider: &GeminiRouteProvider,
+    api_version: &str,
+    method: &'static str,
+    stream: bool,
+) -> Result<Url, GatewayError> {
+    validate_api_version(api_version)?;
+    validate_model_segment(&provider.model)?;
+    validate_method(method)?;
+
+    let mut url = Url::parse(&format!(
+        "{}/{}/models/{}:{}",
+        provider.base_url.trim_end_matches('/'),
+        api_version,
+        provider.model,
+        method
+    ))
+    .map_err(|error| GatewayError::Config(format!("Invalid Gemini base URL: {error}")))?;
+
+    {
+        let mut query = url.query_pairs_mut();
+        if stream {
+            query.append_pair("alt", "sse");
+        }
+        query.append_pair("key", &provider.api_key);
+    }
+
+    Ok(url)
+}
+
+pub(super) async fn send_gemini_request(
+    state: &AppState,
+    provider: &GeminiRouteProvider,
+    api_version: &str,
+    method: &'static str,
+    stream: bool,
+    request: &Value,
+) -> Result<(Option<UnifiedBudgetReservation>, reqwest::Response), ProviderError> {
+    super::super::spend::ensure_budget_available(
+        &state.budget_limits,
+        &provider.provider_name,
+        &provider.model,
+    )?;
+    let mut budget_reservation = super::spend::reserve_gemini_budget(state, provider, request)
+        .map_err(gemini_gateway_error_to_provider_error)?;
+    let url = gemini_url(provider, api_version, method, stream)
+        .map_err(gemini_gateway_error_to_provider_error)?;
+    let response_result = apply_gemini_headers(gemini_http_client().post(url), provider)
+        .header(CONTENT_TYPE, "application/json")
+        .json(request)
+        .timeout(provider.timeout)
+        .send()
+        .await;
+    let response = match response_result {
+        Ok(response) => response,
+        Err(error) => {
+            if let Some(reservation) = budget_reservation.take() {
+                reservation.cancel();
+            }
+            return Err(gemini_gateway_error_to_provider_error(gemini_http_error(
+                error,
+            )));
+        }
+    };
+    let response = match gemini_response_or_provider_error(response, provider).await {
+        Ok(response) => response,
+        Err(error) => {
+            if let Some(reservation) = budget_reservation.take() {
+                reservation.cancel();
+            }
+            return Err(error);
+        }
+    };
+    Ok((budget_reservation, response))
+}
+
+async fn gemini_response_or_provider_error(
+    response: reqwest::Response,
+    provider: &GeminiRouteProvider,
+) -> Result<reqwest::Response, ProviderError> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status = response.status().as_u16();
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    let body = response
+        .bytes()
+        .await
+        .map_err(|error| gemini_gateway_error_to_provider_error(gemini_http_error(error)))?;
+    let body = sanitize_gemini_error_body(body, provider);
+    let body_text = String::from_utf8_lossy(&body).to_string();
+    Err(gemini_upstream_status_provider_error(
+        status,
+        body_text,
+        retry_after,
+    ))
+}
+
+fn gemini_upstream_status_provider_error(
+    status: u16,
+    body: String,
+    retry_after: Option<u64>,
+) -> ProviderError {
+    let message = if body.trim().is_empty() {
+        format!("Gemini upstream returned HTTP {status}")
+    } else {
+        format!("Gemini upstream returned HTTP {status}: {body}")
+    };
+    if status == 429 {
+        ProviderError::rate_limit_with_retry(
+            "gemini_proxy",
+            message,
+            retry_after.or_else(|| parse_retry_after_from_body(&body)),
+        )
+    } else {
+        ProviderError::api_error("gemini_proxy", status, message)
+    }
+}
+
+pub(super) fn gemini_http_error(error: reqwest::Error) -> GatewayError {
+    if error.is_timeout() {
+        GatewayError::timeout("Gemini upstream request timed out")
+    } else {
+        GatewayError::network("Gemini upstream request failed")
+    }
+}
+
+pub(super) fn missing_gemini_provider_error(requested_model: &str) -> GatewayError {
+    GatewayError::Config(format!(
+        "Gemini SDK route provider for model '{requested_model}' is not configured"
+    ))
+}
+
+pub(super) fn gemini_gateway_error_to_provider_error(error: GatewayError) -> ProviderError {
+    match error {
+        GatewayError::Provider(error) => error,
+        GatewayError::Validation(message) | GatewayError::BadRequest(message) => {
+            ProviderError::invalid_request("gemini_proxy", message)
+        }
+        GatewayError::Config(message) => ProviderError::configuration("gemini_proxy", message),
+        GatewayError::Auth(message) => ProviderError::authentication("gemini_proxy", message),
+        GatewayError::Forbidden(message) => ProviderError::api_error("gemini_proxy", 403, message),
+        GatewayError::Timeout(message) => ProviderError::timeout("gemini_proxy", message),
+        GatewayError::RateLimit {
+            message,
+            retry_after,
+            ..
+        } => ProviderError::rate_limit_with_retry("gemini_proxy", message, retry_after),
+        GatewayError::HttpClient(error) => {
+            ProviderError::network("gemini_proxy", error.to_string())
+        }
+        GatewayError::Network(message) => ProviderError::network("gemini_proxy", message),
+        GatewayError::Unavailable(message) => {
+            ProviderError::provider_unavailable("gemini_proxy", message)
+        }
+        other => ProviderError::api_error("gemini_proxy", 500, other.to_string()),
+    }
+}
+
+fn gemini_http_client() -> &'static Client {
+    GEMINI_HTTP_CLIENT.get_or_init(Client::new)
+}
+
+fn apply_gemini_headers(
+    mut request: reqwest::RequestBuilder,
+    provider: &GeminiRouteProvider,
+) -> reqwest::RequestBuilder {
+    for (name, value) in &provider.headers {
+        request = request.header(name.clone(), value.clone());
+    }
+    request
+}
+
+fn sanitize_gemini_error_body(body: Bytes, provider: &GeminiRouteProvider) -> Bytes {
+    if provider.api_key.is_empty() || body.is_empty() {
+        return body;
+    }
+
+    let text = String::from_utf8_lossy(&body);
+    let encoded_key: String =
+        url::form_urlencoded::byte_serialize(provider.api_key.as_bytes()).collect();
+    if !text.contains(&provider.api_key) && !text.contains(&encoded_key) {
+        return body;
+    }
+
+    let mut sanitized = text.replace(&provider.api_key, "[REDACTED]");
+    if encoded_key != provider.api_key {
+        sanitized = sanitized.replace(&encoded_key, "[REDACTED]");
+    }
+    Bytes::from(sanitized)
+}

--- a/src/server/routes/ai/gemini/spend.rs
+++ b/src/server/routes/ai/gemini/spend.rs
@@ -9,7 +9,7 @@ use crate::core::providers::ProviderError;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
-use super::GeminiRouteProvider;
+use super::provider::GeminiRouteProvider;
 
 pub(super) struct GeminiSpendState<'a> {
     pub(super) pricing: &'a PricingService,

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -128,7 +128,7 @@ pub(crate) async fn handle_streaming_response(
         state.unified_router.clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,
-        move |provider, selected_model| {
+        move |provider, selected_model, _selected_deployment_id| {
             let core_request = core_request.clone();
             let ctx = context_clone.clone();
             let budget_limits = budget_limits.clone();

--- a/tests/gemini_router_fallback_routes.rs
+++ b/tests/gemini_router_fallback_routes.rs
@@ -1,0 +1,398 @@
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
+mod tests {
+    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use litellm_rs::server::state::AppState;
+    use serde_json::{Value, json};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    const GEMINI_MODEL: &str = "gemini-3.1-flash-lite";
+    const GEMINI_API_KEY: &str = "test-api-key-12345678901234567890";
+
+    #[derive(Clone, Debug)]
+    struct CapturedGeminiRequest {
+        path_and_query: String,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    struct MockGeminiState {
+        captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
+        failure_status: Option<StatusCode>,
+    }
+
+    struct MockGeminiServer {
+        base_url: String,
+        captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
+        handle: actix_web::dev::ServerHandle,
+        task: tokio::task::JoinHandle<std::io::Result<()>>,
+    }
+
+    impl MockGeminiServer {
+        async fn start_gemini_mock() -> Self {
+            Self::start_gemini_mock_with_status(None).await
+        }
+
+        async fn start_failing_gemini_mock(status: StatusCode) -> Self {
+            Self::start_gemini_mock_with_status(Some(status)).await
+        }
+
+        async fn start_gemini_mock_with_status(failure_status: Option<StatusCode>) -> Self {
+            let captured_requests = Arc::new(Mutex::new(Vec::new()));
+            let state = MockGeminiState {
+                captured_requests: Arc::clone(&captured_requests),
+                failure_status,
+            };
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+            let address = listener
+                .local_addr()
+                .expect("mock server should have address");
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(web::Data::new(state.clone()))
+                    .default_service(web::post().to(mock_gemini))
+            })
+            .listen(listener)
+            .expect("mock server should listen")
+            .run();
+            let handle = server.handle();
+            let task = tokio::spawn(server);
+            wait_for_server(address).await;
+
+            Self {
+                base_url: format!("http://{address}"),
+                captured_requests,
+                handle,
+                task,
+            }
+        }
+
+        fn requests(&self) -> Vec<CapturedGeminiRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+
+        async fn stop_gemini_mock(self) {
+            self.handle.stop(true).await;
+            let result = self.task.await.expect("mock server task should join");
+            if let Err(error) = result {
+                panic!("mock server should stop cleanly: {error}");
+            }
+        }
+    }
+
+    async fn wait_for_server(address: std::net::SocketAddr) {
+        for _ in 0..20 {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("mock server did not accept connections at {address}");
+    }
+
+    async fn mock_gemini(
+        state: web::Data<MockGeminiState>,
+        request: HttpRequest,
+        body: Bytes,
+    ) -> HttpResponse {
+        state
+            .captured_requests
+            .lock()
+            .unwrap()
+            .push(CapturedGeminiRequest {
+                path_and_query: request
+                    .uri()
+                    .path_and_query()
+                    .expect("request should have path")
+                    .as_str()
+                    .to_string(),
+                body: body.to_vec(),
+            });
+
+        if let Some(status) = state.failure_status {
+            return HttpResponse::build(status).json(json!({
+                "error": {
+                    "message": format!("forced upstream {status} at {}", request.uri())
+                }
+            }));
+        }
+
+        if request.path().ends_with(":streamGenerateContent") {
+            return HttpResponse::Ok()
+                .insert_header(("content-type", "text/event-stream"))
+                .body(
+                    "event: message\n\
+                     data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n\
+                     event: message\n\
+                     data: {\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n\n",
+                );
+        }
+
+        HttpResponse::Ok().json(json!({
+            "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15,
+                "cachedContentTokenCount": 2,
+                "thoughtsTokenCount": 1
+            }
+        }))
+    }
+
+    async fn build_test_state(providers: Vec<ProviderConfig>) -> AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = providers;
+
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone()
+    }
+
+    fn gemini_provider(name: &str, base_url: &str) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: GEMINI_API_KEY.to_string(),
+            base_url: Some(base_url.to_string()),
+            models: vec![GEMINI_MODEL.to_string()],
+            ..ProviderConfig::default()
+        }
+    }
+
+    fn gemini_body() -> Value {
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "hello from the Gemini SDK"}]
+            }],
+            "generationConfig": {"maxOutputTokens": 8}
+        })
+    }
+
+    fn configure_exhausted_primary_budget(state: &AppState) {
+        state.budget_limits.providers.set_provider_limit(
+            "gemini",
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .record_spend("gemini", GEMINI_MODEL, 0.01);
+        state.budget_limits.providers.set_provider_limit(
+            "googleai",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        state.budget_limits.models.set_model_limit(
+            GEMINI_MODEL,
+            ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_uses_router_budget_fallback_provider() {
+        let primary = MockGeminiServer::start_gemini_mock().await;
+        let fallback = MockGeminiServer::start_gemini_mock().await;
+        let state = build_test_state(vec![
+            gemini_provider("gemini", &primary.base_url),
+            gemini_provider("googleai", &fallback.base_url),
+        ])
+        .await;
+        configure_exhausted_primary_budget(&state);
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["candidates"][0]["content"]["parts"][0]["text"], "ok");
+        assert!(
+            primary.requests().is_empty(),
+            "router fallback must skip exhausted Gemini provider before upstream"
+        );
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(
+            fallback_requests[0].path_and_query,
+            format!("/v1beta/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}")
+        );
+        let upstream_body: Value =
+            serde_json::from_slice(&fallback_requests[0].body).expect("body should be json");
+        assert_eq!(
+            upstream_body["contents"][0]["parts"][0]["text"],
+            "hello from the Gemini SDK"
+        );
+        let fallback_usage = budget_limits
+            .providers
+            .get_provider_usage("googleai")
+            .expect("fallback provider spend should be recorded");
+        assert!(fallback_usage.current_spend > 0.0);
+
+        primary.stop_gemini_mock().await;
+        fallback.stop_gemini_mock().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_stream_route_uses_router_budget_fallback_provider() {
+        let primary = MockGeminiServer::start_gemini_mock().await;
+        let fallback = MockGeminiServer::start_gemini_mock().await;
+        let state = build_test_state(vec![
+            gemini_provider("gemini", &primary.base_url),
+            gemini_provider("googleai", &fallback.base_url),
+        ])
+        .await;
+        configure_exhausted_primary_budget(&state);
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/models/gemini-3.1-flash-lite:streamGenerateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+        let stream_body = test::read_body(response).await;
+        let stream_text = String::from_utf8(stream_body.to_vec()).expect("stream should be utf8");
+        assert!(stream_text.contains("\"usageMetadata\""));
+        assert!(
+            primary.requests().is_empty(),
+            "router fallback must skip exhausted Gemini stream provider before upstream"
+        );
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(
+            fallback_requests[0].path_and_query,
+            format!("/v1/models/{GEMINI_MODEL}:streamGenerateContent?alt=sse&key={GEMINI_API_KEY}")
+        );
+        let fallback_usage = budget_limits
+            .providers
+            .get_provider_usage("googleai")
+            .expect("fallback provider stream spend should be recorded");
+        assert!(fallback_usage.current_spend > 0.0);
+
+        primary.stop_gemini_mock().await;
+        fallback.stop_gemini_mock().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_uses_router_upstream_error_fallback_provider() {
+        let primary =
+            MockGeminiServer::start_failing_gemini_mock(StatusCode::SERVICE_UNAVAILABLE).await;
+        let fallback = MockGeminiServer::start_gemini_mock().await;
+        let state = build_test_state(vec![
+            gemini_provider("gemini", &primary.base_url),
+            gemini_provider("googleai", &fallback.base_url),
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(primary.requests().len(), 1);
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(
+            fallback_requests[0].path_and_query,
+            format!("/v1beta/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}")
+        );
+
+        primary.stop_gemini_mock().await;
+        fallback.stop_gemini_mock().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_stream_route_uses_router_upstream_error_fallback_provider() {
+        let primary =
+            MockGeminiServer::start_failing_gemini_mock(StatusCode::SERVICE_UNAVAILABLE).await;
+        let fallback = MockGeminiServer::start_gemini_mock().await;
+        let state = build_test_state(vec![
+            gemini_provider("gemini", &primary.base_url),
+            gemini_provider("googleai", &fallback.base_url),
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/models/gemini-3.1-flash-lite:streamGenerateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let stream_body = test::read_body(response).await;
+        let stream_text = String::from_utf8(stream_body.to_vec()).expect("stream should be utf8");
+        assert!(stream_text.contains("\"usageMetadata\""));
+        assert_eq!(primary.requests().len(), 1);
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(
+            fallback_requests[0].path_and_query,
+            format!("/v1/models/{GEMINI_MODEL}:streamGenerateContent?alt=sse&key={GEMINI_API_KEY}")
+        );
+
+        primary.stop_gemini_mock().await;
+        fallback.stop_gemini_mock().await;
+    }
+}


### PR DESCRIPTION
Refs issue 749

## Summary
- route Gemini SDK generateContent and streamGenerateContent through UnifiedRouter fallback selection
- keep streaming deployment leases alive until stream completion or upstream stream failure
- convert retryable Gemini upstream HTTP failures into provider errors before success accounting, cancelling budget reservations before retry/fallback
- add Gemini SDK fallback regressions for provider budget and upstream 503 fallback

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked --message-format=short
- cargo test --all-features --locked --test gemini_router_fallback_routes -- --nocapture
- cargo test --all-features --locked --test gemini_sdk_routes -- --nocapture
- cargo test --locked --no-default-features --features "postgres sqlite redis s3 metrics tracing websockets analytics" --test gemini_router_fallback_routes -- --nocapture
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked --quiet -- --test-threads=1

Issue 749 remains open for the remaining route-family fallback slices.