### PR TITLE
Fix batch route provider fallback

### DIFF
--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -4,6 +4,8 @@
 //! configured OpenAI or OpenAI-compatible provider.
 
 use crate::config::models::provider::ProviderConfig;
+use crate::core::providers::ProviderError;
+use crate::core::router::execution::is_retryable_error;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpResponse, Result as ActixResult, http::StatusCode, http::header, web};
@@ -11,6 +13,7 @@ use reqwest::header::{HeaderName, HeaderValue};
 use reqwest::{Client, RequestBuilder, Url};
 use serde::Deserialize;
 use serde_json::Value;
+use std::future::Future;
 use std::sync::OnceLock;
 use tracing::error;
 
@@ -95,79 +98,129 @@ async fn proxy_batch_create(
     request: Value,
 ) -> Result<HttpResponse, GatewayError> {
     validate_create_batch_request(&request)?;
-    let Some(provider) = select_batch_proxy_provider(state.config().gateway.providers.as_slice())?
-    else {
-        return Err(missing_batch_provider_error());
-    };
-    super::spend::ensure_budget_available(&state.budget_limits, &provider.provider_name, "")?;
-    let url = batch_url(&provider, None, None)?;
-
-    let response = apply_provider_headers(http_client().post(url), &provider)
-        .json(&request)
-        .send()
-        .await?;
-
-    response_to_http_response(response).await
+    execute_batch_proxy_request(state, move |provider| {
+        let request = request.clone();
+        async move {
+            let url = batch_url(&provider, None, None)?;
+            apply_provider_headers(http_client().post(url), &provider)
+                .json(&request)
+                .send()
+                .await
+                .map_err(GatewayError::from)
+        }
+    })
+    .await
 }
 
 async fn proxy_batch_list(
     state: &AppState,
     query: ListBatchesQuery,
 ) -> Result<HttpResponse, GatewayError> {
-    let Some(provider) = select_batch_proxy_provider(state.config().gateway.providers.as_slice())?
-    else {
-        return Err(missing_batch_provider_error());
-    };
-    super::spend::ensure_budget_available(&state.budget_limits, &provider.provider_name, "")?;
-    let mut url = batch_url(&provider, None, None)?;
-    {
-        let mut pairs = url.query_pairs_mut();
-        if let Some(after) = query.after.filter(|after| !after.trim().is_empty()) {
-            pairs.append_pair("after", &after);
-        }
-        if let Some(limit) = query.limit {
-            pairs.append_pair("limit", &limit.to_string());
-        }
-    }
+    execute_batch_proxy_request(state, move |provider| {
+        let query = ListBatchesQuery {
+            after: query.after.clone(),
+            limit: query.limit,
+        };
+        async move {
+            let mut url = batch_url(&provider, None, None)?;
+            {
+                let mut pairs = url.query_pairs_mut();
+                if let Some(after) = query.after.filter(|after| !after.trim().is_empty()) {
+                    pairs.append_pair("after", &after);
+                }
+                if let Some(limit) = query.limit {
+                    pairs.append_pair("limit", &limit.to_string());
+                }
+            }
 
-    let response = apply_provider_headers(http_client().get(url), &provider)
-        .send()
-        .await?;
-
-    response_to_http_response(response).await
+            apply_provider_headers(http_client().get(url), &provider)
+                .send()
+                .await
+                .map_err(GatewayError::from)
+        }
+    })
+    .await
 }
 
 async fn proxy_batch_get(state: &AppState, batch_id: &str) -> Result<HttpResponse, GatewayError> {
-    let Some(provider) = select_batch_proxy_provider(state.config().gateway.providers.as_slice())?
-    else {
-        return Err(missing_batch_provider_error());
-    };
-    super::spend::ensure_budget_available(&state.budget_limits, &provider.provider_name, "")?;
-    let url = batch_url(&provider, Some(batch_id), None)?;
-
-    let response = apply_provider_headers(http_client().get(url), &provider)
-        .send()
-        .await?;
-
-    response_to_http_response(response).await
+    let batch_id = batch_id.to_string();
+    execute_batch_proxy_request(state, move |provider| {
+        let batch_id = batch_id.clone();
+        async move {
+            let url = batch_url(&provider, Some(&batch_id), None)?;
+            apply_provider_headers(http_client().get(url), &provider)
+                .send()
+                .await
+                .map_err(GatewayError::from)
+        }
+    })
+    .await
 }
 
 async fn proxy_batch_cancel(
     state: &AppState,
     batch_id: &str,
 ) -> Result<HttpResponse, GatewayError> {
-    let Some(provider) = select_batch_proxy_provider(state.config().gateway.providers.as_slice())?
-    else {
+    let batch_id = batch_id.to_string();
+    execute_batch_proxy_request(state, move |provider| {
+        let batch_id = batch_id.clone();
+        async move {
+            let url = batch_url(&provider, Some(&batch_id), Some("cancel"))?;
+            apply_provider_headers(http_client().post(url), &provider)
+                .send()
+                .await
+                .map_err(GatewayError::from)
+        }
+    })
+    .await
+}
+
+async fn execute_batch_proxy_request<F, Fut>(
+    state: &AppState,
+    operation: F,
+) -> Result<HttpResponse, GatewayError>
+where
+    F: Fn(BatchProxyProvider) -> Fut,
+    Fut: Future<Output = Result<reqwest::Response, GatewayError>>,
+{
+    let config = state.config();
+    let provider_configs = select_batch_proxy_provider_configs(config.gateway.providers.as_slice());
+    if provider_configs.is_empty() {
         return Err(missing_batch_provider_error());
-    };
-    super::spend::ensure_budget_available(&state.budget_limits, &provider.provider_name, "")?;
-    let url = batch_url(&provider, Some(batch_id), Some("cancel"))?;
+    }
 
-    let response = apply_provider_headers(http_client().post(url), &provider)
-        .send()
-        .await?;
+    let provider_count = provider_configs.len();
+    let mut last_error = None;
+    for (index, provider_config) in provider_configs.into_iter().enumerate() {
+        let is_last_provider = index + 1 == provider_count;
+        let provider = batch_proxy_provider_from_config(provider_config)?;
+        if let Err(error) =
+            super::spend::ensure_budget_available(&state.budget_limits, &provider.provider_name, "")
+                .map_err(GatewayError::Provider)
+        {
+            if !is_last_provider && is_retryable_batch_error(&error) {
+                last_error = Some(error);
+                continue;
+            }
+            return Err(error);
+        }
 
-    response_to_http_response(response).await
+        match operation(provider).await {
+            Ok(response) if should_try_next_batch_provider(response.status()) => {
+                if is_last_provider {
+                    return response_to_http_response(response).await;
+                }
+                last_error = Some(batch_upstream_gateway_error(response).await);
+            }
+            Ok(response) => return response_to_http_response(response).await,
+            Err(error) if !is_last_provider && is_retryable_batch_error(&error) => {
+                last_error = Some(error);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(missing_batch_provider_error))
 }
 
 async fn response_to_http_response(
@@ -188,17 +241,68 @@ async fn response_to_http_response(
         .body(body))
 }
 
+fn is_retryable_batch_error(error: &GatewayError) -> bool {
+    match error {
+        GatewayError::Provider(error) => is_retryable_error(error),
+        GatewayError::HttpClient(_)
+        | GatewayError::Network(_)
+        | GatewayError::Timeout(_)
+        | GatewayError::Unavailable(_)
+        | GatewayError::RateLimit { .. } => true,
+        _ => false,
+    }
+}
+
+fn should_try_next_batch_provider(status: reqwest::StatusCode) -> bool {
+    matches!(
+        status.as_u16(),
+        408 | 429 | 500 | 502 | 503 | 504 | 507 | 529
+    )
+}
+
+async fn batch_upstream_gateway_error(response: reqwest::Response) -> GatewayError {
+    let status = response.status().as_u16();
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("failed to read batch upstream error body: {error}"));
+    let message = if body.trim().is_empty() {
+        format!("Batch upstream returned HTTP {status}")
+    } else {
+        format!("Batch upstream returned HTTP {status}: {body}")
+    };
+
+    let provider_error = match status {
+        408 | 504 => ProviderError::timeout("batch_proxy", message),
+        429 => ProviderError::rate_limit_with_retry("batch_proxy", message, None),
+        502 | 503 => ProviderError::provider_unavailable("batch_proxy", message),
+        _ => ProviderError::api_error("batch_proxy", status, message),
+    };
+    GatewayError::Provider(provider_error)
+}
+
+#[cfg(test)]
 fn select_batch_proxy_provider(
     providers: &[ProviderConfig],
 ) -> Result<Option<BatchProxyProvider>, GatewayError> {
-    let Some(provider) = providers
+    select_batch_proxy_provider_configs(providers)
+        .into_iter()
+        .next()
+        .map(batch_proxy_provider_from_config)
+        .transpose()
+}
+
+fn select_batch_proxy_provider_configs(providers: &[ProviderConfig]) -> Vec<&ProviderConfig> {
+    providers
         .iter()
         .filter(|provider| provider.enabled)
-        .find(|provider| is_openai_batch_provider(provider))
-    else {
-        return Ok(None);
-    };
+        .filter(|provider| is_openai_batch_provider(provider))
+        .collect()
+}
 
+fn batch_proxy_provider_from_config(
+    provider: &ProviderConfig,
+) -> Result<BatchProxyProvider, GatewayError> {
     if provider.api_key.trim().is_empty() {
         return Err(GatewayError::Config(format!(
             "Batch provider '{}' is missing api_key",
@@ -206,12 +310,12 @@ fn select_batch_proxy_provider(
         )));
     }
 
-    Ok(Some(BatchProxyProvider {
+    Ok(BatchProxyProvider {
         provider_name: provider.name.clone(),
         api_key: provider.api_key.clone(),
         base_url: batch_base_url(provider)?,
         headers: batch_provider_headers(provider)?,
-    }))
+    })
 }
 
 fn batch_base_url(provider: &ProviderConfig) -> Result<String, GatewayError> {

--- a/tests/batches_routes.rs
+++ b/tests/batches_routes.rs
@@ -1,10 +1,16 @@
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use actix_web::{
+        App, HttpRequest, HttpResponse, HttpServer,
+        http::{Method, StatusCode},
+        test, web,
+    };
     use bytes::Bytes;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use litellm_rs::server::state::AppState;
     use serde_json::{Value, json};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -22,6 +28,7 @@ mod tests {
     #[derive(Clone)]
     struct MockBatchServerState {
         captured_requests: Arc<Mutex<Vec<CapturedBatchRequest>>>,
+        failure_status: Option<StatusCode>,
     }
 
     struct MockBatchServer {
@@ -33,9 +40,18 @@ mod tests {
 
     impl MockBatchServer {
         async fn start_batch_mock() -> Self {
+            Self::start_batch_mock_with_status(None).await
+        }
+
+        async fn start_failing_batch_mock(status: StatusCode) -> Self {
+            Self::start_batch_mock_with_status(Some(status)).await
+        }
+
+        async fn start_batch_mock_with_status(failure_status: Option<StatusCode>) -> Self {
             let captured_requests = Arc::new(Mutex::new(Vec::new()));
             let state = MockBatchServerState {
                 captured_requests: Arc::clone(&captured_requests),
+                failure_status,
             };
             let listener =
                 std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -87,6 +103,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Accepted().json(json!({
             "id": "batch_mock",
             "object": "batch",
@@ -100,6 +119,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(json!({
             "object": "list",
             "data": [],
@@ -113,6 +135,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(json!({
             "id": "batch_123",
             "object": "batch",
@@ -126,11 +151,27 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(json!({
             "id": "batch_123",
             "object": "batch",
             "status": "cancelled"
         }))
+    }
+
+    fn maybe_failure_response(
+        state: &MockBatchServerState,
+        request: &HttpRequest,
+    ) -> Option<HttpResponse> {
+        state.failure_status.map(|status| {
+            HttpResponse::build(status).json(json!({
+                "error": {
+                    "message": format!("forced upstream {status} at {}", request.uri())
+                }
+            }))
+        })
     }
 
     fn capture_request(state: &MockBatchServerState, request: &HttpRequest, body: Bytes) {
@@ -163,9 +204,7 @@ mod tests {
             });
     }
 
-    async fn build_test_app_state(
-        providers: Vec<ProviderConfig>,
-    ) -> litellm_rs::server::state::AppState {
+    async fn build_test_app_state(providers: Vec<ProviderConfig>) -> AppState {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
@@ -204,6 +243,23 @@ mod tests {
             ),
         ]);
         provider
+    }
+
+    fn batch_route_provider(name: &str, base_url: &str) -> ProviderConfig {
+        let mut provider = batch_route_provider_with_headers(base_url);
+        provider.name = name.to_string();
+        provider.organization = None;
+        provider.project = None;
+        provider.settings.clear();
+        provider
+    }
+
+    fn configure_exhausted_primary_budget(state: &AppState, provider_name: &str) {
+        state.budget_limits.providers.set_provider_limit(
+            provider_name,
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state.budget_limits.record_spend(provider_name, "", 0.01);
     }
 
     #[tokio::test]
@@ -299,5 +355,163 @@ mod tests {
         assert_eq!(requests[3].path, "/v1/batches/batch_123/cancel");
 
         mock_server.stop_batch_mock().await;
+    }
+
+    #[tokio::test]
+    async fn route_uses_batch_fallback_when_primary_budget_exhausted() {
+        let primary = MockBatchServer::start_batch_mock().await;
+        let fallback = MockBatchServer::start_batch_mock().await;
+        let state = build_test_app_state(vec![
+            batch_route_provider("primary-batch", &primary.base_url),
+            batch_route_provider("fallback-batch", &fallback.base_url),
+        ])
+        .await;
+        configure_exhausted_primary_budget(&state, "primary-batch");
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let create_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/batches")
+                .set_json(json!({
+                    "input_file_id": "file_123",
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(create_resp.status(), StatusCode::ACCEPTED);
+        assert!(
+            primary.requests().is_empty(),
+            "budget fallback must skip the exhausted batch provider before upstream"
+        );
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(fallback_requests[0].method, "POST");
+        assert_eq!(fallback_requests[0].path, "/v1/batches");
+        assert_eq!(fallback_requests[0].body["input_file_id"], "file_123");
+
+        primary.stop_batch_mock().await;
+        fallback.stop_batch_mock().await;
+    }
+
+    #[tokio::test]
+    async fn route_uses_batch_fallback_when_primary_upstream_fails() {
+        let primary =
+            MockBatchServer::start_failing_batch_mock(StatusCode::SERVICE_UNAVAILABLE).await;
+        let fallback = MockBatchServer::start_batch_mock().await;
+        let state = build_test_app_state(vec![
+            batch_route_provider("primary-batch", &primary.base_url),
+            batch_route_provider("fallback-batch", &fallback.base_url),
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let scenarios = [
+            (Method::POST, "/v1/batches", "/v1/batches", ""),
+            (
+                Method::GET,
+                "/v1/batches?after=batch_prev&limit=7",
+                "/v1/batches",
+                "after=batch_prev&limit=7",
+            ),
+            (
+                Method::GET,
+                "/v1/batches/batch_123",
+                "/v1/batches/batch_123",
+                "",
+            ),
+            (
+                Method::POST,
+                "/v1/batches/batch_123/cancel",
+                "/v1/batches/batch_123/cancel",
+                "",
+            ),
+        ];
+        for (method, uri, _, _) in &scenarios {
+            let mut request = test::TestRequest::with_uri(uri).method(method.clone());
+            if *uri == "/v1/batches" {
+                request = request.set_json(json!({
+                    "input_file_id": "file_123",
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h"
+                }));
+            }
+            let response = test::call_service(&app, request.to_request()).await;
+            assert!(
+                response.status().is_success(),
+                "{uri} should succeed via fallback, got {}",
+                response.status()
+            );
+        }
+
+        assert_eq!(primary.requests().len(), scenarios.len());
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), scenarios.len());
+        assert_eq!(fallback_requests[0].body["input_file_id"], "file_123");
+        for (request, (method, _, path, query)) in fallback_requests.iter().zip(scenarios.iter()) {
+            assert_eq!(request.method, method.as_str());
+            assert_eq!(request.path, *path);
+            assert_eq!(request.query, *query);
+        }
+
+        primary.stop_batch_mock().await;
+        fallback.stop_batch_mock().await;
+    }
+
+    #[tokio::test]
+    async fn route_does_not_validate_unreached_batch_fallback_provider() {
+        let primary = MockBatchServer::start_batch_mock().await;
+        let mut broken_fallback =
+            batch_route_provider("broken-fallback", "https://unused.invalid/v1");
+        broken_fallback.settings = HashMap::from([(
+            "headers".to_string(),
+            json!({
+                "invalid header name": "not reached"
+            }),
+        )]);
+        let state = build_test_app_state(vec![
+            batch_route_provider("primary-batch", &primary.base_url),
+            broken_fallback,
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let create_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/batches")
+                .set_json(json!({
+                    "input_file_id": "file_123",
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(create_resp.status(), StatusCode::ACCEPTED);
+        let primary_requests = primary.requests();
+        assert_eq!(primary_requests.len(), 1);
+        assert_eq!(primary_requests[0].path, "/v1/batches");
+
+        primary.stop_batch_mock().await;
     }
 }


### PR DESCRIPTION
## Summary
- route batch create/list/get/cancel through ordered provider fallback attempts
- skip exhausted provider-budget candidates before upstream calls
- retry the next batch provider on retryable upstream failures
- keep unreached fallback provider config from breaking a successful primary

Refs #749

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked --message-format=short
- cargo test --all-features --locked --test batches_routes -- --nocapture
- cargo test --all-features --locked server::routes::ai::batches --lib --quiet
- cargo test --locked --no-default-features --features "postgres sqlite redis s3 metrics tracing websockets analytics" --test batches_routes -- --nocapture
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked --quiet -- --test-threads=1

## Notes
- This is one slice of #749. The umbrella issue should remain open for remaining route families.