### PR TITLE
test(openai): assert audio content uses input_audio

### DIFF
--- a/src/core/providers/openai/transformer/request.rs
+++ b/src/core/providers/openai/transformer/request.rs
@@ -296,7 +296,13 @@ mod tests {
         };
 
         let result = OpenAIRequestTransformer::transform(request).unwrap();
-        assert!(result.messages.first().unwrap().content.is_some());
+        assert!(
+            result
+                .messages
+                .first()
+                .and_then(|message| message.content.as_ref())
+                .is_some()
+        );
     }
 
     #[test]
@@ -322,7 +328,13 @@ mod tests {
         };
 
         let result = OpenAIRequestTransformer::transform(request).unwrap();
-        assert!(result.messages.first().unwrap().content.is_some());
+        assert!(
+            result
+                .messages
+                .first()
+                .and_then(|message| message.content.as_ref())
+                .is_some()
+        );
     }
 
     #[test]
@@ -343,7 +355,16 @@ mod tests {
         };
 
         let result = OpenAIRequestTransformer::transform(request).unwrap();
-        assert!(result.messages.first().unwrap().content.is_some());
+        let body = match serde_json::to_value(&result) {
+            Ok(body) => body,
+            Err(error) => panic!("OpenAI request should serialize: {error}"),
+        };
+        let audio_part = &body["messages"][0]["content"][0];
+
+        assert_eq!(audio_part["type"], "input_audio");
+        assert_eq!(audio_part["input_audio"]["data"], "base64data");
+        assert_eq!(audio_part["input_audio"]["format"], "mp3");
+        assert!(audio_part.get("audio").is_none());
     }
 
     #[test]

--- a/src/core/providers/openai/transformer/request.rs
+++ b/src/core/providers/openai/transformer/request.rs
@@ -355,10 +355,7 @@ mod tests {
         };
 
         let result = OpenAIRequestTransformer::transform(request).unwrap();
-        let body = match serde_json::to_value(&result) {
-            Ok(body) => body,
-            Err(error) => panic!("OpenAI request should serialize: {error}"),
-        };
+        let body = serde_json::to_value(&result).expect("OpenAI request should serialize");
         let audio_part = &body["messages"][0]["content"][0];
 
         assert_eq!(audio_part["type"], "input_audio");


### PR DESCRIPTION
Fixes #763.

## Summary
- Tightens the OpenAI request transformer audio content-part regression so the serialized provider body must use type=input_audio with the nested input_audio payload.
- Asserts the old audio key is absent, preventing the parity regression from returning silently.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --all-features --locked
- cargo test test_transform_content_parts --all-features --locked
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features --locked
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh