### PR TITLE
Fix benchmark router selection clippy failure

### DIFF
--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -97,7 +97,7 @@ fn bench_unified_router(c: &mut Criterion) {
                     router.add_deployment(deployment);
                 }
 
-                b.iter(|| black_box(router.select_deployment("gpt-4")));
+                b.iter(|| black_box(router.select_deployment_lease("gpt-4")));
             },
         );
     }
@@ -158,7 +158,7 @@ fn bench_unified_router(c: &mut Criterion) {
                     router.add_deployment(deployment);
                 }
 
-                b.iter(|| black_box(router.select_deployment("gpt-4")));
+                b.iter(|| black_box(router.select_deployment_lease("gpt-4")));
             },
         );
     }
@@ -220,7 +220,7 @@ fn bench_concurrent_router(c: &mut Criterion) {
                         for _ in 0..num_tasks {
                             let router = router.clone();
                             let handle = tokio::spawn(async move {
-                                let _ = router.select_deployment("gpt-4");
+                                let _ = router.select_deployment_lease("gpt-4");
                             });
                             handles.push(handle);
                         }
@@ -265,7 +265,7 @@ fn bench_concurrent_router(c: &mut Criterion) {
                                 } else if i % 3 == 1 {
                                     router.record_failure(&format!("deployment-{}", i % 10));
                                 } else {
-                                    let _ = router.select_deployment("gpt-4");
+                                    let _ = router.select_deployment_lease("gpt-4");
                                 }
                             });
                             handles.push(handle);


### PR DESCRIPTION
Closes #785

## Summary
- replace deprecated `select_deployment` benchmark calls with `select_deployment_lease`
- keep benchmark scope limited to router selection API usage

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo check --benches --features "postgres sqlite redis s3 metrics tracing websockets analytics" --message-format=short
- cargo check --message-format=short

## Threads review
- xhigh reviewer 019f16e6-3bf0-7913-b574-c67c954c2e4c found no P0/P1/P2 blockers