### PR TITLE
Fix requests_per_minute rate limit enforcement

### DIFF
--- a/src/config/models/rate_limit.rs
+++ b/src/config/models/rate_limit.rs
@@ -58,6 +58,14 @@ impl Default for RateLimitConfig {
 }
 
 impl RateLimitConfig {
+    /// Effective gateway requests-per-minute limit.
+    ///
+    /// `requests_per_minute` is accepted for LiteLLM compatibility and takes
+    /// precedence over the older `default_rpm` field when present.
+    pub fn effective_rpm(&self) -> u32 {
+        self.requests_per_minute.unwrap_or(self.default_rpm)
+    }
+
     /// Fields parsed from config but not enforced by the current limiter.
     ///
     /// Keep this list shared with validation and runtime construction so a
@@ -249,6 +257,28 @@ mod tests {
         assert!(!merged.enabled);
         assert_eq!(merged.default_rpm, 1000);
         assert_eq!(merged.default_tpm, 100_000);
+    }
+
+    #[test]
+    fn test_rate_limit_effective_rpm_uses_requests_per_minute_alias() {
+        let config = RateLimitConfig {
+            default_rpm: 1000,
+            requests_per_minute: Some(25),
+            ..RateLimitConfig::default()
+        };
+
+        assert_eq!(config.effective_rpm(), 25);
+    }
+
+    #[test]
+    fn test_rate_limit_effective_rpm_falls_back_to_default_rpm() {
+        let config = RateLimitConfig {
+            default_rpm: 500,
+            requests_per_minute: None,
+            ..RateLimitConfig::default()
+        };
+
+        assert_eq!(config.effective_rpm(), 500);
     }
 
     #[test]

--- a/src/config/models/rate_limit.rs
+++ b/src/config/models/rate_limit.rs
@@ -95,6 +95,9 @@ impl RateLimitConfig {
         }
         if other.default_rpm != default_rpm() {
             self.default_rpm = other.default_rpm;
+            if other.requests_per_minute.is_none() {
+                self.requests_per_minute = None;
+            }
         }
         if other.default_tpm != default_tpm() {
             self.default_tpm = other.default_tpm;
@@ -257,6 +260,23 @@ mod tests {
         assert!(!merged.enabled);
         assert_eq!(merged.default_rpm, 1000);
         assert_eq!(merged.default_tpm, 100_000);
+    }
+
+    #[test]
+    fn test_rate_limit_config_merge_default_rpm_clears_alias() {
+        let base = RateLimitConfig {
+            requests_per_minute: Some(25),
+            ..RateLimitConfig::default()
+        };
+        let other = RateLimitConfig {
+            default_rpm: 500,
+            ..RateLimitConfig::default()
+        };
+
+        let merged = base.merge(other);
+
+        assert_eq!(merged.requests_per_minute, None);
+        assert_eq!(merged.effective_rpm(), 500);
     }
 
     #[test]

--- a/src/config/validation/cache_validators.rs
+++ b/src/config/validation/cache_validators.rs
@@ -41,6 +41,10 @@ impl Validate for RateLimitConfig {
             return Err("Default TPM must be greater than 0".to_string());
         }
 
+        if self.requests_per_minute == Some(0) {
+            return Err("requests_per_minute must be greater than 0".to_string());
+        }
+
         let unimplemented = self.unimplemented_runtime_field_names();
         if !unimplemented.is_empty() {
             return Err(format!(

--- a/src/config/validation/cache_validators.rs
+++ b/src/config/validation/cache_validators.rs
@@ -33,16 +33,12 @@ impl Validate for RateLimitConfig {
             return Ok(());
         }
 
-        if self.default_rpm == 0 {
-            return Err("Default RPM must be greater than 0".to_string());
+        if self.effective_rpm() == 0 {
+            return Err("Effective RPM must be greater than 0".to_string());
         }
 
         if self.default_tpm == 0 {
             return Err("Default TPM must be greater than 0".to_string());
-        }
-
-        if self.requests_per_minute == Some(0) {
-            return Err("requests_per_minute must be greater than 0".to_string());
         }
 
         let unimplemented = self.unimplemented_runtime_field_names();

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -281,6 +281,18 @@ fn test_rate_limit_validation_allows_requests_per_minute_alias() {
 }
 
 #[test]
+fn test_rate_limit_validation_allows_requests_per_minute_alias_with_zero_default_rpm() {
+    let config = RateLimitConfig {
+        enabled: true,
+        default_rpm: 0,
+        requests_per_minute: Some(25),
+        ..Default::default()
+    };
+
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[test]
 fn test_rate_limit_validation_rejects_zero_requests_per_minute_alias() {
     let config = RateLimitConfig {
         enabled: true,
@@ -289,7 +301,7 @@ fn test_rate_limit_validation_rejects_zero_requests_per_minute_alias() {
     };
 
     let error = Validate::validate(&config).unwrap_err();
-    assert!(error.contains("requests_per_minute"));
+    assert!(error.contains("Effective RPM"));
     assert!(error.contains("greater than 0"));
 }
 

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -270,6 +270,30 @@ fn test_rate_limit_validation_allows_enforced_rpm_only() {
 }
 
 #[test]
+fn test_rate_limit_validation_allows_requests_per_minute_alias() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_minute: Some(25),
+        ..Default::default()
+    };
+
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[test]
+fn test_rate_limit_validation_rejects_zero_requests_per_minute_alias() {
+    let config = RateLimitConfig {
+        enabled: true,
+        requests_per_minute: Some(0),
+        ..Default::default()
+    };
+
+    let error = Validate::validate(&config).unwrap_err();
+    assert!(error.contains("requests_per_minute"));
+    assert!(error.contains("greater than 0"));
+}
+
+#[test]
 fn test_database_validation_skips_when_disabled() {
     let config = DatabaseConfig {
         enabled: false,

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -101,18 +101,19 @@ impl RateLimiter {
     }
 
     fn disabled_result(&self) -> RateLimitResult {
+        let limit = self.config.effective_rpm();
         RateLimitResult {
             allowed: true,
             current_count: 0,
-            limit: self.config.default_rpm,
-            remaining: self.config.default_rpm,
+            limit,
+            remaining: limit,
             reset_after_secs: 0,
             retry_after_secs: None,
         }
     }
 
     /// Names of config fields that are parsed but not enforced by any
-    /// strategy yet; only enabled/strategy/default_rpm take effect.
+    /// strategy yet; only enabled/strategy/default_rpm/requests_per_minute take effect.
     fn unimplemented_field_names(config: &RateLimitConfig) -> Vec<&'static str> {
         config.unimplemented_runtime_field_names()
     }
@@ -123,7 +124,7 @@ impl RateLimiter {
         let unimplemented = Self::unimplemented_field_names(config);
         if !unimplemented.is_empty() {
             error!(
-                "rate_limit fields [{}] are set but not enforced yet; only enabled/strategy/default_rpm take effect",
+                "rate_limit fields [{}] are set but not enforced yet; only enabled/strategy/default_rpm/requests_per_minute take effect",
                 unimplemented.join(", ")
             );
         }
@@ -175,7 +176,7 @@ impl RateLimiter {
         #[cfg(feature = "gateway")]
         if let Some(redis) = &self.redis {
             match redis
-                .rate_limit_status(key, self.config.default_rpm, self.window.as_secs())
+                .rate_limit_status(key, self.config.effective_rpm(), self.window.as_secs())
                 .await
             {
                 Ok(result) => return result,
@@ -190,16 +191,31 @@ impl RateLimiter {
 
         match self.config.strategy {
             RateLimitStrategy::SlidingWindow => {
-                self.check_sliding_window_impl(key, self.config.default_rpm, false, Instant::now())
-                    .await
+                self.check_sliding_window_impl(
+                    key,
+                    self.config.effective_rpm(),
+                    false,
+                    Instant::now(),
+                )
+                .await
             }
             RateLimitStrategy::TokenBucket => {
-                self.check_token_bucket_impl(key, self.config.default_rpm, false, Instant::now())
-                    .await
+                self.check_token_bucket_impl(
+                    key,
+                    self.config.effective_rpm(),
+                    false,
+                    Instant::now(),
+                )
+                .await
             }
             RateLimitStrategy::FixedWindow => {
-                self.check_fixed_window_impl(key, self.config.default_rpm, false, Instant::now())
-                    .await
+                self.check_fixed_window_impl(
+                    key,
+                    self.config.effective_rpm(),
+                    false,
+                    Instant::now(),
+                )
+                .await
             }
         }
     }
@@ -217,7 +233,7 @@ impl RateLimiter {
         &self,
         key: &str,
     ) -> (RateLimitResult, RateLimitReservation) {
-        self.check_and_record_with_source_and_limit(key, self.config.default_rpm)
+        self.check_and_record_with_source_and_limit(key, self.config.effective_rpm())
             .await
     }
 
@@ -334,7 +350,7 @@ impl RateLimiter {
     }
 
     fn release_local(&self, key: &str, recorded_at: Option<Instant>) {
-        let limit = self.config.default_rpm as f64;
+        let limit = self.config.effective_rpm() as f64;
         let strategy = self.config.strategy.clone();
         let reservation_window = self.token_bucket_reservation_window();
 

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -25,6 +25,17 @@ fn test_config_with_strategy(
     }
 }
 
+fn test_config_with_requests_per_minute_alias(enabled: bool, rpm: u32) -> RateLimitConfig {
+    RateLimitConfig {
+        enabled,
+        default_rpm: 1000,
+        requests_per_minute: Some(rpm),
+        default_tpm: 100000,
+        strategy: RateLimitStrategy::SlidingWindow,
+        ..Default::default()
+    }
+}
+
 #[tokio::test]
 async fn test_rate_limiter_disabled() {
     let limiter = RateLimiter::new(test_config(false, 10));
@@ -59,6 +70,22 @@ async fn test_sliding_window_blocks_over_limit() {
     let result = limiter.check_and_record("test-key").await;
     assert!(!result.allowed);
     assert!(result.retry_after_secs.is_some());
+}
+
+#[tokio::test]
+async fn test_requests_per_minute_alias_is_enforced() {
+    let limiter = RateLimiter::new(test_config_with_requests_per_minute_alias(true, 2));
+
+    let first = limiter.check_and_record("alias-key").await;
+    let second = limiter.check_and_record("alias-key").await;
+    let third = limiter.check_and_record("alias-key").await;
+
+    assert!(first.allowed);
+    assert_eq!(first.limit, 2);
+    assert!(second.allowed);
+    assert!(!third.allowed);
+    assert_eq!(third.limit, 2);
+    assert_eq!(limiter.limit(), 2);
 }
 
 #[tokio::test]

--- a/src/core/rate_limiter/utils.rs
+++ b/src/core/rate_limiter/utils.rs
@@ -12,7 +12,7 @@ impl RateLimiter {
         let now = Instant::now();
         let window_start = now - self.window;
 
-        let limit = self.config.default_rpm as f64;
+        let limit = self.config.effective_rpm() as f64;
         self.entries.retain(|_, entry| {
             match self.config.strategy {
                 RateLimitStrategy::SlidingWindow => {
@@ -66,6 +66,6 @@ impl RateLimiter {
 
     /// Get the configured limit
     pub fn limit(&self) -> u32 {
-        self.config.default_rpm
+        self.config.effective_rpm()
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -177,7 +177,7 @@ impl HttpServer {
             info!(
                 "Global rate limiter initialized (strategy={:?}, rpm={}, backend={})",
                 cfg.gateway.rate_limit.strategy,
-                cfg.gateway.rate_limit.default_rpm,
+                cfg.gateway.rate_limit.effective_rpm(),
                 if redis_available {
                     "redis"
                 } else {
@@ -187,7 +187,7 @@ impl HttpServer {
         }
         let cors_config = &cfg.gateway.server.cors;
         let rate_limit_enabled = cfg.gateway.rate_limit.enabled;
-        let rate_limit_rpm = cfg.gateway.rate_limit.default_rpm;
+        let rate_limit_rpm = cfg.gateway.rate_limit.effective_rpm();
         let api_key_auth_enabled = cfg.gateway.auth.enable_api_key;
         let default_rate_limit_rpm = rate_limit_enabled.then_some(rate_limit_rpm);
         let cors = Self::build_cors_for_app_factory(cors_config);

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -83,7 +83,7 @@ where
             let enable_api_key = cfg.auth().enable_api_key;
             let api_key_header = cfg.auth().api_key_header.clone();
             let rate_limit_enabled = cfg.gateway.rate_limit.enabled;
-            let rate_limit_rpm = cfg.gateway.rate_limit.default_rpm;
+            let rate_limit_rpm = cfg.gateway.rate_limit.effective_rpm();
             let trusted_proxies = cfg.server().trusted_proxies.clone();
 
             let context = build_request_context(&mut req);

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -379,6 +379,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_requests_per_minute_alias_limits_authenticated_requests() {
+        let state = build_test_state_with_requests_per_minute_alias(1000, 1).await;
+        let principal = seed_valid_principal(&state).await;
+        let effective_rpm = state.config.load().gateway.rate_limit.effective_rpm();
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(RateLimitMiddleware::optional(Some(effective_rpm)))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let first_response = test::call_service(&app, first).await;
+        assert_eq!(first_response.status(), StatusCode::OK);
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second authenticated request should hit requests_per_minute limit");
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn test_valid_auth_releases_gateway_auth_attempt_reservation() {
         let state = build_test_state_with_rate_limit(true, true, false, Some(1)).await;
         let principal = seed_valid_principal(&state).await;

--- a/tests/integration/auth_middleware_tests.rs
+++ b/tests/integration/auth_middleware_tests.rs
@@ -96,6 +96,34 @@ mod tests {
         state
     }
 
+    async fn build_test_state_with_requests_per_minute_alias(
+        default_rpm: u32,
+        requests_per_minute: u32,
+    ) -> AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = true;
+        config.gateway.auth.enable_api_key = true;
+        config.gateway.auth.allow_anonymous = false;
+        config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.rate_limit.enabled = true;
+        config.gateway.rate_limit.default_rpm = default_rpm;
+        config.gateway.rate_limit.requests_per_minute = Some(requests_per_minute);
+
+        let server = HttpServer::new(&config)
+            .await
+            .expect("failed to build HTTP server for requests_per_minute integration test");
+        let state = server.state().clone();
+        state
+            .storage
+            .migrate()
+            .await
+            .expect("failed to run in-memory DB migrations for requests_per_minute test");
+        state
+    }
+
     async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {
         build_test_state_with_rate_limit(enable_jwt, enable_api_key, false, None).await
     }
@@ -303,6 +331,46 @@ mod tests {
         let second_error = test::try_call_service(&app, second)
             .await
             .expect_err("second rotating invalid-auth request should hit gateway rate limit");
+        assert_eq!(
+            second_error.as_response_error().status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_requests_per_minute_alias_limits_rejected_auth() {
+        let state = build_test_state_with_requests_per_minute_alias(1000, 1).await;
+        let hit_counter = Arc::new(AtomicUsize::new(0));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .app_data(web::Data::new(hit_counter.clone()))
+                .wrap(AuthMiddleware)
+                .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+        )
+        .await;
+
+        let first = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.152:1000".parse().unwrap())
+            .to_request();
+        let first_error = test::try_call_service(&app, first)
+            .await
+            .expect_err("first missing-auth request should fail in auth middleware");
+        assert_eq!(
+            first_error.as_response_error().status_code(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let second = test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .peer_addr("203.0.113.152:1001".parse().unwrap())
+            .to_request();
+        let second_error = test::try_call_service(&app, second)
+            .await
+            .expect_err("second missing-auth request should hit requests_per_minute limit");
         assert_eq!(
             second_error.as_response_error().status_code(),
             StatusCode::TOO_MANY_REQUESTS


### PR DESCRIPTION
## Summary
- Treat `rate_limit.requests_per_minute` as the LiteLLM-compatible effective gateway RPM limit when present.
- Wire the effective RPM into global limiter setup, auth rejection limiting, limiter status/check/cleanup paths, and validation.
- Add regression coverage for config alias enforcement and existing API-key RPM behavior.

Fixes #752

## Verification
- cargo fmt --all -- --check
- cargo test --all-features --locked config::models::rate_limit --lib -- --nocapture
- cargo test --all-features --locked config::validation --lib -- --nocapture
- cargo test --all-features --locked core::rate_limiter --lib -- --nocapture
- cargo test --all-features --locked test_requests_per_minute_alias_limits_rejected_auth --test lib -- --nocapture
- cargo test --all-features --locked test_api_key_rpm_is_enforced_without_gateway_default_rate_limit --test lib -- --nocapture
- cargo check --all-features --locked
- cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- cargo test --all-features --locked -- --test-threads=1

Note: default-parallel `cargo test --all-features --locked` was interrupted after an unrelated fine-tuning route test stalled; that same test passed alone, and the full suite passed with `--test-threads=1`.
