### PR TITLE
Add explicit cache admin unsupported surface

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -217,6 +217,7 @@ impl HttpServer {
             .configure(routes::keys::configure_routes)
             .configure(routes::teams::configure_routes)
             .configure(routes::budget::configure_budget_routes)
+            .configure(routes::admin::configure_routes)
             .configure(routes::ai::configure_routes)
             .configure(routes::pricing::configure_pricing_routes)
     }
@@ -635,5 +636,42 @@ mod tests {
         let body = MetricsMiddleware::render_prometheus();
         assert!(body.contains("gateway_http_requests_total 0"));
         assert!(body.contains("gateway_http_responses_total{class=\"2xx\"} 0"));
+    }
+
+    #[tokio::test]
+    async fn app_factory_mounts_explicit_cache_admin_surface() {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.monitoring.metrics.enabled = false;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+
+        let server = match HttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => panic!("server startup failed: {error}"),
+        };
+
+        let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+            server.state().clone(),
+        )))
+        .await;
+
+        let req = actix_test::TestRequest::get()
+            .uri("/admin/cache/status")
+            .to_request();
+        let resp = actix_test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let body: serde_json::Value = actix_test::read_body_json(resp).await;
+        assert_eq!(body["status"], "unsupported");
+        assert!(
+            body["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("not wired")
+        );
     }
 }

