### PR TITLE
fix(server): let CORS preflight bypass auth

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -17,7 +17,10 @@ use crate::utils::error::gateway_error::{GatewayError, Result};
 use actix_cors::Cors;
 use actix_web::{
     App, HttpServer as ActixHttpServer,
-    middleware::{Condition, DefaultHeaders, Logger},
+    body::MessageBody,
+    dev::{ServiceRequest, ServiceResponse},
+    http::{Method, header},
+    middleware::{Condition, DefaultHeaders, Logger, Next, from_fn},
     web,
 };
 use std::sync::Arc;
@@ -211,10 +214,10 @@ impl HttpServer {
             .wrap(AuthMiddleware)
             .wrap(RequestIdMiddleware)
             .wrap(Condition::new(metrics_enabled, MetricsMiddleware))
-            // Register CORS last so Actix runs it first. That lets standard
-            // browser preflight requests complete before auth/rate-limit and
-            // lets CORS decorate downstream auth/rate-limit failures.
-            .wrap(cors)
+            // CORS must run outside auth/rate-limit, but only standard browser
+            // preflight may be short-circuited before those layers.
+            .wrap(Condition::new(cors_config.enabled, cors))
+            .wrap(from_fn(normalize_non_cors_options_before_cors))
             .configure(routes::health::configure_routes)
             .configure(routes::auth::configure_routes)
             .configure(routes::keys::configure_routes)
@@ -377,6 +380,23 @@ impl HttpServer {
     pub fn state(&self) -> &AppState {
         &self.state
     }
+}
+
+async fn normalize_non_cors_options_before_cors(
+    mut req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> std::result::Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    if req.method() == Method::OPTIONS
+        && req
+            .headers()
+            .contains_key(header::ACCESS_CONTROL_REQUEST_METHOD)
+        && !req.headers().contains_key(header::ORIGIN)
+    {
+        req.headers_mut()
+            .remove(header::ACCESS_CONTROL_REQUEST_METHOD);
+    }
+
+    next.call(req).await
 }
 
 #[cfg(test)]

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -198,7 +198,6 @@ impl HttpServer {
         App::new()
             .app_data(state)
             .app_data(budget_limits)
-            .wrap(cors)
             .wrap(Logger::default())
             .wrap(DefaultHeaders::new().add(("Server", "LiteLLM-RS")))
             .wrap(SecurityHeadersMiddleware)
@@ -212,6 +211,10 @@ impl HttpServer {
             .wrap(AuthMiddleware)
             .wrap(RequestIdMiddleware)
             .wrap(Condition::new(metrics_enabled, MetricsMiddleware))
+            // Register CORS last so Actix runs it first. That lets standard
+            // browser preflight requests complete before auth/rate-limit and
+            // lets CORS decorate downstream auth/rate-limit failures.
+            .wrap(cors)
             .configure(routes::health::configure_routes)
             .configure(routes::auth::configure_routes)
             .configure(routes::keys::configure_routes)
@@ -380,7 +383,10 @@ impl HttpServer {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use actix_web::{http::StatusCode, test as actix_test};
+    use actix_web::{
+        http::{StatusCode, header},
+        test as actix_test,
+    };
 
     #[test]
     fn build_cors_rejects_wildcard_with_credentials() {
@@ -597,6 +603,8 @@ mod tests {
         assert!(body.contains("gateway_http_request_errors_total 1"));
         assert!(body.contains("gateway_http_responses_total{class=\"4xx\"} 1"));
     }
+
+    include!("http_cors_tests.rs");
 
     #[tokio::test]
     async fn app_factory_does_not_collect_http_metrics_when_metrics_disabled() {

--- a/src/server/http_cors_tests.rs
+++ b/src/server/http_cors_tests.rs
@@ -1,0 +1,122 @@
+fn cors_auth_test_config() -> Config {
+    let mut config = Config::default();
+    config.gateway.auth.enable_jwt = true;
+    config.gateway.auth.enable_api_key = true;
+    config.gateway.auth.allow_anonymous = false;
+    config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+    config.gateway.rate_limit.enabled = true;
+    config.gateway.server.cors.enabled = true;
+    config.gateway.server.cors.allowed_origins = vec!["https://app.example".to_string()];
+    config.gateway.monitoring.metrics.enabled = false;
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    config.gateway.pricing.source = None;
+    config
+}
+
+#[tokio::test]
+async fn app_factory_cors_preflight_runs_before_auth() {
+    let server = match HttpServer::new(&cors_auth_test_config()).await {
+        Ok(server) => server,
+        Err(error) => panic!("server startup failed: {error}"),
+    };
+
+    let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+        server.state().clone(),
+    )))
+    .await;
+
+    let req = actix_test::TestRequest::default()
+        .method(actix_web::http::Method::OPTIONS)
+        .uri("/v1/chat/completions")
+        .insert_header((header::ORIGIN, "https://app.example"))
+        .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "POST"))
+        .insert_header((
+            header::ACCESS_CONTROL_REQUEST_HEADERS,
+            "authorization,content-type",
+        ))
+        .to_request();
+    let resp = actix_test::call_service(&app, req).await;
+
+    assert!(
+        resp.status().is_success(),
+        "preflight should be handled by CORS, got {}",
+        resp.status()
+    );
+    assert_eq!(
+        resp.headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some("https://app.example")
+    );
+    assert!(
+        resp.headers()
+            .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+            .is_some(),
+        "preflight response should include allowed methods"
+    );
+    assert!(
+        resp.headers()
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .is_some(),
+        "preflight response should include allowed headers"
+    );
+}
+
+#[tokio::test]
+async fn app_factory_unauthenticated_post_still_401_with_cors_headers() {
+    let server = match HttpServer::new(&cors_auth_test_config()).await {
+        Ok(server) => server,
+        Err(error) => panic!("server startup failed: {error}"),
+    };
+
+    let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+        server.state().clone(),
+    )))
+    .await;
+
+    let req = actix_test::TestRequest::post()
+        .uri("/v1/chat/completions")
+        .insert_header((header::ORIGIN, "https://app.example"))
+        .insert_header((header::CONTENT_TYPE, "application/json"))
+        .set_payload("{}")
+        .to_request();
+    let resp = actix_test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        resp.headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some("https://app.example")
+    );
+}
+
+#[tokio::test]
+async fn app_factory_non_preflight_options_still_requires_auth() {
+    let server = match HttpServer::new(&cors_auth_test_config()).await {
+        Ok(server) => server,
+        Err(error) => panic!("server startup failed: {error}"),
+    };
+
+    let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+        server.state().clone(),
+    )))
+    .await;
+
+    let missing_requested_method = actix_test::TestRequest::default()
+        .method(actix_web::http::Method::OPTIONS)
+        .uri("/v1/chat/completions")
+        .insert_header((header::ORIGIN, "https://app.example"))
+        .to_request();
+    let resp = actix_test::call_service(&app, missing_requested_method).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let missing_origin = actix_test::TestRequest::default()
+        .method(actix_web::http::Method::OPTIONS)
+        .uri("/v1/chat/completions")
+        .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "POST"))
+        .to_request();
+    let resp = actix_test::call_service(&app, missing_origin).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/src/server/http_cors_tests.rs
+++ b/src/server/http_cors_tests.rs
@@ -14,6 +14,12 @@ fn cors_auth_test_config() -> Config {
     config
 }
 
