### PR TITLE
docs(spec): SpecRail spec packet for GH833 rate-limit headers

### DIFF
--- a/specs/GH833/product.md
+++ b/specs/GH833/product.md
@@ -1,0 +1,55 @@
+# Product Spec
+
+## Linked Issue
+
+GH-833 / #833
+
+## 用户问题
+
+Provider、A2A、MCP 的 429 错误已经携带退避信息，但 gateway 返回给客户端时丢失
+`Retry-After` / `X-RateLimit-*` 响应头。客户端 SDK 因此无法按上游建议退避，只能盲目重试。
+
+当前证据：
+
+- `ProviderError::RateLimit` 有 `retry_after`、`rpm_limit`、`tpm_limit` 字段。
+- `GatewayError::Provider(ProviderError::RateLimit)` 在 response renderer 中只设置 status/code/message。
+- `GatewayError::RateLimit` 分支才会写限流头。
+- A2A/MCP conversion 把 `retry_after_ms` 写进 message，但 `retry_after: None`。
+
+## 目标
+
+- 所有 gateway 发出的 429 都保留可用的退避和限流头。
+- Provider rate-limit、gateway rate-limit、A2A/MCP rate-limit 采用同一 header 写入逻辑。
+- 不改变 #839 负责的错误 JSON 结构统一范围。
+
+## 非目标
+
+- 不新增完整限流策略或配额算法。
+- 不重新设计 `GatewayError` / `ProviderError` 变体集合。
+- 不保证所有 provider 都能提供 `Retry-After`；只保留已有事实。
+
+## Behavior Invariants
+
+1. `GatewayError::Provider(ProviderError::RateLimit { retry_after, rpm_limit, tpm_limit, .. })`
+   返回 429 时写出对应 header。
+2. `GatewayError::RateLimit { .. }` 的既有 header 行为不回退。
+3. A2A/MCP 的 `retry_after_ms` 转换为 HTTP `Retry-After` 秒值，使用向上取整且最小 1 秒。
+4. 没有 retry metadata 时不伪造 header，但 JSON message 可保持现状。
+5. OpenAI-compatible AI 响应与 canonical 响应都能取得同一组 header facts，避免 #839 合并后再次漂移。
+
+## 验收标准
+
+- [ ] Provider 429 带 `Retry-After`、`X-RateLimit-Limit-Requests`、`X-RateLimit-Limit-Tokens`。
+- [ ] Gateway 自身限流 429 既有 header 测试仍通过。
+- [ ] A2A/MCP `retry_after_ms=1500` 转成 `Retry-After: 2`。
+- [ ] 没有 retry metadata 的 429 不写空 header。
+
+## 边界情况
+
+- `retry_after_ms=0` 或小于 1000ms 时，HTTP header 使用 `1`，避免客户端立即重试。
+- 只存在 rpm 或只存在 tpm 时，只写存在的 header。
+- #839 统一错误映射后，header facts 仍应由单一 helper 提供。
+
+## 发布说明
+
+429 响应现在会保留退避 header，客户端可按 `Retry-After` 与 `X-RateLimit-*` 做正确重试。

