### PR TITLE
fix(anthropic): preserve rich request content

### DIFF
--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -14,8 +14,11 @@ use crate::core::providers::base::{
 use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::{
-    chat::ChatMessage, chat::ChatRequest, content::ContentPart, message::MessageRole,
+    chat::{ChatMessage, ChatRequest},
+    content::ContentPart,
+    message::{MessageContent, MessageRole},
     responses::ChatResponse,
+    tools::{Tool, ToolChoice},
 };
 
 use super::config::AnthropicConfig;
@@ -23,7 +26,9 @@ use super::error::{
     anthropic_api_error, anthropic_auth_error, anthropic_network_error, anthropic_parse_error,
     anthropic_rate_limit_error,
 };
-use super::models::{ModelFeature, get_anthropic_registry};
+#[cfg(test)]
+use super::models::get_anthropic_registry;
+use super::models::{ModelFeature, ModelSpec};
 
 /// Anthropic API client
 #[derive(Debug, Clone)]
@@ -250,228 +255,8 @@ impl AnthropicClient {
             _ => anthropic_api_error(status, body),
         }
     }
-
-    /// Request
-    fn transform_chat_request(&self, request: &ChatRequest) -> Result<Value, ProviderError> {
-        if self.config.uses_compatible_model_allow_list()
-            && !self.config.allows_unknown_model(&request.model)
-        {
-            return Err(anthropic_api_error(
-                400,
-                format!("Unsupported model: {}", request.model),
-            ));
-        }
-
-        let registry = get_anthropic_registry();
-
-        // Check
-        let model_spec = if self.config.uses_compatible_model_allow_list() {
-            None
-        } else {
-            registry.get_model_spec(&request.model)
-        };
-        if model_spec.is_none() && !self.config.allows_unknown_model(&request.model) {
-            return Err(anthropic_api_error(
-                400,
-                format!("Unsupported model: {}", request.model),
-            ));
-        }
-        if model_spec.is_none()
-            && (request
-                .tools
-                .as_ref()
-                .is_some_and(|tools| !tools.is_empty())
-                || Self::has_anthropic_tools_extra_param(request)
-                || request.functions.as_ref().is_some_and(|f| !f.is_empty())
-                || request.function_call.is_some())
-        {
-            return Err(ProviderError::not_supported(
-                "anthropic",
-                format!(
-                    "Unknown model {} cannot declare tool calling support",
-                    request.model
-                ),
-            ));
-        }
-        if model_spec.is_none() && Self::has_unsupported_unknown_model_content(request) {
-            return Err(ProviderError::not_supported(
-                "anthropic",
-                format!(
-                    "Unknown model {} only supports text and image content",
-                    request.model
-                ),
-            ));
-        }
-        if model_spec.is_none()
-            && Self::has_image_content(request)
-            && !self.config.allows_unknown_model_image_input(&request.model)
-        {
-            return Err(ProviderError::not_supported(
-                "anthropic",
-                format!(
-                    "Unknown model {} does not support image input",
-                    request.model
-                ),
-            ));
-        }
-
-        // The Messages API only returns a single candidate; any n other than 1
-        // (including 0) cannot be honored, so reject it instead of silently
-        // returning the wrong number of choices.
-        if let Some(n) = request.n
-            && n != 1
-        {
-            return Err(ProviderError::invalid_request(
-                "anthropic",
-                format!("anthropic only supports n=1 (got n={})", n),
-            ));
-        }
-
-        // Warn once about OpenAI-style parameters Anthropic has no equivalent for.
-        let mut ignored_params = Vec::new();
-        if request.frequency_penalty.is_some() {
-            ignored_params.push("frequency_penalty");
-        }
-        if request.presence_penalty.is_some() {
-            ignored_params.push("presence_penalty");
-        }
-        if request.seed.is_some() {
-            ignored_params.push("seed");
-        }
-        if request.logit_bias.is_some() {
-            ignored_params.push("logit_bias");
-        }
-        if !ignored_params.is_empty() {
-            tracing::warn!(
-                "Anthropic request ignores unsupported parameters: {}",
-                ignored_params.join(", ")
-            );
-        }
-
-        // Separate system messages from user messages
-        let (system_message, messages) = self.separate_system_messages(&request.messages)?;
-        let tool_name_map = self.anthropic_tool_name_map_for_request(request)?;
-
-        let anthropic_messages = self.transform_messages(messages, model_spec, &tool_name_map)?;
-
-        // Request
-        let mut anthropic_request = json!({
-            "model": request.model,
-            "max_tokens": request.max_tokens.unwrap_or(4096),
-            "messages": anthropic_messages,
-        });
-
-        // Add system message
-        if let Some(system) = system_message {
-            anthropic_request["system"] = json!(system);
-        }
-
-        // Add optional parameters
-        if let Some(temperature) = request.temperature {
-            anthropic_request["temperature"] = json!(temperature);
-        }
-
-        if let Some(top_p) = request.top_p {
-            anthropic_request["top_p"] = json!(top_p);
-        }
-
-        if let Some(stop) = &request.stop {
-            anthropic_request["stop_sequences"] = json!(stop);
-        }
-
-        // Add tool support
-        if let Some(tools) = &request.tools
-            && !tools.is_empty()
-        {
-            let Some(model_spec) = model_spec else {
-                return Err(ProviderError::not_supported(
-                    "anthropic",
-                    format!(
-                        "Unknown model {} cannot declare tool calling support",
-                        request.model
-                    ),
-                ));
-            };
-            if !model_spec.features.contains(&ModelFeature::ToolCalling) {
-                return Err(ProviderError::not_supported(
-                    "anthropic",
-                    format!("Model {} does not support tool calling", request.model),
-                ));
-            }
-            let anthropic_tools = self.transform_tools(tools)?;
-            anthropic_request["tools"] = json!(anthropic_tools);
-
-            if let Some(tool_choice) = &request.tool_choice {
-                anthropic_request["tool_choice"] =
-                    self.transform_tool_choice(tool_choice, &tool_name_map)?;
-            }
-        }
-
-        // Add thinking configuration
-        if let Some(thinking) = &request.thinking
-            && thinking.enabled
-        {
-            let Some(model_spec) = model_spec else {
-                return Err(ProviderError::not_supported(
-                    "anthropic",
-                    format!(
-                        "Unknown model {} cannot declare thinking support",
-                        request.model
-                    ),
-                ));
-            };
-            if !model_spec.features.contains(&ModelFeature::ThinkingMode) {
-                return Err(ProviderError::not_supported(
-                    "anthropic",
-                    format!("Model {} does not support thinking", request.model),
-                ));
-            }
-            let budget = thinking.budget_tokens.unwrap_or(10_000);
-            // Anthropic requires max_tokens > budget_tokens. If the default (4096)
-            // is not greater than budget_tokens, raise max_tokens to budget + 1.
-            let current_max = request.max_tokens.unwrap_or(4096);
-            if current_max <= budget {
-                anthropic_request["max_tokens"] = json!(budget + 1);
-            }
-            anthropic_request["thinking"] = json!({
-                "type": "enabled",
-                "budget_tokens": budget
-            });
-        }
-
-        // Structured outputs: pass json_schema response_format to Anthropic.
-        if let Some(rf) = &request.response_format
-            && rf.format_type == "json_schema"
-            && let Some(schema) = &rf.json_schema
-        {
-            anthropic_request["response_format"] = json!({
-                "type": "json_schema",
-                "json_schema": schema
-            });
-        }
-
-        // Anthropic built-in (server-side) tools passed via extra_params.
-        // These are appended after any user-defined function tools.
-        if let Some(arr) = request
-            .extra_params
-            .get("anthropic_tools")
-            .and_then(|v| v.as_array())
-            .filter(|a| !a.is_empty())
-        {
-            let mut merged: Vec<Value> = anthropic_request
-                .get("tools")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
-            merged.extend(arr.iter().cloned());
-            anthropic_request["tools"] = json!(merged);
-        }
-
-        Ok(anthropic_request)
-    }
-
     /// Separate system messages from user messages