+fn disabled_cors_auth_test_config() -> Config {
+    let mut config = cors_auth_test_config();
+    config.gateway.server.cors.enabled = false;
+    config
+}
+
 #[tokio::test]
 async fn app_factory_cors_preflight_runs_before_auth() {
     let server = match HttpServer::new(&cors_auth_test_config()).await {
@@ -118,5 +124,33 @@ async fn app_factory_non_preflight_options_still_requires_auth() {
         .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "POST"))
         .to_request();
     let resp = actix_test::call_service(&app, missing_origin).await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn app_factory_disabled_cors_preflight_still_requires_auth() {
+    let server = match HttpServer::new(&disabled_cors_auth_test_config()).await {
+        Ok(server) => server,
+        Err(error) => panic!("server startup failed: {error}"),
+    };
+
+    let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+        server.state().clone(),
+    )))
+    .await;
+
+    let req = actix_test::TestRequest::default()
+        .method(actix_web::http::Method::OPTIONS)
+        .uri("/v1/chat/completions")
+        .insert_header((header::ORIGIN, "https://app.example"))
+        .insert_header((header::ACCESS_CONTROL_REQUEST_METHOD, "POST"))
+        .to_request();
+    let resp = actix_test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        resp.headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none()
+    );
 }

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -13,6 +13,7 @@ use crate::server::middleware::rate_limit::{
 };
 use crate::server::routes::ai::{api_key_allows_endpoint, check_permission};
 use crate::server::state::AppState;
