### PR TITLE
Use exact OpenAI token counting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2044,17 @@ name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -3077,7 +3099,7 @@ dependencies = [
  "base64",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "fraction",
  "idna",
  "itoa",
@@ -3221,6 +3243,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -5424,6 +5447,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex 0.17.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ chrono = { version = "0.4", features = ["serde"] }
 parking_lot = "0.12"
 arc-swap = "1.6"
 dashmap = "5.5"
+tiktoken-rs = "0.12.0"
 
 # Development dependencies
 [dev-dependencies]

--- a/src/server/routes/ai/spend_provider_reservation_tests.rs
+++ b/src/server/routes/ai/spend_provider_reservation_tests.rs
@@ -63,6 +63,44 @@ fn openai_like_prefixed_chat_reservation_uses_provider_pricing() {
 }
 
 #[test]
+fn openai_chat_reservation_uses_exact_tiktoken_prompt_count() {
+    let budget = UnifiedBudgetLimits::new();
+    let messages = vec![ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Text("Hello, how are you?".to_string())),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
+    }];
+    let prompt_tokens =
+        estimate_chat_prompt_tokens("gpt-3.5-turbo", &messages, None, None, None, None);
+    assert_eq!(prompt_tokens, 13);
+
+    let expected = estimate_cost("gpt-3.5-turbo", "openai", prompt_tokens, Some(10))
+        .unwrap()
+        .max_cost;
+    budget.providers.set_provider_limit(
+        "openai",
+        ProviderLimitConfig::new(expected * 2.0, ResetPeriod::Monthly),
+    );
+    let mut request = ChatCompletionRequest {
+        model: "gpt-3.5-turbo".to_string(),
+        messages,
+        ..Default::default()
+    };
+    request.max_tokens = Some(10);
+
+    let reservation = reserve_chat_completion_budget(&budget, "openai", "gpt-3.5-turbo", &request)
+        .unwrap()
+        .unwrap();
+
+    assert!((reservation.reserved_amount() - expected).abs() < f64::EPSILON);
+    reservation.cancel();
+}
+
+#[test]
 fn chat_prompt_estimate_accounts_for_serialized_tool_parts() {
     let payload = "x".repeat(4_000);
     let messages = vec![ChatMessage {

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -168,6 +168,25 @@ fn test_tool_call_chat_token_count_remains_marked_approximate() {
 }
 
 #[test]
+fn test_tool_result_chat_token_count_remains_marked_approximate() {
+    let counter = TokenCounter::new();
+    let messages = vec![ChatMessage {
+        role: MessageRole::Tool,
+        content: Some(MessageContent::Text("done".to_string())),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: Some("call_123".to_string()),
+        audio: None,
+    }];
+
+    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+
+    assert!(estimate.is_approximate);
+    assert!(estimate.confidence < 1.0);
+}
+
+#[test]
 fn test_context_window_check() {
     let counter = TokenCounter::new();
 

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -1,7 +1,9 @@
 //! Tests for token counter functionality
 
 #[cfg(test)]
-use crate::core::models::openai::{ChatMessage, MessageContent, MessageRole};
+use crate::core::models::openai::{
+    ChatMessage, ContentPart, ImageUrl, MessageContent, MessageRole,
+};
 use crate::utils::ai::counter::token_counter::TokenCounter;
 
 #[test]
@@ -31,7 +33,79 @@ fn test_chat_token_counting() {
         .count_chat_tokens("gpt-3.5-turbo", &messages)
         .unwrap();
     assert!(estimate.input_tokens > 0);
+    assert!(!estimate.is_approximate);
+    assert_eq!(estimate.input_tokens, 13);
+}
+
+#[test]
+fn test_openai_completion_token_count_uses_tiktoken() {
+    let counter = TokenCounter::new();
+
+    let estimate = counter
+        .count_completion_tokens("gpt-3.5-turbo", "Hello world")
+        .unwrap();
+
+    assert_eq!(estimate.input_tokens, 2);
+    assert_eq!(estimate.total_tokens, 2);
+    assert!(!estimate.is_approximate);
+    assert_eq!(estimate.confidence, 1.0);
+}
+
+#[test]
+fn test_openai_chat_system_message_uses_tiktoken() {
+    let counter = TokenCounter::new();
+    let messages = vec![ChatMessage {
+        role: MessageRole::System,
+        content: Some(MessageContent::Text("You are a bot.".to_string())),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
+    }];
+
+    let estimate = counter
+        .count_chat_tokens("openai/gpt-3.5-turbo", &messages)
+        .unwrap();
+
+    assert_eq!(estimate.input_tokens, 12);
+    assert!(!estimate.is_approximate);
+}
+
+#[test]
+fn test_multimodal_chat_token_count_remains_marked_approximate() {
+    let counter = TokenCounter::new();
+    let messages = vec![ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Parts(vec![ContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: "https://example.com/image.png".to_string(),
+                detail: Some("high".to_string()),
+            },
+        }])),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
+    }];
+
+    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+
     assert!(estimate.is_approximate);
+    assert!(estimate.input_tokens >= 85);
+}
+
+#[test]
+fn test_non_openai_token_count_remains_marked_approximate() {
+    let counter = TokenCounter::new();
+
+    let estimate = counter
+        .count_completion_tokens("claude-3-opus", "Hello world")
+        .unwrap();
+
+    assert!(estimate.is_approximate);
+    assert!(estimate.input_tokens > 0);
 }
 
 #[test]

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -97,6 +97,27 @@ fn test_multimodal_chat_token_count_remains_marked_approximate() {
 }
 
 #[test]
