### PR TITLE
Fix fine-tuning route provider fallback

### DIFF
--- a/src/server/routes/ai/fine_tuning.rs
+++ b/src/server/routes/ai/fine_tuning.rs
@@ -4,19 +4,21 @@
 //! proxy them to an enabled OpenAI or OpenAI-compatible provider.
 
 use crate::config::models::provider::ProviderConfig;
-use crate::core::fine_tuning::FineTuningManager;
-use crate::core::fine_tuning::config::{FineTuningConfig, ProviderFineTuningConfig};
-use crate::core::fine_tuning::providers::{FineTuningError, OpenAIFineTuningProvider};
+use crate::core::fine_tuning::config::ProviderFineTuningConfig;
+use crate::core::fine_tuning::providers::{
+    FineTuningError, FineTuningProvider, OpenAIFineTuningProvider,
+};
 use crate::core::fine_tuning::types::{
     CreateJobRequest, FineTuningCheckpoint, ListEventsParams, ListJobsParams,
 };
+use crate::core::router::execution::is_retryable_error;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpResponse, Result as ActixResult, web};
 use reqwest::header::{HeaderName, HeaderValue};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::future::Future;
 use tracing::error;
 
 use super::openai_errors;
@@ -30,9 +32,9 @@ struct FineTuningRouteProvider {
     config: ProviderFineTuningConfig,
 }
 
-struct FineTuningRouteManager {
-    manager: FineTuningManager,
-    default_provider: String,
+enum FineTuningRouteError {
+    Gateway(GatewayError),
+    FineTuning(FineTuningError),
 }
 
 #[derive(Serialize)]
@@ -51,26 +53,20 @@ pub async fn create_fine_tuning_job(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
-        Ok(route_manager) => route_manager,
-        Err(error) => {
-            error!("Fine-tuning create route configuration error: {}", error);
-            return Ok(openai_errors::gateway_error_response(&error));
-        }
-    };
-    if let Err(error) = ensure_fine_tuning_budget(
-        state.get_ref(),
-        &route_manager.default_provider,
-        &request.model,
-    ) {
-        return Ok(openai_errors::gateway_error_response(&error));
-    }
-
-    match route_manager.manager.create_job(None, request).await {
+    let model = request.model.clone();
+    match execute_fine_tuning_route(state.get_ref(), &model, move |provider| {
+        let request = request.clone();
+        async move { provider.create_job(request).await }
+    })
+    .await
+    {
         Ok(job) => Ok(HttpResponse::Ok().json(job)),
         Err(error) => {
-            error!("Fine-tuning create error: {}", error);
-            Ok(fine_tuning_error_response(error))
+            error!(
+                "Fine-tuning create error: {}",
+                fine_tuning_route_error_message(&error)
+            );
+            Ok(fine_tuning_route_error_response(error))
         }
     }
 }
@@ -80,28 +76,20 @@ pub async fn list_fine_tuning_jobs(
     state: web::Data<AppState>,
     query: web::Query<ListJobsParams>,
 ) -> ActixResult<HttpResponse> {
-    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
-        Ok(route_manager) => route_manager,
-        Err(error) => {
-            error!("Fine-tuning list route configuration error: {}", error);
-            return Ok(openai_errors::gateway_error_response(&error));
-        }
-    };
-    if let Err(error) =
-        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
-    {
-        return Ok(openai_errors::gateway_error_response(&error));
-    }
-
-    match route_manager
-        .manager
-        .list_jobs(None, query.into_inner())
-        .await
+    let query = query.into_inner();
+    match execute_fine_tuning_route(state.get_ref(), "", move |provider| {
+        let query = query.clone();
+        async move { provider.list_jobs(query).await }
+    })
+    .await
     {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(error) => {
-            error!("Fine-tuning list error: {}", error);
-            Ok(fine_tuning_error_response(error))
+            error!(
+                "Fine-tuning list error: {}",
+                fine_tuning_route_error_message(&error)
+            );
+            Ok(fine_tuning_route_error_response(error))
         }
     }
 }