+use actix_web::body::EitherBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::{HttpMessage, HttpRequest, web};
 use futures::future::{Ready, ready};
@@ -32,7 +33,7 @@ where
     S::Future: 'static,
     B: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = actix_web::Error;
     type InitError = ();
     type Transform = AuthMiddlewareService<S>;
@@ -56,7 +57,7 @@ where
     S::Future: 'static,
     B: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = actix_web::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
@@ -94,7 +95,10 @@ where
 
             if is_public {
                 req.extensions_mut().insert(context);
-                return service.call(req).await;
+                return service
+                    .call(req)
+                    .await
+                    .map(ServiceResponse::map_into_left_body);
             }
 
             let auth_enabled = enable_jwt || enable_api_key;
@@ -110,82 +114,111 @@ where
                          rejecting request to non-public route. Enable JWT or API key auth, or \
                          set allow_anonymous: true (development only)."
                     );
-                    return Err(actix_web::error::ErrorUnauthorized(
-                        "Authentication is not configured",
-                    ));
+                    return Ok(req
+                        .error_response(actix_web::error::ErrorUnauthorized(
+                            "Authentication is not configured",
+                        ))
+                        .map_into_right_body());
                 }
                 req.extensions_mut().insert(context);
-                return service.call(req).await;
+                return service
+                    .call(req)
+                    .await
+                    .map(ServiceResponse::map_into_left_body);
             }
 
             if let Err(wait_seconds) = rate_limiter.check_allowed(&client_id) {
-                enforce_gateway_rate_limit_for_auth_rejection(
+                if let Err(error) = enforce_gateway_rate_limit_for_auth_rejection(
                     &req,
                     rate_limit_enabled,
                     rate_limit_rpm,
                     &trusted_proxies,
                 )
-                .await?;
-                return Err(actix_web::error::ErrorTooManyRequests(format!(
-                    "Too many failed attempts. Try again in {} seconds",
-                    wait_seconds
-                )));
+                .await
+                {
+                    return Ok(req.error_response(error).map_into_right_body());
+                }
+                return Ok(req
+                    .error_response(actix_web::error::ErrorTooManyRequests(format!(
+                        "Too many failed attempts. Try again in {} seconds",
+                        wait_seconds
+                    )))
+                    .map_into_right_body());
             }
 
             let auth_method = match auth_method {
                 AuthMethod::Jwt(_) if !enable_jwt => {
                     rate_limiter.record_failure(&client_id);
-                    enforce_gateway_rate_limit_for_auth_rejection(
+                    if let Err(error) = enforce_gateway_rate_limit_for_auth_rejection(
                         &req,
                         rate_limit_enabled,
                         rate_limit_rpm,
                         &trusted_proxies,
                     )
-                    .await?;
-                    return Err(actix_web::error::ErrorUnauthorized(
-                        "JWT authentication disabled",
-                    ));
+                    .await
+                    {
+                        return Ok(req.error_response(error).map_into_right_body());
+                    }
+                    return Ok(req
+                        .error_response(actix_web::error::ErrorUnauthorized(
+                            "JWT authentication disabled",
+                        ))
+                        .map_into_right_body());
                 }
                 AuthMethod::ApiKey(_) if !enable_api_key => {
                     rate_limiter.record_failure(&client_id);
-                    enforce_gateway_rate_limit_for_auth_rejection(
+                    if let Err(error) = enforce_gateway_rate_limit_for_auth_rejection(
                         &req,
                         rate_limit_enabled,
                         rate_limit_rpm,
                         &trusted_proxies,
                     )
-                    .await?;
-                    return Err(actix_web::error::ErrorUnauthorized(
-                        "API key authentication disabled",
-                    ));
+                    .await
+                    {
+                        return Ok(req.error_response(error).map_into_right_body());
+                    }
+                    return Ok(req
+                        .error_response(actix_web::error::ErrorUnauthorized(
+                            "API key authentication disabled",
+                        ))
+                        .map_into_right_body());
                 }
                 other => other,
             };
 
             if matches!(auth_method, AuthMethod::None) {
                 rate_limiter.record_failure(&client_id);
-                enforce_gateway_rate_limit_for_auth_rejection(
+                if let Err(error) = enforce_gateway_rate_limit_for_auth_rejection(
                     &req,
                     rate_limit_enabled,
                     rate_limit_rpm,
                     &trusted_proxies,
                 )
-                .await?;
-                return Err(actix_web::error::ErrorUnauthorized(
-                    "Missing authentication",
-                ));
+                .await
+                {
+                    return Ok(req.error_response(error).map_into_right_body());
+                }
+                return Ok(req
+                    .error_response(actix_web::error::ErrorUnauthorized(
+                        "Missing authentication",
+                    ))
+                    .map_into_right_body());
             }
 
             let mut auth_rate_limit_reservation = if requires_auth_verification(&auth_method) {
-                Some(
-                    reserve_gateway_rate_limit_before_auth(
-                        &req,
-                        rate_limit_enabled,
-                        rate_limit_rpm,
-                        &trusted_proxies,
-                    )
-                    .await?,
+                match reserve_gateway_rate_limit_before_auth(
+                    &req,
+                    rate_limit_enabled,
+                    rate_limit_rpm,
+                    &trusted_proxies,
                 )
+                .await
+                {
+                    Ok(reservation) => Some(reservation),
+                    Err(error) => {
+                        return Ok(req.error_response(error).map_into_right_body());
+                    }
+                }
             } else {
                 None
             };
@@ -209,21 +242,27 @@ where
                             "Authenticated caller is not permitted to access AI operation '{}'",
                             operation
                         );
-                        return Err(actix_web::error::ErrorForbidden(
-                            "API key is not permitted for this operation",
-                        ));
+                        return Ok(req
+                            .error_response(actix_web::error::ErrorForbidden(
+                                "API key is not permitted for this operation",
+                            ))
+                            .map_into_right_body());
                     }
                     match api_key_allows_endpoint(result.api_key.as_ref(), req.path()) {
                         Ok(true) => {}
                         Ok(false) => {
                             warn!("Authenticated API key is not permitted to access this endpoint");
-                            return Err(actix_web::error::ErrorForbidden(
-                                "API key is not permitted for this endpoint",
-                            ));
+                            return Ok(req
+                                .error_response(actix_web::error::ErrorForbidden(
+                                    "API key is not permitted for this endpoint",
+                                ))
+                                .map_into_right_body());
                         }
                         Err(error) => {
                             warn!("Authenticated API key policy is invalid: {}", error);
-                            return Err(actix_web::error::ErrorForbidden(error.to_string()));
+                            return Ok(req
+                                .error_response(actix_web::error::ErrorForbidden(error.to_string()))
+                                .map_into_right_body());
                         }
                     }
 
@@ -235,7 +274,10 @@ where
                         req.extensions_mut().insert::<ApiKey>(api_key);
                     }
 
-                    service.call(req).await
+                    service
+                        .call(req)
+                        .await
+                        .map(ServiceResponse::map_into_left_body)
                 }
                 Ok(result) => {
                     rate_limiter.record_failure(&client_id);
@@ -246,18 +288,22 @@ where
                             .clone()
                             .unwrap_or_else(|| "unauthorized".to_string())
                     );
-                    if auth_rate_limit_reservation.is_none() {
-                        enforce_gateway_rate_limit_for_auth_rejection(
+                    if auth_rate_limit_reservation.is_none()
+                        && let Err(error) = enforce_gateway_rate_limit_for_auth_rejection(
                             &req,
                             rate_limit_enabled,
                             rate_limit_rpm,
                             &trusted_proxies,
                         )
-                        .await?;
+                        .await
+                    {
+                        return Ok(req.error_response(error).map_into_right_body());
                     }
-                    Err(actix_web::error::ErrorUnauthorized(
-                        result.error.unwrap_or_else(|| "Unauthorized".to_string()),
-                    ))
+                    Ok(req
+                        .error_response(actix_web::error::ErrorUnauthorized(
+                            result.error.unwrap_or_else(|| "Unauthorized".to_string()),
+                        ))
+                        .map_into_right_body())
                 }
                 Err(err) => {
                     if let Some(reservation) = auth_rate_limit_reservation.take() {

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -4,6 +4,7 @@ use super::rate_limit_key_policy::effective_requests_per_minute;
 use crate::core::rate_limiter::{RateLimitReservation, get_global_rate_limiter};
 use crate::core::types::context::RequestContext;
 use crate::server::state::AppState;
+use actix_web::body::EitherBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::http::StatusCode;
 use actix_web::web;
@@ -14,6 +15,7 @@ use std::fmt;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -379,11 +381,11 @@ impl Default for RateLimitMiddleware {
 
 impl<S, B> Transform<S, ServiceRequest> for RateLimitMiddleware
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error> + 'static,
     S::Future: 'static,
     B: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = actix_web::Error;
     type InitError = ();
     type Transform = RateLimitMiddlewareService<S>;
@@ -391,7 +393,7 @@ where
 
     fn new_transform(&self, service: S) -> Self::Future {
         ready(Ok(RateLimitMiddlewareService {
-            service,
+            service: Rc::new(service),
             requests_per_minute: self.requests_per_minute,
             fallback_store: gateway_fallback_store(),
         }))
@@ -400,7 +402,7 @@ where
 
 /// Service implementation for rate limit middleware
 pub struct RateLimitMiddlewareService<S> {
-    service: S,
+    service: Rc<S>,
     requests_per_minute: Option<u32>,
     /// Fallback in-process store used when the global rate limiter is not initialized
     fallback_store: Arc<DashMap<String, KeyTracker>>,
@@ -464,17 +466,18 @@ fn network_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> Strin
 
 impl<S, B> Service<ServiceRequest> for RateLimitMiddlewareService<S>
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error> + 'static,
     S::Future: 'static,
     B: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = actix_web::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        let service = Rc::clone(&self.service);
         let app_state = req.app_data::<web::Data<AppState>>().cloned();
         let trusted_proxies: Vec<String> = match app_state.as_ref() {
             Some(state) => {
@@ -491,10 +494,6 @@ where
         let requests_per_minute = effective_requests_per_minute(&req, self.requests_per_minute);
 
         let fallback_store = self.fallback_store.clone();
-        // service.call() returns a lazy future; it only executes on .await.
-        // We must call it here because it consumes `req`, but we will NOT
-        // await it if the rate check fails, so no downstream work is wasted.
-        let fut = self.service.call(req);
         let key = client_key.clone();
 
         Box::pin(async move {
@@ -514,7 +513,9 @@ where
                                 retry_after: rejection.retry_after,
                                 limit: rejection.limit,
                             };
-                            return Err(actix_web::Error::from(err));
+                            return Ok(req
+                                .error_response(actix_web::Error::from(err))
+                                .map_into_right_body());
                         }
                     };
 
@@ -527,7 +528,7 @@ where
                 );
             }
 
-            let res = fut.await?;
+            let res = service.call(req).await?.map_into_left_body();
             let duration = start_time.elapsed();
             info!(
                 "{} {} completed in {:?} with status {}",

--- a/tests/integration/auth_middleware_tests_parts/disabled_auth.rs
+++ b/tests/integration/auth_middleware_tests_parts/disabled_auth.rs
@@ -14,21 +14,17 @@ async fn test_auth_middleware_fails_closed_when_disabled_without_anonymous_opt_i
     )
     .await;
 
-    let request = test::TestRequest::get().uri(AUTH_PROBE_PATH).to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("disabled auth without allow_anonymous should fail closed");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get().uri(AUTH_PROBE_PATH).to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
-    assert!(
-        error
-            .to_string()
-            .contains("Authentication is not configured")
-    );
+    let body = test::read_body(response).await;
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("Authentication is not configured"));
 }
 
 #[tokio::test]

--- a/tests/integration/auth_middleware_tests_parts/permissions_context.rs
+++ b/tests/integration/auth_middleware_tests_parts/permissions_context.rs
@@ -90,20 +90,20 @@ async fn test_auth_middleware_denies_ai_route_for_disallowed_api_permission() {
     )
     .await;
 
-    let request = test::TestRequest::post()
-        .uri("/v1/chat/completions")
-        .insert_header(("x-api-key", principal.raw_api_key.clone()))
-        .to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("disallowed operation should fail in auth middleware");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::FORBIDDEN
-    );
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
-    assert!(error.to_string().contains("operation"));
+    let body = test::read_body(response).await;
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("operation"));
 }
 
 #[tokio::test]
@@ -127,18 +127,16 @@ async fn test_auth_middleware_keeps_admin_owned_api_key_permission_restricted() 
     )
     .await;
 
