### PR TITLE
docs(spec): SpecRail spec packet for GH832 CORS preflight auth

### DIFF
--- a/specs/GH832/product.md
+++ b/specs/GH832/product.md
@@ -1,0 +1,54 @@
+# Product Spec
+
+## Linked Issue
+
+GH-832 / #832
+
+## 用户问题
+
+浏览器跨域调用 `/v1/*` 时，CORS preflight `OPTIONS` 请求不带 `Authorization`。当前
+`src/server/http.rs` 先注册 `.wrap(cors)`，但 Actix wrap 逆序执行，导致 CORS 位于最内层；
+请求先经过 `AuthMiddleware`，在 `src/server/middleware/auth.rs:165-175` 因 `AuthMethod::None`
+返回 401，CORS 没机会生成 `Access-Control-Allow-*` 响应头。
+
+结果是浏览器客户端无法使用 gateway，即使 CORS 配置允许该 origin。
+
+## 目标
+
+- CORS preflight 由 CORS 层处理，不要求 API key / JWT。
+- CORS header 出现在 preflight 与后续 auth/rate-limit 失败响应上。
+- 非 preflight 请求的鉴权、限流、metrics 行为不被放宽。
+
+## 非目标
+
+- 不改变 CORS 配置语义或默认 allowed origin。
+- 不把任意 `OPTIONS` 请求都变成公开业务路由；只处理标准 CORS preflight。
+- 不调整 RateLimit/Auth 的相对顺序，除非为 CORS 外层化所必需。
+
+## Behavior Invariants
+
+1. 符合 CORS preflight 条件的请求（`OPTIONS` + `Origin` + `Access-Control-Request-Method`）不进入
+   `AuthMiddleware` 的 missing-auth 401 分支。
+2. 非 preflight 的 `OPTIONS` 或其他方法仍按原有 auth/rate-limit 规则处理。
+3. CORS middleware 必须处于能装饰所有下游响应的位置；auth 失败、rate-limit 失败也应带允许的
+   CORS 响应头。
+4. 变更后 `RequestIdMiddleware`、`MetricsMiddleware`、`RateLimitMiddleware`、`AuthMiddleware`
+   的业务请求相对语义保持不变。
+
+## 验收标准
+
+- [ ] 集成测试：允许 origin 的 preflight `/v1/chat/completions` 返回 2xx/204，并带
+      `Access-Control-Allow-Origin`、`Access-Control-Allow-Methods`、`Access-Control-Allow-Headers`。
+- [ ] 集成测试：同一路径不带 auth 的真实 `POST` 仍返回 401，但响应包含 CORS header。
+- [ ] 集成测试：没有 `Origin` 或没有 `Access-Control-Request-Method` 的 `OPTIONS` 不被误判为 preflight。
+- [ ] middleware 注册顺序有注释或测试锁定，防止再次把 CORS 放回最内层。
+
+## 边界情况
+
+- CORS disabled 时不新增 preflight 放行。
+- 不允许的 origin 仍由 CORS 配置拒绝或不返回 allow header。
+- 管理端和健康检查路由不因本修复改变鉴权规则。
+
+## 发布说明
+
+修复浏览器客户端无法通过 CORS preflight 的 bug。非浏览器客户端和非 preflight 请求行为不变。

