### PR TITLE
fix(error): preserve rate-limit response headers

### DIFF
--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -82,10 +82,20 @@ pub(crate) fn gateway_error_response(error: &GatewayError) -> HttpResponse {
             }
         }
         GatewayError::Provider(ProviderError::RateLimit {
-            retry_after: Some(secs),
+            retry_after,
+            rpm_limit,
+            tpm_limit,
             ..
         }) => {
-            builder.insert_header((header::RETRY_AFTER, secs.to_string()));
+            if let Some(secs) = retry_after {
+                builder.insert_header((header::RETRY_AFTER, secs.to_string()));
+            }
+            if let Some(rpm) = rpm_limit {
+                builder.insert_header(("X-RateLimit-Limit-Requests", rpm.to_string()));
+            }
+            if let Some(tpm) = tpm_limit {
+                builder.insert_header(("X-RateLimit-Limit-Tokens", tpm.to_string()));
+            }
         }
         _ => {}
     }
@@ -429,8 +439,8 @@ mod tests {
             provider: "openai",
             message: "Rate limit exceeded".to_string(),
             retry_after: Some(2),
-            rpm_limit: None,
-            tpm_limit: None,
+            rpm_limit: Some(120),
+            tpm_limit: Some(60000),
             current_usage: None,
         });
 
@@ -438,6 +448,20 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(response.headers().get(header::RETRY_AFTER).unwrap(), "2");
+        assert_eq!(
+            response
+                .headers()
+                .get("X-RateLimit-Limit-Requests")
+                .and_then(|value| value.to_str().ok()),
+            Some("120")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("X-RateLimit-Limit-Tokens")
+                .and_then(|value| value.to_str().ok()),
+            Some("60000")
+        );
         let body = to_json(response).await;
         assert_eq!(body["error"]["type"], "rate_limit_error");
         assert_eq!(body["error"]["code"], "rate_limit_exceeded");
@@ -448,6 +472,30 @@ mod tests {
                 .contains("Rate limit exceeded")
         );
         assert!(body["error"]["retryable"].is_null());
+    }
+
+    #[actix_web::test]
+    async fn provider_rate_limit_without_metadata_does_not_fake_openai_headers() {
+        let error = GatewayError::Provider(ProviderError::RateLimit {
+            provider: "openai",
+            message: "Rate limit exceeded".to_string(),
+            retry_after: None,
+            rpm_limit: None,
+            tpm_limit: None,
+            current_usage: None,
+        });
+
+        let response = gateway_error_response(&error);
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
+        assert!(
+            response
+                .headers()
+                .get("X-RateLimit-Limit-Requests")
+                .is_none()
+        );
+        assert!(response.headers().get("X-RateLimit-Limit-Tokens").is_none());
     }
 
     #[actix_web::test]

--- a/src/utils/error/gateway_error/conversions.rs
+++ b/src/utils/error/gateway_error/conversions.rs
@@ -16,6 +16,10 @@ impl From<ProviderError> for GatewayError {
     }
 }
 
