### PR TITLE
docs(spec): add GH842 chat hot path packet

### DIFF
--- a/specs/GH842/product.md
+++ b/specs/GH842/product.md
@@ -1,0 +1,53 @@
+# Product Spec
+
+## Linked Issue
+
+GH-842 / #842
+
+## 用户问题
+
+chat completion 热路径在 stream 与非 stream 分支中多次整包 clone `ChatCompletionRequest`。请求体可能包含长 messages、
+tool definitions、甚至 base64 图片；每次 clone 都会放大延迟和内存峰值。认证中间件还会把全部非鉴权 header
+复制进 `RequestContext.headers`，随后 handler 再 clone 整个 `RequestContext`。`AppState.key_manager` 按值存放，
+AI route 为 spend 记录反复 clone，连带 `hmac_secret: Option<String>` 分配。
+
+## 目标
+
+- chat stream 与非 stream 路径不再多次整包 clone `ChatCompletionRequest`。
+- `RequestContext` 在 middleware 与 handler 之间共享，避免每个 handler 再深拷贝 headers / metadata。
+- `KeyManager` 在 `AppState` 中按共享 handle 存放或内部 secret 共享化，避免 spend 调用点复制 HMAC secret。
+- 请求处理语义、缓存命中语义、预算/计费语义和 provider 调用结果保持不变。
+
+## 非目标
+
+- 不改变 OpenAI-compatible API schema。
+- 不重构非 chat 端点，除非为共享 `RequestContext` / `KeyManager` 类型调整所必需。
+- 不改变 `allowed_models`、`max_tokens_per_request`、response cache、token policy 或预算结算策略。
+- 不在本 issue 中解决 #840 的预算编排抽象。
+
+## Behavior Invariants
+
+1. 非 stream chat 与 stream chat 在相同输入下选择相同 provider/model，执行相同预算检查、预留、结算和 response cache 行为。
+2. 大请求体只在必须拥有独立可变 provider request 时 clone；budget、cache、token policy、执行闭包共享同一个请求视图。
+3. `RequestContext` 的 `api_key_id`、`api_key_budget_id`、`api_key_max_tokens_per_request`、user/team metadata、request id、client ip、user agent 在 handler 中可见值不变。
+4. 认证敏感 header 仍不得进入可下游透传的 context；迁移不能重新泄漏 `authorization` 或 `x-api-key`。
+5. `KeyManager` 行为不变：API key hash、verify、last_used throttle cache 和 `/v1/keys` 管理路由仍共享同一 manager 状态。
+
+## 验收标准
+
+- [ ] `src/server/routes/ai/chat.rs` stream 与非 stream 路径不再 clone 完整 `ChatCompletionRequest` 3-4 次。
+- [ ] `RequestContext` 从 middleware extensions 到 handler 捕获使用共享 handle，chat handler 不再为 retry closure 深拷贝 headers / metadata。
+- [ ] `AppState.key_manager` 或 `KeyManager.hmac_secret` 改为共享表示，AI route spend 调用点不再复制 HMAC secret 字符串。
+- [ ] 大 payload 聚焦测试或 benchmark 证明请求 clone/alloc 明显下降，PR body 附对比数据。
+- [ ] `cargo test --all-features` 通过。
+
+## 边界情况
+
+- `stream_options.include_usage` 当前会被强制设为 true 以便内部计费，再按客户端请求过滤输出；迁移不能改变这个行为。
+- `prepare_chat_request_for_provider` 仍需要根据 selected provider/model 和 key token policy 生成 provider-specific request；允许这一步为最终 provider 请求拥有一份必要副本。
+- response cache lookup 必须看到原始非 stream request，不得被 token policy 或 stream usage 注入污染。
+- `RequestContext` 可能被测试或 legacy helper 直接构造；公共构造方法需要保持源码兼容或提供清晰迁移。
+
+## 发布说明
+
+内部性能优化，无公开 API 变化。CHANGELOG 以 `perf(chat)` 记录。

