### PR TITLE
docs(spec): add GH843 repo hygiene packet

### DIFF
--- a/specs/GH843/product.md
+++ b/specs/GH843/product.md
@@ -1,0 +1,50 @@
+# Product Spec
+
+## Linked Issue
+
+GH-843 / #843
+
+## 用户问题
+
+仓库当前追踪了编译产物、一次性生成/修复脚本、scratch 文档、大量没有生产调用点的自制并发原语，以及行为与命名不一致的空壳 feature flags。
+这些内容会干扰代码搜索、增大维护面，并让用户以为 `websockets` / `analytics` / `enterprise` 开关会改变实际编译行为。
+
+## 目标
+
+- 版本控制中不再包含编译产物和一次性脚本。
+- `src/utils/sync` 只保留有生产调用点或明确公开用途的并发原语；无调用点的薄封装删除或按维护者批复保留。
+- `websockets` / `analytics` / `enterprise` feature flags 的行为与文档一致：要么真正 gate 对应模块，要么移除并更新 docs.rs / README / Cargo 注释。
+- 清理后 `cargo check --all-features` 与相关测试通过。
+
+## 非目标
+
+- 不清理 `docs/` 下历史审计文档。
+- 不重构运行时代码逻辑；本 issue 只处理仓库卫生、公开导出和 feature gate 对齐。
+- 不删除仍有生产调用点、外部 API 明确承诺或维护者要求保留的工具。
+
+## Behavior Invariants
+
+1. `git ls-files` 不再列出 `.rlib` 编译产物和 issue 中列出的顶层一次性生成/修复脚本。
+2. 删除 `ConcurrentMap` / `ConcurrentVec` / `VersionedMap` 前必须用当前 `origin/main` 的搜索证据证明没有生产调用点；仅测试、doctest、模块自引用不能算生产调用点。
+3. 保留 `AtomicValue`，因为 `AppState.config` 仍有生产使用。
+4. feature flags 调整后，`cargo check` 在默认 features、`--all-features`、docs.rs feature set 下都可解释；不能留下声明了但无行为的开关。
+5. README、模块注释、Cargo feature 注释和 docs.rs metadata 与实际 feature 行为一致。
+
+## 验收标准
+
+- [ ] `git ls-files` 不再包含 `libcache_manager_tests.rlib`、`batch_create_providers.sh`、`create_provider_impls.sh`、`create_providers.sh`、`fix_error_mappers.sh`、`fix_streaming_files.sh`、`STREAMING_FIXES.md`、`plan/2026-02-08_12-09-23-refresh-all-provider-model-catalogs.md`、`src/utils/REORGANIZATION_SUMMARY.md`。
+- [ ] `src/utils/sync` 只导出保留的原语；删除项的 tests、docs、public re-exports 同步移除或替换。
+- [ ] `websockets` / `analytics` / `enterprise` 不再是空壳 feature：每个 feature 都有真实 gate 或被移除并更新所有引用。
+- [ ] `cargo check --all-features` 通过。
+- [ ] 默认 feature set 和 docs.rs feature set 的检查命令在 PR body 记录。
+
+## 边界情况
+
+- `deployment/**/*.sh`、`scripts/guards/*.sh`、`scripts/test/*.sh` 是运行/CI 脚本，不属于本 issue 的一次性脚本清理范围。
+- `utils::sync::*` 可能是 crate public export；删除前必须在 PR body 明确这是有意的公开 API 清理，或按维护者要求先做 deprecation。
+- `enterprise = ["analytics", "vector-db"]` 当前会影响依赖闭包；若移除或改 gate，必须检查 docs.rs metadata 和 feature composition。
+- `websockets` 可能应 gate `src/core/realtime`，但不能只 gate 一个 error enum variant 后声称支持 websockets。
+
+## 发布说明
+
+仓库卫生与 feature flag 对齐。若删除 public exports 或 Cargo features，CHANGELOG 需标注为 breaking 或明确 repo 当前不承诺兼容。