--- a/specs/GH832/tasks.md
+++ b/specs/GH832/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-832 / #832
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP832-T1` Owner: coordinator. Done when: `specs/GH832/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH832"`.
+- [ ] `SP832-T2` Owner: coordinator. Done when: CORS middleware 在 Actix 执行顺序中位于 auth/rate-limit 外层，注释解释 wrap 逆序执行. Verify: focused test fails before reorder and passes after; `git diff -- src/server/http.rs`.
+- [ ] `SP832-T3` Owner: coordinator. Done when: 标准 CORS preflight 不触发 missing-auth 401；若需要 helper，则 helper 严格匹配 `OPTIONS` + `Origin` + `Access-Control-Request-Method`. Verify: `cargo test server::http cors --all-features` 或对应集成测试。
+- [ ] `SP832-T4` Owner: coordinator. Done when: 非 preflight 请求鉴权不变，未授权 POST 仍 401 且带 CORS header. Verify: focused actix test for unauthenticated POST with allowed Origin.
+- [ ] `SP832-T5` Owner: verification owner. Done when: 格式、lint、全量测试通过. Verify: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`.
+
+## 并行拆分
+
+- 单文件/小测试修复，不需要并行拆分。
+
+## 验证
+
+- [ ] `SP832-T6` Owner: verification owner. Done when: 手工或集成测试记录 preflight response status 与 `Access-Control-Allow-*` 头. Verify: PR body 附测试输出。
+
+## Handoff Notes
+
+- 不要把 `/v1/*` 加到 public route。
+- 不要无条件允许所有 `OPTIONS`；只处理标准 CORS preflight。
+- 若调整 middleware 顺序，确认 auth/rate-limit 相对顺序不被破坏。

--- a/specs/GH832/tech.md
+++ b/specs/GH832/tech.md
@@ -1,0 +1,70 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-832 / #832
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Middleware assembly | `src/server/http.rs:198-214` | `.wrap(cors)` 注册最早，Actix 逆序执行后成为最内层 | preflight 先撞 Auth |
+| Auth rejection | `src/server/middleware/auth.rs:165-175` | `AuthMethod::None` 返回 401 | preflight 无凭证必失败 |
+| Public route helper | `src/server/middleware/helpers.rs:82-97` | 只按 path 判断，不看 method/header | 不能靠 public route 表解决 `/v1/*` preflight |
+| CORS config | `src/config/models/gateway.rs` / `src/server/http.rs` | 已有 `CorsConfig` 与 builder | 修复应复用现有配置 |
+
+## 设计方案
+
+1. **CORS 外层化**：调整 `HttpServer` app builder 的 wrap 注册顺序，使 CORS 在 Actix 执行顺序中位于
+   auth/rate-limit 之外。当前注释已经说明 wrap 逆序执行；实现必须同步更新注释，避免后来误读。
+2. **preflight 判定保护**：如单纯外层化不足以覆盖当前 actix-cors 行为，增加一个小 helper
+   `is_cors_preflight(req)`，条件为：
+   - method 为 `OPTIONS`；
+   - 存在 `Origin`；
+   - 存在 `Access-Control-Request-Method`。
+   该 helper 只用于避免 auth/rate-limit 误拦标准 preflight，不进入普通 public route 表。
+3. **下游响应装饰**：CORS 层必须仍能给 auth/rate-limit 失败响应附加 CORS header，保证浏览器能读取错误。
+4. **测试锁顺序**：新增 actix test app 覆盖 preflight 与 unauthenticated POST。测试应从真实
+   `configure_routes` / middleware builder 进入，而不是只单测 helper。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 preflight 不鉴权 | http.rs CORS order / helper | OPTIONS + CORS headers returns 2xx/204 |
+| P2 非 preflight 不放宽 | AuthMiddleware | POST without auth remains 401 |
+| P3 下游错误带 CORS | CORS outer layer | POST 401 response includes allow-origin for allowed origin |
+| P4 顺序防回归 | http.rs test/comment | Test fails if CORS moves inside Auth |
+
+## 数据流
+
+浏览器 preflight → outer CORS middleware validates origin/method/headers → CORS responds before auth.
+
+普通 request → outer CORS middleware wraps response → metrics/request-id/auth/rate-limit/routes execute as before
+→ response decorated with CORS headers when origin is allowed.
+
+## 备选方案
+
+- 把 `/v1/*` 加入 public route：会绕过真实请求鉴权，拒绝。
+- 在 AuthMiddleware 中无条件允许所有 `OPTIONS`：会放宽非 CORS OPTIONS，拒绝。
+- 只在浏览器文档中要求带 auth header：浏览器 preflight 本身不会带凭证，拒绝。
+
+## 风险
+
+- Security: 只放行标准 preflight，不放行业务请求；风险低。
+- Compatibility: 修复浏览器兼容性；非浏览器路径不变。
+- Maintenance: middleware 顺序容易回归，必须用测试锁定。
+
+## 测试计划
+
+- [ ] Integration tests: allowed-origin preflight `/v1/chat/completions`。
+- [ ] Integration tests: unauthenticated POST remains 401 and has CORS header.
+- [ ] Unit/helper tests: missing `Origin` 或 missing `Access-Control-Request-Method` 不算 preflight。
+
+## 回滚方案
+
+单 PR revert；回滚后浏览器 preflight 再次失败，但不影响非浏览器请求。


### PR DESCRIPTION
## Summary
- Adds SpecRail product, tech, and task packet for GH832.
- Scope: CORS middleware order and preflight auth bypass prevention.

## Verification
- python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH832"
- git diff --cached --check

Refs #832