### PR TITLE
docs(spec): add GH841 cache contention packet

### DIFF
--- a/specs/GH841/product.md
+++ b/specs/GH841/product.md
@@ -1,0 +1,54 @@
+# Product Spec
+
+## Linked Issue
+
+GH-841 / #841
+
+## 用户问题
+
+`InMemoryCache` 的主存储使用 `DashMap`，但缓存热路径仍被一个全局
+`Arc<tokio::Mutex<LruCache<CacheKey, ()>>>` 串行化。`get` / `get_entry`
+在命中后都会更新同一把 LRU mutex，`set_with_ttl` / `set_with_size` 在插入后也会更新同一结构。
+当缓存容量满时，LFU 与 TTL 淘汰还会遍历整张 `DashMap` 查找候选项。结果是并发缓存读写无法获得
+`DashMap` 分片并发收益，容量越大淘汰越慢。
+
+## 目标
+
+- 缓存命中与写入路径不再等待全局 LRU mutex。
+- LRU / LFU / TTL / FIFO 淘汰保持现有对外语义，但淘汰候选选择不再做全表扫描。
+- 统计、TTL 过期清理、显式删除、`clear`、`keys`、`stats` 等对外 API 行为保持兼容。
+- 用聚焦并发测试或 benchmark 证明高并发读写吞吐改善，并用单元测试证明淘汰语义未回退。
+
+## 非目标
+
+- 不改变 `InMemoryCache` / `LLMCache` 的公开 API。
+- 不改变默认缓存配置、Redis 缓存行为或 response cache 调用方语义。
+- 不把缓存策略重写成近似随机淘汰，除非产品验收明确接受可解释的近似边界。
+
+## Behavior Invariants
+
+1. `get` / `get_entry` 在未过期命中时返回值、访问计数、最近访问语义与当前实现一致，但不得获取全局 LRU mutex。
+2. `set` / `set_with_ttl` / `set_with_size` 在容量已满时仍按配置的 `EvictionPolicy` 淘汰一个候选项后插入；
+   LFU / TTL / FIFO 不得通过 `cache.iter().min_by_key` 或 `find` 扫描全部 entry。
+3. 删除、过期命中剔除、后台清理和 `clear` 必须同时更新主存储、淘汰索引和统计；不能留下索引孤儿项导致后续淘汰漏删或误删。
+4. 过期 entry 在读取时仍返回 miss，并更新 miss / size / entry_count 统计。
+5. 并发读写下，缓存不会出现 panic、死锁、负 size 统计、entry_count 与 `cache.len()` 长期不一致。
+
+## 验收标准
+
+- [ ] `src/core/cache/memory.rs` 中 `get` / `get_entry` / `set_with_ttl` / `set_with_size` 的正常热路径不再调用全局 `lru_order.lock().await`。
+- [ ] LFU / TTL / FIFO 淘汰路径不再对 `DashMap` 做全表扫描；如保留扫描，只允许在测试或一次性诊断代码中出现。
+- [ ] 淘汰索引与主存储一致性有单元测试覆盖：命中更新、删除、过期剔除、覆盖写入、`clear`。
+- [ ] 并发压测或 criterion bench 覆盖多 task 命中、写入、淘汰混合场景，并在 PR body 附迁移前后对比。
+- [ ] 现有缓存测试和新增聚焦测试通过。
+
+## 边界情况
+
+- `max_size == 0` 当前通过 `NonZeroUsize::MIN` 兜底；实现不得引入 panic 或无限淘汰循环。
+- `CacheEntry::touch` 当前同时更新 `access_count` 与 `last_accessed`；迁移后 LFU 与 LRU 索引必须从同一访问事件更新。
+- 覆盖写入同 key 时，旧 entry 的 size 必须扣减，新 entry 必须只在索引中出现一次。
+- 后台 TTL cleanup 与前台淘汰可能并发删除同一个 key，必须容忍 remove miss。
+
+## 发布说明
+
+内部性能优化，无公开 API 变化。CHANGELOG 以 `perf(cache)` 记录。