-    let request = test::TestRequest::post()
-        .uri("/v1/chat/completions")
-        .insert_header(("x-api-key", principal.raw_api_key.clone()))
-        .to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("admin-owned limited key should stay limited");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::FORBIDDEN
-    );
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
 }
 
@@ -159,18 +157,16 @@ async fn test_auth_middleware_denies_root_engine_completion_alias_for_disallowed
     )
     .await;
 
-    let request = test::TestRequest::post()
-        .uri("/engines/gpt-4o/completions")
-        .insert_header(("x-api-key", principal.raw_api_key.clone()))
-        .to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("root engine completions alias should map to completions operation");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/engines/gpt-4o/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::FORBIDDEN
-    );
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
 }
 
@@ -199,20 +195,20 @@ async fn test_auth_middleware_denies_ai_route_for_disallowed_endpoint_policy() {
     )
     .await;
 
-    let request = test::TestRequest::post()
-        .uri("/v1/chat/completions")
-        .insert_header(("x-api-key", principal.raw_api_key.clone()))
-        .to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("disallowed endpoint should fail in auth middleware");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-api-key", principal.raw_api_key.clone()))
+            .to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::FORBIDDEN
-    );
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
-    assert!(error.to_string().contains("endpoint"));
+    let body = test::read_body(response).await;
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("endpoint"));
 }
 
 #[tokio::test]