+fn test_text_part_chat_token_count_remains_marked_approximate() {
+    let counter = TokenCounter::new();
+    let messages = vec![ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Parts(vec![ContentPart::Text {
+            text: "Hello".to_string(),
+        }])),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
+    }];
+
+    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+
+    assert!(estimate.is_approximate);
+    assert!(estimate.confidence < 1.0);
+}
+
+#[test]
 fn test_non_openai_token_count_remains_marked_approximate() {
     let counter = TokenCounter::new();
 

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 use crate::core::models::openai::{
-    ChatMessage, ContentPart, ImageUrl, MessageContent, MessageRole,
+    ChatMessage, ContentPart, FunctionCall, ImageUrl, MessageContent, MessageRole, ToolCall,
 };
 use crate::utils::ai::counter::token_counter::TokenCounter;
 
@@ -106,6 +106,44 @@ fn test_non_openai_token_count_remains_marked_approximate() {
 
     assert!(estimate.is_approximate);
     assert!(estimate.input_tokens > 0);
+}
+
+#[test]
+fn test_unknown_openai_like_model_remains_marked_approximate() {
+    let counter = TokenCounter::new();
+
+    let estimate = counter
+        .count_completion_tokens("gpt-future-unknown", "Hello world")
+        .unwrap();
+
+    assert!(estimate.is_approximate);
+    assert!(estimate.confidence < 1.0);
+}
+
+#[test]
+fn test_tool_call_chat_token_count_remains_marked_approximate() {
+    let counter = TokenCounter::new();
+    let messages = vec![ChatMessage {
+        role: MessageRole::Assistant,
+        content: None,
+        name: None,
+        function_call: None,
+        tool_calls: Some(vec![ToolCall {
+            id: "call_123".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "lookup".to_string(),
+                arguments: r#"{"query":"hello"}"#.to_string(),
+            },
+        }]),
+        tool_call_id: None,
+        audio: None,
+    }];
+
+    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+
+    assert!(estimate.is_approximate);
+    assert!(estimate.confidence < 1.0);
 }
 
 #[test]

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -357,16 +357,7 @@ fn plain_text_message_content(message: &ChatMessage) -> Option<Option<String>> {
     match &message.content {
         None => Some(None),
         Some(MessageContent::Text(text)) => Some(Some(text.clone())),
-        Some(MessageContent::Parts(parts)) => {
-            let mut text = String::new();
-            for part in parts {
-                let ContentPart::Text { text: part_text } = part else {
-                    return None;
-                };
-                text.push_str(part_text);
-            }
-            Some(Some(text))
-        }
+        Some(MessageContent::Parts(_)) => None,
     }
 }
 

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -4,6 +4,9 @@ use super::types::{ModelTokenConfig, TokenEstimate};
 use crate::core::models::openai::{ChatMessage, ContentPart, MessageContent};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::collections::HashMap;
+use tiktoken_rs::{
+    ChatCompletionRequestMessage, bpe_for_model, cl100k_base_singleton, num_tokens_from_messages,
+};
 
 /// Token counter for different models
 #[derive(Debug, Clone)]
