### PR TITLE
fix(openai): preserve upstream error envelopes

### DIFF
--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -54,54 +54,134 @@ pub struct HttpErrorMapper;
 impl HttpErrorMapper {
     /// Map HTTP status code to provider error.
     pub fn map_status_code(provider: &'static str, status: u16, body: &str) -> ProviderError {
+        let message = extract_error_message(body).unwrap_or_else(|| body.to_string());
+
         match status {
-            400 => ProviderError::invalid_request(provider, body.to_string()),
-            401 => ProviderError::authentication(
-                provider,
-                "Invalid API key or authentication failed".to_string(),
-            ),
-            403 => ProviderError::authentication(
-                provider,
-                "Forbidden: insufficient permissions".to_string(),
-            ),
-            404 => ProviderError::model_not_found(provider, body.to_string()),
-            429 => ProviderError::rate_limit(provider, None),
-            402 => ProviderError::quota_exceeded(provider, "Quota exceeded".to_string()),
-            500..=599 => {
-                ProviderError::api_error(provider, status, format!("Server error: {}", body))
+            400 => {
+                if is_context_length_error(body) {
+                    ProviderError::context_length_exceeded(provider, 0, 0)
+                } else if is_content_filter_error(body) {
+                    ProviderError::content_filtered(provider, message, None, Some(false))
+                } else {
+                    ProviderError::invalid_request(provider, message)
+                }
             }
-            _ => ProviderError::api_error(provider, status, body.to_string()),
+            401 => ProviderError::authentication(provider, message),
+            402 => ProviderError::quota_exceeded(provider, message),
+            403 => {
+                if is_quota_error(body) {
+                    ProviderError::quota_exceeded(provider, message)
+                } else {
+                    ProviderError::authentication(provider, message)
+                }
+            }
+            404 => ProviderError::model_not_found(provider, message),
+            408 | 504 => ProviderError::timeout(provider, message),
+            413 => ProviderError::context_length_exceeded(provider, 0, 0),
+            429 => ProviderError::rate_limit(
+                provider,
+                crate::core::providers::shared::parse_retry_after_from_body(body),
+            ),
+            502 | 503 => ProviderError::provider_unavailable(provider, message),
+            500..=599 => ProviderError::api_error(provider, status, message),
+            _ => ProviderError::api_error(provider, status, message),
         }
     }
 
     /// Parse JSON error response.
     pub fn parse_json_error(provider: &'static str, json: &Value) -> ProviderError {
-        let message = json
-            .get("error")
-            .and_then(|e| e.get("message"))
-            .and_then(|m| m.as_str())
-            .or_else(|| json.get("message").and_then(|m| m.as_str()))
-            .or_else(|| json.get("error").and_then(|e| e.as_str()))
-            .unwrap_or("Unknown error");
+        let message = extract_error_message_from_json(json).unwrap_or("Unknown error");
 
         let error_type = json
             .get("error")
             .and_then(|e| e.get("type"))
             .and_then(|t| t.as_str())
             .or_else(|| json.get("type").and_then(|t| t.as_str()));
+        let error_code = json
+            .get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_str())
+            .or_else(|| json.get("code").and_then(|c| c.as_str()));
 
-        match error_type {
-            Some("invalid_request_error") => {
-                ProviderError::invalid_request(provider, message.to_string())
-            }
-            Some("authentication_error") => {
+        match (error_type, error_code) {
+            (Some("authentication_error" | "permission_error"), _)
+            | (_, Some("invalid_api_key" | "authentication_failed")) => {
                 ProviderError::authentication(provider, message.to_string())
             }
-            Some("rate_limit_error") => ProviderError::rate_limit(provider, None),
-            Some("quota_exceeded") => ProviderError::quota_exceeded(provider, message.to_string()),
+            (Some("rate_limit_error"), _) | (_, Some("rate_limit_exceeded")) => {
+                ProviderError::rate_limit(
+                    provider,
+                    json.get("retry_after")
+                        .and_then(|v| v.as_u64())
+                        .or_else(|| {
+                            json.get("error")
+                                .and_then(|e| e.get("retry_after"))
+                                .and_then(|v| v.as_u64())
+                        }),
+                )
+            }
+            (Some("insufficient_quota"), _)
+            | (_, Some("insufficient_quota" | "quota_exceeded")) => {
+                ProviderError::quota_exceeded(provider, message.to_string())
+            }
+            (_, Some("model_not_found")) => ProviderError::model_not_found(provider, message),
+            (Some("invalid_request_error" | "validation_error"), _) => {
+                ProviderError::invalid_request(provider, message.to_string())
+            }
+            (Some("context_length_exceeded"), _) => {
+                ProviderError::context_length_exceeded(provider, 0, 0)
+            }
+            (Some("content_filter" | "content_filter_error"), _) => {
+                ProviderError::content_filtered(provider, message.to_string(), None, Some(false))
+            }
+            (Some("overloaded_error"), _) => {
+                ProviderError::provider_unavailable(provider, message.to_string())
+            }
+            (Some("api_error" | "server_error"), _) => {
+                ProviderError::api_error(provider, 500, message.to_string())
+            }
             _ => ProviderError::api_error(provider, 500, message.to_string()),
         }
     }
+}
+
+fn extract_error_message(body: &str) -> Option<String> {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|json| extract_error_message_from_json(&json).map(str::to_string))
+}
+
+fn extract_error_message_from_json(json: &Value) -> Option<&str> {
+    json.get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .or_else(|| json.get("message").and_then(|m| m.as_str()))
+        .or_else(|| json.get("detail").and_then(|m| m.as_str()))
+        .or_else(|| json.get("error").and_then(|e| e.as_str()))
+}
+
+fn is_context_length_error(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("context_length")
+        || lower.contains("context length")
+        || lower.contains("maximum context")
+        || lower.contains("too many tokens")
+}
+
+fn is_content_filter_error(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("content_filter")
+        || lower.contains("content filter")
+        || lower.contains("safety")
+        || lower.contains("policy")
+}
+
+fn is_quota_error(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("insufficient_quota")
+        || lower.contains("quota")
+        || lower.contains("billing")
+        || lower.contains("credits")
 }
 
 /// Common URL builder.
@@ -232,4 +312,97 @@ pub fn validate_chat_request_common(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn http_mapper_extracts_json_message_for_invalid_request() {
+        let err = HttpErrorMapper::map_status_code(
+            "openai_like",
+            400,
+            r#"{"error":{"message":"bad prompt","type":"invalid_request_error"}}"#,
+        );
+
+        match err {
+            ProviderError::InvalidRequest { provider, message } => {
+                assert_eq!(provider, "openai_like");
+                assert_eq!(message, "bad prompt");
+            }
+            other => panic!("expected invalid request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_mapper_preserves_retry_after_for_rate_limits() {
+        let err = HttpErrorMapper::map_status_code(
+            "openai_like",
+            429,
+            r#"{"error":{"message":"slow down","retry_after":42}}"#,
+        );
+
+        match err {
+            ProviderError::RateLimit {
+                provider,
+                retry_after,
+                ..
+            } => {
+                assert_eq!(provider, "openai_like");
+                assert_eq!(retry_after, Some(42));
+            }
+            other => panic!("expected rate limit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_mapper_maps_special_statuses_to_specific_variants() {
+        assert!(matches!(
+            HttpErrorMapper::map_status_code("p", 408, "timeout"),
+            ProviderError::Timeout { .. }
+        ));
+        assert!(matches!(
+            HttpErrorMapper::map_status_code("p", 413, "too many tokens"),
+            ProviderError::ContextLengthExceeded { .. }
+        ));
+        assert!(matches!(
+            HttpErrorMapper::map_status_code("p", 503, "overloaded"),
+            ProviderError::ProviderUnavailable { .. }
+        ));
+    }
+
+    #[test]
+    fn json_error_mapper_uses_type_and_code() {
+        let rate = HttpErrorMapper::parse_json_error(
+            "openai_like",
+            &json!({
+                "error": {
+                    "type": "rate_limit_error",
+                    "message": "slow down",
+                    "retry_after": 17
+                }
+            }),
+        );
+        assert!(matches!(
+            rate,
+            ProviderError::RateLimit {
+                retry_after: Some(17),
+                ..
+            }
+        ));
+
+        let not_found = HttpErrorMapper::parse_json_error(
+            "openai_like",
+            &json!({
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "model_not_found",
+                    "message": "missing model"
+                }
+            }),
+        );
+        assert!(matches!(not_found, ProviderError::ModelNotFound { .. }));
+    }
 }

--- a/src/core/providers/openai/error_mapper.rs
+++ b/src/core/providers/openai/error_mapper.rs
@@ -5,6 +5,7 @@
 
 use super::error::OpenAIError;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
+use serde_json::Value;
 
 /// Error mapper for OpenAI provider
 #[derive(Debug, Clone, Copy, Default)]
@@ -12,6 +13,10 @@ pub struct OpenAIErrorMapper;
 
 impl ErrorMapper<OpenAIError> for OpenAIErrorMapper {
     fn map_http_error(&self, status_code: u16, response_body: &str) -> OpenAIError {
+        if has_openai_error_envelope(response_body) {
+            return OpenAIError::api_error("openai", status_code, response_body);
+        }
+
         // Map HTTP status codes to appropriate error types
         // Preserves response_body for structured error information
         match status_code {
@@ -26,6 +31,38 @@ impl ErrorMapper<OpenAIError> for OpenAIErrorMapper {
             500 => OpenAIError::api_error("openai", status_code, response_body),
             502 | 503 => OpenAIError::provider_unavailable("openai", response_body),
             _ => OpenAIError::api_error("openai", status_code, response_body),
+        }
+    }
+}
+
+fn has_openai_error_envelope(response_body: &str) -> bool {
+    serde_json::from_str::<Value>(response_body)
+        .ok()
+        .and_then(|value| value.get("error").cloned())
+        .is_some_and(|error| error.is_object())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::providers::ProviderError;
+
+    #[test]
+    fn map_http_error_preserves_openai_error_envelope_as_api_error() {
+        let body = r#"{"error":{"message":"bad model","type":"invalid_request_error","code":"model_not_found"}}"#;
+        let error = OpenAIErrorMapper.map_http_error(400, body);
+
+        match error {
+            ProviderError::ApiError {
+                provider,
+                status,
+                message,
+            } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(status, 400);
+                assert_eq!(message, body);
+            }
+            other => panic!("expected raw API error envelope, got {other:?}"),
         }
     }
 }

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -96,13 +96,16 @@ async fn test_openai_streaming_maps_non_success_status_before_sse()
     };
 
     match err {
-        ProviderError::RateLimit {
-            provider, message, ..
+        ProviderError::ApiError {
+            provider,
+            status,
+            message,
         } => {
             assert_eq!(provider, "openai");
+            assert_eq!(status, 429);
             assert!(message.contains("rate_limit_error"));
         }
-        other => panic!("expected OpenAI rate limit error, got {other:?}"),
+        other => panic!("expected OpenAI API error envelope, got {other:?}"),
     }
 
     Ok(())

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -4,7 +4,7 @@ use crate::core::providers::ProviderError;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::http::StatusCode;
 use actix_web::{HttpResponse, http::header};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
 struct OpenAiErrorResponse {
@@ -15,34 +15,49 @@ struct OpenAiErrorResponse {
 struct OpenAiErrorDetail {
     message: String,
     #[serde(rename = "type")]
-    error_type: &'static str,
+    error_type: String,
     param: Option<String>,
-    code: Option<&'static str>,
+    code: Option<String>,
 }
 
 struct OpenAiErrorSpec {
     status: StatusCode,
     message: String,
-    error_type: &'static str,
-    code: Option<&'static str>,
+    error_type: String,
+    param: Option<String>,
+    code: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct UpstreamErrorEnvelope {
+    error: UpstreamErrorDetail,
+}
+
+#[derive(Deserialize)]
+struct UpstreamErrorDetail {
+    message: Option<String>,
+    #[serde(rename = "type")]
+    error_type: Option<String>,
+    param: Option<String>,
+    code: Option<serde_json::Value>,
 }
 
 pub(crate) fn validation_error(message: impl Into<String>) -> HttpResponse {
-    build_response(OpenAiErrorSpec {
-        status: StatusCode::BAD_REQUEST,
-        message: message.into(),
-        error_type: "invalid_request_error",
-        code: Some("invalid_request"),
-    })
+    build_response(spec(
+        StatusCode::BAD_REQUEST,
+        message.into(),
+        "invalid_request_error",
+        "invalid_request",
+    ))
 }
 
 pub(crate) fn unauthorized_error(message: impl Into<String>) -> HttpResponse {
-    build_response(OpenAiErrorSpec {
-        status: StatusCode::UNAUTHORIZED,
-        message: message.into(),
-        error_type: "authentication_error",
-        code: Some("authentication_error"),
-    })
+    build_response(spec(
+        StatusCode::UNAUTHORIZED,
+        message.into(),
+        "authentication_error",
+        "authentication_error",
+    ))
 }
 
 pub(crate) fn gateway_error_response(error: &GatewayError) -> HttpResponse {
@@ -75,23 +90,34 @@ pub(crate) fn gateway_error_response(error: &GatewayError) -> HttpResponse {
         _ => {}
     }
 
-    builder.json(response_body(spec.message, spec.error_type, spec.code))
+    builder.json(response_body(
+        spec.message,
+        spec.error_type,
+        spec.param,
+        spec.code,
+    ))
 }
 
 fn build_response(spec: OpenAiErrorSpec) -> HttpResponse {
-    HttpResponse::build(spec.status).json(response_body(spec.message, spec.error_type, spec.code))
+    HttpResponse::build(spec.status).json(response_body(
+        spec.message,
+        spec.error_type,
+        spec.param,
+        spec.code,
+    ))
 }
 
 fn response_body(
     message: String,
-    error_type: &'static str,
-    code: Option<&'static str>,
+    error_type: String,
+    param: Option<String>,
+    code: Option<String>,
 ) -> OpenAiErrorResponse {
     OpenAiErrorResponse {
         error: OpenAiErrorDetail {
             message,
             error_type,
-            param: None,
+            param,
             code,
         },
     }
@@ -255,7 +281,9 @@ fn provider_error_spec(error: &ProviderError) -> OpenAiErrorSpec {
             "invalid_request_error",
             "content_filter",
         ),
-        ProviderError::ApiError { status, .. } => api_error_spec(*status, error.to_string()),
+        ProviderError::ApiError {
+            status, message, ..
+        } => api_error_spec(*status, message.clone()),
         ProviderError::TokenLimitExceeded { .. } => spec(
             StatusCode::BAD_REQUEST,
             error.to_string(),
@@ -297,7 +325,7 @@ fn provider_error_spec(error: &ProviderError) -> OpenAiErrorSpec {
 
 fn api_error_spec(status: u16, message: String) -> OpenAiErrorSpec {
     let status_code = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
-    match status {
+    let mut spec = match status {
         400 => spec(
             status_code,
             message,
@@ -327,6 +355,37 @@ fn api_error_spec(status: u16, message: String) -> OpenAiErrorSpec {
         ),
         500..=599 => spec(status_code, message, "server_error", "provider_api_error"),
         _ => spec(status_code, message, "server_error", "provider_api_error"),
+    };
+
+    if let Some(upstream) = parse_upstream_error_detail(&spec.message) {
+        if let Some(message) = upstream.message {
+            spec.message = message;
+        }
+        if let Some(error_type) = upstream.error_type {
+            spec.error_type = error_type;
+        }
+        if let Some(param) = upstream.param {
+            spec.param = Some(param);
+        }
+        if let Some(code) = upstream.code.and_then(error_code_to_string) {
+            spec.code = Some(code);
+        }
+    }
+
+    spec
+}
+
+fn parse_upstream_error_detail(message: &str) -> Option<UpstreamErrorDetail> {
+    serde_json::from_str::<UpstreamErrorEnvelope>(message)
+        .ok()
+        .map(|envelope| envelope.error)
+}
+
+fn error_code_to_string(value: serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) if !value.is_empty() => Some(value),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
     }
 }
 
@@ -339,8 +398,9 @@ fn spec(
     OpenAiErrorSpec {
         status,
         message,
-        error_type,
-        code: Some(code),
+        error_type: error_type.to_string(),
+        param: None,
+        code: Some(code.to_string()),
     }
 }
 
@@ -400,6 +460,32 @@ mod tests {
         let body = to_json(response).await;
         assert_eq!(body["error"]["type"], "server_error");
         assert_eq!(body["error"]["code"], "timeout");
+    }
+
+    #[actix_web::test]
+    async fn provider_api_error_preserves_upstream_openai_error_fields() {
+        let upstream = serde_json::json!({
+            "error": {
+                "message": "context window exceeded",
+                "type": "invalid_request_error",
+                "param": "messages",
+                "code": "context_length_exceeded"
+            }
+        });
+        let error = GatewayError::Provider(ProviderError::api_error(
+            "openai",
+            400,
+            upstream.to_string(),
+        ));
+
+        let response = gateway_error_response(&error);
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_json(response).await;
+        assert_eq!(body["error"]["message"], "context window exceeded");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["param"], "messages");
+        assert_eq!(body["error"]["code"], "context_length_exceeded");
     }
 
     async fn to_json(response: HttpResponse) -> Value {


### PR DESCRIPTION
## Summary
- preserve structured upstream OpenAI error envelopes as provider API errors instead of flattening them to generic variants
- parse upstream error message/type/param/code when building OpenAI-compatible gateway error responses
- improve shared HTTP error mapping for retry-after, context length, quota, content filter, timeout, and unavailable cases

Fixes #766

## Verification
- `cargo check --all-features --locked`
- `cargo test http_mapper --all-features --locked`
- `cargo test map_http_error_preserves_openai_error_envelope_as_api_error --all-features --locked`
- `cargo test provider_api_error_preserves_upstream_openai_error_fields --all-features --locked`
- `cargo test test_openai_streaming_maps_non_success_status_before_sse --all-features --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --locked`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`