--- a/src/server/routes/admin.rs
+++ b/src/server/routes/admin.rs
@@ -1,0 +1,244 @@
+//! Admin-only operational route surfaces.
+
+use crate::core::models::{
+    ApiKey,
+    user::types::{User, UserRole},
+};
+use crate::server::state::AppState;
+use actix_web::{HttpMessage, HttpRequest, HttpResponse, web};
+use serde::Serialize;
+use tracing::warn;
+
+const CACHE_UNWIRED_MESSAGE: &str = "Response cache is not wired into runtime request handling";
+
+#[derive(Debug, Serialize)]
+struct CacheAdminResponse {
+    success: bool,
+    status: &'static str,
+    cache_enabled: bool,
+    semantic_cache_enabled: bool,
+    message: &'static str,
+}
+
+fn cache_admin_response(state: &web::Data<AppState>) -> CacheAdminResponse {
+    let cfg = state.config.load();
+    CacheAdminResponse {
+        success: false,
+        status: "unsupported",
+        cache_enabled: cfg.gateway.cache.enabled,
+        semantic_cache_enabled: cfg.gateway.cache.semantic_cache,
+        message: CACHE_UNWIRED_MESSAGE,
+    }
+}
+
+fn require_cache_admin(
+    req: &HttpRequest,
+    state: &web::Data<AppState>,
+    action: &str,
+) -> Option<HttpResponse> {
+    let cfg = state.config.load();
+    if !cfg.auth().enable_jwt && !cfg.auth().enable_api_key {
+        return None;
+    }
+
+    let extensions = req.extensions();
+    if let Some(user) = extensions.get::<User>() {
+        if user.has_role(&UserRole::Admin) {
+            return None;
+        }
+        warn!(
+            "User '{}' attempted to {} without admin role",
+            user.username, action
+        );
+    } else if extensions.get::<ApiKey>().is_some() {
+        warn!("API key attempted to {} without admin user context", action);
+    } else {
+        warn!("Unidentified caller attempted to {}", action);
+    }
+
+    Some(HttpResponse::Forbidden().json(serde_json::json!({
+        "success": false,
+        "error": "Admin role required for cache administration"
+    })))
+}
+
+/// GET /admin/cache and /admin/cache/status
+pub async fn cache_status(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+) -> actix_web::Result<HttpResponse> {
+    if let Some(forbidden) = require_cache_admin(&req, &state, "inspect cache status") {
+        return Ok(forbidden);
+    }
+
+    Ok(HttpResponse::NotImplemented().json(cache_admin_response(&state)))
+}
+
+/// POST /admin/cache/clear
+pub async fn clear_response_cache(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+) -> actix_web::Result<HttpResponse> {
+    if let Some(forbidden) = require_cache_admin(&req, &state, "clear cache") {
+        return Ok(forbidden);
+    }
+
+    Ok(HttpResponse::NotImplemented().json(cache_admin_response(&state)))
+}
+
+/// Configure admin routes.
+pub fn configure_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/admin/cache")
+            .route("", web::get().to(cache_status))
+            .route("/", web::get().to(cache_status))
+            .route("/status", web::get().to(cache_status))
+            .route("/clear", web::post().to(clear_response_cache)),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::core::models::{
+        Metadata, UsageStats,
+        user::{
+            preferences::UserPreferences,
+            types::{UserProfile, UserStatus},
+        },
+    };
+    use crate::server::HttpServer;
+    use actix_web::dev::Service;
+    use actix_web::{App, http::StatusCode, test};
+
+    fn base_test_config(auth_enabled: bool) -> Config {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = auth_enabled;
+        config.gateway.auth.enable_api_key = auth_enabled;
+        config.gateway.auth.allow_anonymous = !auth_enabled;
+        config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+        config
+    }
+
+    async fn test_state(config: Config) -> web::Data<AppState> {
+        let server = match HttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => panic!("server startup failed: {error}"),
+        };
+
+        web::Data::new(server.state().clone())
+    }
+
+    fn make_test_user(role: UserRole) -> User {
+        User {
+            metadata: Metadata::new(),
+            username: "testuser".to_string(),
+            email: "test@example.com".to_string(),
+            display_name: None,
+            password_hash: "hash".to_string(),
+            role,
+            status: UserStatus::Active,
+            team_ids: vec![],
+            preferences: UserPreferences::default(),
+            usage_stats: UsageStats::default(),
+            rate_limits: None,
+            last_login_at: None,
+            email_verified: true,
+            two_factor_enabled: false,
+            profile: UserProfile::default(),
+        }
+    }
+
+    #[actix_web::test]
+    async fn cache_status_requires_admin_identity() {
+        let state = test_state(base_test_config(true)).await;
+        let app = test::init_service(App::new().app_data(state).configure(configure_routes)).await;
+
+        let req = test::TestRequest::get().uri("/admin/cache").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn cache_status_rejects_non_admin_user() {
+        let user = make_test_user(UserRole::User);
+        let state = test_state(base_test_config(true)).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert::<User>(user.clone());
+                    srv.call(req)
+                })
+                .configure(configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/admin/cache").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn cache_status_reports_explicit_unsupported_for_admin() {
+        let admin = make_test_user(UserRole::Admin);
+        let state = test_state(base_test_config(true)).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert::<User>(admin.clone());
+                    srv.call(req)
+                })
+                .configure(configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/admin/cache/status")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["success"], false);
+        assert_eq!(body["status"], "unsupported");
+        assert_eq!(body["cache_enabled"], false);
+        assert_eq!(body["semantic_cache_enabled"], false);
+        assert!(
+            body["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("not wired")
+        );
+    }
+
+    #[actix_web::test]
+    async fn clear_cache_reports_explicit_unsupported_for_admin() {
+        let admin = make_test_user(UserRole::Admin);
+        let state = test_state(base_test_config(true)).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert::<User>(admin.clone());
+                    srv.call(req)
+                })
+                .configure(configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/admin/cache/clear")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains all HTTP route handlers organized by functionality.
 
+pub mod admin;
 pub mod ai;
 pub mod auth;
 pub mod budget;


### PR DESCRIPTION
## Summary
- add admin-only `/admin/cache` and `/admin/cache/status` endpoints that return explicit 501 unsupported cache status
- add `/admin/cache/clear` as an explicit 501 response instead of pretending cache clearing is wired
- mount the cache admin surface in the app factory with tests for auth/no-auth and route mounting

## Scope
Refs #753. This is the second narrow PR under issue 753 after metrics PR #790. Issue 753 remains open for full cache runtime wiring.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked
- cargo test --all-features --locked server::routes::admin --lib --quiet
- cargo test --all-features --locked app_factory --lib --quiet
- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo test --lib --features "$FEATURES" --verbose
- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo test --lib --tests --bins --features "$FEATURES" --verbose
- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo clippy --lib --tests --bins --features "$FEATURES" -- -D warnings --force-warn clippy::collapsible-if

## Threads review
- read-only reviewer thread: 019f1949-b168-7561-a6eb-afcc4304d5d3
- final merge-reviewer thread: 019f1973-bec4-7df2-8f01-ccd56e2520b3
- review threads from gemini-code-assist were addressed and resolved on effc1b2f
