### PR TITLE
Fix flat output image pricing parity

### DIFF
--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -174,6 +174,7 @@ fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
         audio_tokens: usage.audio_tokens,
         image_tokens: usage.image_tokens,
         reasoning_tokens: usage.reasoning_tokens,
+        output_image_count: None,
     }
 }
 
@@ -546,6 +547,7 @@ fn has_non_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool 
         || extra_f64(info, "video_cost_per_second").is_some()
         || extra_f64(info, "audio_cost_per_second").is_some()
         || extra_f64(info, "image_cost_per_token").is_some()
+        || extra_f64(info, "output_cost_per_image").is_some()
 }
 
 fn extra_f64(info: &crate::core::pricing::LiteLLMModelInfo, key: &str) -> Option<f64> {

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -525,7 +525,7 @@ fn litellm_to_cost_pricing(
         ),
         input_cost_per_audio_token: extra_f64(info, "input_cost_per_audio_token"),
         output_cost_per_audio_token: extra_f64(info, "output_cost_per_audio_token"),
-        image_cost_per_token: extra_f64(info, "image_cost_per_token"),
+        image_cost_per_token: image_cost_per_token(info),
         reasoning_cost_per_token: extra_f64(info, "output_cost_per_reasoning_token"),
         cost_per_second: info.cost_per_second,
         video_cost_per_second: extra_f64(info, "video_cost_per_second"),
@@ -547,7 +547,7 @@ fn has_non_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool 
     info.cost_per_second.is_some()
         || extra_f64(info, "video_cost_per_second").is_some()
         || extra_f64(info, "audio_cost_per_second").is_some()
-        || extra_f64(info, "image_cost_per_token").is_some()
+        || image_cost_per_token(info).is_some()
         || extra_f64(info, "output_cost_per_image").is_some()
 }
 
