### PR TITLE
Wire HTTP request metrics into /metrics

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -8,8 +8,8 @@ use crate::core::budget::UnifiedBudgetLimits;
 use crate::core::pricing_service::PricingService;
 use crate::core::rate_limiter::{get_global_rate_limiter, init_global_rate_limiter_with_redis};
 use crate::server::middleware::{
-    AuthMiddleware, RateLimitMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware,
-    start_auth_rate_limiter_cleanup_task,
+    AuthMiddleware, MetricsMiddleware, RateLimitMiddleware, RequestIdMiddleware,
+    SecurityHeadersMiddleware, start_auth_rate_limiter_cleanup_task,
 };
 use crate::server::routes;
 use crate::server::state::AppState;
@@ -190,6 +190,7 @@ impl HttpServer {
         let rate_limit_rpm = cfg.gateway.rate_limit.effective_rpm();
         let api_key_auth_enabled = cfg.gateway.auth.enable_api_key;
         let default_rate_limit_rpm = rate_limit_enabled.then_some(rate_limit_rpm);
+        let metrics_enabled = cfg.gateway.monitoring.metrics.enabled;
         let cors = Self::build_cors_for_app_factory(cors_config);
 
         let budget_limits = web::Data::new(Arc::clone(&state.budget_limits));
@@ -210,6 +211,7 @@ impl HttpServer {
             ))
             .wrap(AuthMiddleware)
             .wrap(RequestIdMiddleware)
+            .wrap(Condition::new(metrics_enabled, MetricsMiddleware))
             .configure(routes::health::configure_routes)
             .configure(routes::auth::configure_routes)
             .configure(routes::keys::configure_routes)
@@ -377,6 +379,7 @@ impl HttpServer {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use actix_web::{http::StatusCode, test as actix_test};
 
     #[test]
     fn build_cors_rejects_wildcard_with_credentials() {
@@ -508,5 +511,129 @@ mod tests {
             "disabled DB must keep startup running with in-memory budgets, got: {:?}",
             result.err()
         );
+    }
+
+    #[tokio::test]
+    async fn app_factory_metrics_endpoint_includes_recorded_http_requests() {
+        let _metrics_guard = MetricsMiddleware::test_lock().await;
+        MetricsMiddleware::reset_for_tests();
+
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+
+        let server = match HttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => panic!("server startup failed: {error}"),
+        };
+
+        let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+            server.state().clone(),
+        )))
+        .await;
+
+        let health_req = actix_test::TestRequest::get().uri("/health").to_request();
+        let health_resp = actix_test::call_service(&app, health_req).await;
+        assert_eq!(health_resp.status(), StatusCode::OK);
+        drop(actix_test::read_body(health_resp).await);
+
+        let metrics_req = actix_test::TestRequest::get().uri("/metrics").to_request();
+        let metrics_resp = actix_test::call_service(&app, metrics_req).await;
+        assert_eq!(metrics_resp.status(), StatusCode::OK);
+
+        let body = actix_test::read_body(metrics_resp).await;
+        let body = match std::str::from_utf8(&body) {
+            Ok(body) => body,
+            Err(error) => panic!("metrics response was not utf-8: {error}"),
+        };
+
+        assert!(body.contains("gateway_http_requests_total 1"));
+        assert!(body.contains("gateway_http_responses_total{class=\"2xx\"} 1"));
+
+        let rendered_after_scrape = MetricsMiddleware::render_prometheus();
+        assert!(rendered_after_scrape.contains("gateway_http_requests_total 1"));
+    }
+
+    #[tokio::test]
+    async fn app_factory_metrics_records_auth_rejections_before_handler() {
+        let _metrics_guard = MetricsMiddleware::test_lock().await;
+        MetricsMiddleware::reset_for_tests();
+
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = true;
+        config.gateway.auth.enable_api_key = true;
+        config.gateway.auth.allow_anonymous = false;
+        config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+        config.gateway.rate_limit.enabled = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+
+        let server = match HttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => panic!("server startup failed: {error}"),
+        };
+
+        let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+            server.state().clone(),
+        )))
+        .await;
+
+        let models_req = actix_test::TestRequest::get()
+            .uri("/v1/models")
+            .to_request();
+        match actix_test::try_call_service(&app, models_req).await {
+            Ok(response) => {
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+                drop(actix_test::read_body(response).await);
+            }
+            Err(error) => assert_eq!(
+                error.as_response_error().status_code(),
+                StatusCode::UNAUTHORIZED
+            ),
+        }
+
+        let body = MetricsMiddleware::render_prometheus();
+        assert!(body.contains("gateway_http_requests_total 1"));
+        assert!(body.contains("gateway_http_request_errors_total 1"));
+        assert!(body.contains("gateway_http_responses_total{class=\"4xx\"} 1"));
+    }
+
+    #[tokio::test]
+    async fn app_factory_does_not_collect_http_metrics_when_metrics_disabled() {
+        let _metrics_guard = MetricsMiddleware::test_lock().await;
+        MetricsMiddleware::reset_for_tests();
+
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.monitoring.metrics.enabled = false;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+
+        let server = match HttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => panic!("server startup failed: {error}"),
+        };
+
+        let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+            server.state().clone(),
+        )))
+        .await;
+
+        let health_req = actix_test::TestRequest::get().uri("/health").to_request();
+        let health_resp = actix_test::call_service(&app, health_req).await;
+        assert_eq!(health_resp.status(), StatusCode::OK);
+        drop(actix_test::read_body(health_resp).await);
+
+        let body = MetricsMiddleware::render_prometheus();
+        assert!(body.contains("gateway_http_requests_total 0"));
+        assert!(body.contains("gateway_http_responses_total{class=\"2xx\"} 0"));
     }
 }