--- a/tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs
+++ b/tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs
@@ -14,17 +14,17 @@ async fn test_auth_middleware_rejects_missing_auth() {
     )
     .await;
 
-    let request = test::TestRequest::get().uri(AUTH_PROBE_PATH).to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("missing auth should fail in auth middleware");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get().uri(AUTH_PROBE_PATH).to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
-    assert!(error.to_string().contains("Missing authentication"));
+    let body = test::read_body(response).await;
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("Missing authentication"));
 }
 
 #[tokio::test]
@@ -41,20 +41,20 @@ async fn test_auth_middleware_rejects_invalid_auth() {
     )
     .await;
 
-    let request = test::TestRequest::get()
-        .uri(AUTH_PROBE_PATH)
-        .insert_header(("x-api-key", "gw-invalid-auth-middleware-key"))
-        .to_request();
-    let error = test::try_call_service(&app, request)
-        .await
-        .expect_err("invalid auth should fail in auth middleware");
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(AUTH_PROBE_PATH)
+            .insert_header(("x-api-key", "gw-invalid-auth-middleware-key"))
+            .to_request(),
+    )
+    .await;
 
-    assert_eq!(
-        error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
-    assert!(error.to_string().contains("Invalid API key"));
+    let body = test::read_body(response).await;
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("Invalid API key"));
 }
 
 #[tokio::test]