--- a/specs/GH841/tasks.md
+++ b/specs/GH841/tasks.md
@@ -1,0 +1,30 @@
+# Task Plan
+
+## Linked Issue
+
+GH-841 / #841
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP841-T1` Owner: coordinator. Done when: `specs/GH841/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH841"`.
+- [ ] `SP841-T2` Owner: maintainer. Done when: #841 批复 shard eviction index 方向、是否允许近似淘汰、benchmark 口径和 shard 数默认值（SpecRail human gate `spec_approval`）. Verify: #841 issue thread 明确批复。
+- [ ] `SP841-T3` Owner: coordinator. Done when: `InMemoryCache` 增加私有 shard `EvictionIndex` 与 `access_tick`，LRU 索引不再使用全局 `lru_order`；`get` / `get_entry` 命中路径更新 shard 索引且不锁全局 mutex. Verify: `cargo test core::cache::memory --lib --all-features`; `rg -n "lru_order|update_lru|add_to_lru|remove_from_lru" src/core/cache/memory.rs` 输出只剩兼容注释或零命中。
+- [ ] `SP841-T4` Owner: coordinator. Done when: `set_with_ttl` / `set_with_size` / 覆盖写入 / delete / clear / 前台过期剔除 / 后台 cleanup 全部维护索引与统计一致性. Verify: 新增单测覆盖 overwrite、delete、expired get、cleanup、clear；`cargo test core::cache --lib --all-features`。
+- [ ] `SP841-T5` Owner: coordinator. Done when: LFU / TTL / FIFO 淘汰迁移为索引候选选择，不再对 `DashMap` 全表扫描；并发 remove miss 有有限重试/清理兜底. Verify: `rg -n "cache\\.iter\\(\\).*min_by_key|cache\\.iter\\(\\).*find" src/core/cache/memory.rs` 零命中或仅测试；策略单测证明候选选择。
+- [ ] `SP841-T6` Owner: verification owner. Done when: 并发压测或 criterion bench 覆盖热点命中、写入淘汰、读写混合，PR body 附迁移前后吞吐和 p95 对比. Verify: 记录实际 bench/压测命令与输出路径。
+- [ ] `SP841-T7` Owner: verification owner. Done when: 全仓确定性验证通过. Verify: `cargo test --all-features`。
+
+## 并行拆分
+
+- SP841-T3 与 SP841-T5 都修改 `src/core/cache/memory.rs`，不得并行写同文件。
+- SP841-T6 可在实现分支完成后由只读验证 lane 并行运行。
+
+## Handoff Notes
+
+- 不要在本 issue 中调整 Redis 缓存、response-cache key 语义或缓存配置默认值。
+- 如果实现发现精确 LRU/LFU 与无全局锁之间存在不可接受成本，先回到 #841 说明 tradeoff，不能静默改为随机/近似淘汰。