@@ -116,24 +104,19 @@ pub async fn get_fine_tuning_job(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
-        Ok(route_manager) => route_manager,
-        Err(error) => {
-            error!("Fine-tuning retrieve route configuration error: {}", error);
-            return Ok(openai_errors::gateway_error_response(&error));
-        }
-    };
-    if let Err(error) =
-        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    match execute_fine_tuning_route(state.get_ref(), "", move |provider| {
+        let job_id = job_id.clone();
+        async move { provider.get_job(&job_id).await }
+    })
+    .await
     {
-        return Ok(openai_errors::gateway_error_response(&error));
-    }
-
-    match route_manager.manager.get_job(None, &job_id).await {
         Ok(job) => Ok(HttpResponse::Ok().json(job)),
         Err(error) => {
-            error!("Fine-tuning retrieve error: {}", error);
-            Ok(fine_tuning_error_response(error))
+            error!(
+                "Fine-tuning retrieve error: {}",
+                fine_tuning_route_error_message(&error)
+            );
+            Ok(fine_tuning_route_error_response(error))
         }
     }
 }
@@ -148,24 +131,19 @@ pub async fn cancel_fine_tuning_job(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
-        Ok(route_manager) => route_manager,
-        Err(error) => {
-            error!("Fine-tuning cancel route configuration error: {}", error);
-            return Ok(openai_errors::gateway_error_response(&error));
-        }
-    };
-    if let Err(error) =
-        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    match execute_fine_tuning_route(state.get_ref(), "", move |provider| {
+        let job_id = job_id.clone();
+        async move { provider.cancel_job(&job_id).await }
+    })
+    .await
     {
-        return Ok(openai_errors::gateway_error_response(&error));
-    }
-
-    match route_manager.manager.cancel_job(None, &job_id).await {
         Ok(job) => Ok(HttpResponse::Ok().json(job)),
         Err(error) => {
-            error!("Fine-tuning cancel error: {}", error);
-            Ok(fine_tuning_error_response(error))
+            error!(
+                "Fine-tuning cancel error: {}",
+                fine_tuning_route_error_message(&error)
+            );
+            Ok(fine_tuning_route_error_response(error))
         }
     }
 }
@@ -181,28 +159,21 @@ pub async fn list_fine_tuning_events(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
-        Ok(route_manager) => route_manager,
-        Err(error) => {
-            error!("Fine-tuning events route configuration error: {}", error);
-            return Ok(openai_errors::gateway_error_response(&error));
-        }
-    };
-    if let Err(error) =
-        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
-    {
-        return Ok(openai_errors::gateway_error_response(&error));
-    }
-
-    match route_manager
-        .manager
-        .list_events(None, &job_id, query.into_inner())
-        .await
+    let query = query.into_inner();
+    match execute_fine_tuning_route(state.get_ref(), "", move |provider| {
+        let job_id = job_id.clone();
+        let query = query.clone();
+        async move { provider.list_events(&job_id, query).await }
+    })
+    .await
     {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(error) => {
-            error!("Fine-tuning events error: {}", error);
-            Ok(fine_tuning_error_response(error))
+            error!(
+                "Fine-tuning events error: {}",
+                fine_tuning_route_error_message(&error)
+            );
+            Ok(fine_tuning_route_error_response(error))
         }
     }
 }
@@ -217,70 +188,76 @@ pub async fn list_fine_tuning_checkpoints(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    let route_manager = match build_fine_tuning_manager(state.get_ref()).await {
-        Ok(route_manager) => route_manager,
-        Err(error) => {
-            error!(
-                "Fine-tuning checkpoints route configuration error: {}",
-                error
-            );
-            return Ok(openai_errors::gateway_error_response(&error));
-        }
-    };
-    if let Err(error) =
-        ensure_fine_tuning_budget(state.get_ref(), &route_manager.default_provider, "")
+    match execute_fine_tuning_route(state.get_ref(), "", move |provider| {
+        let job_id = job_id.clone();
+        async move { provider.list_checkpoints(&job_id).await }
+    })
+    .await
     {
-        return Ok(openai_errors::gateway_error_response(&error));
-    }
-
-    match route_manager.manager.list_checkpoints(None, &job_id).await {
         Ok(data) => Ok(HttpResponse::Ok().json(ListCheckpointsResponse {
             object: "list",
             data,
         })),
         Err(error) => {
-            error!("Fine-tuning checkpoints error: {}", error);
-            Ok(fine_tuning_error_response(error))
+            error!(
+                "Fine-tuning checkpoints error: {}",
+                fine_tuning_route_error_message(&error)
+            );
+            Ok(fine_tuning_route_error_response(error))
         }
     }
 }
 
