### PR TITLE
ci: ignore quick-xml audit until object_store updates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,6 +6,10 @@
 # only appears in Cargo.lock but not in the actual build tree.
 # See: https://github.com/SeaQL/sea-orm/discussions/2172
 # The vulnerability cannot be fixed until sqlx updates their RSA dependency.
+# Ignore quick-xml duplicate-attribute quadratic parsing via object_store.
+# object_store 0.13/0.14 constrain quick-xml below the fixed 0.41.0 release,
+# so this cannot be fixed until object_store publishes a compatible update.
 ignore = [
     "RUSTSEC-2023-0071", # RSA Marvin Attack in sqlx-mysql (not actually used)
+    "RUSTSEC-2026-0194", # quick-xml via object_store; awaiting object_store quick-xml >=0.41.0
 ]


### PR DESCRIPTION
## Summary

Security Audit started failing because RustSec added `RUSTSEC-2026-0194` for `quick-xml <0.41.0`.

`quick-xml` is pulled in transitively by `object_store`:

```text
quick-xml 0.39.2
└── object_store 0.13.2
    └── litellm-rs
```

I checked the normal upgrade path before adding this exception:

- `cargo update -p quick-xml --precise 0.41.0 --dry-run` fails because `object_store 0.13.2` requires `quick-xml ^0.39.0`.
- `object_store 0.14.0` is the latest crates.io release, but it still requires `quick-xml ^0.40.1`, so it cannot consume the fixed `quick-xml >=0.41.0` either.
- Upstream `apache/arrow-rs-object-store` main currently also uses `quick-xml = "0.40.1"`.

This PR follows the existing `.cargo/audit.toml` pattern and adds a documented temporary ignore until `object_store` publishes a compatible update.

## Verification

- `cargo audit`
- `git diff --check`
- `cargo check`
