### PR TITLE
Preserve split prompt cache pricing

### DIFF
--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -169,6 +169,8 @@ fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
         completion_tokens: usage.completion_tokens,
         total_tokens: usage.total_tokens,
         cached_tokens: usage.cached_tokens,
+        cache_creation_tokens: None,
+        cache_read_tokens: None,
         audio_tokens: usage.audio_tokens,
         image_tokens: usage.image_tokens,
         reasoning_tokens: usage.reasoning_tokens,

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -500,18 +500,31 @@ fn calculate_usage_cost_with_pricing(
     );
     let cache_read_cost_per_token = tiered_cost_per_token(
         model_info,
-        extra_f64(model_info, "cache_read_input_token_cost"),
+        model_info
+            .extra
+            .get("cache_read_input_token_cost")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(input_cost_per_token),
         "cache_read_input_token_cost_above_",
         usage.prompt_tokens,
     );
-
-    let non_cached_tokens = usage
-        .cached_tokens
-        .map(|cached| usage.prompt_tokens.saturating_sub(cached))
-        .unwrap_or(usage.prompt_tokens);
+    let cache_creation_cost_per_token = tiered_cost_per_token(
+        model_info,
+        model_info
+            .extra
+            .get("cache_creation_input_token_cost")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(input_cost_per_token),
+        "cache_creation_input_token_cost_above_",
+        usage.prompt_tokens,
+    );
+    let cache_creation_tokens = usage.cache_creation_token_count();
+    let cache_read_tokens = usage.cache_read_token_count();
+    let non_cached_tokens = usage.non_cached_prompt_tokens();
     let input_cost = non_cached_tokens as f64 * input_cost_per_token;
     let output_cost = usage.completion_tokens as f64 * output_cost_per_token;
-    let cache_cost = usage.cached_tokens.unwrap_or(0) as f64 * cache_read_cost_per_token;
+    let cache_cost = cache_creation_tokens as f64 * cache_creation_cost_per_token
+        + cache_read_tokens as f64 * cache_read_cost_per_token;
     let audio_cost = usage.audio_tokens.unwrap_or(0) as f64
         * extra_f64(model_info, "input_cost_per_audio_token");
     let image_cost =
@@ -741,21 +754,9 @@ mod tests {
 
         assert_eq!(cost.model, "azure/gpt-5.5-2026-04-23");
         assert_eq!(cost.provider, "azure");
-        assert!(
-            (cost.input_cost - 3.0).abs() < 1e-12,
-            "unexpected input cost: {}",
-            cost.input_cost
-        );
-        assert!(
-            (cost.output_cost - 0.045).abs() < 1e-12,
-            "unexpected output cost: {}",
-            cost.output_cost
-        );
-        assert!(
-            (cost.total_cost - 3.045).abs() < 1e-12,
-            "unexpected total cost: {}",
-            cost.total_cost
-        );
+        assert!((cost.input_cost - 3.0).abs() < 1e-12);
+        assert!((cost.output_cost - 0.045).abs() < 1e-12);
+        assert!((cost.total_cost - 3.045).abs() < 1e-12);
     }
 
     #[test]

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -1,7 +1,9 @@
 //! Tests for the pricing service
 
 #[cfg(test)]
-use crate::core::pricing_service::{LiteLLMModelInfo, PricingService};
+use crate::core::pricing_service::{LiteLLMModelInfo, PricingService, PricingUsage};
+#[cfg(test)]
+use crate::core::types::responses::{PromptTokensDetails, Usage};
 use std::collections::HashMap;
 
 #[test]