-async fn build_fine_tuning_manager(
+async fn execute_fine_tuning_route<T, F, Fut>(
     state: &AppState,
-) -> Result<FineTuningRouteManager, GatewayError> {
-    let providers =
-        select_fine_tuning_route_providers(state.config().gateway.providers.as_slice())?;
-    let Some(default_provider) = providers.first().map(|provider| provider.name.clone()) else {
-        return Err(missing_fine_tuning_provider_error());
-    };
-
-    let provider_configs = providers
-        .iter()
-        .map(|provider| (provider.name.clone(), provider.config.clone()))
-        .collect();
-    let manager = FineTuningManager::new(FineTuningConfig {
-        enabled: true,
-        default_provider: Some(default_provider.clone()),
-        providers: provider_configs,
-        ..FineTuningConfig::default()
-    });
-
-    for provider in providers {
-        manager
-            .register_provider(
-                provider.name.clone(),
-                Arc::new(OpenAIFineTuningProvider::new_named(
-                    provider.config,
-                    provider.name,
-                )),
-            )
-            .await;
+    model: &str,
+    operation: F,
+) -> Result<T, FineTuningRouteError>
+where
+    F: Fn(OpenAIFineTuningProvider) -> Fut,
+    Fut: Future<Output = Result<T, FineTuningError>>,
+{
+    let config = state.config();
+    let provider_configs =
+        select_fine_tuning_route_provider_configs(config.gateway.providers.as_slice());
+    if provider_configs.is_empty() {
+        return Err(FineTuningRouteError::Gateway(
+            missing_fine_tuning_provider_error(),
+        ));
     }
 
-    Ok(FineTuningRouteManager {
-        manager,
-        default_provider,
-    })
+    let provider_count = provider_configs.len();
+    let mut last_error = None;
+    for (index, provider_config) in provider_configs.into_iter().enumerate() {
+        let is_last_provider = index + 1 == provider_count;
+        if let Err(error) = ensure_fine_tuning_budget(state, &provider_config.name, model) {
+            let error = FineTuningRouteError::Gateway(error);
+            if !is_last_provider && is_retryable_fine_tuning_route_error(&error) {
+                last_error = Some(error);
+                continue;
+            }
+            return Err(error);
+        }
+
+        let route_provider =
+            fine_tuning_route_provider(provider_config).map_err(FineTuningRouteError::Gateway)?;
+        let provider =
+            OpenAIFineTuningProvider::new_named(route_provider.config, route_provider.name);
+        match operation(provider).await {
+            Ok(response) => return Ok(response),
+            Err(error) => {
+                let error = FineTuningRouteError::FineTuning(error);
+                if !is_last_provider && is_retryable_fine_tuning_route_error(&error) {
+                    last_error = Some(error);
+                    continue;
+                }
+                return Err(error);
+            }
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| FineTuningRouteError::Gateway(missing_fine_tuning_provider_error())))
 }
 
 fn ensure_fine_tuning_budget(
@@ -292,14 +269,53 @@ fn ensure_fine_tuning_budget(
         .map_err(GatewayError::from)
 }
 
+fn is_retryable_fine_tuning_route_error(error: &FineTuningRouteError) -> bool {
+    match error {
+        FineTuningRouteError::Gateway(GatewayError::Provider(error)) => is_retryable_error(error),
+        FineTuningRouteError::Gateway(
+            GatewayError::Network(_)
+            | GatewayError::Timeout(_)
+            | GatewayError::Unavailable(_)
+            | GatewayError::RateLimit { .. },
+        ) => true,
+        FineTuningRouteError::FineTuning(error) => is_retryable_fine_tuning_error(error),
+        _ => false,
+    }
+}
+
+fn is_retryable_fine_tuning_error(error: &FineTuningError) -> bool {
+    match error {
+        FineTuningError::RateLimited { .. } | FineTuningError::Network { .. } => true,
+        FineTuningError::Provider { message } => {
+            let Some(status) = message
+                .strip_prefix("API error ")
+                .and_then(|tail| tail.split(':').next())
+                .and_then(|status| status.split_whitespace().next())
+                .and_then(|status| status.parse::<u16>().ok())
+            else {
+                return false;
+            };
+            matches!(status, 408 | 429 | 500 | 502 | 503 | 504 | 507 | 529)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
 fn select_fine_tuning_route_providers(
     providers: &[ProviderConfig],
 ) -> Result<Vec<FineTuningRouteProvider>, GatewayError> {
+    select_fine_tuning_route_provider_configs(providers)
+        .into_iter()
+        .map(fine_tuning_route_provider)
+        .collect()
+}
+
+fn select_fine_tuning_route_provider_configs(providers: &[ProviderConfig]) -> Vec<&ProviderConfig> {
     providers
         .iter()
         .filter(|provider| provider.enabled)
         .filter(|provider| is_openai_fine_tuning_provider(provider))
-        .map(fine_tuning_route_provider)
         .collect()
 }
 
@@ -411,6 +427,20 @@ fn missing_fine_tuning_provider_error() -> GatewayError {
     GatewayError::Config(
         "Fine-tuning API requires an enabled openai or openai_compatible provider".to_string(),
     )
+}
+
+fn fine_tuning_route_error_message(error: &FineTuningRouteError) -> String {
+    match error {
+        FineTuningRouteError::Gateway(error) => error.to_string(),
+        FineTuningRouteError::FineTuning(error) => error.to_string(),
+    }
+}
+
+fn fine_tuning_route_error_response(error: FineTuningRouteError) -> HttpResponse {
+    match error {
+        FineTuningRouteError::Gateway(error) => openai_errors::gateway_error_response(&error),
+        FineTuningRouteError::FineTuning(error) => fine_tuning_error_response(error),
+    }
 }
 
 fn fine_tuning_error_response(error: FineTuningError) -> HttpResponse {
@@ -561,5 +591,36 @@ mod tests {
         let error = validate_fine_tuning_job_id("../ftjob_123").unwrap_err();
 
         assert!(error.to_string().contains("safe path segment"));
+    }
+
+    #[test]
+    fn retryable_provider_api_statuses_are_detected() {
+        for status in [
+            "408 Request Timeout",
+            "429 Too Many Requests",
+            "500 Internal Server Error",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+            "504 Gateway Timeout",
+            "507 Insufficient Storage",
+            "529 Site is overloaded",
+        ] {
+            let error = FineTuningError::provider(format!("API error {status}: transient"));
+            assert!(
+                is_retryable_fine_tuning_error(&error),
+                "{status} should be retryable"
+            );
+        }
+
+        for status in ["400 Bad Request", "401 Unauthorized", "404 Not Found"] {
+            let error = FineTuningError::provider(format!("API error {status}: client error"));
+            assert!(
+                !is_retryable_fine_tuning_error(&error),
+                "{status} should not be retryable"
+            );
+        }
+
+        let malformed = FineTuningError::provider("API error unavailable: malformed");
+        assert!(!is_retryable_fine_tuning_error(&malformed));
     }
 }

--- a/tests/fine_tuning_routes.rs
+++ b/tests/fine_tuning_routes.rs
@@ -1,6 +1,10 @@
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use actix_web::{
+        App, HttpRequest, HttpResponse, HttpServer,
+        http::{Method, StatusCode},
+        test, web,
+    };
     use bytes::Bytes;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
@@ -23,6 +27,7 @@ mod tests {
     #[derive(Clone)]
     struct MockFineTuningState {
         captured_requests: Arc<Mutex<Vec<CapturedFineTuningRequest>>>,
+        failure_status: Option<StatusCode>,
     }
 
     struct MockFineTuningServer {
@@ -34,9 +39,18 @@ mod tests {
 
     impl MockFineTuningServer {
         async fn start() -> Self {
+            Self::start_with_status(None).await
+        }
+
+        async fn start_failing(status: StatusCode) -> Self {
+            Self::start_with_status(Some(status)).await
+        }
+
+        async fn start_with_status(failure_status: Option<StatusCode>) -> Self {
             let captured_requests = Arc::new(Mutex::new(Vec::new()));
             let state = MockFineTuningState {
                 captured_requests: Arc::clone(&captured_requests),
+                failure_status,
             };
             let listener =
                 std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -106,6 +120,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(job_json("ftjob_mock", "queued"))
     }
 
@@ -115,6 +132,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(json!({
             "object": "list",
             "data": [job_json("ftjob_mock", "running")],
@@ -128,6 +148,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(job_json("ftjob_mock", "running"))
     }
 
@@ -137,6 +160,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(job_json("ftjob_mock", "cancelled"))
     }
 
@@ -146,6 +172,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(json!({
             "object": "list",
             "data": [{
@@ -165,6 +194,9 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if let Some(response) = maybe_failure_response(&state, &request) {
+            return response;
+        }
         HttpResponse::Ok().json(json!({
             "object": "list",
             "data": [{
@@ -176,6 +208,19 @@ mod tests {
                 "created_at": 1710000002
             }]
         }))
+    }
+
+    fn maybe_failure_response(
+        state: &MockFineTuningState,
+        request: &HttpRequest,
+    ) -> Option<HttpResponse> {
+        state.failure_status.map(|status| {
+            HttpResponse::build(status).json(json!({
+                "error": {
+                    "message": format!("forced upstream {status} at {}", request.uri())
+                }
+            }))
+        })
     }
 
     fn job_json(id: &str, status: &str) -> Value {
@@ -263,6 +308,15 @@ mod tests {
                 }),
             ),
         ]);
+        provider
+    }
+
+    fn named_fine_tuning_provider(name: &str, base_url: &str) -> ProviderConfig {
+        let mut provider = fine_tuning_provider(base_url);
+        provider.name = name.to_string();
+        provider.organization = None;
+        provider.project = None;
+        provider.settings.clear();
         provider
     }
 
@@ -464,5 +518,191 @@ mod tests {
         );
 
         mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn fine_tuning_create_uses_fallback_when_primary_budget_exhausted() {
+        let primary = MockFineTuningServer::start().await;
+        let fallback = MockFineTuningServer::start().await;
+        let mut primary_provider =
+            named_fine_tuning_provider("primary-fine-tuning", &primary.base_url);
+        primary_provider.settings = HashMap::from([(
+            "headers".to_string(),
+            json!({
+                "invalid header name": "budget-skip"
+            }),
+        )]);
+        let state = build_test_state(vec![
+            primary_provider,
+            named_fine_tuning_provider("fallback-fine-tuning", &fallback.base_url),
+        ])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "primary-fine-tuning",
+            ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .providers
+            .record_provider_spend("primary-fine-tuning", 2.0);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/fine_tuning/jobs")
+                .set_json(json!({
+                    "model": "gpt-4o-mini",
+                    "training_file": "file-train"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["provider"], "fallback-fine-tuning");
+        assert!(
+            primary.requests().is_empty(),
+            "budget fallback must skip exhausted fine-tuning provider before upstream"
+        );
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), 1);
+        assert_eq!(fallback_requests[0].path, "/v1/fine_tuning/jobs");
+
+        primary.shutdown().await;
+        fallback.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn fine_tuning_routes_use_fallback_when_primary_upstream_fails() {
+        let primary = MockFineTuningServer::start_failing(StatusCode::SERVICE_UNAVAILABLE).await;
+        let fallback = MockFineTuningServer::start().await;
+        let state = build_test_state(vec![
+            named_fine_tuning_provider("primary-fine-tuning", &primary.base_url),
+            named_fine_tuning_provider("fallback-fine-tuning", &fallback.base_url),
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let scenarios = [
+            (
+                Method::POST,
+                "/v1/fine_tuning/jobs",
+                "/v1/fine_tuning/jobs",
+                "",
+            ),
+            (
+                Method::GET,
+                "/v1/fine_tuning/jobs?after=ftjob_prev&limit=1",
+                "/v1/fine_tuning/jobs",
+                "after=ftjob_prev&limit=1",
+            ),
+            (
+                Method::GET,
+                "/v1/fine_tuning/jobs/ftjob_mock",
+                "/v1/fine_tuning/jobs/ftjob_mock",
+                "",
+            ),
+            (
+                Method::POST,
+                "/v1/fine_tuning/jobs/ftjob_mock/cancel",
+                "/v1/fine_tuning/jobs/ftjob_mock/cancel",
+                "",
+            ),
+            (
+                Method::GET,
+                "/v1/fine_tuning/jobs/ftjob_mock/events?after=ftevent_prev&limit=2",
+                "/v1/fine_tuning/jobs/ftjob_mock/events",
+                "after=ftevent_prev&limit=2",
+            ),
+            (
+                Method::GET,
+                "/v1/fine_tuning/jobs/ftjob_mock/checkpoints",
+                "/v1/fine_tuning/jobs/ftjob_mock/checkpoints",
+                "",
+            ),
+        ];
+        for (method, uri, _, _) in &scenarios {
+            let mut request = test::TestRequest::with_uri(uri).method(method.clone());
+            if *uri == "/v1/fine_tuning/jobs" {
+                request = request.set_json(json!({
+                    "model": "gpt-4o-mini",
+                    "training_file": "file-train"
+                }));
+            }
+            let response = test::call_service(&app, request.to_request()).await;
+            assert!(
+                response.status().is_success(),
+                "{uri} should succeed via fallback, got {}",
+                response.status()
+            );
+        }
+
+        assert_eq!(primary.requests().len(), scenarios.len());
+        let fallback_requests = fallback.requests();
+        assert_eq!(fallback_requests.len(), scenarios.len());
+        assert_eq!(fallback_requests[0].body["training_file"], "file-train");
+        for (request, (method, _, path, query)) in fallback_requests.iter().zip(scenarios.iter()) {
+            assert_eq!(request.method, method.as_str());
+            assert_eq!(request.path, *path);
+            assert_eq!(request.query, *query);
+        }
+
+        primary.shutdown().await;
+        fallback.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn fine_tuning_route_does_not_validate_unreached_fallback_provider() {
+        let primary = MockFineTuningServer::start().await;
+        let mut broken_fallback =
+            named_fine_tuning_provider("broken-fine-tuning", "https://unused.invalid/v1");
+        broken_fallback.settings = HashMap::from([(
+            "headers".to_string(),
+            json!({
+                "invalid header name": "not reached"
+            }),
+        )]);
+        let state = build_test_state(vec![
+            named_fine_tuning_provider("primary-fine-tuning", &primary.base_url),
+            broken_fallback,
+        ])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/fine_tuning/jobs")
+                .set_json(json!({
+                    "model": "gpt-4o-mini",
+                    "training_file": "file-train"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let primary_requests = primary.requests();
+        assert_eq!(primary_requests.len(), 1);
+        assert_eq!(primary_requests[0].path, "/v1/fine_tuning/jobs");
+
+        primary.shutdown().await;
     }
 }


### PR DESCRIPTION
Refs #749

## Summary
- route fine-tuning lifecycle calls through ordered provider fallback
- skip exhausted providers before validating provider-specific config
- retry fallback providers on transient fine-tuning upstream errors

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked --message-format=short
- cargo test --all-features --locked server::routes::ai::fine_tuning --lib --quiet
- cargo test --all-features --locked --test fine_tuning_routes -- --nocapture
- cargo test --locked --no-default-features --features "postgres sqlite redis s3 metrics tracing websockets analytics" --test fine_tuning_routes -- --nocapture
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked --quiet -- --test-threads=1

## Threads review
- xhigh reviewer 019f16c1-7642-72d2-b25f-ca2147513305 found P1/P2; fixed
- xhigh reviewer 019f16c8-8bd5-7eb3-880b-daf5c5e24e2c found no P0/P1/P2 blockers