### PR TITLE
Sanitize Anthropic tool names

### DIFF
--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -350,9 +350,9 @@ impl AnthropicClient {
 
         // Separate system messages from user messages
         let (system_message, messages) = self.separate_system_messages(&request.messages)?;
+        let tool_name_map = self.anthropic_tool_name_map_for_request(request)?;
 
-        // Transform message format
-        let anthropic_messages = self.transform_messages(messages, model_spec)?;
+        let anthropic_messages = self.transform_messages(messages, model_spec, &tool_name_map)?;
 
         // Request
         let mut anthropic_request = json!({
@@ -401,9 +401,9 @@ impl AnthropicClient {
             let anthropic_tools = self.transform_tools(tools)?;
             anthropic_request["tools"] = json!(anthropic_tools);
 
-            // Add tool_choice
             if let Some(tool_choice) = &request.tool_choice {
-                anthropic_request["tool_choice"] = self.transform_tool_choice(tool_choice)?;
+                anthropic_request["tool_choice"] =
+                    self.transform_tool_choice(tool_choice, &tool_name_map)?;
             }
         }
 
@@ -516,6 +516,7 @@ impl AnthropicClient {
         &self,
         messages: Vec<ChatMessage>,
         model_spec: Option<&super::models::ModelSpec>,
+        tool_name_map: &request_utils::ToolNameMap,
     ) -> Result<Vec<Value>, ProviderError> {
         let mut anthropic_messages = Vec::new();
 
@@ -645,7 +646,9 @@ impl AnthropicClient {
                     anthropic_content.push(json!({
                         "type": "tool_use",
                         "id": tool_call.id,
-                        "name": request_utils::anthropic_tool_name(&tool_call.function.name),
+                        "name": request_utils::declared_tool_name(
+                            &tool_call.function.name, tool_name_map, "Tool call"
+                        )?,
                         "input": serde_json::from_str::<Value>(&tool_call.function.arguments)
                             .unwrap_or(json!({}))
                     }));
@@ -759,6 +762,7 @@ impl AnthropicClient {
     fn transform_tool_choice(
         &self,
         tool_choice: &crate::core::types::tools::ToolChoice,
+        tool_name_map: &request_utils::ToolNameMap,
     ) -> Result<Value, ProviderError> {
         match tool_choice {
             crate::core::types::tools::ToolChoice::String(choice) => match choice.as_str() {
@@ -771,7 +775,9 @@ impl AnthropicClient {
                 if let Some(func) = function {
                     Ok(json!({
                         "type": "tool",
-                        "name": request_utils::anthropic_tool_name(&func.name)
+                        "name": request_utils::declared_tool_name(
+                            &func.name, tool_name_map, "Tool choice"
+                        )?
                     }))
                 } else {
                     Ok(json!({"type": "auto"}))

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -644,7 +644,7 @@ impl AnthropicClient {
                     anthropic_content.push(json!({
                         "type": "tool_use",
                         "id": tool_call.id,
-                        "name": tool_call.function.name,
+                        "name": request_utils::anthropic_tool_name(&tool_call.function.name),
                         "input": serde_json::from_str::<Value>(&tool_call.function.arguments)
                             .unwrap_or(json!({}))
                     }));
@@ -751,17 +751,7 @@ impl AnthropicClient {
         &self,
         tools: &[crate::core::types::tools::Tool],
     ) -> Result<Vec<Value>, ProviderError> {
-        let mut anthropic_tools = Vec::new();
-
-        for tool in tools {
-            anthropic_tools.push(json!({
-                "name": tool.function.name,
-                "description": tool.function.description.as_ref().unwrap_or(&String::new()),
-                "input_schema": tool.function.parameters.as_ref().unwrap_or(&json!({}))
-            }));
-        }
-
-        Ok(anthropic_tools)
+        request_utils::anthropic_tools(tools)
     }
 
     /// Transform tool choice
@@ -780,7 +770,7 @@ impl AnthropicClient {
                 if let Some(func) = function {
                     Ok(json!({
                         "type": "tool",
-                        "name": func.name
+                        "name": request_utils::anthropic_tool_name(&func.name)
                     }))
                 } else {
                     Ok(json!({"type": "auto"}))
@@ -790,10 +780,13 @@ impl AnthropicClient {
     }
 }
 
+mod request_utils;
 mod response;
 mod usage;
 
 #[cfg(test)]
 mod compatible_tests;
+#[cfg(test)]
+mod request_tests;
 #[cfg(test)]
 mod tests;

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -70,13 +70,14 @@ impl AnthropicClient {
 
     /// Request
     pub async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, ProviderError> {
+        let tool_name_map = self.anthropic_tool_name_map_for_request(&request)?;
         let anthropic_request = self.transform_chat_request(&request)?;
         let mut headers = self.get_request_headers();
         headers.extend(self.compute_beta_headers(&request));
         let response = self
             .send_request("/v1/messages", anthropic_request, headers)
             .await?;
-        self.transform_chat_response(response)
+        self.transform_chat_response_with_tool_name_map(response, &tool_name_map)
     }
 
     /// Request

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -54,6 +54,28 @@ fn issue_761_anthropic_transform_request_sanitizes_specific_tool_choice() {
 }
 
 #[test]
+fn issue_761_anthropic_transform_request_rejects_sanitized_tool_choice_alias() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229")
+        .add_user_message("weather?")
+        .with_tools(vec![tool("weather_lookup")]);
+    request.tool_choice = Some(ToolChoice::Specific {
+        choice_type: "function".to_string(),
+        function: Some(FunctionChoice {
+            name: "weather.lookup".to_string(),
+        }),
+    });
+
+    let result = anthropic_client().transform_chat_request(&request);
+    let message = result
+        .err()
+        .map_or_else(String::new, |error| error.to_string());
+
+    assert!(message.contains("Tool choice"));
+    assert!(message.contains("weather.lookup"));
+    assert!(message.contains("weather_lookup"));
+}
+
+#[test]
 fn issue_761_anthropic_transform_request_sanitizes_assistant_tool_call_history() {
     let mut request = ChatRequest::new("claude-3-opus-20240229");
     request.messages.push(ChatMessage {
@@ -74,6 +96,35 @@ fn issue_761_anthropic_transform_request_sanitizes_assistant_tool_call_history()
     let content = transformed["messages"][0]["content"].as_array().unwrap();
 
     assert_eq!(content[1]["name"], "weather_lookup");
+}
+
+#[test]
+fn issue_761_anthropic_transform_request_rejects_sanitized_history_alias() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229")
+        .add_user_message("weather?")
+        .with_tools(vec![tool("weather_lookup")]);
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: None,
+        tool_calls: Some(vec![ToolCall {
+            id: "toolu_123".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "weather.lookup".to_string(),
+                arguments: r#"{"city":"Paris"}"#.to_string(),
+            },
+        }]),
+        ..Default::default()
+    });
+
+    let result = anthropic_client().transform_chat_request(&request);
+    let message = result
+        .err()
+        .map_or_else(String::new, |error| error.to_string());
+
+    assert!(message.contains("Tool call"));
+    assert!(message.contains("weather.lookup"));
+    assert!(message.contains("weather_lookup"));
 }
 
 #[test]

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -1,0 +1,86 @@
+use serde_json::json;
+
+use super::*;
+use crate::core::providers::anthropic::config::AnthropicConfig;
+use crate::core::types::chat::{ChatMessage, ChatRequest};
+use crate::core::types::message::{MessageContent, MessageRole};
+use crate::core::types::tools::{
+    FunctionCall, FunctionChoice, FunctionDefinition, Tool, ToolCall, ToolChoice, ToolType,
+};
+
+fn anthropic_client() -> AnthropicClient {
+    AnthropicClient::new(AnthropicConfig::new_test("test-key")).unwrap()
+}
+
+fn tool(name: &str) -> Tool {
+    Tool {
+        tool_type: ToolType::Function,
+        function: FunctionDefinition {
+            name: name.to_string(),
+            description: Some("lookup".to_string()),
+            parameters: Some(json!({"type": "object"})),
+        },
+    }
+}
+
+#[test]
+fn issue_761_anthropic_transform_tools_sanitizes_invalid_function_names() {
+    let result = anthropic_client()
+        .transform_tools(&[tool("actions/download-job-logs.for-workflow-run")])
+        .unwrap();
+
+    assert_eq!(
+        result[0]["name"],
+        "actions_download-job-logs_for-workflow-run"
+    );
+}
+
+#[test]
+fn issue_761_anthropic_transform_request_sanitizes_specific_tool_choice() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229")
+        .add_user_message("weather?")
+        .with_tools(vec![tool("weather.lookup")]);
+    request.tool_choice = Some(ToolChoice::Specific {
+        choice_type: "function".to_string(),
+        function: Some(FunctionChoice {
+            name: "weather.lookup".to_string(),
+        }),
+    });
+
+    let transformed = anthropic_client().transform_chat_request(&request).unwrap();
+
+    assert_eq!(transformed["tools"][0]["name"], "weather_lookup");
+    assert_eq!(transformed["tool_choice"]["name"], "weather_lookup");
+}
+
+#[test]
+fn issue_761_anthropic_transform_request_sanitizes_assistant_tool_call_history() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Text("checking".to_string())),
+        tool_calls: Some(vec![ToolCall {
+            id: "toolu_123".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "weather.lookup".to_string(),
+                arguments: r#"{"city":"Paris"}"#.to_string(),
+            },
+        }]),
+        ..Default::default()
+    });
+
+    let transformed = anthropic_client().transform_chat_request(&request).unwrap();
+    let content = transformed["messages"][0]["content"].as_array().unwrap();
+
+    assert_eq!(content[1]["name"], "weather_lookup");
+}
+
+#[test]
+fn issue_761_anthropic_transform_tools_rejects_sanitized_name_collisions() {
+    let error = anthropic_client()
+        .transform_tools(&[tool("weather.lookup"), tool("weather/lookup")])
+        .expect_err("colliding sanitized names must fail closed");
+
+    assert!(error.to_string().contains("collides"));
+}

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -81,6 +81,42 @@ fn issue_761_anthropic_transform_tools_rejects_sanitized_name_collisions() {
     let error = anthropic_client()
         .transform_tools(&[tool("weather.lookup"), tool("weather/lookup")])
         .expect_err("colliding sanitized names must fail closed");
+    let message = error.to_string();
 
-    assert!(error.to_string().contains("collides"));
+    assert!(message.contains("weather.lookup"));
+    assert!(message.contains("weather/lookup"));
+    assert!(message.contains("weather_lookup"));
+}
+
+#[test]
+fn issue_761_anthropic_transform_response_restores_original_tool_names()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let client = anthropic_client();
+    let request = ChatRequest::new("claude-3-opus-20240229")
+        .add_user_message("weather?")
+        .with_tools(vec![tool("weather.lookup")]);
+    let tool_name_map = client.anthropic_tool_name_map_for_request(&request)?;
+    let response = json!({
+        "id": "msg_123",
+        "model": "claude-3-opus-20240229",
+        "content": [{
+            "type": "tool_use",
+            "id": "toolu_123",
+            "name": "weather_lookup",
+            "input": {"city": "Paris"}
+        }],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 10, "output_tokens": 5}
+    });
+
+    let result = client.transform_chat_response_with_tool_name_map(response, &tool_name_map)?;
+    let name = result.choices[0]
+        .message
+        .tool_calls
+        .as_ref()
+        .and_then(|tool_calls| tool_calls.first())
+        .map(|tool_call| tool_call.function.name.as_str());
+
+    assert_eq!(name, Some("weather.lookup"));
+    Ok(())
 }

--- a/src/core/providers/anthropic/client/request_utils.rs
+++ b/src/core/providers/anthropic/client/request_utils.rs
@@ -1,0 +1,88 @@
+use std::collections::HashSet;
+
+use serde_json::{Value, json};
+
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::tools::Tool;
+
+const ANTHROPIC_TOOL_NAME_MAX_LEN: usize = 64;
+
+pub(super) fn anthropic_tool_name(name: &str) -> String {
+    let mut sanitized = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        sanitized.push_str("tool");
+    }
+    sanitized.truncate(ANTHROPIC_TOOL_NAME_MAX_LEN);
+    sanitized
+}
+
+pub(super) fn anthropic_tools(tools: &[Tool]) -> Result<Vec<Value>, ProviderError> {
+    let names =
+        sanitized_anthropic_tool_names(tools.iter().map(|tool| tool.function.name.as_str()))?;
+    Ok(tools
+        .iter()
+        .zip(names)
+        .map(|(tool, name)| {
+            json!({
+                "name": name,
+                "description": tool.function.description.as_deref().unwrap_or(""),
+                "input_schema": tool.function.parameters.as_ref().unwrap_or(&json!({}))
+            })
+        })
+        .collect())
+}
+
+fn sanitized_anthropic_tool_names<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+) -> Result<Vec<String>, ProviderError> {
+    let mut seen = HashSet::new();
+    let mut sanitized_names = Vec::new();
+
+    for name in names {
+        let sanitized = anthropic_tool_name(name);
+        if !seen.insert(sanitized.clone()) {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!(
+                    "Tool name '{}' collides after Anthropic name sanitization",
+                    name
+                ),
+            ));
+        }
+        sanitized_names.push(sanitized);
+    }
+
+    Ok(sanitized_names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn issue_761_sanitizes_tool_names_to_anthropic_shape() {
+        assert_eq!(
+            anthropic_tool_name("get.weather forecast"),
+            "get_weather_forecast"
+        );
+        assert_eq!(anthropic_tool_name(""), "tool");
+        assert_eq!(anthropic_tool_name(&"a".repeat(80)).len(), 64);
+    }
+
+    #[test]
+    fn issue_761_rejects_sanitized_tool_name_collisions() {
+        let error = sanitized_anthropic_tool_names(["get.weather", "get_weather"])
+            .expect_err("sanitized tool names must be unique");
+
+        assert!(error.to_string().contains("collides"));
+    }
+}