-    fn separate_system_messages(
+    pub(super) fn separate_system_messages(
         &self,
         messages: &[ChatMessage],
     ) -> Result<(Option<String>, Vec<ChatMessage>), ProviderError> {
@@ -483,13 +268,20 @@ impl AnthropicClient {
                 MessageRole::System | MessageRole::Developer => {
                     if let Some(content) = &message.content {
                         match content {
-                            crate::core::types::message::MessageContent::Text(text) => {
+                            MessageContent::Text(text) => {
                                 system_parts.push(text.clone());
                             }
-                            crate::core::types::message::MessageContent::Parts(parts) => {
+                            MessageContent::Parts(parts) => {
                                 for part in parts {
-                                    if let ContentPart::Text { text } = part {
-                                        system_parts.push(text.clone());
+                                    match part {
+                                        ContentPart::Text { text } => {
+                                            system_parts.push(text.clone());
+                                        }
+                                        other => {
+                                            return Err(request_utils::unsupported_content_part(
+                                                other,
+                                            ));
+                                        }
                                     }
                                 }
                             }
@@ -512,10 +304,10 @@ impl AnthropicClient {
     }
 
     /// Transform messages to Anthropic format
-    fn transform_messages(
+    pub(super) fn transform_messages(
         &self,
         messages: Vec<ChatMessage>,
-        model_spec: Option<&super::models::ModelSpec>,
+        model_spec: Option<&ModelSpec>,
         tool_name_map: &request_utils::ToolNameMap,
     ) -> Result<Vec<Value>, ProviderError> {
         let mut anthropic_messages = Vec::new();
@@ -525,12 +317,13 @@ impl AnthropicClient {
                 let tool_use_id = message.tool_call_id.clone().ok_or_else(|| {
                     anthropic_parse_error("Tool/function message missing tool_call_id")
                 })?;
+                let content = Self::tool_result_content(message.content.clone())?;
                 anthropic_messages.push(json!({
                     "role": "user",
                     "content": [{
                         "type": "tool_result",
                         "tool_use_id": tool_use_id,
-                        "content": Self::tool_result_content(message.content.clone())
+                        "content": content
                     }]
                 }));
                 continue;
@@ -545,10 +338,8 @@ impl AnthropicClient {
 
             let content = if let Some(content) = message.content {
                 match content {
-                    crate::core::types::message::MessageContent::Text(text) => {
-                        json!(text)
-                    }
-                    crate::core::types::message::MessageContent::Parts(parts) => {
+                    MessageContent::Text(text) => json!(text),
+                    MessageContent::Parts(parts) => {
                         let mut anthropic_parts = Vec::new();
 
                         for part in parts {
@@ -567,22 +358,26 @@ impl AnthropicClient {
                                     // Handle
                                     if image_url.url.starts_with("data:") {
                                         // Base64 format image
-                                        let parts: Vec<&str> = image_url.url.split(',').collect();
-                                        if parts.len() == 2 {
-                                            let media_type = parts[0]
-                                                .strip_prefix("data:")
-                                                .and_then(|s| s.split(';').next())
-                                                .unwrap_or("image/jpeg");
+                                        let (metadata, data) =
+                                            image_url.url.split_once(',').ok_or_else(|| {
+                                                ProviderError::invalid_request(
+                                                    "anthropic",
+                                                    "Invalid data URL image content",
+                                                )
+                                            })?;
+                                        let media_type = metadata
+                                            .strip_prefix("data:")
+                                            .and_then(|s| s.split(';').next())
+                                            .unwrap_or("image/jpeg");
 
-                                            anthropic_parts.push(json!({
-                                                "type": "image",
-                                                "source": {
-                                                    "type": "base64",
-                                                    "media_type": media_type,
-                                                    "data": parts[1]
-                                                }
-                                            }));
-                                        }
+                                        anthropic_parts.push(json!({
+                                            "type": "image",
+                                            "source": {
+                                                "type": "base64",
+                                                "media_type": media_type,
+                                                "data": data
+                                            }
+                                        }));
                                     } else {
                                         // URL format image - requires download and conversion
                                         // NOTE: URL image download and conversion not yet implemented
@@ -606,22 +401,53 @@ impl AnthropicClient {
                                         }
                                     }));
                                 }
-                                ContentPart::Document { source, .. }
-                                    if model_spec.is_some_and(|spec| {
-                                        spec.features.contains(&ModelFeature::MultimodalSupport)
-                                    }) =>
+                                ContentPart::Document {
+                                    source,
+                                    cache_control,
+                                } if model_spec.is_some_and(|spec| {
+                                    spec.features.contains(&ModelFeature::MultimodalSupport)
+                                }) =>
                                 {
-                                    anthropic_parts.push(json!({
+                                    let mut document = json!({
                                         "type": "document",
                                         "source": {
                                             "type": "base64",
                                             "media_type": source.media_type,
                                             "data": source.data
                                         }
+                                    });
+                                    if self.config.enable_cache_control
+                                        && let Some(cache_control) = cache_control
+                                    {
+                                        document["cache_control"] = json!(cache_control);
+                                    }
+                                    anthropic_parts.push(document);
+                                }
+                                ContentPart::ToolUse { id, name, input } if role == "assistant" => {
+                                    anthropic_parts.push(json!({
+                                        "type": "tool_use",
+                                        "id": id,
+                                        "name": request_utils::anthropic_tool_name(&name),
+                                        "input": input
                                     }));
                                 }
-                                _ => {
-                                    // Other content types not yet supported
+                                ContentPart::ToolResult {
+                                    tool_use_id,
+                                    content,
+                                    is_error,
+                                } if role == "user" => {
+                                    let mut tool_result = json!({
+                                        "type": "tool_result",
+                                        "tool_use_id": tool_use_id,
+                                        "content": content
+                                    });
+                                    if let Some(is_error) = is_error {
+                                        tool_result["is_error"] = json!(is_error);
+                                    }
+                                    anthropic_parts.push(tool_result);
+                                }
+                                other => {
+                                    return Err(request_utils::unsupported_content_part(&other));
                                 }
                             }
                         }
@@ -643,14 +469,23 @@ impl AnthropicClient {
                 let mut anthropic_content =
                     Self::content_value_to_blocks(&anthropic_message["content"]);
                 for tool_call in tool_calls {
+                    let input = serde_json::from_str::<Value>(&tool_call.function.arguments)
+                        .map_err(|error| {
+                            ProviderError::invalid_request(
+                                "anthropic",
+                                format!(
+                                    "Tool call '{}' arguments must be valid JSON: {}",
+                                    tool_call.id, error
+                                ),
+                            )
+                        })?;
                     anthropic_content.push(json!({
                         "type": "tool_use",
                         "id": tool_call.id,
                         "name": request_utils::declared_tool_name(
                             &tool_call.function.name, tool_name_map, "Tool call"
                         )?,
-                        "input": serde_json::from_str::<Value>(&tool_call.function.arguments)
-                            .unwrap_or(json!({}))
+                        "input": input
                     }));
                 }
                 anthropic_message["content"] = json!(anthropic_content);
@@ -732,46 +567,43 @@ impl AnthropicClient {
         }
     }
 
-    fn tool_result_content(content: Option<crate::core::types::message::MessageContent>) -> Value {
+    fn tool_result_content(content: Option<MessageContent>) -> Result<Value, ProviderError> {
         match content {
-            Some(crate::core::types::message::MessageContent::Text(text)) => json!(text),
-            Some(crate::core::types::message::MessageContent::Parts(parts)) => {
+            Some(MessageContent::Text(text)) => Ok(json!(text)),
+            Some(MessageContent::Parts(parts)) => {
                 let text = parts
                     .into_iter()
-                    .filter_map(|part| match part {
-                        ContentPart::Text { text } => Some(text),
-                        _ => None,
+                    .map(|part| match part {
+                        ContentPart::Text { text } => Ok(text),
+                        other => Err(request_utils::unsupported_content_part(&other)),
                     })
-                    .collect::<Vec<_>>()
+                    .collect::<Result<Vec<_>, _>>()?
                     .join("\n");
-                json!(text)
+                Ok(json!(text))
             }
-            None => json!(""),
+            None => Ok(json!("")),
         }
     }
 
     /// Transform tool definitions
-    fn transform_tools(
-        &self,
-        tools: &[crate::core::types::tools::Tool],
-    ) -> Result<Vec<Value>, ProviderError> {
+    pub(super) fn transform_tools(&self, tools: &[Tool]) -> Result<Vec<Value>, ProviderError> {
         request_utils::anthropic_tools(tools)
     }
 
     /// Transform tool choice
-    fn transform_tool_choice(
+    pub(super) fn transform_tool_choice(
         &self,
-        tool_choice: &crate::core::types::tools::ToolChoice,
+        tool_choice: &ToolChoice,
         tool_name_map: &request_utils::ToolNameMap,
     ) -> Result<Value, ProviderError> {
         match tool_choice {
-            crate::core::types::tools::ToolChoice::String(choice) => match choice.as_str() {
+            ToolChoice::String(choice) => match choice.as_str() {
                 "auto" => Ok(json!({"type": "auto"})),
                 "none" => Ok(json!({"type": "none"})),
                 "required" => Ok(json!({"type": "any"})),
                 _ => Ok(json!({"type": "auto"})),
             },
-            crate::core::types::tools::ToolChoice::Specific { function, .. } => {
+            ToolChoice::Specific { function, .. } => {
                 if let Some(func) = function {
                     Ok(json!({
                         "type": "tool",
@@ -787,6 +619,7 @@ impl AnthropicClient {
     }
 }
 
+mod request;
 mod request_utils;
 mod response;
 mod usage;

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -30,6 +30,8 @@ use super::error::{
 use super::models::get_anthropic_registry;
 use super::models::{ModelFeature, ModelSpec};
 
+const EXTENDED_CACHE_TTL_BETA: &str = "extended-cache-ttl-2025-04-11";
+
 /// Anthropic API client
 #[derive(Debug, Clone)]
 pub struct AnthropicClient {
@@ -180,7 +182,7 @@ impl AnthropicClient {
 
         // Extended / interleaved thinking requires the beta header.
         if request.thinking.as_ref().is_some_and(|t| t.enabled) {
-            features.push("interleaved-thinking-2025-05-14".to_string());
+            Self::push_beta_feature(&mut features, "interleaved-thinking-2025-05-14");
         }
 
         // Computer-use built-in tool requires its own beta header.
@@ -191,10 +193,14 @@ impl AnthropicClient {
         {
             for tool in arr {
                 if tool.get("type").and_then(|t| t.as_str()) == Some("computer_20241022") {
-                    features.push("computer-use-2024-10-22".to_string());
+                    Self::push_beta_feature(&mut features, "computer-use-2024-10-22");
                     break;
                 }
             }
+        }
+
+        if Self::request_uses_extended_cache_ttl(request) {
+            Self::push_beta_feature(&mut features, EXTENDED_CACHE_TTL_BETA);
         }
 
         // Caller-supplied beta flags via extra_params["anthropic_beta"].
@@ -203,15 +209,12 @@ impl AnthropicClient {
                 Value::Array(arr) => {
                     for item in arr {
                         if let Some(s) = item.as_str() {
-                            let s = s.to_string();
-                            if !features.contains(&s) {
-                                features.push(s);
-                            }
+                            Self::push_beta_feature(&mut features, s);
                         }
                     }
                 }
-                Value::String(s) if !features.contains(s) => {
-                    features.push(s.clone());
+                Value::String(s) => {
+                    Self::push_beta_feature(&mut features, s);
                 }
                 _ => {}
             }
@@ -222,6 +225,34 @@ impl AnthropicClient {
         }
 
         vec![header("anthropic-beta", features.join(","))]
+    }
+
+    fn push_beta_feature(features: &mut Vec<String>, feature: &str) {
+        if !features.iter().any(|existing| existing == feature) {
+            features.push(feature.to_string());
+        }
+    }
+
+    fn request_uses_extended_cache_ttl(request: &ChatRequest) -> bool {
+        request
+            .extra_params
+            .get("cache_control")
+            .is_some_and(Self::cache_control_value_uses_extended_ttl)
+    }
+
+    fn cache_control_value_uses_extended_ttl(value: &Value) -> bool {
+        match value {
+            Value::Object(map) => {
+                map.get("ttl").and_then(Value::as_str) == Some("1h")
+                    || map
+                        .values()
+                        .any(Self::cache_control_value_uses_extended_ttl)
+            }
+            Value::Array(values) => values
+                .iter()
+                .any(Self::cache_control_value_uses_extended_ttl),
+            _ => false,
+        }
     }
 
     /// Handle
@@ -307,6 +338,7 @@ impl AnthropicClient {
     pub(super) fn transform_messages(
         &self,
         messages: Vec<ChatMessage>,
+        model: &str,
         model_spec: Option<&ModelSpec>,
         tool_name_map: &request_utils::ToolNameMap,
     ) -> Result<Vec<Value>, ProviderError> {
@@ -317,7 +349,8 @@ impl AnthropicClient {
                 let tool_use_id = message.tool_call_id.clone().ok_or_else(|| {
                     anthropic_parse_error("Tool/function message missing tool_call_id")
                 })?;
-                let content = Self::tool_result_content(message.content.clone())?;
+                let content =
+                    self.tool_result_content(message.content.clone(), model, model_spec)?;
                 anthropic_messages.push(json!({
                     "role": "user",
                     "content": [{
@@ -347,87 +380,23 @@ impl AnthropicClient {
                                 ContentPart::Text { text } => {
                                     anthropic_parts.push(json!({
                                         "type": "text",
-                                        "text": text
+                                            "text": text
                                     }));
                                 }
-                                ContentPart::ImageUrl { image_url }
-                                    if model_spec.is_none_or(|spec| {
-                                        spec.features.contains(&ModelFeature::MultimodalSupport)
-                                    }) =>
-                                {
-                                    // Handle
-                                    if image_url.url.starts_with("data:") {
-                                        // Base64 format image
-                                        let (metadata, data) =
-                                            image_url.url.split_once(',').ok_or_else(|| {
-                                                ProviderError::invalid_request(
-                                                    "anthropic",
-                                                    "Invalid data URL image content",
-                                                )
-                                            })?;
-                                        let media_type = metadata
-                                            .strip_prefix("data:")
-                                            .and_then(|s| s.split(';').next())
-                                            .unwrap_or("image/jpeg");
-
-                                        anthropic_parts.push(json!({
-                                            "type": "image",
-                                            "source": {
-                                                "type": "base64",
-                                                "media_type": media_type,
-                                                "data": data
-                                            }
-                                        }));
-                                    } else {
-                                        // URL format image - requires download and conversion
-                                        // NOTE: URL image download and conversion not yet implemented
-                                        return Err(anthropic_api_error(
-                                            400,
-                                            "URL images not yet supported, use base64 format",
-                                        ));
-                                    }
-                                }
-                                ContentPart::Image { source, .. }
-                                    if model_spec.is_none_or(|spec| {
-                                        spec.features.contains(&ModelFeature::MultimodalSupport)
-                                    }) =>
-                                {
-                                    anthropic_parts.push(json!({
-                                        "type": "image",
-                                        "source": {
-                                            "type": "base64",
-                                            "media_type": source.media_type,
-                                            "data": source.data
-                                        }
-                                    }));
-                                }
-                                ContentPart::Document {
-                                    source,
-                                    cache_control,
-                                } if model_spec.is_some_and(|spec| {
-                                    spec.features.contains(&ModelFeature::MultimodalSupport)
-                                }) =>
-                                {
-                                    let mut document = json!({
-                                        "type": "document",
-                                        "source": {
-                                            "type": "base64",
-                                            "media_type": source.media_type,
-                                            "data": source.data
-                                        }
-                                    });
-                                    if self.config.enable_cache_control
-                                        && let Some(cache_control) = cache_control
-                                    {
-                                        document["cache_control"] = json!(cache_control);
-                                    }
-                                    anthropic_parts.push(document);
+                                ContentPart::ImageUrl { .. }
+                                | ContentPart::Image { .. }
+                                | ContentPart::Document { .. } => {
+                                    anthropic_parts.push(self.content_part_to_anthropic_block(
+                                        part, model, model_spec,
+                                    )?);
                                 }
                                 ContentPart::ToolUse { id, name, input } if role == "assistant" => {
                                     anthropic_parts.push(json!({
                                         "type": "tool_use",
                                         "id": id,
-                                        "name": request_utils::anthropic_tool_name(&name),
+                                        "name": request_utils::declared_tool_name(
+                                            &name, tool_name_map, "Tool use"
+                                        )?,
                                         "input": input
                                     }));
                                 }
@@ -495,6 +464,120 @@ impl AnthropicClient {
         }
 
         Ok(anthropic_messages)
+    }
+
+    fn content_part_to_anthropic_block(
+        &self,
+        part: ContentPart,
+        model: &str,
+        model_spec: Option<&ModelSpec>,
+    ) -> Result<Value, ProviderError> {
+        match part {
+            ContentPart::Text { text } => Ok(json!({
+                "type": "text",
+                "text": text
+            })),
+            ContentPart::ImageUrl { image_url } => {
+                if !Self::supports_multimodal_content(model_spec) {
+                    return Err(ProviderError::not_supported(
+                        "anthropic",
+                        format!("Model {} does not support image content", model),
+                    ));
+                }
+                if !image_url.url.starts_with("data:") {
+                    return Err(anthropic_api_error(
+                        400,
+                        "URL images not yet supported, use base64 format",
+                    ));
+                }
+
+                let (metadata, data) = image_url.url.split_once(',').ok_or_else(|| {
+                    ProviderError::invalid_request("anthropic", "Invalid data URL image content")
+                })?;
+                let media_type = metadata
+                    .strip_prefix("data:")
+                    .and_then(|s| s.split(';').next())
+                    .unwrap_or("image/jpeg");
+
+                Ok(json!({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": data
+                    }
+                }))
+            }
+            ContentPart::Image { source, .. } => {
+                if !Self::supports_multimodal_content(model_spec) {
+                    return Err(ProviderError::not_supported(
+                        "anthropic",
+                        format!("Model {} does not support image content", model),
+                    ));
+                }
+                Ok(json!({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": source.media_type,
+                        "data": source.data
+                    }
+                }))
+            }
+            ContentPart::Document {
+                source,
+                cache_control,
+            } => {
+                if !Self::supports_multimodal_content(model_spec) {
+                    return Err(ProviderError::not_supported(
+                        "anthropic",
+                        format!("Model {} does not support document content", model),
+                    ));
+                }
+                let mut document = json!({
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": source.media_type,
+                        "data": source.data
+                    }
+                });
+                if self.config.enable_cache_control
+                    && let Some(cache_control) = cache_control
+                {
+                    Self::ensure_cache_control_supported(model, model_spec)?;
+                    document["cache_control"] = json!(cache_control);
+                }
+                Ok(document)
+            }
+            other => Err(request_utils::unsupported_content_part(&other)),
+        }
+    }
+
+    fn supports_multimodal_content(model_spec: Option<&ModelSpec>) -> bool {
+        model_spec.is_none_or(|spec| spec.features.contains(&ModelFeature::MultimodalSupport))
+    }
+
+    pub(super) fn ensure_cache_control_supported(
+        model: &str,
+        model_spec: Option<&ModelSpec>,
+    ) -> Result<(), ProviderError> {
+        let Some(model_spec) = model_spec else {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} cannot declare cache control support",
+                    model
+                ),
+            ));
+        };
+        if model_spec.features.contains(&ModelFeature::CacheControl) {
+            return Ok(());
+        }
+        Err(ProviderError::not_supported(
+            "anthropic",
+            format!("Model {} does not support cache control", model),
+        ))
     }
 
     pub(crate) fn has_multimodal_content(request: &ChatRequest) -> bool {
@@ -567,19 +650,28 @@ impl AnthropicClient {
         }
     }
 
-    fn tool_result_content(content: Option<MessageContent>) -> Result<Value, ProviderError> {
+    fn tool_result_content(
+        &self,
+        content: Option<MessageContent>,
+        model: &str,
+        model_spec: Option<&ModelSpec>,
+    ) -> Result<Value, ProviderError> {
         match content {
             Some(MessageContent::Text(text)) => Ok(json!(text)),
             Some(MessageContent::Parts(parts)) => {
-                let text = parts
+                let blocks = parts
                     .into_iter()
                     .map(|part| match part {
-                        ContentPart::Text { text } => Ok(text),
+                        ContentPart::Text { .. }
+                        | ContentPart::ImageUrl { .. }
+                        | ContentPart::Image { .. }
+                        | ContentPart::Document { .. } => {
+                            self.content_part_to_anthropic_block(part, model, model_spec)
+                        }
                         other => Err(request_utils::unsupported_content_part(&other)),
                     })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .join("\n");
-                Ok(json!(text))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(json!(blocks))
             }
             None => Ok(json!("")),
         }

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -111,7 +111,8 @@ impl AnthropicClient {
         let (system_message, messages) = self.separate_system_messages(&request.messages)?;
         let tool_name_map = self.anthropic_tool_name_map_for_request(request)?;
 
-        let anthropic_messages = self.transform_messages(messages, model_spec, &tool_name_map)?;
+        let anthropic_messages =
+            self.transform_messages(messages, &request.model, model_spec, &tool_name_map)?;
 
         let mut anthropic_request = json!({
             "model": request.model,
@@ -139,6 +140,7 @@ impl AnthropicClient {
         if self.config.enable_cache_control
             && let Some(cache_control) = request.extra_params.get("cache_control")
         {
+            Self::ensure_cache_control_supported(&request.model, model_spec)?;
             anthropic_request["cache_control"] = cache_control.clone();
         }
 

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -1,0 +1,239 @@
+//! Anthropic request transformation.
+
+use serde_json::{Value, json};
+
+use crate::core::providers::anthropic::error::anthropic_api_error;
+use crate::core::providers::anthropic::models::{ModelFeature, get_anthropic_registry};
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::chat::ChatRequest;
+
+use super::AnthropicClient;
+
+impl AnthropicClient {
+    pub(super) fn transform_chat_request(
+        &self,
+        request: &ChatRequest,
+    ) -> Result<Value, ProviderError> {
+        if self.config.uses_compatible_model_allow_list()
+            && !self.config.allows_unknown_model(&request.model)
+        {
+            return Err(anthropic_api_error(
+                400,
+                format!("Unsupported model: {}", request.model),
+            ));
+        }
+
+        let registry = get_anthropic_registry();
+
+        let model_spec = if self.config.uses_compatible_model_allow_list() {
+            None
+        } else {
+            registry.get_model_spec(&request.model)
+        };
+        if model_spec.is_none() && !self.config.allows_unknown_model(&request.model) {
+            return Err(anthropic_api_error(
+                400,
+                format!("Unsupported model: {}", request.model),
+            ));
+        }
+        if model_spec.is_none()
+            && (request
+                .tools
+                .as_ref()
+                .is_some_and(|tools| !tools.is_empty())
+                || Self::has_anthropic_tools_extra_param(request)
+                || request.functions.as_ref().is_some_and(|f| !f.is_empty())
+                || request.function_call.is_some())
+        {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} cannot declare tool calling support",
+                    request.model
+                ),
+            ));
+        }
+        if model_spec.is_none() && Self::has_unsupported_unknown_model_content(request) {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} only supports text and image content",
+                    request.model
+                ),
+            ));
+        }
+        if model_spec.is_none()
+            && Self::has_image_content(request)
+            && !self.config.allows_unknown_model_image_input(&request.model)
+        {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Unknown model {} does not support image input",
+                    request.model
+                ),
+            ));
+        }
+
+        // The Messages API only returns a single candidate; any n other than 1
+        // (including 0) cannot be honored, so reject it instead of silently
+        // returning the wrong number of choices.
+        if let Some(n) = request.n
+            && n != 1
+        {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!("anthropic only supports n=1 (got n={})", n),
+            ));
+        }
+
+        // Warn once about OpenAI-style parameters Anthropic has no equivalent for.
+        let mut ignored_params = Vec::new();
+        if request.frequency_penalty.is_some() {
+            ignored_params.push("frequency_penalty");
+        }
+        if request.presence_penalty.is_some() {
+            ignored_params.push("presence_penalty");
+        }
+        if request.seed.is_some() {
+            ignored_params.push("seed");
+        }
+        if request.logit_bias.is_some() {
+            ignored_params.push("logit_bias");
+        }
+        if !ignored_params.is_empty() {
+            tracing::warn!(
+                "Anthropic request ignores unsupported parameters: {}",
+                ignored_params.join(", ")
+            );
+        }
+
+        let (system_message, messages) = self.separate_system_messages(&request.messages)?;
+        let tool_name_map = self.anthropic_tool_name_map_for_request(request)?;
+
+        let anthropic_messages = self.transform_messages(messages, model_spec, &tool_name_map)?;
+
+        let mut anthropic_request = json!({
+            "model": request.model,
+            "max_tokens": request.max_tokens.unwrap_or(4096),
+            "messages": anthropic_messages,
+        });
+
+        if let Some(system) = system_message {
+            anthropic_request["system"] = json!(system);
+        }
+
+        // Add optional parameters
+        if let Some(temperature) = request.temperature {
+            anthropic_request["temperature"] = json!(temperature);
+        }
+
+        if let Some(top_p) = request.top_p {
+            anthropic_request["top_p"] = json!(top_p);
+        }
+
+        if let Some(user) = &request.user {
+            anthropic_request["metadata"] = json!({ "user_id": user });
+        }
+
+        if self.config.enable_cache_control
+            && let Some(cache_control) = request.extra_params.get("cache_control")
+        {
+            anthropic_request["cache_control"] = cache_control.clone();
+        }
+
+        if let Some(stop) = &request.stop {
+            anthropic_request["stop_sequences"] = json!(stop);
+        }
+
+        // Add tool support
+        if let Some(tools) = &request.tools
+            && !tools.is_empty()
+        {
+            let Some(model_spec) = model_spec else {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare tool calling support",
+                        request.model
+                    ),
+                ));
+            };
+            if !model_spec.features.contains(&ModelFeature::ToolCalling) {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!("Model {} does not support tool calling", request.model),
+                ));
+            }
+            let anthropic_tools = self.transform_tools(tools)?;
+            anthropic_request["tools"] = json!(anthropic_tools);
+
+            if let Some(tool_choice) = &request.tool_choice {
+                anthropic_request["tool_choice"] =
+                    self.transform_tool_choice(tool_choice, &tool_name_map)?;
+            }
+        }
+
+        // Add thinking configuration
+        if let Some(thinking) = &request.thinking
+            && thinking.enabled
+        {
+            let Some(model_spec) = model_spec else {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!(
+                        "Unknown model {} cannot declare thinking support",
+                        request.model
+                    ),
+                ));
+            };
+            if !model_spec.features.contains(&ModelFeature::ThinkingMode) {
+                return Err(ProviderError::not_supported(
+                    "anthropic",
+                    format!("Model {} does not support thinking", request.model),
+                ));
+            }
+            let budget = thinking.budget_tokens.unwrap_or(10_000);
+            // Anthropic requires max_tokens > budget_tokens. If the default (4096)
+            // is not greater than budget_tokens, raise max_tokens to budget + 1.
+            let current_max = request.max_tokens.unwrap_or(4096);
+            if current_max <= budget {
+                anthropic_request["max_tokens"] = json!(budget + 1);
+            }
+            anthropic_request["thinking"] = json!({
+                "type": "enabled",
+                "budget_tokens": budget
+            });
+        }
+
+        // Structured outputs: pass json_schema response_format to Anthropic.
+        if let Some(rf) = &request.response_format
+            && rf.format_type == "json_schema"
+            && let Some(schema) = &rf.json_schema
+        {
+            anthropic_request["response_format"] = json!({
+                "type": "json_schema",
+                "json_schema": schema
+            });
+        }
+
+        // Anthropic built-in (server-side) tools passed via extra_params.
+        // These are appended after any user-defined function tools.
+        if let Some(arr) = request
+            .extra_params
+            .get("anthropic_tools")
+            .and_then(|v| v.as_array())
+            .filter(|a| !a.is_empty())
+        {
+            let mut merged: Vec<Value> = anthropic_request
+                .get("tools")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            merged.extend(arr.iter().cloned());
+            anthropic_request["tools"] = json!(merged);
+        }
+
+        Ok(anthropic_request)
+    }
+}

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -3,7 +3,9 @@ use serde_json::json;
 use super::*;
 use crate::core::providers::anthropic::config::AnthropicConfig;
 use crate::core::types::chat::{ChatMessage, ChatRequest};
-use crate::core::types::content::{AudioData, CacheControl, ContentPart, DocumentSource};
+use crate::core::types::content::{
+    AudioData, CacheControl, ContentPart, DocumentSource, ImageSource,
+};
 use crate::core::types::message::{MessageContent, MessageRole};
 use crate::core::types::tools::{
     FunctionCall, FunctionChoice, FunctionDefinition, Tool, ToolCall, ToolChoice, ToolType,
@@ -320,4 +322,109 @@ fn issue_762_preserves_tool_use_and_tool_result_content_parts()
     assert_eq!(tool_result["tool_use_id"], "toolu_123");
     assert_eq!(tool_result["is_error"], false);
     Ok(())
+}
+
+#[test]
+fn issue_802_rejects_rich_tool_use_alias_against_declared_tools() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229")
+        .add_user_message("weather?")
+        .with_tools(vec![tool("weather_lookup")]);
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Parts(vec![ContentPart::ToolUse {
+            id: "toolu_123".to_string(),
+            name: "weather.lookup".to_string(),
+            input: json!({"city": "Paris"}),
+        }])),
+        ..Default::default()
+    });
+
+    let message = match anthropic_client().transform_chat_request(&request) {
+        Ok(_) => panic!("rich tool-use aliases must fail closed"),
+        Err(error) => error.to_string(),
+    };
+
+    assert!(message.contains("Tool use"));
+    assert!(message.contains("weather.lookup"));
+    assert!(message.contains("weather_lookup"));
+}
+
+#[test]
+fn issue_802_preserves_multimodal_tool_role_result_content()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Tool,
+        tool_call_id: Some("toolu_123".to_string()),
+        content: Some(MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "screenshot".to_string(),
+            },
+            ContentPart::Image {
+                source: ImageSource {
+                    media_type: "image/png".to_string(),
+                    data: "iVBORw0KGgo=".to_string(),
+                },
+                detail: None,
+                image_url: None,
+            },
+            ContentPart::Document {
+                source: DocumentSource {
+                    media_type: "application/pdf".to_string(),
+                    data: "JVBERi0=".to_string(),
+                },
+                cache_control: Some(CacheControl {
+                    cache_type: "ephemeral".to_string(),
+                }),
+            },
+        ])),
+        ..Default::default()
+    });
+
+    let transformed = anthropic_client().transform_chat_request(&request)?;
+    let tool_result = &transformed["messages"][0]["content"][0];
+    let blocks = tool_result["content"].as_array().unwrap();
+
+    assert_eq!(tool_result["type"], "tool_result");
+    assert_eq!(tool_result["tool_use_id"], "toolu_123");
+    assert_eq!(blocks[0], json!({"type": "text", "text": "screenshot"}));
+    assert_eq!(blocks[1]["type"], "image");
+    assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+    assert_eq!(blocks[2]["type"], "document");
+    assert_eq!(blocks[2]["cache_control"], json!({"type": "ephemeral"}));
+    Ok(())
+}
+
+#[test]
+fn issue_802_rejects_cache_control_on_models_without_cache_support() {
+    let mut request = ChatRequest::new("claude-2.1").add_user_message("hello");
+    request
+        .extra_params
+        .insert("cache_control".to_string(), json!({"type": "ephemeral"}));
+
+    let message = match anthropic_client().transform_chat_request(&request) {
+        Ok(_) => panic!("cache_control must fail closed for unsupported known models"),
+        Err(error) => error.to_string(),
+    };
+
+    assert!(message.contains("claude-2.1"));
+    assert!(message.contains("cache control"));
+}
+
+#[test]
+fn issue_802_adds_extended_cache_beta_for_one_hour_cache_control() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229").add_user_message("hello");
+    request.extra_params.insert(
+        "cache_control".to_string(),
+        json!({"type": "ephemeral", "ttl": "1h"}),
+    );
+
+    let headers = anthropic_client().compute_beta_headers(&request);
+    let beta = headers
+        .iter()
+        .find(|(name, _)| name.as_ref() == "anthropic-beta")
+        .map(|(_, value)| value.as_ref())
+        .unwrap_or("");
+
+    assert!(beta.contains(EXTENDED_CACHE_TTL_BETA));
 }

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 use super::*;
 use crate::core::providers::anthropic::config::AnthropicConfig;
 use crate::core::types::chat::{ChatMessage, ChatRequest};
+use crate::core::types::content::{AudioData, CacheControl, ContentPart, DocumentSource};
 use crate::core::types::message::{MessageContent, MessageRole};
 use crate::core::types::tools::{
     FunctionCall, FunctionChoice, FunctionDefinition, Tool, ToolCall, ToolChoice, ToolType,
@@ -169,5 +170,154 @@ fn issue_761_anthropic_transform_response_restores_original_tool_names()
         .map(|tool_call| tool_call.function.name.as_str());
 
     assert_eq!(name, Some("weather.lookup"));
+    Ok(())
+}
+
+#[test]
+fn issue_764_maps_user_and_top_level_cache_control()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let mut request = ChatRequest::new("claude-3-opus-20240229").add_user_message("hello");
+    request.user = Some("user-123".to_string());
+    request
+        .extra_params
+        .insert("cache_control".to_string(), json!({"type": "ephemeral"}));
+
+    let transformed = anthropic_client().transform_chat_request(&request)?;
+
+    assert_eq!(transformed["metadata"]["user_id"], "user-123");
+    assert_eq!(transformed["cache_control"], json!({"type": "ephemeral"}));
+    Ok(())
+}
+
+#[test]
+fn issue_764_preserves_document_cache_control()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Parts(vec![ContentPart::Document {
+            source: DocumentSource {
+                media_type: "application/pdf".to_string(),
+                data: "JVBERi0=".to_string(),
+            },
+            cache_control: Some(CacheControl {
+                cache_type: "ephemeral".to_string(),
+            }),
+        }])),
+        ..Default::default()
+    });
+
+    let transformed = anthropic_client().transform_chat_request(&request)?;
+    let content = &transformed["messages"][0]["content"][0];
+
+    assert_eq!(content["type"], "document");
+    assert_eq!(content["cache_control"], json!({"type": "ephemeral"}));
+    Ok(())
+}
+
+#[test]
+fn issue_762_rejects_unsupported_audio_content_part() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Parts(vec![ContentPart::Audio {
+            audio: AudioData {
+                data: "AAAA".to_string(),
+                format: Some("mp3".to_string()),
+            },
+        }])),
+        ..Default::default()
+    });
+
+    let message = match anthropic_client().transform_chat_request(&request) {
+        Ok(_) => panic!("audio parts must fail closed"),
+        Err(error) => error.to_string(),
+    };
+
+    assert!(message.contains("audio"));
+    assert!(message.contains("does not support"));
+}
+
+#[test]
+fn issue_762_rejects_non_text_system_content_part() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::System,
+        content: Some(MessageContent::Parts(vec![ContentPart::Audio {
+            audio: AudioData {
+                data: "AAAA".to_string(),
+                format: Some("mp3".to_string()),
+            },
+        }])),
+        ..Default::default()
+    });
+
+    let message = match anthropic_client().transform_chat_request(&request) {
+        Ok(_) => panic!("system audio parts must fail closed"),
+        Err(error) => error.to_string(),
+    };
+
+    assert!(message.contains("audio"));
+}
+
+#[test]
+fn issue_762_rejects_invalid_assistant_tool_call_json() {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: None,
+        tool_calls: Some(vec![ToolCall {
+            id: "toolu_bad".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "weather.lookup".to_string(),
+                arguments: "{bad json".to_string(),
+            },
+        }]),
+        ..Default::default()
+    });
+
+    let message = match anthropic_client().transform_chat_request(&request) {
+        Ok(_) => panic!("invalid assistant tool-call JSON must fail closed"),
+        Err(error) => error.to_string(),
+    };
+
+    assert!(message.contains("toolu_bad"));
+    assert!(message.contains("valid JSON"));
+}
+
+#[test]
+fn issue_762_preserves_tool_use_and_tool_result_content_parts()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Parts(vec![ContentPart::ToolUse {
+            id: "toolu_123".to_string(),
+            name: "weather.lookup".to_string(),
+            input: json!({"city": "Paris"}),
+        }])),
+        ..Default::default()
+    });
+    request.messages.push(ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Parts(vec![ContentPart::ToolResult {
+            tool_use_id: "toolu_123".to_string(),
+            content: json!("sunny"),
+            is_error: Some(false),
+        }])),
+        ..Default::default()
+    });
+
+    let transformed = anthropic_client().transform_chat_request(&request)?;
+    let tool_use = &transformed["messages"][0]["content"][0];
+    let tool_result = &transformed["messages"][1]["content"][0];
+
+    assert_eq!(tool_use["type"], "tool_use");
+    assert_eq!(tool_use["name"], "weather_lookup");
+    assert_eq!(tool_use["input"], json!({"city": "Paris"}));
+    assert_eq!(tool_result["type"], "tool_result");
+    assert_eq!(tool_result["tool_use_id"], "toolu_123");
+    assert_eq!(tool_result["is_error"], false);
     Ok(())
 }