--- a/specs/GH841/tech.md
+++ b/specs/GH841/tech.md
@@ -1,0 +1,79 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-841 / #841
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| 主缓存 | `src/core/cache/memory.rs:20-37` | `DashMap<CacheKey, CacheEntry<T>>` 存储 entry，另有全局 `lru_order: Arc<Mutex<LruCache<CacheKey, ()>>>` | 需要移除全局热锁 |
+| 读取热路径 | `src/core/cache/memory.rs:88-127` | 命中后 `entry.touch()`，再 `update_lru(key).await` | 每次命中都等待同一把 mutex |
+| 写入热路径 | `src/core/cache/memory.rs:140-180` | 容量满时先 `evict_one().await`，插入后 `update_lru` 或 `add_to_lru` | 写入和命中争用同一 LRU 结构 |
+| LRU 辅助方法 | `src/core/cache/memory.rs:257-275` | `update_lru` / `add_to_lru` / `remove_from_lru` 都锁全局 LRU | 迁移目标 |
+| LFU/TTL/FIFO 淘汰 | `src/core/cache/memory.rs:306-368` | LFU / TTL / FIFO 通过 `cache.iter()` 查找 min 或 expired | 容量满插入时 O(n) |
+| Entry 元数据 | `src/core/cache/types.rs:80-151` | `CacheEntry` 保存 `access_count`、`last_accessed`、`created_at`、TTL | 新索引必须与这些元数据一致 |
+
+## 设计方案
+
+1. **引入淘汰索引层**
+   - 在 `memory.rs` 内新增私有 `EvictionIndex`，由固定 shard 组成。
+   - 每个 shard 维护该 shard 内 key 的 LRU / LFU / TTL / FIFO 排序元数据；锁粒度为 shard，而不是全局缓存。
+   - shard 选择使用 `CacheKey::hash_value()`，避免额外 hash 分配。
+   - 全局淘汰从各 shard 的 front candidate 中选择最小/最旧候选，复杂度为 `O(shards + log shard_size)`，不随 entry 总数线性增长。
+
+2. **访问元数据更新**
+   - 在 `InMemoryCache` 增加单调 `AtomicU64 access_tick`。
+   - 命中时先更新主 entry 的 `touch` 语义，再用新 tick 更新对应 shard 的索引项。
+   - 若实现选择将访问计数/最近访问 tick 拆到专用 metadata 结构，必须保持 `get_entry` 返回的 `CacheEntry` 元数据与当前 API 兼容。
+   - 不能用异步全局后台队列作为唯一索引更新路径；读取后立即淘汰必须能看到本次访问或有明确测试证明不会违反 LRU/LFU 语义。
+
+3. **淘汰路径**
+   - `evict_lru` 从 shard fronts 中选全局最小 `last_access_tick`。
+   - `evict_lfu` 从 shard fronts 中选全局最小 `(access_count, last_access_tick, key)`，用 tick 作为稳定 tie-breaker。
+   - `evict_ttl` 先从 TTL 索引取已过期候选；没有过期候选时选最早过期 entry。
+   - `evict_fifo` 用 `created_at` / 插入 tick 的索引选最旧 entry；不得继续 `cache.iter().min_by_key`。
+   - 淘汰从索引取候选后再 `cache.remove(&key)`；若主存储已被并发删除，清理索引后重试有限次数，避免死循环。
+
+4. **一致性维护**
+   - `set_with_ttl` / `set_with_size` 覆盖旧 key 时，先移除旧索引项，再插入新索引项，size 统计按当前语义更新。
+   - `delete`、前台过期 remove、后台 `cleanup_expired`、`clear` 必须调用同一套 index remove/clear helper。
+   - 索引 helper 保持私有，不暴露给 `LLMCache` 调用方。
+
+5. **测试与 benchmark**
+   - 新增聚焦单元测试覆盖每个策略的插入、命中、覆盖、删除、过期、clear。
+   - 新增并发压力测试或 criterion benchmark：固定大缓存、多 task 读同一热点、多 task 写入触发淘汰、读写混合。
+   - benchmark 输出写入 PR body；仓库不强制提交生成的 benchmark 报告。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 热路径无全局 mutex | `InMemoryCache::get{,_entry}` + index update | `rg -n "update_lru|lru_order\\.lock" src/core/cache/memory.rs` 只允许迁移兼容/测试残留；聚焦命中测试 |
+| P2 淘汰无全表扫描 | `evict_lru` / `evict_lfu` / `evict_ttl` / `evict_fifo` | `rg -n "cache\\.iter\\(\\).*min_by_key|cache\\.iter\\(\\).*find" src/core/cache/memory.rs` 零命中或仅测试 |
+| P3 索引一致性 | delete / expired / cleanup / clear | 单测：删除后淘汰不返回旧 key；过期前台/后台并发 remove 不 panic |
+| P4 统计兼容 | stats 更新点 | 现有缓存统计测试 + 新增 size/entry_count 断言 |
+| P5 并发安全 | shard index + DashMap | 多 task 压测或 criterion bench |
+
+## 风险
+
+- Concurrency: shard 索引与主存储双写可能产生短暂不一致；必须通过 remove miss 重试和索引清理兜底。
+- Compatibility: `CacheEntry` 是公开结构，不能随意把字段改为 atomic 类型并破坏 Clone/Serialize 转换路径。
+- Performance: shard 锁数量过少会残留争用，数量过多会增加 eviction front 合并成本；初始 shard 数应固定且有基准支撑。
+
+## 测试计划
+
+- [ ] `cargo test core::cache::memory --lib --all-features`
+- [ ] `cargo test core::cache --lib --all-features`
+- [ ] `cargo test --all-features cache`
+- [ ] 并发 benchmark 或压测命令在 PR body 记录迁移前后吞吐、p95 latency、entry 数量、task 数。
+- [ ] `cargo test --all-features`
+
+## 回滚方案
+
+单 PR revert。实现应保持在 `memory.rs` 私有结构内，外部 API 不变，回滚不需要迁移调用方。


### PR DESCRIPTION
Refs #841

## Summary
- Add product, tech, and task specs for InMemoryCache global LRU mutex contention and O(n) eviction scans.
- Scope is spec-only; implementation remains gated by spec approval.

## Verification
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH841"`
- `git diff --check`