### PR TITLE
chore(audit): acknowledge quick-xml namespace advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,4 +12,5 @@
 ignore = [
     "RUSTSEC-2023-0071", # RSA Marvin Attack in sqlx-mysql (not actually used)
     "RUSTSEC-2026-0194", # quick-xml via object_store; awaiting object_store quick-xml >=0.41.0
+    "RUSTSEC-2026-0195", # quick-xml via object_store; awaiting object_store quick-xml >=0.41.0
 ]


### PR DESCRIPTION
## Summary
- acknowledge RUSTSEC-2026-0195 for quick-xml via object_store
- keep the existing object_store upgrade rationale alongside RUSTSEC-2026-0194
- unblock the #727 oversized-file refactor queue audit gate

Refs #727

## Verification
- cargo audit
- cargo check --all-features --locked
- git diff --check