--- a/specs/GH833/tasks.md
+++ b/specs/GH833/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-833 / #833
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP833-T1` Owner: coordinator. Done when: `specs/GH833/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH833"`.
+- [ ] `SP833-T2` Owner: coordinator. Done when: rate-limit header facts helper 覆盖 `GatewayError::RateLimit` 与 `GatewayError::Provider(ProviderError::RateLimit)`. Verify: focused unit tests assert headers for both variants.
+- [ ] `SP833-T3` Owner: coordinator. Done when: response renderer writes `Retry-After`, `X-RateLimit-Limit-Requests`, `X-RateLimit-Limit-Tokens` for provider 429 when metadata exists. Verify: `cargo test utils::error::gateway_error --lib --all-features` or exact module test.
+- [ ] `SP833-T4` Owner: coordinator. Done when: A2A/MCP conversions preserve `retry_after_ms` as HTTP seconds with ceil/min-1 semantics. Verify: conversion unit tests for `1500 -> 2`, `1 -> 1`, `None -> None`.
+- [ ] `SP833-T5` Owner: verification owner. Done when: #839 compatibility note added to tests or code comments so future mapping unification cannot drop headers. Verify: `rg -n "Retry-After|X-RateLimit-Limit|rate_limit_headers|http_facts" src/utils src/server`.
+- [ ] `SP833-T6` Owner: verification owner. Done when: format/lint/tests pass. Verify: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`.
+
+## 并行拆分
+
+- T2/T3 and T4 touch different functions but same module family; keep in one small PR to avoid partial header behavior.
+
+## 验证
+
+- [ ] `SP833-T7` Owner: verification owner. Done when: PR body includes fresh test output for provider, gateway, A2A, and MCP rate-limit cases. Verify: paste command output from this session.
+
+## Handoff Notes
+
+- Do not stringify/parse retry metadata.
+- Do not invent headers when metadata is absent.
+- If #839 lands first, implement this in the canonical facts layer instead of adding a temporary duplicate table.

--- a/specs/GH833/tech.md
+++ b/specs/GH833/tech.md
@@ -1,0 +1,69 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-833 / #833
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Provider facts | `src/core/providers/unified_provider_error.rs:11-19` | `RateLimit` carries retry/rpm/tpm | Header source exists |
+| Response renderer | `src/utils/error/gateway_error/response.rs:31-36,207-226` | Provider 429 does not insert headers; gateway 429 does | Missing branch |
+| A2A conversion | `src/utils/error/gateway_error/conversions.rs:84-101` | `retry_after_ms` only in message, `retry_after: None` | Metadata lost |
+| MCP conversion | `src/utils/error/gateway_error/conversions.rs:210-227` | Same as A2A | Metadata lost |
+| Future mapping | `specs/GH839/` | Plans canonical HTTP facts | This fix must be compatible |
+
+## 设计方案
+
+1. **Header facts helper**：新增或复用一个 small helper，例如
+   `rate_limit_headers(error: &GatewayError) -> RateLimitHeaderFacts`，覆盖：
+   - `GatewayError::RateLimit`;
+   - `GatewayError::Provider(ProviderError::RateLimit)`.
+2. **Response renderer 接入**：`GatewayError::error_response` 在构造 429 response 时调用 helper，
+   不再只匹配 `GatewayError::RateLimit`。
+3. **A2A/MCP ms 转秒**：conversion 中把 `retry_after_ms: Option<u64>` 转为
+   `retry_after: Option<u64>` 秒值：`ceil(ms / 1000)`，且 `Some(0)` 变为 `Some(1)`。
+4. **#839 兼容**：如果 #839 的 `http_facts` 先落地，本 issue 的 helper 应并入 facts；如果本 issue 先落地，
+   #839 迁移时必须保留这些 header tests。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 Provider headers | response.rs helper | Unit test ProviderError::RateLimit emits headers |
+| P2 Gateway headers | existing branch | Regression test existing GatewayError::RateLimit |
+| P3 A2A/MCP ms conversion | conversions.rs | Unit tests 1500ms -> 2s, 1ms -> 1s |
+| P4 no fake headers | helper | Unit test metadata None writes no headers |
+
+## 数据流
+
+Provider/A2A/MCP error → `GatewayError` with structured retry facts → renderer/header facts helper →
+HTTP 429 response with JSON body and rate-limit headers.
+
+## 备选方案
+
+- Parse retry seconds back out of message strings: fragile and locale-dependent，拒绝。
+- Wait for #839 only: leaves current bug open and risks losing facts before the refactor，拒绝。
+- Always set fixed `Retry-After`: invents metadata，拒绝。
+
+## 风险
+
+- Compatibility: Adds headers only; body/status remain unchanged.
+- Security: No sensitive data; rpm/tpm values are already intended rate-limit metadata.
+- Maintenance: Keep helper close to #839 facts to avoid third mapping table.
+
+## 测试计划
+
+- [ ] Unit tests: provider rate limit headers.
+- [ ] Unit tests: gateway rate limit headers remain.
+- [ ] Unit tests: A2A/MCP retry_after_ms conversion.
+- [ ] Integration/focused route test if existing test harness can trigger 429.
+
+## 回滚方案
+
+Single PR revert. Reverting loses retry headers but restores previous body/status behavior.


### PR DESCRIPTION
## Summary
- Adds SpecRail product, tech, and task packet for GH833.
- Scope: preserve Retry-After and X-RateLimit headers across provider/A2A/MCP paths.

## Verification
- python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH833"
- git diff --cached --check

Refs #833