@@ -560,6 +560,11 @@ fn extra_token_cost_per_1k(
     key: &str,
 ) -> Option<f64> {
     extra_f64(info, key).map(price_per_token_to_per_1k)
+}
+
+fn image_cost_per_token(info: &crate::core::pricing::LiteLLMModelInfo) -> Option<f64> {
+    extra_f64(info, "image_cost_per_token")
+        .or_else(|| extra_f64(info, "output_cost_per_image_token"))
 }
 
 fn extra_cost_per_image(

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -529,7 +529,7 @@ fn litellm_to_cost_pricing(
         cost_per_second: info.cost_per_second,
         video_cost_per_second: extra_f64(info, "video_cost_per_second"),
         audio_cost_per_second: extra_f64(info, "audio_cost_per_second"),
-        cost_per_image: None,
+        cost_per_image: extra_cost_per_image(model, info)?,
         tiered_pricing: extra_tiered_pricing_per_1k(info),
         batch_discount: extra_f64(info, "batch_discount"),
         currency: "USD".to_string(),
@@ -559,6 +559,26 @@ fn extra_token_cost_per_1k(
     key: &str,
 ) -> Option<f64> {
     extra_f64(info, key).map(price_per_token_to_per_1k)
+}
+
+fn extra_cost_per_image(
+    model: &str,
+    info: &crate::core::pricing::LiteLLMModelInfo,
+) -> Result<Option<std::collections::HashMap<String, f64>>, CostError> {
+    let Some(price) = extra_f64(info, "output_cost_per_image") else {
+        return Ok(None);
+    };
+    if !price.is_finite() || price < 0.0 {
+        return Err(CostError::InvalidUsage {
+            message: format!(
+                "Invalid image pricing for model {model}: output_cost_per_image ({price})"
+            ),
+        });
+    }
+    Ok(Some(std::collections::HashMap::from([(
+        "base".to_string(),
+        price,
+    )])))
 }
 
 fn extra_tiered_pricing_per_1k(

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -175,6 +175,7 @@ fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
         image_tokens: usage.image_tokens,
         reasoning_tokens: usage.reasoning_tokens,
         output_image_count: None,
+        output_image_pricing_keys: Vec::new(),
     }
 }
 

--- a/src/core/cost/calculator/pricing_regression_tests.rs
+++ b/src/core/cost/calculator/pricing_regression_tests.rs
@@ -124,6 +124,16 @@ fn test_litellm_pricing_rejects_negative_flat_output_image_pricing() {
 }
 
 #[test]
+fn test_generic_cost_fails_closed_for_flat_image_without_image_count() {
+    let mut usage = UsageTokens::new(0, 0);
+    usage.image_tokens = Some(1);
+
+    let result = generic_cost_per_token("amazon.nova-canvas-v1:0", &usage, "bedrock");
+
+    assert!(matches!(result, Err(CostError::MissingPricing { .. })));
+}
+
+#[test]
 fn test_litellm_pricing_allows_single_missing_side_for_embedding() {
     // Embeddings can have only input-side token pricing.
     let info = model_info_from_json(serde_json::json!({

--- a/src/core/cost/calculator/pricing_regression_tests.rs
+++ b/src/core/cost/calculator/pricing_regression_tests.rs
@@ -74,6 +74,23 @@ fn test_litellm_pricing_allows_missing_mode_with_non_token_pricing() {
 }
 
 #[test]
+fn test_litellm_pricing_allows_flat_output_image_pricing_without_token_prices() {
+    let info = model_info_from_json(serde_json::json!({
+        "litellm_provider": "bedrock",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.06
+    }));
+
+    let pricing = match litellm_to_cost_pricing("flat-image-model", &info) {
+        Ok(pricing) => pricing,
+        Err(err) => panic!("flat image pricing should not require token prices: {err}"),
+    };
+
+    assert_eq!(pricing.input_cost_per_1k_tokens, 0.0);
+    assert_eq!(pricing.output_cost_per_1k_tokens, 0.0);
+}
+
+#[test]
 fn test_litellm_pricing_allows_single_missing_side_for_embedding() {
     // Embeddings can have only input-side token pricing.
     let info = model_info_from_json(serde_json::json!({

--- a/src/core/cost/calculator/pricing_regression_tests.rs
+++ b/src/core/cost/calculator/pricing_regression_tests.rs
@@ -91,6 +91,39 @@ fn test_litellm_pricing_allows_flat_output_image_pricing_without_token_prices() 
 }
 
 #[test]
+fn test_litellm_pricing_maps_flat_output_image_pricing_to_legacy_cost_per_image() {
+    let info = model_info_from_json(serde_json::json!({
+        "litellm_provider": "bedrock",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.06
+    }));
+
+    let pricing = litellm_to_cost_pricing("flat-image-model", &info)
+        .expect("flat image pricing should convert");
+
+    assert_eq!(
+        pricing
+            .cost_per_image
+            .as_ref()
+            .and_then(|prices| prices.get("base")),
+        Some(&0.06)
+    );
+}
+
+#[test]
+fn test_litellm_pricing_rejects_negative_flat_output_image_pricing() {
+    let info = model_info_from_json(serde_json::json!({
+        "litellm_provider": "bedrock",
+        "mode": "image_generation",
+        "output_cost_per_image": -0.06
+    }));
+
+    let result = litellm_to_cost_pricing("negative-flat-image-model", &info);
+
+    assert!(matches!(result, Err(CostError::InvalidUsage { .. })));
+}
+
+#[test]
 fn test_litellm_pricing_allows_single_missing_side_for_embedding() {
     // Embeddings can have only input-side token pricing.
     let info = model_info_from_json(serde_json::json!({

--- a/src/core/models/openai/requests.rs
+++ b/src/core/models/openai/requests.rs
@@ -208,6 +208,8 @@ pub struct ImageGenerationRequest {
     pub n: Option<u32>,
     /// Image size
     pub size: Option<String>,
+    /// Image quality
+    pub quality: Option<String>,
     /// Response format
     pub response_format: Option<String>,
     /// User identifier
@@ -656,6 +658,7 @@ mod tests {
             model: None,
             n: None,
             size: None,
+            quality: None,
             response_format: None,
             user: None,
         };
@@ -671,6 +674,7 @@ mod tests {
             model: Some("dall-e-3".to_string()),
             n: Some(2),
             size: Some("1024x1024".to_string()),
+            quality: Some("hd".to_string()),
             response_format: Some("url".to_string()),
             user: Some("user-456".to_string()),
         };
@@ -678,6 +682,7 @@ mod tests {
         assert_eq!(req.model, Some("dall-e-3".to_string()));
         assert_eq!(req.n, Some(2));
         assert_eq!(req.size, Some("1024x1024".to_string()));
+        assert_eq!(req.quality, Some("hd".to_string()));
         assert_eq!(req.response_format, Some("url".to_string()));
     }
 
@@ -688,6 +693,7 @@ mod tests {
             model: Some("dall-e-2".to_string()),
             n: Some(1),
             size: Some("512x512".to_string()),
+            quality: None,
             response_format: Some("b64_json".to_string()),
             user: None,
         };
@@ -702,6 +708,7 @@ mod tests {
             model: Some("dall-e-3".to_string()),
             n: Some(1),
             size: Some("1792x1024".to_string()),
+            quality: Some("standard".to_string()),
             response_format: None,
             user: None,
         };
@@ -710,6 +717,7 @@ mod tests {
         assert!(json.contains("Mountain landscape"));
         assert!(json.contains("dall-e-3"));
         assert!(json.contains("1792x1024"));
+        assert!(json.contains("standard"));
     }
 
     #[test]
@@ -719,6 +727,7 @@ mod tests {
             model: Some("dall-e-3".to_string()),
             n: Some(1),
             size: None,
+            quality: None,
             response_format: None,
             user: None,
         };

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -408,6 +408,11 @@ fn has_non_token_database_pricing(pricing: &ModelPricing) -> bool {
             .get("image_cost_per_token")
             .and_then(serde_json::Value::as_f64)
             .is_some()
+        || pricing
+            .extra
+            .get("output_cost_per_image")
+            .and_then(serde_json::Value::as_f64)
+            .is_some()
 }
 
 fn pricing_matches_provider(_model_key: &str, pricing: &ModelPricing, provider: &str) -> bool {

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -473,18 +473,8 @@ fn calculate_usage_cost_with_pricing(
     model_info: &LiteLLMModelInfo,
     usage: &PricingUsage,
 ) -> Result<PricingCostBreakdown> {
-    let input_cost_per_token = super::service::require_pricing_field(
-        model_info.input_cost_per_token,
-        model,
-        "token pricing",
-        "input_cost_per_token",
-    )?;
-    let output_cost_per_token = super::service::require_pricing_field(
-        model_info.output_cost_per_token,
-        model,
-        "token pricing",
-        "output_cost_per_token",
-    )?;
+    let (input_cost_per_token, output_cost_per_token) =
+        super::image_pricing::token_unit_prices(model, model_info, usage)?;
 
     let input_cost_per_token = tiered_cost_per_token(
         model_info,
@@ -527,8 +517,9 @@ fn calculate_usage_cost_with_pricing(
         + cache_read_tokens as f64 * cache_read_cost_per_token;
     let audio_cost = usage.audio_tokens.unwrap_or(0) as f64
         * extra_f64(model_info, "input_cost_per_audio_token");
-    let image_cost =
-        usage.image_tokens.unwrap_or(0) as f64 * extra_f64(model_info, "image_cost_per_token");
+    let image_cost_per_token = extra_f64(model_info, "image_cost_per_token");
+    let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
+        + super::image_pricing::output_image_cost(model, model_info, usage, image_cost_per_token)?;
     let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64
         * extra_f64(model_info, "output_cost_per_reasoning_token");
     let total_cost =

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -517,7 +517,8 @@ fn calculate_usage_cost_with_pricing(
         + cache_read_tokens as f64 * cache_read_cost_per_token;
     let audio_cost = usage.audio_tokens.unwrap_or(0) as f64
         * extra_f64(model_info, "input_cost_per_audio_token");
-    let image_cost_per_token = extra_f64(model_info, "image_cost_per_token");
+    let image_cost_per_token =
+        super::image_pricing::image_token_unit_price(model_info).unwrap_or(0.0);
     let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
         + super::image_pricing::output_image_cost(model, model_info, usage)?;
     let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -519,7 +519,7 @@ fn calculate_usage_cost_with_pricing(
         * extra_f64(model_info, "input_cost_per_audio_token");
     let image_cost_per_token = extra_f64(model_info, "image_cost_per_token");
     let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
-        + super::image_pricing::output_image_cost(model, model_info, usage, image_cost_per_token)?;
+        + super::image_pricing::output_image_cost(model, model_info, usage)?;
     let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64
         * extra_f64(model_info, "output_cost_per_reasoning_token");
     let total_cost =

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -36,32 +36,92 @@ pub(super) fn output_image_cost(
     model_info: &LiteLLMModelInfo,
     usage: &PricingUsage,
 ) -> Result<f64> {
-    let count = usage.output_image_count.unwrap_or(0);
     let has_image_token_price = model_info
         .extra
         .get("image_cost_per_token")
         .and_then(serde_json::Value::as_f64)
         .is_some();
-    if count == 0 || usage.image_tokens.is_some() && has_image_token_price {
+    if usage.image_tokens.is_some() && has_image_token_price {
         return Ok(0.0);
     }
-    let price = model_info
+
+    let price = match model_info
         .extra
         .get("output_cost_per_image")
         .and_then(serde_json::Value::as_f64)
-        .ok_or_else(|| {
-            GatewayError::Config(format!(
+    {
+        Some(price) => price,
+        None if model_info.input_cost_per_token.is_some()
+            || model_info.output_cost_per_token.is_some() =>
+        {
+            return Ok(0.0);
+        }
+        None => {
+            return Err(GatewayError::Config(format!(
                 "Missing image pricing for model {}: output_cost_per_image",
                 model
-            ))
-        })?;
+            )));
+        }
+    };
+    let count = usage.output_image_count.ok_or_else(|| {
+        GatewayError::Config(format!(
+            "Missing image count for model {}: output_image_count",
+            model
+        ))
+    })?;
+    if count == 0 {
+        return Ok(0.0);
+    }
     if price < 0.0 || price.is_nan() {
         return Err(GatewayError::Config(format!(
             "Invalid image pricing for model {}: output_cost_per_image ({})",
             model, price
         )));
     }
+    if !flat_image_pricing_key_matches(model, usage) {
+        return Err(GatewayError::Config(format!(
+            "Missing image pricing variant for model {}: output_image_pricing_keys",
+            model
+        )));
+    }
     Ok(count as f64 * price)
+}
+
+fn flat_image_pricing_key_matches(model: &str, usage: &PricingUsage) -> bool {
+    if usage.output_image_pricing_keys.is_empty() {
+        return !is_variant_image_pricing_key(model);
+    }
+
+    usage.output_image_pricing_keys.iter().any(|key| {
+        key == model
+            || (!is_variant_image_pricing_key(model)
+                && key
+                    .strip_suffix(model)
+                    .is_some_and(|prefix| prefix.is_empty() || prefix.ends_with('/')))
+    })
+}
+
+fn is_variant_image_pricing_key(model: &str) -> bool {
+    let mut segments = model.rsplitn(2, '/');
+    let _model_id = segments.next();
+    let Some(prefix) = segments.next() else {
+        return false;
+    };
+
+    prefix.split('/').any(is_image_variant_segment)
+}
+
+fn is_image_variant_segment(segment: &str) -> bool {
+    let segment = segment.to_ascii_lowercase();
+    matches!(
+        segment.as_str(),
+        "hd" | "standard" | "low" | "medium" | "high" | "max-steps"
+    ) || segment.ends_with("-steps")
+        || segment.contains("-x-")
+        || segment.split_once('x').is_some_and(|(width, height)| {
+            width.chars().all(|ch| ch.is_ascii_digit())
+                && height.chars().all(|ch| ch.is_ascii_digit())
+        })
 }
 
 fn price_for_units(

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -1,0 +1,74 @@
+//! Image-specific pricing helpers for LiteLLM flat image cost fields.
+
+use super::types::{LiteLLMModelInfo, PricingUsage};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+
+pub(super) fn token_unit_prices(
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+) -> Result<(f64, f64)> {
+    let has_flat_image_price = usage.output_image_count.unwrap_or(0) > 0
+        && model_info
+            .extra
+            .get("output_cost_per_image")
+            .and_then(serde_json::Value::as_f64)
+            .is_some();
+    let input = price_for_units(
+        model_info.input_cost_per_token,
+        usage.prompt_tokens,
+        model,
+        "input_cost_per_token",
+        has_flat_image_price,
+    )?;
+    let output = price_for_units(
+        model_info.output_cost_per_token,
+        usage.completion_tokens,
+        model,
+        "output_cost_per_token",
+        has_flat_image_price,
+    )?;
+    Ok((input, output))
+}
+
+pub(super) fn output_image_cost(
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+    image_token_cost: f64,
+) -> Result<f64> {
+    let count = usage.output_image_count.unwrap_or(0);
+    if count == 0 || usage.image_tokens.is_some() && image_token_cost > 0.0 {
+        return Ok(0.0);
+    }
+    let price = model_info
+        .extra
+        .get("output_cost_per_image")
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| {
+            GatewayError::Config(format!(
+                "Missing image pricing for model {}: output_cost_per_image",
+                model
+            ))
+        })?;
+    if price < 0.0 || price.is_nan() {
+        return Err(GatewayError::Config(format!(
+            "Invalid image pricing for model {}: output_cost_per_image ({})",
+            model, price
+        )));
+    }
+    Ok(count as f64 * price)
+}
+
+fn price_for_units(
+    price: Option<f64>,
+    units: u32,
+    model: &str,
+    field: &str,
+    allow_missing_for_flat_image: bool,
+) -> Result<f64> {
+    if units == 0 || price.is_none() && allow_missing_for_flat_image {
+        return Ok(price.unwrap_or(0.0));
+    }
+    super::service::require_pricing_field(price, model, "token pricing", field)
+}

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -36,12 +36,7 @@ pub(super) fn output_image_cost(
     model_info: &LiteLLMModelInfo,
     usage: &PricingUsage,
 ) -> Result<f64> {
-    let has_image_token_price = model_info
-        .extra
-        .get("image_cost_per_token")
-        .and_then(serde_json::Value::as_f64)
-        .is_some();
-    if usage.image_tokens.is_some() && has_image_token_price {
+    if usage.image_tokens.is_some() && image_token_unit_price(model_info).is_some() {
         return Ok(0.0);
     }
 
@@ -63,12 +58,16 @@ pub(super) fn output_image_cost(
             )));
         }
     };
-    let count = usage.output_image_count.ok_or_else(|| {
-        GatewayError::Config(format!(
-            "Missing image count for model {}: output_image_count",
-            model
-        ))
-    })?;
+    let Some(count) = usage.output_image_count else {
+        return if usage.image_tokens.is_some() {
+            Err(GatewayError::Config(format!(
+                "Missing image count for model {}: output_image_count",
+                model
+            )))
+        } else {
+            Ok(0.0)
+        };
+    };
     if count == 0 {
         return Ok(0.0);
     }
@@ -85,6 +84,17 @@ pub(super) fn output_image_cost(
         )));
     }
     Ok(count as f64 * price)
+}
+
+pub(super) fn image_token_unit_price(model_info: &LiteLLMModelInfo) -> Option<f64> {
+    ["image_cost_per_token", "output_cost_per_image_token"]
+        .into_iter()
+        .find_map(|key| {
+            model_info
+                .extra
+                .get(key)
+                .and_then(serde_json::Value::as_f64)
+        })
 }
 
 fn flat_image_pricing_key_matches(model: &str, usage: &PricingUsage) -> bool {

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -35,10 +35,14 @@ pub(super) fn output_image_cost(
     model: &str,
     model_info: &LiteLLMModelInfo,
     usage: &PricingUsage,
-    image_token_cost: f64,
 ) -> Result<f64> {
     let count = usage.output_image_count.unwrap_or(0);
-    if count == 0 || usage.image_tokens.is_some() && image_token_cost > 0.0 {
+    let has_image_token_price = model_info
+        .extra
+        .get("image_cost_per_token")
+        .and_then(serde_json::Value::as_f64)
+        .is_some();
+    if count == 0 || usage.image_tokens.is_some() && has_image_token_price {
         return Ok(0.0);
     }
     let price = model_info

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -6,6 +6,7 @@
 mod authority;
 mod cache;
 mod events;
+mod image_pricing;
 mod loader;
 mod service;
 mod types;

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -318,3 +318,24 @@ fn provider_pricing_prefers_image_token_price_over_flat_output_image_price() {
     assert!((cost.image_cost - 1.0).abs() < f64::EPSILON);
     assert!((cost.total_cost - 1.0).abs() < f64::EPSILON);
 }
+
+#[test]
+fn provider_pricing_treats_explicit_zero_image_token_price_as_present() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.extra.insert(
+        "image_cost_per_token".to_string(),
+        serde_json::Value::from(0.0),
+    );
+    service.add_custom_model("zero-image-token-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.image_tokens = Some(100);
+    usage.output_image_count = Some(3);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "zero-image-token-model", &usage)
+        .unwrap();
+
+    assert_eq!(cost.image_cost, 0.0);
+    assert_eq!(cost.total_cost, 0.0);
+}

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -402,3 +402,43 @@ fn provider_pricing_charges_matching_flat_image_variant() {
 
     assert!((cost.image_cost - 0.12).abs() < f64::EPSILON);
 }
+
+#[test]
+fn provider_pricing_charges_output_image_token_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.extra.insert(
+        "output_cost_per_image_token".to_string(),
+        serde_json::Value::from(0.03),
+    );
+    service.add_custom_model("image-token-output-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.image_tokens = Some(4);
+    usage.output_image_count = Some(1);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "image-token-output-model", &usage)
+        .unwrap();
+
+    assert!((cost.image_cost - 0.12).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.12).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_pricing_ignores_optional_flat_image_price_for_text_usage() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(Some(0.06));
+    model_info.input_cost_per_token = Some(0.01);
+    model_info.output_cost_per_token = Some(0.02);
+    service.add_custom_model("text-with-image-output-model".to_string(), model_info);
+    let usage = PricingUsage::new(2, 3);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "text-with-image-output-model", &usage)
+        .unwrap();
+
+    assert!((cost.input_cost - 0.02).abs() < f64::EPSILON);
+    assert!((cost.output_cost - 0.06).abs() < f64::EPSILON);
+    assert_eq!(cost.image_cost, 0.0);
+    assert!((cost.total_cost - 0.08).abs() < f64::EPSILON);
+}

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -339,3 +339,66 @@ fn provider_pricing_treats_explicit_zero_image_token_price_as_present() {
     assert_eq!(cost.image_cost, 0.0);
     assert_eq!(cost.total_cost, 0.0);
 }
+
+#[test]
+fn provider_pricing_does_not_require_flat_price_for_token_priced_image_model() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.input_cost_per_token = Some(0.01);
+    model_info.output_cost_per_token = Some(0.0);
+    service.add_custom_model("token-priced-image-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(2, 0);
+    usage.image_tokens = Some(100);
+    usage.output_image_count = Some(1);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "token-priced-image-model", &usage)
+        .unwrap();
+
+    assert!((cost.input_cost - 0.02).abs() < f64::EPSILON);
+    assert_eq!(cost.image_cost, 0.0);
+}
+
+#[test]
+fn provider_pricing_fails_closed_for_mismatched_flat_image_variant() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "1024-x-1024/50-steps/flat-variant-model".to_string(),
+        flat_image_model_info(Some(0.06)),
+    );
+    let mut usage = PricingUsage::new(0, 0);
+    usage.output_image_count = Some(1);
+    usage
+        .output_image_pricing_keys
+        .push("1024-x-1024/flat-variant-model".to_string());
+
+    let error = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "flat-variant-model", &usage)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("output_image_pricing_keys"));
+}
+
+#[test]
+fn provider_pricing_charges_matching_flat_image_variant() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "1024-x-1024/flat-variant-model".to_string(),
+        flat_image_model_info(Some(0.06)),
+    );
+    let mut usage = PricingUsage::new(0, 0);
+    usage.output_image_count = Some(2);
+    usage
+        .output_image_pricing_keys
+        .push("1024-x-1024/flat-variant-model".to_string());
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider(
+            "bedrock",
+            "1024-x-1024/flat-variant-model",
+            &usage,
+        )
+        .unwrap();
+
+    assert!((cost.image_cost - 0.12).abs() < f64::EPSILON);
+}

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -216,3 +216,105 @@ fn provider_pricing_uses_input_price_when_cache_prices_are_missing() {
     assert!((cost.cache_cost - 0.007).abs() < f64::EPSILON);
     assert!((cost.total_cost - 0.013).abs() < f64::EPSILON);
 }
+
+fn flat_image_model_info(output_cost_per_image: Option<f64>) -> LiteLLMModelInfo {
+    let mut extra = HashMap::new();
+    if let Some(price) = output_cost_per_image {
+        extra.insert(
+            "output_cost_per_image".to_string(),
+            serde_json::Value::from(price),
+        );
+    }
+    LiteLLMModelInfo {
+        max_tokens: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        input_cost_per_token: None,
+        output_cost_per_token: None,
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: None,
+        litellm_provider: "bedrock".to_string(),
+        mode: "image_generation".to_string(),
+        supports_function_calling: None,
+        supports_vision: None,
+        supports_streaming: None,
+        supports_parallel_function_calling: None,
+        supports_system_message: None,
+        extra,
+    }
+}
+
+#[test]
+fn provider_pricing_charges_flat_output_image_cost_without_token_prices() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "flat-image-model".to_string(),
+        flat_image_model_info(Some(0.06)),
+    );
+    let mut usage = PricingUsage::new(25, 0);
+    usage.output_image_count = Some(3);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "flat-image-model", &usage)
+        .unwrap();
+
+    assert_eq!(cost.input_cost, 0.0);
+    assert!((cost.image_cost - 0.18).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.18).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_pricing_fails_closed_for_missing_flat_output_image_price() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "missing-image-price".to_string(),
+        flat_image_model_info(None),
+    );
+    let mut usage = PricingUsage::new(0, 0);
+    usage.output_image_count = Some(1);
+
+    let error = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "missing-image-price", &usage)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("output_cost_per_image"));
+}
+
+#[test]
+fn provider_pricing_fails_closed_for_invalid_flat_output_image_price() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "invalid-image-price".to_string(),
+        flat_image_model_info(Some(-0.1)),
+    );
+    let mut usage = PricingUsage::new(0, 0);
+    usage.output_image_count = Some(1);
+
+    let error = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "invalid-image-price", &usage)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("Invalid image pricing"));
+}
+
+#[test]
+fn provider_pricing_prefers_image_token_price_over_flat_output_image_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(Some(0.06));
+    model_info.extra.insert(
+        "image_cost_per_token".to_string(),
+        serde_json::Value::from(0.01),
+    );
+    service.add_custom_model("image-token-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.image_tokens = Some(100);
+    usage.output_image_count = Some(3);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "image-token-model", &usage)
+        .unwrap();
+
+    assert!((cost.image_cost - 1.0).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 1.0).abs() < f64::EPSILON);
+}

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -83,6 +83,7 @@ pub struct PricingUsage {
     pub audio_tokens: Option<u32>,
     pub image_tokens: Option<u32>,
     pub reasoning_tokens: Option<u32>,
+    pub output_image_count: Option<u32>,
 }
 
 impl PricingUsage {
@@ -97,6 +98,7 @@ impl PricingUsage {
             audio_tokens: None,
             image_tokens: None,
             reasoning_tokens: None,
+            output_image_count: None,
         }
     }
 
