### PR TITLE
docs(spec): SpecRail spec packet for GH836 Redis limiter degradation

### DIFF
--- a/specs/GH836/product.md
+++ b/specs/GH836/product.md
@@ -1,0 +1,50 @@
+# Product Spec
+
+## Linked Issue
+
+GH-836 / #836
+
+## 用户问题
+
+Redis 分布式限流发生错误时，`RateLimiter` 只写 `warn!`，随后静默回退到进程内限流。
+多节点部署下每个节点独立计数，实际全局限额扩大为节点数倍。操作员也没有 metric 能及时发现降级。
+
+这是 user-visible correctness issue：限流承诺在 Redis 故障期间不再成立。
+
+## 目标
+
+- Redis 限流故障不再静默；必须 error 级日志 + metric。
+- 操作者可显式选择 Redis 故障策略：fail-closed 或 fail-open-local。
+- 默认策略保守，避免多节点下无声扩大限额。
+
+## 非目标
+
+- 不重写整个 rate limiter 算法。
+- 不改变无 Redis / 单进程限流配置的行为。
+- 不实现 Redis 自动恢复面板；只暴露状态与 metric。
+
+## Behavior Invariants
+
+1. 配置了 Redis 分布式限流且 Redis 操作失败时，gateway 必须记录 error 级日志并递增 degraded metric。
+2. 默认模式为 fail-closed：Redis check/check_and_record 失败时返回 503 或限流型 429，不回退本地放行。
+3. 只有显式配置 `fail_open_local` 时才允许本地 fallback；该 fallback 仍必须标记 degraded metric 和 response/log metadata。
+4. `release` 失败也必须可观测，但不应导致已完成请求变成失败响应。
+5. 没有 Redis backend 或 Redis pool 是 noop 时，现有进程内限流行为保持。
+
+## 验收标准
+
+- [ ] Redis `check` 失败默认 fail-closed，不走 local limiter。
+- [ ] Redis `check_and_record` 失败默认 fail-closed，不创建 local reservation。
+- [ ] `fail_open_local` 显式开启时才回退本地，且 metric/log 标记 degraded。
+- [ ] `/metrics` 或 metrics collector 可观测 `rate_limiter_degraded_total{operation,mode}`。
+- [ ] release 失败产生 error/metric，不影响响应完成。
+
+## 边界情况
+
+- Redis pool 初始化为 noop：不是故障，不打 degraded metric。
+- Redis timeout 与 Redis command error 都算 degraded。
+- 多节点部署文档/CHANGELOG 说明默认行为收紧与逃生门。
+
+## 发布说明
+
+Redis 分布式限流故障默认 fail-closed，并新增 degraded metric。需要旧的本地 fallback 行为时必须显式配置。