@@ -26,6 +29,16 @@ impl TokenCounter {
         model: &str,
         messages: &[ChatMessage],
     ) -> Result<TokenEstimate> {
+        if let Some(total_tokens) = self.exact_chat_tokens(model, messages)? {
+            return Ok(TokenEstimate {
+                input_tokens: total_tokens,
+                output_tokens: None,
+                total_tokens,
+                is_approximate: false,
+                confidence: 1.0,
+            });
+        }
+
         let config = self.get_model_config(model)?;
         let mut total_tokens = config.request_overhead;
 
@@ -141,6 +154,16 @@ impl TokenCounter {
 
     /// Count tokens in completion request
     pub fn count_completion_tokens(&self, model: &str, prompt: &str) -> Result<TokenEstimate> {
+        if let Some(input_tokens) = exact_text_tokens(model, prompt)? {
+            return Ok(TokenEstimate {
+                input_tokens,
+                output_tokens: None,
+                total_tokens: input_tokens,
+                is_approximate: false,
+                confidence: 1.0,
+            });
+        }
+
         let config = self.get_model_config(model)?;
         let input_tokens = config.request_overhead + self.estimate_text_tokens(config, prompt);
 
@@ -155,6 +178,21 @@ impl TokenCounter {
 
     /// Count tokens in embedding request
     pub fn count_embedding_tokens(&self, model: &str, input: &[String]) -> Result<TokenEstimate> {
+        let exact_counts = input
+            .iter()
+            .map(|text| exact_text_tokens(model, text))
+            .collect::<Result<Vec<_>>>()?;
+        if exact_counts.iter().all(Option::is_some) {
+            let total_tokens = exact_counts.into_iter().flatten().sum();
+            return Ok(TokenEstimate {
+                input_tokens: total_tokens,
+                output_tokens: None,
+                total_tokens,
+                is_approximate: false,
+                confidence: 1.0,
+            });
+        }
+
         let config = self.get_model_config(model)?;
         let mut total_tokens = config.request_overhead;
 
@@ -256,12 +294,106 @@ impl TokenCounter {
     pub fn get_supported_models(&self) -> Vec<String> {
         self.model_configs.keys().cloned().collect()
     }
+
+    fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<Option<u32>> {
+        let mut tiktoken_messages = Vec::with_capacity(messages.len());
+        for message in messages {
+            let Some(content) = plain_text_message_content(message) else {
+                return Ok(None);
+            };
+            tiktoken_messages.push(ChatCompletionRequestMessage {
+                role: ToString::to_string(&message.role),
+                content,
+                name: message.name.clone(),
+                function_call: message.function_call.as_ref().map(|function_call| {
+                    tiktoken_rs::FunctionCall {
+                        name: function_call.name.clone(),
+                        arguments: function_call.arguments.clone(),
+                    }
+                }),
+                tool_calls: message
+                    .tool_calls
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|tool_call| tiktoken_rs::FunctionCall {
+                        name: tool_call.function.name.clone(),
+                        arguments: tool_call.function.arguments.clone(),
+                    })
+                    .collect(),
+                refusal: None,
+            });
+        }
+        match num_tokens_from_messages(tokenizer_model_name(model), &tiktoken_messages) {
+            Ok(tokens) => Ok(Some(usize_to_u32(tokens)?)),
+            Err(_) => Ok(None),
+        }
+    }
 }
 
 impl Default for TokenCounter {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn exact_text_tokens(model: &str, text: &str) -> Result<Option<u32>> {
+    match exact_bpe_for_model(model) {
+        Ok(bpe) => Ok(Some(usize_to_u32(bpe.count_with_special_tokens(text))?)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn exact_bpe_for_model(model: &str) -> std::result::Result<&'static tiktoken_rs::CoreBPE, ()> {
+    let model = tokenizer_model_name(model);
+    bpe_for_model(model).or_else(|_| {
+        if is_openai_tokenizer_model(model) {
+            Ok(cl100k_base_singleton())
+        } else {
+            Err(())
+        }
+    })
+}
+
+fn plain_text_message_content(message: &ChatMessage) -> Option<Option<String>> {
+    match &message.content {
+        None => Some(None),
+        Some(MessageContent::Text(text)) => Some(Some(text.clone())),
+        Some(MessageContent::Parts(parts)) => {
+            let mut text = String::new();
+            for part in parts {
+                let ContentPart::Text { text: part_text } = part else {
+                    return None;
+                };
+                text.push_str(part_text);
+            }
+            Some(Some(text))
+        }
+    }
+}
+
+fn tokenizer_model_name(model: &str) -> &str {
+    model
+        .rsplit_once('/')
+        .map(|(_, model)| model)
+        .unwrap_or(model)
+}
+
+fn is_openai_tokenizer_model(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    model.starts_with("gpt-")
+        || model.starts_with("chatgpt-")
+        || model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("o4")
+        || model.starts_with("codex-")
+        || model.starts_with("text-")
+        || matches!(model.as_str(), "davinci" | "curie" | "babbage" | "ada")
+}
+
+fn usize_to_u32(value: usize) -> Result<u32> {
+    u32::try_from(value)
+        .map_err(|_| GatewayError::Config(format!("token count {value} exceeds u32 range")))
 }
 
 // ==================== Unit Tests ====================
@@ -433,7 +565,7 @@ mod tests {
         assert!(result.is_ok());
         let estimate = result.unwrap();
         assert!(estimate.input_tokens > 0);
-        assert!(estimate.is_approximate);
+        assert!(!estimate.is_approximate);
     }
 
     #[test]
@@ -442,8 +574,8 @@ mod tests {
         let result = counter.count_completion_tokens("gpt-4", "");
         assert!(result.is_ok());
         let estimate = result.unwrap();
-        // Should still have request overhead
-        assert!(estimate.input_tokens > 0);
+        assert_eq!(estimate.input_tokens, 0);
+        assert!(!estimate.is_approximate);
     }
 
     #[test]
@@ -477,7 +609,7 @@ mod tests {
 
         assert_eq!(estimate.total_tokens, estimate.input_tokens);
         assert!(estimate.output_tokens.is_none());
-        assert!(estimate.is_approximate);
+        assert!(!estimate.is_approximate);
     }
 
     // ==================== Embedding Token Counting Tests ====================
@@ -490,7 +622,8 @@ mod tests {
         assert!(result.is_ok());
         let estimate = result.unwrap();
         assert!(estimate.input_tokens > 0);
-        assert_eq!(estimate.confidence, 0.9);
+        assert_eq!(estimate.confidence, 1.0);
+        assert!(!estimate.is_approximate);
     }
 
     #[test]

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -4,9 +4,7 @@ use super::types::{ModelTokenConfig, TokenEstimate};
 use crate::core::models::openai::{ChatMessage, ContentPart, MessageContent};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::collections::HashMap;
-use tiktoken_rs::{
-    ChatCompletionRequestMessage, bpe_for_model, cl100k_base_singleton, num_tokens_from_messages,
-};
+use tiktoken_rs::{ChatCompletionRequestMessage, bpe_for_model, num_tokens_from_messages};
 
 /// Token counter for different models
 #[derive(Debug, Clone)]
@@ -298,6 +296,13 @@ impl TokenCounter {
     fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<Option<u32>> {
         let mut tiktoken_messages = Vec::with_capacity(messages.len());
         for message in messages {
+            if message
+                .tool_calls
+                .as_ref()
+                .is_some_and(|calls| !calls.is_empty())
+            {
+                return Ok(None);
+            }
             let Some(content) = plain_text_message_content(message) else {
                 return Ok(None);
             };
@@ -345,14 +350,7 @@ fn exact_text_tokens(model: &str, text: &str) -> Result<Option<u32>> {
 }
 
 fn exact_bpe_for_model(model: &str) -> std::result::Result<&'static tiktoken_rs::CoreBPE, ()> {
-    let model = tokenizer_model_name(model);
-    bpe_for_model(model).or_else(|_| {
-        if is_openai_tokenizer_model(model) {
-            Ok(cl100k_base_singleton())
-        } else {
-            Err(())
-        }
-    })
+    bpe_for_model(tokenizer_model_name(model)).map_err(|_| ())
 }
 
 fn plain_text_message_content(message: &ChatMessage) -> Option<Option<String>> {
@@ -377,18 +375,6 @@ fn tokenizer_model_name(model: &str) -> &str {
         .rsplit_once('/')
         .map(|(_, model)| model)
         .unwrap_or(model)
-}
-
-fn is_openai_tokenizer_model(model: &str) -> bool {
-    let model = model.to_ascii_lowercase();
-    model.starts_with("gpt-")
-        || model.starts_with("chatgpt-")
-        || model.starts_with("o1")
-        || model.starts_with("o3")
-        || model.starts_with("o4")
-        || model.starts_with("codex-")
-        || model.starts_with("text-")
-        || matches!(model.as_str(), "davinci" | "curie" | "babbage" | "ada")
 }
 
 fn usize_to_u32(value: usize) -> Result<u32> {

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -296,6 +296,9 @@ impl TokenCounter {
     fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<Option<u32>> {
         let mut tiktoken_messages = Vec::with_capacity(messages.len());
         for message in messages {
+            if message.tool_call_id.is_some() {
+                return Ok(None);
+            }
             if message
                 .tool_calls
                 .as_ref()

--- a/src/utils/ai/tokens.rs
+++ b/src/utils/ai/tokens.rs
@@ -1,6 +1,7 @@
 use crate::core::providers::unified_provider::ProviderError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tiktoken_rs::{CoreBPE, bpe_for_model, cl100k_base_singleton};
 
 #[derive(Debug, Clone)]
 pub enum TokenizerType {
@@ -104,7 +105,7 @@ impl TokenUtils {
         let tokenizer_type = Self::select_tokenizer(model)?;
 
         match tokenizer_type {
-            TokenizerType::OpenAI => Self::encode_openai(text),
+            TokenizerType::OpenAI => Self::encode_openai(model, text),
             TokenizerType::Claude => Self::encode_claude(text),
             TokenizerType::HuggingFace => Self::encode_huggingface(text),
             TokenizerType::Custom(_) => Self::encode_generic(text),
@@ -115,7 +116,7 @@ impl TokenUtils {
         let tokenizer_type = Self::select_tokenizer(model)?;
 
         match tokenizer_type {
-            TokenizerType::OpenAI => Self::decode_openai(tokens),
+            TokenizerType::OpenAI => Self::decode_openai(model, tokens),
             TokenizerType::Claude => Self::decode_claude(tokens),
             TokenizerType::HuggingFace => Self::decode_huggingface(tokens),
             TokenizerType::Custom(_) => Self::decode_generic(tokens),
@@ -142,7 +143,7 @@ impl TokenUtils {
         let tokenizer_type = Self::select_tokenizer(model)?;
 
         match tokenizer_type {
-            TokenizerType::OpenAI => Ok(Self::estimate_openai_tokens(text)),
+            TokenizerType::OpenAI => Ok(Self::encode_openai(model, text)?.len()),
             TokenizerType::Claude => Ok(Self::estimate_claude_tokens(text)),
             _ => Ok(Self::estimate_generic_tokens(text)),
         }
@@ -171,9 +172,8 @@ impl TokenUtils {
         Ok(total_tokens)
     }
 
-    fn encode_openai(text: &str) -> Result<Vec<u32>, ProviderError> {
-        let tokens: Vec<u32> = text.chars().enumerate().map(|(i, _)| i as u32).collect();
-        Ok(tokens)
+    fn encode_openai(model: &str, text: &str) -> Result<Vec<u32>, ProviderError> {
+        Ok(exact_bpe_for_model(model).encode_with_special_tokens(text))
     }
 
     fn encode_claude(text: &str) -> Result<Vec<u32>, ProviderError> {
@@ -203,13 +203,10 @@ impl TokenUtils {
         Ok(tokens)
     }
 
-    fn decode_openai(tokens: &[u32]) -> Result<String, ProviderError> {
-        let text: String = tokens
-            .iter()
-            .enumerate()
-            .map(|(i, _)| char::from(65 + (i % 26) as u8))
-            .collect();
-        Ok(text)
+    fn decode_openai(model: &str, tokens: &[u32]) -> Result<String, ProviderError> {
+        exact_bpe_for_model(model)
+            .decode(tokens)
+            .map_err(|error| ProviderError::invalid_request("tokenizer", error.to_string()))
     }
 
     fn decode_claude(tokens: &[u32]) -> Result<String, ProviderError> {
@@ -237,11 +234,6 @@ impl TokenUtils {
             .map(|(i, _)| char::from(33 + (i % 94) as u8))
             .collect();
         Ok(text)
-    }
-
-    fn estimate_openai_tokens(text: &str) -> usize {
-        let words = text.split_whitespace().count();
-        (words as f64 * 1.3).ceil() as usize
     }
 
     fn estimate_claude_tokens(text: &str) -> usize {
@@ -414,6 +406,18 @@ impl TokenUtils {
     }
 }
 
+fn exact_bpe_for_model(model: &str) -> &'static CoreBPE {
+    let model = tokenizer_model_name(model);
+    bpe_for_model(model).unwrap_or_else(|_| cl100k_base_singleton())
+}
+
+fn tokenizer_model_name(model: &str) -> &str {
+    model
+        .rsplit_once('/')
+        .map(|(_, model)| model)
+        .unwrap_or(model)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenUsage {
     pub prompt_tokens: usize,
@@ -462,7 +466,7 @@ mod tests {
     fn test_token_counting() {
         let text = "Hello world this is a test";
         let count = TokenUtils::count_tokens_for_text("gpt-4", text).unwrap();
-        assert!(count > 0);
+        assert_eq!(count, 6);
     }
 
     #[test]
@@ -470,7 +474,7 @@ mod tests {
         let text = "Hello world";
         let tokens = TokenUtils::encode("gpt-4", text).unwrap();
         let decoded = TokenUtils::decode("gpt-4", &tokens).unwrap();
-        assert_eq!(decoded.len(), text.len());
+        assert_eq!(decoded, text);
     }
 
     #[test]

--- a/src/utils/ai/tokens.rs
+++ b/src/utils/ai/tokens.rs
@@ -1,7 +1,7 @@
 use crate::core::providers::unified_provider::ProviderError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tiktoken_rs::{CoreBPE, bpe_for_model, cl100k_base_singleton};
+use tiktoken_rs::{CoreBPE, bpe_for_model};
 
 #[derive(Debug, Clone)]
 pub enum TokenizerType {
@@ -173,7 +173,7 @@ impl TokenUtils {
     }
 
     fn encode_openai(model: &str, text: &str) -> Result<Vec<u32>, ProviderError> {
-        Ok(exact_bpe_for_model(model).encode_with_special_tokens(text))
+        Ok(exact_bpe_for_model(model)?.encode_with_special_tokens(text))
     }
 
     fn encode_claude(text: &str) -> Result<Vec<u32>, ProviderError> {
@@ -204,7 +204,7 @@ impl TokenUtils {
     }
 
     fn decode_openai(model: &str, tokens: &[u32]) -> Result<String, ProviderError> {
-        exact_bpe_for_model(model)
+        exact_bpe_for_model(model)?
             .decode(tokens)
             .map_err(|error| ProviderError::invalid_request("tokenizer", error.to_string()))
     }
@@ -406,9 +406,14 @@ impl TokenUtils {
     }
 }
 
-fn exact_bpe_for_model(model: &str) -> &'static CoreBPE {
+fn exact_bpe_for_model(model: &str) -> Result<&'static CoreBPE, ProviderError> {
     let model = tokenizer_model_name(model);
-    bpe_for_model(model).unwrap_or_else(|_| cl100k_base_singleton())
+    bpe_for_model(model).map_err(|error| {
+        ProviderError::invalid_request(
+            "tokenizer",
+            format!("unsupported OpenAI tokenizer model '{model}': {error}"),
+        )
+    })
 }
 
 fn tokenizer_model_name(model: &str) -> &str {
@@ -475,6 +480,17 @@ mod tests {
         let tokens = TokenUtils::encode("gpt-4", text).unwrap();
         let decoded = TokenUtils::decode("gpt-4", &tokens).unwrap();
         assert_eq!(decoded, text);
+    }
+
+    #[test]
+    fn test_openai_unknown_model_does_not_silently_fallback() {
+        let error = TokenUtils::encode("gpt-future-unknown", "Hello").unwrap_err();
+        match error {
+            ProviderError::InvalidRequest { message, .. } => {
+                assert!(message.contains("unsupported OpenAI tokenizer model"));
+            }
+            other => panic!("expected invalid tokenizer request, got {other}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `tiktoken-rs` and use tokenizer-backed counts for OpenAI text, chat, and embedding token estimates.
- Preserve explicit approximate fallback for unsupported and multimodal paths instead of pretending heuristic counts are exact.
- Update spend/budget tests so OpenAI chat reservation uses the exact `gpt-3.5-turbo` tiktoken prompt count.

Fixes #759

## Verification
- `cargo test --all-features --locked openai_chat_reservation_uses_exact_tiktoken_prompt_count --lib --quiet`
- `cargo test --all-features --locked token_counter --lib --quiet`
- `cargo test --all-features --locked utils::ai::tokens::tests --lib --quiet`
- `cargo check --all-features --locked`

## Scope
This PR intentionally does not implement full upstream parity for tool definition formatting, provider API count-token endpoints, or image dimension/tile counting. Those remain approximate and visibly marked as such.