--- a/src/core/providers/anthropic/client/request_utils.rs
+++ b/src/core/providers/anthropic/client/request_utils.rs
@@ -1,9 +1,12 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, hash_map::Entry};
 
 use serde_json::{Value, json};
 
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::chat::ChatRequest;
 use crate::core::types::tools::Tool;
+
+use super::AnthropicClient;
 
 const ANTHROPIC_TOOL_NAME_MAX_LEN: usize = 64;
 
@@ -26,14 +29,12 @@ pub(super) fn anthropic_tool_name(name: &str) -> String {
 }
 
 pub(super) fn anthropic_tools(tools: &[Tool]) -> Result<Vec<Value>, ProviderError> {
-    let names =
-        sanitized_anthropic_tool_names(tools.iter().map(|tool| tool.function.name.as_str()))?;
+    anthropic_tool_name_map(tools)?;
     Ok(tools
         .iter()
-        .zip(names)
-        .map(|(tool, name)| {
+        .map(|tool| {
             json!({
-                "name": name,
+                "name": anthropic_tool_name(&tool.function.name),
                 "description": tool.function.description.as_deref().unwrap_or(""),
                 "input_schema": tool.function.parameters.as_ref().unwrap_or(&json!({}))
             })
@@ -41,27 +42,50 @@ pub(super) fn anthropic_tools(tools: &[Tool]) -> Result<Vec<Value>, ProviderErro
         .collect())
 }
 
-fn sanitized_anthropic_tool_names<'a>(
-    names: impl IntoIterator<Item = &'a str>,
-) -> Result<Vec<String>, ProviderError> {
-    let mut seen = HashSet::new();
-    let mut sanitized_names = Vec::new();
+pub(super) fn anthropic_tool_name_map(
+    tools: &[Tool],
+) -> Result<HashMap<String, String>, ProviderError> {
+    let mut names = HashMap::new();
 
-    for name in names {
+    for tool in tools {
+        let name = &tool.function.name;
         let sanitized = anthropic_tool_name(name);
-        if !seen.insert(sanitized.clone()) {
-            return Err(ProviderError::invalid_request(
-                "anthropic",
-                format!(
-                    "Tool name '{}' collides after Anthropic name sanitization",
-                    name
-                ),
-            ));
+        match names.entry(sanitized.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert(name.clone());
+            }
+            Entry::Occupied(entry) => {
+                return Err(ProviderError::invalid_request(
+                    "anthropic",
+                    format!(
+                        "Tool name '{}' collides with '{}' after Anthropic name sanitization to '{}'",
+                        name,
+                        entry.get(),
+                        sanitized
+                    ),
+                ));
+            }
         }
-        sanitized_names.push(sanitized);
     }
 
-    Ok(sanitized_names)
+    Ok(names)
+}
+
+pub(super) fn restore_tool_name(name: &str, map: &HashMap<String, String>) -> String {
+    map.get(name).cloned().unwrap_or_else(|| name.to_string())
+}
+
+impl AnthropicClient {
+    pub(crate) fn anthropic_tool_name_map_for_request(
+        &self,
+        request: &ChatRequest,
+    ) -> Result<HashMap<String, String>, ProviderError> {
+        request
+            .tools
+            .as_deref()
+            .map(anthropic_tool_name_map)
+            .unwrap_or_else(|| Ok(HashMap::new()))
+    }
 }
 
 #[cfg(test)]
@@ -80,9 +104,23 @@ mod tests {
 
     #[test]
     fn issue_761_rejects_sanitized_tool_name_collisions() {
-        let error = sanitized_anthropic_tool_names(["get.weather", "get_weather"])
-            .expect_err("sanitized tool names must be unique");
+        let tools = vec![test_tool("get.weather"), test_tool("get_weather")];
+        let error =
+            anthropic_tool_name_map(&tools).expect_err("sanitized tool names must be unique");
+        let message = error.to_string();
 
-        assert!(error.to_string().contains("collides"));
+        assert!(message.contains("get.weather"));
+        assert!(message.contains("get_weather"));
+    }
+
+    fn test_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: crate::core::types::tools::ToolType::Function,
+            function: crate::core::types::tools::FunctionDefinition {
+                name: name.to_string(),
+                description: None,
+                parameters: None,
+            },
+        }
     }
 }

--- a/src/core/providers/anthropic/client/request_utils.rs
+++ b/src/core/providers/anthropic/client/request_utils.rs
@@ -10,6 +10,8 @@ use super::AnthropicClient;
 
 const ANTHROPIC_TOOL_NAME_MAX_LEN: usize = 64;
 
+pub(super) type ToolNameMap = HashMap<String, String>;
+
 pub(super) fn anthropic_tool_name(name: &str) -> String {
     let mut sanitized = name
         .chars()
@@ -42,9 +44,7 @@ pub(super) fn anthropic_tools(tools: &[Tool]) -> Result<Vec<Value>, ProviderErro
         .collect())
 }
 
-pub(super) fn anthropic_tool_name_map(
-    tools: &[Tool],
-) -> Result<HashMap<String, String>, ProviderError> {
+pub(super) fn anthropic_tool_name_map(tools: &[Tool]) -> Result<ToolNameMap, ProviderError> {
     let mut names = HashMap::new();
 
     for tool in tools {
@@ -71,15 +71,41 @@ pub(super) fn anthropic_tool_name_map(
     Ok(names)
 }
 
-pub(super) fn restore_tool_name(name: &str, map: &HashMap<String, String>) -> String {
+pub(super) fn restore_tool_name(name: &str, map: &ToolNameMap) -> String {
     map.get(name).cloned().unwrap_or_else(|| name.to_string())
+}
+
+pub(super) fn declared_tool_name(
+    name: &str,
+    map: &ToolNameMap,
+    field: &str,
+) -> Result<String, ProviderError> {
+    let sanitized = anthropic_tool_name(name);
+    if map.is_empty() {
+        return Ok(sanitized);
+    }
+
+    match map.get(&sanitized) {
+        Some(original) if original == name => Ok(sanitized),
+        Some(original) => Err(ProviderError::invalid_request(
+            "anthropic",
+            format!(
+                "{} '{}' sanitizes to '{}' but declared tool '{}' already uses that Anthropic name",
+                field, name, sanitized, original
+            ),
+        )),
+        None => Err(ProviderError::invalid_request(
+            "anthropic",
+            format!("{} '{}' does not match a declared tool", field, name),
+        )),
+    }
 }
 
 impl AnthropicClient {
     pub(crate) fn anthropic_tool_name_map_for_request(
         &self,
         request: &ChatRequest,
-    ) -> Result<HashMap<String, String>, ProviderError> {
+    ) -> Result<ToolNameMap, ProviderError> {
         request
             .tools
             .as_deref()

--- a/src/core/providers/anthropic/client/response.rs
+++ b/src/core/providers/anthropic/client/response.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde_json::Value;
 
 use crate::core::providers::unified_provider::ProviderError;
@@ -9,7 +11,7 @@ use crate::core::types::{
     tools::{FunctionCall, ToolCall},
 };
 
-use super::{AnthropicClient, anthropic_parse_error, usage};
+use super::{AnthropicClient, anthropic_parse_error, request_utils, usage};
 
 fn parse_anthropic_stop_reason(reason: &str) -> FinishReason {
     match reason {
@@ -25,9 +27,18 @@ fn parse_anthropic_stop_reason(reason: &str) -> FinishReason {
 
 impl AnthropicClient {
     /// Response
+    #[cfg(test)]
     pub(super) fn transform_chat_response(
         &self,
         response: Value,
+    ) -> Result<ChatResponse, ProviderError> {
+        self.transform_chat_response_with_tool_name_map(response, &HashMap::new())
+    }
+
+    pub(crate) fn transform_chat_response_with_tool_name_map(
+        &self,
+        response: Value,
+        tool_name_map: &HashMap<String, String>,
     ) -> Result<ChatResponse, ProviderError> {
         // Extract basic information
         let id = response
@@ -76,7 +87,7 @@ impl AnthropicClient {
                             id: id.to_string(),
                             tool_type: "function".to_string(),
                             function: FunctionCall {
-                                name: name.to_string(),
+                                name: request_utils::restore_tool_name(name, tool_name_map),
                                 arguments: input.to_string(),
                             },
                         });

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -305,7 +305,7 @@ fn test_anthropic_transform_messages_preserves_assistant_text_with_tool_use() {
     }];
 
     let transformed = client
-        .transform_messages(messages, Some(model_spec))
+        .transform_messages(messages, Some(model_spec), &Default::default())
         .unwrap();
     assert_eq!(transformed[0]["role"], "assistant");
     let content = transformed[0]["content"].as_array().unwrap();
@@ -337,7 +337,7 @@ fn test_anthropic_transform_messages_tool_role_to_tool_result() {
     }];
 
     let transformed = client
-        .transform_messages(messages, Some(model_spec))
+        .transform_messages(messages, Some(model_spec), &Default::default())
         .unwrap();
     assert_eq!(transformed[0]["role"], "user");
     let content = transformed[0]["content"].as_array().unwrap();
@@ -354,7 +354,9 @@ fn test_transform_tool_choice_auto() {
     let client = AnthropicClient::new(config).unwrap();
 
     let tool_choice = crate::core::types::tools::ToolChoice::String("auto".to_string());
-    let result = client.transform_tool_choice(&tool_choice).unwrap();
+    let result = client
+        .transform_tool_choice(&tool_choice, &Default::default())
+        .unwrap();
 
     assert_eq!(result["type"], "auto");
 }
@@ -365,7 +367,9 @@ fn test_transform_tool_choice_none() {
     let client = AnthropicClient::new(config).unwrap();
 
     let tool_choice = crate::core::types::tools::ToolChoice::String("none".to_string());
-    let result = client.transform_tool_choice(&tool_choice).unwrap();
+    let result = client
+        .transform_tool_choice(&tool_choice, &Default::default())
+        .unwrap();
 
     assert_eq!(result["type"], "none");
 }
@@ -376,7 +380,9 @@ fn test_transform_tool_choice_required() {
     let client = AnthropicClient::new(config).unwrap();
 
     let tool_choice = crate::core::types::tools::ToolChoice::String("required".to_string());
-    let result = client.transform_tool_choice(&tool_choice).unwrap();
+    let result = client
+        .transform_tool_choice(&tool_choice, &Default::default())
+        .unwrap();
 
     assert_eq!(result["type"], "any");
 }

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -391,7 +391,7 @@ fn test_transform_tools() {
     let tools = vec![crate::core::types::tools::Tool {
         tool_type: crate::core::types::tools::ToolType::Function,
         function: crate::core::types::tools::FunctionDefinition {
-            name: "get_weather".to_string(),
+            name: "get.weather forecast".to_string(),
             description: Some("Get weather for a location".to_string()),
             parameters: Some(json!({"type": "object"})),
         },
@@ -399,7 +399,7 @@ fn test_transform_tools() {
 
     let result = client.transform_tools(&tools).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "get_weather");
+    assert_eq!(result[0]["name"], "get_weather_forecast");
     assert_eq!(result[0]["description"], "Get weather for a location");
 }
 

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -24,7 +24,6 @@ use crate::core::types::{
 use super::client::AnthropicClient;
 use super::config::AnthropicConfig;
 use super::models::{ModelFeature, get_anthropic_registry};
-use super::streaming::AnthropicStream;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
 const COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS: u32 = 128_000;
@@ -370,8 +369,7 @@ impl LLMProvider for AnthropicProvider {
             ));
         }
 
-        let response = self.client.chat_stream(request.clone()).await?;
-        let stream = AnthropicStream::from_response(response, request.model);
+        let stream = self.client.chat_stream_chunks(request).await?;
 
         Ok(Box::pin(stream))
     }

--- a/src/core/providers/anthropic/streaming.rs
+++ b/src/core/providers/anthropic/streaming.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses the unified SSE parser with AnthropicTransformer for event-based streaming.
 
-use std::pin::Pin;
+use std::{collections::HashMap, pin::Pin};
 
 use bytes::Bytes;
 use futures::Stream;
@@ -10,7 +10,9 @@ use pin_project_lite::pin_project;
 
 use crate::core::providers::base::sse::{AnthropicTransformer, UnifiedSSEStream};
 use crate::core::providers::unified_provider::ProviderError;
-use crate::core::types::responses::ChatChunk;
+use crate::core::types::{chat::ChatRequest, responses::ChatChunk};
+
+use super::client::AnthropicClient;
 
 /// Anthropic SSE stream type
 pub type AnthropicSSEStream = UnifiedSSEStream<
@@ -29,11 +31,35 @@ pin_project! {
 impl AnthropicStream {
     /// Create stream from response
     pub fn from_response(response: reqwest::Response, model: String) -> Self {
-        let transformer = AnthropicTransformer::new(model);
+        Self::from_response_with_tool_name_map(response, model, HashMap::new())
+    }
+
+    pub fn from_response_with_tool_name_map(
+        response: reqwest::Response,
+        model: String,
+        tool_name_map: HashMap<String, String>,
+    ) -> Self {
+        let transformer = AnthropicTransformer::new(model).with_tool_name_map(tool_name_map);
         let stream = UnifiedSSEStream::new(Box::pin(response.bytes_stream()), transformer);
         Self {
             inner: Box::pin(stream),
         }
+    }
+}
+
+impl AnthropicClient {
+    pub(crate) async fn chat_stream_chunks(
+        &self,
+        request: ChatRequest,
+    ) -> Result<AnthropicStream, ProviderError> {
+        let tool_name_map = self.anthropic_tool_name_map_for_request(&request)?;
+        let model = request.model.clone();
+        let response = self.chat_stream(request).await?;
+        Ok(AnthropicStream::from_response_with_tool_name_map(
+            response,
+            model,
+            tool_name_map,
+        ))
     }
 }
 

--- a/src/core/providers/base/sse/anthropic.rs
+++ b/src/core/providers/base/sse/anthropic.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde_json::Value;
 use tracing::warn;
 
@@ -17,13 +19,27 @@ use crate::core::types::thinking::ThinkingDelta;
 #[derive(Debug, Clone)]
 pub struct AnthropicTransformer {
     model: String,
+    tool_name_map: HashMap<String, String>,
 }
 
 impl AnthropicTransformer {
     pub fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
+            tool_name_map: HashMap::new(),
         }
+    }
+
+    pub fn with_tool_name_map(mut self, tool_name_map: HashMap<String, String>) -> Self {
+        self.tool_name_map = tool_name_map;
+        self
+    }
+
+    fn restore_tool_name(&self, name: &str) -> String {
+        self.tool_name_map
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| name.to_string())
     }
 
     fn parse_anthropic_finish_reason(reason: &str) -> FinishReason {
@@ -143,7 +159,7 @@ impl SSETransformer for AnthropicTransformer {
                         let name = content_block
                             .get("name")
                             .and_then(|v| v.as_str())
-                            .map(str::to_string);
+                            .map(|name| self.restore_tool_name(name));
                         let arguments = content_block.get("input").and_then(|input| {
                             if input.is_null()
                                 || input
@@ -375,5 +391,37 @@ mod tests {
         let chunk = t.transform_chunk(&event.to_string()).unwrap().unwrap();
         let usage = chunk.usage.as_ref().unwrap();
         assert!(usage.prompt_tokens_details.is_none());
+    }
+
+    #[test]
+    fn issue_761_stream_restores_original_tool_names()
+    -> Result<(), crate::core::providers::unified_provider::ProviderError> {
+        let t =
+            AnthropicTransformer::new("claude-3-5-sonnet").with_tool_name_map(HashMap::from([(
+                "weather_lookup".to_string(),
+                "weather.lookup".to_string(),
+            )]));
+        let event = serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "weather_lookup",
+                "input": {}
+            }
+        });
+
+        let chunk = t.transform_chunk(&event.to_string())?;
+        let name = chunk
+            .as_ref()
+            .and_then(|chunk| chunk.choices.first())
+            .and_then(|choice| choice.delta.tool_calls.as_ref())
+            .and_then(|tool_calls| tool_calls.first())
+            .and_then(|tool_call| tool_call.function.as_ref())
+            .and_then(|function| function.name.as_deref());
+
+        assert_eq!(name, Some("weather.lookup"));
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixes #761.

## Summary
- sanitize Anthropic tool definition names, forced tool_choice names, and assistant tool-call history names
- reject sanitized-name collisions instead of silently sending duplicate Anthropic tool names
- keep the fix scoped to the Anthropic request transform path; #762-#767 remain separate issues

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test --lib issue_761_ --quiet
- cargo test --lib test_transform_tools --quiet
- cargo test --lib test_transform_tool_choice --quiet
- cargo test --lib anthropic --quiet
- cargo check --all-features --locked
- cargo test --all-features --locked -- --test-threads=1