--- a/specs/GH836/tasks.md
+++ b/specs/GH836/tasks.md
@@ -1,0 +1,34 @@
+# Task Plan
+
+## Linked Issue
+
+GH-836 / #836
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP836-T1` Owner: coordinator. Done when: `specs/GH836/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH836"`.
+- [ ] `SP836-T2` Owner: coordinator. Done when: rate limit config adds `redis_failure_mode` with default `fail_closed`, parse/merge/validation tests. Verify: `cargo test config --lib --all-features redis_failure_mode`.
+- [ ] `SP836-T3` Owner: coordinator. Done when: Redis `check` failure follows policy: default fail-closed, explicit fail-open-local uses local limiter. Verify: focused limiter tests with fake Redis failure.
+- [ ] `SP836-T4` Owner: coordinator. Done when: Redis `check_and_record` failure follows policy and does not create local reservation in fail-closed mode. Verify: focused limiter tests.
+- [ ] `SP836-T5` Owner: coordinator. Done when: degraded metric/log helper covers check, check_and_record, and release; release failure remains non-fatal. Verify: metrics/log tests or observable counter assertions.
+- [ ] `SP836-T6` Owner: docs owner. Done when: CHANGELOG/docs mention default behavior tightening and `fail_open_local` escape hatch. Verify: `rg -n "redis_failure_mode|fail_open_local|rate_limiter_degraded" docs README.md CHANGELOG.md src`.
+- [ ] `SP836-T7` Owner: verification owner. Done when: format/lint/full tests pass. Verify: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`.
+
+## 并行拆分
+
+- Config and limiter code are coupled; keep in one PR to avoid a config that does nothing.
+
+## 验证
+
+- [ ] `SP836-T8` Owner: verification owner. Done when: PR body includes tests proving Redis failure no longer silently falls back by default. Verify: fresh command output.
+
+## Handoff Notes
+
+- Do not reuse storage `allow_degraded`; rate-limit semantics need explicit naming.
+- Do not emit only warn logs; Redis distributed limiter failure is error-level degraded state.
+- Noop Redis pool remains local limiter path and should not count as degraded.

--- a/specs/GH836/tech.md
+++ b/specs/GH836/tech.md
@@ -1,0 +1,75 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-836 / #836
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Redis check | `src/core/rate_limiter/limiter.rs:176-190` | Redis error -> warn -> local check | Silent fail-open |
+| Redis check_and_record | `src/core/rate_limiter/limiter.rs:254-283` | Redis error -> warn -> local record | Multiplies quota |
+| Redis release | `src/core/rate_limiter/limiter.rs:343-344` | release error handling is local to reservation | Must observe but not fail response |
+| Config | `src/config/models/gateway.rs` / rate-limit config | No explicit degraded policy | Need operator choice |
+| Metrics | `src/monitoring` / metrics middleware | No degraded counter | Need observability |
+
+## 设计方案
+
+1. **Config**：add explicit degraded policy under rate limit config:
+   `redis_failure_mode: fail_closed | fail_open_local`, default `fail_closed`.
+   Naming must make local fallback explicit; do not overload storage `allow_degraded`.
+2. **check/check_and_record behavior**:
+   - If Redis succeeds, unchanged.
+   - If Redis fails and mode is `fail_closed`, return a denied/unavailable result without touching local limiter.
+   - If Redis fails and mode is `fail_open_local`, run current local fallback.
+3. **Observability**:
+   - log at error level on Redis operation failure;
+   - increment `rate_limiter_degraded_total{operation,mode}` for check/check_and_record/release;
+   - optionally expose last degraded timestamp in health/debug state if local pattern exists.
+4. **Release**：Redis release failure cannot change already-sent response, but must log error and metric.
+5. **Tests**：use a fake Redis pool or trait seam. If current RedisPool is hard to fake, introduce a narrow internal trait for
+   rate-limit Redis operations rather than hitting a real Redis service in unit tests.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 no silent degrade | limiter.rs error branch | error log/metric test |
+| P2 default fail-closed | config + limiter | Redis error returns denied/unavailable and no local increment |
+| P3 explicit fallback | config + limiter | fail_open_local uses local limiter and marks degraded |
+| P4 release observable | reservation/release path | release error increments metric but does not fail completed request |
+| P5 no Redis unchanged | constructor/noop path | local limiter tests unchanged |
+
+## 数据流
+
+Request → RateLimitMiddleware → RateLimiter Redis operation →
+success: distributed result; failure: degraded metric/log → policy decision fail_closed or explicit local fallback.
+
+## 备选方案
+
+- Keep warn + local fallback: violates no silent degradation，拒绝。
+- Always fail-open but add metric: still violates configured global limit by default，拒绝。
+- Require Redis for all rate limiting, no fallback option: too disruptive for single-node users，拒绝。
+
+## 风险
+
+- Compatibility: Default fail-closed is behavior tightening for Redis deployments; document escape hatch.
+- Availability: Redis outage can reject traffic by default; this is intentional for global limit correctness.
+- Maintenance: Avoid duplicating metrics code in two branches; use helper.
+
+## 测试计划
+
+- [ ] Config tests: default `fail_closed`, parse `fail_open_local`.
+- [ ] Unit tests: Redis check failure in both modes.
+- [ ] Unit tests: Redis check_and_record failure in both modes and reservation source.
+- [ ] Unit tests: release failure metric/log path.
+- [ ] Metrics test: degraded counter labels.
+
+## 回滚方案
+
+Set `redis_failure_mode=fail_open_local` to restore old runtime behavior with observability. Code revert restores silent fallback.


### PR DESCRIPTION
## Summary
- Adds SpecRail product, tech, and task packet for GH836.
- Scope: Redis rate limiter failure policy, degraded metrics, and no silent local fallback.

## Verification
- python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH836"
- git diff --cached --check

Refs #836