### PR TITLE
docs(api): clarify batch endpoint support

### DIFF
--- a/docs/PYTHON_VS_RUST_ANALYSIS.md
+++ b/docs/PYTHON_VS_RUST_ANALYSIS.md
@@ -52,7 +52,7 @@
 | acompletion() | ✅ | ✅ | 完整 |
 | completion_stream() | ✅ | ✅ | 完整 |
 | rerank() | ✅ | ✅ | 完整 |
-| batch operations | ✅ | ✅ | 完整 |
+| batch operations | ✅ | ⚠️ | OpenAI-compatible provider proxy; no durable local batch execution |
 
 ### 部分实现 API
 

--- a/docs/comparison/03-providers.md
+++ b/docs/comparison/03-providers.md
@@ -267,7 +267,7 @@ class BaseConfig(ABC):
 | **Tool Calling** | Full support in types | Full support |
 | **Vision/Multimodal** | Types defined (ContentPart) | Full implementation |
 | **Audio (TTS/STT)** | Groq STT only | 10+ providers |
-| **Batches** | Azure batches | Anthropic, Azure, Vertex AI |
+| **Batches** | OpenAI-compatible provider proxy routes | Anthropic, Azure, Vertex AI |
 | **Fine-tuning** | OpenAI module exists | OpenAI, Azure |
 | **Assistants** | Azure assistants | OpenAI, Azure |
 | **Realtime** | OpenAI module exists | OpenAI, Azure |

--- a/docs/comparison/04-api-compatibility.md
+++ b/docs/comparison/04-api-compatibility.md
@@ -250,7 +250,7 @@ pub struct Model {
 | `/v1/audio/translations` | Yes | Yes | Audio translation |
 | `/v1/moderations` | No | Yes | Content moderation |
 | `/v1/files` | No | Yes | File management |
-| `/v1/batches` | No | Yes | Batch processing |
+| `/v1/batches` | Partial | Yes | Provider-backed OpenAI-compatible create/list/get/cancel proxy; no durable local batch execution |
 | `/v1/fine_tuning/jobs` | No | Yes | Fine-tuning |
 | `/v1/assistants` | No | Yes | Assistants API |
 | `/v1/threads` | No | Yes | Threads API |


### PR DESCRIPTION
## Summary
- update the Python/Rust comparison to mark batch operations as partial provider-proxy support
- update provider and API comparison docs so `/v1/batches` no longer appears missing
- call out the remaining lack of durable local batch execution

Fixes #767

## Verification
- `git diff --check`
- `cargo check --all-features --locked`
- `cargo test test_batch_routes_mounted_with_expected_methods --all-features --locked`
- `cargo test --all-features --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`