### PR TITLE
Fix API key policy enforcement parity

### DIFF
--- a/src/auth/api_key/management.rs
+++ b/src/auth/api_key/management.rs
@@ -14,7 +14,7 @@ impl ApiKeyHandler {
     /// Look up an API key by ID and invalidate its Redis cache entry.
     /// Errors are logged but not propagated so the caller's primary
     /// mutation is never blocked by a cache failure.
-    async fn invalidate_cache_for_key_id(&self, key_id: Uuid) {
+    pub async fn invalidate_cache_for_key_id(&self, key_id: Uuid) {
         match self.storage.db().find_api_key_by_id(key_id).await {
             Ok(Some(key)) => self.invalidate_api_key_cache(&key.key_hash).await,
             Ok(None) => {

--- a/src/auth/system.rs
+++ b/src/auth/system.rs
@@ -9,6 +9,7 @@ use crate::storage::StorageLayer;
 use crate::utils::error::gateway_error::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
+use uuid::Uuid;
 
 /// Main authentication system
 #[derive(Clone)]
@@ -160,6 +161,11 @@ impl AuthSystem {
         match self.api_key.verify_key(key).await {
             Ok(Some((api_key, user))) => {
                 context.set_api_key_id(api_key.metadata.id);
+                if let Some(budget_id) = api_key_budget_id(&api_key) {
+                    context.set_api_key_budget_id(budget_id);
+                } else {
+                    context.clear_api_key_budget_id();
+                }
                 context.user_id = api_key.user_id.map(|id| id.to_string());
                 if let Some(team_id) = api_key.team_id {
                     context.set_team_id(team_id);
@@ -290,4 +296,14 @@ impl AuthSystem {
     pub fn rbac(&self) -> &crate::auth::rbac::RbacSystem {
         &self.rbac
     }
+}
+
+fn api_key_budget_id(api_key: &crate::core::models::ApiKey) -> Option<Uuid> {
+    api_key
+        .metadata
+        .extra
+        .get("__core_keys")
+        .and_then(|value| value.get("budget_id"))
+        .and_then(|value| value.as_str())
+        .and_then(|value| Uuid::parse_str(value).ok())
 }

--- a/src/core/keys/types.rs
+++ b/src/core/keys/types.rs
@@ -428,6 +428,9 @@ pub struct KeyInfo {
     /// Team ID
     pub team_id: Option<Uuid>,
 
+    /// Associated budget ID for spend tracking
+    pub budget_id: Option<Uuid>,
+
     /// Current status
     pub status: KeyStatus,
 
@@ -459,6 +462,7 @@ impl From<&ManagedApiKey> for KeyInfo {
             description: key.description.clone(),
             user_id: key.user_id,
             team_id: key.team_id,
+            budget_id: key.budget_id,
             status: key.effective_status(),
             permissions: key.permissions.clone(),
             rate_limits: key.rate_limits.clone(),

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -190,15 +190,15 @@ impl RateLimiter {
 
         match self.config.strategy {
             RateLimitStrategy::SlidingWindow => {
-                self.check_sliding_window_impl(key, false, Instant::now())
+                self.check_sliding_window_impl(key, self.config.default_rpm, false, Instant::now())
                     .await
             }
             RateLimitStrategy::TokenBucket => {
-                self.check_token_bucket_impl(key, false, Instant::now())
+                self.check_token_bucket_impl(key, self.config.default_rpm, false, Instant::now())
                     .await
             }
             RateLimitStrategy::FixedWindow => {
-                self.check_fixed_window_impl(key, false, Instant::now())
+                self.check_fixed_window_impl(key, self.config.default_rpm, false, Instant::now())
                     .await
             }
         }
@@ -217,6 +217,16 @@ impl RateLimiter {
         &self,
         key: &str,
     ) -> (RateLimitResult, RateLimitReservation) {
+        self.check_and_record_with_source_and_limit(key, self.config.default_rpm)
+            .await
+    }
+
+    /// Atomically check and record a request with a per-request RPM limit.
+    pub(crate) async fn check_and_record_with_source_and_limit(
+        &self,
+        key: &str,
+        requests_per_minute: u32,
+    ) -> (RateLimitResult, RateLimitReservation) {
         if !self.config.enabled {
             let recorded_at = Instant::now();
             return (
@@ -228,7 +238,7 @@ impl RateLimiter {
         #[cfg(feature = "gateway")]
         if let Some(redis) = &self.redis {
             match redis
-                .rate_limit_check_and_record(key, self.config.default_rpm, self.window.as_secs())
+                .rate_limit_check_and_record(key, requests_per_minute, self.window.as_secs())
                 .await
             {
                 Ok(result) => {
@@ -257,7 +267,9 @@ impl RateLimiter {
         }
 
         let recorded_at = Instant::now();
-        let result = self.check_and_record_local(key, recorded_at).await;
+        let result = self
+            .check_and_record_local(key, recorded_at, requests_per_minute)
+            .await;
         let reservation = if result.allowed {
             let reset_after_secs = self.local_reservation_reset_after_secs(&result);
             RateLimitReservation::new(RateLimitRecordSource::Local, recorded_at, reset_after_secs)
@@ -267,16 +279,24 @@ impl RateLimiter {
         (result, reservation)
     }
 
-    async fn check_and_record_local(&self, key: &str, recorded_at: Instant) -> RateLimitResult {
+    async fn check_and_record_local(
+        &self,
+        key: &str,
+        recorded_at: Instant,
+        requests_per_minute: u32,
+    ) -> RateLimitResult {
         match self.config.strategy {
             RateLimitStrategy::SlidingWindow => {
-                self.check_sliding_window_impl(key, true, recorded_at).await
+                self.check_sliding_window_impl(key, requests_per_minute, true, recorded_at)
+                    .await
             }
             RateLimitStrategy::TokenBucket => {
-                self.check_token_bucket_impl(key, true, recorded_at).await
+                self.check_token_bucket_impl(key, requests_per_minute, true, recorded_at)
+                    .await
             }
             RateLimitStrategy::FixedWindow => {
-                self.check_fixed_window_impl(key, true, recorded_at).await
+                self.check_fixed_window_impl(key, requests_per_minute, true, recorded_at)
+                    .await
             }
         }
     }

--- a/src/core/rate_limiter/strategies.rs
+++ b/src/core/rate_limiter/strategies.rs
@@ -11,11 +11,11 @@ impl RateLimiter {
     pub(super) async fn check_sliding_window_impl(
         &self,
         key: &str,
+        limit: u32,
         record: bool,
         now: Instant,
     ) -> RateLimitResult {
         let window_start = now - self.window;
-        let limit = self.config.default_rpm;
 
         let mut entry = self.entries.entry(key.to_string()).or_default();
 
@@ -71,10 +71,10 @@ impl RateLimiter {
     pub(super) async fn check_token_bucket_impl(
         &self,
         key: &str,
+        limit: u32,
         record: bool,
         now: Instant,
     ) -> RateLimitResult {
-        let limit = self.config.default_rpm;
         let tokens_per_second = limit as f64 / 60.0;
 
         let mut entry = self
@@ -139,11 +139,10 @@ impl RateLimiter {
     pub(super) async fn check_fixed_window_impl(
         &self,
         key: &str,
+        limit: u32,
         record: bool,
         now: Instant,
     ) -> RateLimitResult {
-        let limit = self.config.default_rpm;
-
         let mut entry = self.entries.entry(key.to_string()).or_default();
 
         if entry.timestamps.is_empty() {

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -159,6 +159,22 @@ async fn test_atomic_check_and_record() {
 }
 
 #[tokio::test]
+async fn test_check_and_record_with_source_and_limit_uses_override_rpm() {
+    let limiter = RateLimiter::new(test_config(true, 10));
+
+    let (first, _) = limiter
+        .check_and_record_with_source_and_limit("api-key", 1)
+        .await;
+    let (second, _) = limiter
+        .check_and_record_with_source_and_limit("api-key", 1)
+        .await;
+
+    assert!(first.allowed);
+    assert!(!second.allowed);
+    assert_eq!(second.limit, 1);
+}
+
+#[tokio::test]
 async fn test_release_recorded_local_source_restores_capacity() {
     let limiter = RateLimiter::new(test_config(true, 1));
 

--- a/src/core/types/context.rs
+++ b/src/core/types/context.rs
@@ -6,6 +6,8 @@ use uuid::Uuid;
 
 const TEAM_ID_METADATA_KEY: &str = "team_id";
 const API_KEY_ID_METADATA_KEY: &str = "api_key_id";
+const API_KEY_BUDGET_ID_METADATA_KEY: &str = "api_key_budget_id";
+const API_KEY_MAX_TOKENS_PER_REQUEST_KEY: &str = "api_key_max_tokens_per_request";
 
 /// Request context for tracking and metadata
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -72,6 +74,12 @@ impl RequestContext {
     /// Set API key information.
     pub fn with_api_key(mut self, api_key_id: Uuid) -> Self {
         self.set_api_key_id(api_key_id);
+        self
+    }
+
+    /// Set API key budget information.
+    pub fn with_api_key_budget(mut self, budget_id: Uuid) -> Self {
+        self.set_api_key_budget_id(budget_id);
         self
     }
 
@@ -165,6 +173,48 @@ impl RequestContext {
     /// Remove API key ID from metadata.
     pub fn clear_api_key_id(&mut self) {
         self.metadata.remove(API_KEY_ID_METADATA_KEY);
+    }
+
+    /// Set API key budget ID in metadata.
+    pub fn set_api_key_budget_id(&mut self, budget_id: Uuid) {
+        self.metadata.insert(
+            API_KEY_BUDGET_ID_METADATA_KEY.to_string(),
+            serde_json::json!(budget_id.to_string()),
+        );
+    }
+
+    /// Get API key budget ID from metadata.
+    pub fn api_key_budget_id(&self) -> Option<Uuid> {
+        self.metadata
+            .get(API_KEY_BUDGET_ID_METADATA_KEY)
+            .and_then(|value| value.as_str())
+            .and_then(|value| Uuid::parse_str(value).ok())
+    }
+
+    /// Remove API key budget ID from metadata.
+    pub fn clear_api_key_budget_id(&mut self) {
+        self.metadata.remove(API_KEY_BUDGET_ID_METADATA_KEY);
+    }
+
+    /// Set API key max output token policy in metadata.
+    pub fn set_api_key_max_tokens_per_request(&mut self, max_tokens: u32) {
+        self.metadata.insert(
+            API_KEY_MAX_TOKENS_PER_REQUEST_KEY.to_string(),
+            serde_json::json!(max_tokens),
+        );
+    }
+
+    /// Get API key max output token policy from metadata.
+    pub fn api_key_max_tokens_per_request(&self) -> Option<u32> {
+        self.metadata
+            .get(API_KEY_MAX_TOKENS_PER_REQUEST_KEY)
+            .and_then(|value| value.as_u64())
+            .and_then(|value| u32::try_from(value).ok())
+    }
+
+    /// Remove API key max output token policy from metadata.
+    pub fn clear_api_key_max_tokens_per_request(&mut self) {
+        self.metadata.remove(API_KEY_MAX_TOKENS_PER_REQUEST_KEY);
     }
 
     /// Get elapsed time

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -188,6 +188,8 @@ impl HttpServer {
         let cors_config = &cfg.gateway.server.cors;
         let rate_limit_enabled = cfg.gateway.rate_limit.enabled;
         let rate_limit_rpm = cfg.gateway.rate_limit.default_rpm;
+        let api_key_auth_enabled = cfg.gateway.auth.enable_api_key;
+        let default_rate_limit_rpm = rate_limit_enabled.then_some(rate_limit_rpm);
         let cors = Self::build_cors_for_app_factory(cors_config);
 
         let budget_limits = web::Data::new(Arc::clone(&state.budget_limits));
@@ -203,8 +205,8 @@ impl HttpServer {
             // limiter before auth so successful auth context is available when
             // rate-limit keys are chosen.
             .wrap(Condition::new(
-                rate_limit_enabled,
-                RateLimitMiddleware::new(rate_limit_rpm),
+                rate_limit_enabled || api_key_auth_enabled,
+                RateLimitMiddleware::optional(default_rate_limit_rpm),
             ))
             .wrap(AuthMiddleware)
             .wrap(RequestIdMiddleware)

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -11,6 +11,7 @@ use crate::server::middleware::rate_limit::{
     AuthRateLimitReservation, enforce_rate_limit_for_rejected_auth,
     reserve_rate_limit_for_auth_attempt,
 };
+use crate::server::routes::ai::{api_key_allows_endpoint, check_permission};
 use crate::server::state::AppState;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{HttpMessage, HttpRequest, web};
@@ -197,6 +198,35 @@ where
                     rate_limiter.record_success(&client_id);
                     debug!("Authentication succeeded");
 
+                    if let Some(operation) = ai_operation_for_path(req.path())
+                        && !check_permission(
+                            result.user.as_ref(),
+                            result.api_key.as_ref(),
+                            operation,
+                        )
+                    {
+                        warn!(
+                            "Authenticated caller is not permitted to access AI operation '{}'",
+                            operation
+                        );
+                        return Err(actix_web::error::ErrorForbidden(
+                            "API key is not permitted for this operation",
+                        ));
+                    }
+                    match api_key_allows_endpoint(result.api_key.as_ref(), req.path()) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            warn!("Authenticated API key is not permitted to access this endpoint");
+                            return Err(actix_web::error::ErrorForbidden(
+                                "API key is not permitted for this endpoint",
+                            ));
+                        }
+                        Err(error) => {
+                            warn!("Authenticated API key policy is invalid: {}", error);
+                            return Err(actix_web::error::ErrorForbidden(error.to_string()));
+                        }
+                    }
+
                     req.extensions_mut().insert(result.context.clone());
                     if let Some(user) = result.user {
                         req.extensions_mut().insert::<User>(user);
@@ -312,6 +342,74 @@ fn parse_peer_ip(peer: &str) -> String {
 fn hash_credential(credential: &str) -> String {
     use sha2::{Digest, Sha256};
     format!("{:x}", Sha256::digest(credential.as_bytes()))
+}
+
+fn ai_operation_for_path(path: &str) -> Option<&'static str> {
+    let normalized = path.trim_end_matches('/');
+
+    if normalized == "/v1/chat/completions"
+        || (normalized.starts_with("/v1/engines/") && normalized.ends_with("/chat/completions"))
+        || (normalized.starts_with("/openai/deployments/")
+            && normalized.ends_with("/chat/completions"))
+    {
+        return Some("chat");
+    }
+    if normalized == "/completions"
+        || normalized == "/v1/completions"
+        || (normalized.starts_with("/engines/") && normalized.ends_with("/completions"))
+        || (normalized.starts_with("/v1/engines/") && normalized.ends_with("/completions"))
+        || (normalized.starts_with("/openai/deployments/") && normalized.ends_with("/completions"))
+    {
+        return Some("completions");
+    }
+    if normalized == "/v1/embeddings"
+        || (normalized.starts_with("/v1/engines/") && normalized.ends_with("/embeddings"))
+        || (normalized.starts_with("/openai/deployments/") && normalized.ends_with("/embeddings"))
+    {
+        return Some("embeddings");
+    }
+    if normalized.starts_with("/v1/images/") {
+        return Some("images");
+    }
+    if normalized.starts_with("/v1/audio/") {
+        return Some("audio");
+    }
+    if normalized == "/moderations" || normalized == "/v1/moderations" {
+        return Some("moderations");
+    }
+    if normalized == "/rerank" || normalized == "/v1/rerank" {
+        return Some("rerank");
+    }
+    if normalized == "/v1/files" || normalized.starts_with("/v1/files/") {
+        return Some("files");
+    }
+    if normalized == "/v1/fine_tuning/jobs" || normalized.starts_with("/v1/fine_tuning/jobs/") {
+        return Some("fine_tuning");
+    }
+    if normalized == "/v1/models" || normalized == "/v1/engines" {
+        return Some("models");
+    }
+    if normalized.starts_with("/v1/models/") || normalized.starts_with("/v1/engines/") {
+        if normalized.contains(":generateContent") || normalized.contains(":streamGenerateContent")
+        {
+            return Some("chat");
+        }
+        return Some("models");
+    }
+    if normalized == "/v1/responses" || normalized.starts_with("/v1/responses/") {
+        return Some("responses");
+    }
+    if normalized == "/v1/batches" || normalized.starts_with("/v1/batches/") {
+        return Some("batches");
+    }
+    if normalized.starts_with("/v1beta/models/")
+        || normalized.starts_with("/gemini/v1beta/models/")
+        || normalized.starts_with("/gemini/v1/models/")
+    {
+        return Some("chat");
+    }
+
+    None
 }
 
 fn build_request_context(req: &mut ServiceRequest) -> RequestContext {

--- a/src/server/middleware/mod.rs
+++ b/src/server/middleware/mod.rs
@@ -14,6 +14,7 @@ mod auth_rate_limiter;
 mod helpers;
 mod metrics;
 mod rate_limit;
+mod rate_limit_key_policy;
 mod request_id;
 mod security;
 

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -1,5 +1,6 @@
 //! Rate limiting middleware
 
+use super::rate_limit_key_policy::effective_requests_per_minute;
 use crate::core::rate_limiter::{RateLimitReservation, get_global_rate_limiter};
 use crate::core::types::context::RequestContext;
 use crate::server::state::AppState;
@@ -174,20 +175,21 @@ async fn check_rate_limit_key(
     fallback_store: &DashMap<String, KeyTracker>,
 ) -> Result<RateLimitPass, RateLimitRejection> {
     if let Some(global_limiter) = get_global_rate_limiter() {
-        let limit = global_limiter.limit();
-        let (result, reservation) = global_limiter.check_and_record_with_source(key).await;
+        let (result, reservation) = global_limiter
+            .check_and_record_with_source_and_limit(key, requests_per_minute)
+            .await;
 
         if !result.allowed {
             return Err(RateLimitRejection {
                 source: GLOBAL_LIMITER_SOURCE,
                 retry_after: result.retry_after_secs.unwrap_or(60),
-                limit,
+                limit: requests_per_minute,
             });
         }
 
         return Ok(RateLimitPass {
             source: GLOBAL_LIMITER_SOURCE,
-            limit,
+            limit: requests_per_minute,
             remaining: result.remaining,
             reservation: RecordedRateLimitReservation::Global(reservation),
         });
@@ -352,11 +354,17 @@ impl ResponseError for RateLimitError {
 
 /// Rate limit middleware for Actix-web
 pub struct RateLimitMiddleware {
-    requests_per_minute: u32,
+    requests_per_minute: Option<u32>,
 }
 
 impl RateLimitMiddleware {
     pub fn new(requests_per_minute: u32) -> Self {
+        Self {
+            requests_per_minute: Some(requests_per_minute),
+        }
+    }
+
+    pub fn optional(requests_per_minute: Option<u32>) -> Self {
         Self {
             requests_per_minute,
         }
@@ -393,7 +401,7 @@ where
 /// Service implementation for rate limit middleware
 pub struct RateLimitMiddlewareService<S> {
     service: S,
-    requests_per_minute: u32,
+    requests_per_minute: Option<u32>,
     /// Fallback in-process store used when the global rate limiter is not initialized
     fallback_store: Arc<DashMap<String, KeyTracker>>,
 }
@@ -475,12 +483,12 @@ where
             }
             None => Vec::new(),
         };
-        let requests_per_minute = self.requests_per_minute;
         let start_time = Instant::now();
         let path = req.path().to_string();
         let method = req.method().to_string();
 
         let client_key = extract_client_key(&req, &trusted_proxies);
+        let requests_per_minute = effective_requests_per_minute(&req, self.requests_per_minute);
 
         let fallback_store = self.fallback_store.clone();
         // service.call() returns a lazy future; it only executes on .await.
@@ -490,32 +498,34 @@ where
         let key = client_key.clone();
 
         Box::pin(async move {
-            let pass = match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await
-            {
-                Ok(pass) => pass,
-                Err(rejection) => {
-                    warn!(
-                        client = %key,
-                        path = %path,
-                        "Rate limit exceeded ({} limiter): retry after {}s",
-                        rejection.source,
-                        rejection.retry_after
-                    );
-                    let err = RateLimitError {
-                        retry_after: rejection.retry_after,
-                        limit: rejection.limit,
+            if let Some(requests_per_minute) = requests_per_minute {
+                let pass =
+                    match check_rate_limit_key(&key, requests_per_minute, &fallback_store).await {
+                        Ok(pass) => pass,
+                        Err(rejection) => {
+                            warn!(
+                                client = %key,
+                                path = %path,
+                                "Rate limit exceeded ({} limiter): retry after {}s",
+                                rejection.source,
+                                rejection.retry_after
+                            );
+                            let err = RateLimitError {
+                                retry_after: rejection.retry_after,
+                                limit: rejection.limit,
+                            };
+                            return Err(actix_web::Error::from(err));
+                        }
                     };
-                    return Err(actix_web::Error::from(err));
-                }
-            };
 
-            debug!(
-                client = %key,
-                limit = pass.limit,
-                remaining = pass.remaining,
-                "Rate limit check passed ({} limiter)",
-                pass.source
-            );
+                debug!(
+                    client = %key,
+                    limit = pass.limit,
+                    remaining = pass.remaining,
+                    "Rate limit check passed ({} limiter)",
+                    pass.source
+                );
+            }
 
             let res = fut.await?;
             let duration = start_time.elapsed();
@@ -532,249 +542,5 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use actix_web::test::TestRequest;
-    use uuid::Uuid;
-
-    fn require_recorded_at(value: Option<Instant>) -> Instant {
-        match value {
-            Some(value) => value,
-            None => panic!("allowed reservation should record a timestamp"),
-        }
-    }
-
-    #[test]
-    fn test_parse_peer_ip_ipv4_with_port() {
-        assert_eq!(parse_peer_ip("127.0.0.1:1234"), "127.0.0.1");
-    }
-
-    #[test]
-    fn test_parse_peer_ip_ipv4_no_port() {
-        assert_eq!(parse_peer_ip("10.0.0.1"), "10.0.0.1");
-    }
-
-    #[test]
-    fn test_parse_peer_ip_ipv6_with_port() {
-        assert_eq!(parse_peer_ip("[::1]:8080"), "::1");
-    }
-
-    #[test]
-    fn test_parse_peer_ip_unknown_falls_back() {
-        assert_eq!(parse_peer_ip("unknown"), "unknown");
-    }
-
-    #[test]
-    fn test_trusted_proxy_match() {
-        let proxies = ["10.0.0.1".to_string()];
-        assert!(proxies.iter().any(|p| p == "10.0.0.1"));
-    }
-
-    #[test]
-    fn test_trusted_proxy_no_match() {
-        let proxies = ["10.0.0.1".to_string()];
-        assert!(!proxies.iter().any(|p| p == "10.0.0.2"));
-    }
-
-    #[test]
-    fn test_trusted_proxy_empty_list() {
-        let proxies: Vec<String> = vec![];
-        assert!(!proxies.iter().any(|p| p == "127.0.0.1"));
-    }
-
-    #[test]
-    fn test_extract_client_key_ignores_rotating_authorization_headers() {
-        let req_a = TestRequest::default()
-            .peer_addr("203.0.113.10:1000".parse().unwrap())
-            .insert_header(("Authorization", "Bearer bogus-a"))
-            .to_srv_request();
-        let req_b = TestRequest::default()
-            .peer_addr("203.0.113.10:1000".parse().unwrap())
-            .insert_header(("Authorization", "Bearer bogus-b"))
-            .to_srv_request();
-
-        let key_a = extract_client_key(&req_a, &[]);
-        let key_b = extract_client_key(&req_b, &[]);
-
-        assert_eq!(key_a, "ip:203.0.113.10");
-        assert_eq!(key_a, key_b);
-    }
-
-    #[test]
-    fn test_extract_client_key_ignores_rotating_api_key_headers() {
-        let req_a = TestRequest::default()
-            .peer_addr("203.0.113.20:1000".parse().unwrap())
-            .insert_header(("x-api-key", "bogus-a"))
-            .to_srv_request();
-        let req_b = TestRequest::default()
-            .peer_addr("203.0.113.20:1000".parse().unwrap())
-            .insert_header(("x-api-key", "bogus-b"))
-            .to_srv_request();
-
-        let key_a = extract_client_key(&req_a, &[]);
-        let key_b = extract_client_key(&req_b, &[]);
-
-        assert_eq!(key_a, "ip:203.0.113.20");
-        assert_eq!(key_a, key_b);
-    }
-
-    #[test]
-    fn test_extract_client_key_uses_trusted_forwarded_ip() {
-        let req = TestRequest::default()
-            .peer_addr("10.0.0.1:1000".parse().unwrap())
-            .insert_header(("X-Forwarded-For", "198.51.100.7, 10.0.0.2"))
-            .to_srv_request();
-
-        let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
-
-        assert_eq!(key, "ip:198.51.100.7");
-    }
-
-    #[test]
-    fn test_extract_client_key_prefers_authenticated_api_key_id() {
-        let api_key_id = Uuid::new_v4();
-        let req = TestRequest::default()
-            .peer_addr("203.0.113.30:1000".parse().unwrap())
-            .to_srv_request();
-        req.extensions_mut()
-            .insert(RequestContext::new().with_api_key(api_key_id));
-
-        let key = extract_client_key(&req, &[]);
-
-        assert_eq!(key, format!("api_key:{}", api_key_id));
-    }
-
-    #[test]
-    fn test_extract_client_key_uses_authenticated_user_id_without_api_key() {
-        let req = TestRequest::default()
-            .peer_addr("203.0.113.40:1000".parse().unwrap())
-            .to_srv_request();
-        req.extensions_mut()
-            .insert(RequestContext::new().with_user_id("user-123"));
-
-        let key = extract_client_key(&req, &[]);
-
-        assert_eq!(key, "user:user-123");
-    }
-
-    #[test]
-    fn test_key_tracker_release_removes_recorded_slot() {
-        let mut tracker = KeyTracker::new();
-        let window = Duration::from_secs(60);
-
-        let (allowed, _, recorded_at) = tracker.check_and_record(1, window);
-        assert!(allowed);
-        let recorded_at = require_recorded_at(recorded_at);
-        assert_eq!(tracker.timestamps.len(), 1);
-
-        tracker.release(recorded_at);
-
-        assert!(tracker.timestamps.is_empty());
-    }
-
-    #[test]
-    fn test_key_tracker_release_allows_new_reservation() {
-        let mut tracker = KeyTracker::new();
-        let window = Duration::from_secs(60);
-        let (allowed, _, recorded_at) = tracker.check_and_record(1, window);
-        assert!(allowed);
-        let recorded_at = require_recorded_at(recorded_at);
-        let (allowed, retry_after, _) = tracker.check_and_record(1, window);
-        assert!(!allowed);
-        assert!(retry_after > 0);
-
-        tracker.release(recorded_at);
-        let (allowed, retry_after, _) = tracker.check_and_record(1, window);
-
-        assert!(allowed);
-        assert_eq!(retry_after, 0);
-    }
-
-    #[test]
-    fn test_key_tracker_release_keeps_newer_rejected_auth_slot() {
-        let mut tracker = KeyTracker::new();
-        let window = Duration::from_secs(60);
-
-        let (first_allowed, _, first_recorded_at) = tracker.check_and_record(2, window);
-        assert!(first_allowed);
-        let first_recorded_at = require_recorded_at(first_recorded_at);
-
-        std::thread::sleep(Duration::from_millis(1));
-
-        let (second_allowed, _, second_recorded_at) = tracker.check_and_record(2, window);
-        assert!(second_allowed);
-        let second_recorded_at = require_recorded_at(second_recorded_at);
-
-        tracker.release(first_recorded_at);
-
-        assert_eq!(tracker.timestamps, vec![second_recorded_at]);
-    }
-
-    #[actix_web::test]
-    async fn test_auth_attempt_reservation_blocks_next_attempt_before_auth_result() {
-        let first = TestRequest::default()
-            .peer_addr(SocketAddr::from(([203, 0, 113, 210], 1000)))
-            .to_srv_request();
-        let second = TestRequest::default()
-            .peer_addr(SocketAddr::from(([203, 0, 113, 210], 1001)))
-            .to_srv_request();
-
-        let reservation = match reserve_rate_limit_for_auth_attempt(&first, 1, &[]).await {
-            Ok(reservation) => reservation,
-            Err(err) => panic!("first auth attempt should reserve capacity: {err}"),
-        };
-        let second_result = reserve_rate_limit_for_auth_attempt(&second, 1, &[]).await;
-        reservation.release().await;
-
-        let rejected = match second_result {
-            Ok(_) => panic!("second auth attempt should see the existing reservation"),
-            Err(err) => err,
-        };
-        assert_eq!(
-            rejected.as_response_error().status_code(),
-            StatusCode::TOO_MANY_REQUESTS
-        );
-    }
-
-    #[test]
-    fn test_enforce_fallback_capacity_evicts_stale_first() {
-        let store: DashMap<String, KeyTracker> = DashMap::new();
-        let now = Instant::now();
-        let window = Duration::from_secs(60);
-        // 3 stale + 2 fresh trackers
-        for i in 0..3 {
-            let mut t = KeyTracker::new();
-            t.timestamps.push(now - Duration::from_secs(120));
-            store.insert(format!("stale-{i}"), t);
-        }
-        for i in 0..2 {
-            let mut t = KeyTracker::new();
-            t.timestamps.push(now);
-            store.insert(format!("fresh-{i}"), t);
-        }
-        assert_eq!(store.len(), 5);
-        enforce_fallback_capacity(&store, window);
-        // Stale entries dropped, fresh kept; cap is generous so no LRU pass.
-        assert_eq!(store.len(), 2);
-        assert!(store.contains_key("fresh-0"));
-        assert!(store.contains_key("fresh-1"));
-    }
-
-    #[test]
-    fn test_enforce_fallback_capacity_evicts_oldest_when_all_fresh() {
-        // Force the LRU branch by setting a tiny cap via a parallel helper.
-        let store: DashMap<String, KeyTracker> = DashMap::new();
-        let base = Instant::now();
-        for i in 0..MAX_FALLBACK_ENTRIES + 5 {
-            let mut t = KeyTracker::new();
-            t.timestamps.push(base + Duration::from_millis(i as u64));
-            store.insert(format!("k-{i}"), t);
-        }
-        // All within window so the stale-pass doesn't shrink the map.
-        enforce_fallback_capacity(&store, Duration::from_secs(60));
-        assert!(store.len() <= MAX_FALLBACK_ENTRIES);
-        // The 5 oldest should be evicted, the rest kept.
-        assert!(!store.contains_key("k-0"));
-        assert!(store.contains_key(&format!("k-{}", MAX_FALLBACK_ENTRIES + 4)));
-    }
-}
+#[path = "rate_limit_tests.rs"]
+mod tests;

--- a/src/server/middleware/rate_limit_key_policy.rs
+++ b/src/server/middleware/rate_limit_key_policy.rs
@@ -1,0 +1,67 @@
+use crate::core::models::ApiKey;
+use actix_web::HttpMessage;
+use actix_web::dev::ServiceRequest;
+
+pub(super) fn effective_requests_per_minute(
+    req: &ServiceRequest,
+    default_rpm: Option<u32>,
+) -> Option<u32> {
+    req.extensions()
+        .get::<ApiKey>()
+        .and_then(|api_key| api_key.rate_limits.as_ref())
+        .and_then(|limits| limits.rpm)
+        .or(default_rpm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
+    use actix_web::test::TestRequest;
+
+    fn api_key_with_rpm(rpm: Option<u32>) -> ApiKey {
+        ApiKey {
+            metadata: Metadata::new(),
+            name: "test-key".to_string(),
+            key_hash: "hash".to_string(),
+            key_prefix: "sk-test".to_string(),
+            user_id: None,
+            team_id: None,
+            permissions: vec![],
+            rate_limits: Some(RateLimits {
+                rpm,
+                tpm: None,
+                rpd: None,
+                tpd: None,
+                concurrent: None,
+            }),
+            expires_at: None,
+            is_active: true,
+            last_used_at: None,
+            usage_stats: UsageStats::default(),
+        }
+    }
+
+    #[test]
+    fn uses_api_key_rpm_before_default() {
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(api_key_with_rpm(Some(2)));
+
+        assert_eq!(effective_requests_per_minute(&req, Some(60)), Some(2));
+    }
+
+    #[test]
+    fn falls_back_to_default_when_key_has_no_rpm() {
+        let req = TestRequest::default().to_srv_request();
+        req.extensions_mut().insert(api_key_with_rpm(None));
+
+        assert_eq!(effective_requests_per_minute(&req, Some(60)), Some(60));
+    }
+
+    #[test]
+    fn returns_none_without_key_rpm_or_default() {
+        let req = TestRequest::default().to_srv_request();
+
+        assert_eq!(effective_requests_per_minute(&req, None), None);
+    }
+}

--- a/src/server/middleware/rate_limit_tests.rs
+++ b/src/server/middleware/rate_limit_tests.rs
@@ -1,0 +1,239 @@
+use super::*;
+use actix_web::test::TestRequest;
+use uuid::Uuid;
+
+fn require_recorded_at(value: Option<Instant>) -> Instant {
+    match value {
+        Some(value) => value,
+        None => panic!("allowed reservation should record a timestamp"),
+    }
+}
+
+#[test]
+fn test_parse_peer_ip_ipv4_with_port() {
+    assert_eq!(parse_peer_ip("127.0.0.1:1234"), "127.0.0.1");
+}
+
+#[test]
+fn test_parse_peer_ip_ipv4_no_port() {
+    assert_eq!(parse_peer_ip("10.0.0.1"), "10.0.0.1");
+}
+
+#[test]
+fn test_parse_peer_ip_ipv6_with_port() {
+    assert_eq!(parse_peer_ip("[::1]:8080"), "::1");
+}
+
+#[test]
+fn test_parse_peer_ip_unknown_falls_back() {
+    assert_eq!(parse_peer_ip("unknown"), "unknown");
+}
+
+#[test]
+fn test_trusted_proxy_match() {
+    let proxies = ["10.0.0.1".to_string()];
+    assert!(proxies.iter().any(|p| p == "10.0.0.1"));
+}
+
+#[test]
+fn test_trusted_proxy_no_match() {
+    let proxies = ["10.0.0.1".to_string()];
+    assert!(!proxies.iter().any(|p| p == "10.0.0.2"));
+}
+
+#[test]
+fn test_trusted_proxy_empty_list() {
+    let proxies: Vec<String> = vec![];
+    assert!(!proxies.iter().any(|p| p == "127.0.0.1"));
+}
+
+#[test]
+fn test_extract_client_key_ignores_rotating_authorization_headers() {
+    let req_a = TestRequest::default()
+        .peer_addr("203.0.113.10:1000".parse().unwrap())
+        .insert_header(("Authorization", "Bearer bogus-a"))
+        .to_srv_request();
+    let req_b = TestRequest::default()
+        .peer_addr("203.0.113.10:1000".parse().unwrap())
+        .insert_header(("Authorization", "Bearer bogus-b"))
+        .to_srv_request();
+
+    let key_a = extract_client_key(&req_a, &[]);
+    let key_b = extract_client_key(&req_b, &[]);
+
+    assert_eq!(key_a, "ip:203.0.113.10");
+    assert_eq!(key_a, key_b);
+}
+
+#[test]
+fn test_extract_client_key_ignores_rotating_api_key_headers() {
+    let req_a = TestRequest::default()
+        .peer_addr("203.0.113.20:1000".parse().unwrap())
+        .insert_header(("x-api-key", "bogus-a"))
+        .to_srv_request();
+    let req_b = TestRequest::default()
+        .peer_addr("203.0.113.20:1000".parse().unwrap())
+        .insert_header(("x-api-key", "bogus-b"))
+        .to_srv_request();
+
+    let key_a = extract_client_key(&req_a, &[]);
+    let key_b = extract_client_key(&req_b, &[]);
+
+    assert_eq!(key_a, "ip:203.0.113.20");
+    assert_eq!(key_a, key_b);
+}
+
+#[test]
+fn test_extract_client_key_uses_trusted_forwarded_ip() {
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "198.51.100.7, 10.0.0.2"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
+
+    assert_eq!(key, "ip:198.51.100.7");
+}
+
+#[test]
+fn test_extract_client_key_prefers_authenticated_api_key_id() {
+    let api_key_id = Uuid::new_v4();
+    let req = TestRequest::default()
+        .peer_addr("203.0.113.30:1000".parse().unwrap())
+        .to_srv_request();
+    req.extensions_mut()
+        .insert(RequestContext::new().with_api_key(api_key_id));
+
+    let key = extract_client_key(&req, &[]);
+
+    assert_eq!(key, format!("api_key:{}", api_key_id));
+}
+
+#[test]
+fn test_extract_client_key_uses_authenticated_user_id_without_api_key() {
+    let req = TestRequest::default()
+        .peer_addr("203.0.113.40:1000".parse().unwrap())
+        .to_srv_request();
+    req.extensions_mut()
+        .insert(RequestContext::new().with_user_id("user-123"));
+
+    let key = extract_client_key(&req, &[]);
+
+    assert_eq!(key, "user:user-123");
+}
+
+#[test]
+fn test_key_tracker_release_removes_recorded_slot() {
+    let mut tracker = KeyTracker::new();
+    let window = Duration::from_secs(60);
+
+    let (allowed, _, recorded_at) = tracker.check_and_record(1, window);
+    assert!(allowed);
+    let recorded_at = require_recorded_at(recorded_at);
+    assert_eq!(tracker.timestamps.len(), 1);
+
+    tracker.release(recorded_at);
+
+    assert!(tracker.timestamps.is_empty());
+}
+
+#[test]
+fn test_key_tracker_release_allows_new_reservation() {
+    let mut tracker = KeyTracker::new();
+    let window = Duration::from_secs(60);
+    let (allowed, _, recorded_at) = tracker.check_and_record(1, window);
+    assert!(allowed);
+    let recorded_at = require_recorded_at(recorded_at);
+    let (allowed, retry_after, _) = tracker.check_and_record(1, window);
+    assert!(!allowed);
+    assert!(retry_after > 0);
+
+    tracker.release(recorded_at);
+    let (allowed, retry_after, _) = tracker.check_and_record(1, window);
+
+    assert!(allowed);
+    assert_eq!(retry_after, 0);
+}
+
+#[test]
+fn test_key_tracker_release_keeps_newer_rejected_auth_slot() {
+    let mut tracker = KeyTracker::new();
+    let window = Duration::from_secs(60);
+
+    let (first_allowed, _, first_recorded_at) = tracker.check_and_record(2, window);
+    assert!(first_allowed);
+    let first_recorded_at = require_recorded_at(first_recorded_at);
+
+    std::thread::sleep(Duration::from_millis(1));
+
+    let (second_allowed, _, second_recorded_at) = tracker.check_and_record(2, window);
+    assert!(second_allowed);
+    let second_recorded_at = require_recorded_at(second_recorded_at);
+
+    tracker.release(first_recorded_at);
+
+    assert_eq!(tracker.timestamps, vec![second_recorded_at]);
+}
+
+#[actix_web::test]
+async fn test_auth_attempt_reservation_blocks_next_attempt_before_auth_result() {
+    let first = TestRequest::default()
+        .peer_addr(SocketAddr::from(([203, 0, 113, 210], 1000)))
+        .to_srv_request();
+    let second = TestRequest::default()
+        .peer_addr(SocketAddr::from(([203, 0, 113, 210], 1001)))
+        .to_srv_request();
+
+    let reservation = match reserve_rate_limit_for_auth_attempt(&first, 1, &[]).await {
+        Ok(reservation) => reservation,
+        Err(err) => panic!("first auth attempt should reserve capacity: {err}"),
+    };
+    let second_result = reserve_rate_limit_for_auth_attempt(&second, 1, &[]).await;
+    reservation.release().await;
+
+    let rejected = match second_result {
+        Ok(_) => panic!("second auth attempt should see the existing reservation"),
+        Err(err) => err,
+    };
+    assert_eq!(
+        rejected.as_response_error().status_code(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+}
+
+#[test]
+fn test_enforce_fallback_capacity_evicts_stale_first() {
+    let store: DashMap<String, KeyTracker> = DashMap::new();
+    let now = Instant::now();
+    let window = Duration::from_secs(60);
+    for i in 0..3 {
+        let mut t = KeyTracker::new();
+        t.timestamps.push(now - Duration::from_secs(120));
+        store.insert(format!("stale-{i}"), t);
+    }
+    for i in 0..2 {
+        let mut t = KeyTracker::new();
+        t.timestamps.push(now);
+        store.insert(format!("fresh-{i}"), t);
+    }
+    assert_eq!(store.len(), 5);
+    enforce_fallback_capacity(&store, window);
+    assert_eq!(store.len(), 2);
+    assert!(store.contains_key("fresh-0"));
+    assert!(store.contains_key("fresh-1"));
+}
+
+#[test]
+fn test_enforce_fallback_capacity_evicts_oldest_when_all_fresh() {
+    let store: DashMap<String, KeyTracker> = DashMap::new();
+    let base = Instant::now();
+    for i in 0..MAX_FALLBACK_ENTRIES + 5 {
+        let mut t = KeyTracker::new();
+        t.timestamps.push(base + Duration::from_millis(i as u64));
+        store.insert(format!("k-{i}"), t);
+    }
+    enforce_fallback_capacity(&store, Duration::from_secs(60));
+    assert!(store.len() <= MAX_FALLBACK_ENTRIES);
+    assert!(!store.contains_key("k-0"));
+    assert!(store.contains_key(&format!("k-{}", MAX_FALLBACK_ENTRIES + 4)));
+}

--- a/src/server/routes/ai/audio/budgeting.rs
+++ b/src/server/routes/ai/audio/budgeting.rs
@@ -1,8 +1,11 @@
-use crate::core::budget::UnifiedBudgetLimits;
+use crate::core::budget::{
+    BudgetManager, BudgetReservation, UnifiedBudgetLimits, UnifiedBudgetReservation,
+};
 use crate::core::keys::KeyManager;
 use crate::core::pricing_service::PricingService;
 use crate::core::pricing_service::PricingUsage;
 use crate::core::providers::ProviderError;
+use uuid::Uuid;
 
 const ESTIMATED_AUDIO_BYTES_PER_SECOND: usize = 16_000;
 
@@ -25,14 +28,82 @@ pub(super) fn estimated_audio_file_seconds(file: &[u8]) -> f64 {
     file.len().max(1).div_ceil(ESTIMATED_AUDIO_BYTES_PER_SECOND) as f64
 }
 
-pub(super) fn reserve_audio_budget(
+#[allow(clippy::too_many_arguments)]
+pub(super) fn reserve_audio_budget_with_pricing(
+    pricing_service: &PricingService,
+    budget_manager: &BudgetManager,
     budget_limits: &UnifiedBudgetLimits,
-    provider: &str,
-    model: &str,
-    _usage: &PricingUsage,
-) -> Result<(), ProviderError> {
-    super::super::spend::ensure_budget_available(budget_limits, provider, model)?;
-    Ok(())
+    api_key_budget_id: Option<Uuid>,
+    budget_provider: &str,
+    budget_model: &str,
+    pricing_provider: &str,
+    pricing_model: &str,
+    total_time_seconds: Option<f64>,
+    usage: &PricingUsage,
+) -> Result<(Option<UnifiedBudgetReservation>, Option<BudgetReservation>), ProviderError> {
+    super::super::spend::ensure_budget_available(budget_limits, budget_provider, budget_model)?;
+    let budget_reservation = if is_time_priced_audio(
+        pricing_service,
+        pricing_provider,
+        pricing_model,
+        total_time_seconds,
+    ) {
+        let cost = pricing_service
+            .calculate_loaded_completion_cost_for_provider(
+                pricing_provider,
+                pricing_model,
+                0,
+                0,
+                None,
+                None,
+                total_time_seconds,
+            )
+            .map_err(|error| {
+                ProviderError::invalid_request(
+                    "pricing",
+                    format!(
+                        "pricing is required for audio budget reservation for \
+                         '{budget_provider}'/'{budget_model}': {error}"
+                    ),
+                )
+            })?
+            .total_cost;
+        if cost > 0.0 {
+            budget_limits
+                .reserve_spend(budget_provider, budget_model, cost)
+                .map(Some)
+                .map_err(|error| {
+                    super::super::spend::reservation_error_to_provider_error(
+                        error,
+                        budget_provider,
+                        budget_model,
+                    )
+                })?
+        } else {
+            super::super::spend::ensure_budget_available(
+                budget_limits,
+                budget_provider,
+                budget_model,
+            )?;
+            None
+        }
+    } else {
+        super::super::spend::reserve_pricing_usage_budget_with_pricing(
+            pricing_service,
+            budget_limits,
+            budget_provider,
+            budget_model,
+            pricing_provider,
+            pricing_model,
+            usage,
+        )?
+    };
+    let key_budget_reservation = super::super::spend::reserve_api_key_budget_for_reservation(
+        budget_manager,
+        api_key_budget_id,
+        budget_reservation.as_ref(),
+    )?;
+    Ok((budget_reservation, key_budget_reservation))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -47,12 +118,16 @@ pub(super) async fn record_audio_spend(
     pricing_model: &str,
     total_time_seconds: Option<f64>,
     usage: &PricingUsage,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     if let Some(total_time_seconds) = total_time_seconds
-        && pricing_service
-            .get_model_info_for_provider(pricing_provider, pricing_model)
-            .map(|(_, model_info)| model_info.cost_per_second.is_some())
-            .unwrap_or(false)
+        && is_time_priced_audio(
+            pricing_service,
+            pricing_provider,
+            pricing_model,
+            Some(total_time_seconds),
+        )
     {
         match pricing_service.calculate_loaded_completion_cost_for_provider(
             pricing_provider,
@@ -64,7 +139,19 @@ pub(super) async fn record_audio_spend(
             Some(total_time_seconds),
         ) {
             Ok(cost) => {
-                budget_limits.record_spend(budget_provider, budget_model, cost.total_cost);
+                settle_audio_budget_or_record(
+                    budget_limits,
+                    budget_provider,
+                    budget_model,
+                    budget_reservation,
+                    cost.total_cost,
+                    "time-based audio spend",
+                );
+                super::super::spend::settle_api_key_budget_reservation(
+                    key_budget_reservation,
+                    cost.total_cost,
+                    "time-based audio spend",
+                );
                 record_key_usage(key_manager, api_key_id, usage, cost.total_cost).await;
             }
             Err(error) => {
@@ -73,7 +160,12 @@ pub(super) async fn record_audio_spend(
                      '{pricing_provider}' budget provider '{budget_provider}' model \
                      '{budget_model}': {error}; skipping budget spend"
                 );
-                record_key_usage(key_manager, api_key_id, usage, 0.0).await;
+                let reserved = settle_reserved_audio_budget_on_error(
+                    budget_reservation,
+                    key_budget_reservation,
+                    "time-based audio spend calculation failed",
+                );
+                record_key_usage(key_manager, api_key_id, usage, reserved).await;
             }
         }
         return;
@@ -89,9 +181,65 @@ pub(super) async fn record_audio_spend(
         pricing_provider,
         pricing_model,
         usage,
-        None,
+        budget_reservation,
+        key_budget_reservation,
     )
     .await;
+}
+
+fn is_time_priced_audio(
+    pricing_service: &PricingService,
+    pricing_provider: &str,
+    pricing_model: &str,
+    total_time_seconds: Option<f64>,
+) -> bool {
+    total_time_seconds.is_some()
+        && pricing_service
+            .get_model_info_for_provider(pricing_provider, pricing_model)
+            .map(|(_, model_info)| model_info.cost_per_second.is_some())
+            .unwrap_or(false)
+}
+
+fn settle_audio_budget_or_record(
+    budget_limits: &UnifiedBudgetLimits,
+    budget_provider: &str,
+    budget_model: &str,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    cost: f64,
+    context: &str,
+) {
+    if let Some(reservation) = budget_reservation {
+        if let Err(error) = reservation.settle(cost) {
+            tracing::error!("failed to settle {context}: {error:?}");
+        }
+    } else {
+        budget_limits.record_spend(budget_provider, budget_model, cost);
+    }
+}
+
+fn settle_reserved_audio_budget_on_error(
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
+    context: &str,
+) -> f64 {
+    let Some(budget_reservation) = budget_reservation else {
+        super::super::spend::settle_api_key_budget_reservation(
+            key_budget_reservation,
+            0.0,
+            context,
+        );
+        return 0.0;
+    };
+    let reserved = budget_reservation.reserved_amount();
+    if let Err(error) = budget_reservation.settle(reserved) {
+        tracing::error!("failed to settle {context}: {error:?}");
+    }
+    super::super::spend::settle_api_key_budget_reservation(
+        key_budget_reservation,
+        reserved,
+        context,
+    );
+    reserved
 }
 
 async fn record_key_usage(
@@ -122,6 +270,8 @@ fn estimated_audio_text_tokens(text: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::budget::{BudgetConfig, BudgetScope};
+    use crate::core::keys::InMemoryKeyRepository;
 
     #[test]
     fn audio_file_usage_keeps_audio_tokens_out_of_total_tokens() {
@@ -131,5 +281,43 @@ mod tests {
         assert_eq!(usage.completion_tokens, 0);
         assert_eq!(usage.total_tokens, 2);
         assert_eq!(usage.audio_tokens, Some(4));
+    }
+
+    #[tokio::test]
+    async fn record_audio_spend_settles_api_key_budget_reservation() {
+        let pricing = PricingService::with_embedded_default()
+            .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+        let budget_limits = UnifiedBudgetLimits::new();
+        let key_manager = KeyManager::new(InMemoryKeyRepository::new());
+        let budget_manager = BudgetManager::new();
+        let scope = BudgetScope::ApiKey("audio-key-budget".to_string());
+        budget_manager
+            .create_budget(scope.clone(), BudgetConfig::new("audio key", 1.0))
+            .await
+            .unwrap_or_else(|error| panic!("API key budget should be created: {error}"));
+        let key_budget_reservation = budget_manager
+            .tracker()
+            .reserve_spend(&scope, 0.5)
+            .unwrap_or_else(|error| panic!("API key budget should reserve: {error:?}"));
+
+        record_audio_spend(
+            &pricing,
+            &budget_limits,
+            &key_manager,
+            None,
+            "openai",
+            "gpt-4o",
+            "openai",
+            "gpt-4o",
+            None,
+            &PricingUsage::new(10, 5),
+            None,
+            Some(key_budget_reservation),
+        )
+        .await;
+
+        let spend = budget_manager.get_current_spend(&scope);
+        assert!(spend > 0.0, "API key budget spend should be recorded");
+        assert!(spend < 0.5, "reservation should settle to actual spend");
     }
 }

--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -8,7 +8,9 @@ use serde::Deserialize;
 use tracing::{error, info};
 
 use super::super::execution::execute_with_selected_deployment;
-use crate::server::routes::ai::context::get_request_context;
+use crate::server::routes::ai::context::{
+    enforce_api_key_model_and_token_limits, get_request_context,
+};
 use crate::server::routes::ai::openai_errors;
 
 /// Audio speech generation request
@@ -60,6 +62,10 @@ pub async fn audio_speech(
         ));
     }
 
+    if let Err(error) = enforce_api_key_model_and_token_limits(&req, &request.model, None) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
     let speech_request = SpeechRequest {
         input: request.input.clone(),
         model: request.model.clone(),
@@ -71,6 +77,8 @@ pub async fn audio_speech(
     let requested_model = request.model.clone();
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
     let budget_limits = state.budget_limits.clone();
     let key_manager = state.key_manager.clone();
     let pricing_service = state.pricing.clone();
@@ -82,17 +90,12 @@ pub async fn audio_speech(
         move |provider, selected_model, _deployment_id| {
             let mut request = speech_request.clone();
             let context = context_for_execution.clone();
+            let budget_manager = budget_manager.clone();
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
             async move {
                 let usage = super::budgeting::speech_usage(&request.input);
-                super::budgeting::reserve_audio_budget(
-                    &budget_limits,
-                    provider.name(),
-                    &selected_model,
-                    &usage,
-                )?;
                 let budget_provider = provider.name().to_string();
                 let (pricing_provider, pricing_model) =
                     super::super::spend::pricing_identity_for_provider(
@@ -100,6 +103,19 @@ pub async fn audio_speech(
                         &provider,
                         &selected_model,
                     );
+                let (budget_reservation, key_budget_reservation) =
+                    super::budgeting::reserve_audio_budget_with_pricing(
+                        pricing_service.as_ref(),
+                        &budget_manager,
+                        &budget_limits,
+                        api_key_budget_id,
+                        &budget_provider,
+                        &selected_model,
+                        &pricing_provider,
+                        &pricing_model,
+                        None,
+                        &usage,
+                    )?;
                 request.model = selected_model.clone();
                 let response = provider.text_to_speech(request, context).await?;
                 let tokens_used = u64::from(usage.total_tokens);
@@ -114,6 +130,8 @@ pub async fn audio_speech(
                     &pricing_model,
                     None,
                     &usage,
+                    budget_reservation,
+                    key_budget_reservation,
                 )
                 .await;
                 Ok((response, tokens_used))

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -13,7 +13,9 @@ use super::upload::{
     drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
     read_text_field, upload_error_response,
 };
-use crate::server::routes::ai::context::get_request_context;
+use crate::server::routes::ai::context::{
+    enforce_api_key_model_and_token_limits, get_request_context,
+};
 use crate::server::routes::ai::openai_errors;
 
 /// Audio transcriptions endpoint
@@ -128,6 +130,10 @@ pub async fn audio_transcriptions(
         return Ok(error_response);
     }
 
+    if let Err(error) = enforce_api_key_model_and_token_limits(&req, &model, None) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
     // Create transcription request
     let transcription_request = TranscriptionRequest {
         file,
@@ -143,6 +149,8 @@ pub async fn audio_transcriptions(
     let requested_model = model;
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
     let budget_limits = state.budget_limits.clone();
     let key_manager = state.key_manager.clone();
     let pricing_service = state.pricing.clone();
@@ -154,6 +162,7 @@ pub async fn audio_transcriptions(
         move |provider, selected_model, _deployment_id| {
             let mut request = transcription_request.clone();
             let context = context_for_execution.clone();
+            let budget_manager = budget_manager.clone();
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
@@ -162,12 +171,6 @@ pub async fn audio_transcriptions(
                     super::budgeting::audio_file_usage(&request.file, request.prompt.as_deref());
                 let total_time_seconds =
                     super::budgeting::estimated_audio_file_seconds(&request.file);
-                super::budgeting::reserve_audio_budget(
-                    &budget_limits,
-                    provider.name(),
-                    &selected_model,
-                    &usage,
-                )?;
                 let budget_provider = provider.name().to_string();
                 let (pricing_provider, pricing_model) =
                     super::super::spend::pricing_identity_for_provider(
@@ -175,6 +178,19 @@ pub async fn audio_transcriptions(
                         &provider,
                         &selected_model,
                     );
+                let (budget_reservation, key_budget_reservation) =
+                    super::budgeting::reserve_audio_budget_with_pricing(
+                        pricing_service.as_ref(),
+                        &budget_manager,
+                        &budget_limits,
+                        api_key_budget_id,
+                        &budget_provider,
+                        &selected_model,
+                        &pricing_provider,
+                        &pricing_model,
+                        Some(total_time_seconds),
+                        &usage,
+                    )?;
                 request.model = selected_model.clone();
                 let response = provider.audio_transcription(request, context).await?;
                 let tokens_used = u64::from(usage.total_tokens);
@@ -189,6 +205,8 @@ pub async fn audio_transcriptions(
                     &pricing_model,
                     Some(total_time_seconds),
                     &usage,
+                    budget_reservation,
+                    key_budget_reservation,
                 )
                 .await;
                 Ok((response, tokens_used))

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -13,7 +13,9 @@ use super::upload::{
     drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
     read_text_field, upload_error_response,
 };
-use crate::server::routes::ai::context::get_request_context;
+use crate::server::routes::ai::context::{
+    enforce_api_key_model_and_token_limits, get_request_context,
+};
 use crate::server::routes::ai::openai_errors;
 
 /// Audio translations endpoint
@@ -119,6 +121,10 @@ pub async fn audio_translations(
         return Ok(error_response);
     }
 
+    if let Err(error) = enforce_api_key_model_and_token_limits(&req, &model, None) {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
     let translation_request = TranslationRequest {
         file,
         filename,
@@ -131,6 +137,8 @@ pub async fn audio_translations(
     let requested_model = model;
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
     let budget_limits = state.budget_limits.clone();
     let key_manager = state.key_manager.clone();
     let pricing_service = state.pricing.clone();
@@ -142,6 +150,7 @@ pub async fn audio_translations(
         move |provider, selected_model, _deployment_id| {
             let mut request = translation_request.clone();
             let context = context_for_execution.clone();
+            let budget_manager = budget_manager.clone();
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
@@ -150,12 +159,6 @@ pub async fn audio_translations(
                     super::budgeting::audio_file_usage(&request.file, request.prompt.as_deref());
                 let total_time_seconds =
                     super::budgeting::estimated_audio_file_seconds(&request.file);
-                super::budgeting::reserve_audio_budget(
-                    &budget_limits,
-                    provider.name(),
-                    &selected_model,
-                    &usage,
-                )?;
                 let budget_provider = provider.name().to_string();
                 let (pricing_provider, pricing_model) =
                     super::super::spend::pricing_identity_for_provider(
@@ -163,6 +166,19 @@ pub async fn audio_translations(
                         &provider,
                         &selected_model,
                     );
+                let (budget_reservation, key_budget_reservation) =
+                    super::budgeting::reserve_audio_budget_with_pricing(
+                        pricing_service.as_ref(),
+                        &budget_manager,
+                        &budget_limits,
+                        api_key_budget_id,
+                        &budget_provider,
+                        &selected_model,
+                        &pricing_provider,
+                        &pricing_model,
+                        Some(total_time_seconds),
+                        &usage,
+                    )?;
                 request.model = selected_model.clone();
                 let response = provider.audio_translation(request, context).await?;
                 let tokens_used = u64::from(usage.total_tokens);
@@ -177,6 +193,8 @@ pub async fn audio_translations(
                     &pricing_model,
                     Some(total_time_seconds),
                     &usage,
+                    budget_reservation,
+                    key_budget_reservation,
                 )
                 .await;
                 Ok((response, tokens_used))

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -26,6 +26,13 @@ use tracing::{error, info, warn};
 use super::context::get_request_context;
 use super::execution::{execute_stream_with_selected_deployment, execute_with_selected_deployment};
 use super::openai_errors;
+#[path = "chat_delta.rs"]
+mod chat_delta;
+use chat_delta::{convert_function_call_delta, convert_tool_call_delta};
+#[path = "chat_sse.rs"]
+pub(super) mod chat_sse;
+use chat_sse::format_sse_error;
+pub(super) use chat_sse::sse_error_classification;
 
 /// Chat completions endpoint
 ///
@@ -37,7 +44,8 @@ pub async fn chat_completions(
 ) -> ActixResult<HttpResponse> {
     info!("Chat completion request for model: {}", request.model);
 
-    let context = get_request_context(&req)?;
+    let mut context = get_request_context(&req)?;
+    super::token_policy::attach_api_key_token_limit(&req, &mut context)?;
 
     if let Err(e) = RequestValidator::validate_chat_completion_request(
         &request.model,
@@ -47,6 +55,13 @@ pub async fn chat_completions(
     ) {
         warn!("Invalid chat completion request: {}", e);
         return Ok(openai_errors::validation_error(e.to_string()));
+    }
+    if let Err(error) = super::context::enforce_api_key_model_and_token_limits(
+        &req,
+        &request.model,
+        super::token_policy::requested_chat_output_token_limit(&request),
+    ) {
+        return Ok(openai_errors::gateway_error_response(&error));
     }
 
     if request.stream.unwrap_or(false) {
@@ -97,6 +112,8 @@ async fn handle_streaming_chat_completion(
     let context_for_execution = context.clone();
     let (budget_limits, pricing_service) = (state.budget_limits.clone(), state.pricing.clone());
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
     match execute_stream_with_selected_deployment(
         state.unified_router.clone(),
         &requested_model,
@@ -105,6 +122,7 @@ async fn handle_streaming_chat_completion(
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());
+            let budget_manager = budget_manager.clone();
             let request_for_budget = request_for_budget.clone();
             async move {
                 super::spend::ensure_budget_available(
@@ -112,6 +130,15 @@ async fn handle_streaming_chat_completion(
                     provider.name(),
                     &selected_model,
                 )?;
+                let provider_name = provider.name().to_string();
+                let (request_for_provider, request_for_budget) =
+                    super::token_policy::prepare_chat_request_for_provider(
+                        context.api_key_max_tokens_per_request(),
+                        provider.name(),
+                        &selected_model,
+                        core_request.clone(),
+                        request_for_budget,
+                    )?;
                 let budget_reservation = super::spend::reserve_chat_completion_budget_with_pricing(
                     pricing_service.as_ref(),
                     &budget_limits,
@@ -119,19 +146,36 @@ async fn handle_streaming_chat_completion(
                     &selected_model,
                     &request_for_budget,
                 )?;
-                let provider_name = provider.name().to_string();
-                let mut request_for_provider = core_request.clone();
-                request_for_provider.model = selected_model.clone();
+                let key_budget_reservation = super::spend::reserve_api_key_budget_for_reservation(
+                    &budget_manager,
+                    api_key_budget_id,
+                    budget_reservation.as_ref(),
+                )?;
                 let stream = provider
                     .chat_completion_stream(request_for_provider, context)
                     .await?;
-                Ok((stream, provider_name, selected_model, budget_reservation))
+                Ok((
+                    stream,
+                    provider_name,
+                    selected_model,
+                    budget_reservation,
+                    key_budget_reservation,
+                ))
             }
         },
     )
     .await
     {
-        Ok(((mut stream, served_provider, served_model, mut budget_reservation), lease)) => {
+        Ok((
+            (
+                mut stream,
+                served_provider,
+                served_model,
+                mut budget_reservation,
+                mut key_budget_reservation,
+            ),
+            lease,
+        )) => {
             // Use a channel so that when the client disconnects and actix-web
             // drops the response stream, the receiver is dropped, which causes
             // the sender to fail. This breaks the upstream read loop and drops
@@ -158,6 +202,7 @@ async fn handle_streaming_chat_completion(
                                 &served_model,
                                 final_usage.as_ref(),
                                 budget_reservation.take(),
+                                key_budget_reservation.take(),
                             )
                             .await;
                         }
@@ -293,6 +338,7 @@ async fn handle_streaming_chat_completion(
                             &served_model,
                             final_usage.as_ref(),
                             budget_reservation.take(),
+                            key_budget_reservation.take(),
                         )
                         .await;
                         return;
@@ -315,6 +361,7 @@ async fn handle_streaming_chat_completion(
                         usage: final_usage.as_ref(),
                         saw_upstream_output,
                         budget_reservation: budget_reservation.take(),
+                        key_budget_reservation: key_budget_reservation.take(),
                     },
                 )
                 .await;
@@ -366,6 +413,8 @@ async fn handle_chat_completion_internal(
     let (budget_limits, pricing_service) = (state.budget_limits.clone(), state.pricing.clone());
     let key_manager = state.key_manager.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
 
     let core_response = execute_with_selected_deployment(
         unified_router,
@@ -376,6 +425,7 @@ async fn handle_chat_completion_internal(
             let context = context_for_execution.clone();
             let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());
             let key_manager = key_manager.clone();
+            let budget_manager = budget_manager.clone();
             let request_for_budget = request_for_budget.clone();
             async move {
                 // Reject before spending upstream tokens when the selected
@@ -385,6 +435,14 @@ async fn handle_chat_completion_internal(
                     provider.name(),
                     &selected_model,
                 )?;
+                let (request_for_provider, request_for_budget) =
+                    super::token_policy::prepare_chat_request_for_provider(
+                        context.api_key_max_tokens_per_request(),
+                        provider.name(),
+                        &selected_model,
+                        core_request.clone(),
+                        request_for_budget,
+                    )?;
                 let budget_reservation = super::spend::reserve_chat_completion_budget_with_pricing(
                     pricing_service.as_ref(),
                     &budget_limits,
@@ -392,8 +450,11 @@ async fn handle_chat_completion_internal(
                     &selected_model,
                     &request_for_budget,
                 )?;
-                let mut request_for_provider = core_request.clone();
-                request_for_provider.model = selected_model.clone();
+                let key_budget_reservation = super::spend::reserve_api_key_budget_for_reservation(
+                    &budget_manager,
+                    api_key_budget_id,
+                    budget_reservation.as_ref(),
+                )?;
                 let response = provider
                     .chat_completion(request_for_provider, context)
                     .await?;
@@ -411,6 +472,7 @@ async fn handle_chat_completion_internal(
                     &selected_model,
                     response.usage.as_ref(),
                     budget_reservation,
+                    key_budget_reservation,
                 )
                 .await;
                 Ok((response, tokens))
@@ -669,48 +731,6 @@ fn convert_usage(usage: types::responses::Usage) -> Usage {
     }
 }
 
-/// Format a provider error into SSE error type and code for OpenAI-compatible responses.
-pub(super) fn sse_error_classification(error: &ProviderError) -> (&'static str, &'static str) {
-    match error {
-        ProviderError::Authentication { .. } => ("invalid_request_error", "authentication_error"),
-        ProviderError::RateLimit { .. } => ("rate_limit_error", "rate_limit_exceeded"),
-        ProviderError::InvalidRequest { .. } => ("invalid_request_error", "invalid_request"),
-        ProviderError::ModelNotFound { .. } => ("invalid_request_error", "model_not_found"),
-        ProviderError::Timeout { .. } => ("server_error", "timeout"),
-        ProviderError::ContentFiltered { .. } => ("invalid_request_error", "content_filter"),
-        ProviderError::ContextLengthExceeded { .. } => {
-            ("invalid_request_error", "context_length_exceeded")
-        }
-        ProviderError::TokenLimitExceeded { .. } => {
-            ("invalid_request_error", "token_limit_exceeded")
-        }
-        _ => ("server_error", "internal_error"),
-    }
-}
-
-/// Format an error as an SSE event matching OpenAI's streaming error format.
-///
-/// Produces:
-/// ```text
-/// data: {"error":{"message":"...","type":"server_error","code":"internal_error"}}
-///
-/// data: [DONE]
-/// ```
-fn format_sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
-    let error_json = json!({
-        "error": {
-            "message": message,
-            "type": error_type,
-            "code": code,
-        }
-    });
-    let error_event = Event::default().data(&error_json.to_string());
-    let done_event = Event::default().data("[DONE]");
-    let mut combined = error_event.to_bytes().to_vec();
-    combined.extend_from_slice(&done_event.to_bytes());
-    Bytes::from(combined)
-}
-
 fn convert_core_chunk_to_streaming(
     chunk: types::responses::ChatChunk,
 ) -> Result<ChatCompletionChunk, ProviderError> {
@@ -767,31 +787,6 @@ fn convert_core_chunk_to_streaming(
         choices,
         usage: chunk.usage.map(convert_usage),
     })
-}
-
-fn convert_function_call_delta(
-    function: types::responses::FunctionCallDelta,
-) -> crate::core::streaming::types::FunctionCallDelta {
-    crate::core::streaming::types::FunctionCallDelta {
-        name: function.name,
-        arguments: function.arguments,
-    }
-}
-
-fn convert_tool_call_delta(
-    delta: types::responses::ToolCallDelta,
-) -> crate::core::streaming::types::ToolCallDelta {
-    crate::core::streaming::types::ToolCallDelta {
-        index: delta.index,
-        id: delta.id,
-        tool_type: delta.tool_type,
-        function: delta.function.map(
-            |function| crate::core::streaming::types::FunctionCallDelta {
-                name: function.name,
-                arguments: function.arguments,
-            },
-        ),
-    }
 }
 
 #[cfg(test)]

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -195,14 +195,13 @@ async fn handle_streaming_chat_completion(
                     () => {
                         if final_usage.is_some() || saw_upstream_output {
                             super::spend::record_stream_disconnect_spend_with_reservation_with_pricing(
-                                pricing_service.as_ref(), &budget_limits,
-                                &key_manager,
-                                api_key_id,
-                                &served_provider,
-                                &served_model,
-                                final_usage.as_ref(),
-                                budget_reservation.take(),
-                                key_budget_reservation.take(),
+                                pricing_service.as_ref(),
+                                super::spend::usage_spend_settlement(
+                                    (&budget_limits, &key_manager, api_key_id),
+                                    (&served_provider, &served_model, final_usage.as_ref()),
+                                    budget_reservation.take(),
+                                    key_budget_reservation.take(),
+                                ),
                             )
                             .await;
                         }
@@ -331,14 +330,12 @@ async fn handle_streaming_chat_completion(
                         info!("Client disconnected during streaming, cancelling upstream");
                         super::spend::record_stream_disconnect_spend_with_reservation_with_pricing(
                             pricing_service.as_ref(),
-                            &budget_limits,
-                            &key_manager,
-                            api_key_id,
-                            &served_provider,
-                            &served_model,
-                            final_usage.as_ref(),
-                            budget_reservation.take(),
-                            key_budget_reservation.take(),
+                            super::spend::usage_spend_settlement(
+                                (&budget_limits, &key_manager, api_key_id),
+                                (&served_provider, &served_model, final_usage.as_ref()),
+                                budget_reservation.take(),
+                                key_budget_reservation.take(),
+                            ),
                         )
                         .await;
                         return;
@@ -465,14 +462,12 @@ async fn handle_chat_completion_internal(
                     .unwrap_or_default();
                 super::spend::record_completion_spend_with_reservation_with_pricing(
                     pricing_service.as_ref(),
-                    &budget_limits,
-                    &key_manager,
-                    api_key_id,
-                    provider.name(),
-                    &selected_model,
-                    response.usage.as_ref(),
-                    budget_reservation,
-                    key_budget_reservation,
+                    super::spend::usage_spend_settlement(
+                        (&budget_limits, &key_manager, api_key_id),
+                        (provider.name(), &selected_model, response.usage.as_ref()),
+                        budget_reservation,
+                        key_budget_reservation,
+                    ),
                 )
                 .await;
                 Ok((response, tokens))

--- a/src/server/routes/ai/chat_delta.rs
+++ b/src/server/routes/ai/chat_delta.rs
@@ -1,0 +1,26 @@
+use crate::core::types;
+
+pub(super) fn convert_function_call_delta(
+    function: types::responses::FunctionCallDelta,
+) -> crate::core::streaming::types::FunctionCallDelta {
+    crate::core::streaming::types::FunctionCallDelta {
+        name: function.name,
+        arguments: function.arguments,
+    }
+}
+
+pub(super) fn convert_tool_call_delta(
+    delta: types::responses::ToolCallDelta,
+) -> crate::core::streaming::types::ToolCallDelta {
+    crate::core::streaming::types::ToolCallDelta {
+        index: delta.index,
+        id: delta.id,
+        tool_type: delta.tool_type,
+        function: delta.function.map(
+            |function| crate::core::streaming::types::FunctionCallDelta {
+                name: function.name,
+                arguments: function.arguments,
+            },
+        ),
+    }
+}

--- a/src/server/routes/ai/chat_sse.rs
+++ b/src/server/routes/ai/chat_sse.rs
@@ -1,0 +1,42 @@
+use bytes::Bytes;
+use serde_json::json;
+
+use crate::core::providers::ProviderError;
+use crate::core::streaming::types::Event;
+
+/// Format a provider error into SSE error type and code for OpenAI-compatible responses.
+pub(in crate::server::routes::ai) fn sse_error_classification(
+    error: &ProviderError,
+) -> (&'static str, &'static str) {
+    match error {
+        ProviderError::Authentication { .. } => ("invalid_request_error", "authentication_error"),
+        ProviderError::RateLimit { .. } => ("rate_limit_error", "rate_limit_exceeded"),
+        ProviderError::InvalidRequest { .. } => ("invalid_request_error", "invalid_request"),
+        ProviderError::ModelNotFound { .. } => ("invalid_request_error", "model_not_found"),
+        ProviderError::Timeout { .. } => ("server_error", "timeout"),
+        ProviderError::ContentFiltered { .. } => ("invalid_request_error", "content_filter"),
+        ProviderError::ContextLengthExceeded { .. } => {
+            ("invalid_request_error", "context_length_exceeded")
+        }
+        ProviderError::TokenLimitExceeded { .. } => {
+            ("invalid_request_error", "token_limit_exceeded")
+        }
+        _ => ("server_error", "internal_error"),
+    }
+}
+
+/// Format an error as an SSE event matching OpenAI's streaming error format.
+pub(super) fn format_sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
+    let error_json = json!({
+        "error": {
+            "message": message,
+            "type": error_type,
+            "code": code,
+        }
+    });
+    let error_event = Event::default().data(&error_json.to_string());
+    let done_event = Event::default().data("[DONE]");
+    let mut combined = error_event.to_bytes().to_vec();
+    combined.extend_from_slice(&done_event.to_bytes());
+    Bytes::from(combined)
+}

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -5,7 +5,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use bytes::Bytes;
 use futures::StreamExt;
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -25,6 +25,12 @@ use crate::utils::error::gateway_error::GatewayError;
 use super::context::get_request_context;
 use super::execution::execute_stream_with_selected_deployment;
 use super::openai_errors;
+#[path = "completions_spend.rs"]
+mod completions_spend;
+use completions_spend::settle_stream_spend_if_chargeable;
+#[path = "completions_sse.rs"]
+mod completions_sse;
+use completions_sse::send_stream_error;
 
 #[derive(Debug, Clone)]
 struct CompletionAdapterRequest {
@@ -69,7 +75,8 @@ async fn completions_inner(
     path_model: Option<String>,
     request: Value,
 ) -> ActixResult<HttpResponse> {
-    let context = get_request_context(&req)?;
+    let mut context = get_request_context(&req)?;
+    super::token_policy::attach_api_key_token_limit(&req, &mut context)?;
     let adapter_request = match completion_request_from_value(request, path_model) {
         Ok(request) => request,
         Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
@@ -83,6 +90,13 @@ async fn completions_inner(
     ) {
         warn!("Invalid completions request: {}", error);
         return Ok(openai_errors::validation_error(error.to_string()));
+    }
+    if let Err(error) = super::context::enforce_api_key_model_and_token_limits(
+        &req,
+        &adapter_request.chat_request.model,
+        super::token_policy::requested_chat_output_token_limit(&adapter_request.chat_request),
+    ) {
+        return Ok(openai_errors::gateway_error_response(&error));
     }
 
     if adapter_request.stream {
@@ -137,6 +151,8 @@ async fn handle_streaming_completion(
     let context_for_execution = context.clone();
     let (budget_limits, pricing_service) = (state.budget_limits.clone(), state.pricing.clone());
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
 
     match execute_stream_with_selected_deployment(
         state.unified_router.clone(),
@@ -146,33 +162,60 @@ async fn handle_streaming_completion(
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             let (budget_limits, pricing_service) = (budget_limits.clone(), pricing_service.clone());
+            let budget_manager = budget_manager.clone();
             let request_for_budget = request_for_budget.clone();
             async move {
+                let provider_name = provider.name().to_string();
+                let (request_for_provider, request_for_budget) =
+                    super::token_policy::prepare_chat_request_for_provider(
+                        context.api_key_max_tokens_per_request(),
+                        &provider_name,
+                        &selected_model,
+                        core_request.clone(),
+                        request_for_budget,
+                    )?;
                 super::spend::ensure_budget_available(
                     &budget_limits,
-                    provider.name(),
+                    &provider_name,
                     &selected_model,
                 )?;
                 let budget_reservation = super::spend::reserve_chat_completion_budget_with_pricing(
                     pricing_service.as_ref(),
                     &budget_limits,
-                    provider.name(),
+                    &provider_name,
                     &selected_model,
                     &request_for_budget,
                 )?;
-                let provider_name = provider.name().to_string();
-                let mut request_for_provider = core_request.clone();
-                request_for_provider.model = selected_model.clone();
+                let key_budget_reservation = super::spend::reserve_api_key_budget_for_reservation(
+                    &budget_manager,
+                    api_key_budget_id,
+                    budget_reservation.as_ref(),
+                )?;
                 let stream = provider
                     .chat_completion_stream(request_for_provider, context)
                     .await?;
-                Ok((stream, provider_name, selected_model, budget_reservation))
+                Ok((
+                    stream,
+                    provider_name,
+                    selected_model,
+                    budget_reservation,
+                    key_budget_reservation,
+                ))
             }
         },
     )
     .await
     {
-        Ok(((mut stream, served_provider, served_model, mut budget_reservation), lease)) => {
+        Ok((
+            (
+                mut stream,
+                served_provider,
+                served_model,
+                mut budget_reservation,
+                mut key_budget_reservation,
+            ),
+            lease,
+        )) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let budget_limits = state.budget_limits.clone();
@@ -226,6 +269,7 @@ async fn handle_streaming_completion(
                                     &served_model,
                                     final_usage.as_ref(),
                                     budget_reservation.take(),
+                                    key_budget_reservation.take(),
                                     saw_upstream_output,
                                 )
                                 .await;
@@ -285,6 +329,7 @@ async fn handle_streaming_completion(
                                         &served_model,
                                         final_usage.as_ref(),
                                         budget_reservation.take(),
+                                        key_budget_reservation.take(),
                                         saw_upstream_output,
                                     )
                                     .await;
@@ -310,6 +355,7 @@ async fn handle_streaming_completion(
                                 &served_model,
                                 final_usage.as_ref(),
                                 budget_reservation.take(),
+                                key_budget_reservation.take(),
                                 saw_upstream_output,
                             )
                             .await;
@@ -327,6 +373,7 @@ async fn handle_streaming_completion(
                             &served_model,
                             final_usage.as_ref(),
                             budget_reservation.take(),
+                            key_budget_reservation.take(),
                             saw_upstream_output,
                         )
                         .await;
@@ -346,6 +393,7 @@ async fn handle_streaming_completion(
                         usage: final_usage.as_ref(),
                         saw_upstream_output,
                         budget_reservation: budget_reservation.take(),
+                        key_budget_reservation: key_budget_reservation.take(),
                     },
                 )
                 .await;
@@ -367,62 +415,6 @@ async fn handle_streaming_completion(
             error!("Failed to create streaming completion response: {}", error);
             Ok(openai_errors::gateway_error_response(&error))
         }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn settle_stream_spend(
-    pricing_service: &crate::core::pricing_service::PricingService,
-    budget_limits: &crate::core::budget::UnifiedBudgetLimits,
-    key_manager: &crate::core::keys::KeyManager,
-    api_key_id: Option<uuid::Uuid>,
-    provider: &str,
-    model: &str,
-    usage: Option<&Usage>,
-    budget_reservation: Option<crate::core::budget::UnifiedBudgetReservation>,
-    saw_upstream_output: bool,
-) {
-    super::spend::record_finished_stream_spend_with_reservation_with_pricing(
-        pricing_service,
-        super::spend::StreamSpendSettlement {
-            budget_limits,
-            key_manager,
-            api_key_id,
-            provider,
-            model,
-            usage,
-            saw_upstream_output,
-            budget_reservation,
-        },
-    )
-    .await;
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn settle_stream_spend_if_chargeable(
-    pricing_service: &crate::core::pricing_service::PricingService,
-    budget_limits: &crate::core::budget::UnifiedBudgetLimits,
-    key_manager: &crate::core::keys::KeyManager,
-    api_key_id: Option<uuid::Uuid>,
-    provider: &str,
-    model: &str,
-    usage: Option<&Usage>,
-    budget_reservation: Option<crate::core::budget::UnifiedBudgetReservation>,
-    saw_upstream_output: bool,
-) {
-    if usage.is_some() || saw_upstream_output {
-        settle_stream_spend(
-            pricing_service,
-            budget_limits,
-            key_manager,
-            api_key_id,
-            provider,
-            model,
-            usage,
-            budget_reservation,
-            saw_upstream_output,
-        )
-        .await;
     }
 }
 
@@ -773,20 +765,4 @@ fn finish_reason_to_string(reason: types::responses::FinishReason) -> String {
         types::responses::FinishReason::PauseTurn => "pause_turn",
     }
     .to_string()
-}
-
-async fn send_stream_error(tx: &mpsc::Sender<Bytes>, message: &str, error_type: &str, code: &str) {
-    let error_json = json!({
-        "error": {
-            "message": message,
-            "type": error_type,
-            "code": code,
-        }
-    });
-    let mut bytes = Event::default()
-        .data(&error_json.to_string())
-        .to_bytes()
-        .to_vec();
-    bytes.extend_from_slice(&Event::default().data("[DONE]").to_bytes());
-    let _ = tx.send(Bytes::from(bytes)).await;
 }

--- a/src/server/routes/ai/completions_spend.rs
+++ b/src/server/routes/ai/completions_spend.rs
@@ -1,0 +1,66 @@
+use crate::core::budget::{BudgetReservation, UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::keys::KeyManager;
+use crate::core::models::openai::Usage;
+use crate::core::pricing_service::PricingService;
+
+use super::super::spend;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn settle_stream_spend(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<uuid::Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
+    saw_upstream_output: bool,
+) {
+    spend::record_finished_stream_spend_with_reservation_with_pricing(
+        pricing_service,
+        spend::StreamSpendSettlement {
+            budget_limits,
+            key_manager,
+            api_key_id,
+            provider,
+            model,
+            usage,
+            saw_upstream_output,
+            budget_reservation,
+            key_budget_reservation,
+        },
+    )
+    .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn settle_stream_spend_if_chargeable(
+    pricing_service: &PricingService,
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
+    api_key_id: Option<uuid::Uuid>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
+    saw_upstream_output: bool,
+) {
+    if usage.is_some() || saw_upstream_output {
+        settle_stream_spend(
+            pricing_service,
+            budget_limits,
+            key_manager,
+            api_key_id,
+            provider,
+            model,
+            usage,
+            budget_reservation,
+            key_budget_reservation,
+            saw_upstream_output,
+        )
+        .await;
+    }
+}

--- a/src/server/routes/ai/completions_sse.rs
+++ b/src/server/routes/ai/completions_sse.rs
@@ -1,0 +1,25 @@
+use crate::core::streaming::types::Event;
+use bytes::Bytes;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+pub(super) async fn send_stream_error(
+    tx: &mpsc::Sender<Bytes>,
+    message: &str,
+    error_type: &str,
+    code: &str,
+) {
+    let error_json = json!({
+        "error": {
+            "message": message,
+            "type": error_type,
+            "code": code,
+        }
+    });
+    let mut bytes = Event::default()
+        .data(&error_json.to_string())
+        .to_bytes()
+        .to_vec();
+    bytes.extend_from_slice(&Event::default().data("[DONE]").to_bytes());
+    let _ = tx.send(Bytes::from(bytes)).await;
+}

--- a/src/server/routes/ai/context.rs
+++ b/src/server/routes/ai/context.rs
@@ -5,9 +5,25 @@ use crate::core::models::user::types::User;
 use crate::core::types::context::RequestContext;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result as ActixResult};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::future::Future;
 use tracing::{debug, error};
+
+const CORE_KEYS_EXTRA_NAMESPACE: &str = "__core_keys";
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct RuntimeKeyPermissions {
+    #[serde(default)]
+    allowed_models: Vec<String>,
+    #[serde(default)]
+    allowed_endpoints: Vec<String>,
+    #[serde(default)]
+    max_tokens_per_request: Option<u32>,
+    #[serde(default)]
+    is_admin: bool,
+    #[serde(default)]
+    custom_permissions: Vec<String>,
+}
 
 /// Get request context from headers and middleware extensions
 pub fn get_request_context(req: &HttpRequest) -> ActixResult<RequestContext> {
@@ -51,13 +67,13 @@ pub fn get_authenticated_api_key(req: &HttpRequest) -> Option<ApiKey> {
 /// Permission logic (two-role model: admin vs user):
 /// - Unauthenticated requests are always denied.
 /// - Admin roles (`SuperAdmin`, `Admin`) have full access to every operation.
-/// - API-usage operations (`chat`, `completions`, `models`, `embeddings`, `images`,
-///   `audio`, `moderations`, `rerank`, `assistants`, `files`, `fine_tuning`) are
-///   allowed for any authenticated user/key.
+/// - API-usage operations are allowed for authenticated users and for legacy
+///   API keys that carry no explicit operation permissions.
 /// - Management operations (`keys.list_all`, `users.manage`, `config.manage`,
 ///   `teams.manage`, `analytics.admin`) require an admin role.
 /// - API key `permissions` can grant admin-level access via `"*"` or `"system.admin"`,
-///   or grant a specific operation directly.
+///   grant a specific operation directly, or restrict the key to its listed
+///   operations.
 pub fn check_permission(user: Option<&User>, api_key: Option<&ApiKey>, operation: &str) -> bool {
     use crate::core::models::user::types::UserRole;
 
@@ -66,45 +82,200 @@ pub fn check_permission(user: Option<&User>, api_key: Option<&ApiKey>, operation
         return false;
     }
 
-    // Check if the user has an admin role
-    let user_is_admin = user
-        .map(|u| matches!(u.role, UserRole::SuperAdmin | UserRole::Admin))
-        .unwrap_or(false);
-
     // Check if the API key carries admin-level permissions
-    let key_is_admin = api_key
-        .map(|k| {
-            k.permissions
-                .iter()
-                .any(|p| p == "*" || p == "system.admin")
-        })
-        .unwrap_or(false);
+    let key_is_admin = api_key.map(api_key_has_admin_permission).unwrap_or(false);
 
-    if user_is_admin || key_is_admin {
+    if key_is_admin {
         return true;
     }
 
     // Check if the API key explicitly grants this operation
     let key_has_operation = api_key
-        .map(|k| k.permissions.iter().any(|p| p == operation))
+        .map(|k| api_key_has_operation_permission(k, operation))
         .unwrap_or(false);
 
     if key_has_operation {
         return true;
     }
 
-    // Management operations require admin — deny for non-admin callers
-    let is_management_op = matches!(
-        operation,
-        "keys.list_all" | "users.manage" | "config.manage" | "teams.manage" | "analytics.admin"
-    );
+    if api_key
+        .map(api_key_has_explicit_operation_permissions)
+        .unwrap_or(false)
+    {
+        return false;
+    }
 
-    if is_management_op {
+    // Check if the user has an admin role. This intentionally happens after
+    // API-key restrictions so an admin-owned limited key remains limited.
+    let user_is_admin = user
+        .map(|u| matches!(u.role, UserRole::SuperAdmin | UserRole::Admin))
+        .unwrap_or(false);
+
+    if user_is_admin {
+        return true;
+    }
+
+    // Management operations require admin — deny for non-admin callers
+    if is_management_operation(operation) {
         return false;
     }
 
     // API-usage operations are allowed for any authenticated caller
     true
+}
+
+fn api_key_has_admin_permission(api_key: &ApiKey) -> bool {
+    if api_key
+        .permissions
+        .iter()
+        .any(|p| p == "*" || p == "system.admin")
+    {
+        return true;
+    }
+
+    matches!(
+        runtime_key_permissions(api_key),
+        Ok(Some(permissions))
+            if permissions.is_admin
+                || permissions
+                    .custom_permissions
+                    .iter()
+                    .any(|p| p == "*" || p == "system.admin")
+    )
+}
+
+fn api_key_has_explicit_operation_permissions(api_key: &ApiKey) -> bool {
+    if !api_key.permissions.is_empty() {
+        return true;
+    }
+
+    matches!(
+        runtime_key_permissions(api_key),
+        Ok(Some(permissions))
+            if permissions.is_admin || !permissions.custom_permissions.is_empty()
+    )
+}
+
+fn api_key_has_operation_permission(api_key: &ApiKey, operation: &str) -> bool {
+    if api_key
+        .permissions
+        .iter()
+        .any(|p| permission_matches_operation(p, operation))
+    {
+        return true;
+    }
+
+    matches!(
+        runtime_key_permissions(api_key),
+        Ok(Some(permissions))
+            if permissions
+                .custom_permissions
+                .iter()
+                .any(|p| permission_matches_operation(p, operation))
+    )
+}
+
+fn is_management_operation(operation: &str) -> bool {
+    matches!(
+        operation,
+        "keys.list_all" | "users.manage" | "config.manage" | "teams.manage" | "analytics.admin"
+    )
+}
+
+fn permission_matches_operation(permission: &str, operation: &str) -> bool {
+    permission == operation
+        || permission.strip_prefix("api.") == Some(operation)
+        || (permission == "use:api" && !is_management_operation(operation))
+}
+
+fn pattern_list_allows(patterns: &[String], value: &str) -> bool {
+    if patterns.is_empty() {
+        return true;
+    }
+
+    patterns.iter().any(|pattern| {
+        pattern == "*"
+            || pattern == value
+            || pattern
+                .strip_suffix('*')
+                .is_some_and(|prefix| value.starts_with(prefix))
+    })
+}
+
+fn runtime_key_permissions(
+    api_key: &ApiKey,
+) -> Result<Option<RuntimeKeyPermissions>, GatewayError> {
+    let Some(payload) = api_key.metadata.extra.get(CORE_KEYS_EXTRA_NAMESPACE) else {
+        return Ok(None);
+    };
+    let Some(permissions) = payload.get("permissions") else {
+        return Ok(None);
+    };
+    if permissions.is_null() {
+        return Ok(None);
+    }
+
+    serde_json::from_value::<RuntimeKeyPermissions>(permissions.clone())
+        .map(Some)
+        .map_err(|error| {
+            GatewayError::forbidden(format!("API key runtime policy is invalid: {error}"))
+        })
+}
+
+pub fn api_key_allows_endpoint(
+    api_key: Option<&ApiKey>,
+    endpoint: &str,
+) -> Result<bool, GatewayError> {
+    let Some(permissions) = api_key.map(runtime_key_permissions).transpose()?.flatten() else {
+        return Ok(true);
+    };
+
+    Ok(pattern_list_allows(
+        &permissions.allowed_endpoints,
+        endpoint,
+    ))
+}
+
+pub fn api_key_max_tokens_per_request(req: &HttpRequest) -> Result<Option<u32>, GatewayError> {
+    let extensions = req.extensions();
+    let Some(api_key) = extensions.get::<ApiKey>() else {
+        return Ok(None);
+    };
+    let Some(permissions) = runtime_key_permissions(api_key)? else {
+        return Ok(None);
+    };
+    Ok(permissions.max_tokens_per_request)
+}
+
+pub fn enforce_api_key_model_and_token_limits(
+    req: &HttpRequest,
+    model: &str,
+    requested_tokens: Option<u32>,
+) -> Result<(), GatewayError> {
+    let extensions = req.extensions();
+    let Some(api_key) = extensions.get::<ApiKey>() else {
+        return Ok(());
+    };
+    let Some(permissions) = runtime_key_permissions(api_key)? else {
+        return Ok(());
+    };
+
+    if !pattern_list_allows(&permissions.allowed_models, model) {
+        return Err(GatewayError::forbidden(format!(
+            "API key is not permitted to use model '{model}'"
+        )));
+    }
+
+    if let (Some(limit), Some(requested_tokens)) =
+        (permissions.max_tokens_per_request, requested_tokens)
+        && requested_tokens > limit
+    {
+        return Err(GatewayError::forbidden(format!(
+            "requested token limit {requested_tokens} exceeds API key max_tokens_per_request {limit}"
+        )));
+    }
+
+    Ok(())
 }
 
 /// Log API usage for billing and analytics
@@ -193,6 +364,27 @@ mod tests {
     fn create_admin_api_key() -> ApiKey {
         let mut key = create_test_api_key();
         key.permissions = vec!["*".to_string()];
+        key
+    }
+
+    fn api_key_with_runtime_permissions(
+        allowed_models: Vec<&str>,
+        allowed_endpoints: Vec<&str>,
+        max_tokens_per_request: Option<u32>,
+    ) -> ApiKey {
+        let mut key = create_test_api_key();
+        key.metadata.set_extra(
+            CORE_KEYS_EXTRA_NAMESPACE,
+            serde_json::json!({
+                "permissions": {
+                    "allowed_models": allowed_models,
+                    "allowed_endpoints": allowed_endpoints,
+                    "max_tokens_per_request": max_tokens_per_request,
+                    "is_admin": false,
+                    "custom_permissions": [],
+                }
+            }),
+        );
         key
     }
 
@@ -330,6 +522,49 @@ mod tests {
         key.permissions = vec!["keys.list_all".to_string()];
         assert!(check_permission(None, Some(&key), "keys.list_all"));
         assert!(!check_permission(None, Some(&key), "users.manage"));
+    }
+
+    #[test]
+    fn test_api_key_with_specific_api_permission_denies_other_api_usage() {
+        let mut key = create_test_api_key();
+        key.permissions = vec!["embeddings".to_string()];
+
+        assert!(check_permission(None, Some(&key), "embeddings"));
+        assert!(!check_permission(None, Some(&key), "chat"));
+    }
+
+    #[test]
+    fn test_api_key_accepts_rbac_api_permission_namespace() {
+        let mut key = create_test_api_key();
+        key.permissions = vec!["api.chat".to_string()];
+
+        assert!(check_permission(None, Some(&key), "chat"));
+        assert!(!check_permission(None, Some(&key), "embeddings"));
+    }
+
+    #[test]
+    fn test_api_key_endpoint_payload_restricts_endpoint_patterns() {
+        let key = api_key_with_runtime_permissions(Vec::new(), vec!["/v1/chat/*"], None);
+
+        assert!(matches!(
+            api_key_allows_endpoint(Some(&key), "/v1/chat/completions"),
+            Ok(true)
+        ));
+        assert!(matches!(
+            api_key_allows_endpoint(Some(&key), "/v1/embeddings"),
+            Ok(false)
+        ));
+    }
+
+    #[test]
+    fn test_api_key_model_and_token_payload_restricts_request() {
+        let key = api_key_with_runtime_permissions(vec!["gpt-4o"], Vec::new(), Some(128));
+        let req = actix_web::test::TestRequest::default().to_http_request();
+        req.extensions_mut().insert(key);
+
+        assert!(enforce_api_key_model_and_token_limits(&req, "gpt-4o", Some(128)).is_ok());
+        assert!(enforce_api_key_model_and_token_limits(&req, "gpt-4o-mini", Some(128)).is_err());
+        assert!(enforce_api_key_model_and_token_limits(&req, "gpt-4o", Some(129)).is_err());
     }
 
     // ==================== get_authenticated_user Tests ====================

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -57,13 +57,16 @@ pub async fn embeddings(
     request: web::Json<EmbeddingRequest>,
 ) -> ActixResult<HttpResponse> {
     info!("Embedding request for model: {}", request.model);
+    let request = request.into_inner();
+    if let Err(error) =
+        super::context::enforce_api_key_model_and_token_limits(&req, &request.model, None)
+    {
+        return Ok(super::openai_errors::gateway_error_response(&error));
+    }
 
-    handle_ai_request(
-        &req,
-        request.into_inner(),
-        "Embedding",
-        |request, context| handle_embedding_with_state(state.get_ref(), request, context),
-    )
+    handle_ai_request(&req, request, "Embedding", |request, context| {
+        handle_embedding_with_state(state.get_ref(), request, context)
+    })
     .await
 }
 
@@ -101,7 +104,9 @@ async fn handle_embedding_internal(
     let requested_model = core_request.model.clone();
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
     let budget_limits = state.budget_limits.clone();
+    let budget_manager = state.budget_manager.clone();
     let key_manager = state.key_manager.clone();
     let pricing_service = state.pricing.clone();
     let core_response = execute_with_selected_deployment(
@@ -112,6 +117,7 @@ async fn handle_embedding_internal(
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
             let budget_limits = budget_limits.clone();
+            let budget_manager = budget_manager.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
             async move {
@@ -134,6 +140,13 @@ async fn handle_embedding_internal(
                     &pricing_provider,
                     &pricing_model,
                     &core_request.input,
+                )?;
+                let key_budget_reservation = super::spend::reserve_api_key_budget(
+                    &budget_manager,
+                    api_key_budget_id,
+                    budget_reservation
+                        .as_ref()
+                        .map(|reservation| reservation.reserved_amount()),
                 )?;
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = selected_model.clone();
@@ -158,6 +171,7 @@ async fn handle_embedding_internal(
                         &pricing_model,
                         &usage,
                         budget_reservation,
+                        key_budget_reservation,
                     )
                     .await;
                 } else {
@@ -170,6 +184,7 @@ async fn handle_embedding_internal(
                         &selected_model,
                         None,
                         budget_reservation,
+                        key_budget_reservation,
                     )
                     .await;
                 }

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -177,14 +177,12 @@ async fn handle_embedding_internal(
                 } else {
                     super::spend::record_completion_spend_with_reservation_with_pricing(
                         pricing_service.as_ref(),
-                        &budget_limits,
-                        &key_manager,
-                        api_key_id,
-                        &budget_provider,
-                        &selected_model,
-                        None,
-                        budget_reservation,
-                        key_budget_reservation,
+                        super::spend::usage_spend_settlement(
+                            (&budget_limits, &key_manager, api_key_id),
+                            (&budget_provider, &selected_model, None),
+                            budget_reservation,
+                            key_budget_reservation,
+                        ),
                     )
                     .await;
                 }

--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -184,13 +184,15 @@ async fn proxy_gemini_route_inner(
 
                         let response = gemini_upstream_response_to_http_response(
                             state,
-                            context,
-                            provider,
-                            budget_reservation,
-                            key_budget_reservation,
-                            response,
-                            stream,
-                            None,
+                            GeminiUpstreamResponseParts {
+                                context,
+                                provider,
+                                budget_reservation,
+                                key_budget_reservation,
+                                response,
+                                stream,
+                                stream_lease: None,
+                            },
                         )
                         .await
                         .map_err(gemini_gateway_error_to_provider_error)?;
@@ -276,13 +278,15 @@ async fn proxy_gemini_stream_route_inner(
             Ok(((provider, budget_reservation, key_budget_reservation, response), lease)) => {
                 return gemini_upstream_response_to_http_response(
                     state,
-                    context,
-                    provider,
-                    budget_reservation,
-                    key_budget_reservation,
-                    response,
-                    true,
-                    Some(lease),
+                    GeminiUpstreamResponseParts {
+                        context,
+                        provider,
+                        budget_reservation,
+                        key_budget_reservation,
+                        response,
+                        stream: true,
+                        stream_lease: Some(lease),
+                    },
                 )
                 .await;
             }
@@ -302,8 +306,7 @@ async fn proxy_gemini_stream_route_inner(
     Err(last_router_error.unwrap_or_else(|| missing_gemini_provider_error(&requested_model)))
 }
 
-async fn gemini_upstream_response_to_http_response(
-    state: &AppState,
+struct GeminiUpstreamResponseParts {
     context: crate::core::types::context::RequestContext,
     provider: GeminiRouteProvider,
     budget_reservation: Option<UnifiedBudgetReservation>,
@@ -311,7 +314,22 @@ async fn gemini_upstream_response_to_http_response(
     response: reqwest::Response,
     stream: bool,
     stream_lease: Option<StreamingDeploymentLease>,
+}
+
+async fn gemini_upstream_response_to_http_response(
+    state: &AppState,
+    parts: GeminiUpstreamResponseParts,
 ) -> Result<HttpResponse, GatewayError> {
+    let GeminiUpstreamResponseParts {
+        context,
+        provider,
+        budget_reservation,
+        key_budget_reservation,
+        response,
+        stream,
+        stream_lease,
+    } = parts;
+
     let status = StatusCode::from_u16(response.status().as_u16())
         .map_err(|error| GatewayError::internal(format!("Invalid upstream status: {error}")))?;
     let content_type = response

--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::error;
 
-use crate::core::budget::UnifiedBudgetReservation;
+use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
 use crate::core::providers::ProviderError;
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
@@ -119,11 +119,19 @@ async fn proxy_gemini_route_inner(
     stream: bool,
     request: Value,
 ) -> Result<HttpResponse, GatewayError> {
-    let context = ensure_gemini_route_authorized(state, req)?;
+    let mut context = ensure_gemini_route_authorized(state, req)?;
+    super::token_policy::attach_api_key_token_limit(req, &mut context)?;
+    let request =
+        apply_gemini_api_key_output_token_limit(context.api_key_max_tokens_per_request(), request)?;
     validate_api_version(api_version)?;
     validate_method(method)?;
     validate_model_segment(&requested_model)?;
     validate_gemini_request_size(&request)?;
+    super::context::enforce_api_key_model_and_token_limits(
+        req,
+        &requested_model,
+        gemini_requested_max_output_tokens(&request),
+    )?;
 
     ensure_gemini_provider_candidate_configured(state.config().providers(), &requested_model)?;
     if stream {
@@ -162,21 +170,24 @@ async fn proxy_gemini_route_inner(
                             &selected_model,
                             &requested_model,
                         )?;
-                        let (budget_reservation, response) = send_gemini_request(
-                            state,
-                            &provider,
-                            api_version,
-                            method,
-                            false,
-                            &request,
-                        )
-                        .await?;
+                        let (budget_reservation, key_budget_reservation, response) =
+                            send_gemini_request(
+                                state,
+                                &provider,
+                                api_version,
+                                method,
+                                false,
+                                &request,
+                                context.api_key_budget_id(),
+                            )
+                            .await?;
 
                         let response = gemini_upstream_response_to_http_response(
                             state,
                             context,
                             provider,
                             budget_reservation,
+                            key_budget_reservation,
                             response,
                             stream,
                             None,
@@ -217,6 +228,7 @@ async fn proxy_gemini_stream_route_inner(
     request: Value,
 ) -> Result<HttpResponse, GatewayError> {
     let router_models = gemini_router_models(state.config().providers(), &requested_model);
+    let api_key_budget_id = context.api_key_budget_id();
     let mut last_router_error = None;
     for router_model in router_models {
         let result = execute_stream_with_selected_deployment(
@@ -237,16 +249,23 @@ async fn proxy_gemini_stream_route_inner(
                             &selected_model,
                             &requested_model,
                         )?;
-                        let (budget_reservation, response) = send_gemini_request(
-                            state,
-                            &provider,
-                            api_version,
-                            method,
-                            true,
-                            &request,
-                        )
-                        .await?;
-                        Ok((provider, budget_reservation, response))
+                        let (budget_reservation, key_budget_reservation, response) =
+                            send_gemini_request(
+                                state,
+                                &provider,
+                                api_version,
+                                method,
+                                true,
+                                &request,
+                                api_key_budget_id,
+                            )
+                            .await?;
+                        Ok((
+                            provider,
+                            budget_reservation,
+                            key_budget_reservation,
+                            response,
+                        ))
                     }
                 }
             },
@@ -254,12 +273,13 @@ async fn proxy_gemini_stream_route_inner(
         .await;
 
         match result {
-            Ok(((provider, budget_reservation, response), lease)) => {
+            Ok(((provider, budget_reservation, key_budget_reservation, response), lease)) => {
                 return gemini_upstream_response_to_http_response(
                     state,
                     context,
                     provider,
                     budget_reservation,
+                    key_budget_reservation,
                     response,
                     true,
                     Some(lease),
@@ -287,6 +307,7 @@ async fn gemini_upstream_response_to_http_response(
     context: crate::core::types::context::RequestContext,
     provider: GeminiRouteProvider,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
     response: reqwest::Response,
     stream: bool,
     stream_lease: Option<StreamingDeploymentLease>,
@@ -313,6 +334,7 @@ async fn gemini_upstream_response_to_http_response(
                 context,
                 provider,
                 budget_reservation,
+                key_budget_reservation,
                 response,
                 status,
                 content_type,
@@ -329,7 +351,15 @@ async fn gemini_upstream_response_to_http_response(
             key_manager: &state.key_manager,
             api_key_id: context.api_key_id(),
         };
-        record_gemini_spend(&spend_state, &provider, &body, budget_reservation, true).await;
+        record_gemini_spend(
+            &spend_state,
+            &provider,
+            &body,
+            budget_reservation,
+            key_budget_reservation,
+            true,
+        )
+        .await;
     }
 
     Ok(HttpResponse::build(status)
@@ -341,6 +371,7 @@ struct GeminiStreamResponseParts {
     context: crate::core::types::context::RequestContext,
     provider: GeminiRouteProvider,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
     response: reqwest::Response,
     status: StatusCode,
     content_type: String,
@@ -352,6 +383,7 @@ fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts)
         context,
         provider,
         mut budget_reservation,
+        mut key_budget_reservation,
         response,
         status,
         content_type,
@@ -397,6 +429,7 @@ fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts)
                         &provider,
                         should_record_spend.then(|| final_usage.take()).flatten(),
                         budget_reservation.take(),
+                        key_budget_reservation.take(),
                         false,
                     )
                     .await;
@@ -428,6 +461,7 @@ fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts)
                     &provider,
                     should_record_spend.then(|| final_usage.take()).flatten(),
                     budget_reservation.take(),
+                    key_budget_reservation.take(),
                     should_record_spend && saw_upstream_output,
                 )
                 .await;
@@ -454,6 +488,7 @@ fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts)
                 None
             },
             budget_reservation.take(),
+            key_budget_reservation.take(),
             should_record_spend && saw_upstream_output,
         )
         .await;
@@ -536,4 +571,47 @@ fn validate_gemini_request_size(request: &Value) -> Result<(), GatewayError> {
         return Err(GatewayError::validation("Gemini request body too large"));
     }
     Ok(())
+}
+
+fn gemini_requested_max_output_tokens(request: &Value) -> Option<u32> {
+    request
+        .pointer("/generationConfig/maxOutputTokens")
+        .and_then(Value::as_u64)
+        .and_then(|tokens| u32::try_from(tokens).ok())
+}
+
+fn apply_gemini_api_key_output_token_limit(
+    max_tokens_per_request: Option<u32>,
+    mut request: Value,
+) -> Result<Value, GatewayError> {
+    let Some(limit) = max_tokens_per_request else {
+        return Ok(request);
+    };
+
+    if let Some(requested) = gemini_requested_max_output_tokens(&request)
+        && requested > limit
+    {
+        return Err(GatewayError::validation(format!(
+            "requested token limit {requested} exceeds API key max_tokens_per_request {limit}"
+        )));
+    }
+
+    let Some(object) = request.as_object_mut() else {
+        return Err(GatewayError::validation(
+            "Gemini request body must be a JSON object",
+        ));
+    };
+    let generation_config = object
+        .entry("generationConfig")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(generation_config) = generation_config.as_object_mut() else {
+        return Err(GatewayError::validation(
+            "generationConfig must be a JSON object",
+        ));
+    };
+    generation_config
+        .entry("maxOutputTokens")
+        .or_insert_with(|| Value::from(limit));
+
+    Ok(request)
 }

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -8,13 +8,14 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::config::models::provider::ProviderConfig;
-use crate::core::budget::UnifiedBudgetReservation;
+use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
 use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::{Provider, ProviderError};
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
 use super::{validate_api_version, validate_method, validate_model_segment};
+use uuid::Uuid;
 
 const GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com";
 
@@ -29,6 +30,23 @@ pub(super) struct GeminiRouteProvider {
     base_url: String,
     headers: Vec<(HeaderName, HeaderValue)>,
     timeout: Duration,
+}
+
+#[cfg(test)]
+pub(super) fn test_gemini_route_provider(
+    provider_name: impl Into<String>,
+    pricing_provider: impl Into<String>,
+    model: impl Into<String>,
+) -> GeminiRouteProvider {
+    GeminiRouteProvider {
+        provider_name: provider_name.into(),
+        pricing_provider: pricing_provider.into(),
+        model: model.into(),
+        api_key: String::new(),
+        base_url: String::new(),
+        headers: Vec::new(),
+        timeout: Duration::from_secs(1),
+    }
 }
 
 pub(super) fn ensure_gemini_provider_candidate_configured(
@@ -285,7 +303,15 @@ pub(super) async fn send_gemini_request(
     method: &'static str,
     stream: bool,
     request: &Value,
-) -> Result<(Option<UnifiedBudgetReservation>, reqwest::Response), ProviderError> {
+    api_key_budget_id: Option<Uuid>,
+) -> Result<
+    (
+        Option<UnifiedBudgetReservation>,
+        Option<BudgetReservation>,
+        reqwest::Response,
+    ),
+    ProviderError,
+> {
     super::super::spend::ensure_budget_available(
         &state.budget_limits,
         &provider.provider_name,
@@ -293,6 +319,11 @@ pub(super) async fn send_gemini_request(
     )?;
     let mut budget_reservation = super::spend::reserve_gemini_budget(state, provider, request)
         .map_err(gemini_gateway_error_to_provider_error)?;
+    let mut key_budget_reservation = super::super::spend::reserve_api_key_budget_for_reservation(
+        &state.budget_manager,
+        api_key_budget_id,
+        budget_reservation.as_ref(),
+    )?;
     let url = gemini_url(provider, api_version, method, stream)
         .map_err(gemini_gateway_error_to_provider_error)?;
     let response_result = apply_gemini_headers(gemini_http_client().post(url), provider)
@@ -307,6 +338,9 @@ pub(super) async fn send_gemini_request(
             if let Some(reservation) = budget_reservation.take() {
                 reservation.cancel();
             }
+            if let Some(reservation) = key_budget_reservation.take() {
+                reservation.cancel();
+            }
             return Err(gemini_gateway_error_to_provider_error(gemini_http_error(
                 error,
             )));
@@ -318,10 +352,13 @@ pub(super) async fn send_gemini_request(
             if let Some(reservation) = budget_reservation.take() {
                 reservation.cancel();
             }
+            if let Some(reservation) = key_budget_reservation.take() {
+                reservation.cancel();
+            }
             return Err(error);
         }
     };
-    Ok((budget_reservation, response))
+    Ok((budget_reservation, key_budget_reservation, response))
 }
 
 async fn gemini_response_or_provider_error(

--- a/src/server/routes/ai/gemini/spend.rs
+++ b/src/server/routes/ai/gemini/spend.rs
@@ -2,7 +2,9 @@ use bytes::Bytes;
 use serde_json::Value;
 use tracing::error;
 
-use crate::core::budget::{BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::budget::{
+    BudgetReservation, BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation,
+};
 use crate::core::keys::KeyManager;
 use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::ProviderError;
@@ -23,15 +25,24 @@ pub(super) async fn settle_gemini_stream_spend(
     provider: &GeminiRouteProvider,
     usage: Option<PricingUsage>,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
     saw_upstream_output: bool,
 ) {
     if let Some(usage) = usage {
-        record_gemini_usage(spend_state, provider, usage, budget_reservation).await;
+        record_gemini_usage(
+            spend_state,
+            provider,
+            usage,
+            budget_reservation,
+            key_budget_reservation,
+        )
+        .await;
     } else if saw_upstream_output {
         settle_gemini_reserved_spend_without_usage(
             spend_state,
             provider,
             budget_reservation,
+            key_budget_reservation,
             "Gemini SDK stream ended without usageMetadata",
         )
         .await;
@@ -66,6 +77,7 @@ pub(super) async fn record_gemini_spend(
     provider: &GeminiRouteProvider,
     body: &[u8],
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
     settle_without_usage: bool,
 ) {
     let Ok(value) = serde_json::from_slice::<Value>(body) else {
@@ -73,6 +85,7 @@ pub(super) async fn record_gemini_spend(
             spend_state,
             provider,
             budget_reservation,
+            key_budget_reservation,
             "Gemini SDK response was not valid JSON",
         )
         .await;
@@ -84,13 +97,21 @@ pub(super) async fn record_gemini_spend(
                 spend_state,
                 provider,
                 budget_reservation,
+                key_budget_reservation,
                 "Gemini SDK response had no usageMetadata",
             )
             .await;
         }
         return;
     };
-    record_gemini_usage(spend_state, provider, usage, budget_reservation).await;
+    record_gemini_usage(
+        spend_state,
+        provider,
+        usage,
+        budget_reservation,
+        key_budget_reservation,
+    )
+    .await;
 }
 
 pub(super) fn reserve_gemini_budget(
@@ -125,6 +146,7 @@ async fn record_gemini_usage(
     provider: &GeminiRouteProvider,
     usage: PricingUsage,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     let cost = match spend_state
         .pricing
@@ -139,6 +161,7 @@ async fn record_gemini_usage(
                 spend_state,
                 provider,
                 budget_reservation,
+                key_budget_reservation,
                 &format!("Gemini SDK cost calculation failed: {error}"),
             )
             .await;
@@ -158,6 +181,11 @@ async fn record_gemini_usage(
             .budget_limits
             .record_spend(&provider.provider_name, &provider.model, cost);
     }
+    super::super::spend::settle_api_key_budget_reservation(
+        key_budget_reservation,
+        cost,
+        "Gemini SDK spend",
+    );
 
     if let Some(key_id) = spend_state.api_key_id
         && let Err(error) = spend_state
@@ -173,9 +201,15 @@ async fn settle_gemini_reserved_spend_without_usage(
     spend_state: &GeminiSpendState<'_>,
     provider: &GeminiRouteProvider,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
     context: &str,
 ) {
     let Some(reservation) = budget_reservation else {
+        super::super::spend::settle_api_key_budget_reservation(
+            key_budget_reservation,
+            0.0,
+            context,
+        );
         error!(
             "{context} for provider '{}' model '{}'; spend not recorded",
             provider.provider_name, provider.model
@@ -189,6 +223,11 @@ async fn settle_gemini_reserved_spend_without_usage(
             provider.provider_name, provider.model
         );
     }
+    super::super::spend::settle_api_key_budget_reservation(
+        key_budget_reservation,
+        reserved,
+        context,
+    );
     if let Some(key_id) = spend_state.api_key_id
         && let Err(error) = spend_state
             .key_manager
@@ -317,6 +356,10 @@ fn collect_text_chars(value: &Value, chars: &mut usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::budget::{BudgetConfig, BudgetManager, BudgetScope};
+    use crate::core::keys::{InMemoryKeyRepository, KeyManager};
+    use crate::core::pricing_service::PricingService;
+    use crate::server::routes::ai::gemini::provider::test_gemini_route_provider;
 
     #[test]
     fn extracts_usage_from_crlf_sse_event_boundaries() {
@@ -335,5 +378,44 @@ mod tests {
         assert_eq!(usage.completion_tokens, 2);
         assert_eq!(usage.total_tokens, 3);
         assert!(buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_gemini_spend_settles_api_key_budget_reservation() {
+        let pricing = PricingService::with_embedded_default()
+            .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+        let budget_limits = UnifiedBudgetLimits::new();
+        let key_manager = KeyManager::new(InMemoryKeyRepository::new());
+        let budget_manager = BudgetManager::new();
+        let scope = BudgetScope::ApiKey("gemini-key-budget".to_string());
+        budget_manager
+            .create_budget(scope.clone(), BudgetConfig::new("gemini key", 1.0))
+            .await
+            .unwrap_or_else(|error| panic!("API key budget should be created: {error}"));
+        let key_budget_reservation = budget_manager
+            .tracker()
+            .reserve_spend(&scope, 0.5)
+            .unwrap_or_else(|error| panic!("API key budget should reserve: {error:?}"));
+        let provider = test_gemini_route_provider("openai", "openai", "gpt-4o");
+        let spend_state = GeminiSpendState {
+            pricing: &pricing,
+            budget_limits: &budget_limits,
+            key_manager: &key_manager,
+            api_key_id: None,
+        };
+
+        record_gemini_spend(
+            &spend_state,
+            &provider,
+            br#"{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#,
+            None,
+            Some(key_budget_reservation),
+            true,
+        )
+        .await;
+
+        let spend = budget_manager.get_current_spend(&scope);
+        assert!(spend > 0.0, "API key budget spend should be recorded");
+        assert!(spend < 0.5, "reservation should settle to actual spend");
     }
 }

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -3,6 +3,7 @@
 use crate::config::models::provider::ProviderConfig;
 mod generation;
 
+use crate::core::budget::BudgetReservation;
 use crate::core::models::openai::ImageGenerationRequest;
 use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::{Provider, ProviderError};
@@ -62,6 +63,13 @@ pub async fn image_generations(
 ) -> ActixResult<HttpResponse> {
     info!("Image generation request for model: {:?}", request.model);
 
+    if let Some(model) = request.model.as_deref()
+        && let Err(error) =
+            super::context::enforce_api_key_model_and_token_limits(&req, model, None)
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
     handle_ai_request(
         &req,
         request.into_inner(),
@@ -116,11 +124,12 @@ async fn proxy_image_multipart_endpoint(
     payload: web::Payload,
     endpoint: ImageProxyEndpoint,
 ) -> Result<HttpResponse, GatewayError> {
-    ensure_image_route_authorized(state, req)?;
+    let context = ensure_image_route_authorized(state, req)?;
     let content_type = image_multipart_content_type(req)?;
     let body = read_image_multipart_payload(payload).await?;
     let form_fields = extract_image_proxy_form_fields(&body, &content_type);
     let requested_model = required_image_proxy_model(&form_fields)?;
+    super::context::enforce_api_key_model_and_token_limits(req, requested_model, None)?;
     ensure_image_proxy_candidate_configured(
         state.config().gateway.providers.as_slice(),
         requested_model,
@@ -136,6 +145,7 @@ async fn proxy_image_multipart_endpoint(
         )));
     }
     let api_key_id = super::context::get_authenticated_api_key(req).map(|key| key.metadata.id);
+    let api_key_budget_id = context.api_key_budget_id();
 
     let mut last_router_error = None;
     for router_model in router_models {
@@ -163,20 +173,37 @@ async fn proxy_image_multipart_endpoint(
                             &provider.provider_name,
                             requested_model,
                         )?;
+                        let mut key_budget_reservation = super::spend::reserve_api_key_budget(
+                            &state.budget_manager,
+                            api_key_budget_id,
+                            Some(estimated_cost),
+                        )?;
                         let url = image_proxy_url(&provider, endpoint)
                             .map_err(image_proxy_gateway_error_to_provider_error)?;
-                        let response =
+                        let response_result =
                             apply_image_proxy_headers(image_http_client().post(url), &provider)
                                 .header(reqwest::header::CONTENT_TYPE, content_type)
                                 .body(body)
                                 .timeout(provider.timeout)
                                 .send()
-                                .await
-                                .map_err(|error| {
-                                    ProviderError::network("image_proxy", error.to_string())
-                                })?;
+                                .await;
+                        let response = match response_result {
+                            Ok(response) => response,
+                            Err(error) => {
+                                if let Some(reservation) = key_budget_reservation.take() {
+                                    reservation.cancel();
+                                }
+                                return Err(ProviderError::network(
+                                    "image_proxy",
+                                    error.to_string(),
+                                ));
+                            }
+                        };
 
                         if !response.status().is_success() {
+                            if let Some(reservation) = key_budget_reservation.take() {
+                                reservation.cancel();
+                            }
                             return Err(image_proxy_upstream_error(response).await);
                         }
 
@@ -187,6 +214,7 @@ async fn proxy_image_multipart_endpoint(
                             &usage,
                             estimated_cost,
                             api_key_id,
+                            key_budget_reservation.take(),
                         )
                         .await;
                         let tokens_used = image_proxy_tokens_used(&usage);
@@ -224,6 +252,7 @@ async fn record_image_proxy_spend(
     usage: &PricingUsage,
     cost: f64,
     api_key_id: Option<uuid::Uuid>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     state
         .budget_limits
@@ -242,6 +271,7 @@ async fn record_image_proxy_spend(
             error!("failed to record image proxy usage for key {api_key_id}: {error}");
         }
     }
+    super::spend::settle_api_key_budget_reservation(key_budget_reservation, cost, "image proxy");
 }
 
 fn required_image_proxy_model(form_fields: &ImageProxyFormFields) -> Result<&str, GatewayError> {

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -35,6 +35,8 @@ pub async fn handle_image_generation_with_state(
 
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
     let budget_limits = state.budget_limits.clone();
     let key_manager = state.key_manager.clone();
     let pricing_service = state.pricing.clone();
@@ -45,6 +47,7 @@ pub async fn handle_image_generation_with_state(
         move |provider, selected_model, _deployment_id| {
             let core_request = core_request.clone();
             let context = context_for_execution.clone();
+            let budget_manager = budget_manager.clone();
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
@@ -72,6 +75,12 @@ pub async fn handle_image_generation_with_state(
                         &pricing_model,
                         &usage,
                     )?;
+                let key_budget_reservation =
+                    super::super::spend::reserve_api_key_budget_for_reservation(
+                        &budget_manager,
+                        api_key_budget_id,
+                        budget_reservation.as_ref(),
+                    )?;
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = Some(selected_model.clone());
                 let response = provider
@@ -93,6 +102,7 @@ pub async fn handle_image_generation_with_state(
                     &pricing_model,
                     &usage,
                     budget_reservation,
+                    key_budget_reservation,
                 )
                 .await;
                 Ok((response, tokens_used))

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -24,6 +24,7 @@ mod rerank;
 mod responses;
 mod responses_stream;
 mod spend;
+mod token_policy;
 
 // Public re-exports for backward compatibility
 pub use audio::{audio_speech, audio_transcriptions, audio_translations};
@@ -31,8 +32,8 @@ pub use batches::{cancel_batch, create_batch, get_batch, list_batches};
 pub use chat::chat_completions;
 pub use completions::{completions, engine_completions};
 pub use context::{
-    check_permission, get_authenticated_api_key, get_authenticated_user, get_request_context,
-    handle_ai_request, log_api_usage,
+    api_key_allows_endpoint, check_permission, get_authenticated_api_key, get_authenticated_user,
+    get_request_context, handle_ai_request, log_api_usage,
 };
 pub use embeddings::embeddings;
 pub use files::{create_file, delete_file, get_file, get_file_content, list_files};

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -37,7 +37,7 @@ pub async fn create_moderation(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
-    match proxy_moderation(state.get_ref(), request.into_inner()).await {
+    match proxy_moderation(state.get_ref(), &req, request.into_inner()).await {
         Ok(response) => Ok(response),
         Err(error) => {
             error!("Moderation route error: {}", error);
@@ -68,9 +68,11 @@ fn ensure_moderation_route_authorized(
 
 async fn proxy_moderation(
     state: &AppState,
+    req: &HttpRequest,
     mut request: Value,
 ) -> Result<HttpResponse, GatewayError> {
     let resolved_model = validate_moderation_request(&request)?;
+    super::context::enforce_api_key_model_and_token_limits(req, &resolved_model, None)?;
     apply_resolved_moderation_model(&mut request, &resolved_model);
     ensure_moderation_proxy_candidate_configured(
         state.config().gateway.providers.as_slice(),

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -27,6 +27,12 @@ pub async fn rerank(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
+    if let Err(error) =
+        super::context::enforce_api_key_model_and_token_limits(&req, &request.model, None)
+    {
+        return Ok(openai_errors::gateway_error_response(&error));
+    }
+
     match handle_rerank_with_state(state.get_ref(), request.into_inner()).await {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(error) => {

--- a/src/server/routes/ai/responses.rs
+++ b/src/server/routes/ai/responses.rs
@@ -31,12 +31,20 @@ pub async fn create_response(
 ) -> ActixResult<HttpResponse> {
     info!("Responses API request for model: {}", payload.model);
 
-    let context = super::context::get_request_context(&req)?;
+    let mut context = super::context::get_request_context(&req)?;
+    super::token_policy::attach_api_key_token_limit(&req, &mut context)?;
     let owner = lifecycle::response_owner(&context);
     let request = payload.into_inner();
 
     if request.model.trim().is_empty() {
         return Ok(openai_errors::validation_error("model must not be empty"));
+    }
+    if let Err(error) = super::context::enforce_api_key_model_and_token_limits(
+        &req,
+        &request.model,
+        request.max_output_tokens,
+    ) {
+        return Ok(openai_errors::gateway_error_response(&error));
     }
 
     match &request.input {
@@ -243,6 +251,7 @@ pub(crate) fn build_chat_request(
         model: req.model.clone(),
         messages,
         temperature: req.temperature,
+        max_tokens: req.max_output_tokens,
         max_completion_tokens: req.max_output_tokens,
         top_p: req.top_p,
         stream: req.stream,
@@ -488,6 +497,7 @@ mod tests {
         req.max_output_tokens = Some(512);
         let chat = build_chat_request(&req).unwrap();
         assert_eq!(chat.max_completion_tokens, Some(512));
+        assert_eq!(chat.max_tokens, Some(512));
     }
 
     #[test]

--- a/src/server/routes/ai/responses/lifecycle.rs
+++ b/src/server/routes/ai/responses/lifecycle.rs
@@ -339,6 +339,7 @@ fn cleanup_response_store() {
             remove_response_and_task(response_id);
         }
     }
+    remove_orphaned_background_tasks();
 
     entries.retain(|(_, created_at)| now.saturating_sub(*created_at) <= RESPONSE_STORE_TTL_SECS);
     let overflow = entries
@@ -359,6 +360,19 @@ fn remove_response_and_task(response_id: &str) {
     RESPONSE_STORE.remove(response_id);
     if let Some((_, task)) = BACKGROUND_TASKS.remove(response_id) {
         task.abort();
+    }
+}
+
+fn remove_orphaned_background_tasks() {
+    let orphaned = BACKGROUND_TASKS
+        .iter()
+        .filter(|entry| !RESPONSE_STORE.contains_key(entry.key().as_str()))
+        .map(|entry| entry.key().clone())
+        .collect::<Vec<_>>();
+    for response_id in orphaned {
+        if let Some((_, task)) = BACKGROUND_TASKS.remove(&response_id) {
+            task.abort();
+        }
     }
 }
 

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -3,15 +3,12 @@
 //! Translates internal `ChatChunk` SSE events into Responses API streaming
 //! events as defined in the OpenAI Responses API specification.
 
-use crate::core::budget::{UnifiedBudgetLimits, UnifiedBudgetReservation};
-use crate::core::keys::KeyManager;
 use crate::core::models::openai::requests::{ChatCompletionRequest, StreamOptions};
 use crate::core::models::openai::responses_api::{
     ResponseFunctionCall, ResponseInputTokensDetails, ResponseOutputContent, ResponseOutputItem,
     ResponseOutputMessage, ResponseOutputTokensDetails, ResponseReasoningItem, ResponseStreamEvent,
     ResponseUsage, ResponsesApiRequest, ResponsesApiResponse,
 };
-use crate::core::pricing_service::PricingService;
 use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
 use crate::core::types::responses::Usage as ChatUsage;
@@ -29,13 +26,14 @@ use bytes::Bytes;
 use futures::StreamExt;
 use serde_json::json;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
-use uuid::Uuid;
 
 use super::{openai_errors, spend};
+#[path = "responses_stream_budget.rs"]
+mod responses_stream_budget;
+use responses_stream_budget::StreamBudgetSettlement;
 
 /// Accumulated state for one in-progress tool call during streaming.
 struct ToolCallAccum {
@@ -44,49 +42,6 @@ struct ToolCallAccum {
     name: String,
     arguments: String,
     output_index: u32,
-}
-
-struct StreamBudgetSettlement {
-    pricing_service: Arc<PricingService>,
-    budget_limits: Arc<UnifiedBudgetLimits>,
-    key_manager: KeyManager,
-    api_key_id: Option<Uuid>,
-    provider: String,
-    model: String,
-    reservation: Option<UnifiedBudgetReservation>,
-}
-
-impl StreamBudgetSettlement {
-    async fn record_completion(mut self, usage: Option<&ChatUsage>, saw_upstream_output: bool) {
-        spend::record_finished_stream_spend_with_reservation_with_pricing(
-            self.pricing_service.as_ref(),
-            spend::StreamSpendSettlement {
-                budget_limits: self.budget_limits.as_ref(),
-                key_manager: &self.key_manager,
-                api_key_id: self.api_key_id,
-                provider: &self.provider,
-                model: &self.model,
-                usage,
-                saw_upstream_output,
-                budget_reservation: self.reservation.take(),
-            },
-        )
-        .await;
-    }
-
-    async fn record_disconnect(&mut self, usage: Option<&ChatUsage>) {
-        spend::record_stream_disconnect_spend_with_reservation_with_pricing(
-            self.pricing_service.as_ref(),
-            self.budget_limits.as_ref(),
-            &self.key_manager,
-            self.api_key_id,
-            &self.provider,
-            &self.model,
-            usage,
-            self.reservation.take(),
-        )
-        .await;
-    }
 }
 
 /// Streaming path for POST /v1/responses.
@@ -123,6 +78,8 @@ pub(crate) async fn handle_streaming_response(
     let budget_limits = state.budget_limits.clone();
     let pricing_service = state.pricing.clone();
     let api_key_id = context.api_key_id();
+    let api_key_budget_id = context.api_key_budget_id();
+    let budget_manager = state.budget_manager.clone();
 
     match execute_stream_with_selected_deployment(
         state.unified_router.clone(),
@@ -133,27 +90,48 @@ pub(crate) async fn handle_streaming_response(
             let ctx = context_clone.clone();
             let budget_limits = budget_limits.clone();
             let pricing_service = pricing_service.clone();
+            let budget_manager = budget_manager.clone();
             let request_for_budget = request_for_budget.clone();
             async move {
-                spend::ensure_budget_available(&budget_limits, provider.name(), &selected_model)?;
+                let provider_name = provider.name().to_string();
+                let (req, request_for_budget) =
+                    super::token_policy::prepare_chat_request_for_provider(
+                        ctx.api_key_max_tokens_per_request(),
+                        &provider_name,
+                        &selected_model,
+                        core_request.clone(),
+                        request_for_budget,
+                    )?;
+                spend::ensure_budget_available(&budget_limits, &provider_name, &selected_model)?;
                 let budget_reservation = spend::reserve_chat_completion_budget_with_pricing(
                     pricing_service.as_ref(),
                     &budget_limits,
-                    provider.name(),
+                    &provider_name,
                     &selected_model,
                     &request_for_budget,
                 )?;
-                let provider_name = provider.name().to_string();
-                let mut req = core_request.clone();
-                req.model = selected_model.clone();
+                let key_budget_reservation = spend::reserve_api_key_budget_for_reservation(
+                    &budget_manager,
+                    api_key_budget_id,
+                    budget_reservation.as_ref(),
+                )?;
                 let stream = provider.chat_completion_stream(req, ctx).await?;
-                Ok((stream, provider_name, selected_model, budget_reservation))
+                Ok((
+                    stream,
+                    provider_name,
+                    selected_model,
+                    budget_reservation,
+                    key_budget_reservation,
+                ))
             }
         },
     )
     .await
     {
-        Ok(((mut stream, served_provider, served_model, budget_reservation), lease)) => {
+        Ok((
+            (mut stream, served_provider, served_model, budget_reservation, key_budget_reservation),
+            lease,
+        )) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout = state.config.load().gateway.server.stream_idle_timeout;
             let settlement = StreamBudgetSettlement {
@@ -164,6 +142,7 @@ pub(crate) async fn handle_streaming_response(
                 provider: served_provider,
                 model: served_model,
                 reservation: budget_reservation,
+                key_budget_reservation,
             };
 
             tokio::spawn(async move {

--- a/src/server/routes/ai/responses_stream_budget.rs
+++ b/src/server/routes/ai/responses_stream_budget.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::core::budget::{BudgetReservation, UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::keys::KeyManager;
+use crate::core::models::openai::Usage as ChatUsage;
+use crate::core::pricing_service::PricingService;
+
+use super::spend;
+
+pub(super) struct StreamBudgetSettlement {
+    pub(super) pricing_service: Arc<PricingService>,
+    pub(super) budget_limits: Arc<UnifiedBudgetLimits>,
+    pub(super) key_manager: KeyManager,
+    pub(super) api_key_id: Option<Uuid>,
+    pub(super) provider: String,
+    pub(super) model: String,
+    pub(super) reservation: Option<UnifiedBudgetReservation>,
+    pub(super) key_budget_reservation: Option<BudgetReservation>,
+}
+
+impl StreamBudgetSettlement {
+    pub(super) async fn record_completion(
+        mut self,
+        usage: Option<&ChatUsage>,
+        saw_upstream_output: bool,
+    ) {
+        spend::record_finished_stream_spend_with_reservation_with_pricing(
+            self.pricing_service.as_ref(),
+            spend::StreamSpendSettlement {
+                budget_limits: self.budget_limits.as_ref(),
+                key_manager: &self.key_manager,
+                api_key_id: self.api_key_id,
+                provider: &self.provider,
+                model: &self.model,
+                usage,
+                saw_upstream_output,
+                budget_reservation: self.reservation.take(),
+                key_budget_reservation: self.key_budget_reservation.take(),
+            },
+        )
+        .await;
+    }
+
+    pub(super) async fn record_disconnect(&mut self, usage: Option<&ChatUsage>) {
+        spend::record_stream_disconnect_spend_with_reservation_with_pricing(
+            self.pricing_service.as_ref(),
+            self.budget_limits.as_ref(),
+            &self.key_manager,
+            self.api_key_id,
+            &self.provider,
+            &self.model,
+            usage,
+            self.reservation.take(),
+            self.key_budget_reservation.take(),
+        )
+        .await;
+    }
+}

--- a/src/server/routes/ai/responses_stream_budget.rs
+++ b/src/server/routes/ai/responses_stream_budget.rs
@@ -46,14 +46,16 @@ impl StreamBudgetSettlement {
     pub(super) async fn record_disconnect(&mut self, usage: Option<&ChatUsage>) {
         spend::record_stream_disconnect_spend_with_reservation_with_pricing(
             self.pricing_service.as_ref(),
-            self.budget_limits.as_ref(),
-            &self.key_manager,
-            self.api_key_id,
-            &self.provider,
-            &self.model,
-            usage,
-            self.reservation.take(),
-            self.key_budget_reservation.take(),
+            spend::usage_spend_settlement(
+                (
+                    self.budget_limits.as_ref(),
+                    &self.key_manager,
+                    self.api_key_id,
+                ),
+                (&self.provider, &self.model, usage),
+                self.reservation.take(),
+                self.key_budget_reservation.take(),
+            ),
         )
         .await;
     }

--- a/src/server/routes/ai/responses_stream_tests.rs
+++ b/src/server/routes/ai/responses_stream_tests.rs
@@ -166,6 +166,7 @@ async fn disconnect_after_upstream_output_settles_reserved_budget() {
         provider: "openai".to_string(),
         model: "gpt-4o".to_string(),
         reservation: Some(reservation),
+        key_budget_reservation: None,
     };
 
     settlement.record_disconnect(None).await;
@@ -212,6 +213,7 @@ async fn completed_stream_without_usage_after_output_settles_reserved_budget() {
         provider: "openai".to_string(),
         model: "gpt-4o".to_string(),
         reservation: Some(reservation),
+        key_budget_reservation: None,
     };
 
     settlement.record_completion(None, true).await;

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -4,11 +4,14 @@
 //! path: once a completion succeeds and its token usage is known, the served
 //! provider/model budget spend and the calling key's usage are recorded.
 
+mod key_budget;
 mod pricing;
 
 use uuid::Uuid;
 
-use crate::core::budget::{BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::budget::{
+    BudgetReservation, BudgetReservationError, UnifiedBudgetLimits, UnifiedBudgetReservation,
+};
 use crate::core::keys::KeyManager;
 use crate::core::models::openai::requests::ChatCompletionRequest;
 use crate::core::models::openai::{
@@ -21,6 +24,10 @@ use crate::utils::ai::counter::token_counter::TokenCounter;
 #[cfg(test)]
 use std::sync::LazyLock;
 
+pub(in crate::server::routes::ai) use key_budget::{
+    reserve_api_key_budget, reserve_api_key_budget_for_reservation,
+    settle_api_key_budget_reservation,
+};
 pub(super) use pricing::{
     pricing_identity_for_provider, record_pricing_usage_spend_with_reservation_with_pricing,
     reserve_embedding_budget_with_pricing, reserve_pricing_usage_budget_with_pricing,
@@ -413,7 +420,7 @@ fn fallback_message_tokens(messages: &[ChatMessage]) -> u32 {
     u32::try_from(chars.div_ceil(4).saturating_add(overhead)).unwrap_or(u32::MAX)
 }
 
-fn reservation_error_to_provider_error(
+pub(in crate::server::routes::ai) fn reservation_error_to_provider_error(
     error: BudgetReservationError,
     provider: &str,
     model: &str,
@@ -457,6 +464,7 @@ pub(super) async fn record_completion_spend_with_reservation(
     model: &str,
     usage: Option<&Usage>,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     record_completion_spend_with_reservation_with_pricing(
         default_spend_pricing_service(),
@@ -467,6 +475,7 @@ pub(super) async fn record_completion_spend_with_reservation(
         model,
         usage,
         budget_reservation,
+        key_budget_reservation,
     )
     .await;
 }
@@ -481,6 +490,7 @@ pub(super) async fn record_completion_spend_with_reservation_with_pricing(
     model: &str,
     usage: Option<&Usage>,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     let Some(usage) = usage else {
         record_reserved_spend_without_usage(
@@ -489,6 +499,7 @@ pub(super) async fn record_completion_spend_with_reservation_with_pricing(
             provider,
             model,
             budget_reservation,
+            key_budget_reservation,
             "provider returned no usage for a successful completion",
         )
         .await;
@@ -524,6 +535,11 @@ pub(super) async fn record_completion_spend_with_reservation_with_pricing(
         } else {
             budget_limits.record_spend(provider, model, cost);
         }
+        settle_api_key_budget_reservation(
+            key_budget_reservation,
+            cost,
+            &format!("{provider}/{model}"),
+        );
     }
 
     if let Some(key_id) = api_key_id {
@@ -544,6 +560,7 @@ async fn record_reserved_spend_without_usage(
     provider: &str,
     model: &str,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
     context: &str,
 ) {
     let Some(reservation) = budget_reservation else {
@@ -561,6 +578,7 @@ async fn record_reserved_spend_without_usage(
     {
         tracing::error!("failed to record reserved usage for key {key_id}: {error}");
     }
+    settle_api_key_budget_reservation(key_budget_reservation, reserved, context);
 }
 
 #[cfg(test)]
@@ -572,6 +590,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation(
     model: &str,
     usage: Option<&Usage>,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     record_stream_disconnect_spend_with_reservation_with_pricing(
         default_spend_pricing_service(),
@@ -582,6 +601,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation(
         model,
         usage,
         budget_reservation,
+        key_budget_reservation,
     )
     .await;
 }
@@ -596,6 +616,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing
     model: &str,
     usage: Option<&Usage>,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     if let Some(usage) = usage {
         record_completion_spend_with_reservation_with_pricing(
@@ -607,6 +628,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing
             model,
             Some(usage),
             budget_reservation,
+            key_budget_reservation,
         )
         .await;
         return;
@@ -618,6 +640,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing
         provider,
         model,
         budget_reservation,
+        key_budget_reservation,
         "client disconnected before provider returned usage",
     )
     .await;
@@ -632,6 +655,7 @@ pub(super) struct StreamSpendSettlement<'a> {
     pub(super) usage: Option<&'a Usage>,
     pub(super) saw_upstream_output: bool,
     pub(super) budget_reservation: Option<UnifiedBudgetReservation>,
+    pub(super) key_budget_reservation: Option<BudgetReservation>,
 }
 
 #[cfg(test)]
@@ -658,6 +682,7 @@ pub(super) async fn record_finished_stream_spend_with_reservation_with_pricing(
         usage,
         saw_upstream_output,
         budget_reservation,
+        key_budget_reservation,
     } = settlement;
 
     if usage.is_some() || saw_upstream_output {
@@ -670,6 +695,7 @@ pub(super) async fn record_finished_stream_spend_with_reservation_with_pricing(
             model,
             usage,
             budget_reservation,
+            key_budget_reservation,
         )
         .await;
         return;
@@ -684,6 +710,7 @@ pub(super) async fn record_finished_stream_spend_with_reservation_with_pricing(
         model,
         usage,
         budget_reservation,
+        key_budget_reservation,
     )
     .await;
 }

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -455,19 +455,26 @@ pub(in crate::server::routes::ai) fn reservation_error_to_provider_error(
 /// response. When the cost cannot be priced, token usage is still recorded but
 /// budget spend is skipped rather than booked at $0 — under-counting a budget is
 /// worse than leaving it unchanged with a loud error.
-#[cfg(test)]
-pub(super) async fn record_completion_spend_with_reservation(
-    budget_limits: &UnifiedBudgetLimits,
-    key_manager: &KeyManager,
-    api_key_id: Option<Uuid>,
-    provider: &str,
-    model: &str,
-    usage: Option<&Usage>,
+pub(super) struct UsageSpendSettlement<'a> {
+    pub(super) budget_limits: &'a UnifiedBudgetLimits,
+    pub(super) key_manager: &'a KeyManager,
+    pub(super) api_key_id: Option<Uuid>,
+    pub(super) provider: &'a str,
+    pub(super) model: &'a str,
+    pub(super) usage: Option<&'a Usage>,
+    pub(super) budget_reservation: Option<UnifiedBudgetReservation>,
+    pub(super) key_budget_reservation: Option<BudgetReservation>,
+}
+
+pub(super) fn usage_spend_settlement<'a>(
+    core: (&'a UnifiedBudgetLimits, &'a KeyManager, Option<Uuid>),
+    usage: (&'a str, &'a str, Option<&'a Usage>),
     budget_reservation: Option<UnifiedBudgetReservation>,
     key_budget_reservation: Option<BudgetReservation>,
-) {
-    record_completion_spend_with_reservation_with_pricing(
-        default_spend_pricing_service(),
+) -> UsageSpendSettlement<'a> {
+    let (budget_limits, key_manager, api_key_id) = core;
+    let (provider, model, usage) = usage;
+    UsageSpendSettlement {
         budget_limits,
         key_manager,
         api_key_id,
@@ -476,22 +483,33 @@ pub(super) async fn record_completion_spend_with_reservation(
         usage,
         budget_reservation,
         key_budget_reservation,
+    }
+}
+
+#[cfg(test)]
+pub(super) async fn record_completion_spend_with_reservation(settlement: UsageSpendSettlement<'_>) {
+    record_completion_spend_with_reservation_with_pricing(
+        default_spend_pricing_service(),
+        settlement,
     )
     .await;
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn record_completion_spend_with_reservation_with_pricing(
     pricing_service: &PricingService,
-    budget_limits: &UnifiedBudgetLimits,
-    key_manager: &KeyManager,
-    api_key_id: Option<Uuid>,
-    provider: &str,
-    model: &str,
-    usage: Option<&Usage>,
-    budget_reservation: Option<UnifiedBudgetReservation>,
-    key_budget_reservation: Option<BudgetReservation>,
+    settlement: UsageSpendSettlement<'_>,
 ) {
+    let UsageSpendSettlement {
+        budget_limits,
+        key_manager,
+        api_key_id,
+        provider,
+        model,
+        usage,
+        budget_reservation,
+        key_budget_reservation,
+    } = settlement;
+
     let Some(usage) = usage else {
         record_reserved_spend_without_usage(
             key_manager,
@@ -583,17 +601,20 @@ async fn record_reserved_spend_without_usage(
 
 #[cfg(test)]
 pub(super) async fn record_stream_disconnect_spend_with_reservation(
-    budget_limits: &UnifiedBudgetLimits,
-    key_manager: &KeyManager,
-    api_key_id: Option<Uuid>,
-    provider: &str,
-    model: &str,
-    usage: Option<&Usage>,
-    budget_reservation: Option<UnifiedBudgetReservation>,
-    key_budget_reservation: Option<BudgetReservation>,
+    settlement: UsageSpendSettlement<'_>,
 ) {
     record_stream_disconnect_spend_with_reservation_with_pricing(
         default_spend_pricing_service(),
+        settlement,
+    )
+    .await;
+}
+
+pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing(
+    pricing_service: &PricingService,
+    settlement: UsageSpendSettlement<'_>,
+) {
+    let UsageSpendSettlement {
         budget_limits,
         key_manager,
         api_key_id,
@@ -602,33 +623,17 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation(
         usage,
         budget_reservation,
         key_budget_reservation,
-    )
-    .await;
-}
+    } = settlement;
 
-#[allow(clippy::too_many_arguments)]
-pub(super) async fn record_stream_disconnect_spend_with_reservation_with_pricing(
-    pricing_service: &PricingService,
-    budget_limits: &UnifiedBudgetLimits,
-    key_manager: &KeyManager,
-    api_key_id: Option<Uuid>,
-    provider: &str,
-    model: &str,
-    usage: Option<&Usage>,
-    budget_reservation: Option<UnifiedBudgetReservation>,
-    key_budget_reservation: Option<BudgetReservation>,
-) {
     if let Some(usage) = usage {
         record_completion_spend_with_reservation_with_pricing(
             pricing_service,
-            budget_limits,
-            key_manager,
-            api_key_id,
-            provider,
-            model,
-            Some(usage),
-            budget_reservation,
-            key_budget_reservation,
+            usage_spend_settlement(
+                (budget_limits, key_manager, api_key_id),
+                (provider, model, Some(usage)),
+                budget_reservation,
+                key_budget_reservation,
+            ),
         )
         .await;
         return;
@@ -688,14 +693,12 @@ pub(super) async fn record_finished_stream_spend_with_reservation_with_pricing(
     if usage.is_some() || saw_upstream_output {
         record_stream_disconnect_spend_with_reservation_with_pricing(
             pricing_service,
-            budget_limits,
-            key_manager,
-            api_key_id,
-            provider,
-            model,
-            usage,
-            budget_reservation,
-            key_budget_reservation,
+            usage_spend_settlement(
+                (budget_limits, key_manager, api_key_id),
+                (provider, model, usage),
+                budget_reservation,
+                key_budget_reservation,
+            ),
         )
         .await;
         return;
@@ -703,14 +706,12 @@ pub(super) async fn record_finished_stream_spend_with_reservation_with_pricing(
 
     record_completion_spend_with_reservation_with_pricing(
         pricing_service,
-        budget_limits,
-        key_manager,
-        api_key_id,
-        provider,
-        model,
-        usage,
-        budget_reservation,
-        key_budget_reservation,
+        usage_spend_settlement(
+            (budget_limits, key_manager, api_key_id),
+            (provider, model, usage),
+            budget_reservation,
+            key_budget_reservation,
+        ),
     )
     .await;
 }

--- a/src/server/routes/ai/spend/key_budget.rs
+++ b/src/server/routes/ai/spend/key_budget.rs
@@ -1,0 +1,142 @@
+use uuid::Uuid;
+
+use crate::core::budget::{
+    BudgetManager, BudgetReservation, BudgetReservationError, BudgetScope, UnifiedBudgetReservation,
+};
+use crate::core::providers::unified_provider::ProviderError;
+
+pub(in crate::server::routes::ai) fn reserve_api_key_budget(
+    budget_manager: &BudgetManager,
+    api_key_budget_id: Option<Uuid>,
+    estimated_cost: Option<f64>,
+) -> Result<Option<BudgetReservation>, ProviderError> {
+    let Some(budget_id) = api_key_budget_id else {
+        return Ok(None);
+    };
+    let Some(estimated_cost) = estimated_cost.filter(|cost| *cost > 0.0) else {
+        return Err(ProviderError::invalid_request(
+            "pricing",
+            format!("pricing is required for API key budget '{budget_id}'"),
+        ));
+    };
+
+    let scope = key_budget_scope(budget_manager, budget_id)?;
+    budget_manager
+        .tracker()
+        .reserve_spend(&scope, estimated_cost)
+        .map(Some)
+        .map_err(|error| key_reservation_error_to_provider_error(error, budget_id))
+}
+
+pub(in crate::server::routes::ai) fn reserve_api_key_budget_for_reservation(
+    budget_manager: &BudgetManager,
+    api_key_budget_id: Option<Uuid>,
+    budget_reservation: Option<&UnifiedBudgetReservation>,
+) -> Result<Option<BudgetReservation>, ProviderError> {
+    reserve_api_key_budget(
+        budget_manager,
+        api_key_budget_id,
+        budget_reservation.map(UnifiedBudgetReservation::reserved_amount),
+    )
+}
+
+pub(in crate::server::routes::ai) fn settle_api_key_budget_reservation(
+    reservation: Option<BudgetReservation>,
+    actual_cost: f64,
+    context: &str,
+) {
+    let Some(reservation) = reservation else {
+        return;
+    };
+
+    if let Err(error) = reservation.settle(actual_cost) {
+        tracing::error!("failed to settle API key budget for {context}: {error:?}");
+    }
+}
+
+fn key_budget_scope(
+    budget_manager: &BudgetManager,
+    budget_id: Uuid,
+) -> Result<BudgetScope, ProviderError> {
+    budget_manager
+        .get_budget_by_id(&budget_id.to_string())
+        .map(|budget| budget.scope)
+        .ok_or_else(|| {
+            ProviderError::quota_exceeded(
+                "budget",
+                format!("API key budget '{budget_id}' is not configured"),
+            )
+        })
+}
+
+fn key_reservation_error_to_provider_error(
+    error: BudgetReservationError,
+    budget_id: Uuid,
+) -> ProviderError {
+    match error {
+        BudgetReservationError::BudgetExceeded => ProviderError::quota_exceeded(
+            "budget",
+            format!("API key budget '{budget_id}' exceeded"),
+        ),
+        BudgetReservationError::InvalidAmount(error) => ProviderError::invalid_request(
+            "budget",
+            format!("invalid API key budget reservation amount for '{budget_id}': {error}"),
+        ),
+        BudgetReservationError::ActualExceedsReservation => ProviderError::invalid_request(
+            "budget",
+            format!("actual spend exceeded reserved API key budget '{budget_id}'"),
+        ),
+        BudgetReservationError::ProviderBudgetExceeded
+        | BudgetReservationError::ModelBudgetExceeded => ProviderError::quota_exceeded(
+            "budget",
+            format!("API key budget '{budget_id}' exceeded"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::budget::BudgetConfig;
+
+    #[tokio::test]
+    async fn reserve_api_key_budget_rejects_unknown_budget_id() {
+        let manager = BudgetManager::new();
+        let budget_id = Uuid::new_v4();
+
+        let error = match reserve_api_key_budget(&manager, Some(budget_id), Some(0.01)) {
+            Ok(_) => panic!("unknown API key budget should fail closed"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, ProviderError::QuotaExceeded { .. }));
+    }
+
+    #[tokio::test]
+    async fn reserve_api_key_budget_uses_configured_budget_scope() {
+        let manager = BudgetManager::new();
+        let scope = BudgetScope::ApiKey("key-budget-scope".to_string());
+        let budget = match manager
+            .create_budget(scope.clone(), BudgetConfig::new("key budget", 1.0))
+            .await
+        {
+            Ok(budget) => budget,
+            Err(error) => panic!("key budget should be created: {error}"),
+        };
+        let budget_id = match Uuid::parse_str(&budget.id) {
+            Ok(budget_id) => budget_id,
+            Err(error) => panic!("budget id should be a UUID string: {error}"),
+        };
+
+        let reservation = match reserve_api_key_budget(&manager, Some(budget_id), Some(0.25)) {
+            Ok(Some(reservation)) => reservation,
+            Ok(None) => panic!("configured API key budget should reserve spend"),
+            Err(error) => panic!("configured API key budget should reserve: {error}"),
+        };
+        assert_eq!(manager.get_current_spend(&scope), 0.25);
+
+        settle_api_key_budget_reservation(Some(reservation), 0.10, "test");
+
+        assert_eq!(manager.get_current_spend(&scope), 0.10);
+    }
+}

--- a/src/server/routes/ai/spend/key_budget.rs
+++ b/src/server/routes/ai/spend/key_budget.rs
@@ -13,12 +13,15 @@ pub(in crate::server::routes::ai) fn reserve_api_key_budget(
     let Some(budget_id) = api_key_budget_id else {
         return Ok(None);
     };
-    let Some(estimated_cost) = estimated_cost.filter(|cost| *cost > 0.0) else {
+    let Some(estimated_cost) = estimated_cost else {
         return Err(ProviderError::invalid_request(
             "pricing",
             format!("pricing is required for API key budget '{budget_id}'"),
         ));
     };
+    if estimated_cost <= 0.0 {
+        return Ok(None);
+    }
 
     let scope = key_budget_scope(budget_manager, budget_id)?;
     budget_manager
@@ -33,10 +36,13 @@ pub(in crate::server::routes::ai) fn reserve_api_key_budget_for_reservation(
     api_key_budget_id: Option<Uuid>,
     budget_reservation: Option<&UnifiedBudgetReservation>,
 ) -> Result<Option<BudgetReservation>, ProviderError> {
+    let Some(budget_reservation) = budget_reservation else {
+        return Ok(None);
+    };
     reserve_api_key_budget(
         budget_manager,
         api_key_budget_id,
-        budget_reservation.map(UnifiedBudgetReservation::reserved_amount),
+        Some(budget_reservation.reserved_amount()),
     )
 }
 
@@ -138,5 +144,44 @@ mod tests {
         settle_api_key_budget_reservation(Some(reservation), 0.10, "test");
 
         assert_eq!(manager.get_current_spend(&scope), 0.10);
+    }
+
+    #[tokio::test]
+    async fn reserve_api_key_budget_allows_zero_cost_priced_request() {
+        let manager = BudgetManager::new();
+        let scope = BudgetScope::ApiKey("free-key-budget-scope".to_string());
+        let budget = match manager
+            .create_budget(scope.clone(), BudgetConfig::new("free key budget", 1.0))
+            .await
+        {
+            Ok(budget) => budget,
+            Err(error) => panic!("key budget should be created: {error}"),
+        };
+        let budget_id = match Uuid::parse_str(&budget.id) {
+            Ok(budget_id) => budget_id,
+            Err(error) => panic!("budget id should be a UUID string: {error}"),
+        };
+
+        let reservation = match reserve_api_key_budget(&manager, Some(budget_id), Some(0.0)) {
+            Ok(reservation) => reservation,
+            Err(error) => panic!("zero-cost priced request should not fail: {error}"),
+        };
+
+        assert!(reservation.is_none());
+        assert_eq!(manager.get_current_spend(&scope), 0.0);
+    }
+
+    #[tokio::test]
+    async fn reserve_api_key_budget_for_absent_reservation_is_noop() {
+        let manager = BudgetManager::new();
+        let budget_id = Uuid::new_v4();
+
+        let reservation =
+            match reserve_api_key_budget_for_reservation(&manager, Some(budget_id), None) {
+                Ok(reservation) => reservation,
+                Err(error) => panic!("absent upstream reservation should not fail: {error}"),
+            };
+
+        assert!(reservation.is_none());
     }
 }

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-use crate::core::budget::{UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::budget::{BudgetReservation, UnifiedBudgetLimits, UnifiedBudgetReservation};
 use crate::core::keys::KeyManager;
 use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::Provider;
@@ -141,6 +141,7 @@ pub(in crate::server::routes::ai) async fn record_pricing_usage_spend_with_reser
     pricing_model: &str,
     usage: &PricingUsage,
     budget_reservation: Option<UnifiedBudgetReservation>,
+    key_budget_reservation: Option<BudgetReservation>,
 ) {
     let cost = match pricing_service.calculate_loaded_usage_cost_for_provider(
         pricing_provider,
@@ -169,6 +170,11 @@ pub(in crate::server::routes::ai) async fn record_pricing_usage_spend_with_reser
         } else {
             budget_limits.record_spend(budget_provider, budget_model, cost);
         }
+        super::settle_api_key_budget_reservation(
+            key_budget_reservation,
+            cost,
+            &format!("{budget_provider}/{budget_model}"),
+        );
     }
 
     if let Some(key_id) = api_key_id {

--- a/src/server/routes/ai/spend_no_usage_tests.rs
+++ b/src/server/routes/ai/spend_no_usage_tests.rs
@@ -34,6 +34,7 @@ async fn successful_completion_without_usage_settles_reserved_budget() {
         "gpt-4o",
         None,
         Some(reservation),
+        None,
     )
     .await;
 

--- a/src/server/routes/ai/spend_no_usage_tests.rs
+++ b/src/server/routes/ai/spend_no_usage_tests.rs
@@ -26,16 +26,12 @@ async fn successful_completion_without_usage_settles_reserved_budget() {
         .expect("priced model should reserve budget");
     let reserved = reservation.reserved_amount();
 
-    record_completion_spend_with_reservation(
-        &budget,
-        &keys,
-        Some(key_id),
-        "openai",
-        "gpt-4o",
-        None,
+    record_completion_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, Some(key_id)),
+        ("openai", "gpt-4o", None),
         Some(reservation),
         None,
-    )
+    ))
     .await;
 
     assert_eq!(

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -163,14 +163,16 @@ async fn record_completion_spend_uses_runtime_pricing_service() {
 
     record_completion_spend_with_reservation_with_pricing(
         &pricing,
-        &budget,
-        &keys,
-        None,
-        "runtime_provider",
-        "runtime-only-priced-model",
-        Some(&response_usage(1000, 500)),
-        None,
-        None,
+        usage_spend_settlement(
+            (&budget, &keys, None),
+            (
+                "runtime_provider",
+                "runtime-only-priced-model",
+                Some(&response_usage(1000, 500)),
+            ),
+            None,
+            None,
+        ),
     )
     .await;
 
@@ -206,14 +208,16 @@ async fn record_completion_spend_prices_xai_openai_like_prefix() {
 
     record_completion_spend_with_reservation_with_pricing(
         pricing,
-        &budget,
-        &keys,
-        None,
-        "openai_like",
-        "xai/grok-4.3",
-        Some(&response_usage(1000, 500)),
-        None,
-        None,
+        usage_spend_settlement(
+            (&budget, &keys, None),
+            (
+                "openai_like",
+                "xai/grok-4.3",
+                Some(&response_usage(1000, 500)),
+            ),
+            None,
+            None,
+        ),
     )
     .await;
 

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -170,6 +170,7 @@ async fn record_completion_spend_uses_runtime_pricing_service() {
         "runtime-only-priced-model",
         Some(&response_usage(1000, 500)),
         None,
+        None,
     )
     .await;
 
@@ -211,6 +212,7 @@ async fn record_completion_spend_prices_xai_openai_like_prefix() {
         "openai_like",
         "xai/grok-4.3",
         Some(&response_usage(1000, 500)),
+        None,
         None,
     )
     .await;

--- a/src/server/routes/ai/spend_stream_disconnect_tests.rs
+++ b/src/server/routes/ai/spend_stream_disconnect_tests.rs
@@ -34,6 +34,7 @@ async fn stream_disconnect_without_usage_records_reserved_key_cost() {
         "gpt-4o",
         None,
         Some(reservation),
+        None,
     )
     .await;
 
@@ -79,6 +80,7 @@ async fn finished_stream_without_usage_records_reserved_key_cost_after_output() 
         usage: None,
         saw_upstream_output: true,
         budget_reservation: Some(reservation),
+        key_budget_reservation: None,
     })
     .await;
 

--- a/src/server/routes/ai/spend_stream_disconnect_tests.rs
+++ b/src/server/routes/ai/spend_stream_disconnect_tests.rs
@@ -26,16 +26,12 @@ async fn stream_disconnect_without_usage_records_reserved_key_cost() {
         .expect("priced model should reserve budget");
     let reserved = reservation.reserved_amount();
 
-    record_stream_disconnect_spend_with_reservation(
-        &budget,
-        &keys,
-        Some(key_id),
-        "openai",
-        "gpt-4o",
-        None,
+    record_stream_disconnect_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, Some(key_id)),
+        ("openai", "gpt-4o", None),
         Some(reservation),
         None,
-    )
+    ))
     .await;
 
     let stats = keys

--- a/src/server/routes/ai/spend_tests.rs
+++ b/src/server/routes/ai/spend_tests.rs
@@ -49,16 +49,12 @@ async fn records_provider_spend_for_priced_model() {
     );
     let keys = KeyManager::new(InMemoryKeyRepository::new());
 
-    record_completion_spend_with_reservation(
-        &budget,
-        &keys,
-        None,
-        "openai",
-        "gpt-4o",
-        Some(&usage(1000, 1000)),
+    record_completion_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, None),
+        ("openai", "gpt-4o", Some(&usage(1000, 1000))),
         None,
         None,
-    )
+    ))
     .await;
 
     let spent = budget
@@ -95,16 +91,12 @@ async fn reserved_completion_settles_actual_spend_and_refunds_estimate() {
         estimate.max_cost
     );
 
-    record_completion_spend_with_reservation(
-        &budget,
-        &keys,
-        None,
-        "openai",
-        "gpt-4o",
-        Some(&usage(0, 50)),
+    record_completion_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, None),
+        ("openai", "gpt-4o", Some(&usage(0, 50))),
         Some(reservation),
         None,
-    )
+    ))
     .await;
 
     let expected = generic_cost_per_token("gpt-4o", &UsageTokens::new(0, 50), "openai")
@@ -147,16 +139,12 @@ async fn reserved_completion_records_actual_when_usage_exceeds_estimate() {
         .unwrap()
         .unwrap();
 
-    record_completion_spend_with_reservation(
-        &budget,
-        &keys,
-        None,
-        "openai",
-        "gpt-4o",
-        Some(&usage(0, 100)),
+    record_completion_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, None),
+        ("openai", "gpt-4o", Some(&usage(0, 100))),
         Some(reservation),
         None,
-    )
+    ))
     .await;
 
     assert_eq!(
@@ -587,16 +575,12 @@ async fn reservation_settlement_after_reset_records_actual_spend() {
         .unwrap();
     assert!(budget.providers.reset_provider_budget("openai"));
 
-    record_completion_spend_with_reservation(
-        &budget,
-        &keys,
-        None,
-        "openai",
-        "gpt-4o",
-        Some(&usage(0, 50)),
+    record_completion_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, None),
+        ("openai", "gpt-4o", Some(&usage(0, 50))),
         Some(reservation),
         None,
-    )
+    ))
     .await;
 
     let expected = generic_cost_per_token("gpt-4o", &UsageTokens::new(0, 50), "openai")
@@ -637,16 +621,12 @@ async fn stream_disconnect_without_usage_settles_reserved_budget() {
         .unwrap();
     let reserved = reservation.reserved_amount();
 
-    record_stream_disconnect_spend_with_reservation(
-        &budget,
-        &keys,
-        None,
-        "openai",
-        "gpt-4o",
-        None,
+    record_stream_disconnect_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, None),
+        ("openai", "gpt-4o", None),
         Some(reservation),
         None,
-    )
+    ))
     .await;
 
     assert_eq!(
@@ -740,16 +720,16 @@ async fn unpriced_model_records_no_budget_spend() {
 
     // Unknown model has no pricing: budget spend must stay at 0 rather than
     // being booked at a fabricated $0 cost silently.
-    record_completion_spend_with_reservation(
-        &budget,
-        &keys,
+    record_completion_spend_with_reservation(usage_spend_settlement(
+        (&budget, &keys, None),
+        (
+            "openai",
+            "definitely-not-a-real-model-xyz",
+            Some(&usage(1000, 1000)),
+        ),
         None,
-        "openai",
-        "definitely-not-a-real-model-xyz",
-        Some(&usage(1000, 1000)),
         None,
-        None,
-    )
+    ))
     .await;
 
     let spent = budget

--- a/src/server/routes/ai/spend_tests.rs
+++ b/src/server/routes/ai/spend_tests.rs
@@ -57,6 +57,7 @@ async fn records_provider_spend_for_priced_model() {
         "gpt-4o",
         Some(&usage(1000, 1000)),
         None,
+        None,
     )
     .await;
 
@@ -102,6 +103,7 @@ async fn reserved_completion_settles_actual_spend_and_refunds_estimate() {
         "gpt-4o",
         Some(&usage(0, 50)),
         Some(reservation),
+        None,
     )
     .await;
 
@@ -153,6 +155,7 @@ async fn reserved_completion_records_actual_when_usage_exceeds_estimate() {
         "gpt-4o",
         Some(&usage(0, 100)),
         Some(reservation),
+        None,
     )
     .await;
 
@@ -592,6 +595,7 @@ async fn reservation_settlement_after_reset_records_actual_spend() {
         "gpt-4o",
         Some(&usage(0, 50)),
         Some(reservation),
+        None,
     )
     .await;
 
@@ -641,6 +645,7 @@ async fn stream_disconnect_without_usage_settles_reserved_budget() {
         "gpt-4o",
         None,
         Some(reservation),
+        None,
     )
     .await;
 
@@ -742,6 +747,7 @@ async fn unpriced_model_records_no_budget_spend() {
         "openai",
         "definitely-not-a-real-model-xyz",
         Some(&usage(1000, 1000)),
+        None,
         None,
     )
     .await;

--- a/src/server/routes/ai/token_policy.rs
+++ b/src/server/routes/ai/token_policy.rs
@@ -1,0 +1,158 @@
+use crate::core::models::openai::requests::ChatCompletionRequest;
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::chat::ChatRequest;
+use crate::core::types::context::RequestContext;
+use crate::utils::error::gateway_error::GatewayError;
+use actix_web::HttpRequest;
+
+pub(super) fn attach_api_key_token_limit(
+    req: &HttpRequest,
+    context: &mut RequestContext,
+) -> Result<(), GatewayError> {
+    if let Some(limit) = super::context::api_key_max_tokens_per_request(req)? {
+        context.set_api_key_max_tokens_per_request(limit);
+    }
+    Ok(())
+}
+
+pub(super) fn requested_chat_output_token_limit(request: &ChatCompletionRequest) -> Option<u32> {
+    requested_output_token_limit(request.max_tokens, request.max_completion_tokens)
+}
+
+pub(super) fn requested_output_token_limit(
+    max_tokens: Option<u32>,
+    max_completion_tokens: Option<u32>,
+) -> Option<u32> {
+    max_tokens.into_iter().chain(max_completion_tokens).max()
+}
+
+pub(super) fn apply_api_key_output_token_limit(
+    max_tokens_per_request: Option<u32>,
+    provider: &str,
+    model: &str,
+    request: &mut ChatRequest,
+) -> Result<(), ProviderError> {
+    let Some(limit) = max_tokens_per_request else {
+        return Ok(());
+    };
+
+    if let Some(requested) =
+        requested_output_token_limit(request.max_tokens, request.max_completion_tokens)
+        && requested > limit
+    {
+        return Err(token_policy_error(requested, limit));
+    }
+
+    if request.max_tokens.is_none() {
+        request.max_tokens = request.max_completion_tokens.or(Some(limit));
+    }
+
+    if let Some(effective) = provider_effective_output_cap(provider, model, request)
+        && effective > limit
+    {
+        return Err(token_policy_error(effective, limit));
+    }
+
+    Ok(())
+}
+
+pub(super) fn prepare_chat_request_for_provider(
+    max_tokens_per_request: Option<u32>,
+    provider: &str,
+    model: &str,
+    mut core_request: ChatRequest,
+    mut budget_request: ChatCompletionRequest,
+) -> Result<(ChatRequest, ChatCompletionRequest), ProviderError> {
+    core_request.model = model.to_string();
+    apply_api_key_output_token_limit(max_tokens_per_request, provider, model, &mut core_request)?;
+    budget_request.max_tokens = core_request.max_tokens;
+    budget_request.max_completion_tokens = core_request.max_completion_tokens;
+    Ok((core_request, budget_request))
+}
+
+fn provider_effective_output_cap(
+    provider: &str,
+    model: &str,
+    request: &ChatRequest,
+) -> Option<u32> {
+    let provider = crate::core::pricing::normalize_pricing_provider(provider);
+    match provider.as_str() {
+        "openai" | "azure" | "azure_ai" | "openai_like" | "openrouter" | "xai" | "groq"
+        | "deepseek" | "moonshot" | "minimax" | "zhipuai" | "xiaomi_mimo" | "amazon_nova"
+        | "baseten" | "huggingface" => request.max_completion_tokens.or(request.max_tokens),
+        "anthropic" => Some(request.max_tokens.unwrap_or(4096)),
+        "bedrock" => bedrock_effective_output_cap(model, request),
+        "cohere" | "replicate" => request.max_tokens.or(request.max_completion_tokens),
+        _ => request.max_tokens,
+    }
+}
+
+fn bedrock_effective_output_cap(model: &str, request: &ChatRequest) -> Option<u32> {
+    use crate::core::providers::bedrock::BedrockApiType;
+
+    let Ok(config) = crate::core::providers::bedrock::get_model_config_for_model_id(model) else {
+        return request.max_tokens;
+    };
+
+    match config.api_type {
+        BedrockApiType::Converse | BedrockApiType::ConverseStream => {
+            request.max_completion_tokens.or(request.max_tokens)
+        }
+        BedrockApiType::Invoke | BedrockApiType::InvokeStream => request.max_tokens,
+    }
+}
+
+fn token_policy_error(requested: u32, limit: u32) -> ProviderError {
+    ProviderError::authentication(
+        "api_key",
+        format!("requested token limit {requested} exceeds API key max_tokens_per_request {limit}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requested_output_token_limit_uses_largest_supplied_cap() {
+        assert_eq!(requested_output_token_limit(Some(100), Some(10)), Some(100));
+        assert_eq!(requested_output_token_limit(None, Some(10)), Some(10));
+    }
+
+    #[test]
+    fn rejects_bypass_when_legacy_max_tokens_exceeds_limit() {
+        let mut request = ChatRequest {
+            max_tokens: Some(100),
+            max_completion_tokens: Some(10),
+            ..Default::default()
+        };
+
+        assert!(
+            apply_api_key_output_token_limit(Some(20), "anthropic", "claude-3-haiku", &mut request)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn fills_provider_effective_cap_when_only_max_completion_tokens_is_set() {
+        let mut request = ChatRequest {
+            max_completion_tokens: Some(10),
+            ..Default::default()
+        };
+
+        apply_api_key_output_token_limit(Some(20), "anthropic", "claude-3-haiku", &mut request)
+            .expect("max_completion_tokens should cap max_tokens-only providers");
+
+        assert_eq!(request.max_tokens, Some(10));
+    }
+
+    #[test]
+    fn caps_provider_default_when_request_omits_token_limit() {
+        let mut request = ChatRequest::default();
+
+        apply_api_key_output_token_limit(Some(20), "anthropic", "claude-3-haiku", &mut request)
+            .expect("missing token cap should be filled from key limit");
+
+        assert_eq!(request.max_tokens, Some(20));
+    }
+}

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -1,0 +1,253 @@
+use super::types::{CreateKeyRequest, KeyErrorResponse, UpdateKeyRequest};
+use crate::auth::{AuthMethod, AuthResult};
+use crate::core::keys::{KeyInfo, KeyPermissions, KeyRateLimits, KeyStatus};
+use crate::core::models::user::types::{User, UserRole};
+use crate::core::types::context::RequestContext;
+use crate::server::middleware::extract_auth_method_with_api_key_header;
+use crate::server::routes::ApiResponse;
+use crate::server::state::AppState;
+use actix_web::{HttpRequest, HttpResponse, web};
+use tracing::error;
+use uuid::Uuid;
+
+const MANAGEMENT_PERMISSIONS: &[&str] = &[
+    "*",
+    "system.admin",
+    "keys.list_all",
+    "users.manage",
+    "config.manage",
+    "teams.manage",
+    "analytics.admin",
+];
+
+fn permissions_grant_management_access(permissions: &KeyPermissions) -> bool {
+    permissions.is_admin
+        || permissions
+            .custom_permissions
+            .iter()
+            .any(|permission| MANAGEMENT_PERMISSIONS.contains(&permission.as_str()))
+}
+
+fn auth_can_grant_management_access(auth: &AuthResult) -> bool {
+    auth.user
+        .as_ref()
+        .map(|user| user.has_role(&UserRole::Admin))
+        .unwrap_or(false)
+}
+
+pub(super) fn check_ownership(
+    requesting_user: &User,
+    key_user_id: Option<Uuid>,
+    key_team_id: Option<Uuid>,
+) -> bool {
+    if requesting_user.has_role(&UserRole::Admin) {
+        return true;
+    }
+    if key_user_id == Some(requesting_user.id()) {
+        return true;
+    }
+    if requesting_user.has_role(&UserRole::Manager)
+        && let Some(team_id) = key_team_id
+    {
+        return requesting_user.team_ids.contains(&team_id);
+    }
+    false
+}
+
+pub(super) fn check_auth_result_ownership(
+    auth: &AuthResult,
+    key_user_id: Option<Uuid>,
+    key_team_id: Option<Uuid>,
+) -> bool {
+    if let Some(ref user) = auth.user {
+        check_ownership(user, key_user_id, key_team_id)
+    } else {
+        let caller_team = auth.context.team_id();
+        caller_team.is_some() && caller_team == key_team_id
+    }
+}
+
+pub(super) fn is_auth_enabled(state: &web::Data<AppState>) -> bool {
+    let cfg = state.config.load();
+    cfg.auth().enable_jwt || cfg.auth().enable_api_key
+}
+
+pub(super) async fn invalidate_api_key_auth_cache(state: &web::Data<AppState>, key_id: Uuid) {
+    state
+        .auth
+        .api_key()
+        .invalidate_cache_for_key_id(key_id)
+        .await;
+}
+
+pub(super) async fn authenticate_request(
+    req: &HttpRequest,
+    state: &web::Data<AppState>,
+) -> Result<Option<AuthResult>, HttpResponse> {
+    let api_key_header = state.config.load().auth().api_key_header.clone();
+    let auth_method =
+        extract_auth_method_with_api_key_header(req.headers(), api_key_header.as_str());
+
+    if matches!(auth_method, AuthMethod::None) {
+        return Ok(None);
+    }
+
+    let context = RequestContext::new();
+    match state.auth.authenticate(auth_method, context).await {
+        Ok(result) if result.success => Ok(Some(result)),
+        Ok(result) => {
+            let msg = result
+                .error
+                .unwrap_or_else(|| "Authentication failed".to_string());
+            let error_response = KeyErrorResponse::unauthorized(msg);
+            Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
+        }
+        Err(e) => {
+            error!("Authentication error: {}", e);
+            let error_response = KeyErrorResponse::unauthorized("Authentication error");
+            Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
+        }
+    }
+}
+
+pub(super) fn resolve_create_key_scope(
+    auth: &AuthResult,
+    request: &CreateKeyRequest,
+) -> std::result::Result<(Option<Uuid>, Option<Uuid>), &'static str> {
+    let requested_user_id = request.user_id;
+    let requested_team_id = request.team_id;
+    let requests_management_key = request
+        .permissions
+        .as_ref()
+        .map(permissions_grant_management_access)
+        .unwrap_or(false);
+
+    if let Some(ref user) = auth.user {
+        let is_admin = user.has_role(&UserRole::Admin);
+        if is_admin {
+            return Ok((requested_user_id, requested_team_id));
+        }
+
+        if requests_management_key {
+            return Err("Only admin can create API keys with management permissions");
+        }
+
+        match (requested_user_id, requested_team_id) {
+            (Some(user_id), None) if user_id == user.id() => Ok((Some(user_id), None)),
+            (None, Some(team_id))
+                if user.has_role(&UserRole::Manager) && user.team_ids.contains(&team_id) =>
+            {
+                Ok((None, Some(team_id)))
+            }
+            (None, None) => Ok((Some(user.id()), None)),
+            _ => Err("Not authorized to create API key for this scope"),
+        }
+    } else {
+        if requests_management_key {
+            return Err("Team-scoped API keys cannot create API keys with management permissions");
+        }
+
+        let caller_team_id = auth.context.team_id();
+        match (requested_user_id, requested_team_id, caller_team_id) {
+            (None, Some(requested_team), Some(caller_team)) if requested_team == caller_team => {
+                Ok((None, Some(caller_team)))
+            }
+            (None, None, Some(caller_team)) => Ok((None, Some(caller_team))),
+            _ => Err("Not authorized to create API key for this scope"),
+        }
+    }
+}
+
+pub(super) fn validate_update_key_permissions(
+    auth: Option<&AuthResult>,
+    request: &UpdateKeyRequest,
+) -> std::result::Result<(), &'static str> {
+    let Some(permissions) = request.permissions.as_ref() else {
+        return Ok(());
+    };
+
+    if !permissions_grant_management_access(permissions) {
+        return Ok(());
+    }
+
+    if auth.map(auth_can_grant_management_access).unwrap_or(true) {
+        return Ok(());
+    }
+
+    Err("Only admin can update API keys with management permissions")
+}
+
+pub(super) fn validate_create_key_rate_limits(
+    request: &CreateKeyRequest,
+) -> std::result::Result<(), &'static str> {
+    validate_supported_key_rate_limits(request.rate_limits.as_ref())
+}
+
+pub(super) fn validate_update_key_rate_limits(
+    request: &UpdateKeyRequest,
+) -> std::result::Result<(), &'static str> {
+    validate_supported_key_rate_limits(request.rate_limits.as_ref())
+}
+
+fn validate_supported_key_rate_limits(
+    rate_limits: Option<&KeyRateLimits>,
+) -> std::result::Result<(), &'static str> {
+    let Some(rate_limits) = rate_limits else {
+        return Ok(());
+    };
+
+    if rate_limits.tokens_per_minute.is_some()
+        || rate_limits.requests_per_day.is_some()
+        || rate_limits.tokens_per_day.is_some()
+        || rate_limits.max_concurrent_requests.is_some()
+    {
+        return Err(
+            "Only requests_per_minute API key rate limits are currently enforced; token, daily, and concurrency limits are not supported",
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) fn filter_and_paginate_keys(
+    keys: Vec<KeyInfo>,
+    status: Option<KeyStatus>,
+    limit: usize,
+    offset: usize,
+) -> (Vec<KeyInfo>, u64) {
+    let filtered: Vec<KeyInfo> = keys
+        .into_iter()
+        .filter(|key| status.map(|s| key.status == s).unwrap_or(true))
+        .collect();
+    let total = filtered.len() as u64;
+    let page = filtered.into_iter().skip(offset).take(limit).collect();
+    (page, total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_unset_or_rpm_only_key_rate_limits() {
+        assert!(validate_supported_key_rate_limits(None).is_ok());
+        assert!(
+            validate_supported_key_rate_limits(Some(&KeyRateLimits {
+                requests_per_minute: Some(60),
+                ..Default::default()
+            }))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_key_rate_limits_that_are_not_enforced() {
+        let unsupported_limits = KeyRateLimits {
+            requests_per_minute: Some(60),
+            tokens_per_minute: Some(1000),
+            ..Default::default()
+        };
+
+        assert!(validate_supported_key_rate_limits(Some(&unsupported_limits)).is_err());
+    }
+}

--- a/src/server/routes/keys/api_key_budget.rs
+++ b/src/server/routes/keys/api_key_budget.rs
@@ -1,0 +1,64 @@
+use uuid::Uuid;
+
+use crate::server::state::AppState;
+
+use super::types::UpdateKeyRequest;
+
+pub(super) async fn validate_create_key_budget_fields(
+    state: &AppState,
+    budget_id: Option<Uuid>,
+    max_budget: Option<f64>,
+) -> Result<(), String> {
+    reject_unsupported_max_budget(max_budget)?;
+    validate_referenced_budget(state, budget_id).await
+}
+
+pub(super) async fn validate_update_key_budget_fields(
+    state: &AppState,
+    request: &UpdateKeyRequest,
+) -> Result<(), String> {
+    reject_unsupported_max_budget(request.max_budget)?;
+    if let Some(Some(budget_id)) = request.budget_id {
+        validate_referenced_budget(state, Some(budget_id)).await?;
+    }
+    Ok(())
+}
+
+pub(super) async fn validate_referenced_budget(
+    state: &AppState,
+    budget_id: Option<Uuid>,
+) -> Result<(), String> {
+    let Some(budget_id) = budget_id else {
+        return Ok(());
+    };
+    if state
+        .budget_manager
+        .get_budget_by_id(&budget_id.to_string())
+        .is_some()
+    {
+        Ok(())
+    } else {
+        Err(format!("API key budget '{budget_id}' is not configured"))
+    }
+}
+
+fn reject_unsupported_max_budget(max_budget: Option<f64>) -> Result<(), String> {
+    if max_budget.is_some() {
+        return Err(
+            "max_budget is not supported for persisted API keys; create a budget and pass budget_id"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_budget_is_rejected_until_api_key_budgets_are_persisted() {
+        assert!(reject_unsupported_max_budget(Some(1.0)).is_err());
+        assert!(reject_unsupported_max_budget(None).is_ok());
+    }
+}

--- a/src/server/routes/keys/handlers.rs
+++ b/src/server/routes/keys/handlers.rs
@@ -1,227 +1,24 @@
 //! HTTP request handlers for API key management
 
+use super::access::{
+    authenticate_request, check_auth_result_ownership, check_ownership, filter_and_paginate_keys,
+    invalidate_api_key_auth_cache, is_auth_enabled, resolve_create_key_scope,
+    validate_create_key_rate_limits, validate_update_key_permissions,
+    validate_update_key_rate_limits,
+};
 use super::types::{
     CreateKeyRequest, CreateKeyResponse, KeyErrorResponse, KeyResponse, KeyUsageResponse,
     ListKeysQuery, ListKeysResponse, PaginationInfo, RevokeKeyResponse, RotateKeyResponse,
     UpdateKeyRequest, VerifyKeyRequest, VerifyKeyResponse,
 };
-use crate::auth::{AuthMethod, AuthResult};
 use crate::core::keys::KeyManager;
-use crate::core::keys::{CreateKeyConfig, KeyInfo, KeyStatus, UpdateKeyConfig};
-use crate::core::models::user::types::{User, UserRole};
-use crate::core::types::context::RequestContext;
-use crate::server::middleware::extract_auth_method_with_api_key_header;
+use crate::core::keys::{CreateKeyConfig, KeyStatus, UpdateKeyConfig};
+use crate::core::models::user::types::UserRole;
 use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use tracing::{error, info, warn};
 use uuid::Uuid;
-
-const MANAGEMENT_PERMISSIONS: &[&str] = &[
-    "*",
-    "system.admin",
-    "keys.list_all",
-    "users.manage",
-    "config.manage",
-    "teams.manage",
-    "analytics.admin",
-];
-
-fn permissions_grant_management_access(permissions: &crate::core::keys::KeyPermissions) -> bool {
-    permissions.is_admin
-        || permissions
-            .custom_permissions
-            .iter()
-            .any(|permission| MANAGEMENT_PERMISSIONS.contains(&permission.as_str()))
-}
-
-fn auth_can_grant_management_access(auth: &AuthResult) -> bool {
-    auth.user
-        .as_ref()
-        .map(|user| user.has_role(&UserRole::Admin))
-        .unwrap_or(false)
-}
-
-/// Check whether `requesting_user` is allowed to access the key.
-///
-/// Admins and super-admins bypass the ownership check.
-/// Managers can access team-scoped keys for teams they belong to.
-fn check_ownership(
-    requesting_user: &User,
-    key_user_id: Option<Uuid>,
-    key_team_id: Option<Uuid>,
-) -> bool {
-    // Admin (and SuperAdmin via has_role hierarchy) bypass all ownership checks.
-    if requesting_user.has_role(&UserRole::Admin) {
-        return true;
-    }
-    // User directly owns the key.
-    if key_user_id == Some(requesting_user.id()) {
-        return true;
-    }
-    // Managers can access team-scoped keys for teams they belong to.
-    // has_role(Manager) is true for Manager, Admin, and SuperAdmin.
-    if requesting_user.has_role(&UserRole::Manager)
-        && let Some(team_id) = key_team_id
-    {
-        return requesting_user.team_ids.contains(&team_id);
-    }
-    false
-}
-
-/// Check whether an authenticated caller is allowed to access a key.
-///
-/// Handles both user-based callers (JWT / user-linked API key) and team-only
-/// API keys (`user == None`, team context set on the request context).
-fn check_auth_result_ownership(
-    auth: &AuthResult,
-    key_user_id: Option<Uuid>,
-    key_team_id: Option<Uuid>,
-) -> bool {
-    if let Some(ref user) = auth.user {
-        check_ownership(user, key_user_id, key_team_id)
-    } else {
-        // Team-only API key: allow access only to keys owned by the same team.
-        let caller_team = auth.context.team_id();
-        caller_team.is_some() && caller_team == key_team_id
-    }
-}
-
-/// Returns `true` when at least one auth backend is enabled.
-///
-/// When both backends are disabled the gateway runs in no-auth mode and the
-/// middleware already bypasses all credential checks, so handler-level checks
-/// must be skipped too to preserve that behaviour.
-fn is_auth_enabled(state: &web::Data<AppState>) -> bool {
-    let cfg = state.config.load();
-    cfg.auth().enable_jwt || cfg.auth().enable_api_key
-}
-
-/// Extract and authenticate the requesting caller from the request headers.
-///
-/// Supports the same credential schemes as the auth middleware:
-/// `Authorization: Bearer`, `Authorization: ApiKey`, `Authorization: gw-...`,
-/// and `X-API-Key`.
-///
-/// Returns `Ok(Some(result))` when valid credentials are present and accepted
-/// (the caller may be a user OR a team-only API key with `result.user == None`),
-/// `Ok(None)` when no credentials are present at all, and `Err(HttpResponse)`
-/// when credentials are present but invalid.
-async fn authenticate_request(
-    req: &HttpRequest,
-    state: &web::Data<AppState>,
-) -> Result<Option<AuthResult>, HttpResponse> {
-    let api_key_header = state.config.load().auth().api_key_header.clone();
-    let auth_method =
-        extract_auth_method_with_api_key_header(req.headers(), api_key_header.as_str());
-
-    if matches!(auth_method, AuthMethod::None) {
-        return Ok(None);
-    }
-
-    let context = RequestContext::new();
-    match state.auth.authenticate(auth_method, context).await {
-        Ok(result) if result.success => Ok(Some(result)),
-        Ok(result) => {
-            let msg = result
-                .error
-                .unwrap_or_else(|| "Authentication failed".to_string());
-            let error_response = KeyErrorResponse::unauthorized(msg);
-            Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
-        }
-        Err(e) => {
-            error!("Authentication error: {}", e);
-            let error_response = KeyErrorResponse::unauthorized("Authentication error");
-            Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
-        }
-    }
-}
-
-/// Resolve and authorize create-key ownership scope from caller auth context.
-///
-/// Returns the effective `(user_id, team_id)` pair to persist.
-fn resolve_create_key_scope(
-    auth: &AuthResult,
-    request: &CreateKeyRequest,
-) -> std::result::Result<(Option<Uuid>, Option<Uuid>), &'static str> {
-    let requested_user_id = request.user_id;
-    let requested_team_id = request.team_id;
-    let requests_management_key = request
-        .permissions
-        .as_ref()
-        .map(permissions_grant_management_access)
-        .unwrap_or(false);
-
-    if let Some(ref user) = auth.user {
-        let is_admin = user.has_role(&UserRole::Admin);
-        if is_admin {
-            return Ok((requested_user_id, requested_team_id));
-        }
-
-        if requests_management_key {
-            return Err("Only admin can create API keys with management permissions");
-        }
-
-        match (requested_user_id, requested_team_id) {
-            (Some(user_id), None) if user_id == user.id() => Ok((Some(user_id), None)),
-            (None, Some(team_id))
-                if user.has_role(&UserRole::Manager) && user.team_ids.contains(&team_id) =>
-            {
-                Ok((None, Some(team_id)))
-            }
-            (None, None) => Ok((Some(user.id()), None)),
-            _ => Err("Not authorized to create API key for this scope"),
-        }
-    } else {
-        // Team-only API key caller.
-        if requests_management_key {
-            return Err("Team-scoped API keys cannot create API keys with management permissions");
-        }
-
-        let caller_team_id = auth.context.team_id();
-        match (requested_user_id, requested_team_id, caller_team_id) {
-            (None, Some(requested_team), Some(caller_team)) if requested_team == caller_team => {
-                Ok((None, Some(caller_team)))
-            }
-            (None, None, Some(caller_team)) => Ok((None, Some(caller_team))),
-            _ => Err("Not authorized to create API key for this scope"),
-        }
-    }
-}
-
-fn validate_update_key_permissions(
-    auth: Option<&AuthResult>,
-    request: &UpdateKeyRequest,
-) -> std::result::Result<(), &'static str> {
-    let Some(permissions) = request.permissions.as_ref() else {
-        return Ok(());
-    };
-
-    if !permissions_grant_management_access(permissions) {
-        return Ok(());
-    }
-
-    if auth.map(auth_can_grant_management_access).unwrap_or(true) {
-        return Ok(());
-    }
-
-    Err("Only admin can update API keys with management permissions")
-}
-
-fn filter_and_paginate_keys(
-    keys: Vec<KeyInfo>,
-    status: Option<KeyStatus>,
-    limit: usize,
-    offset: usize,
-) -> (Vec<KeyInfo>, u64) {
-    let filtered: Vec<KeyInfo> = keys
-        .into_iter()
-        .filter(|key| status.map(|s| key.status == s).unwrap_or(true))
-        .collect();
-    let total = filtered.len() as u64;
-    let page = filtered.into_iter().skip(offset).take(limit).collect();
-    (page, total)
-}
 
 /// POST /v1/keys - Create a new API key
 pub async fn create_key(
@@ -258,6 +55,20 @@ pub async fn create_key(
 
     // Get key manager from state
     let key_manager = get_key_manager(&state);
+    if let Err(message) = super::api_key_budget::validate_create_key_budget_fields(
+        state.get_ref(),
+        request.budget_id,
+        request.max_budget,
+    )
+    .await
+    {
+        let error_response = KeyErrorResponse::validation(message);
+        return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(error_response.error)));
+    }
+    if let Err(message) = validate_create_key_rate_limits(&request) {
+        let error_response = KeyErrorResponse::validation(message);
+        return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(error_response.error)));
+    }
 
     // Build creation config
     let config = CreateKeyConfig {
@@ -561,6 +372,17 @@ pub async fn update_key(
         return Ok(HttpResponse::Forbidden().json(ApiResponse::<()>::error(error_response.error)));
     }
 
+    if let Err(message) =
+        super::api_key_budget::validate_update_key_budget_fields(state.get_ref(), &request).await
+    {
+        let error_response = KeyErrorResponse::validation(message);
+        return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(error_response.error)));
+    }
+    if let Err(message) = validate_update_key_rate_limits(&request) {
+        let error_response = KeyErrorResponse::validation(message);
+        return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(error_response.error)));
+    }
+
     let config = UpdateKeyConfig {
         name: request.name.clone(),
         description: request.description.clone(),
@@ -573,6 +395,7 @@ pub async fn update_key(
 
     match key_manager.update_key(key_id, config).await {
         Ok(key) => {
+            invalidate_api_key_auth_cache(&state, key_id).await;
             info!("API key updated successfully: {}", key_id);
             let response = KeyResponse { key };
             Ok(HttpResponse::Ok().json(ApiResponse::success(response)))
@@ -653,6 +476,7 @@ pub async fn revoke_key(
 
     match key_manager.revoke_key(key_id).await {
         Ok(()) => {
+            invalidate_api_key_auth_cache(&state, key_id).await;
             info!("API key revoked successfully: {}", key_id);
             let response = RevokeKeyResponse {
                 key_id,
@@ -738,6 +562,7 @@ pub async fn rotate_key(
 
     match key_manager.rotate_key(key_id).await {
         Ok((new_key_id, new_raw_key)) => {
+            invalidate_api_key_auth_cache(&state, key_id).await;
             // Get new key info
             let key_info = key_manager
                 .get_key(new_key_id)
@@ -886,424 +711,5 @@ fn get_key_manager(state: &web::Data<AppState>) -> KeyManager {
 }
 
 #[cfg(test)]
-mod handler_tests {
-    use super::*;
-    use crate::core::keys::{KeyPermissions, KeyRateLimits, KeyUsageStats};
-    use chrono::Utc;
-
-    #[test]
-    fn test_create_key_config_from_request() {
-        let request = CreateKeyRequest {
-            name: "Test Key".to_string(),
-            description: Some("A test".to_string()),
-            user_id: None,
-            team_id: None,
-            budget_id: None,
-            permissions: None,
-            rate_limits: None,
-            expires_at: None,
-            metadata: None,
-        };
-
-        let config = CreateKeyConfig {
-            name: request.name.clone(),
-            description: request.description.clone(),
-            user_id: request.user_id,
-            team_id: request.team_id,
-            budget_id: request.budget_id,
-            permissions: request.permissions.clone().unwrap_or_default(),
-            rate_limits: request.rate_limits.clone().unwrap_or_default(),
-            expires_at: request.expires_at,
-            metadata: request.metadata.clone().unwrap_or(serde_json::Value::Null),
-        };
-
-        assert_eq!(config.name, "Test Key");
-        assert!(config.description.is_some());
-    }
-
-    fn make_user(role: UserRole, team_ids: Vec<Uuid>) -> User {
-        use crate::core::models::Metadata;
-        use crate::core::models::UsageStats;
-        use crate::core::models::user::preferences::UserPreferences;
-        use crate::core::models::user::types::{UserProfile, UserStatus};
-        User {
-            metadata: Metadata::new(),
-            username: "testuser".to_string(),
-            email: "test@example.com".to_string(),
-            display_name: None,
-            password_hash: "hash".to_string(),
-            role,
-            status: UserStatus::Active,
-            team_ids,
-            preferences: UserPreferences::default(),
-            usage_stats: UsageStats::default(),
-            rate_limits: None,
-            last_login_at: None,
-            email_verified: true,
-            two_factor_enabled: false,
-            profile: UserProfile::default(),
-        }
-    }
-
-    fn make_user_auth(user: User) -> AuthResult {
-        AuthResult {
-            success: true,
-            user: Some(user),
-            api_key: None,
-            session: None,
-            error: None,
-            context: RequestContext::new(),
-        }
-    }
-
-    fn make_team_auth(team_id: Uuid) -> AuthResult {
-        let mut context = RequestContext::new();
-        context.set_team_id(team_id);
-        AuthResult {
-            success: true,
-            user: None,
-            api_key: None,
-            session: None,
-            error: None,
-            context,
-        }
-    }
-
-    fn create_request_with_permissions(permissions: Option<KeyPermissions>) -> CreateKeyRequest {
-        CreateKeyRequest {
-            name: "scoped".to_string(),
-            description: None,
-            user_id: None,
-            team_id: None,
-            budget_id: None,
-            permissions,
-            rate_limits: None,
-            expires_at: None,
-            metadata: None,
-        }
-    }
-
-    fn update_request_with_permissions(permissions: Option<KeyPermissions>) -> UpdateKeyRequest {
-        UpdateKeyRequest {
-            name: None,
-            description: None,
-            permissions,
-            rate_limits: None,
-            budget_id: None,
-            expires_at: None,
-            metadata: None,
-        }
-    }
-
-    fn make_key_info(id: Uuid, status: KeyStatus) -> KeyInfo {
-        KeyInfo {
-            id,
-            key_prefix: "gw-test".to_string(),
-            name: format!("key-{id}"),
-            description: None,
-            user_id: None,
-            team_id: None,
-            status,
-            permissions: KeyPermissions::default(),
-            rate_limits: KeyRateLimits::default(),
-            expires_at: None,
-            created_at: Utc::now(),
-            last_used_at: None,
-            usage_stats: KeyUsageStats::default(),
-        }
-    }
-
-    #[test]
-    fn test_check_ownership_admin_bypasses() {
-        let admin = make_user(UserRole::Admin, vec![]);
-        let other_user_id = Uuid::new_v4();
-        assert!(check_ownership(&admin, Some(other_user_id), None));
-        assert!(check_ownership(&admin, None, None));
-        assert!(check_ownership(&admin, None, Some(Uuid::new_v4())));
-    }
-
-    #[test]
-    fn test_check_ownership_super_admin_bypasses() {
-        let super_admin = make_user(UserRole::SuperAdmin, vec![]);
-        let other_user_id = Uuid::new_v4();
-        assert!(check_ownership(&super_admin, Some(other_user_id), None));
-        assert!(check_ownership(&super_admin, None, None));
-    }
-
-    #[test]
-    fn test_check_ownership_user_owns_key() {
-        let user = make_user(UserRole::User, vec![]);
-        let user_id = user.id();
-        assert!(check_ownership(&user, Some(user_id), None));
-        assert!(!check_ownership(&user, Some(Uuid::new_v4()), None));
-        // Key without owner — regular user cannot access
-        assert!(!check_ownership(&user, None, None));
-    }
-
-    #[test]
-    fn test_check_ownership_manager_team_access() {
-        let team_id = Uuid::new_v4();
-        let other_team = Uuid::new_v4();
-        let manager = make_user(UserRole::Manager, vec![team_id]);
-
-        // Manager can access team-scoped keys for their own team
-        assert!(check_ownership(&manager, None, Some(team_id)));
-        // Manager cannot access keys for a team they don't belong to
-        assert!(!check_ownership(&manager, None, Some(other_team)));
-        // Manager cannot access user-owned keys for other users
-        assert!(!check_ownership(&manager, Some(Uuid::new_v4()), None));
-    }
-
-    #[test]
-    fn test_check_ownership_regular_user_cannot_access_team_key() {
-        let team_id = Uuid::new_v4();
-        let user = make_user(UserRole::User, vec![team_id]);
-        // Regular users do NOT get team-level management access even if team members
-        assert!(!check_ownership(&user, None, Some(team_id)));
-    }
-
-    #[test]
-    fn test_is_auth_enabled_logic() {
-        let regular_user = make_user(UserRole::User, vec![]);
-        // Regular users must NOT pass the list-all-keys gate
-        assert!(!check_ownership(&regular_user, None, None));
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_user_defaults_to_self() {
-        let user = make_user(UserRole::User, vec![]);
-        let user_id = user.id();
-        let auth = make_user_auth(user);
-        let request = CreateKeyRequest {
-            name: "self".to_string(),
-            description: None,
-            user_id: None,
-            team_id: None,
-            budget_id: None,
-            permissions: None,
-            rate_limits: None,
-            expires_at: None,
-            metadata: None,
-        };
-
-        let resolved = resolve_create_key_scope(&auth, &request).unwrap();
-        assert_eq!(resolved, (Some(user_id), None));
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_user_cannot_target_other_user() {
-        let user = make_user(UserRole::User, vec![]);
-        let auth = make_user_auth(user);
-        let request = CreateKeyRequest {
-            name: "other".to_string(),
-            description: None,
-            user_id: Some(Uuid::new_v4()),
-            team_id: None,
-            budget_id: None,
-            permissions: None,
-            rate_limits: None,
-            expires_at: None,
-            metadata: None,
-        };
-
-        assert!(resolve_create_key_scope(&auth, &request).is_err());
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_user_cannot_create_admin_key() {
-        let user = make_user(UserRole::User, vec![]);
-        let auth = make_user_auth(user);
-        let request = create_request_with_permissions(Some(KeyPermissions::admin()));
-
-        assert_eq!(
-            resolve_create_key_scope(&auth, &request),
-            Err("Only admin can create API keys with management permissions")
-        );
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_user_cannot_create_system_admin_custom_permission() {
-        let user = make_user(UserRole::User, vec![]);
-        let auth = make_user_auth(user);
-        let permissions = KeyPermissions {
-            custom_permissions: vec!["system.admin".to_string()],
-            ..Default::default()
-        };
-        let request = create_request_with_permissions(Some(permissions));
-
-        assert_eq!(
-            resolve_create_key_scope(&auth, &request),
-            Err("Only admin can create API keys with management permissions")
-        );
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_team_api_key_cannot_create_management_permission() {
-        let team_id = Uuid::new_v4();
-        let auth = make_team_auth(team_id);
-        let permissions = KeyPermissions {
-            custom_permissions: vec!["users.manage".to_string()],
-            ..Default::default()
-        };
-        let request = create_request_with_permissions(Some(permissions));
-
-        assert_eq!(
-            resolve_create_key_scope(&auth, &request),
-            Err("Team-scoped API keys cannot create API keys with management permissions")
-        );
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_admin_can_create_management_key() {
-        let admin = make_user(UserRole::Admin, vec![]);
-        let auth = make_user_auth(admin);
-        let request = create_request_with_permissions(Some(KeyPermissions::admin()));
-
-        assert!(resolve_create_key_scope(&auth, &request).is_ok());
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_manager_can_target_own_team() {
-        let team_id = Uuid::new_v4();
-        let manager = make_user(UserRole::Manager, vec![team_id]);
-        let auth = make_user_auth(manager);
-        let request = CreateKeyRequest {
-            name: "team".to_string(),
-            description: None,
-            user_id: None,
-            team_id: Some(team_id),
-            budget_id: None,
-            permissions: None,
-            rate_limits: None,
-            expires_at: None,
-            metadata: None,
-        };
-
-        let resolved = resolve_create_key_scope(&auth, &request).unwrap();
-        assert_eq!(resolved, (None, Some(team_id)));
-    }
-
-    #[test]
-    fn test_resolve_create_key_scope_team_api_key_defaults_to_team_scope() {
-        let team_id = Uuid::new_v4();
-        let auth = make_team_auth(team_id);
-        let request = CreateKeyRequest {
-            name: "team-api".to_string(),
-            description: None,
-            user_id: None,
-            team_id: None,
-            budget_id: None,
-            permissions: None,
-            rate_limits: None,
-            expires_at: None,
-            metadata: None,
-        };
-
-        let resolved = resolve_create_key_scope(&auth, &request).unwrap();
-        assert_eq!(resolved, (None, Some(team_id)));
-    }
-
-    #[test]
-    fn test_validate_update_key_permissions_user_cannot_promote_to_admin() {
-        let user = make_user(UserRole::User, vec![]);
-        let auth = make_user_auth(user);
-        let request = update_request_with_permissions(Some(KeyPermissions::admin()));
-
-        assert_eq!(
-            validate_update_key_permissions(Some(&auth), &request),
-            Err("Only admin can update API keys with management permissions")
-        );
-    }
-
-    #[test]
-    fn test_validate_update_key_permissions_manager_cannot_grant_system_admin() {
-        let team_id = Uuid::new_v4();
-        let manager = make_user(UserRole::Manager, vec![team_id]);
-        let auth = make_user_auth(manager);
-        let permissions = KeyPermissions {
-            custom_permissions: vec!["system.admin".to_string()],
-            ..Default::default()
-        };
-        let request = update_request_with_permissions(Some(permissions));
-
-        assert_eq!(
-            validate_update_key_permissions(Some(&auth), &request),
-            Err("Only admin can update API keys with management permissions")
-        );
-    }
-
-    #[test]
-    fn test_validate_update_key_permissions_team_api_key_cannot_grant_wildcard() {
-        let auth = make_team_auth(Uuid::new_v4());
-        let permissions = KeyPermissions {
-            custom_permissions: vec!["*".to_string()],
-            ..Default::default()
-        };
-        let request = update_request_with_permissions(Some(permissions));
-
-        assert_eq!(
-            validate_update_key_permissions(Some(&auth), &request),
-            Err("Only admin can update API keys with management permissions")
-        );
-    }
-
-    #[test]
-    fn test_validate_update_key_permissions_admin_can_grant_management_access() {
-        let admin = make_user(UserRole::Admin, vec![]);
-        let auth = make_user_auth(admin);
-        let request = update_request_with_permissions(Some(KeyPermissions::admin()));
-
-        assert!(validate_update_key_permissions(Some(&auth), &request).is_ok());
-    }
-
-    #[test]
-    fn test_validate_update_key_permissions_allows_non_management_permissions() {
-        let user = make_user(UserRole::User, vec![]);
-        let auth = make_user_auth(user);
-        let permissions = KeyPermissions {
-            custom_permissions: vec!["api.chat".to_string()],
-            ..Default::default()
-        };
-        let request = update_request_with_permissions(Some(permissions));
-
-        assert!(validate_update_key_permissions(Some(&auth), &request).is_ok());
-    }
-
-    #[test]
-    fn test_filter_and_paginate_keys_reports_filtered_total() {
-        let first_active = Uuid::new_v4();
-        let revoked = Uuid::new_v4();
-        let second_active = Uuid::new_v4();
-        let keys = vec![
-            make_key_info(first_active, KeyStatus::Active),
-            make_key_info(revoked, KeyStatus::Revoked),
-            make_key_info(second_active, KeyStatus::Active),
-        ];
-
-        let (page, total) = filter_and_paginate_keys(keys, Some(KeyStatus::Active), 1, 1);
-
-        assert_eq!(total, 2);
-        assert_eq!(page.len(), 1);
-        assert_eq!(page[0].id, second_active);
-    }
-
-    #[test]
-    fn test_filter_and_paginate_keys_applies_limit_without_status_filter() {
-        let first = Uuid::new_v4();
-        let second = Uuid::new_v4();
-        let third = Uuid::new_v4();
-        let keys = vec![
-            make_key_info(first, KeyStatus::Active),
-            make_key_info(second, KeyStatus::Revoked),
-            make_key_info(third, KeyStatus::Active),
-        ];
-
-        let (page, total) = filter_and_paginate_keys(keys, None, 2, 1);
-
-        assert_eq!(total, 3);
-        assert_eq!(
-            page.iter().map(|key| key.id).collect::<Vec<_>>(),
-            vec![second, third]
-        );
-    }
-}
+#[path = "handlers_tests.rs"]
+mod handler_tests;

--- a/src/server/routes/keys/handlers_tests.rs
+++ b/src/server/routes/keys/handlers_tests.rs
@@ -1,0 +1,428 @@
+use super::super::access::{
+    check_ownership, filter_and_paginate_keys, resolve_create_key_scope,
+    validate_update_key_permissions,
+};
+use super::*;
+use crate::auth::AuthResult;
+use crate::core::keys::{KeyInfo, KeyPermissions, KeyRateLimits, KeyUsageStats};
+use crate::core::models::user::types::{User, UserRole};
+use crate::core::types::context::RequestContext;
+use chrono::Utc;
+
+#[test]
+fn test_create_key_config_from_request() {
+    let request = CreateKeyRequest {
+        name: "Test Key".to_string(),
+        description: Some("A test".to_string()),
+        user_id: None,
+        team_id: None,
+        budget_id: None,
+        max_budget: None,
+        permissions: None,
+        rate_limits: None,
+        expires_at: None,
+        metadata: None,
+    };
+
+    let config = CreateKeyConfig {
+        name: request.name.clone(),
+        description: request.description.clone(),
+        user_id: request.user_id,
+        team_id: request.team_id,
+        budget_id: request.budget_id,
+        permissions: request.permissions.clone().unwrap_or_default(),
+        rate_limits: request.rate_limits.clone().unwrap_or_default(),
+        expires_at: request.expires_at,
+        metadata: request.metadata.clone().unwrap_or(serde_json::Value::Null),
+    };
+
+    assert_eq!(config.name, "Test Key");
+    assert!(config.description.is_some());
+}
+
+fn make_user(role: UserRole, team_ids: Vec<Uuid>) -> User {
+    use crate::core::models::Metadata;
+    use crate::core::models::UsageStats;
+    use crate::core::models::user::preferences::UserPreferences;
+    use crate::core::models::user::types::{UserProfile, UserStatus};
+    User {
+        metadata: Metadata::new(),
+        username: "testuser".to_string(),
+        email: "test@example.com".to_string(),
+        display_name: None,
+        password_hash: "hash".to_string(),
+        role,
+        status: UserStatus::Active,
+        team_ids,
+        preferences: UserPreferences::default(),
+        usage_stats: UsageStats::default(),
+        rate_limits: None,
+        last_login_at: None,
+        email_verified: true,
+        two_factor_enabled: false,
+        profile: UserProfile::default(),
+    }
+}
+
+fn make_user_auth(user: User) -> AuthResult {
+    AuthResult {
+        success: true,
+        user: Some(user),
+        api_key: None,
+        session: None,
+        error: None,
+        context: RequestContext::new(),
+    }
+}
+
+fn make_team_auth(team_id: Uuid) -> AuthResult {
+    let mut context = RequestContext::new();
+    context.set_team_id(team_id);
+    AuthResult {
+        success: true,
+        user: None,
+        api_key: None,
+        session: None,
+        error: None,
+        context,
+    }
+}
+
+fn create_request_with_permissions(permissions: Option<KeyPermissions>) -> CreateKeyRequest {
+    CreateKeyRequest {
+        name: "scoped".to_string(),
+        description: None,
+        user_id: None,
+        team_id: None,
+        budget_id: None,
+        max_budget: None,
+        permissions,
+        rate_limits: None,
+        expires_at: None,
+        metadata: None,
+    }
+}
+
+fn update_request_with_permissions(permissions: Option<KeyPermissions>) -> UpdateKeyRequest {
+    UpdateKeyRequest {
+        name: None,
+        description: None,
+        permissions,
+        rate_limits: None,
+        budget_id: None,
+        max_budget: None,
+        expires_at: None,
+        metadata: None,
+    }
+}
+
+fn make_key_info(id: Uuid, status: KeyStatus) -> KeyInfo {
+    KeyInfo {
+        id,
+        key_prefix: "gw-test".to_string(),
+        name: format!("key-{id}"),
+        description: None,
+        user_id: None,
+        team_id: None,
+        budget_id: None,
+        status,
+        permissions: KeyPermissions::default(),
+        rate_limits: KeyRateLimits::default(),
+        expires_at: None,
+        created_at: Utc::now(),
+        last_used_at: None,
+        usage_stats: KeyUsageStats::default(),
+    }
+}
+
+#[test]
+fn test_check_ownership_admin_bypasses() {
+    let admin = make_user(UserRole::Admin, vec![]);
+    let other_user_id = Uuid::new_v4();
+    assert!(check_ownership(&admin, Some(other_user_id), None));
+    assert!(check_ownership(&admin, None, None));
+    assert!(check_ownership(&admin, None, Some(Uuid::new_v4())));
+}
+
+#[test]
+fn test_check_ownership_super_admin_bypasses() {
+    let super_admin = make_user(UserRole::SuperAdmin, vec![]);
+    let other_user_id = Uuid::new_v4();
+    assert!(check_ownership(&super_admin, Some(other_user_id), None));
+    assert!(check_ownership(&super_admin, None, None));
+}
+
+#[test]
+fn test_check_ownership_user_owns_key() {
+    let user = make_user(UserRole::User, vec![]);
+    let user_id = user.id();
+    assert!(check_ownership(&user, Some(user_id), None));
+    assert!(!check_ownership(&user, Some(Uuid::new_v4()), None));
+    assert!(!check_ownership(&user, None, None));
+}
+
+#[test]
+fn test_check_ownership_manager_team_access() {
+    let team_id = Uuid::new_v4();
+    let other_team = Uuid::new_v4();
+    let manager = make_user(UserRole::Manager, vec![team_id]);
+
+    assert!(check_ownership(&manager, None, Some(team_id)));
+    assert!(!check_ownership(&manager, None, Some(other_team)));
+    assert!(!check_ownership(&manager, Some(Uuid::new_v4()), None));
+}
+
+#[test]
+fn test_check_ownership_regular_user_cannot_access_team_key() {
+    let team_id = Uuid::new_v4();
+    let user = make_user(UserRole::User, vec![team_id]);
+    assert!(!check_ownership(&user, None, Some(team_id)));
+}
+
+#[test]
+fn test_is_auth_enabled_logic() {
+    let regular_user = make_user(UserRole::User, vec![]);
+    assert!(!check_ownership(&regular_user, None, None));
+}
+
+#[test]
+fn test_resolve_create_key_scope_user_defaults_to_self() {
+    let user = make_user(UserRole::User, vec![]);
+    let user_id = user.id();
+    let auth = make_user_auth(user);
+    let request = CreateKeyRequest {
+        name: "self".to_string(),
+        description: None,
+        user_id: None,
+        team_id: None,
+        budget_id: None,
+        max_budget: None,
+        permissions: None,
+        rate_limits: None,
+        expires_at: None,
+        metadata: None,
+    };
+
+    let resolved = resolve_create_key_scope(&auth, &request).unwrap();
+    assert_eq!(resolved, (Some(user_id), None));
+}
+
+#[test]
+fn test_resolve_create_key_scope_user_cannot_target_other_user() {
+    let user = make_user(UserRole::User, vec![]);
+    let auth = make_user_auth(user);
+    let request = CreateKeyRequest {
+        name: "other".to_string(),
+        description: None,
+        user_id: Some(Uuid::new_v4()),
+        team_id: None,
+        budget_id: None,
+        max_budget: None,
+        permissions: None,
+        rate_limits: None,
+        expires_at: None,
+        metadata: None,
+    };
+
+    assert!(resolve_create_key_scope(&auth, &request).is_err());
+}
+
+#[test]
+fn test_resolve_create_key_scope_user_cannot_create_admin_key() {
+    let user = make_user(UserRole::User, vec![]);
+    let auth = make_user_auth(user);
+    let request = create_request_with_permissions(Some(KeyPermissions::admin()));
+
+    assert_eq!(
+        resolve_create_key_scope(&auth, &request),
+        Err("Only admin can create API keys with management permissions")
+    );
+}
+
+#[test]
+fn test_resolve_create_key_scope_user_cannot_create_system_admin_custom_permission() {
+    let user = make_user(UserRole::User, vec![]);
+    let auth = make_user_auth(user);
+    let permissions = KeyPermissions {
+        custom_permissions: vec!["system.admin".to_string()],
+        ..Default::default()
+    };
+    let request = create_request_with_permissions(Some(permissions));
+
+    assert_eq!(
+        resolve_create_key_scope(&auth, &request),
+        Err("Only admin can create API keys with management permissions")
+    );
+}
+
+#[test]
+fn test_resolve_create_key_scope_team_api_key_cannot_create_management_permission() {
+    let team_id = Uuid::new_v4();
+    let auth = make_team_auth(team_id);
+    let permissions = KeyPermissions {
+        custom_permissions: vec!["users.manage".to_string()],
+        ..Default::default()
+    };
+    let request = create_request_with_permissions(Some(permissions));
+
+    assert_eq!(
+        resolve_create_key_scope(&auth, &request),
+        Err("Team-scoped API keys cannot create API keys with management permissions")
+    );
+}
+
+#[test]
+fn test_resolve_create_key_scope_admin_can_create_management_key() {
+    let admin = make_user(UserRole::Admin, vec![]);
+    let auth = make_user_auth(admin);
+    let request = create_request_with_permissions(Some(KeyPermissions::admin()));
+
+    assert!(resolve_create_key_scope(&auth, &request).is_ok());
+}
+
+#[test]
+fn test_resolve_create_key_scope_manager_can_target_own_team() {
+    let team_id = Uuid::new_v4();
+    let manager = make_user(UserRole::Manager, vec![team_id]);
+    let auth = make_user_auth(manager);
+    let request = CreateKeyRequest {
+        name: "team".to_string(),
+        description: None,
+        user_id: None,
+        team_id: Some(team_id),
+        budget_id: None,
+        max_budget: None,
+        permissions: None,
+        rate_limits: None,
+        expires_at: None,
+        metadata: None,
+    };
+
+    let resolved = resolve_create_key_scope(&auth, &request).unwrap();
+    assert_eq!(resolved, (None, Some(team_id)));
+}
+
+#[test]
+fn test_resolve_create_key_scope_team_api_key_defaults_to_team_scope() {
+    let team_id = Uuid::new_v4();
+    let auth = make_team_auth(team_id);
+    let request = CreateKeyRequest {
+        name: "team-api".to_string(),
+        description: None,
+        user_id: None,
+        team_id: None,
+        budget_id: None,
+        max_budget: None,
+        permissions: None,
+        rate_limits: None,
+        expires_at: None,
+        metadata: None,
+    };
+
+    let resolved = resolve_create_key_scope(&auth, &request).unwrap();
+    assert_eq!(resolved, (None, Some(team_id)));
+}
+
+#[test]
+fn test_validate_update_key_permissions_user_cannot_promote_to_admin() {
+    let user = make_user(UserRole::User, vec![]);
+    let auth = make_user_auth(user);
+    let request = update_request_with_permissions(Some(KeyPermissions::admin()));
+
+    assert_eq!(
+        validate_update_key_permissions(Some(&auth), &request),
+        Err("Only admin can update API keys with management permissions")
+    );
+}
+
+#[test]
+fn test_validate_update_key_permissions_manager_cannot_grant_system_admin() {
+    let team_id = Uuid::new_v4();
+    let manager = make_user(UserRole::Manager, vec![team_id]);
+    let auth = make_user_auth(manager);
+    let permissions = KeyPermissions {
+        custom_permissions: vec!["system.admin".to_string()],
+        ..Default::default()
+    };
+    let request = update_request_with_permissions(Some(permissions));
+
+    assert_eq!(
+        validate_update_key_permissions(Some(&auth), &request),
+        Err("Only admin can update API keys with management permissions")
+    );
+}
+
+#[test]
+fn test_validate_update_key_permissions_team_api_key_cannot_grant_wildcard() {
+    let auth = make_team_auth(Uuid::new_v4());
+    let permissions = KeyPermissions {
+        custom_permissions: vec!["*".to_string()],
+        ..Default::default()
+    };
+    let request = update_request_with_permissions(Some(permissions));
+
+    assert_eq!(
+        validate_update_key_permissions(Some(&auth), &request),
+        Err("Only admin can update API keys with management permissions")
+    );
+}
+
+#[test]
+fn test_validate_update_key_permissions_admin_can_grant_management_access() {
+    let admin = make_user(UserRole::Admin, vec![]);
+    let auth = make_user_auth(admin);
+    let request = update_request_with_permissions(Some(KeyPermissions::admin()));
+
+    assert!(validate_update_key_permissions(Some(&auth), &request).is_ok());
+}
+
+#[test]
+fn test_validate_update_key_permissions_allows_non_management_permissions() {
+    let user = make_user(UserRole::User, vec![]);
+    let auth = make_user_auth(user);
+    let permissions = KeyPermissions {
+        custom_permissions: vec!["api.chat".to_string()],
+        ..Default::default()
+    };
+    let request = update_request_with_permissions(Some(permissions));
+
+    assert!(validate_update_key_permissions(Some(&auth), &request).is_ok());
+}
+
+#[test]
+fn test_filter_and_paginate_keys_reports_filtered_total() {
+    let first_active = Uuid::new_v4();
+    let revoked = Uuid::new_v4();
+    let second_active = Uuid::new_v4();
+    let keys = vec![
+        make_key_info(first_active, KeyStatus::Active),
+        make_key_info(revoked, KeyStatus::Revoked),
+        make_key_info(second_active, KeyStatus::Active),
+    ];
+
+    let (page, total) = filter_and_paginate_keys(keys, Some(KeyStatus::Active), 1, 1);
+
+    assert_eq!(total, 2);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].id, second_active);
+}
+
+#[test]
+fn test_filter_and_paginate_keys_applies_limit_without_status_filter() {
+    let first = Uuid::new_v4();
+    let second = Uuid::new_v4();
+    let third = Uuid::new_v4();
+    let keys = vec![
+        make_key_info(first, KeyStatus::Active),
+        make_key_info(second, KeyStatus::Revoked),
+        make_key_info(third, KeyStatus::Active),
+    ];
+
+    let (page, total) = filter_and_paginate_keys(keys, None, 2, 1);
+
+    assert_eq!(total, 3);
+    assert_eq!(
+        page.iter().map(|key| key.id).collect::<Vec<_>>(),
+        vec![second, third]
+    );
+}

--- a/src/server/routes/keys/mod.rs
+++ b/src/server/routes/keys/mod.rs
@@ -13,6 +13,8 @@
 //! - `GET /v1/keys/{id}/usage` - Get usage statistics
 //! - `POST /v1/keys/verify` - Verify a key
 
+mod access;
+mod api_key_budget;
 mod handlers;
 mod middleware;
 mod types;

--- a/src/server/routes/keys/types.rs
+++ b/src/server/routes/keys/types.rs
@@ -31,6 +31,10 @@ pub struct CreateKeyRequest {
     #[serde(default)]
     pub budget_id: Option<Uuid>,
 
+    /// Unsupported until API-key-scoped budgets are persisted; use budget_id.
+    #[serde(default)]
+    pub max_budget: Option<f64>,
+
     /// Key permissions
     #[serde(default)]
     pub permissions: Option<KeyPermissions>,
@@ -70,6 +74,10 @@ pub struct UpdateKeyRequest {
     /// Update budget ID
     #[serde(default)]
     pub budget_id: Option<Option<Uuid>>,
+
+    /// Unsupported until API-key-scoped budgets are persisted; use budget_id.
+    #[serde(default)]
+    pub max_budget: Option<f64>,
 
     /// Update expiration date
     #[serde(default)]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -3,7 +3,7 @@
 //! This module provides the AppState struct and its implementations.
 
 use crate::config::Config;
-use crate::core::budget::UnifiedBudgetLimits;
+use crate::core::budget::{BudgetManager, UnifiedBudgetLimits};
 use crate::core::keys::{DatabaseKeyRepository, KeyManager};
 use crate::core::pricing_service::PricingService;
 use crate::core::teams::TeamManager;
@@ -34,6 +34,8 @@ pub struct AppState {
     pub pricing: Arc<PricingService>,
     /// Budget limits for provider and model cost tracking
     pub budget_limits: Arc<UnifiedBudgetLimits>,
+    /// General budget manager for keyed budget scopes such as API key budgets
+    pub budget_manager: Arc<BudgetManager>,
     /// Team manager for team lifecycle operations (shared, in-memory by default)
     pub team_manager: Arc<TeamManager>,
     /// API key manager for `/v1/keys` route handlers (shared across requests)
@@ -63,6 +65,7 @@ impl AppState {
             storage,
             pricing,
             budget_limits,
+            budget_manager: Arc::new(BudgetManager::new()),
             team_manager,
             key_manager,
         }

--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -1,288 +1,19 @@
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
+#[path = "gemini_sdk_routes/support.rs"]
+mod support;
+
+#[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
-    use bytes::Bytes;
-    use litellm_rs::Config;
-    use litellm_rs::config::models::provider::ProviderConfig;
+    use super::support::{
+        BrokenGeminiStreamServer, MockGeminiServer, api_key_with_max_tokens_per_request,
+        build_auth_required_state, build_test_state, gemini_body,
+        gemini_body_without_generation_config, gemini_provider, gemini_upstream_error_body,
+    };
+    use actix_web::{App, HttpMessage, dev::Service};
+    use actix_web::{http::StatusCode, test, web};
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
-    use litellm_rs::server::HttpServer as GatewayHttpServer;
-    use litellm_rs::server::state::AppState;
+    use litellm_rs::core::models::ApiKey;
     use serde_json::{Value, json};
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
-    use std::time::Duration;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    #[derive(Clone, Debug)]
-    struct CapturedGeminiRequest {
-        path_and_query: String,
-        headers: HashMap<String, String>,
-        body: Vec<u8>,
-    }
-
-    #[derive(Clone)]
-    struct MockGeminiState {
-        captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
-    }
-
-    struct MockGeminiServer {
-        base_url: String,
-        captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
-        handle: actix_web::dev::ServerHandle,
-        task: tokio::task::JoinHandle<std::io::Result<()>>,
-    }
-
-    impl MockGeminiServer {
-        async fn start() -> Self {
-            let captured_requests = Arc::new(Mutex::new(Vec::new()));
-            let state = MockGeminiState {
-                captured_requests: Arc::clone(&captured_requests),
-            };
-            let listener =
-                std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
-            let address = listener
-                .local_addr()
-                .expect("mock server should have address");
-            let server = HttpServer::new(move || {
-                App::new()
-                    .app_data(web::Data::new(state.clone()))
-                    .default_service(web::post().to(mock_gemini))
-            })
-            .listen(listener)
-            .expect("mock server should listen")
-            .run();
-            let handle = server.handle();
-            let task = tokio::spawn(server);
-            wait_for_server(address).await;
-
-            Self {
-                base_url: format!("http://{address}"),
-                captured_requests,
-                handle,
-                task,
-            }
-        }
-
-        fn requests(&self) -> Vec<CapturedGeminiRequest> {
-            self.captured_requests.lock().unwrap().clone()
-        }
-
-        async fn stop(self) {
-            self.handle.stop(true).await;
-            let result = self.task.await.expect("mock server task should join");
-            if let Err(error) = result {
-                panic!("mock server should stop cleanly: {error}");
-            }
-        }
-    }
-
-    struct BrokenGeminiStreamServer {
-        base_url: String,
-        task: tokio::task::JoinHandle<()>,
-    }
-
-    impl BrokenGeminiStreamServer {
-        async fn start() -> Self {
-            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-                .await
-                .expect("broken stream server should bind");
-            let address = listener
-                .local_addr()
-                .expect("broken stream server should have address");
-            let task = tokio::spawn(async move {
-                let (mut socket, _) = listener
-                    .accept()
-                    .await
-                    .expect("broken stream server should accept");
-                let mut buffer = [0_u8; 4096];
-                let _ = socket.read(&mut buffer).await;
-                let response = concat!(
-                    "HTTP/1.1 200 OK\r\n",
-                    "content-type: text/event-stream\r\n",
-                    "content-length: 4096\r\n",
-                    "connection: close\r\n",
-                    "\r\n",
-                    "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"partial\"}]}}]}\n\n"
-                );
-                socket
-                    .write_all(response.as_bytes())
-                    .await
-                    .expect("broken stream server should write partial response");
-                let _ = socket.shutdown().await;
-            });
-
-            Self {
-                base_url: format!("http://{address}"),
-                task,
-            }
-        }
-
-        async fn stop(self) {
-            self.task
-                .await
-                .expect("broken stream server task should join");
-        }
-    }
-
-    async fn wait_for_server(address: std::net::SocketAddr) {
-        for _ in 0..20 {
-            if tokio::net::TcpStream::connect(address).await.is_ok() {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        panic!("mock server did not accept connections at {address}");
-    }
-
-    async fn mock_gemini(
-        state: web::Data<MockGeminiState>,
-        request: HttpRequest,
-        body: Bytes,
-    ) -> HttpResponse {
-        let headers = request
-            .headers()
-            .iter()
-            .filter_map(|(name, value)| {
-                value
-                    .to_str()
-                    .ok()
-                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
-            })
-            .collect();
-        state
-            .captured_requests
-            .lock()
-            .unwrap()
-            .push(CapturedGeminiRequest {
-                path_and_query: request
-                    .uri()
-                    .path_and_query()
-                    .expect("request should have path")
-                    .as_str()
-                    .to_string(),
-                headers,
-                body: body.to_vec(),
-            });
-
-        if request.path().ends_with(":streamGenerateContent") {
-            let should_fail_stream = serde_json::from_slice::<Value>(&body)
-                .ok()
-                .and_then(|value| value.get("forceUpstreamError").and_then(Value::as_bool))
-                .unwrap_or(false);
-            if should_fail_stream {
-                return HttpResponse::BadGateway()
-                    .insert_header(("content-type", "text/event-stream"))
-                    .body(format!(
-                        "event: error\n\
-                         data: {{\"error\":{{\"message\":\"upstream failed at {}\"}}}}\n\n",
-                        request.uri()
-                    ));
-            }
-            return HttpResponse::Ok()
-                .insert_header(("content-type", "text/event-stream"))
-                .body(
-                    "event: message\n\
-                     data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n\
-                     event: message\n\
-                     data: {\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n\n",
-                );
-        }
-
-        let should_fail = serde_json::from_slice::<Value>(&body)
-            .ok()
-            .and_then(|value| value.get("forceUpstreamError").and_then(Value::as_bool))
-            .unwrap_or(false);
-        if should_fail {
-            return HttpResponse::BadGateway().json(json!({
-                "error": {
-                    "message": format!("upstream failed at {}", request.uri())
-                }
-            }));
-        }
-
-        HttpResponse::Ok().json(json!({
-            "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
-            "usageMetadata": {
-                "promptTokenCount": 10,
-                "candidatesTokenCount": 5,
-                "totalTokenCount": 15,
-                "cachedContentTokenCount": 2,
-                "thoughtsTokenCount": 1
-            }
-        }))
-    }
-
-    async fn build_test_state(providers: Vec<ProviderConfig>) -> AppState {
-        let mut config = Config::default();
-        config.gateway.auth.enable_jwt = false;
-        config.gateway.auth.enable_api_key = false;
-        config.gateway.auth.allow_anonymous = true;
-        config.gateway.storage.database.enabled = false;
-        config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
-
-        GatewayHttpServer::new(&config)
-            .await
-            .expect("gateway server should initialize")
-            .state()
-            .clone()
-    }
-
-    async fn build_auth_required_state(providers: Vec<ProviderConfig>) -> AppState {
-        let mut config = Config::default();
-        config.gateway.storage.database.enabled = false;
-        config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
-
-        GatewayHttpServer::new(&config)
-            .await
-            .expect("gateway server should initialize")
-            .state()
-            .clone()
-    }
-
-    fn gemini_provider(name: &str, base_url: &str, models: Vec<String>) -> ProviderConfig {
-        let mut provider = ProviderConfig {
-            name: name.to_string(),
-            provider_type: "openai_compatible".to_string(),
-            api_key: "test-api-key-12345678901234567890".to_string(),
-            base_url: Some(base_url.to_string()),
-            models,
-            ..ProviderConfig::default()
-        };
-        provider.settings = HashMap::from([
-            (
-                "headers".to_string(),
-                json!({
-                    "X-Base-Header": "base-value",
-                    "X-Ignored-Non-String": false
-                }),
-            ),
-            (
-                "custom_headers".to_string(),
-                json!({
-                    "X-Custom-Header": "custom-value"
-                }),
-            ),
-        ]);
-        provider
-    }
-
-    fn gemini_body() -> Value {
-        json!({
-            "contents": [{
-                "role": "user",
-                "parts": [{"text": "hello from the Gemini SDK"}]
-            }],
-            "generationConfig": {"maxOutputTokens": 8}
-        })
-    }
-
-    fn gemini_upstream_error_body() -> Value {
-        let mut body = gemini_body();
-        body["forceUpstreamError"] = json!(true);
-        body
-    }
 
     #[tokio::test]
     async fn gemini_sdk_routes_without_provider_fail_closed() {
@@ -315,7 +46,7 @@ mod tests {
 
     #[tokio::test]
     async fn gemini_sdk_route_proxies_native_body_and_records_spend() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![
             gemini_provider(
                 "googleai",
@@ -384,12 +115,12 @@ mod tests {
             .expect("model spend should be recorded");
         assert!(model_usage.current_spend > 0.0);
 
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_stream_route_uses_sse_alt_query() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -448,12 +179,12 @@ mod tests {
             .expect("model stream spend should be recorded");
         assert!(model_usage.current_spend > 0.0);
 
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_prefixed_sdk_route_is_supported() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -483,12 +214,12 @@ mod tests {
             "/v1beta/models/gemini-3.1-flash-lite:generateContent?key=test-api-key-12345678901234567890"
         );
 
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_route_rejects_unauthenticated_when_auth_enabled() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_auth_required_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -513,12 +244,54 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert!(mock.requests().is_empty());
-        mock.stop().await;
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_route_applies_api_key_token_limit_when_native_cap_is_omitted() {
+        let mock = MockGeminiServer::launch().await;
+        let state = build_auth_required_state(vec![gemini_provider(
+            "gemini",
+            &mock.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        )])
+        .await;
+        let api_key = api_key_with_max_tokens_per_request(7);
+        let app = test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert::<ApiKey>(api_key.clone());
+                    srv.call(req)
+                })
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body_without_generation_config())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let requests = mock.requests();
+        assert_eq!(requests.len(), 1);
+        let upstream_body: Value =
+            serde_json::from_slice(&requests[0].body).expect("body should be json");
+        assert_eq!(
+            upstream_body["generationConfig"]["maxOutputTokens"],
+            json!(7)
+        );
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_route_rejects_unsafe_model_segment_before_upstream() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state =
             build_test_state(vec![gemini_provider("gemini", &mock.base_url, Vec::new())]).await;
         let app = test::init_service(
@@ -539,12 +312,12 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert!(mock.requests().is_empty());
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_route_rejects_exhausted_provider_budget_before_upstream() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -576,12 +349,12 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(mock.requests().is_empty());
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_route_reserves_budget_before_upstream() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -614,7 +387,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(mock.requests().is_empty());
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
@@ -650,7 +423,7 @@ mod tests {
 
     #[tokio::test]
     async fn gemini_sdk_route_redacts_key_from_upstream_error_body() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -680,12 +453,12 @@ mod tests {
         assert!(text.contains("key=[REDACTED]"));
         assert!(!text.contains("test-api-key-12345678901234567890"));
 
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_stream_route_does_not_charge_upstream_error_body() {
-        let mock = MockGeminiServer::start().await;
+        let mock = MockGeminiServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &mock.base_url,
@@ -734,12 +507,12 @@ mod tests {
             .expect("model budget should exist");
         assert_eq!(model_usage.current_spend, 0.0);
 
-        mock.stop().await;
+        mock.shutdown().await;
     }
 
     #[tokio::test]
     async fn gemini_sdk_stream_route_releases_budget_on_midstream_read_error() {
-        let broken = BrokenGeminiStreamServer::start().await;
+        let broken = BrokenGeminiStreamServer::launch().await;
         let state = build_test_state(vec![gemini_provider(
             "gemini",
             &broken.base_url,
@@ -787,6 +560,6 @@ mod tests {
             .expect("model budget should exist");
         assert_eq!(model_usage.current_spend, 0.0);
 
-        broken.stop().await;
+        broken.shutdown().await;
     }
 }

--- a/tests/gemini_sdk_routes/support.rs
+++ b/tests/gemini_sdk_routes/support.rs
@@ -1,0 +1,320 @@
+use actix_web::{App, HttpRequest, HttpResponse, HttpServer, web};
+use bytes::Bytes;
+use litellm_rs::Config;
+use litellm_rs::config::models::provider::ProviderConfig;
+use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+use litellm_rs::server::HttpServer as GatewayHttpServer;
+use litellm_rs::server::state::AppState;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[derive(Clone, Debug)]
+pub(crate) struct CapturedGeminiRequest {
+    pub(crate) path_and_query: String,
+    pub(crate) headers: HashMap<String, String>,
+    pub(crate) body: Vec<u8>,
+}
+
+#[derive(Clone)]
+struct MockGeminiState {
+    captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
+}
+
+pub(crate) struct MockGeminiServer {
+    pub(crate) base_url: String,
+    captured_requests: Arc<Mutex<Vec<CapturedGeminiRequest>>>,
+    handle: actix_web::dev::ServerHandle,
+    task: tokio::task::JoinHandle<std::io::Result<()>>,
+}
+
+impl MockGeminiServer {
+    pub(crate) async fn launch() -> Self {
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let state = MockGeminiState {
+            captured_requests: Arc::clone(&captured_requests),
+        };
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock server should have address");
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(state.clone()))
+                .default_service(web::post().to(mock_gemini))
+        })
+        .listen(listener)
+        .expect("mock server should listen")
+        .run();
+        let handle = server.handle();
+        let task = tokio::spawn(server);
+        wait_for_server(address).await;
+
+        Self {
+            base_url: format!("http://{address}"),
+            captured_requests,
+            handle,
+            task,
+        }
+    }
+
+    pub(crate) fn requests(&self) -> Vec<CapturedGeminiRequest> {
+        self.captured_requests.lock().unwrap().clone()
+    }
+
+    pub(crate) async fn shutdown(self) {
+        self.handle.stop(true).await;
+        let result = self.task.await.expect("mock server task should join");
+        if let Err(error) = result {
+            panic!("mock server should stop cleanly: {error}");
+        }
+    }
+}
+
+pub(crate) struct BrokenGeminiStreamServer {
+    pub(crate) base_url: String,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl BrokenGeminiStreamServer {
+    pub(crate) async fn launch() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("broken stream server should bind");
+        let address = listener
+            .local_addr()
+            .expect("broken stream server should have address");
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("broken stream server should accept");
+            let mut buffer = [0_u8; 4096];
+            let _ = socket.read(&mut buffer).await;
+            let response = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "content-type: text/event-stream\r\n",
+                "content-length: 4096\r\n",
+                "connection: close\r\n",
+                "\r\n",
+                "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"partial\"}]}}]}\n\n"
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("broken stream server should write partial response");
+            let _ = socket.shutdown().await;
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            task,
+        }
+    }
+
+    pub(crate) async fn shutdown(self) {
+        self.task
+            .await
+            .expect("broken stream server task should join");
+    }
+}
+
+async fn wait_for_server(address: std::net::SocketAddr) {
+    for _ in 0..20 {
+        if tokio::net::TcpStream::connect(address).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("mock server did not accept connections at {address}");
+}
+
+async fn mock_gemini(
+    state: web::Data<MockGeminiState>,
+    request: HttpRequest,
+    body: Bytes,
+) -> HttpResponse {
+    let headers = request
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect();
+    state
+        .captured_requests
+        .lock()
+        .unwrap()
+        .push(CapturedGeminiRequest {
+            path_and_query: request
+                .uri()
+                .path_and_query()
+                .expect("request should have path")
+                .as_str()
+                .to_string(),
+            headers,
+            body: body.to_vec(),
+        });
+
+    if request.path().ends_with(":streamGenerateContent") {
+        let should_fail_stream = serde_json::from_slice::<Value>(&body)
+            .ok()
+            .and_then(|value| value.get("forceUpstreamError").and_then(Value::as_bool))
+            .unwrap_or(false);
+        if should_fail_stream {
+            return HttpResponse::BadGateway()
+                .insert_header(("content-type", "text/event-stream"))
+                .body(format!(
+                    "event: error\n\
+                     data: {{\"error\":{{\"message\":\"upstream failed at {}\"}}}}\n\n",
+                    request.uri()
+                ));
+        }
+        return HttpResponse::Ok()
+            .insert_header(("content-type", "text/event-stream"))
+            .body(
+                "event: message\n\
+                 data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n\
+                 event: message\n\
+                 data: {\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15}}\n\n",
+            );
+    }
+
+    let should_fail = serde_json::from_slice::<Value>(&body)
+        .ok()
+        .and_then(|value| value.get("forceUpstreamError").and_then(Value::as_bool))
+        .unwrap_or(false);
+    if should_fail {
+        return HttpResponse::BadGateway().json(json!({
+            "error": {
+                "message": format!("upstream failed at {}", request.uri())
+            }
+        }));
+    }
+
+    HttpResponse::Ok().json(json!({
+        "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 15,
+            "cachedContentTokenCount": 2,
+            "thoughtsTokenCount": 1
+        }
+    }))
+}
+
+pub(crate) async fn build_test_state(providers: Vec<ProviderConfig>) -> AppState {
+    let mut config = Config::default();
+    config.gateway.auth.enable_jwt = false;
+    config.gateway.auth.enable_api_key = false;
+    config.gateway.auth.allow_anonymous = true;
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    config.gateway.providers = providers;
+
+    GatewayHttpServer::new(&config)
+        .await
+        .expect("gateway server should initialize")
+        .state()
+        .clone()
+}
+
+pub(crate) async fn build_auth_required_state(providers: Vec<ProviderConfig>) -> AppState {
+    let mut config = Config::default();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    config.gateway.providers = providers;
+
+    GatewayHttpServer::new(&config)
+        .await
+        .expect("gateway server should initialize")
+        .state()
+        .clone()
+}
+
+pub(crate) fn gemini_provider(name: &str, base_url: &str, models: Vec<String>) -> ProviderConfig {
+    let mut provider = ProviderConfig {
+        name: name.to_string(),
+        provider_type: "openai_compatible".to_string(),
+        api_key: "test-api-key-12345678901234567890".to_string(),
+        base_url: Some(base_url.to_string()),
+        models,
+        ..ProviderConfig::default()
+    };
+    provider.settings = HashMap::from([
+        (
+            "headers".to_string(),
+            json!({
+                "X-Base-Header": "base-value",
+                "X-Ignored-Non-String": false
+            }),
+        ),
+        (
+            "custom_headers".to_string(),
+            json!({
+                "X-Custom-Header": "custom-value"
+            }),
+        ),
+    ]);
+    provider
+}
+
+pub(crate) fn gemini_body() -> Value {
+    json!({
+        "contents": [{
+            "role": "user",
+            "parts": [{"text": "hello from the Gemini SDK"}]
+        }],
+        "generationConfig": {"maxOutputTokens": 8}
+    })
+}
+
+pub(crate) fn gemini_body_without_generation_config() -> Value {
+    json!({
+        "contents": [{
+            "role": "user",
+            "parts": [{"text": "hello from the Gemini SDK"}]
+        }]
+    })
+}
+
+pub(crate) fn api_key_with_max_tokens_per_request(limit: u32) -> ApiKey {
+    let mut metadata = Metadata::new();
+    metadata.extra.insert(
+        "__core_keys".to_string(),
+        json!({
+            "permissions": {
+                "allowed_models": ["gemini-*"],
+                "allowed_endpoints": [],
+                "max_tokens_per_request": limit,
+                "custom_permissions": []
+            }
+        }),
+    );
+    ApiKey {
+        metadata,
+        name: "gemini-test-key".to_string(),
+        key_hash: "hash".to_string(),
+        key_prefix: "gw-gemini".to_string(),
+        user_id: None,
+        team_id: None,
+        permissions: Vec::new(),
+        rate_limits: None,
+        expires_at: None,
+        is_active: true,
+        last_used_at: None,
+        usage_stats: UsageStats::default(),
+    }
+}
+
+pub(crate) fn gemini_upstream_error_body() -> Value {
+    let mut body = gemini_body();
+    body["forceUpstreamError"] = json!(true);
+    body
+}

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -7,8 +7,8 @@ mod tests {
     use actix_web::http::StatusCode;
     use actix_web::{App, HttpMessage, HttpRequest, HttpResponse, test, web};
     use litellm_rs::Config;
-    use litellm_rs::core::models::user::types::{User, UserStatus};
-    use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+    use litellm_rs::core::models::user::types::{User, UserRole, UserStatus};
+    use litellm_rs::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
     use litellm_rs::core::types::context::RequestContext;
     use litellm_rs::server::http::HttpServer;
     use litellm_rs::server::middleware::{AuthMiddleware, RateLimitMiddleware};
@@ -35,6 +35,7 @@ mod tests {
         request_id: Option<String>,
         user_id: Option<String>,
         api_key_id: Option<String>,
+        api_key_budget_id: Option<String>,
     }
 
     async fn auth_probe(
@@ -56,6 +57,9 @@ mod tests {
             api_key_id: context
                 .as_ref()
                 .and_then(|ctx| ctx.api_key_id().map(|id| id.to_string())),
+            api_key_budget_id: context
+                .as_ref()
+                .and_then(|ctx| ctx.api_key_budget_id().map(|id| id.to_string())),
         };
 
         HttpResponse::Ok().json(payload)
@@ -97,11 +101,35 @@ mod tests {
     }
 
     async fn seed_valid_principal(state: &AppState) -> SeededPrincipal {
+        seed_principal_with_role_and_api_key(
+            state,
+            UserRole::User,
+            vec!["use:api".to_string()],
+            Metadata::new(),
+        )
+        .await
+    }
+
+    async fn seed_principal_with_api_key(
+        state: &AppState,
+        permissions: Vec<String>,
+        metadata: Metadata,
+    ) -> SeededPrincipal {
+        seed_principal_with_role_and_api_key(state, UserRole::User, permissions, metadata).await
+    }
+
+    async fn seed_principal_with_role_and_api_key(
+        state: &AppState,
+        role: UserRole,
+        permissions: Vec<String>,
+        metadata: Metadata,
+    ) -> SeededPrincipal {
         let mut user = User::new(
             "auth-mw-user".to_string(),
             "auth-mw-user@example.com".to_string(),
             "hashed-password".to_string(),
         );
+        user.role = role;
         user.status = UserStatus::Active;
 
         let user = state
@@ -113,13 +141,13 @@ mod tests {
 
         let raw_api_key = "gw-valid-auth-middleware-key-123456".to_string();
         let api_key = ApiKey {
-            metadata: Metadata::new(),
+            metadata,
             name: "auth-middleware-test-key".to_string(),
             key_hash: hash_api_key(&raw_api_key, None),
             key_prefix: extract_api_key_prefix(&raw_api_key),
             user_id: Some(user.id()),
             team_id: None,
-            permissions: vec!["use:api".to_string()],
+            permissions,
             rate_limits: None,
             expires_at: None,
             is_active: true,
@@ -322,6 +350,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_api_key_rpm_is_enforced_without_gateway_default_rate_limit() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_valid_principal(&state).await;
+        let key_id = uuid::Uuid::parse_str(&principal.api_key_id)
+            .expect("seeded API key id should be a UUID");
+        state
+            .storage
+            .db()
+            .update_api_key_rate_limits(
+                key_id,
+                &RateLimits {
+                    rpm: Some(1),
+                    tpm: None,
+                    rpd: None,
+                    tpd: None,
+                    concurrent: None,
+                },
+            )
+            .await
+            .expect("failed to update seeded API key rate limit");
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::optional(None))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let first_response = test::call_service(&app, first).await;
+        assert_eq!(first_response.status(), StatusCode::OK);
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second request should hit the API key rpm limit");
+
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn test_auth_middleware_accepts_valid_auth_and_propagates_principal_context() {
         let state = build_test_state(true, true).await;
         let principal = seed_valid_principal(&state).await;
@@ -363,6 +446,224 @@ mod tests {
                 .as_deref()
                 .is_some_and(|value| !value.is_empty()),
             "request context should include a non-empty request id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_allows_legacy_use_api_permission_on_ai_route() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_valid_principal(&state).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route("/v1/chat/completions", web::post().to(auth_probe)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .insert_header(("x-api-key", principal.raw_api_key.clone()))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_denies_ai_route_for_disallowed_api_permission() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_principal_with_api_key(
+            &state,
+            vec!["api.embeddings".to_string()],
+            Metadata::new(),
+        )
+        .await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route("/v1/chat/completions", web::post().to(auth_probe)),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let error = test::try_call_service(&app, request)
+            .await
+            .expect_err("disallowed operation should fail in auth middleware");
+
+        assert_eq!(
+            error.as_response_error().status_code(),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+        assert!(error.to_string().contains("operation"));
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_keeps_admin_owned_api_key_permission_restricted() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_principal_with_role_and_api_key(
+            &state,
+            UserRole::Admin,
+            vec!["api.embeddings".to_string()],
+            Metadata::new(),
+        )
+        .await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route("/v1/chat/completions", web::post().to(auth_probe)),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let error = test::try_call_service(&app, request)
+            .await
+            .expect_err("admin-owned limited key should stay limited");
+
+        assert_eq!(
+            error.as_response_error().status_code(),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_denies_root_engine_completion_alias_for_disallowed_permission() {
+        let state = build_test_state(true, true).await;
+        let principal = seed_principal_with_api_key(
+            &state,
+            vec!["api.embeddings".to_string()],
+            Metadata::new(),
+        )
+        .await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route("/engines/gpt-4o/completions", web::post().to(auth_probe)),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/engines/gpt-4o/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let error = test::try_call_service(&app, request)
+            .await
+            .expect_err("root engine completions alias should map to completions operation");
+
+        assert_eq!(
+            error.as_response_error().status_code(),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_denies_ai_route_for_disallowed_endpoint_policy() {
+        let state = build_test_state(true, true).await;
+        let mut metadata = Metadata::new();
+        metadata.set_extra(
+            "__core_keys",
+            serde_json::json!({
+                "permissions": {
+                    "allowed_endpoints": ["/v1/embeddings"]
+                }
+            }),
+        );
+        let principal =
+            seed_principal_with_api_key(&state, vec!["use:api".to_string()], metadata).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route("/v1/chat/completions", web::post().to(auth_probe)),
+        )
+        .await;
+
+        let request = test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let error = test::try_call_service(&app, request)
+            .await
+            .expect_err("disallowed endpoint should fail in auth middleware");
+
+        assert_eq!(
+            error.as_response_error().status_code(),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+        assert!(error.to_string().contains("endpoint"));
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_propagates_api_key_budget_id_context() {
+        let state = build_test_state(true, true).await;
+        let budget_id = uuid::Uuid::new_v4();
+        let mut metadata = Metadata::new();
+        metadata.set_extra(
+            "__core_keys",
+            serde_json::json!({
+                "budget_id": budget_id.to_string()
+            }),
+        );
+        let principal =
+            seed_principal_with_api_key(&state, vec!["use:api".to_string()], metadata).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(AUTH_PROBE_PATH)
+                .insert_header(("x-api-key", principal.raw_api_key.clone()))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload: AuthProbePayload = test::read_body_json(response).await;
+        let budget_id_string = budget_id.to_string();
+        assert_eq!(
+            payload.api_key_budget_id.as_deref(),
+            Some(budget_id_string.as_str())
         );
     }
 


### PR DESCRIPTION
Fixes #751.

## Summary
- enforce API key endpoint/model/token permissions across AI routes, including native Gemini requests
- apply API-key RPM overrides and reject unsupported key rate-limit fields instead of silently accepting them
- require persisted budget IDs for API-key budgets and reserve/settle key budgets across success, errors, and streams
- split large route/test files while keeping all edited Rust files under 800 lines

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked --message-format=short
- cargo test --all-features --locked --test gemini_sdk_routes -- --nocapture
- cargo test --all-features --locked
