### PR TITLE
Fix budget enforcement gaps

### DIFF
--- a/src/server/routes/ai/audio/budgeting.rs
+++ b/src/server/routes/ai/audio/budgeting.rs
@@ -16,7 +16,7 @@ pub(super) fn audio_file_usage(file: &[u8], prompt: Option<&str>) -> PricingUsag
         .unwrap_or(u32::MAX)
         .max(1);
     let prompt_tokens = prompt.map(estimated_audio_text_tokens).unwrap_or(0);
-    let mut usage = PricingUsage::new(file_tokens.saturating_add(prompt_tokens), 0);
+    let mut usage = PricingUsage::new(prompt_tokens, 0);
     usage.audio_tokens = Some(file_tokens);
     usage
 }
@@ -117,4 +117,19 @@ fn estimated_audio_text_tokens(text: &str) -> u32 {
     u32::try_from(text.chars().count().div_ceil(4))
         .unwrap_or(u32::MAX)
         .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_file_usage_keeps_audio_tokens_out_of_total_tokens() {
+        let usage = audio_file_usage(&[0; 16], Some("guide"));
+
+        assert_eq!(usage.prompt_tokens, 2);
+        assert_eq!(usage.completion_tokens, 0);
+        assert_eq!(usage.total_tokens, 2);
+        assert_eq!(usage.audio_tokens, Some(4));
+    }
 }