@@ -132,6 +134,7 @@ impl From<&crate::core::types::responses::Usage> for PricingUsage {
                 .completion_tokens_details
                 .as_ref()
                 .and_then(|details| details.reasoning_tokens),
+            output_image_count: None,
         }
     }
 }

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -84,6 +84,7 @@ pub struct PricingUsage {
     pub image_tokens: Option<u32>,
     pub reasoning_tokens: Option<u32>,
     pub output_image_count: Option<u32>,
+    pub output_image_pricing_keys: Vec<String>,
 }
 
 impl PricingUsage {
@@ -99,6 +100,7 @@ impl PricingUsage {
             image_tokens: None,
             reasoning_tokens: None,
             output_image_count: None,
+            output_image_pricing_keys: Vec::new(),
         }
     }
 
@@ -135,6 +137,7 @@ impl From<&crate::core::types::responses::Usage> for PricingUsage {
                 .as_ref()
                 .and_then(|details| details.reasoning_tokens),
             output_image_count: None,
+            output_image_pricing_keys: Vec::new(),
         }
     }
 }

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -308,6 +308,7 @@ fn estimated_image_proxy_usage(form_fields: &ImageProxyFormFields) -> PricingUsa
     );
     let mut usage = PricingUsage::new(prompt_tokens, 0);
     usage.image_tokens = Some(image_tokens);