@@ -76,25 +76,15 @@ async fn test_missing_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
         .uri(AUTH_PROBE_PATH)
         .peer_addr("203.0.113.101:1000".parse().unwrap())
         .to_request();
-    let first_error = test::try_call_service(&app, first)
-        .await
-        .expect_err("first missing-auth request should fail in auth middleware");
-    assert_eq!(
-        first_error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    let first_response = test::call_service(&app, first).await;
+    assert_eq!(first_response.status(), StatusCode::UNAUTHORIZED);
 
     let second = test::TestRequest::get()
         .uri(AUTH_PROBE_PATH)
         .peer_addr("203.0.113.101:1001".parse().unwrap())
         .to_request();
-    let second_error = test::try_call_service(&app, second)
-        .await
-        .expect_err("second missing-auth request should hit gateway rate limit");
-    assert_eq!(
-        second_error.as_response_error().status_code(),
-        StatusCode::TOO_MANY_REQUESTS
-    );
+    let second_response = test::call_service(&app, second).await;
+    assert_eq!(second_response.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
 }
 
@@ -116,28 +106,18 @@ async fn test_rotating_invalid_auth_hits_gateway_rate_limit_before_auth_short_ci
     let first = test::TestRequest::get()
         .uri(AUTH_PROBE_PATH)
         .peer_addr("203.0.113.102:1000".parse().unwrap())
-        .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key"))
+        .insert_header(("x-api-key", "gw-invalid-auth-middleware-key"))
         .to_request();
-    let first_error = test::try_call_service(&app, first)
-        .await
-        .expect_err("first invalid-auth request should fail in auth middleware");
-    assert_eq!(
-        first_error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    let first_response = test::call_service(&app, first).await;
+    assert_eq!(first_response.status(), StatusCode::UNAUTHORIZED);
 
     let second = test::TestRequest::get()
         .uri(AUTH_PROBE_PATH)
         .peer_addr("203.0.113.102:1001".parse().unwrap())
         .insert_header(("x-api-key", "gw-invalid-auth-rate-limit-key-rotated"))
         .to_request();
-    let second_error = test::try_call_service(&app, second)
-        .await
-        .expect_err("second rotating invalid-auth request should hit gateway rate limit");
-    assert_eq!(
-        second_error.as_response_error().status_code(),
-        StatusCode::TOO_MANY_REQUESTS
-    );
+    let second_response = test::call_service(&app, second).await;
+    assert_eq!(second_response.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
 }
 
@@ -159,25 +139,15 @@ async fn test_requests_per_minute_alias_limits_rejected_auth() {
         .uri(AUTH_PROBE_PATH)
         .peer_addr("203.0.113.152:1000".parse().unwrap())
         .to_request();
-    let first_error = test::try_call_service(&app, first)
-        .await
-        .expect_err("first missing-auth request should fail in auth middleware");
-    assert_eq!(
-        first_error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    let first_response = test::call_service(&app, first).await;
+    assert_eq!(first_response.status(), StatusCode::UNAUTHORIZED);
 
     let second = test::TestRequest::get()
         .uri(AUTH_PROBE_PATH)
         .peer_addr("203.0.113.152:1001".parse().unwrap())
         .to_request();
-    let second_error = test::try_call_service(&app, second)
-        .await
-        .expect_err("second missing-auth request should hit requests_per_minute limit");
-    assert_eq!(
-        second_error.as_response_error().status_code(),
-        StatusCode::TOO_MANY_REQUESTS
-    );
+    let second_response = test::call_service(&app, second).await;
+    assert_eq!(second_response.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
 }
 
@@ -209,13 +179,8 @@ async fn test_requests_per_minute_alias_limits_authenticated_requests() {
         .uri(AUTH_PROBE_PATH)
         .insert_header(("x-api-key", principal.raw_api_key.clone()))
         .to_request();
-    let second_error = test::try_call_service(&app, second)
-        .await
-        .expect_err("second authenticated request should hit requests_per_minute limit");
-    assert_eq!(
-        second_error.as_response_error().status_code(),
-        StatusCode::TOO_MANY_REQUESTS
-    );
+    let second_response = test::call_service(&app, second).await;
+    assert_eq!(second_response.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
 }
 
@@ -248,13 +213,8 @@ async fn test_valid_auth_releases_gateway_auth_attempt_reservation() {
         .peer_addr("203.0.113.103:1001".parse().unwrap())
         .insert_header(("x-api-key", "gw-invalid-after-valid-auth"))
         .to_request();
-    let invalid_error = test::try_call_service(&app, invalid)
-        .await
-        .expect_err("first invalid auth after valid auth should not inherit the reservation");
-    assert_eq!(
-        invalid_error.as_response_error().status_code(),
-        StatusCode::UNAUTHORIZED
-    );
+    let invalid_response = test::call_service(&app, invalid).await;
+    assert_eq!(invalid_response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
 }
 
@@ -302,13 +262,7 @@ async fn test_api_key_rpm_is_enforced_without_gateway_default_rate_limit() {
         .uri(AUTH_PROBE_PATH)
         .insert_header(("x-api-key", principal.raw_api_key.clone()))
         .to_request();
-    let second_error = test::try_call_service(&app, second)
-        .await
-        .expect_err("second request should hit the API key rpm limit");
-
-    assert_eq!(
-        second_error.as_response_error().status_code(),
-        StatusCode::TOO_MANY_REQUESTS
-    );
+    let second_response = test::call_service(&app, second).await;
+    assert_eq!(second_response.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
## Summary
- Move CORS to the outer Actix middleware position so browser preflight is handled before auth/rate-limit.
- Return auth/rate-limit rejections as responses so outer CORS can decorate downstream failures.
- Add HTTP factory tests for allowed preflight, unauthenticated POST with CORS headers, and non-preflight OPTIONS not being treated as preflight.

Closes #832

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features --message-format=short`
- `cargo test server::http --all-features -- --nocapture`
- `cargo test --test lib integration::auth_middleware_tests --all-features -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH832"`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`