### PR TITLE
docs(spec): SpecRail spec packet for GH835 route 4xx errors

### DIFF
--- a/specs/GH835/product.md
+++ b/specs/GH835/product.md
@@ -1,0 +1,48 @@
+# Product Spec
+
+## Linked Issue
+
+GH-835 / #835
+
+## 用户问题
+
+客户端请求未配置的 batch/image 模型时，gateway 返回 HTTP 500。实际原因是 route-local
+“provider/model 未配置”错误使用 `GatewayError::Config`，而 OpenAI error renderer 将所有
+`Config` 统一映射为 500。用户可触发的 bad model / unsupported endpoint 因此污染 5xx 指标并诱导重试。
+
+## 目标
+
+- batch/image 的“未配置 provider/model”返回 OpenAI-compatible 4xx。
+- 真正的启动/内部配置错误仍是 5xx。
+- 错误 code/type 能让客户端区分 unsupported/missing model 与服务端故障。
+
+## 非目标
+
+- 不全局改变 `GatewayError::Config` 的 HTTP 映射。
+- 不修复 #839 的全局错误映射重复问题。
+- 不改变 batch/image proxy 的成功路径或 provider selection。
+
+## Behavior Invariants
+
+1. 没有配置任何 batch provider 时，`/v1/batches` 返回 4xx，不返回 500。
+2. image edit/variation 未配置 provider 或 requested model 没有候选时返回 4xx，不返回 500。
+3. pricing 数据损坏、URL/header 构造错误等内部配置/程序错误仍可返回 5xx。
+4. OpenAI-compatible body shape 保持 `{error:{message,type,param,code}}`。
+5. 已有 tests 中断言 500 的用例必须改为新语义，不能删除覆盖。
+
+## 验收标准
+
+- [ ] `/v1/batches` 无 provider 返回 400/404，error code 不是 `internal_error`。
+- [ ] `/v1/images/edits` / `/v1/images/variations` 无 provider 或 model 未配置返回 400/404。
+- [ ] `GatewayError::Config` 的全局 renderer 仍对真正 internal config 映射 500。
+- [ ] 5xx metrics 不再因这类客户端请求增加。
+
+## 边界情况
+
+- provider configured but upstream returns non-2xx：不在本 issue 改语义。
+- provider URL/header invalid：属于配置错误，可保持 5xx。
+- missing pricing 与 unpriced model 归 #831，不在本 issue 混修。
+
+## 发布说明
+
+未配置 batch/image model/provider 的客户端错误现在返回 4xx，而不是 500。

--- a/specs/GH835/tasks.md
+++ b/specs/GH835/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-835 / #835
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP835-T1` Owner: coordinator. Done when: `specs/GH835/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH835"`.
+- [ ] `SP835-T2` Owner: coordinator. Done when: batch missing-provider helper no longer returns `GatewayError::Config`; it returns a semantic 4xx error. Verify: focused test for `/v1/batches` no provider.
+- [ ] `SP835-T3` Owner: coordinator. Done when: image proxy no-provider and unsupported requested model errors return semantic 4xx. Verify: focused tests for image edits/variations provider absent and model unsupported.
+- [ ] `SP835-T4` Owner: coordinator. Done when: true internal config errors still map to 500. Verify: renderer regression test with `GatewayError::Config`.
+- [ ] `SP835-T5` Owner: verification owner. Done when: old tests asserting 500 are updated, not removed, and all focused tests pass. Verify: `cargo test server::routes::ai --all-features`.
+- [ ] `SP835-T6` Owner: verification owner. Done when: format/lint/full tests pass. Verify: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`.
+
+## 并行拆分
+
+- Batch and image helpers are small but share renderer semantics; keep in one PR.
+
+## 验证
+
+- [ ] `SP835-T7` Owner: verification owner. Done when: PR body includes status/body snippets or focused test output proving 4xx and non-internal code. Verify: fresh command output.
+
+## Handoff Notes
+
+- Do not globally remap `GatewayError::Config`.
+- Do not weaken upstream proxy error behavior.
+- Keep #839 boundary: this issue fixes concrete route-local status errors only.

--- a/specs/GH835/tech.md
+++ b/specs/GH835/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-835 / #835
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| OpenAI renderer | `src/server/routes/ai/openai_errors.rs:126-133` | `GatewayError::Config` -> 500/internal_error | Do not use for user bad model |
+| Batch no provider | `src/server/routes/ai/batches.rs:368-372` | `missing_batch_provider_error()` returns Config | User-triggerable |
+| Image no provider/model | `src/server/routes/ai/images.rs:430-448,696-701` | Missing image candidate returns Config | User-triggerable |
+| Existing GatewayError | `src/utils/error/gateway_error/types.rs` | Has `BadRequest`, `NotFound`, `Provider(ModelNotFound)` | Prefer semantic variant |
+
+## 设计方案
+
+1. **Route-local semantic errors**：replace user-triggerable missing provider/model helpers with semantic 4xx variants:
+   - batch provider absent: `GatewayError::BadRequest` or `ProviderError::NotSupported` wrapped for OpenAI shape;
+   - image requested model unsupported/no candidate: `GatewayError::Provider(ProviderError::ModelNotFound { provider: "image_proxy", model })`
+     or `GatewayError::BadRequest` with explicit OpenAI code mapping.
+2. **No global Config remap**：do not change `GatewayError::Config` globally; startup/invalid URL/header config remains 500.
+3. **Renderer coverage**：ensure chosen variant maps to OpenAI 4xx body. If current `openai_errors.rs` lacks desired code,
+   add a route-specific helper or a narrow mapping test rather than broad Config remap.
+4. **Test update**：change existing test that asserts 500 for missing provider/model to assert 4xx and non-internal code.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 batch missing provider 4xx | batches.rs helper | Route/unit test status and code |
+| P2 image no candidate 4xx | images.rs helper | Route/unit test status and code |
+| P3 internal config remains 5xx | openai_errors.rs | Regression test Config still 500 |
+| P4 body shape | OpenAI renderer | JSON shape assertion |
+
+## 数据流
+
+Request → route validates configured provider/candidate → user-triggerable absence becomes semantic 4xx →
+OpenAI renderer returns client error body.
+
+## 备选方案
+
+- Globally map `GatewayError::Config` to 400: would hide real server misconfiguration，拒绝。
+- Leave status 500 and change message only: still pollutes metrics and retries，拒绝。
+- Convert every provider setup error to 4xx: invalid URL/header is operator error，拒绝。
+
+## 风险
+
+- Compatibility: Clients that retried these 500s will now see non-retryable 4xx.
+- Maintenance: Need clear helper naming to prevent future user errors using `Config`.
+- Observability: 5xx metrics become cleaner.
+
+## 测试计划
+
+- [ ] Unit/route tests for missing batch provider.
+- [ ] Unit/route tests for image provider absent and model unsupported.
+- [ ] Renderer regression test for real Config -> 500.
+
+## 回滚方案
+
+Single PR revert; status codes return to previous 500 behavior.


### PR DESCRIPTION
## Summary
- Adds SpecRail product, tech, and task packet for GH835.
- Scope: user-triggerable missing batch/image provider/model errors should be 4xx, not 500.

## Verification
- python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH835"
- git diff --cached --check

Refs #835