+    usage.output_image_count = Some(form_fields.n.max(1));
     usage
 }
 

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -2,6 +2,7 @@
 
 use crate::config::models::provider::ProviderConfig;
 mod generation;
+mod pricing_keys;
 
 use crate::core::budget::BudgetReservation;
 use crate::core::models::openai::ImageGenerationRequest;
@@ -136,9 +137,17 @@ async fn proxy_image_multipart_endpoint(
     )?;
     let router_models =
         image_proxy_router_models(state.config().gateway.providers.as_slice(), requested_model);
-    let usage = estimated_image_proxy_usage(&form_fields);
+    let pricing_model = pricing_keys::resolve_image_pricing_model(
+        state.pricing.as_ref(),
+        "openai",
+        requested_model,
+        form_fields.size.as_deref(),
+        form_fields.quality.as_deref(),
+    )
+    .unwrap_or_else(|| requested_model.to_string());
+    let usage = estimated_image_proxy_usage(&form_fields, "openai", &pricing_model);
     let estimated_cost =
-        image_proxy_cost(state.pricing.as_ref(), "openai", requested_model, &usage)?;
+        image_proxy_cost(state.pricing.as_ref(), "openai", &pricing_model, &usage)?;
     if estimated_cost <= 0.0 {
         return Err(GatewayError::Config(format!(
             "Image model '{requested_model}' has non-positive pricing"
@@ -295,7 +304,11 @@ fn image_proxy_cost(
         .map(|breakdown| breakdown.total_cost)
 }
 
-fn estimated_image_proxy_usage(form_fields: &ImageProxyFormFields) -> PricingUsage {
+fn estimated_image_proxy_usage(
+    form_fields: &ImageProxyFormFields,
+    pricing_provider: &str,
+    pricing_model: &str,
+) -> PricingUsage {
     let prompt_tokens = form_fields
         .prompt
         .as_deref()
@@ -309,6 +322,12 @@ fn estimated_image_proxy_usage(form_fields: &ImageProxyFormFields) -> PricingUsa
     let mut usage = PricingUsage::new(prompt_tokens, 0);
     usage.image_tokens = Some(image_tokens);
     usage.output_image_count = Some(form_fields.n.max(1));
+    usage.output_image_pricing_keys = pricing_keys::image_pricing_keys(
+        pricing_provider,
+        pricing_model,
+        form_fields.size.as_deref(),
+        form_fields.quality.as_deref(),
+    );
     usage
 }
 

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -29,7 +29,7 @@ pub async fn handle_image_generation_with_state(
         size: request.size,
         response_format: request.response_format,
         user: request.user,
-        quality: None,
+        quality: request.quality,
         style: None,
     };
 

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -58,13 +58,42 @@ pub async fn handle_image_generation_with_state(
                     &selected_model,
                 )?;
                 let budget_provider = provider.name().to_string();
-                let (pricing_provider, pricing_model) =
+                let (pricing_provider, mut pricing_model) =
                     super::super::spend::pricing_identity_for_provider(
                         pricing_service.as_ref(),
                         &provider,
                         &selected_model,
                     );
-                let usage = estimated_image_generation_usage(&core_request);
+                let mut usage_pricing_model =
+                    if super::pricing_keys::is_variant_image_pricing_key(&pricing_model) {
+                        selected_model.clone()
+                    } else {
+                        pricing_model.clone()
+                    };
+                if let Some(variant_model) = super::pricing_keys::resolve_image_pricing_model(
+                    pricing_service.as_ref(),
+                    &pricing_provider,
+                    &selected_model,
+                    core_request.size.as_deref(),
+                    core_request.quality.as_deref(),
+                )
+                .or_else(|| {
+                    super::pricing_keys::resolve_image_pricing_model(
+                        pricing_service.as_ref(),
+                        &pricing_provider,
+                        &pricing_model,
+                        core_request.size.as_deref(),
+                        core_request.quality.as_deref(),
+                    )
+                }) {
+                    usage_pricing_model = variant_model.clone();
+                    pricing_model = variant_model;
+                }
+                let usage = estimated_image_generation_usage(
+                    &core_request,
+                    &pricing_provider,
+                    &usage_pricing_model,
+                );
                 let budget_reservation =
                     super::super::spend::reserve_pricing_usage_budget_with_pricing(
                         pricing_service.as_ref(),
@@ -126,7 +155,11 @@ pub async fn handle_image_generation_with_state(
     Ok(response)
 }
 
-fn estimated_image_generation_usage(request: &CoreImageRequest) -> PricingUsage {
+fn estimated_image_generation_usage(
+    request: &CoreImageRequest,
+    pricing_provider: &str,
+    pricing_model: &str,
+) -> PricingUsage {
     let prompt_tokens = super::estimated_text_tokens(&request.prompt);
     let image_count = request.n.unwrap_or(1);
     let image_tokens = super::estimated_image_output_tokens(
@@ -137,5 +170,11 @@ fn estimated_image_generation_usage(request: &CoreImageRequest) -> PricingUsage 
     let mut usage = PricingUsage::new(prompt_tokens, 0);
     usage.image_tokens = Some(image_tokens);
     usage.output_image_count = Some(image_count.max(1));
+    usage.output_image_pricing_keys = super::pricing_keys::image_pricing_keys(
+        pricing_provider,
+        pricing_model,
+        request.size.as_deref(),
+        request.quality.as_deref(),
+    );
     usage
 }

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -128,12 +128,14 @@ pub async fn handle_image_generation_with_state(
 
 fn estimated_image_generation_usage(request: &CoreImageRequest) -> PricingUsage {
     let prompt_tokens = super::estimated_text_tokens(&request.prompt);
+    let image_count = request.n.unwrap_or(1);
     let image_tokens = super::estimated_image_output_tokens(
         request.size.as_deref(),
         request.quality.as_deref(),
-        request.n.unwrap_or(1),
+        image_count,
     );
     let mut usage = PricingUsage::new(prompt_tokens, 0);
     usage.image_tokens = Some(image_tokens);
+    usage.output_image_count = Some(image_count.max(1));
     usage
 }

--- a/src/server/routes/ai/images/pricing_keys.rs
+++ b/src/server/routes/ai/images/pricing_keys.rs
@@ -12,10 +12,7 @@ pub(super) fn image_pricing_keys(
     }
 
     let size = size.map(normalize_image_pricing_size);
-    let quality = quality
-        .map(str::trim)
-        .filter(|quality| !quality.is_empty())
-        .map(str::to_ascii_lowercase);
+    let qualities = image_pricing_quality_segments(quality);
     let provider = pricing_provider.trim();
     let mut keys = Vec::new();
     push_unique_key(&mut keys, model.to_string());
@@ -24,7 +21,7 @@ pub(super) fn image_pricing_keys(
         if !provider.is_empty() {
             push_unique_key(&mut keys, format!("{provider}/{size}/{model}"));
         }
-        if let Some(quality) = quality.as_deref() {
+        for quality in &qualities {
             push_unique_key(&mut keys, format!("{quality}/{size}/{model}"));
             push_unique_key(&mut keys, format!("{size}/{quality}/{model}"));
             if !provider.is_empty() {
@@ -32,10 +29,12 @@ pub(super) fn image_pricing_keys(
                 push_unique_key(&mut keys, format!("{provider}/{size}/{quality}/{model}"));
             }
         }
-    } else if let Some(quality) = quality.as_deref() {
-        push_unique_key(&mut keys, format!("{quality}/{model}"));
-        if !provider.is_empty() {
-            push_unique_key(&mut keys, format!("{provider}/{quality}/{model}"));
+    } else {
+        for quality in &qualities {
+            push_unique_key(&mut keys, format!("{quality}/{model}"));
+            if !provider.is_empty() {
+                push_unique_key(&mut keys, format!("{provider}/{quality}/{model}"));
+            }
         }
     }
     keys
@@ -76,19 +75,18 @@ fn image_pricing_model_candidates(
     }
 
     let size = size.map(normalize_image_pricing_size);
-    let quality = quality
-        .map(str::trim)
-        .filter(|quality| !quality.is_empty())
-        .map(str::to_ascii_lowercase);
+    let qualities = image_pricing_quality_segments(quality);
     let mut candidates = Vec::new();
     if let Some(size) = size.as_deref() {
-        if let Some(quality) = quality.as_deref() {
+        for quality in &qualities {
             push_unique_key(&mut candidates, format!("{quality}/{size}/{model}"));
             push_unique_key(&mut candidates, format!("{size}/{quality}/{model}"));
         }
         push_unique_key(&mut candidates, format!("{size}/{model}"));
-    } else if let Some(quality) = quality.as_deref() {
-        push_unique_key(&mut candidates, format!("{quality}/{model}"));
+    } else {
+        for quality in &qualities {
+            push_unique_key(&mut candidates, format!("{quality}/{model}"));
+        }
     }
     candidates
 }
@@ -103,6 +101,23 @@ fn image_pricing_base_model(model: &str) -> &str {
 
 fn normalize_image_pricing_size(size: &str) -> String {
     size.trim().replace('x', "-x-")
+}
+
+fn image_pricing_quality_segments(quality: Option<&str>) -> Vec<String> {
+    let Some(quality) = quality
+        .map(str::trim)
+        .filter(|quality| !quality.is_empty())
+        .map(str::to_ascii_lowercase)
+    else {
+        return Vec::new();
+    };
+    let mut segments = vec![quality.clone()];
+    match quality.as_str() {
+        "standard" => push_unique_key(&mut segments, "30-steps".to_string()),
+        "hd" => push_unique_key(&mut segments, "50-steps".to_string()),
+        _ => {}
+    }
+    segments
 }
 
 fn supports_image_output_pricing(info: &LiteLLMModelInfo) -> bool {
@@ -147,6 +162,13 @@ mod tests {
     use std::collections::HashMap;
 
     fn model_info(extra: HashMap<String, serde_json::Value>) -> LiteLLMModelInfo {
+        model_info_for_provider("openai", extra)
+    }
+
+    fn model_info_for_provider(
+        provider: &str,
+        extra: HashMap<String, serde_json::Value>,
+    ) -> LiteLLMModelInfo {
         LiteLLMModelInfo {
             max_tokens: None,
             max_input_tokens: None,
@@ -156,7 +178,7 @@ mod tests {
             input_cost_per_character: None,
             output_cost_per_character: None,
             cost_per_second: None,
-            litellm_provider: "openai".to_string(),
+            litellm_provider: provider.to_string(),
             mode: "image_generation".to_string(),
             supports_function_calling: None,
             supports_vision: None,
@@ -211,6 +233,48 @@ mod tests {
         assert_eq!(
             resolved,
             Some("hd/1024-x-1024/flat-variant-model".to_string())
+        );
+    }
+
+    #[test]
+    fn image_pricing_keys_include_bedrock_hd_step_alias() {
+        let keys = image_pricing_keys(
+            "bedrock",
+            "stability.stable-diffusion-xl-v1",
+            Some("1024x1024"),
+            Some("hd"),
+        );
+
+        assert!(
+            keys.contains(&"1024-x-1024/50-steps/stability.stable-diffusion-xl-v1".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_image_pricing_model_accepts_bedrock_hd_step_variant() {
+        let service = PricingService::new(None);
+        service.add_custom_model(
+            "1024-x-1024/50-steps/stability.stable-diffusion-xl-v1".to_string(),
+            model_info_for_provider(
+                "bedrock",
+                HashMap::from([(
+                    "output_cost_per_image".to_string(),
+                    serde_json::Value::from(0.04),
+                )]),
+            ),
+        );
+
+        let resolved = resolve_image_pricing_model(
+            &service,
+            "bedrock",
+            "stability.stable-diffusion-xl-v1",
+            Some("1024x1024"),
+            Some("hd"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some("1024-x-1024/50-steps/stability.stable-diffusion-xl-v1".to_string())
         );
     }
 }

--- a/src/server/routes/ai/images/pricing_keys.rs
+++ b/src/server/routes/ai/images/pricing_keys.rs
@@ -1,0 +1,123 @@
+use crate::core::pricing_service::PricingService;
+
+pub(super) fn image_pricing_keys(
+    pricing_provider: &str,
+    pricing_model: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+) -> Vec<String> {
+    let model = pricing_model.trim();
+    if model.is_empty() {
+        return Vec::new();
+    }
+
+    let size = size.map(normalize_image_pricing_size);
+    let quality = quality
+        .map(str::trim)
+        .filter(|quality| !quality.is_empty())
+        .map(str::to_ascii_lowercase);
+    let provider = pricing_provider.trim();
+    let mut keys = Vec::new();
+    push_unique_key(&mut keys, model.to_string());
+    if let Some(size) = size.as_deref() {
+        push_unique_key(&mut keys, format!("{size}/{model}"));
+        if !provider.is_empty() {
+            push_unique_key(&mut keys, format!("{provider}/{size}/{model}"));
+        }
+        if let Some(quality) = quality.as_deref() {
+            push_unique_key(&mut keys, format!("{quality}/{size}/{model}"));
+            push_unique_key(&mut keys, format!("{size}/{quality}/{model}"));
+            if !provider.is_empty() {
+                push_unique_key(&mut keys, format!("{provider}/{quality}/{size}/{model}"));
+                push_unique_key(&mut keys, format!("{provider}/{size}/{quality}/{model}"));
+            }
+        }
+    } else if let Some(quality) = quality.as_deref() {
+        push_unique_key(&mut keys, format!("{quality}/{model}"));
+        if !provider.is_empty() {
+            push_unique_key(&mut keys, format!("{provider}/{quality}/{model}"));
+        }
+    }
+    keys
+}
+
+pub(super) fn resolve_image_pricing_model(
+    pricing_service: &PricingService,
+    pricing_provider: &str,
+    model: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+) -> Option<String> {
+    image_pricing_model_candidates(model, size, quality)
+        .into_iter()
+        .find(|candidate| {
+            pricing_service
+                .get_model_info_for_provider(pricing_provider, candidate)
+                .is_some_and(|(resolved, _)| resolved == candidate.as_str())
+        })
+}
+
+pub(super) fn is_variant_image_pricing_key(model: &str) -> bool {
+    model
+        .rsplit_once('/')
+        .is_some_and(|(prefix, _)| prefix.split('/').any(is_image_variant_segment))
+}
+
+fn image_pricing_model_candidates(
+    model: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+) -> Vec<String> {
+    let model = image_pricing_base_model(model.trim());
+    if model.is_empty() {
+        return Vec::new();
+    }
+
+    let size = size.map(normalize_image_pricing_size);
+    let quality = quality
+        .map(str::trim)
+        .filter(|quality| !quality.is_empty())
+        .map(str::to_ascii_lowercase);
+    let mut candidates = Vec::new();
+    if let Some(size) = size.as_deref() {
+        if let Some(quality) = quality.as_deref() {
+            push_unique_key(&mut candidates, format!("{quality}/{size}/{model}"));
+            push_unique_key(&mut candidates, format!("{size}/{quality}/{model}"));
+        }
+        push_unique_key(&mut candidates, format!("{size}/{model}"));
+    } else if let Some(quality) = quality.as_deref() {
+        push_unique_key(&mut candidates, format!("{quality}/{model}"));
+    }
+    candidates
+}
+
+fn image_pricing_base_model(model: &str) -> &str {
+    model
+        .rsplit_once('/')
+        .filter(|(prefix, _)| prefix.split('/').any(is_image_variant_segment))
+        .map(|(_, model_id)| model_id)
+        .unwrap_or(model)
+}
+
+fn normalize_image_pricing_size(size: &str) -> String {
+    size.trim().replace('x', "-x-")
+}
+
+fn is_image_variant_segment(segment: &str) -> bool {
+    let segment = segment.to_ascii_lowercase();
+    matches!(
+        segment.as_str(),
+        "hd" | "standard" | "low" | "medium" | "high" | "max-steps"
+    ) || segment.ends_with("-steps")
+        || segment.contains("-x-")
+        || segment.split_once('x').is_some_and(|(width, height)| {
+            width.chars().all(|ch| ch.is_ascii_digit())
+                && height.chars().all(|ch| ch.is_ascii_digit())
+        })
+}
+
+fn push_unique_key(keys: &mut Vec<String>, key: String) {
+    if !keys.contains(&key) {
+        keys.push(key);
+    }
+}

--- a/src/server/routes/ai/images/pricing_keys.rs
+++ b/src/server/routes/ai/images/pricing_keys.rs
@@ -1,4 +1,4 @@
-use crate::core::pricing_service::PricingService;
+use crate::core::pricing_service::{LiteLLMModelInfo, PricingService};
 
 pub(super) fn image_pricing_keys(
     pricing_provider: &str,
@@ -53,7 +53,9 @@ pub(super) fn resolve_image_pricing_model(
         .find(|candidate| {
             pricing_service
                 .get_model_info_for_provider(pricing_provider, candidate)
-                .is_some_and(|(resolved, _)| resolved == candidate.as_str())
+                .is_some_and(|(resolved, info)| {
+                    resolved == candidate.as_str() && supports_image_output_pricing(&info)
+                })
         })
 }
 
@@ -103,6 +105,23 @@ fn normalize_image_pricing_size(size: &str) -> String {
     size.trim().replace('x', "-x-")
 }
 
+fn supports_image_output_pricing(info: &LiteLLMModelInfo) -> bool {
+    info.input_cost_per_token.is_some()
+        || info.output_cost_per_token.is_some()
+        || [
+            "output_cost_per_image",
+            "image_cost_per_token",
+            "output_cost_per_image_token",
+        ]
+        .into_iter()
+        .any(|key| {
+            info.extra
+                .get(key)
+                .and_then(serde_json::Value::as_f64)
+                .is_some()
+        })
+}
+
 fn is_image_variant_segment(segment: &str) -> bool {
     let segment = segment.to_ascii_lowercase();
     matches!(
@@ -119,5 +138,79 @@ fn is_image_variant_segment(segment: &str) -> bool {
 fn push_unique_key(keys: &mut Vec<String>, key: String) {
     if !keys.contains(&key) {
         keys.push(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn model_info(extra: HashMap<String, serde_json::Value>) -> LiteLLMModelInfo {
+        LiteLLMModelInfo {
+            max_tokens: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            input_cost_per_token: None,
+            output_cost_per_token: None,
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: "openai".to_string(),
+            mode: "image_generation".to_string(),
+            supports_function_calling: None,
+            supports_vision: None,
+            supports_streaming: None,
+            supports_parallel_function_calling: None,
+            supports_system_message: None,
+            extra,
+        }
+    }
+
+    #[test]
+    fn resolve_image_pricing_model_skips_unsupported_input_only_variant() {
+        let service = PricingService::new(None);
+        service.add_custom_model(
+            "medium/1024-x-1024/gpt-image-1.5".to_string(),
+            model_info(HashMap::from([(
+                "input_cost_per_image".to_string(),
+                serde_json::Value::from(0.034),
+            )])),
+        );
+
+        let resolved = resolve_image_pricing_model(
+            &service,
+            "openai",
+            "gpt-image-1.5",
+            Some("1024x1024"),
+            Some("medium"),
+        );
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_image_pricing_model_accepts_output_priced_variant() {
+        let service = PricingService::new(None);
+        service.add_custom_model(
+            "hd/1024-x-1024/flat-variant-model".to_string(),
+            model_info(HashMap::from([(
+                "output_cost_per_image".to_string(),
+                serde_json::Value::from(0.10),
+            )])),
+        );
+
+        let resolved = resolve_image_pricing_model(
+            &service,
+            "openai",
+            "flat-variant-model",
+            Some("1024x1024"),
+            Some("hd"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some("hd/1024-x-1024/flat-variant-model".to_string())
+        );
     }
 }

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -462,11 +462,11 @@ mod tests {
         )])
         .await;
         state.pricing.add_custom_model(
-            "512-x-512/flat-variant-model".to_string(),
+            "standard/512-x-512/flat-variant-model".to_string(),
             flat_image_model_info(0.05),
         );
         state.pricing.add_custom_model(
-            "1024-x-1024/flat-variant-model".to_string(),
+            "hd/512-x-512/flat-variant-model".to_string(),
             flat_image_model_info(0.10),
         );
         state.budget_limits.providers.set_provider_limit(
@@ -489,6 +489,7 @@ mod tests {
                     "model": "flat-variant-alias",
                     "prompt": "make an icon",
                     "size": "512x512",
+                    "quality": "hd",
                     "n": 2
                 }))
                 .to_request(),
@@ -509,7 +510,7 @@ mod tests {
             .get_provider_usage("openai-primary")
             .map(|usage| usage.current_spend)
             .unwrap_or_default();
-        assert!((spent - 0.10).abs() < f64::EPSILON);
+        assert!((spent - 0.20).abs() < f64::EPSILON);
         mock.stop().await;
     }
 

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -189,6 +189,27 @@ mod tests {
         }
     }
 
+    fn token_priced_image_model_info(input_cost_per_token: f64) -> LiteLLMModelInfo {
+        LiteLLMModelInfo {
+            max_tokens: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            input_cost_per_token: Some(input_cost_per_token),
+            output_cost_per_token: Some(0.0),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: "openai".to_string(),
+            mode: "image_generation".to_string(),
+            supports_function_calling: None,
+            supports_vision: None,
+            supports_streaming: None,
+            supports_parallel_function_calling: None,
+            supports_system_message: None,
+            extra: HashMap::new(),
+        }
+    }
+
     fn image_edit_multipart_body(boundary: &str) -> Vec<u8> {
         image_edit_multipart_body_for_model(boundary, "gpt-image-1-mini", 1)
     }
@@ -377,6 +398,118 @@ mod tests {
             .map(|usage| usage.current_spend)
             .unwrap_or_default();
         assert!((spent - 0.12).abs() < f64::EPSILON);
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn image_generation_allows_token_priced_image_model_without_flat_price() {
+        let mock = MockImageServer::start().await;
+        let state = build_test_state(vec![openai_image_provider_with_mapping(
+            "openai-primary",
+            &mock.base_url,
+            "token-image-alias",
+            "token-priced-image-model",
+        )])
+        .await;
+        state.pricing.add_custom_model(
+            "token-priced-image-model".to_string(),
+            token_priced_image_model_info(0.01),
+        );
+        state.budget_limits.providers.set_provider_limit(
+            "openai-primary",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/generations")
+                .set_json(json!({
+                    "model": "token-image-alias",
+                    "prompt": "make an icon",
+                    "size": "1024x1024"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.paths(), vec!["/v1/images/generations".to_string()]);
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("openai-primary")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!((spent - 0.03).abs() < f64::EPSILON);
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn image_generation_records_matching_flat_output_image_variant_spend() {
+        let mock = MockImageServer::start().await;
+        let state = build_test_state(vec![openai_image_provider_with_mapping(
+            "openai-primary",
+            &mock.base_url,
+            "flat-variant-alias",
+            "flat-variant-model",
+        )])
+        .await;
+        state.pricing.add_custom_model(
+            "512-x-512/flat-variant-model".to_string(),
+            flat_image_model_info(0.05),
+        );
+        state.pricing.add_custom_model(
+            "1024-x-1024/flat-variant-model".to_string(),
+            flat_image_model_info(0.10),
+        );
+        state.budget_limits.providers.set_provider_limit(
+            "openai-primary",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/generations")
+                .set_json(json!({
+                    "model": "flat-variant-alias",
+                    "prompt": "make an icon",
+                    "size": "512x512",
+                    "n": 2
+                }))
+                .to_request(),
+        )
+        .await;
+
+        if resp.status() != StatusCode::OK {
+            let status = resp.status();
+            let body = test::read_body(resp).await;
+            panic!(
+                "expected variant image generation to succeed, got {status}: {}",
+                String::from_utf8_lossy(&body)
+            );
+        }
+        assert_eq!(mock.paths(), vec!["/v1/images/generations".to_string()]);
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("openai-primary")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!((spent - 0.10).abs() < f64::EPSILON);
         mock.stop().await;
     }
 

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -5,9 +5,10 @@ mod tests {
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
-    use litellm_rs::core::pricing_service::PricingUsage;
+    use litellm_rs::core::pricing_service::{LiteLLMModelInfo, PricingUsage};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
+    use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -162,10 +163,41 @@ mod tests {
         provider
     }
 
+    fn flat_image_model_info(output_cost_per_image: f64) -> LiteLLMModelInfo {
+        let mut extra = HashMap::new();
+        extra.insert(
+            "output_cost_per_image".to_string(),
+            serde_json::Value::from(output_cost_per_image),
+        );
+        LiteLLMModelInfo {
+            max_tokens: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            input_cost_per_token: None,
+            output_cost_per_token: None,
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: "openai".to_string(),
+            mode: "image_generation".to_string(),
+            supports_function_calling: None,
+            supports_vision: None,
+            supports_streaming: None,
+            supports_parallel_function_calling: None,
+            supports_system_message: None,
+            extra,
+        }
+    }
+
     fn image_edit_multipart_body(boundary: &str) -> Vec<u8> {
+        image_edit_multipart_body_for_model(boundary, "gpt-image-1-mini", 1)
+    }
+
+    fn image_edit_multipart_body_for_model(boundary: &str, model: &str, quantity: u32) -> Vec<u8> {
         let mut body = Vec::new();
-        add_text_field(&mut body, boundary, "model", "gpt-image-1-mini");
+        add_text_field(&mut body, boundary, "model", model);
         add_text_field(&mut body, boundary, "prompt", "make it lighter");
+        add_text_field(&mut body, boundary, "n", &quantity.to_string());
         add_file_field(&mut body, boundary, "image", "input.png", b"png-bytes");
         body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
         body
@@ -295,6 +327,110 @@ mod tests {
             (spent - expected_cost).abs() < f64::EPSILON,
             "successful image generation must record full image-token spend"
         );
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn image_generation_records_flat_output_image_spend_after_success() {
+        let mock = MockImageServer::start().await;
+        let state = build_test_state(vec![openai_image_provider_with_mapping(
+            "openai-primary",
+            &mock.base_url,
+            "flat-image-alias",
+            "flat-image-model",
+        )])
+        .await;
+        state
+            .pricing
+            .add_custom_model("flat-image-model".to_string(), flat_image_model_info(0.06));
+        state.budget_limits.providers.set_provider_limit(
+            "openai-primary",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/generations")
+                .set_json(json!({
+                    "model": "flat-image-alias",
+                    "prompt": "make an icon",
+                    "size": "1024x1024",
+                    "n": 2
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.paths(), vec!["/v1/images/generations".to_string()]);
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("openai-primary")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!((spent - 0.12).abs() < f64::EPSILON);
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    async fn image_edit_records_flat_output_image_spend_after_success() {
+        let mock = MockImageServer::start().await;
+        let state = build_test_state(vec![image_provider(
+            "openai-primary",
+            "openai",
+            &mock.base_url,
+            vec!["flat-image-model".to_string()],
+        )])
+        .await;
+        state
+            .pricing
+            .add_custom_model("flat-image-model".to_string(), flat_image_model_info(0.06));
+        state.budget_limits.providers.set_provider_limit(
+            "openai-primary",
+            ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        );
+        let budget_limits = state.budget_limits.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-flat-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body_for_model(
+                    boundary,
+                    "flat-image-model",
+                    2,
+                ))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(mock.paths(), vec!["/v1/images/edits".to_string()]);
+        let spent = budget_limits
+            .providers
+            .get_provider_usage("openai-primary")
+            .map(|usage| usage.current_spend)
+            .unwrap_or_default();
+        assert!((spent - 0.12).abs() < f64::EPSILON);
         mock.stop().await;
     }
 


### PR DESCRIPTION
## Summary
- add PricingUsage output_image_count for flat output image pricing
- charge output_cost_per_image for image generation/edit routes when token image pricing is absent
- fail closed for missing or invalid flat image prices and preserve legacy non-token-pricing detection

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo test --all-features --locked --lib --quiet
- FEATURES="postgres sqlite redis s3 metrics tracing websockets analytics" cargo test --lib --tests --bins --features "$FEATURES" --verbose

Fixes #758