@@ -52,4 +54,165 @@ async fn test_token_based_cost_calculation() {
     assert!((result.total_cost - 2.0).abs() < f64::EPSILON);
     assert_eq!(result.input_tokens, 1000);
     assert_eq!(result.output_tokens, 500);
+}
+
+#[test]
+fn pricing_usage_preserves_cache_creation_and_read_tokens() {
+    let usage = Usage {
+        prompt_tokens: 1000,
+        completion_tokens: 100,
+        total_tokens: 1100,
+        prompt_tokens_details: Some(PromptTokensDetails {
+            cached_tokens: Some(700),
+            cache_creation_tokens: Some(200),
+            cache_read_tokens: Some(500),
+            audio_tokens: None,
+        }),
+        completion_tokens_details: None,
+        thinking_usage: None,
+    };
+
+    let pricing_usage = PricingUsage::from(&usage);
+
+    assert_eq!(pricing_usage.cached_tokens, Some(700));
+    assert_eq!(pricing_usage.cache_creation_tokens, Some(200));
+    assert_eq!(pricing_usage.cache_read_tokens, Some(500));
+    assert_eq!(pricing_usage.non_cached_prompt_tokens(), 300);
+}
+
+#[test]
+fn pricing_usage_treats_cached_tokens_as_read_fallback() {
+    let mut pricing_usage = PricingUsage::new(1000, 100);
+    pricing_usage.cached_tokens = Some(500);
+    pricing_usage.cache_creation_tokens = Some(200);
+
+    assert_eq!(pricing_usage.cache_read_token_count(), 500);
+    assert_eq!(pricing_usage.non_cached_prompt_tokens(), 300);
+}
+
+#[test]
+fn provider_pricing_charges_cache_creation_and_read_separately() {
+    let service = PricingService::new(None);
+    let mut model_info = LiteLLMModelInfo {
+        max_tokens: Some(4096),
+        max_input_tokens: None,
+        max_output_tokens: None,
+        input_cost_per_token: Some(0.00001),
+        output_cost_per_token: Some(0.00003),
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: None,
+        litellm_provider: "openai".to_string(),
+        mode: "chat".to_string(),
+        supports_function_calling: None,
+        supports_vision: None,
+        supports_streaming: None,
+        supports_parallel_function_calling: None,
+        supports_system_message: None,
+        extra: HashMap::new(),
+    };
+    model_info.extra.insert(
+        "cache_creation_input_token_cost".to_string(),
+        serde_json::Value::from(0.000012),
+    );
+    model_info.extra.insert(
+        "cache_read_input_token_cost".to_string(),
+        serde_json::Value::from(0.000002),
+    );
+    service.add_custom_model("cache-priced-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(1000, 100);
+    usage.cached_tokens = Some(700);
+    usage.cache_creation_tokens = Some(200);
+    usage.cache_read_tokens = Some(500);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("openai", "cache-priced-model", &usage)
+        .unwrap();
+
+    assert!((cost.input_cost - 0.003).abs() < f64::EPSILON);
+    assert!((cost.output_cost - 0.003).abs() < f64::EPSILON);
+    assert!((cost.cache_cost - 0.0034).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.0094).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_pricing_honors_explicit_zero_cache_prices() {
+    let service = PricingService::new(None);
+    let mut model_info = LiteLLMModelInfo {
+        max_tokens: Some(4096),
+        max_input_tokens: None,
+        max_output_tokens: None,
+        input_cost_per_token: Some(0.00001),
+        output_cost_per_token: Some(0.00003),
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: None,
+        litellm_provider: "openai".to_string(),
+        mode: "chat".to_string(),
+        supports_function_calling: None,
+        supports_vision: None,
+        supports_streaming: None,
+        supports_parallel_function_calling: None,
+        supports_system_message: None,
+        extra: HashMap::new(),
+    };
+    model_info.extra.insert(
+        "cache_creation_input_token_cost".to_string(),
+        serde_json::Value::from(0.0),
+    );
+    model_info.extra.insert(
+        "cache_read_input_token_cost".to_string(),
+        serde_json::Value::from(0.0),
+    );
+    service.add_custom_model("zero-cache-priced-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(1000, 100);
+    usage.cached_tokens = Some(700);
+    usage.cache_creation_tokens = Some(200);
+    usage.cache_read_tokens = Some(500);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("openai", "zero-cache-priced-model", &usage)
+        .unwrap();
+
+    assert!((cost.input_cost - 0.003).abs() < f64::EPSILON);
+    assert!((cost.output_cost - 0.003).abs() < f64::EPSILON);
+    assert_eq!(cost.cache_cost, 0.0);
+    assert!((cost.total_cost - 0.006).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_pricing_uses_input_price_when_cache_prices_are_missing() {
+    let service = PricingService::new(None);
+    let model_info = LiteLLMModelInfo {
+        max_tokens: Some(4096),
+        max_input_tokens: None,
+        max_output_tokens: None,
+        input_cost_per_token: Some(0.00001),
+        output_cost_per_token: Some(0.00003),
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: None,
+        litellm_provider: "openai".to_string(),
+        mode: "chat".to_string(),
+        supports_function_calling: None,
+        supports_vision: None,
+        supports_streaming: None,
+        supports_parallel_function_calling: None,
+        supports_system_message: None,
+        extra: HashMap::new(),
+    };
+    service.add_custom_model("cache-unpriced-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(1000, 100);
+    usage.cached_tokens = Some(700);
+    usage.cache_creation_tokens = Some(200);
+    usage.cache_read_tokens = Some(500);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("openai", "cache-unpriced-model", &usage)
+        .unwrap();
+
+    assert!((cost.input_cost - 0.003).abs() < f64::EPSILON);
+    assert!((cost.output_cost - 0.003).abs() < f64::EPSILON);
+    assert!((cost.cache_cost - 0.007).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.013).abs() < f64::EPSILON);
 }

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -78,6 +78,8 @@ pub struct PricingUsage {
     pub completion_tokens: u32,
     pub total_tokens: u32,
     pub cached_tokens: Option<u32>,
+    pub cache_creation_tokens: Option<u32>,
+    pub cache_read_tokens: Option<u32>,
     pub audio_tokens: Option<u32>,
     pub image_tokens: Option<u32>,
     pub reasoning_tokens: Option<u32>,
@@ -90,27 +92,41 @@ impl PricingUsage {
             completion_tokens,
             total_tokens: prompt_tokens.saturating_add(completion_tokens),
             cached_tokens: None,
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
             audio_tokens: None,
             image_tokens: None,
             reasoning_tokens: None,
         }
     }
+
+    pub fn cache_creation_token_count(&self) -> u32 {
+        self.cache_creation_tokens.unwrap_or(0)
+    }
+
+    pub fn cache_read_token_count(&self) -> u32 {
+        self.cache_read_tokens.or(self.cached_tokens).unwrap_or(0)
+    }
+
+    pub fn non_cached_prompt_tokens(&self) -> u32 {
+        self.prompt_tokens.saturating_sub(
+            self.cache_creation_token_count()
+                .saturating_add(self.cache_read_token_count()),
+        )
+    }
 }
 
 impl From<&crate::core::types::responses::Usage> for PricingUsage {
     fn from(usage: &crate::core::types::responses::Usage) -> Self {
+        let prompt_details = usage.prompt_tokens_details.as_ref();
         Self {
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens,
             total_tokens: usage.total_tokens,
-            cached_tokens: usage
-                .prompt_tokens_details
-                .as_ref()
-                .and_then(|details| details.cached_tokens),
-            audio_tokens: usage
-                .prompt_tokens_details
-                .as_ref()
-                .and_then(|details| details.audio_tokens),
+            cached_tokens: prompt_details.and_then(|details| details.cached_tokens),
+            cache_creation_tokens: prompt_details.and_then(|details| details.cache_creation_tokens),
+            cache_read_tokens: prompt_details.and_then(|details| details.cache_read_tokens),
+            audio_tokens: prompt_details.and_then(|details| details.audio_tokens),
             image_tokens: None,
             reasoning_tokens: usage
                 .completion_tokens_details

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -490,6 +490,7 @@ fn test_anthropic_usage_cache_details() {
         .as_ref()
         .and_then(|usage| usage.prompt_tokens_details.as_ref())
         .unwrap();
+    assert_eq!(result.usage.as_ref().unwrap().prompt_tokens, 146);
     assert_eq!(details.cached_tokens, Some(34));
     assert_eq!(details.cache_creation_tokens, Some(12));
     assert_eq!(details.cache_read_tokens, Some(34));
@@ -789,8 +790,7 @@ fn test_transform_chat_response_preserves_cache_details_without_double_counting(
         .unwrap()
         .usage
         .unwrap();
-    // Anthropic input_tokens already includes cache_creation and cache_read tokens.
-    assert_eq!(usage.prompt_tokens, 100);
+    assert_eq!(usage.prompt_tokens, 150);
     assert_eq!(usage.completion_tokens, 50);
-    assert_eq!(usage.total_tokens, 150);
+    assert_eq!(usage.total_tokens, 200);
 }

--- a/src/core/providers/anthropic/client/usage.rs
+++ b/src/core/providers/anthropic/client/usage.rs
@@ -8,9 +8,10 @@ pub(super) fn build_usage(usage_data: &Value) -> Usage {
     let to_u32 = |v: u64| u32::try_from(v).unwrap_or(u32::MAX);
     let cache_creation = read("cache_creation_input_tokens");
     let cache_read = read("cache_read_input_tokens");
-    // Anthropic input_tokens already includes cache creation/read tokens;
-    // expose cache details without double-counting prompt or total tokens.
-    let prompt_tokens = read("input_tokens");
+    let input_tokens = read("input_tokens");
+    let prompt_tokens = input_tokens
+        .saturating_add(cache_creation)
+        .saturating_add(cache_read);
     let completion_tokens = read("output_tokens");
 
     Usage {

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -356,6 +356,10 @@ pub struct OpenAITokenDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cached_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u32>,

--- a/src/core/providers/openai/transformer/response.rs
+++ b/src/core/providers/openai/transformer/response.rs
@@ -177,8 +177,8 @@ impl OpenAIResponseTransformer {
             prompt_tokens_details: usage.prompt_tokens_details.map(|details| {
                 crate::core::types::responses::PromptTokensDetails {
                     cached_tokens: details.cached_tokens,
-                    cache_creation_tokens: None,
-                    cache_read_tokens: details.cached_tokens,
+                    cache_creation_tokens: details.cache_creation_tokens,
+                    cache_read_tokens: details.cache_read_tokens,
                     audio_tokens: details.audio_tokens,
                 }
             }),

--- a/src/core/providers/openai/transformer/response_tests.rs
+++ b/src/core/providers/openai/transformer/response_tests.rs
@@ -95,11 +95,15 @@ fn test_transform_response_with_usage_details() {
             total_tokens: 150,
             prompt_tokens_details: Some(OpenAITokenDetails {
                 cached_tokens: Some(20),
+                cache_creation_tokens: Some(3),
+                cache_read_tokens: Some(17),
                 audio_tokens: Some(5),
                 reasoning_tokens: None,
             }),
             completion_tokens_details: Some(OpenAITokenDetails {
                 cached_tokens: None,
+                cache_creation_tokens: None,
+                cache_read_tokens: None,
                 audio_tokens: Some(10),
                 reasoning_tokens: Some(15),
             }),
@@ -114,6 +118,22 @@ fn test_transform_response_with_usage_details() {
     assert_eq!(
         usage.prompt_tokens_details.as_ref().unwrap().cached_tokens,
         Some(20)
+    );
+    assert_eq!(
+        usage
+            .prompt_tokens_details
+            .as_ref()
+            .unwrap()
+            .cache_creation_tokens,
+        Some(3)
+    );
+    assert_eq!(
+        usage
+            .prompt_tokens_details
+            .as_ref()
+            .unwrap()
+            .cache_read_tokens,
+        Some(17)
     );
     assert_eq!(
         usage


### PR DESCRIPTION
## Summary
- preserve OpenAI cache_creation_tokens/cache_read_tokens in canonical usage
- price cache creation and cache read tokens separately in the provider pricing path
- add regression coverage for split cache usage preservation and pricing

## Tests
- cargo fmt --all -- --check
- cargo check --all-features --locked
- cargo test --all-features --locked pricing_service --lib --quiet
- cargo test --all-features --locked core::providers::openai::transformer::response::response_tests --lib --quiet
- cargo test --all-features --locked --lib --quiet

Fixes #757