--- a/specs/GH842/tasks.md
+++ b/specs/GH842/tasks.md
@@ -1,0 +1,32 @@
+# Task Plan
+
+## Linked Issue
+
+GH-842 / #842
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP842-T1` Owner: coordinator. Done when: `specs/GH842/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH842"`.
+- [ ] `SP842-T2` Owner: maintainer. Done when: #842 批复 `Arc<ChatCompletionRequest>` / `Arc<RequestContext>` / `Arc<KeyManager>` 方向和 benchmark 口径（SpecRail human gate `spec_approval`）. Verify: #842 issue thread 明确批复。
+- [ ] `SP842-T3` Owner: coordinator. Done when: chat non-stream request flow 改为共享原始 request，`response_cache`、budget estimation、token policy 不再各持一份完整 clone；行为测试覆盖 cache hit、预算不足、provider 成功、provider 失败. Verify: `cargo test server::routes::ai::chat --lib --all-features`。
+- [ ] `SP842-T4` Owner: coordinator. Done when: chat stream request flow 改为共享原始 request，内部 usage 注入只发生在 provider request builder 中，客户端 usage 输出过滤行为不变. Verify: stream 聚焦测试覆盖 `client_requested_usage=true/false`。
+- [ ] `SP842-T5` Owner: coordinator. Done when: `RequestContext` 在 middleware extensions 与 handlers 中以共享 handle 传递，鉴权 metadata 保持可见，敏感 headers 继续排除. Verify: `cargo test server::middleware::auth --lib --all-features`; `cargo test server::routes::ai::context --lib --all-features`。
+- [ ] `SP842-T6` Owner: coordinator. Done when: `AppState.key_manager` 或 `KeyManager.hmac_secret` 共享化，AI route spend 调用不再复制 HMAC secret 字符串；key management route 行为不变. Verify: `cargo test core::keys --lib --all-features`; key route 聚焦测试。
+- [ ] `SP842-T7` Owner: verification owner. Done when: 大 payload allocation test 或 benchmark 证明 request/context/key_manager clone 分配下降，PR body 附命令与前后数据. Verify: 记录实际 bench/测试输出。
+- [ ] `SP842-T8` Owner: verification owner. Done when: 全仓确定性验证通过. Verify: `cargo test --all-features`。
+
+## 并行拆分
+
+- SP842-T3/T4 都修改 `src/server/routes/ai/chat.rs`，不得并行写同文件。
+- SP842-T5 会触碰 shared handler signatures，需在 SP842-T3/T4 前后由同一 owner 串行收敛。
+- SP842-T7 可由只读验证 lane 在实现分支稳定后并行运行。
+
+## Handoff Notes
+
+- 不要把本 issue 与 #840 预算编排合并；本 issue 只降低分配，不改变预算生命周期。
+- 任何静态 guard 都要允许最终 provider request 的必要 clone，不能用过宽规则阻止合法拥有权转换。