--- a/src/server/middleware/metrics.rs
+++ b/src/server/middleware/metrics.rs
@@ -1,24 +1,79 @@
 //! Metrics middleware for request monitoring
 
-use crate::server::state::AppState;
+use actix_web::body::{BodySize, MessageBody};
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
-use actix_web::web;
+use bytes::Bytes;
 use futures::future::{Ready, ready};
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Instant;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 use tracing::info;
 
 /// Metrics middleware for Actix-web
 pub struct MetricsMiddleware;
 
+impl MetricsMiddleware {
+    /// Render process-local HTTP request metrics in Prometheus text format.
+    pub fn render_prometheus() -> String {
+        let snapshot = http_metrics_snapshot();
+        format!(
+            r#"# HELP gateway_http_requests_total Total HTTP requests observed by the gateway middleware
+# TYPE gateway_http_requests_total counter
+gateway_http_requests_total {}
+
+# HELP gateway_http_request_errors_total Total HTTP requests with status code >= 400
+# TYPE gateway_http_request_errors_total counter
+gateway_http_request_errors_total {}
+
+# HELP gateway_http_responses_total Total HTTP responses by status class
+# TYPE gateway_http_responses_total counter
+gateway_http_responses_total{{class="1xx"}} {}
+gateway_http_responses_total{{class="2xx"}} {}
+gateway_http_responses_total{{class="3xx"}} {}
+gateway_http_responses_total{{class="4xx"}} {}
+gateway_http_responses_total{{class="5xx"}} {}
+
+# HELP gateway_http_request_duration_ms_sum Sum of observed HTTP request durations in milliseconds
+# TYPE gateway_http_request_duration_ms_sum counter
+gateway_http_request_duration_ms_sum {:.3}
+
+# HELP gateway_http_request_duration_ms_count Count of observed HTTP request durations
+# TYPE gateway_http_request_duration_ms_count counter
+gateway_http_request_duration_ms_count {}
+"#,
+            snapshot.requests_total,
+            snapshot.errors_total,
+            snapshot.status_1xx_total,
+            snapshot.status_2xx_total,
+            snapshot.status_3xx_total,
+            snapshot.status_4xx_total,
+            snapshot.status_5xx_total,
+            snapshot.latency_micros_sum as f64 / 1000.0,
+            snapshot.latency_ms_count
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reset_for_tests() {
+        reset_http_metrics_for_tests();
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn test_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        HTTP_METRICS_TEST_LOCK.lock().await
+    }
+}
+
 impl<S, B> Transform<S, ServiceRequest> for MetricsMiddleware
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
     S::Future: 'static,
-    B: 'static,
+    B: MessageBody + 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<MetricsResponseBody<B>>;
     type Error = actix_web::Error;
     type InitError = ();
     type Transform = MetricsMiddlewareService<S>;
@@ -49,13 +104,199 @@ pub struct MiddlewareRequestMetrics {
     pub api_key_id: Option<String>,
 }
 
+/// Snapshot of process-local HTTP request metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HttpMetricsSnapshot {
+    requests_total: u64,
+    errors_total: u64,
+    status_1xx_total: u64,
+    status_2xx_total: u64,
+    status_3xx_total: u64,
+    status_4xx_total: u64,
+    status_5xx_total: u64,
+    latency_micros_sum: u64,
+    latency_ms_count: u64,
+}
+
+struct HttpMetricsRegistry {
+    requests_total: AtomicU64,
+    errors_total: AtomicU64,
+    status_1xx_total: AtomicU64,
+    status_2xx_total: AtomicU64,
+    status_3xx_total: AtomicU64,
+    status_4xx_total: AtomicU64,
+    status_5xx_total: AtomicU64,
+    latency_micros_sum: AtomicU64,
+    latency_ms_count: AtomicU64,
+}
+
+static HTTP_METRICS: HttpMetricsRegistry = HttpMetricsRegistry {
+    requests_total: AtomicU64::new(0),
+    errors_total: AtomicU64::new(0),
+    status_1xx_total: AtomicU64::new(0),
+    status_2xx_total: AtomicU64::new(0),
+    status_3xx_total: AtomicU64::new(0),
+    status_4xx_total: AtomicU64::new(0),
+    status_5xx_total: AtomicU64::new(0),
+    latency_micros_sum: AtomicU64::new(0),
+    latency_ms_count: AtomicU64::new(0),
+};
+
+fn should_record_request_path(path: &str) -> bool {
+    path != "/metrics"
+}
+
+#[cfg(test)]
+static HTTP_METRICS_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Return the current process-local HTTP request metrics.
+fn http_metrics_snapshot() -> HttpMetricsSnapshot {
+    HttpMetricsSnapshot {
+        requests_total: HTTP_METRICS.requests_total.load(Ordering::Relaxed),
+        errors_total: HTTP_METRICS.errors_total.load(Ordering::Relaxed),
+        status_1xx_total: HTTP_METRICS.status_1xx_total.load(Ordering::Relaxed),
+        status_2xx_total: HTTP_METRICS.status_2xx_total.load(Ordering::Relaxed),
+        status_3xx_total: HTTP_METRICS.status_3xx_total.load(Ordering::Relaxed),
+        status_4xx_total: HTTP_METRICS.status_4xx_total.load(Ordering::Relaxed),
+        status_5xx_total: HTTP_METRICS.status_5xx_total.load(Ordering::Relaxed),
+        latency_micros_sum: HTTP_METRICS.latency_micros_sum.load(Ordering::Relaxed),
+        latency_ms_count: HTTP_METRICS.latency_ms_count.load(Ordering::Relaxed),
+    }
+}
+
+fn record_http_metrics(status_code: u16, latency: Duration) {
+    let latency_micros = latency.as_micros().min(u128::from(u64::MAX)) as u64;
+
+    HTTP_METRICS.requests_total.fetch_add(1, Ordering::Relaxed);
+    HTTP_METRICS
+        .latency_micros_sum
+        .fetch_add(latency_micros, Ordering::Relaxed);
+    HTTP_METRICS
+        .latency_ms_count
+        .fetch_add(1, Ordering::Relaxed);
+
+    if status_code >= 400 {
+        HTTP_METRICS.errors_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    match status_code {
+        100..=199 => {
+            HTTP_METRICS
+                .status_1xx_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        200..=299 => {
+            HTTP_METRICS
+                .status_2xx_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        300..=399 => {
+            HTTP_METRICS
+                .status_3xx_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        400..=499 => {
+            HTTP_METRICS
+                .status_4xx_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        500..=599 => {
+            HTTP_METRICS
+                .status_5xx_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
+}
+
+fn record_and_log_http_metrics(method: &str, path: &str, status_code: u16, start_time: Instant) {
+    let response_time = start_time.elapsed();
+    record_http_metrics(status_code, response_time);
+
+    info!(
+        "{} {} -> {} in {:?}",
+        method, path, status_code, response_time
+    );
+}
+
+struct ResponseMetricsRecorder {
+    method: String,
+    path: String,
+    status_code: u16,
+    start_time: Instant,
+}
+
+impl ResponseMetricsRecorder {
+    fn record(self) {
+        record_and_log_http_metrics(&self.method, &self.path, self.status_code, self.start_time);
+    }
+}
+
+pin_project! {
+    pub struct MetricsResponseBody<B> {
+        #[pin]
+        body: B,
+        recorder: Option<ResponseMetricsRecorder>,
+    }
+
+    impl<B> PinnedDrop for MetricsResponseBody<B> {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+            if let Some(recorder) = this.recorder.take() {
+                recorder.record();
+            }
+        }
+    }
+}
+
+impl<B> MessageBody for MetricsResponseBody<B>
+where
+    B: MessageBody,
+{
+    type Error = B::Error;
+
+    fn size(&self) -> BodySize {
+        self.body.size()
+    }
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        let this = self.project();
+
+        match this.body.poll_next(cx) {
+            Poll::Ready(None) => {
+                if let Some(recorder) = this.recorder.take() {
+                    recorder.record();
+                }
+                Poll::Ready(None)
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn reset_http_metrics_for_tests() {
+    HTTP_METRICS.requests_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.errors_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.status_1xx_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.status_2xx_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.status_3xx_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.status_4xx_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.status_5xx_total.store(0, Ordering::Relaxed);
+    HTTP_METRICS.latency_micros_sum.store(0, Ordering::Relaxed);
+    HTTP_METRICS.latency_ms_count.store(0, Ordering::Relaxed);
+}
+
 impl<S, B> Service<ServiceRequest> for MetricsMiddlewareService<S>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
     S::Future: 'static,
-    B: 'static,
+    B: MessageBody + 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<MetricsResponseBody<B>>;
     type Error = actix_web::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
@@ -63,43 +304,136 @@ where
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let start_time = Instant::now();
-        let method = req.method().to_string();
-        let path = req.path().to_string();
+        let should_record = should_record_request_path(req.path());
+        let request_summary =
+            should_record.then(|| (req.method().to_string(), req.path().to_string()));
 
-        let user_agent = req
-            .headers()
-            .get("user-agent")
-            .and_then(|h| h.to_str().ok())
-            .map(|s| s.to_string());
-
-        let client_ip = req.connection_info().peer_addr().map(|s| s.to_string());
-
-        let request_size = req
-            .headers()
-            .get("content-length")
-            .and_then(|h| h.to_str().ok())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let app_state = req.app_data::<web::Data<AppState>>().cloned();
         let fut = self.service.call(req);
 
         Box::pin(async move {
-            let res = fut.await?;
+            let res = match fut.await {
+                Ok(res) => res,
+                Err(err) => {
+                    if let Some((method, path)) = request_summary {
+                        let status_code = err.as_response_error().status_code().as_u16();
+                        record_and_log_http_metrics(&method, &path, status_code, start_time);
+                    }
+                    return Err(err);
+                }
+            };
 
-            let response_time = start_time.elapsed();
-            let status_code = res.status().as_u16();
+            let recorder = request_summary.map(|(method, path)| ResponseMetricsRecorder {
+                method,
+                path,
+                status_code: res.status().as_u16(),
+                start_time,
+            });
 
-            // Metrics recording is handled by MonitoringSystem if configured
-            // For now, just log the request completion
-            let _ = (app_state, request_size, user_agent, client_ip);
-
-            info!(
-                "{} {} -> {} in {:?}",
-                method, path, status_code, response_time
-            );
-
-            Ok(res)
+            Ok(res.map_body(|_, body| MetricsResponseBody { body, recorder }))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{App, HttpResponse, http::StatusCode, test, web};
+    use bytes::Bytes;
+
+    #[actix_web::test]
+    async fn middleware_records_status_classes_and_rendered_output() {
+        let _metrics_guard = MetricsMiddleware::test_lock().await;
+        MetricsMiddleware::reset_for_tests();
+        let app = test::init_service(
+            App::new()
+                .wrap(MetricsMiddleware)
+                .route("/ok", web::get().to(HttpResponse::Ok))
+                .route("/missing", web::get().to(HttpResponse::NotFound))
+                .route(
+                    "/boom",
+                    web::get().to(|| async {
+                        Err::<HttpResponse, _>(actix_web::error::ErrorBadRequest("bad"))
+                    }),
+                ),
+        )
+        .await;
+
+        let ok_req = test::TestRequest::get().uri("/ok").to_request();
+        let ok_resp = test::call_service(&app, ok_req).await;
+        assert_eq!(ok_resp.status(), StatusCode::OK);
+        drop(test::read_body(ok_resp).await);
+
+        let missing_req = test::TestRequest::get().uri("/missing").to_request();
+        let missing_resp = test::call_service(&app, missing_req).await;
+        assert_eq!(missing_resp.status(), StatusCode::NOT_FOUND);
+        drop(test::read_body(missing_resp).await);
+
+        let boom_req = test::TestRequest::get().uri("/boom").to_request();
+        let boom_resp = test::call_service(&app, boom_req).await;
+        assert_eq!(boom_resp.status(), StatusCode::BAD_REQUEST);
+        drop(test::read_body(boom_resp).await);
+
+        let snapshot = http_metrics_snapshot();
+        assert_eq!(snapshot.requests_total, 3);
+        assert_eq!(snapshot.errors_total, 2);
+        assert_eq!(snapshot.status_2xx_total, 1);
+        assert_eq!(snapshot.status_4xx_total, 2);
+        assert_eq!(snapshot.latency_ms_count, 3);
+
+        let rendered = MetricsMiddleware::render_prometheus();
+        assert!(rendered.contains("gateway_http_requests_total 3"));
+        assert!(rendered.contains("gateway_http_request_errors_total 2"));
+        assert!(rendered.contains("gateway_http_responses_total{class=\"2xx\"} 1"));
+        assert!(rendered.contains("gateway_http_responses_total{class=\"4xx\"} 2"));
+    }
+
+    #[actix_web::test]
+    async fn middleware_records_streaming_response_after_body_completion() {
+        let _metrics_guard = MetricsMiddleware::test_lock().await;
+        MetricsMiddleware::reset_for_tests();
+        let app = test::init_service(App::new().wrap(MetricsMiddleware).route(
+            "/stream",
+            web::get().to(|| async {
+                let stream = futures::stream::once(async {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    Ok::<_, actix_web::Error>(Bytes::from_static(b"chunk"))
+                });
+                HttpResponse::Ok().streaming(stream)
+            }),
+        ))
+        .await;
+
+        let req = test::TestRequest::get().uri("/stream").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(http_metrics_snapshot().requests_total, 0);
+
+        let body = test::read_body(resp).await;
+        assert_eq!(body, Bytes::from_static(b"chunk"));
+
+        let snapshot = http_metrics_snapshot();
+        assert_eq!(snapshot.requests_total, 1);
+        assert_eq!(snapshot.status_2xx_total, 1);
+        assert_eq!(snapshot.latency_ms_count, 1);
+        assert!(snapshot.latency_micros_sum >= 10_000);
+    }
+
+    #[actix_web::test]
+    async fn middleware_does_not_record_metrics_scrapes() {
+        let _metrics_guard = MetricsMiddleware::test_lock().await;
+        MetricsMiddleware::reset_for_tests();
+        let app = test::init_service(App::new().wrap(MetricsMiddleware).route(
+            "/metrics",
+            web::get().to(|| async { HttpResponse::Ok().body("metrics") }),
+        ))
+        .await;
+
+        let req = test::TestRequest::get().uri("/metrics").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test::read_body(resp).await;
+        assert_eq!(body, Bytes::from_static(b"metrics"));
+
+        assert_eq!(http_metrics_snapshot().requests_total, 0);
     }
 }

--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -36,6 +36,7 @@
 
 #![allow(dead_code)]
 
+use crate::server::middleware::MetricsMiddleware;
 use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
 use actix_web::{HttpResponse, Result as ActixResult, web};
@@ -197,9 +198,18 @@ async fn version_info() -> HttpResponse {
 async fn metrics(state: web::Data<AppState>) -> ActixResult<HttpResponse> {
     debug!("Metrics requested");
 
-    // NOTE: Proper Prometheus metrics not yet implemented.
-    // For now, return basic metrics in Prometheus format
-    let metrics = format!(
+    let metrics = render_prometheus_metrics(
+        state.config.load().providers().len(),
+        &MetricsMiddleware::render_prometheus(),
+    );
+
+    Ok(HttpResponse::Ok()
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
+        .body(metrics))
+}
+
+fn render_prometheus_metrics(providers_count: usize, http_metrics: &str) -> String {
+    format!(
         r#"# HELP gateway_uptime_seconds Total uptime of the gateway in seconds
 # TYPE gateway_uptime_seconds counter
 gateway_uptime_seconds {}
@@ -215,16 +225,15 @@ gateway_cpu_usage_percent {}
 # HELP gateway_providers_total Total number of configured providers
 # TYPE gateway_providers_total gauge
 gateway_providers_total {}
+
+{}
 "#,
         get_uptime_seconds(),
         get_memory_usage(),
         get_cpu_usage(),
-        state.config.load().providers().len()
-    );
-
-    Ok(HttpResponse::Ok()
-        .content_type("text/plain; version=0.0.4; charset=utf-8")
-        .body(metrics))
+        providers_count,
+        http_metrics
+    )
 }
 
 /// Basic liveness response body.
@@ -679,6 +688,19 @@ mod tests {
         let verdict = aggregate_readiness(&storage_ok(), &providers);
         assert!(verdict.ready);
         assert_eq!(providers.enabled_providers, 1);
+    }
+
+    #[test]
+    fn prometheus_metrics_include_http_request_counters() {
+        let body = render_prometheus_metrics(
+            2,
+            "gateway_http_requests_total 7\n\
+             gateway_http_responses_total{class=\"2xx\"} 5\n",
+        );
+
+        assert!(body.contains("gateway_providers_total 2"));
+        assert!(body.contains("gateway_http_requests_total 7"));
+        assert!(body.contains("gateway_http_responses_total{class=\"2xx\"} 5"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- mount the existing MetricsMiddleware in the real HTTP app factory
- record process-local HTTP request counters, status classes, errors, and duration totals
- append those counters to the existing Prometheus /metrics output while preserving existing gauges

## Scope
Metrics-only first PR for issue #753. Cache and admin surfaces remain follow-up PRs under the same issue.

Refs #753

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test --all-features --locked server::middleware::metrics --lib --quiet
- cargo test --all-features --locked server::routes::health --lib --quiet
- cargo test --all-features --locked server::http --lib --quiet
- cargo check --all-features --locked
- cargo test --all-features --locked -- --test-threads=1

## Threads review
- ISSUE_753_SPLIT planner: metrics is the smallest first PR; cache/admin require follow-up PRs
- REVIEW_ISSUE_753_METRICS: no remaining P0/P1/P2 after test-race fix