--- a/specs/GH843/tasks.md
+++ b/specs/GH843/tasks.md
@@ -1,0 +1,31 @@
+# Task Plan
+
+## Linked Issue
+
+GH-843 / #843
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP843-T1` Owner: coordinator. Done when: `specs/GH843/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH843"`.
+- [ ] `SP843-T2` Owner: maintainer. Done when: #843 批复 public export 删除策略、feature flag 是 gate 还是移除、是否需要 breaking CHANGELOG（SpecRail human gate `spec_approval`）. Verify: #843 issue thread 明确批复。
+- [ ] `SP843-T3` Owner: coordinator. Done when: 删除 `.rlib`、一次性顶层脚本和 scratch 文档，并更新 `.gitignore` 防止编译产物再次提交；合法 deployment/guard/test scripts 保留. Verify: `git ls-files <target paths>` 无输出；`cargo check`。
+- [ ] `SP843-T4` Owner: coordinator. Done when: 用当前 main 搜索确认 `ConcurrentMap` / `ConcurrentVec` / `VersionedMap` 没有生产调用点；删除无调用点实现、tests、docs/re-exports，保留 `AtomicValue`. Verify: production `rg` 输出；`cargo check --all-features`。
+- [ ] `SP843-T5` Owner: coordinator. Done when: `websockets` / `analytics` / `enterprise` feature flags 完成 gate-or-remove 决策，`Cargo.toml`、health feature reporting、docs.rs metadata、README/Cargo 注释与实际行为一致. Verify: `cargo check`; `cargo check --all-features`; adjusted docs.rs `cargo doc` command。
+- [ ] `SP843-T6` Owner: verification owner. Done when: 全仓 deterministic checks 通过，PR body 附 git/ripgrep/feature matrix 输出. Verify: `cargo test --all-features`。
+
+## 并行拆分
+
+- SP843-T3 只改仓库文件清理和 `.gitignore`，可独立 PR。
+- SP843-T4 改 `src/utils/sync` 与 exports，不得与其他 lane 同写这些文件。
+- SP843-T5 改 `Cargo.toml`、feature-gated modules 和 docs，不得与 feature 相关 PR 并行写同文件。
+
+## Handoff Notes
+
+- 不要删除 `deployment/`、`scripts/guards/`、`scripts/test/` 下仍有运行价值的脚本。
+- 如果维护者不接受 public export 删除，SP843-T4 改为 deprecate-first，并重新更新验收标准。
+- feature flag 清理要以“真实编译行为”为准，不接受只更新 health 文本的表面修复。

--- a/specs/GH843/tech.md
+++ b/specs/GH843/tech.md
@@ -1,0 +1,77 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-843 / #843
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| 追踪产物/一次性文件 | `libcache_manager_tests.rlib`、顶层 `batch_create_providers.sh`、`create_provider_impls.sh`、`create_providers.sh`、`fix_error_mappers.sh`、`fix_streaming_files.sh`、`STREAMING_FIXES.md`、`plan/2026-02-08_12-09-23-refresh-all-provider-model-catalogs.md`、`src/utils/REORGANIZATION_SUMMARY.md` | `git ls-files` 仍追踪 | 清理对象 |
+| 合法脚本 | `deployment/**/*.sh`、`scripts/guards/*.sh`、`scripts/test/*.sh` | 仍为运行/CI/guard 脚本 | 不应误删 |
+| sync exports | `src/utils/sync/mod.rs`、`src/utils/mod.rs` | 公开 re-export `AtomicValue`、`ConcurrentMap`、`ConcurrentVec`、`VersionedMap` | 删除需要同步 export/docs |
+| production use | `src/server/state.rs:13,30,69` | 仅 `AtomicValue<Config>` 有生产使用 | 保留 `AtomicValue` |
+| sync implementation | `src/utils/sync/{concurrent_map.rs,concurrent_vec.rs,versioned_map.rs}` 与对应 tests | 大量薄封装和测试/示例自引用 | 候选删除对象 |
+| feature flags | `Cargo.toml:198-203`、`src/server/routes/health.rs:534-538`、`src/utils/error/canonical.rs:261`、`src/core/mod.rs:7,35` | `websockets` / `analytics` / `enterprise` 声明与实际模块 gate 不一致 | 需要 gate 或移除 |
+
+## 设计方案
+
+1. **产物与一次性文件清理**
+   - 删除 `libcache_manager_tests.rlib`，并在 `.gitignore` 加入适当规则（例如 `*.rlib` 或更窄路径）防止再次提交编译产物。
+   - 删除 issue 中列出的顶层一次性脚本与 scratch 文档；不要删除 `deployment/` 和 `scripts/guards/` 下仍被文档/CI 使用的脚本。
+   - PR body 附 `git ls-files` 检查输出，证明目标文件不再追踪。
+
+2. **`utils/sync` 调用点审计**
+   - 先运行生产调用点搜索：
+     `rg -n "ConcurrentMap|ConcurrentVec|VersionedMap|AtomicValue" src --glob '*.rs' --glob '!src/utils/sync/**'`。
+   - 若只有 `AtomicValue` 有生产调用点，则删除 `concurrent_map.rs`、`concurrent_vec.rs`、`versioned_map.rs` 及对应 tests，更新 `src/utils/sync/mod.rs` 与 `src/utils/mod.rs` re-export。
+   - 若发现生产调用点，先替换为标准库 / `DashMap` / `Arc<RwLock<_>>` / 现有类型，再删除；不能留下 broken public export。
+   - 由于这些类型当前是 public export，PR body 需要明确破坏性影响，或按维护者批复改为 deprecate-first。
+
+3. **feature flag 对齐**
+   - 对每个 feature 做二选一决策：
+     - `websockets`: gate 实际 realtime/websocket 模块、routes、依赖和 canonical error variant；或删除 feature 并移除 docs.rs / `full` 引用。
+     - `analytics`: gate `src/core/analytics` 及 health feature reporting；或删除 feature 并更新 `enterprise` composition。
+     - `enterprise`: 如果只是 meta-feature，文档必须说清楚其包含项；否则必须 gate enterprise-only 模块/行为。
+   - `health` 路由的 feature 列表必须来自真实 compile-time behavior，不可只展示空壳 feature。
+   - docs.rs metadata、`full` feature、README/Cargo 注释同步更新。
+
+4. **验证矩阵**
+   - 默认 features: `cargo check`
+   - all features: `cargo check --all-features`
+   - docs.rs feature set: `env DOCS_RS=1 cargo doc --no-deps --features "postgres sqlite redis s3 metrics tracing websockets analytics providers-extra providers-extended"`，如果 features 改名/删除，命令同步调整。
+   - 静态检查：目标文件不在 `git ls-files`；空 feature 搜索无残留误导。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 产物/一次性文件不追踪 | git index + `.gitignore` | `git ls-files <target paths>` 无输出 |
+| P2 删除前有调用点证据 | `src/utils/sync` | `rg` production-use 搜索输出进 PR body |
+| P3 `AtomicValue` 保留 | `state.rs` + sync exports | `cargo check --all-features` |
+| P4 feature 行为一致 | `Cargo.toml` + gated modules + health | 默认/all/docs.rs 检查 + health tests |
+| P5 docs 一致 | README/Cargo/module docs | `rg -n "websockets|analytics|enterprise|ConcurrentMap|ConcurrentVec|VersionedMap"` 人工核对 |
+
+## 风险
+
+- Compatibility: 删除 public exports 或 features 可能影响外部用户；本 repo AGENTS 允许优先清洁架构，但 PR body 必须显式说明。
+- Build matrix: feature composition 改动可能影响 docs.rs 和 `full`。必须跑默认、all、docs.rs 三类检查。
+- Scope creep: 不要在同一 PR 中顺手重构 analytics/realtime 行为；feature gate 只做启停边界对齐。
+
+## 测试计划
+
+- [ ] `git ls-files libcache_manager_tests.rlib batch_create_providers.sh create_provider_impls.sh create_providers.sh fix_error_mappers.sh fix_streaming_files.sh STREAMING_FIXES.md plan/2026-02-08_12-09-23-refresh-all-provider-model-catalogs.md src/utils/REORGANIZATION_SUMMARY.md`
+- [ ] `rg -n "ConcurrentMap|ConcurrentVec|VersionedMap|AtomicValue" src --glob '*.rs' --glob '!src/utils/sync/**'`
+- [ ] `cargo check`
+- [ ] `cargo check --all-features`
+- [ ] docs.rs compatibility command adjusted to final feature set.
+- [ ] `cargo test --all-features` before merge if implementation touches Rust source.
+
+## 回滚方案
+
+按切片 revert：产物/脚本删除、`utils/sync` 删除、feature flag 对齐应分提交实现。若 feature flag 改动影响下游，可先 revert feature 切片而保留产物清理。


### PR DESCRIPTION
Refs #843

## Summary
- Add product, tech, and task specs for tracked artifacts, dead sync utilities, and empty feature flags.
- Scope is spec-only; implementation remains gated by spec approval.

## Verification
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH843"`
- `git diff --check`