--- a/specs/GH842/tech.md
+++ b/specs/GH842/tech.md
@@ -1,0 +1,81 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-842 / #842
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| chat stream | `src/server/routes/ai/chat.rs:83-127` | `request_for_budget = request.clone()`，构造 `core_request` 后 closure 内再 clone `core_request`、`context`、`request_for_budget` | stream 热路径重复 clone 大请求体 |
+| chat non-stream | `src/server/routes/ai/chat.rs:396-455` | `request_for_budget` 与 `request_for_cache` 各 clone 一份，retry closure 内再 clone request/context/handles | 非 stream 热路径重复 clone |
+| Auth context | `src/server/middleware/auth.rs:415-448` | 每个请求复制全部非鉴权 header 到 `HashMap<String,String>` | 大 header 集下每请求固定分配 |
+| Context extraction | `src/server/routes/ai/context.rs:28-32` | 从 request extensions 取 `RequestContext` 后 clone 整体返回 | handler 捕获再次复制 context |
+| RequestContext 类型 | `src/core/types/context.rs:12-33` | `#[derive(Clone)]`，headers/metadata 为 owned `HashMap` | 需要共享或瘦身 |
+| AppState KeyManager | `src/server/state.rs:45-46` | `key_manager: KeyManager` 按值存放；chat 等 spend 站点 clone manager | clone 会复制 `hmac_secret: Option<String>` |
+| KeyManager | `src/core/keys/manager.rs:24-33` | repository/cache 为 `Arc`，但 `hmac_secret` 是 owned `Option<String>` | 可改为 `Option<Arc<str>>` 或把 AppState 字段改为 `Arc<KeyManager>` |
+
+## 设计方案
+
+1. **共享 chat request**
+   - 在 `handle_chat_completion_internal` 与 `handle_streaming_chat_completion` 入口尽早将原始 `ChatCompletionRequest`
+     包成 `Arc<ChatCompletionRequest>`。
+   - response cache、budget estimation、token policy 读取原始 request 时接收 `&ChatCompletionRequest` 或 `Arc` 引用，
+     不再需要 `request_for_budget` / `request_for_cache` 两份 owned clone。
+   - `build_core_chat_request` 拆成借用版本（例如 `build_core_chat_request_ref(&ChatCompletionRequest, ...)`）或只 clone最终 provider request 所需字段。
+   - `prepare_chat_request_for_provider` 改为接收 borrowed original request + owned/borrowed core template，并只在生成最终 provider request 时拥有必要数据。
+
+2. **stream usage 注入保持隔离**
+   - 当前 stream 会把 `stream_options.include_usage` 强制设为 true。迁移后不要 mut 原始 `Arc<ChatCompletionRequest>`。
+   - 建议新增小型 builder：从 borrowed original request 构造 provider request 时注入内部 usage 需求，同时保留 `client_requested_usage` 用于响应过滤。
+   - budget/cache 读取必须使用未污染的 original request。
+
+3. **共享 RequestContext**
+   - 在 request extensions 中存放 `Arc<RequestContext>`，并让 `get_request_context` 返回 `Arc<RequestContext>` 或新的 `RequestContextRef`。
+   - handler 与 retry closure clone 的是 `Arc`，不是 `HashMap` / metadata。
+   - `RequestContext` 本身的 public builder API 可保留；middleware 构建完成后再 `Arc::new(context)`。
+   - header 收集改为白名单或 lazy 模式：只保留实际使用字段（request id、user agent、client ip、auth metadata），自定义 headers 仅在有明确调用点时填充。鉴权 header 继续排除。
+
+4. **共享 KeyManager**
+   - 首选把 `AppState.key_manager` 改为 `Arc<KeyManager>`，保持 manager 内部状态共享，AI route closure 只 clone `Arc`。
+   - 若调用面过大，也可以先将 `KeyManager.hmac_secret` 改为 `Option<Arc<str>>`，并在第二步收敛 `AppState` 字段；但最终验收需证明 AI route 不复制 secret string。
+   - `/v1/keys` 管理路由必须继续通过同一个 manager 访问 repository 和 last-used throttle cache。
+
+5. **可测 guard**
+   - 为 chat 增加大 payload 聚焦测试或 criterion benchmark，构造多 message + image_url/base64 payload。
+   - 如 Rust 代码难以直接统计 clone 次数，可用 allocation counter、custom test payload size、或 benchmark 输出作为证据。
+   - 添加静态 guard：在 `chat.rs` 中禁止 `request.clone()` 用于 budget/cache 分叉，允许注释说明的最终 provider request clone。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 行为不变 | chat stream/non-stream | 现有 chat tests + budget/cache 聚焦测试 |
+| P2 请求共享 | `chat.rs` + token_policy/cache helpers | 静态 guard + 大 payload allocation/bench 对比 |
+| P3 context 共享 | auth middleware + `context.rs` + handlers | 单测：metadata/auth fields 可见；handler closure clone 不复制 HashMap |
+| P4 header 安全 | auth middleware | 单测：`authorization` / `x-api-key` 不进入 context |
+| P5 KeyManager 共享 | `state.rs` + key routes + spend call sites | 单测/compile：`Arc<KeyManager>` 或 `Arc<str>` secret；key route tests 通过 |
+
+## 风险
+
+- Compatibility: `get_request_context` 返回类型变化会触碰多个 route；迁移需一次性修完编译错误，不能留 Any/alias 逃逸。
+- Security: header 收集调整不能泄漏鉴权 header，也不能丢失 auth metadata。
+- Performance: `Arc` 降低 clone 成本，但如果 builder 为每次 attempt 仍 clone完整 messages，收益会被抵消；provider request 构造需单独检查。
+
+## 测试计划
+
+- [ ] `cargo test server::routes::ai::chat --lib --all-features`
+- [ ] `cargo test server::middleware::auth --lib --all-features`
+- [ ] `cargo test core::keys --lib --all-features`
+- [ ] 大 payload allocation test 或 criterion bench，PR body 记录迁移前后数据。
+- [ ] `cargo test --all-features`
+- [ ] 静态 guard: `rg -n "request_for_budget|request_for_cache|request\\.clone\\(\\)|context_for_execution = context\\.clone\\(\\)|state\\.key_manager\\.clone\\(\\)" src/server/routes/ai/chat.rs src/server/routes/ai`.
+
+## 回滚方案
+
+优先按 chat/request sharing、context sharing、KeyManager sharing 三个提交分层实现；任一层出问题可单独 revert。公开 API schema 不变，回滚不需要数据迁移。


### PR DESCRIPTION
Refs #842

## Summary
- Add product, tech, and task specs for chat request/context/key_manager hot-path clone reduction.
- Scope is spec-only; implementation remains gated by spec approval.

## Verification
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH842"`
- `git diff --check`