### PR TITLE
docs(spec): SpecRail spec packet for GH834 image model authz

### DIFF
--- a/specs/GH834/product.md
+++ b/specs/GH834/product.md
@@ -1,0 +1,51 @@
+# Product Spec
+
+## Linked Issue
+
+GH-834 / #834
+
+## 用户问题
+
+`/v1/images/generations` 只有在请求显式包含 `model` 时才调用
+`enforce_api_key_model_and_token_limits`。当 `model` 省略时，检查整段跳过，后续 provider
+使用默认模型执行。带 `allowed_models` 限制的 API key 可以借此绕过模型白名单。
+
+这是 security issue：用户授权范围由 API key policy 定义，默认模型不能成为绕过路径。
+
+## 目标
+
+- image generation 请求无论是否显式传入 `model`，都必须对实际生效模型执行 API key model 限制。
+- 无法在 provider 调用前确定唯一生效模型时，受限 key 请求必须 fail-closed，而不是交给 provider 默认。
+- 不影响 image edit / variation proxy 已要求 multipart `model` 的路径。
+
+## 非目标
+
+- 不改变 provider 默认模型本身。
+- 不扩大 allowed_models 语义到非模型资源。
+- 不重构整个 image routing 架构。
+
+## Behavior Invariants
+
+1. `allowed_models` 存在且请求省略 `model` 时，gateway 不得在未校验生效模型的情况下调用 provider。
+2. 若能根据配置解析唯一 effective image generation model，则对该模型调用现有
+   `enforce_api_key_model_and_token_limits`。
+3. 若无法唯一解析 effective model，受限 key 请求返回 OpenAI 形状 4xx，要求显式 `model` 或说明模型不被允许。
+4. 没有 model 限制的 key 保持现有默认模型行为。
+5. 错误不能泄露无关 provider secrets 或内部 routing config。
+
+## 验收标准
+
+- [ ] 测试：`allowed_models=["gpt-4o"]`，image generation 省略 `model`，provider 默认 image model 不在白名单时返回 4xx，provider 未调用。
+- [ ] 测试：省略 `model` 但可解析默认模型且在白名单内时请求通过 authz 检查。
+- [ ] 测试：显式 `model` 的既有允许/拒绝行为不回退。
+- [ ] image edit / variation proxy 仍要求 multipart model，并继续先 authz 再 routing。
+
+## 边界情况
+
+- 多个 image provider 候选且默认模型不唯一：受限 key fail-closed。
+- allowed_models 为空/未设置：不新增强制 model 要求。
+- wildcard / pattern 规则若已存在，必须复用现有 `enforce_api_key_model_and_token_limits` 语义。
+
+## 发布说明
+
+修复 image generation 省略 `model` 时绕过 API key allowed_models 的安全问题。受限 key 可能需要显式传入允许的 image model。

--- a/specs/GH834/tasks.md
+++ b/specs/GH834/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-834 / #834
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP834-T1` Owner: coordinator. Done when: `specs/GH834/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH834"`.
+- [ ] `SP834-T2` Owner: coordinator. Done when: image generation route resolves explicit/effective authz model before provider invocation. Verify: focused unit tests for resolver.
+- [ ] `SP834-T3` Owner: coordinator. Done when: missing model + restricted API key cannot reach provider unless a unique allowed effective model is resolved. Verify: route test with sentinel provider/router not called on deny.
+- [ ] `SP834-T4` Owner: coordinator. Done when: unrestricted key/no allowed_models preserves old omitted-model behavior. Verify: route or resolver test.
+- [ ] `SP834-T5` Owner: coordinator. Done when: explicit model allowed/denied behavior and image edit/variation model-required behavior remain unchanged. Verify: focused regression tests.
+- [ ] `SP834-T6` Owner: verification owner. Done when: format/lint/tests pass. Verify: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`.
+
+## 并行拆分
+
+- Single security fix PR; do not split authz and tests.
+
+## 验证
+
+- [ ] `SP834-T7` Owner: verification owner. Done when: PR body includes before/after evidence that missing-model restricted request is denied before provider. Verify: focused test output from this session.
+
+## Handoff Notes
+
+- Do not duplicate allowed_models matching logic; call the existing helper.
+- Do not rely on provider-side defaults for restricted keys unless gateway can prove the same effective model before provider call.
+- Treat ambiguous default resolution as deny/4xx, not as allow.

--- a/specs/GH834/tech.md
+++ b/specs/GH834/tech.md
@@ -1,0 +1,70 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-834 / #834
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Image generation route | `src/server/routes/ai/images.rs:60-72` | authz only inside `if let Some(model)` | Missing-model bypass |
+| Image proxy paths | `src/server/routes/ai/images.rs:130-137` | multipart model required and checked | Should remain unchanged |
+| Authz helper | `src/server/routes/ai/context.rs:250` | Existing API key allowed_models/token limit enforcement | Reuse, do not fork policy |
+| Provider defaults | provider image implementations | Many providers choose defaults internally | Must resolve or fail before provider |
+
+## 设计方案
+
+1. **effective model resolver**：在 image generation route 增加 helper，例如
+   `resolve_image_generation_authz_model(request, providers) -> Result<Option<String>, GatewayError>`。
+   - If request has `model`, return it.
+   - If request has no `model` and key has no model restriction, return `None` and preserve old default behavior.
+   - If request has no `model` and key has model restriction, resolve the single configured image generation default/candidate model
+     if deterministic; otherwise return 4xx requiring explicit `model`.
+2. **authz before provider**：call `enforce_api_key_model_and_token_limits` with resolved effective model before
+   `handle_ai_request` invokes provider code.
+3. **fail-closed ambiguity**：multiple possible provider defaults, no configured default, or provider-only hidden defaults
+   are not safe for restricted keys. Return OpenAI-compatible 4xx (`invalid_request` or `model_not_allowed`) without
+   touching provider.
+4. **test doubles**：use route tests with a request extension/API key context and a sentinel provider/router to prove provider
+   is not invoked on denied missing-model requests.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 no bypass | images.rs route | Missing model + restricted key denied before provider |
+| P2 deterministic default allowed | resolver | Default in allowed_models passes authz |
+| P3 ambiguity fail-closed | resolver | Multiple/unknown defaults return 4xx |
+| P4 unrestricted unchanged | route | No allowed_models keeps old no-model behavior |
+
+## 数据流
+
+Request JSON → resolve explicit/effective authz model → enforce API key model policy if needed →
+existing `handle_ai_request` → provider/routing.
+
+## 备选方案
+
+- Require `model` for every image generation request: safe but breaks unrestricted clients unnecessarily，拒绝。
+- Check after provider picks default: too late; provider call already escaped authz，拒绝。
+- Duplicate allowed_models matching in images.rs: risks drift from central helper，拒绝。
+
+## 风险
+
+- Security: Fixes privilege bypass; fail-closed for ambiguous restricted-key cases.
+- Compatibility: Restricted keys omitting model may now get 4xx; unrestricted keys unchanged.
+- Maintenance: Resolver must stay tied to routing/provider default semantics.
+
+## 测试计划
+
+- [ ] Unit tests: effective model resolver explicit/default/ambiguous cases.
+- [ ] Route tests: missing model with restricted key denied before provider.
+- [ ] Regression tests: explicit model allow/deny unchanged.
+
+## 回滚方案
+
+Single PR revert; revert reopens allowed_models bypass for image generation missing-model requests.


### PR DESCRIPTION
## Summary
- Adds SpecRail product, tech, and task packet for GH834.
- Scope: missing image generation model must not bypass API key allowed_models.

## Verification
- python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH834"
- git diff --cached --check

Refs #834