--- a/src/core/providers/anthropic/client/request_utils.rs
+++ b/src/core/providers/anthropic/client/request_utils.rs
@@ -4,6 +4,7 @@ use serde_json::{Value, json};
 
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::chat::ChatRequest;
+use crate::core::types::content::ContentPart;
 use crate::core::types::tools::Tool;
 
 use super::AnthropicClient;
@@ -98,6 +99,28 @@ pub(super) fn declared_tool_name(
             "anthropic",
             format!("{} '{}' does not match a declared tool", field, name),
         )),
+    }
+}
+
+pub(super) fn unsupported_content_part(part: &ContentPart) -> ProviderError {
+    ProviderError::invalid_request(
+        "anthropic",
+        format!(
+            "Anthropic request transformation does not support {} content parts in this position",
+            content_part_type(part)
+        ),
+    )
+}
+
+fn content_part_type(part: &ContentPart) -> &'static str {
+    match part {
+        ContentPart::Text { .. } => "text",
+        ContentPart::ImageUrl { .. } => "image_url",
+        ContentPart::Audio { .. } => "audio",
+        ContentPart::Image { .. } => "image",
+        ContentPart::Document { .. } => "document",
+        ContentPart::ToolResult { .. } => "tool_result",
+        ContentPart::ToolUse { .. } => "tool_use",
     }
 }
 

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -305,7 +305,12 @@ fn test_anthropic_transform_messages_preserves_assistant_text_with_tool_use() {
     }];
 
     let transformed = client
-        .transform_messages(messages, Some(model_spec), &Default::default())
+        .transform_messages(
+            messages,
+            "claude-3-opus-20240229",
+            Some(model_spec),
+            &Default::default(),
+        )
         .unwrap();
     assert_eq!(transformed[0]["role"], "assistant");
     let content = transformed[0]["content"].as_array().unwrap();
@@ -337,7 +342,12 @@ fn test_anthropic_transform_messages_tool_role_to_tool_result() {
     }];
 
     let transformed = client
-        .transform_messages(messages, Some(model_spec), &Default::default())
+        .transform_messages(
+            messages,
+            "claude-3-opus-20240229",
+            Some(model_spec),
+            &Default::default(),
+        )
         .unwrap();
     assert_eq!(transformed[0]["role"], "user");
     let content = transformed[0]["content"].as_array().unwrap();


### PR DESCRIPTION
## Summary
- preserve Anthropic request user metadata, cache_control, document cache_control, tool_use, and tool_result blocks
- reject unsupported content parts and invalid assistant tool-call JSON instead of silently dropping or mutating them
- split top-level Anthropic request construction into a focused request module so client.rs stays below the file-size hard limit

Fixes #762
Fixes #764

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked
- cargo test request_tests --all-features --locked
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features --locked
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh