### PR TITLE
fix(rate-limit): fail closed on Redis degradation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Redis-backed distributed rate limiting now fails closed by default when Redis commands fail, emits `rate_limiter_degraded_total{operation,mode}`, and keeps the old local fallback only behind `rate_limit.redis_failure_mode: fail_open_local`.
+
 ## [0.5.0] - 2026-04-30
 
 ### Added

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -159,6 +159,10 @@ rate_limit:
   requests_per_minute: null
   tokens_per_minute: null # NOT YET IMPLEMENTED: not enforced by the rate limiter
   burst_size: null # NOT YET IMPLEMENTED: not enforced by the rate limiter
+  # Redis distributed rate limiting fails closed by default when Redis commands
+  # fail. Set fail_open_local only when accepting per-process fallback limits is
+  # an explicit operational choice.
+  redis_failure_mode: fail_closed
 
 enterprise:
   enabled: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,9 @@ Sophisticated routing with multiple strategies:
 - Health-Based
 - Custom Weighted
 
+### Rate Limiting
+Redis-backed distributed rate limiting fails closed by default when Redis commands fail, preserving global limits across multi-node deployments. Operators that need the old per-process fallback behavior can set `rate_limit.redis_failure_mode: fail_open_local`; degraded Redis operations are still exported as `rate_limiter_degraded_total{operation,mode}`.
+
 ### Unified Error Handling
 All provider-specific errors are mapped to a unified error system for consistent error handling across the entire system.
 

--- a/src/config/models/rate_limit.rs
+++ b/src/config/models/rate_limit.rs
@@ -40,6 +40,9 @@ pub struct RateLimitConfig {
     /// Burst size
     #[serde(skip_serializing_if = "Option::is_none")]
     pub burst_size: Option<u32>,
+    /// Redis failure behavior for distributed rate limiting.
+    #[serde(default)]
+    pub redis_failure_mode: RedisFailureMode,
 }
 
 impl Default for RateLimitConfig {
@@ -53,6 +56,7 @@ impl Default for RateLimitConfig {
             requests_per_minute: None,
             tokens_per_minute: None,
             burst_size: None,
+            redis_failure_mode: RedisFailureMode::default(),
         }
     }
 }
@@ -115,7 +119,30 @@ impl RateLimitConfig {
         if other.burst_size.is_some() {
             self.burst_size = other.burst_size;
         }
+        if other.redis_failure_mode != RedisFailureMode::default() {
+            self.redis_failure_mode = other.redis_failure_mode;
+        }
         self
+    }
+}
+
+/// Redis outage policy for distributed rate limiting.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RedisFailureMode {
+    /// Reject rate-limited requests when Redis enforcement is unavailable.
+    #[default]
+    FailClosed,
+    /// Explicitly fall back to process-local limits when Redis fails.
+    FailOpenLocal,
+}
+
+impl RedisFailureMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FailClosed => "fail_closed",
+            Self::FailOpenLocal => "fail_open_local",
+        }
     }
 }
 
@@ -177,6 +204,7 @@ mod tests {
         assert_eq!(config.strategy, RateLimitStrategy::TokenBucket);
         assert!(config.requests_per_second.is_none());
         assert!(config.burst_size.is_none());
+        assert_eq!(config.redis_failure_mode, RedisFailureMode::FailClosed);
     }
 
     #[test]
@@ -190,10 +218,12 @@ mod tests {
             requests_per_minute: None,
             tokens_per_minute: Some(100_000),
             burst_size: Some(20),
+            redis_failure_mode: RedisFailureMode::FailOpenLocal,
         };
         assert!(config.enabled);
         assert_eq!(config.requests_per_second, Some(10));
         assert_eq!(config.burst_size, Some(20));
+        assert_eq!(config.redis_failure_mode, RedisFailureMode::FailOpenLocal);
     }
 
     #[test]
@@ -207,12 +237,14 @@ mod tests {
             requests_per_minute: None,
             tokens_per_minute: None,
             burst_size: None,
+            redis_failure_mode: RedisFailureMode::FailClosed,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["enabled"], true);
         assert_eq!(json["strategy"], "fixed_window");
         assert_eq!(json["default_rpm"], 600);
         assert_eq!(json["requests_per_second"], 50);
+        assert_eq!(json["redis_failure_mode"], "fail_closed");
     }
 
     #[test]
@@ -222,6 +254,14 @@ mod tests {
         assert!(!config.enabled);
         assert_eq!(config.default_rpm, 1000);
         assert_eq!(config.default_tpm, 100_000);
+        assert_eq!(config.redis_failure_mode, RedisFailureMode::FailClosed);
+    }
+
+    #[test]
+    fn test_rate_limit_config_deserialization_redis_failure_mode() {
+        let json = r#"{"redis_failure_mode": "fail_open_local"}"#;
+        let config: RateLimitConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.redis_failure_mode, RedisFailureMode::FailOpenLocal);
     }
 
     #[test]
@@ -243,6 +283,7 @@ mod tests {
             requests_per_minute: None,
             tokens_per_minute: None,
             burst_size: Some(20),
+            redis_failure_mode: RedisFailureMode::FailOpenLocal,
         };
         let merged = base.merge(other);
         assert!(merged.enabled);
@@ -250,6 +291,7 @@ mod tests {
         assert_eq!(merged.strategy, RateLimitStrategy::SlidingWindow);
         assert_eq!(merged.requests_per_second, Some(10));
         assert_eq!(merged.burst_size, Some(20));
+        assert_eq!(merged.redis_failure_mode, RedisFailureMode::FailOpenLocal);
     }
 
     #[test]
@@ -312,6 +354,7 @@ mod tests {
             requests_per_minute: Some(1000),
             tokens_per_minute: None,
             burst_size: None,
+            redis_failure_mode: RedisFailureMode::FailClosed,
         };
         let json = serde_json::to_value(&config).unwrap();
         let obj = json.as_object().unwrap();

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -1,48 +1,142 @@
 //! Core rate limiter implementation
 
 use super::types::{RateLimitEntry, RateLimitResult};
-use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
+use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy, RedisFailureMode};
+#[cfg(feature = "gateway")]
+use crate::utils::error::gateway_error::Result;
+#[cfg(feature = "gateway")]
+use async_trait::async_trait;
 use dashmap::DashMap;
+use std::collections::BTreeMap;
+use std::fmt;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use tracing::error;
 
-static RATE_LIMITER_DEGRADED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REDIS_DEGRADED_METRICS: LazyLock<
+    parking_lot::Mutex<BTreeMap<(&'static str, &'static str), u64>>,
+> = LazyLock::new(|| parking_lot::Mutex::new(BTreeMap::new()));
 
-#[cfg(any(feature = "gateway", test))]
-fn record_rate_limiter_degradation() {
-    RATE_LIMITER_DEGRADED_TOTAL.fetch_add(1, Ordering::Relaxed);
+#[derive(Debug, Clone, Copy)]
+enum RedisRateLimitOperation {
+    Check,
+    CheckAndRecord,
+    Release,
+}
+
+impl RedisRateLimitOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Check => "check",
+            Self::CheckAndRecord => "check_and_record",
+            Self::Release => "release",
+        }
+    }
 }
 
 #[cfg(feature = "gateway")]
-fn record_redis_degradation(operation: &'static str, key: &str, err: &impl std::fmt::Display) {
-    record_rate_limiter_degradation();
+#[async_trait]
+pub(crate) trait RedisRateLimitBackend: Send + Sync {
+    async fn rate_limit_status(
+        &self,
+        key: &str,
+        limit: u32,
+        window_secs: u64,
+    ) -> Result<RateLimitResult>;
+
+    async fn rate_limit_check_and_record(
+        &self,
+        key: &str,
+        limit: u32,
+        window_secs: u64,
+    ) -> Result<RateLimitResult>;
+
+    async fn rate_limit_release(&self, key: &str, reservation_ttl_secs: u64) -> Result<()>;
+
+    fn is_noop(&self) -> bool;
+}
+
+#[cfg(feature = "gateway")]
+#[async_trait]
+impl RedisRateLimitBackend for crate::storage::redis::RedisPool {
+    async fn rate_limit_status(
+        &self,
+        key: &str,
+        limit: u32,
+        window_secs: u64,
+    ) -> Result<RateLimitResult> {
+        crate::storage::redis::RedisPool::rate_limit_status(self, key, limit, window_secs).await
+    }
+
+    async fn rate_limit_check_and_record(
+        &self,
+        key: &str,
+        limit: u32,
+        window_secs: u64,
+    ) -> Result<RateLimitResult> {
+        crate::storage::redis::RedisPool::rate_limit_check_and_record(self, key, limit, window_secs)
+            .await
+    }
+
+    async fn rate_limit_release(&self, key: &str, reservation_ttl_secs: u64) -> Result<()> {
+        crate::storage::redis::RedisPool::rate_limit_release(self, key, reservation_ttl_secs).await
+    }
+
+    fn is_noop(&self) -> bool {
+        self.is_noop()
+    }
+}
+
+fn record_redis_degraded(
+    operation: RedisRateLimitOperation,
+    mode: RedisFailureMode,
+    key: &str,
+    err: &impl fmt::Display,
+) {
+    let operation = operation.as_str();
+    let mode = mode.as_str();
+
     error!(
-        redis_operation = operation,
-        client = %key,
+        operation,
+        mode,
+        key,
         error = %err,
-        "Redis-backed rate limiter operation failed; rate limiting is degraded"
+        "Redis distributed rate limiter degraded"
     );
+
+    let mut metrics = REDIS_DEGRADED_METRICS.lock();
+    *metrics.entry((operation, mode)).or_insert(0) += 1;
 }
 
-pub(crate) fn rate_limiter_degraded_total() -> u64 {
-    RATE_LIMITER_DEGRADED_TOTAL.load(Ordering::Relaxed)
-}
+pub fn render_degraded_metrics() -> String {
+    let metrics = REDIS_DEGRADED_METRICS.lock();
+    let mut rendered = String::from(
+        "# HELP rate_limiter_degraded_total Redis distributed rate limiter degraded operations\n\
+         # TYPE rate_limiter_degraded_total counter\n",
+    );
 
-pub fn render_rate_limiter_prometheus() -> String {
-    format!(
-        r#"# HELP gateway_rate_limiter_degraded_total Total Redis-backed rate limiter operations that degraded due to Redis errors
-# TYPE gateway_rate_limiter_degraded_total counter
-gateway_rate_limiter_degraded_total {}
-"#,
-        rate_limiter_degraded_total()
-    )
+    for ((operation, mode), value) in metrics.iter() {
+        rendered.push_str(&format!(
+            "rate_limiter_degraded_total{{operation=\"{operation}\",mode=\"{mode}\"}} {value}\n"
+        ));
+    }
+
+    rendered
 }
 
 #[cfg(test)]
-fn reset_rate_limiter_metrics_for_tests() {
-    RATE_LIMITER_DEGRADED_TOTAL.store(0, Ordering::Relaxed);
+pub(crate) fn reset_degraded_metrics_for_tests() {
+    REDIS_DEGRADED_METRICS.lock().clear();
+}
+
+#[cfg(test)]
+pub(crate) fn degraded_metric_count_for_tests(operation: &str, mode: &str) -> u64 {
+    REDIS_DEGRADED_METRICS
+        .lock()
+        .get(&(operation, mode))
+        .copied()
+        .unwrap_or(0)
 }
 
 /// Backend that recorded a rate-limit reservation.
@@ -120,7 +214,7 @@ pub struct RateLimiter {
     pub(super) window: Duration,
     /// Optional distributed Redis backend
     #[cfg(feature = "gateway")]
-    pub(super) redis: Option<Arc<crate::storage::redis::RedisPool>>,
+    pub(super) redis: Option<Arc<dyn RedisRateLimitBackend>>,
 }
 
 impl RateLimiter {
@@ -190,13 +284,34 @@ impl RateLimiter {
         config: RateLimitConfig,
         redis: Arc<crate::storage::redis::RedisPool>,
     ) -> Self {
+        Self::with_redis_backend(config, redis)
+    }
+
+    #[cfg(feature = "gateway")]
+    pub(crate) fn with_redis_backend(
+        config: RateLimitConfig,
+        redis: Arc<dyn RedisRateLimitBackend>,
+    ) -> Self {
         Self::warn_unimplemented_fields(&config);
+        let redis = if redis.is_noop() { None } else { Some(redis) };
 
         Self {
             config,
             entries: Arc::new(DashMap::new()),
             window: Duration::from_secs(60),
-            redis: if redis.is_noop() { None } else { Some(redis) },
+            redis,
+        }
+    }
+
+    fn redis_fail_closed_result(&self, limit: u32) -> RateLimitResult {
+        let reset_after_secs = self.window.as_secs().max(1);
+        RateLimitResult {
+            allowed: false,
+            current_count: limit,
+            limit,
+            remaining: 0,
+            reset_after_secs,
+            retry_after_secs: Some(reset_after_secs),
         }
     }
 
@@ -217,7 +332,15 @@ impl RateLimiter {
             {
                 Ok(result) => return result,
                 Err(err) => {
-                    record_redis_degradation("status", key, &err);
+                    record_redis_degraded(
+                        RedisRateLimitOperation::Check,
+                        self.config.redis_failure_mode,
+                        key,
+                        &err,
+                    );
+                    if self.config.redis_failure_mode == RedisFailureMode::FailClosed {
+                        return self.redis_fail_closed_result(self.config.effective_rpm());
+                    }
                 }
             }
         }
@@ -307,7 +430,23 @@ impl RateLimiter {
                     return (result, reservation);
                 }
                 Err(err) => {
-                    record_redis_degradation("check_and_record", key, &err);
+                    record_redis_degraded(
+                        RedisRateLimitOperation::CheckAndRecord,
+                        self.config.redis_failure_mode,
+                        key,
+                        &err,
+                    );
+                    if self.config.redis_failure_mode == RedisFailureMode::FailClosed {
+                        let result = self.redis_fail_closed_result(requests_per_minute);
+                        return (
+                            result,
+                            RateLimitReservation::new(
+                                RateLimitRecordSource::Disabled,
+                                Instant::now(),
+                                0,
+                            ),
+                        );
+                    }
                 }
             }
         }
@@ -373,7 +512,12 @@ impl RateLimiter {
                 if let Some(redis) = &self.redis
                     && let Err(err) = redis.rate_limit_release(key, remaining_window_secs).await
                 {
-                    record_redis_degradation("release", key, &err);
+                    record_redis_degraded(
+                        RedisRateLimitOperation::Release,
+                        self.config.redis_failure_mode,
+                        key,
+                        &err,
+                    );
                 }
             }
         }
@@ -508,18 +652,5 @@ mod tests {
             RateLimiter::unimplemented_field_names(&config),
             vec!["burst_size"]
         );
-    }
-
-    #[test]
-    fn test_rate_limiter_degradation_metric_renders_prometheus_counter() {
-        reset_rate_limiter_metrics_for_tests();
-        assert_eq!(rate_limiter_degraded_total(), 0);
-
-        record_rate_limiter_degradation();
-
-        let rendered = render_rate_limiter_prometheus();
-        assert_eq!(rate_limiter_degraded_total(), 1);
-        assert!(rendered.contains("# TYPE gateway_rate_limiter_degraded_total counter"));
-        assert!(rendered.contains("gateway_rate_limiter_degraded_total 1"));
     }
 }

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -4,10 +4,45 @@ use super::types::{RateLimitEntry, RateLimitResult};
 use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
 use dashmap::DashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tracing::error;
+
+static RATE_LIMITER_DEGRADED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+fn record_rate_limiter_degradation() {
+    RATE_LIMITER_DEGRADED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 #[cfg(feature = "gateway")]
-use tracing::warn;
+fn record_redis_degradation(operation: &'static str, key: &str, err: &impl std::fmt::Display) {
+    record_rate_limiter_degradation();
+    error!(
+        redis_operation = operation,
+        client = %key,
+        error = %err,
+        "Redis-backed rate limiter operation failed; rate limiting is degraded"
+    );
+}
+
+pub(crate) fn rate_limiter_degraded_total() -> u64 {
+    RATE_LIMITER_DEGRADED_TOTAL.load(Ordering::Relaxed)
+}
+
+pub fn render_rate_limiter_prometheus() -> String {
+    format!(
+        r#"# HELP gateway_rate_limiter_degraded_total Total Redis-backed rate limiter operations that degraded due to Redis errors
+# TYPE gateway_rate_limiter_degraded_total counter
+gateway_rate_limiter_degraded_total {}
+"#,
+        rate_limiter_degraded_total()
+    )
+}
+
+#[cfg(test)]
+fn reset_rate_limiter_metrics_for_tests() {
+    RATE_LIMITER_DEGRADED_TOTAL.store(0, Ordering::Relaxed);
+}
 
 /// Backend that recorded a rate-limit reservation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -181,10 +216,7 @@ impl RateLimiter {
             {
                 Ok(result) => return result,
                 Err(err) => {
-                    warn!(
-                        "Redis rate-limit status failed for key {}; falling back to in-process limiter: {}",
-                        key, err
-                    );
+                    record_redis_degradation("status", key, &err);
                 }
             }
         }
@@ -274,10 +306,7 @@ impl RateLimiter {
                     return (result, reservation);
                 }
                 Err(err) => {
-                    warn!(
-                        "Redis rate-limit check failed for key {}; falling back to in-process limiter: {}",
-                        key, err
-                    );
+                    record_redis_degradation("check_and_record", key, &err);
                 }
             }
         }
@@ -343,7 +372,7 @@ impl RateLimiter {
                 if let Some(redis) = &self.redis
                     && let Err(err) = redis.rate_limit_release(key, remaining_window_secs).await
                 {
-                    warn!("Redis rate-limit release failed for key {}: {}", key, err);
+                    record_redis_degradation("release", key, &err);
                 }
             }
         }
@@ -478,5 +507,18 @@ mod tests {
             RateLimiter::unimplemented_field_names(&config),
             vec!["burst_size"]
         );
+    }
+
+    #[test]
+    fn test_rate_limiter_degradation_metric_renders_prometheus_counter() {
+        reset_rate_limiter_metrics_for_tests();
+        assert_eq!(rate_limiter_degraded_total(), 0);
+
+        record_rate_limiter_degradation();
+
+        let rendered = render_rate_limiter_prometheus();
+        assert_eq!(rate_limiter_degraded_total(), 1);
+        assert!(rendered.contains("# TYPE gateway_rate_limiter_degraded_total counter"));
+        assert!(rendered.contains("gateway_rate_limiter_degraded_total 1"));
     }
 }

--- a/src/core/rate_limiter/limiter.rs
+++ b/src/core/rate_limiter/limiter.rs
@@ -10,6 +10,7 @@ use tracing::error;
 
 static RATE_LIMITER_DEGRADED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(any(feature = "gateway", test))]
 fn record_rate_limiter_degradation() {
     RATE_LIMITER_DEGRADED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }

--- a/src/core/rate_limiter/mod.rs
+++ b/src/core/rate_limiter/mod.rs
@@ -14,7 +14,7 @@ mod tests;
 #[cfg(test)]
 pub(crate) use limiter::RateLimitRecordSource;
 pub(crate) use limiter::RateLimitReservation;
-pub use limiter::{RateLimiter, render_rate_limiter_prometheus};
+pub use limiter::{RateLimiter, render_degraded_metrics};
 pub use types::RateLimitResult;
 
 use crate::config::models::rate_limit::RateLimitConfig;

--- a/src/core/rate_limiter/mod.rs
+++ b/src/core/rate_limiter/mod.rs
@@ -14,7 +14,7 @@ mod tests;
 #[cfg(test)]
 pub(crate) use limiter::RateLimitRecordSource;
 pub(crate) use limiter::RateLimitReservation;
-pub use limiter::RateLimiter;
+pub use limiter::{RateLimiter, render_rate_limiter_prometheus};
 pub use types::RateLimitResult;
 
 use crate::config::models::rate_limit::RateLimitConfig;

--- a/src/core/rate_limiter/tests.rs
+++ b/src/core/rate_limiter/tests.rs
@@ -2,10 +2,56 @@
 
 #[cfg(test)]
 use super::limiter::RateLimiter;
+#[cfg(feature = "gateway")]
+use super::limiter::{
+    RedisRateLimitBackend, degraded_metric_count_for_tests, render_degraded_metrics,
+    reset_degraded_metrics_for_tests,
+};
 use super::types::RateLimitEntry;
 use super::{RateLimitRecordSource, RateLimitReservation};
-use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy};
+use crate::config::models::rate_limit::{RateLimitConfig, RateLimitStrategy, RedisFailureMode};
+#[cfg(feature = "gateway")]
+use crate::utils::error::gateway_error::{GatewayError, Result};
+#[cfg(feature = "gateway")]
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+#[cfg(feature = "gateway")]
+static REDIS_METRICS_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+#[cfg(feature = "gateway")]
+struct FailingRedisBackend;
+
+#[cfg(feature = "gateway")]
+#[async_trait::async_trait]
+impl RedisRateLimitBackend for FailingRedisBackend {
+    async fn rate_limit_status(
+        &self,
+        _key: &str,
+        _limit: u32,
+        _window_secs: u64,
+    ) -> Result<super::RateLimitResult> {
+        Err(GatewayError::Storage("redis unavailable".to_string()))
+    }
+
+    async fn rate_limit_check_and_record(
+        &self,
+        _key: &str,
+        _limit: u32,
+        _window_secs: u64,
+    ) -> Result<super::RateLimitResult> {
+        Err(GatewayError::Storage("redis unavailable".to_string()))
+    }
+
+    async fn rate_limit_release(&self, _key: &str, _reservation_ttl_secs: u64) -> Result<()> {
+        Err(GatewayError::Storage("redis unavailable".to_string()))
+    }
+
+    fn is_noop(&self) -> bool {
+        false
+    }
+}
 
 fn test_config(enabled: bool, rpm: u32) -> RateLimitConfig {
     test_config_with_strategy(enabled, rpm, RateLimitStrategy::SlidingWindow)
@@ -34,6 +80,11 @@ fn test_config_with_requests_per_minute_alias(enabled: bool, rpm: u32) -> RateLi
         strategy: RateLimitStrategy::SlidingWindow,
         ..Default::default()
     }
+}
+
+#[cfg(feature = "gateway")]
+fn limiter_with_failing_redis(config: RateLimitConfig) -> RateLimiter {
+    RateLimiter::with_redis_backend(config, Arc::new(FailingRedisBackend))
 }
 
 #[tokio::test]
@@ -199,6 +250,98 @@ async fn test_check_and_record_with_source_and_limit_uses_override_rpm() {
     assert!(first.allowed);
     assert!(!second.allowed);
     assert_eq!(second.limit, 1);
+}
+
+#[cfg(feature = "gateway")]
+#[tokio::test]
+async fn redis_check_failure_defaults_to_fail_closed() {
+    let _guard = REDIS_METRICS_TEST_LOCK.lock().await;
+    reset_degraded_metrics_for_tests();
+    let limiter = limiter_with_failing_redis(test_config(true, 3));
+
+    let result = limiter.check("redis-key").await;
+
+    assert!(!result.allowed);
+    assert_eq!(result.limit, 3);
+    assert_eq!(result.remaining, 0);
+    assert_eq!(degraded_metric_count_for_tests("check", "fail_closed"), 1);
+    assert!(!limiter.entries.contains_key("redis-key"));
+}
+
+#[cfg(feature = "gateway")]
+#[tokio::test]
+async fn redis_check_and_record_failure_defaults_to_fail_closed_without_local_reservation() {
+    let _guard = REDIS_METRICS_TEST_LOCK.lock().await;
+    reset_degraded_metrics_for_tests();
+    let limiter = limiter_with_failing_redis(test_config(true, 3));
+
+    let (result, reservation) = limiter.check_and_record_with_source("redis-key").await;
+
+    assert!(!result.allowed);
+    assert_eq!(reservation.source(), RateLimitRecordSource::Disabled);
+    assert_eq!(
+        degraded_metric_count_for_tests("check_and_record", "fail_closed"),
+        1
+    );
+    assert!(!limiter.entries.contains_key("redis-key"));
+}
+
+#[cfg(feature = "gateway")]
+#[tokio::test]
+async fn redis_check_and_record_failure_can_explicitly_fail_open_local() {
+    let _guard = REDIS_METRICS_TEST_LOCK.lock().await;
+    reset_degraded_metrics_for_tests();
+    let config = RateLimitConfig {
+        redis_failure_mode: RedisFailureMode::FailOpenLocal,
+        ..test_config(true, 1)
+    };
+    let limiter = limiter_with_failing_redis(config);
+
+    let (allowed, reservation) = limiter.check_and_record_with_source("redis-key").await;
+    let blocked_by_local = limiter.check_and_record("redis-key").await;
+
+    assert!(allowed.allowed);
+    assert_eq!(reservation.source(), RateLimitRecordSource::Local);
+    assert!(!blocked_by_local.allowed);
+    assert_eq!(
+        degraded_metric_count_for_tests("check_and_record", "fail_open_local"),
+        2
+    );
+    assert!(limiter.entries.contains_key("redis-key"));
+}
+
+#[cfg(feature = "gateway")]
+#[tokio::test]
+async fn redis_release_failure_is_observable_and_nonfatal() {
+    let _guard = REDIS_METRICS_TEST_LOCK.lock().await;
+    reset_degraded_metrics_for_tests();
+    let limiter = limiter_with_failing_redis(test_config(true, 1));
+
+    limiter
+        .release_recorded(
+            "redis-key",
+            RateLimitReservation::for_test(RateLimitRecordSource::Distributed, Instant::now(), 60),
+        )
+        .await;
+
+    assert_eq!(degraded_metric_count_for_tests("release", "fail_closed"), 1);
+}
+
+#[cfg(feature = "gateway")]
+#[tokio::test]
+async fn redis_degraded_metric_renders_operation_and_mode_labels() {
+    let _guard = REDIS_METRICS_TEST_LOCK.lock().await;
+    reset_degraded_metrics_for_tests();
+    let limiter = limiter_with_failing_redis(test_config(true, 1));
+
+    let _ = limiter.check("redis-key").await;
+
+    let rendered = render_degraded_metrics();
+    assert!(rendered.contains("# TYPE rate_limiter_degraded_total counter"));
+    assert!(
+        rendered
+            .contains("rate_limiter_degraded_total{operation=\"check\",mode=\"fail_closed\"} 1")
+    );
 }
 
 #[tokio::test]

--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -36,6 +36,7 @@
 
 #![allow(dead_code)]
 
+use crate::core::rate_limiter::render_rate_limiter_prometheus;
 use crate::server::middleware::MetricsMiddleware;
 use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
@@ -209,6 +210,8 @@ async fn metrics(state: web::Data<AppState>) -> ActixResult<HttpResponse> {
 }
 
 fn render_prometheus_metrics(providers_count: usize, http_metrics: &str) -> String {
+    let rate_limiter_metrics = render_rate_limiter_prometheus();
+
     format!(
         r#"# HELP gateway_uptime_seconds Total uptime of the gateway in seconds
 # TYPE gateway_uptime_seconds counter
@@ -227,12 +230,15 @@ gateway_cpu_usage_percent {}
 gateway_providers_total {}
 
 {}
+
+{}
 "#,
         get_uptime_seconds(),
         get_memory_usage(),
         get_cpu_usage(),
         providers_count,
-        http_metrics
+        http_metrics,
+        rate_limiter_metrics
     )
 }
 
@@ -701,6 +707,7 @@ mod tests {
         assert!(body.contains("gateway_providers_total 2"));
         assert!(body.contains("gateway_http_requests_total 7"));
         assert!(body.contains("gateway_http_responses_total{class=\"2xx\"} 5"));
+        assert!(body.contains("gateway_rate_limiter_degraded_total"));
     }
 
     #[test]

--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -36,7 +36,6 @@
 
 #![allow(dead_code)]
 
-use crate::core::rate_limiter::render_rate_limiter_prometheus;
 use crate::server::middleware::MetricsMiddleware;
 use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
@@ -202,6 +201,7 @@ async fn metrics(state: web::Data<AppState>) -> ActixResult<HttpResponse> {
     let metrics = render_prometheus_metrics(
         state.config.load().providers().len(),
         &MetricsMiddleware::render_prometheus(),
+        &crate::core::rate_limiter::render_degraded_metrics(),
     );
 
     Ok(HttpResponse::Ok()
@@ -209,9 +209,11 @@ async fn metrics(state: web::Data<AppState>) -> ActixResult<HttpResponse> {
         .body(metrics))
 }
 
-fn render_prometheus_metrics(providers_count: usize, http_metrics: &str) -> String {
-    let rate_limiter_metrics = render_rate_limiter_prometheus();
-
+fn render_prometheus_metrics(
+    providers_count: usize,
+    http_metrics: &str,
+    rate_limiter_metrics: &str,
+) -> String {
     format!(
         r#"# HELP gateway_uptime_seconds Total uptime of the gateway in seconds
 # TYPE gateway_uptime_seconds counter
@@ -702,12 +704,13 @@ mod tests {
             2,
             "gateway_http_requests_total 7\n\
              gateway_http_responses_total{class=\"2xx\"} 5\n",
+            "# HELP rate_limiter_degraded_total Redis distributed rate limiter degraded operations\n",
         );
 
         assert!(body.contains("gateway_providers_total 2"));
         assert!(body.contains("gateway_http_requests_total 7"));
         assert!(body.contains("gateway_http_responses_total{class=\"2xx\"} 5"));
-        assert!(body.contains("gateway_rate_limiter_degraded_total"));
+        assert!(body.contains("rate_limiter_degraded_total"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Make Redis-backed distributed rate limiting fail closed by default when Redis commands fail, instead of silently falling back to process-local limits.
- Add explicit `rate_limit.redis_failure_mode: fail_open_local` for operators that intentionally accept local fallback during Redis outages.
- Emit error-level Redis degradation logs and export `rate_limiter_degraded_total{operation,mode}` from `/metrics`.
- Document the default behavior change and config escape hatch.

## SpecRail
- `specs/GH836/product.md`
- `specs/GH836/tech.md`
- `specs/GH836/tasks.md`

## Validation
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH836"`
- `cargo fmt --all -- --check`
- `cargo check --all-features --message-format=short`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

Closes #836