### PR TITLE
Fix Azure Assistants endpoint URL joining

### DIFF
--- a/src/core/providers/azure/assistants.rs
+++ b/src/core/providers/azure/assistants.rs
@@ -210,31 +210,35 @@ impl AzureAssistantHandler {
         Ok(Self { client })
     }
 
-    fn build_assistants_url(&self, path: &str) -> String {
+    fn build_api_url(&self, resource: &str, path: &str) -> String {
+        let endpoint = self
+            .client
+            .get_config()
+            .azure_endpoint
+            .as_deref()
+            .unwrap_or("")
+            .trim_end_matches('/');
+        let base = if endpoint.is_empty() {
+            format!("openai/{}", resource)
+        } else {
+            format!("{}/openai/{}", endpoint, resource)
+        };
+
         format!(
-            "{}openai/assistants{}?api-version={}",
-            self.client
-                .get_config()
-                .azure_endpoint
-                .as_deref()
-                .unwrap_or(""),
+            "{}{}?api-version={}",
+            base,
             path,
             self.client.get_config().api_version
         )
     }
 
+    fn build_assistants_url(&self, path: &str) -> String {
+        self.build_api_url("assistants", path)
+    }
+
     #[cfg(test)]
     fn build_threads_url(&self, path: &str) -> String {
-        format!(
-            "{}openai/threads{}?api-version={}",
-            self.client
-                .get_config()
-                .azure_endpoint
-                .as_deref()
-                .unwrap_or(""),
-            path,
-            self.client.get_config().api_version
-        )
+        self.build_api_url("threads", path)
     }
 }
 

--- a/src/core/providers/azure/assistants_tests.rs
+++ b/src/core/providers/azure/assistants_tests.rs
@@ -534,59 +534,82 @@ fn test_validate_assistant_request_all_models() {
 
 // ==================== AzureAssistantHandler URL Tests ====================
 
-#[test]
-fn test_azure_assistant_handler_build_assistants_url() {
+fn azure_assistant_handler(endpoint: &str) -> AzureAssistantHandler {
     let config = AzureConfig::new()
-        .with_azure_endpoint("https://myresource.openai.azure.com/".to_string())
+        .with_azure_endpoint(endpoint.to_string())
         .with_api_version("2024-02-15-preview".to_string())
         .with_api_key("test-key".to_string());
 
-    let handler = AzureAssistantHandler::new(config).unwrap();
+    match AzureAssistantHandler::new(config) {
+        Ok(handler) => handler,
+        Err(error) => panic!("AzureAssistantHandler should initialize in URL tests: {error}"),
+    }
+}
+
+#[test]
+fn test_azure_assistant_handler_build_assistants_url_with_trailing_slash() {
+    let handler = azure_assistant_handler("https://myresource.openai.azure.com/");
     let url = handler.build_assistants_url("");
 
-    assert!(url.contains("myresource.openai.azure.com"));
-    assert!(url.contains("openai/assistants"));
-    assert!(url.contains("api-version=2024-02-15-preview"));
+    assert_eq!(
+        url,
+        "https://myresource.openai.azure.com/openai/assistants?api-version=2024-02-15-preview"
+    );
+}
+
+#[test]
+fn test_azure_assistant_handler_build_assistants_url_without_trailing_slash() {
+    let handler = azure_assistant_handler("https://myresource.openai.azure.com");
+    let url = handler.build_assistants_url("");
+
+    assert_eq!(
+        url,
+        "https://myresource.openai.azure.com/openai/assistants?api-version=2024-02-15-preview"
+    );
 }
 
 #[test]
 fn test_azure_assistant_handler_build_assistants_url_with_id() {
-    let config = AzureConfig::new()
-        .with_azure_endpoint("https://myresource.openai.azure.com/".to_string())
-        .with_api_version("2024-02-15-preview".to_string())
-        .with_api_key("test-key".to_string());
-
-    let handler = AzureAssistantHandler::new(config).unwrap();
+    let handler = azure_assistant_handler("https://myresource.openai.azure.com");
     let url = handler.build_assistants_url("/asst_abc123");
 
-    assert!(url.contains("/asst_abc123"));
+    assert_eq!(
+        url,
+        "https://myresource.openai.azure.com/openai/assistants/asst_abc123?api-version=2024-02-15-preview"
+    );
 }
 
 #[test]
-fn test_azure_assistant_handler_build_threads_url() {
-    let config = AzureConfig::new()
-        .with_azure_endpoint("https://myresource.openai.azure.com/".to_string())
-        .with_api_version("2024-02-15-preview".to_string())
-        .with_api_key("test-key".to_string());
-
-    let handler = AzureAssistantHandler::new(config).unwrap();
+fn test_azure_assistant_handler_build_threads_url_with_trailing_slash() {
+    let handler = azure_assistant_handler("https://myresource.openai.azure.com/");
     let url = handler.build_threads_url("");
 
-    assert!(url.contains("openai/threads"));
-    assert!(url.contains("api-version=2024-02-15-preview"));
+    assert_eq!(
+        url,
+        "https://myresource.openai.azure.com/openai/threads?api-version=2024-02-15-preview"
+    );
+}
+
+#[test]
+fn test_azure_assistant_handler_build_threads_url_without_trailing_slash() {
+    let handler = azure_assistant_handler("https://myresource.openai.azure.com");
+    let url = handler.build_threads_url("");
+
+    assert_eq!(
+        url,
+        "https://myresource.openai.azure.com/openai/threads?api-version=2024-02-15-preview"
+    );
 }
 
 #[test]
 fn test_azure_assistant_handler_build_threads_url_with_path() {
-    let config = AzureConfig::new()
-        .with_azure_endpoint("https://myresource.openai.azure.com/".to_string())
-        .with_api_version("2024-02-15-preview".to_string())
-        .with_api_key("test-key".to_string());
-
-    let handler = AzureAssistantHandler::new(config).unwrap();
+    let handler = azure_assistant_handler("https://myresource.openai.azure.com");
     let url = handler.build_threads_url("/thread_123/messages");
 
-    assert!(url.contains("/thread_123/messages"));
+    assert_eq!(
+        url,
+        "https://myresource.openai.azure.com/openai/threads/thread_123/messages?api-version=2024-02-15-preview"
+    );
 }
 
 // ==================== Clone and Debug Tests ====================


### PR DESCRIPTION
## Summary
- Normalize Azure Assistants and Threads helper URLs by trimming the configured endpoint before appending `/openai/...`.
- Add exact URL regression coverage for endpoint values with and without a trailing slash.

Fixes #737

## Verification
- `cargo fmt --all`
- `git diff --check`
- `cargo test core::providers::azure::assistants::tests --lib --features providers-extra --quiet`
- `cargo test core::providers::azure::assistants --lib --all-features --quiet`
- `cargo check --all-features --locked`
- `cargo test --all-features --locked`