+fn retry_after_ms_to_secs(retry_after_ms: Option<u64>) -> Option<u64> {
+    retry_after_ms.map(|ms| (ms.saturating_add(999) / 1000).max(1))
+}
+
 // Conversion from A2AError to GatewayError
 impl From<A2AError> for GatewayError {
     fn from(err: A2AError) -> Self {
@@ -95,7 +99,7 @@ impl From<A2AError> for GatewayError {
                 };
                 GatewayError::RateLimit {
                     message: msg,
-                    retry_after: None,
+                    retry_after: retry_after_ms_to_secs(retry_after_ms),
                     rpm_limit: None,
                     tpm_limit: None,
                 }
@@ -221,7 +225,7 @@ impl From<McpError> for GatewayError {
                 };
                 GatewayError::RateLimit {
                     message: msg,
-                    retry_after: None,
+                    retry_after: retry_after_ms_to_secs(retry_after_ms),
                     rpm_limit: None,
                     tpm_limit: None,
                 }

--- a/src/utils/error/gateway_error/conversions_tests.rs
+++ b/src/utils/error/gateway_error/conversions_tests.rs
@@ -245,38 +245,39 @@ fn test_a2a_unsupported_provider_conversion() {
 fn test_a2a_rate_limit_with_retry_conversion() {
     let a2a_err = A2AError::RateLimitExceeded {
         agent_name: "agent".to_string(),
-        retry_after_ms: Some(5000),
+        retry_after_ms: Some(1500),
     };
     let gateway_err: GatewayError = a2a_err.into();
     match gateway_err {
         GatewayError::RateLimit {
             message: msg,
-            retry_after: None,
+            retry_after: Some(2),
             rpm_limit: None,
             tpm_limit: None,
         } => {
             assert!(msg.contains("A2A"));
-            assert!(msg.contains("5000ms"));
+            assert!(msg.contains("1500ms"));
         }
         _ => panic!("Expected RateLimit error"),
     }
 }
 
 #[test]
-fn test_a2a_conversion_keeps_legacy_message_shape() {
+fn test_a2a_rate_limit_minimum_retry_after_is_one_second() {
     let a2a_err = A2AError::RateLimitExceeded {
         agent_name: "agent".to_string(),
-        retry_after_ms: Some(1200),
+        retry_after_ms: Some(0),
     };
     let gateway_err: GatewayError = a2a_err.into();
     match gateway_err {
         GatewayError::RateLimit {
             message: msg,
-            retry_after: None,
+            retry_after: Some(1),
             rpm_limit: None,
             tpm_limit: None,
         } => {
             assert!(msg.contains("A2A rate limit exceeded"));
+            assert!(msg.contains("0ms"));
             assert!(!msg.contains("protocol_code="));
             assert!(!msg.contains("canonical_code="));
             assert!(!msg.contains("retryable="));
@@ -561,34 +562,34 @@ fn test_mcp_invalid_url_conversion() {
 fn test_mcp_rate_limit_with_retry_conversion() {
     let mcp_err = McpError::RateLimitExceeded {
         server_name: "github".to_string(),
-        retry_after_ms: Some(5000),
+        retry_after_ms: Some(1500),
     };
     let gateway_err: GatewayError = mcp_err.into();
     match gateway_err {
         GatewayError::RateLimit {
             message: msg,
-            retry_after: None,
+            retry_after: Some(2),
             rpm_limit: None,
             tpm_limit: None,
         } => {
             assert!(msg.contains("MCP"));
-            assert!(msg.contains("5000ms"));
+            assert!(msg.contains("1500ms"));
         }
         _ => panic!("Expected RateLimit error"),
     }
 }
 
 #[test]
-fn test_mcp_conversion_keeps_legacy_message_shape() {
+fn test_mcp_rate_limit_minimum_retry_after_is_one_second() {
     let mcp_err = McpError::RateLimitExceeded {
         server_name: "github".to_string(),
-        retry_after_ms: Some(800),
+        retry_after_ms: Some(1),
     };
     let gateway_err: GatewayError = mcp_err.into();
     match gateway_err {
         GatewayError::RateLimit {
             message: msg,
-            retry_after: None,
+            retry_after: Some(1),
             rpm_limit: None,
             tpm_limit: None,
         } => {

--- a/src/utils/error/gateway_error/response.rs
+++ b/src/utils/error/gateway_error/response.rs
@@ -3,7 +3,52 @@
 use super::types::GatewayError;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::error::canonical::CanonicalError;
-use actix_web::{HttpResponse, ResponseError};
+use actix_web::{HttpResponse, HttpResponseBuilder, ResponseError};
+
+#[derive(Debug, Clone, Copy, Default)]
+struct RateLimitHeaderFacts {
+    retry_after: Option<u64>,
+    rpm_limit: Option<u32>,
+    tpm_limit: Option<u32>,
+}
+
+fn rate_limit_headers(error: &GatewayError) -> Option<RateLimitHeaderFacts> {
+    match error {
+        GatewayError::RateLimit {
+            retry_after,
+            rpm_limit,
+            tpm_limit,
+            ..
+        } => Some(RateLimitHeaderFacts {
+            retry_after: *retry_after,
+            rpm_limit: *rpm_limit,
+            tpm_limit: *tpm_limit,
+        }),
+        GatewayError::Provider(ProviderError::RateLimit {
+            retry_after,
+            rpm_limit,
+            tpm_limit,
+            ..
+        }) => Some(RateLimitHeaderFacts {
+            retry_after: *retry_after,
+            rpm_limit: *rpm_limit,
+            tpm_limit: *tpm_limit,
+        }),
+        _ => None,
+    }
+}
+
+fn insert_rate_limit_headers(builder: &mut HttpResponseBuilder, facts: RateLimitHeaderFacts) {
+    if let Some(secs) = facts.retry_after {
+        builder.insert_header(("Retry-After", secs.to_string()));
+    }
+    if let Some(rpm) = facts.rpm_limit {
+        builder.insert_header(("X-RateLimit-Limit-Requests", rpm.to_string()));
+    }
+    if let Some(tpm) = facts.tpm_limit {
+        builder.insert_header(("X-RateLimit-Limit-Tokens", tpm.to_string()));
+    }
+}
 
 impl ResponseError for GatewayError {
     fn error_response(&self) -> HttpResponse {
@@ -206,23 +251,10 @@ impl ResponseError for GatewayError {
 
         let mut builder = HttpResponse::build(status_code);
 
-        // Add rate limit headers for 429 responses
-        if let GatewayError::RateLimit {
-            retry_after,
-            rpm_limit,
-            tpm_limit,
-            ..
-        } = self
-        {
-            if let Some(secs) = retry_after {
-                builder.insert_header(("Retry-After", secs.to_string()));
-            }
-            if let Some(rpm) = rpm_limit {
-                builder.insert_header(("X-RateLimit-Limit-Requests", rpm.to_string()));
-            }
-            if let Some(tpm) = tpm_limit {
-                builder.insert_header(("X-RateLimit-Limit-Tokens", tpm.to_string()));
-            }
+        // Keep 429 header facts in one helper so the future #839 HTTP facts
+        // consolidation cannot drop Retry-After / X-RateLimit metadata.
+        if let Some(facts) = rate_limit_headers(self) {
+            insert_rate_limit_headers(&mut builder, facts);
         }
 
         builder.json(error_response)

--- a/src/utils/error/gateway_error/response_tests.rs
+++ b/src/utils/error/gateway_error/response_tests.rs
@@ -1,5 +1,16 @@
 use super::*;
+use crate::core::providers::unified_provider::ProviderError;
 use actix_web::http::StatusCode;
+
+fn assert_header(response: &actix_web::HttpResponse, name: &str, expected: &str) {
+    assert_eq!(
+        response
+            .headers()
+            .get(name)
+            .and_then(|value| value.to_str().ok()),
+        Some(expected)
+    );
+}
 
 // ==================== ErrorDetail Tests ====================
 
@@ -169,33 +180,52 @@ fn test_gateway_error_rate_limit_response() {
     };
     let response = error.error_response();
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
-    assert_eq!(
-        response
-            .headers()
-            .get("Retry-After")
-            .unwrap()
-            .to_str()
-            .unwrap(),
-        "60"
-    );
-    assert_eq!(
+    assert_header(&response, "Retry-After", "60");
+    assert_header(&response, "X-RateLimit-Limit-Requests", "100");
+    assert_header(&response, "X-RateLimit-Limit-Tokens", "50000");
+}
+
+#[test]
+fn test_provider_rate_limit_response_preserves_headers() {
+    let error = GatewayError::Provider(ProviderError::RateLimit {
+        provider: "openai",
+        message: "Upstream rate limited".to_string(),
+        retry_after: Some(42),
+        rpm_limit: Some(120),
+        tpm_limit: Some(60000),
+        current_usage: None,
+    });
+
+    let response = error.error_response();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_header(&response, "Retry-After", "42");
+    assert_header(&response, "X-RateLimit-Limit-Requests", "120");
+    assert_header(&response, "X-RateLimit-Limit-Tokens", "60000");
+}
+
+#[test]
+fn test_provider_rate_limit_without_metadata_does_not_fake_headers() {
+    let error = GatewayError::Provider(ProviderError::RateLimit {
+        provider: "openai",
+        message: "Upstream rate limited".to_string(),
+        retry_after: None,
+        rpm_limit: None,
+        tpm_limit: None,
+        current_usage: None,
+    });
+
+    let response = error.error_response();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(response.headers().get("Retry-After").is_none());
+    assert!(
         response
             .headers()
             .get("X-RateLimit-Limit-Requests")
-            .unwrap()
-            .to_str()
-            .unwrap(),
-        "100"
+            .is_none()
     );
-    assert_eq!(
-        response
-            .headers()
-            .get("X-RateLimit-Limit-Tokens")
-            .unwrap()
-            .to_str()
-            .unwrap(),
-        "50000"
-    );
+    assert!(response.headers().get("X-RateLimit-Limit-Tokens").is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Preserve `Retry-After`, `X-RateLimit-Limit-Requests`, and `X-RateLimit-Limit-Tokens` on provider-originated 429 responses.
- Convert A2A/MCP `retry_after_ms` into HTTP `Retry-After` seconds using ceiling semantics with a minimum of 1 second.
- Keep 429 header extraction centralized for the future #839 HTTP facts consolidation.

Closes #833

## SpecRail
- `specs/GH833/product.md`
- `specs/GH833/tech.md`
- `specs/GH833/tasks.md`

## Verification
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH833"`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --all-features --message-format=short`
- `cargo test utils::error::gateway_error --lib --all-features -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