--- a/src/server/routes/ai/audio/budgeting.rs
+++ b/src/server/routes/ai/audio/budgeting.rs
@@ -1,0 +1,120 @@
+use crate::core::budget::UnifiedBudgetLimits;
+use crate::core::keys::KeyManager;
+use crate::core::pricing_service::PricingService;
+use crate::core::pricing_service::PricingUsage;
+use crate::core::providers::ProviderError;
+
+const ESTIMATED_AUDIO_BYTES_PER_SECOND: usize = 16_000;
+
+pub(super) fn speech_usage(input: &str) -> PricingUsage {
+    let tokens = estimated_audio_text_tokens(input);
+    PricingUsage::new(tokens, tokens)
+}
+
+pub(super) fn audio_file_usage(file: &[u8], prompt: Option<&str>) -> PricingUsage {
+    let file_tokens = u32::try_from(file.len().div_ceil(4))
+        .unwrap_or(u32::MAX)
+        .max(1);
+    let prompt_tokens = prompt.map(estimated_audio_text_tokens).unwrap_or(0);
+    let mut usage = PricingUsage::new(file_tokens.saturating_add(prompt_tokens), 0);
+    usage.audio_tokens = Some(file_tokens);
+    usage
+}
+
+pub(super) fn estimated_audio_file_seconds(file: &[u8]) -> f64 {
+    file.len().max(1).div_ceil(ESTIMATED_AUDIO_BYTES_PER_SECOND) as f64
+}
+
+pub(super) fn reserve_audio_budget(
+    budget_limits: &UnifiedBudgetLimits,
+    provider: &str,
+    model: &str,
+    _usage: &PricingUsage,
+) -> Result<(), ProviderError> {
+    super::super::spend::ensure_budget_available(budget_limits, provider, model)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn record_audio_spend(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<uuid::Uuid>,
+    budget_provider: &str,
+    budget_model: &str,
+    pricing_provider: &str,
+    pricing_model: &str,
+    total_time_seconds: Option<f64>,
+    usage: &PricingUsage,
+) {
+    if let Some(total_time_seconds) = total_time_seconds
+        && pricing_service
+            .get_model_info_for_provider(pricing_provider, pricing_model)
+            .map(|(_, model_info)| model_info.cost_per_second.is_some())
+            .unwrap_or(false)
+    {
+        match pricing_service.calculate_loaded_completion_cost_for_provider(
+            pricing_provider,
+            pricing_model,
+            0,
+            0,
+            None,
+            None,
+            Some(total_time_seconds),
+        ) {
+            Ok(cost) => {
+                budget_limits.record_spend(budget_provider, budget_model, cost.total_cost);
+                record_key_usage(key_manager, api_key_id, usage, cost.total_cost).await;
+            }
+            Err(error) => {
+                tracing::error!(
+                    "time-based audio spend calculation failed for pricing provider \
+                     '{pricing_provider}' budget provider '{budget_provider}' model \
+                     '{budget_model}': {error}; skipping budget spend"
+                );
+                record_key_usage(key_manager, api_key_id, usage, 0.0).await;
+            }
+        }
+        return;
+    }
+
+    super::super::spend::record_pricing_usage_spend_with_reservation_with_pricing(
+        pricing_service,
+        budget_limits,
+        key_manager,
+        api_key_id,
+        budget_provider,
+        budget_model,
+        pricing_provider,
+        pricing_model,
+        usage,
+        None,
+    )
+    .await;
+}
+
+async fn record_key_usage(
+    key_manager: &KeyManager,
+    api_key_id: Option<uuid::Uuid>,
+    usage: &PricingUsage,
+    cost: f64,
+) {
+    if let Some(key_id) = api_key_id {
+        let total_tokens = usage
+            .total_tokens
+            .saturating_add(usage.audio_tokens.unwrap_or(0));
+        if let Err(error) = key_manager
+            .record_usage(key_id, u64::from(total_tokens), cost)
+            .await
+        {
+            tracing::error!("failed to record usage for key {key_id}: {error}");
+        }
+    }
+}
+
+fn estimated_audio_text_tokens(text: &str) -> u32 {
+    u32::try_from(text.chars().count().div_ceil(4))
+        .unwrap_or(u32::MAX)
+        .max(1)
+}

--- a/src/server/routes/ai/audio/mod.rs
+++ b/src/server/routes/ai/audio/mod.rs
@@ -1,5 +1,6 @@
 //! Audio endpoints (transcription, translation, speech)
 
+mod budgeting;
 mod speech;
 mod transcriptions;
 mod translations;

--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -70,6 +70,10 @@ pub async fn audio_speech(
 
     let requested_model = request.model.clone();
     let context_for_execution = context.clone();
+    let api_key_id = context.api_key_id();
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let pricing_service = state.pricing.clone();
 
     match execute_with_selected_deployment(
         &state.unified_router,
@@ -78,10 +82,41 @@ pub async fn audio_speech(
         move |provider, selected_model, _deployment_id| {
             let mut request = speech_request.clone();
             let context = context_for_execution.clone();
+            let budget_limits = budget_limits.clone();
+            let key_manager = key_manager.clone();
+            let pricing_service = pricing_service.clone();
             async move {
-                request.model = selected_model;
+                let usage = super::budgeting::speech_usage(&request.input);
+                super::budgeting::reserve_audio_budget(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                    &usage,
+                )?;
+                let budget_provider = provider.name().to_string();
+                let (pricing_provider, pricing_model) =
+                    super::super::spend::pricing_identity_for_provider(
+                        pricing_service.as_ref(),
+                        &provider,
+                        &selected_model,
+                    );
+                request.model = selected_model.clone();
                 let response = provider.text_to_speech(request, context).await?;
-                Ok((response, 0))
+                let tokens_used = u64::from(usage.total_tokens);
+                super::budgeting::record_audio_spend(
+                    pricing_service.as_ref(),
+                    &budget_limits,
+                    &key_manager,
+                    api_key_id,
+                    &budget_provider,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
+                    None,
+                    &usage,
+                )
+                .await;
+                Ok((response, tokens_used))
             }
         },
     )

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -142,6 +142,10 @@ pub async fn audio_transcriptions(
 
     let requested_model = model;
     let context_for_execution = context.clone();
+    let api_key_id = context.api_key_id();
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let pricing_service = state.pricing.clone();
 
     match execute_with_selected_deployment(
         &state.unified_router,
@@ -150,10 +154,44 @@ pub async fn audio_transcriptions(
         move |provider, selected_model, _deployment_id| {
             let mut request = transcription_request.clone();
             let context = context_for_execution.clone();
+            let budget_limits = budget_limits.clone();
+            let key_manager = key_manager.clone();
+            let pricing_service = pricing_service.clone();
             async move {
-                request.model = selected_model;
+                let usage =
+                    super::budgeting::audio_file_usage(&request.file, request.prompt.as_deref());
+                let total_time_seconds =
+                    super::budgeting::estimated_audio_file_seconds(&request.file);
+                super::budgeting::reserve_audio_budget(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                    &usage,
+                )?;
+                let budget_provider = provider.name().to_string();
+                let (pricing_provider, pricing_model) =
+                    super::super::spend::pricing_identity_for_provider(
+                        pricing_service.as_ref(),
+                        &provider,
+                        &selected_model,
+                    );
+                request.model = selected_model.clone();
                 let response = provider.audio_transcription(request, context).await?;
-                Ok((response, 0))
+                let tokens_used = u64::from(usage.total_tokens);
+                super::budgeting::record_audio_spend(
+                    pricing_service.as_ref(),
+                    &budget_limits,
+                    &key_manager,
+                    api_key_id,
+                    &budget_provider,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
+                    Some(total_time_seconds),
+                    &usage,
+                )
+                .await;
+                Ok((response, tokens_used))
             }
         },
     )

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -130,6 +130,10 @@ pub async fn audio_translations(
 
     let requested_model = model;
     let context_for_execution = context.clone();
+    let api_key_id = context.api_key_id();
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let pricing_service = state.pricing.clone();
 
     match execute_with_selected_deployment(
         &state.unified_router,
@@ -138,10 +142,44 @@ pub async fn audio_translations(
         move |provider, selected_model, _deployment_id| {
             let mut request = translation_request.clone();
             let context = context_for_execution.clone();
+            let budget_limits = budget_limits.clone();
+            let key_manager = key_manager.clone();
+            let pricing_service = pricing_service.clone();
             async move {
-                request.model = selected_model;
+                let usage =
+                    super::budgeting::audio_file_usage(&request.file, request.prompt.as_deref());
+                let total_time_seconds =
+                    super::budgeting::estimated_audio_file_seconds(&request.file);
+                super::budgeting::reserve_audio_budget(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                    &usage,
+                )?;
+                let budget_provider = provider.name().to_string();
+                let (pricing_provider, pricing_model) =
+                    super::super::spend::pricing_identity_for_provider(
+                        pricing_service.as_ref(),
+                        &provider,
+                        &selected_model,
+                    );
+                request.model = selected_model.clone();
                 let response = provider.audio_translation(request, context).await?;
-                Ok((response, 0))
+                let tokens_used = u64::from(usage.total_tokens);
+                super::budgeting::record_audio_spend(
+                    pricing_service.as_ref(),
+                    &budget_limits,
+                    &key_manager,
+                    api_key_id,
+                    &budget_provider,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
+                    Some(total_time_seconds),
+                    &usage,
+                )
+                .await;
+                Ok((response, tokens_used))
             }
         },
     )

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -1,6 +1,7 @@
 //! Embeddings endpoint
 
 use crate::core::models::openai::{EmbeddingRequest, EmbeddingResponse};
+use crate::core::pricing_service::PricingUsage;
 use crate::core::types::{
     context::RequestContext, embedding::EmbeddingInput,
     embedding::EmbeddingRequest as CoreEmbeddingRequest, model::ProviderCapability,
@@ -72,12 +73,11 @@ pub async fn handle_embedding_with_state(
     request: EmbeddingRequest,
     context: RequestContext,
 ) -> Result<EmbeddingResponse, GatewayError> {
-    let unified_router = &state.unified_router;
-    handle_embedding_internal(unified_router, request, context).await
+    handle_embedding_internal(state, request, context).await
 }
 
 async fn handle_embedding_internal(
-    unified_router: &crate::core::router::UnifiedRouter,
+    state: &AppState,
     request: EmbeddingRequest,
     context: RequestContext,
 ) -> Result<EmbeddingResponse, GatewayError> {
@@ -100,16 +100,43 @@ async fn handle_embedding_internal(
 
     let requested_model = core_request.model.clone();
     let context_for_execution = context.clone();
+    let api_key_id = context.api_key_id();
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let pricing_service = state.pricing.clone();
     let core_response = execute_with_selected_deployment(
-        unified_router,
+        &state.unified_router,
         &requested_model,
         ProviderCapability::Embeddings,
         move |provider, selected_model, _deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
+            let budget_limits = budget_limits.clone();
+            let key_manager = key_manager.clone();
+            let pricing_service = pricing_service.clone();
             async move {
+                super::spend::ensure_budget_available(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                )?;
+                let budget_provider = provider.name().to_string();
+                let (pricing_provider, pricing_model) = super::spend::pricing_identity_for_provider(
+                    pricing_service.as_ref(),
+                    &provider,
+                    &selected_model,
+                );
+                let budget_reservation = super::spend::reserve_embedding_budget_with_pricing(
+                    pricing_service.as_ref(),
+                    &budget_limits,
+                    &budget_provider,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
+                    &core_request.input,
+                )?;
                 let mut request_for_provider = core_request.clone();
-                request_for_provider.model = selected_model;
+                request_for_provider.model = selected_model.clone();
                 let response = provider
                     .create_embeddings(request_for_provider, context)
                     .await?;
@@ -118,6 +145,34 @@ async fn handle_embedding_internal(
                     .as_ref()
                     .map(|usage| u64::from(usage.total_tokens))
                     .unwrap_or_default();
+                if let Some(usage) = response.usage.as_ref() {
+                    let usage = PricingUsage::from(usage);
+                    super::spend::record_pricing_usage_spend_with_reservation_with_pricing(
+                        pricing_service.as_ref(),
+                        &budget_limits,
+                        &key_manager,
+                        api_key_id,
+                        &budget_provider,
+                        &selected_model,
+                        &pricing_provider,
+                        &pricing_model,
+                        &usage,
+                        budget_reservation,
+                    )
+                    .await;
+                } else {
+                    super::spend::record_completion_spend_with_reservation_with_pricing(
+                        pricing_service.as_ref(),
+                        &budget_limits,
+                        &key_manager,
+                        api_key_id,
+                        &budget_provider,
+                        &selected_model,
+                        None,
+                        budget_reservation,
+                    )
+                    .await;
+                }
                 Ok((response, tokens))
             }
         },

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -1,11 +1,12 @@
 //! Image API endpoints
 
 use crate::config::models::provider::ProviderConfig;
-use crate::core::models::openai::{ImageGenerationRequest, ImageGenerationResponse};
+mod generation;
+
+use crate::core::models::openai::ImageGenerationRequest;
 use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::{Provider, ProviderError};
 use crate::core::types::context::RequestContext;
-use crate::core::types::image::ImageGenerationRequest as CoreImageRequest;
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
@@ -65,7 +66,9 @@ pub async fn image_generations(
         &req,
         request.into_inner(),
         "Image generation",
-        |request, context| handle_image_generation_with_state(state.get_ref(), request, context),
+        |request, context| {
+            generation::handle_image_generation_with_state(state.get_ref(), request, context)
+        },
     )
     .await
 }
@@ -105,76 +108,6 @@ pub async fn image_variations(
             Ok(openai_errors::gateway_error_response(&error))
         }
     }
-}
-
-/// Handle image generation with app state (UnifiedRouter only)
-pub async fn handle_image_generation_with_state(
-    state: &AppState,
-    request: ImageGenerationRequest,
-    context: RequestContext,
-) -> Result<ImageGenerationResponse, GatewayError> {
-    let unified_router = &state.unified_router;
-    handle_image_generation_internal(unified_router, request, context).await
-}
-
-async fn handle_image_generation_internal(
-    unified_router: &crate::core::router::UnifiedRouter,
-    request: ImageGenerationRequest,
-    context: RequestContext,
-) -> Result<ImageGenerationResponse, GatewayError> {
-    let requested_model = request
-        .model
-        .clone()
-        .ok_or_else(|| GatewayError::validation("Model is required"))?;
-    if requested_model.trim().is_empty() {
-        return Err(GatewayError::validation("Model is required"));
-    }
-
-    let core_request = CoreImageRequest {
-        prompt: request.prompt,
-        model: Some(requested_model.clone()),
-        n: request.n,
-        size: request.size,
-        response_format: request.response_format,
-        user: request.user,
-        quality: None,
-        style: None,
-    };
-
-    let context_for_execution = context.clone();
-    let core_response = execute_with_selected_deployment(
-        unified_router,
-        &requested_model,
-        ProviderCapability::ImageGeneration,
-        move |provider, selected_model, _deployment_id| {
-            let core_request = core_request.clone();
-            let context = context_for_execution.clone();
-            async move {
-                let mut request_for_provider = core_request.clone();
-                request_for_provider.model = Some(selected_model);
-                let response = provider
-                    .create_images(request_for_provider, context)
-                    .await?;
-                Ok((response, 0))
-            }
-        },
-    )
-    .await?;
-
-    // Convert core response to OpenAI format
-    let response = ImageGenerationResponse {
-        created: core_response.created,
-        data: core_response
-            .data
-            .into_iter()
-            .map(|d| crate::core::models::openai::ImageObject {
-                url: d.url,
-                b64_json: d.b64_json,
-            })
-            .collect(),
-    };
-
-    Ok(response)
 }
 
 async fn proxy_image_multipart_endpoint(
@@ -343,7 +276,7 @@ fn estimated_image_proxy_usage(form_fields: &ImageProxyFormFields) -> PricingUsa
         form_fields.quality.as_deref(),
         form_fields.n,
     );
-    let mut usage = PricingUsage::new(prompt_tokens, image_tokens);
+    let mut usage = PricingUsage::new(prompt_tokens, 0);
     usage.image_tokens = Some(image_tokens);
     usage
 }

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -1,0 +1,129 @@
+use crate::core::models::openai::{ImageGenerationRequest, ImageGenerationResponse};
+use crate::core::pricing_service::PricingUsage;
+use crate::core::types::context::RequestContext;
+use crate::core::types::image::ImageGenerationRequest as CoreImageRequest;
+use crate::core::types::model::ProviderCapability;
+use crate::server::state::AppState;
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::super::execution::execute_with_selected_deployment;
+
+/// Handle image generation with app state (UnifiedRouter only)
+pub async fn handle_image_generation_with_state(
+    state: &AppState,
+    request: ImageGenerationRequest,
+    context: RequestContext,
+) -> Result<ImageGenerationResponse, GatewayError> {
+    let requested_model = request
+        .model
+        .clone()
+        .ok_or_else(|| GatewayError::validation("Model is required"))?;
+    if requested_model.trim().is_empty() {
+        return Err(GatewayError::validation("Model is required"));
+    }
+
+    let core_request = CoreImageRequest {
+        prompt: request.prompt,
+        model: Some(requested_model.clone()),
+        n: request.n,
+        size: request.size,
+        response_format: request.response_format,
+        user: request.user,
+        quality: None,
+        style: None,
+    };
+
+    let context_for_execution = context.clone();
+    let api_key_id = context.api_key_id();
+    let budget_limits = state.budget_limits.clone();
+    let key_manager = state.key_manager.clone();
+    let pricing_service = state.pricing.clone();
+    let core_response = execute_with_selected_deployment(
+        &state.unified_router,
+        &requested_model,
+        ProviderCapability::ImageGeneration,
+        move |provider, selected_model, _deployment_id| {
+            let core_request = core_request.clone();
+            let context = context_for_execution.clone();
+            let budget_limits = budget_limits.clone();
+            let key_manager = key_manager.clone();
+            let pricing_service = pricing_service.clone();
+            async move {
+                super::super::spend::ensure_budget_available(
+                    &budget_limits,
+                    provider.name(),
+                    &selected_model,
+                )?;
+                let budget_provider = provider.name().to_string();
+                let (pricing_provider, pricing_model) =
+                    super::super::spend::pricing_identity_for_provider(
+                        pricing_service.as_ref(),
+                        &provider,
+                        &selected_model,
+                    );
+                let usage = estimated_image_generation_usage(&core_request);
+                let budget_reservation =
+                    super::super::spend::reserve_pricing_usage_budget_with_pricing(
+                        pricing_service.as_ref(),
+                        &budget_limits,
+                        &budget_provider,
+                        &selected_model,
+                        &pricing_provider,
+                        &pricing_model,
+                        &usage,
+                    )?;
+                let mut request_for_provider = core_request.clone();
+                request_for_provider.model = Some(selected_model.clone());
+                let response = provider
+                    .create_images(request_for_provider, context)
+                    .await?;
+                let tokens_used = u64::from(
+                    usage
+                        .total_tokens
+                        .saturating_add(usage.image_tokens.unwrap_or(0)),
+                );
+                super::super::spend::record_pricing_usage_spend_with_reservation_with_pricing(
+                    pricing_service.as_ref(),
+                    &budget_limits,
+                    &key_manager,
+                    api_key_id,
+                    &budget_provider,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
+                    &usage,
+                    budget_reservation,
+                )
+                .await;
+                Ok((response, tokens_used))
+            }
+        },
+    )
+    .await?;
+
+    let response = ImageGenerationResponse {
+        created: core_response.created,
+        data: core_response
+            .data
+            .into_iter()
+            .map(|d| crate::core::models::openai::ImageObject {
+                url: d.url,
+                b64_json: d.b64_json,
+            })
+            .collect(),
+    };
+
+    Ok(response)
+}
+
+fn estimated_image_generation_usage(request: &CoreImageRequest) -> PricingUsage {
+    let prompt_tokens = super::estimated_text_tokens(&request.prompt);
+    let image_tokens = super::estimated_image_output_tokens(
+        request.size.as_deref(),
+        request.quality.as_deref(),
+        request.n.unwrap_or(1),
+    );
+    let mut usage = PricingUsage::new(prompt_tokens, 0);
+    usage.image_tokens = Some(image_tokens);
+    usage
+}

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -4,6 +4,8 @@
 //! path: once a completion succeeds and its token usage is known, the served
 //! provider/model budget spend and the calling key's usage are recorded.
 
+mod pricing;
+
 use uuid::Uuid;
 
 use crate::core::budget::{BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation};
@@ -18,6 +20,11 @@ use crate::core::types::responses::Usage;
 use crate::utils::ai::counter::token_counter::TokenCounter;
 #[cfg(test)]
 use std::sync::LazyLock;
+
+pub(super) use pricing::{
+    pricing_identity_for_provider, record_pricing_usage_spend_with_reservation_with_pricing,
+    reserve_embedding_budget_with_pricing, reserve_pricing_usage_budget_with_pricing,
+};
 
 const IMAGE_PROMPT_BASE_TOKENS: u32 = 85;
 const IMAGE_HIGH_DETAIL_PROMPT_TOKENS: u32 = 1_105;

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -1,0 +1,254 @@
+use uuid::Uuid;
+
+use crate::core::budget::{UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::keys::KeyManager;
+use crate::core::pricing_service::{PricingService, PricingUsage};
+use crate::core::providers::Provider;
+use crate::core::providers::provider_type::ProviderType;
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::embedding::EmbeddingInput;
+use crate::utils::ai::counter::token_counter::TokenCounter;
+
+pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
+    pricing_service: &PricingService,
+    provider: &Provider,
+    model: &str,
+) -> (String, String) {
+    let provider_name = provider.name();
+    let mut provider_candidates = vec![provider_name.to_string()];
+
+    match provider.provider_type() {
+        ProviderType::OpenAI => provider_candidates.push("openai".to_string()),
+        ProviderType::OpenAICompatible => {
+            provider_candidates.push("openai_like".to_string());
+            provider_candidates.push("openai".to_string());
+        }
+        ProviderType::Azure => provider_candidates.push("azure".to_string()),
+        ProviderType::AzureAI => provider_candidates.push("azure_ai".to_string()),
+        other => provider_candidates.push(other.to_string()),
+    }
+
+    let provider_candidates =
+        provider_candidates
+            .into_iter()
+            .fold(Vec::new(), |mut unique, candidate| {
+                if !unique.contains(&candidate) {
+                    unique.push(candidate);
+                }
+                unique
+            });
+
+    let mut model_candidates = vec![model.to_string()];
+    if let Provider::OpenAI(provider) = provider {
+        let mapped = provider.config.get_model_mapping(model);
+        if !model_candidates.contains(&mapped) {
+            model_candidates.insert(0, mapped);
+        }
+    }
+
+    for pricing_provider in &provider_candidates {
+        for pricing_model in &model_candidates {
+            if let Some((resolved_model, _)) =
+                pricing_service.get_model_info_for_provider(pricing_provider, pricing_model)
+            {
+                return (pricing_provider.clone(), resolved_model);
+            }
+        }
+    }
+
+    (provider_name.to_string(), model.to_string())
+}
+
+pub(in crate::server::routes::ai) fn reserve_embedding_budget_with_pricing(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    budget_provider: &str,
+    budget_model: &str,
+    pricing_provider: &str,
+    pricing_model: &str,
+    input: &EmbeddingInput,
+) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
+    let prompt_tokens = estimate_embedding_input_tokens(pricing_model, input);
+    reserve_completion_budget_with_split_pricing(
+        pricing_service,
+        budget_limits,
+        budget_provider,
+        budget_model,
+        pricing_provider,
+        pricing_model,
+        prompt_tokens,
+        Some(0),
+    )
+}
+
+pub(in crate::server::routes::ai) fn reserve_pricing_usage_budget_with_pricing(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    budget_provider: &str,
+    budget_model: &str,
+    pricing_provider: &str,
+    pricing_model: &str,
+    usage: &PricingUsage,
+) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
+    let cost = match pricing_service.calculate_loaded_usage_cost_for_provider(
+        pricing_provider,
+        pricing_model,
+        usage,
+    ) {
+        Ok(breakdown) => breakdown.total_cost,
+        Err(error) => {
+            tracing::error!(
+                "cost estimation failed for pricing provider '{pricing_provider}' budget provider \
+                 '{budget_provider}' model '{budget_model}': {error}; checking exhausted status without \
+                 reservation"
+            );
+            if super::pricing_required_for_budget(budget_limits, budget_provider, budget_model) {
+                return Err(ProviderError::invalid_request(
+                    "pricing",
+                    format!(
+                        "pricing is required for budget reservation for \
+                         '{budget_provider}'/'{budget_model}': {error}"
+                    ),
+                ));
+            }
+            super::ensure_budget_available(budget_limits, budget_provider, budget_model)?;
+            return Ok(None);
+        }
+    };
+
+    if cost <= 0.0 {
+        super::ensure_budget_available(budget_limits, budget_provider, budget_model)?;
+        return Ok(None);
+    }
+
+    budget_limits
+        .reserve_spend(budget_provider, budget_model, cost)
+        .map(Some)
+        .map_err(|error| {
+            super::reservation_error_to_provider_error(error, budget_provider, budget_model)
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::server::routes::ai) async fn record_pricing_usage_spend_with_reservation_with_pricing(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<Uuid>,
+    budget_provider: &str,
+    budget_model: &str,
+    pricing_provider: &str,
+    pricing_model: &str,
+    usage: &PricingUsage,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+) {
+    let cost = match pricing_service.calculate_loaded_usage_cost_for_provider(
+        pricing_provider,
+        pricing_model,
+        usage,
+    ) {
+        Ok(breakdown) => Some(breakdown.total_cost),
+        Err(error) => {
+            tracing::error!(
+                "cost calculation failed for pricing provider '{pricing_provider}' budget provider \
+                 '{budget_provider}' model '{budget_model}': {error}; recording token usage without cost \
+                 and skipping budget spend"
+            );
+            None
+        }
+    };
+
+    if let Some(cost) = cost {
+        if let Some(reservation) = budget_reservation {
+            if let Err(error) = reservation.settle(cost) {
+                tracing::error!(
+                    "failed to settle reserved budget for '{budget_provider}'/'{budget_model}': \
+                     {error:?}; spend not recorded because reservation settlement failed"
+                );
+            }
+        } else {
+            budget_limits.record_spend(budget_provider, budget_model, cost);
+        }
+    }
+
+    if let Some(key_id) = api_key_id {
+        let total_tokens = usage
+            .total_tokens
+            .saturating_add(usage.audio_tokens.unwrap_or(0))
+            .saturating_add(usage.image_tokens.unwrap_or(0));
+        if let Err(error) = key_manager
+            .record_usage(key_id, u64::from(total_tokens), cost.unwrap_or(0.0))
+            .await
+        {
+            tracing::error!("failed to record usage for key {key_id}: {error}");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn reserve_completion_budget_with_split_pricing(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    budget_provider: &str,
+    budget_model: &str,
+    pricing_provider: &str,
+    pricing_model: &str,
+    estimated_prompt_tokens: u32,
+    max_output_tokens: Option<u32>,
+) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
+    let estimate = match pricing_service.estimate_loaded_completion_cost_for_provider(
+        pricing_provider,
+        pricing_model,
+        estimated_prompt_tokens,
+        max_output_tokens,
+    ) {
+        Ok(estimate) => estimate,
+        Err(error) => {
+            tracing::error!(
+                "cost estimation failed for pricing provider '{pricing_provider}' budget provider \
+                 '{budget_provider}' model '{budget_model}': {error}; checking exhausted status without \
+                 reservation"
+            );
+            if super::pricing_required_for_budget(budget_limits, budget_provider, budget_model) {
+                return Err(ProviderError::invalid_request(
+                    "pricing",
+                    format!(
+                        "pricing is required for budget reservation for \
+                         '{budget_provider}'/'{budget_model}': {error}"
+                    ),
+                ));
+            }
+            super::ensure_budget_available(budget_limits, budget_provider, budget_model)?;
+            return Ok(None);
+        }
+    };
+
+    if estimate.max_cost <= 0.0 {
+        super::ensure_budget_available(budget_limits, budget_provider, budget_model)?;
+        return Ok(None);
+    }
+
+    budget_limits
+        .reserve_spend(budget_provider, budget_model, estimate.max_cost)
+        .map(Some)
+        .map_err(|error| {
+            super::reservation_error_to_provider_error(error, budget_provider, budget_model)
+        })
+}
+
+fn estimate_embedding_input_tokens(model: &str, input: &EmbeddingInput) -> u32 {
+    let counter = TokenCounter::new();
+    input.iter().fold(0u32, |total, text| {
+        let tokens = counter
+            .count_completion_tokens(model, text)
+            .map(|estimate| estimate.input_tokens)
+            .unwrap_or_else(|error| {
+                tracing::warn!(
+                    "embedding token estimation failed for model '{model}': {error}; \
+                     using fallback estimate"
+                );
+                u32::try_from(text.chars().count().div_ceil(4)).unwrap_or(u32::MAX)
+            });
+        total.saturating_add(tokens)
+    })
+}

--- a/tests/audio_routes.rs
+++ b/tests/audio_routes.rs
@@ -4,6 +4,8 @@ mod tests {
     use bytes::Bytes;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::pricing_service::LiteLLMModelInfo;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
     use std::collections::HashMap;
@@ -177,6 +179,58 @@ mod tests {
             .clone()
     }
 
+    fn add_test_audio_pricing(state: &litellm_rs::server::state::AppState, model: &str) {
+        state.pricing.add_custom_model(
+            model.to_string(),
+            LiteLLMModelInfo {
+                max_tokens: Some(4096),
+                max_input_tokens: Some(4096),
+                max_output_tokens: Some(4096),
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00002),
+                input_cost_per_character: None,
+                output_cost_per_character: None,
+                cost_per_second: None,
+                litellm_provider: "openai".to_string(),
+                mode: "audio_speech".to_string(),
+                supports_function_calling: Some(false),
+                supports_vision: Some(false),
+                supports_streaming: Some(false),
+                supports_parallel_function_calling: Some(false),
+                supports_system_message: Some(false),
+                extra: HashMap::new(),
+            },
+        );
+    }
+
+    fn add_test_time_audio_pricing(
+        state: &litellm_rs::server::state::AppState,
+        model: &str,
+        cost_per_second: f64,
+    ) {
+        state.pricing.add_custom_model(
+            model.to_string(),
+            LiteLLMModelInfo {
+                max_tokens: None,
+                max_input_tokens: None,
+                max_output_tokens: None,
+                input_cost_per_token: None,
+                output_cost_per_token: None,
+                input_cost_per_character: None,
+                output_cost_per_character: None,
+                cost_per_second: Some(cost_per_second),
+                litellm_provider: "openai".to_string(),
+                mode: "audio_transcription".to_string(),
+                supports_function_calling: Some(false),
+                supports_vision: Some(false),
+                supports_streaming: Some(false),
+                supports_parallel_function_calling: Some(false),
+                supports_system_message: Some(false),
+                extra: HashMap::new(),
+            },
+        );
+    }
+
     fn audio_multipart_body(
         boundary: &str,
         model: &str,
@@ -222,6 +276,12 @@ mod tests {
     async fn audio_transcriptions_route_executes_openai_provider() {
         let mock = MockAudioServer::start().await;
         let state = build_audio_state(&mock.base_url).await;
+        add_test_time_audio_pricing(&state, "whisper-1", 0.001);
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-audio",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(state))
@@ -229,6 +289,7 @@ mod tests {
         )
         .await;
         let boundary = "litellm-rs-audio-boundary";
+        let audio_content = vec![b'a'; 32_000];
 
         let req = test::TestRequest::post()
             .uri("/v1/audio/transcriptions")
@@ -240,7 +301,7 @@ mod tests {
                 boundary,
                 "whisper-1",
                 "sample.mp3",
-                b"audio-bytes",
+                &audio_content,
             ))
             .to_request();
         let resp = test::call_service(&app, req).await;
@@ -264,6 +325,15 @@ mod tests {
         assert!(multipart_body.contains("name=\"model\""));
         assert!(multipart_body.contains("whisper-1"));
         assert!(multipart_body.contains("filename=\"sample.mp3\""));
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("mock-openai-audio")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!(
+            (spent - 0.002).abs() < f64::EPSILON,
+            "successful time-priced transcription must record spend"
+        );
         mock.shutdown().await;
     }
 
@@ -271,6 +341,12 @@ mod tests {
     async fn audio_translations_route_executes_openai_provider() {
         let mock = MockAudioServer::start().await;
         let state = build_audio_state(&mock.base_url).await;
+        add_test_time_audio_pricing(&state, "whisper-1", 0.001);
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-audio",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(state))
@@ -278,6 +354,7 @@ mod tests {
         )
         .await;
         let boundary = "litellm-rs-audio-boundary";
+        let audio_content = vec![b'a'; 32_000];
 
         let req = test::TestRequest::post()
             .uri("/v1/audio/translations")
@@ -289,7 +366,7 @@ mod tests {
                 boundary,
                 "whisper-1",
                 "sample.mp3",
-                b"audio-bytes",
+                &audio_content,
             ))
             .to_request();
         let resp = test::call_service(&app, req).await;
@@ -304,6 +381,15 @@ mod tests {
         let multipart_body = String::from_utf8_lossy(&captured[0].body);
         assert!(multipart_body.contains("whisper-1"));
         assert!(multipart_body.contains("filename=\"sample.mp3\""));
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("mock-openai-audio")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!(
+            (spent - 0.002).abs() < f64::EPSILON,
+            "successful time-priced translation must record spend"
+        );
         mock.shutdown().await;
     }
 
@@ -311,6 +397,12 @@ mod tests {
     async fn audio_speech_route_executes_openai_provider() {
         let mock = MockAudioServer::start().await;
         let state = build_audio_state(&mock.base_url).await;
+        add_test_audio_pricing(&state, "tts-1");
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-audio",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(state))
@@ -348,6 +440,92 @@ mod tests {
         assert_eq!(forwarded["model"], "tts-1");
         assert_eq!(forwarded["input"], "hello from litellm rs");
         assert_eq!(forwarded["voice"], "alloy");
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("mock-openai-audio")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!(spent > 0.0, "successful audio speech must record spend");
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn audio_routes_reject_exhausted_provider_budget_before_upstream() {
+        assert_audio_budget_rejected("/v1/audio/transcriptions", "transcription").await;
+        assert_audio_budget_rejected("/v1/audio/translations", "translation").await;
+
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state(&mock.base_url).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-audio",
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .record_spend("mock-openai-audio", "tts-1", 0.01);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/audio/speech")
+            .set_json(json!({
+                "model": "tts-1",
+                "input": "hello from litellm rs",
+                "voice": "alloy"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            mock.requests().is_empty(),
+            "speech budget rejection must happen before upstream"
+        );
+        mock.shutdown().await;
+    }
+
+    async fn assert_audio_budget_rejected(uri: &str, route_name: &str) {
+        let mock = MockAudioServer::start().await;
+        let state = build_audio_state(&mock.base_url).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-audio",
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .record_spend("mock-openai-audio", "whisper-1", 0.01);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-audio-boundary";
+
+        let req = test::TestRequest::post()
+            .uri(uri)
+            .insert_header((
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(audio_multipart_body(
+                boundary,
+                "whisper-1",
+                "sample.mp3",
+                b"audio-bytes",
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            mock.requests().is_empty(),
+            "{route_name} budget rejection must happen before upstream"
+        );
         mock.shutdown().await;
     }
 

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -5,6 +5,7 @@ mod tests {
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::pricing_service::PricingUsage;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
     use std::collections::HashMap;
@@ -377,6 +378,24 @@ mod tests {
             "gpt-image-1-mini",
             ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
+        let mut edit_usage = PricingUsage::new(4, 0);
+        edit_usage.image_tokens = Some(1024);
+        let mut variation_usage = PricingUsage::new(1, 0);
+        variation_usage.image_tokens = Some(1024);
+        let expected_cost = state
+            .pricing
+            .calculate_loaded_usage_cost_for_provider("openai", "gpt-image-1-mini", &edit_usage)
+            .expect("edit image pricing should be available")
+            .total_cost
+            + state
+                .pricing
+                .calculate_loaded_usage_cost_for_provider(
+                    "openai",
+                    "gpt-image-1-mini",
+                    &variation_usage,
+                )
+                .expect("variation image pricing should be available")
+                .total_cost;
         let budget_limits = state.budget_limits.clone();
         let app = test::init_service(
             App::new()
@@ -450,21 +469,23 @@ mod tests {
         assert!(edit_multipart.contains("filename=\"input.png\""));
         let variation_multipart = String::from_utf8_lossy(&captured[1].body);
         assert!(variation_multipart.contains("filename=\"source.png\""));
+        let provider_spend = budget_limits
+            .providers
+            .get_provider_usage("mock-openai-compatible")
+            .expect("provider spend should be recorded")
+            .current_spend;
         assert!(
-            budget_limits
-                .providers
-                .get_provider_usage("mock-openai-compatible")
-                .expect("provider spend should be recorded")
-                .current_spend
-                > 0.0
+            (provider_spend - expected_cost).abs() < f64::EPSILON,
+            "image proxy spend must charge image tokens once"
         );
+        let model_spend = budget_limits
+            .models
+            .get_model_usage("gpt-image-1-mini")
+            .expect("model spend should be recorded")
+            .current_spend;
         assert!(
-            budget_limits
-                .models
-                .get_model_usage("gpt-image-1-mini")
-                .expect("model spend should be recorded")
-                .current_spend
-                > 0.0
+            (model_spend - expected_cost).abs() < f64::EPSILON,
+            "image proxy model spend must charge image tokens once"
         );
 
         mock.stop_image_mock().await;

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -5,6 +5,7 @@ mod tests {
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::pricing_service::PricingUsage;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
     use std::sync::{Arc, Mutex};
@@ -34,6 +35,10 @@ mod tests {
             let server = HttpServer::new(move || {
                 App::new()
                     .app_data(web::Data::new(state.clone()))
+                    .route(
+                        "/v1/images/generations",
+                        web::post().to(mock_image_generation),
+                    )
                     .route("/v1/images/edits", web::post().to(mock_image_edit))
             })
             .listen(listener)
@@ -86,6 +91,18 @@ mod tests {
         }))
     }
 
+    async fn mock_image_generation(
+        state: web::Data<MockImageState>,
+        request: HttpRequest,
+        _body: Bytes,
+    ) -> HttpResponse {
+        state.paths.lock().unwrap().push(request.path().to_string());
+        HttpResponse::Ok().json(json!({
+            "created": 1710000002,
+            "data": [{ "url": "https://images.example.test/generated.png" }]
+        }))
+    }
+
     async fn build_test_state(
         providers: Vec<ProviderConfig>,
     ) -> litellm_rs::server::state::AppState {
@@ -118,6 +135,31 @@ mod tests {
             models,
             ..ProviderConfig::default()
         }
+    }
+
+    fn openai_image_provider(name: &str, base_url: &str, models: Vec<String>) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(base_url.to_string()),
+            models,
+            ..ProviderConfig::default()
+        }
+    }
+
+    fn openai_image_provider_with_mapping(
+        name: &str,
+        base_url: &str,
+        alias: &str,
+        upstream_model: &str,
+    ) -> ProviderConfig {
+        let mut provider = openai_image_provider(name, base_url, vec![alias.to_string()]);
+        provider.settings.insert(
+            "model_mappings".to_string(),
+            json!({ alias: upstream_model }),
+        );
+        provider
     }
 
     fn image_edit_multipart_body(boundary: &str) -> Vec<u8> {
@@ -153,6 +195,107 @@ mod tests {
         body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
         body.extend_from_slice(content);
         body.extend_from_slice(b"\r\n");
+    }
+
+    #[tokio::test]
+    async fn image_generation_rejects_exhausted_provider_budget_before_upstream() {
+        let mock = MockImageServer::start().await;
+        let state = build_test_state(vec![openai_image_provider_with_mapping(
+            "openai-primary",
+            &mock.base_url,
+            "image-alias",
+            "gpt-image-1-mini",
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "openai-primary",
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .record_spend("openai-primary", "image-alias", 0.01);
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/generations")
+                .set_json(json!({
+                    "model": "image-alias",
+                    "prompt": "make an icon",
+                    "size": "1024x1024"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(
+            mock.paths().is_empty(),
+            "image generation budget rejection must happen before upstream"
+        );
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn image_generation_records_provider_spend_after_success() {
+        let mock = MockImageServer::start().await;
+        let state = build_test_state(vec![openai_image_provider_with_mapping(
+            "openai-primary",
+            &mock.base_url,
+            "image-alias",
+            "gpt-image-1-mini",
+        )])
+        .await;
+        state.budget_limits.providers.set_provider_limit(
+            "openai-primary",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let mut expected_usage = PricingUsage::new(3, 0);
+        expected_usage.image_tokens = Some(1024);
+        let expected_cost = state
+            .pricing
+            .calculate_loaded_usage_cost_for_provider("openai", "gpt-image-1-mini", &expected_usage)
+            .expect("image generation pricing should be available")
+            .total_cost;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/generations")
+                .set_json(json!({
+                    "model": "image-alias",
+                    "prompt": "make an icon",
+                    "size": "1024x1024"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.paths(), vec!["/v1/images/generations".to_string()]);
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("openai-primary")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!(
+            (spent - expected_cost).abs() < f64::EPSILON,
+            "successful image generation must record full image-token spend"
+        );
+        mock.stop().await;
     }
 
     #[tokio::test]

--- a/tests/integration/http_routes_tests.rs
+++ b/tests/integration/http_routes_tests.rs
@@ -9,6 +9,7 @@ mod tests {
     use actix_web::{App, HttpResponse, HttpServer, test, web};
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use litellm_rs::server::middleware::AuthMiddleware;
     use litellm_rs::server::routes;
@@ -341,6 +342,112 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0]["model"], "text-embedding-3-small");
         assert_ne!(requests[0]["model"], "body-model");
+    }
+
+    #[tokio::test]
+    async fn test_embeddings_rejects_exhausted_provider_budget_before_upstream() {
+        let captured_requests = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock server should have local address");
+        let captured_for_server = Arc::clone(&captured_requests);
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(Arc::clone(&captured_for_server)))
+                .route("/embeddings", web::post().to(mock_embeddings))
+        })
+        .listen(listener)
+        .expect("mock server should listen")
+        .run();
+        let handle = server.handle();
+        let task = tokio::spawn(server);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let state = build_openai_alias_state(&format!("http://{address}")).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai",
+            ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
+        );
+        state
+            .budget_limits
+            .record_spend("mock-openai", "text-embedding-3-small", 0.01);
+        let app = test::init_service(build_test_app(state)).await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/embeddings")
+            .set_json(serde_json::json!({
+                "model": "text-embedding-3-small",
+                "input": "hello"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        handle.stop(true).await;
+        let _ = task.await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(resp).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("provider 'mock-openai' budget exceeded")
+        );
+        assert!(
+            captured_requests.lock().unwrap().is_empty(),
+            "budget rejection must happen before upstream embedding call"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_embeddings_record_provider_spend_after_success() {
+        let captured_requests = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock server should have local address");
+        let captured_for_server = Arc::clone(&captured_requests);
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(Arc::clone(&captured_for_server)))
+                .route("/embeddings", web::post().to(mock_embeddings))
+        })
+        .listen(listener)
+        .expect("mock server should listen")
+        .run();
+        let handle = server.handle();
+        let task = tokio::spawn(server);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let state = build_openai_alias_state(&format!("http://{address}")).await;
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = Arc::clone(&state.budget_limits);
+        let app = test::init_service(build_test_app(state)).await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/embeddings")
+            .set_json(serde_json::json!({
+                "model": "text-embedding-3-small",
+                "input": "hello"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        handle.stop(true).await;
+        let _ = task.await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(captured_requests.lock().unwrap().len(), 1);
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("mock-openai")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!(spent > 0.0, "successful embedding usage must record spend");
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add budget preflight, reservation, and spend settlement for embeddings and image generation
- record audio route spend after successful speech/transcription/translation calls, including time-priced audio models
- split budget identity from pricing identity so custom OpenAI deployment aliases still price against upstream catalog models
- prevent image token double-counting in generation and image edit/variation proxy paths

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked --message-format=short
- cargo test --all-features --locked test_embeddings --test lib -- --nocapture
- cargo test --all-features --locked image_generation --test image_router_fallback_routes -- --nocapture
- cargo test --all-features --locked audio_transcriptions_route_executes_openai_provider --test audio_routes -- --nocapture
- cargo test --all-features --locked audio_translations_route_executes_openai_provider --test audio_routes -- --nocapture
- cargo test --all-features --locked image_edit_and_variation_routes_proxy_openai_compatible_provider --test image_edit_variation_routes -- --nocapture
- cargo test --all-features --locked audio_routes_reject_exhausted_provider_budget_before_upstream --test audio_routes -- --nocapture
- cargo test --all-features --locked audio_speech_route_executes_openai_provider --test audio_routes -- --nocapture
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked --quiet -- --test-threads=1

Fixes #750