### PR TITLE
fix(routes): map unconfigured batch image to client errors

### DIFF
--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -366,7 +366,7 @@ fn batch_url(
 }
 
 fn missing_batch_provider_error() -> GatewayError {
-    GatewayError::Config(
+    GatewayError::BadRequest(
         "Batch API requires an enabled openai or openai_compatible provider".to_string(),
     )
 }

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -449,8 +449,9 @@ fn ensure_image_proxy_candidate_configured(
     {
         Ok(())
     } else {
-        Err(GatewayError::Config(format!(
-            "Image provider for model '{requested_model}' is not configured"
+        Err(GatewayError::Provider(ProviderError::model_not_found(
+            "image_proxy",
+            requested_model,
         )))
     }
 }
@@ -701,7 +702,7 @@ fn multipart_part_has_field_name(headers: &str, field_name: &str) -> bool {
 }
 
 fn missing_image_proxy_provider_error() -> GatewayError {
-    GatewayError::Config(
+    GatewayError::BadRequest(
         "Image edits and variations API requires an enabled openai or openai_compatible provider"
             .to_string(),
     )

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -255,7 +255,7 @@ mod tests {
             }))
             .to_request();
         let create_resp = test::call_service(&app, create_req).await;
-        assert_eq!(create_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(create_resp.status(), StatusCode::BAD_REQUEST);
         let create_body: Value = test::read_body_json(create_resp).await;
         assert!(
             create_body["error"]["message"]
@@ -263,22 +263,24 @@ mod tests {
                 .expect("error message")
                 .contains("Batch API requires")
         );
+        assert_eq!(create_body["error"]["type"], "invalid_request_error");
+        assert_eq!(create_body["error"]["code"], "invalid_request");
 
         let list_req = test::TestRequest::get().uri("/v1/batches").to_request();
         let list_resp = test::call_service(&app, list_req).await;
-        assert_eq!(list_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(list_resp.status(), StatusCode::BAD_REQUEST);
 
         let get_req = test::TestRequest::get()
             .uri("/v1/batches/batch_test")
             .to_request();
         let get_resp = test::call_service(&app, get_req).await;
-        assert_eq!(get_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(get_resp.status(), StatusCode::BAD_REQUEST);
 
         let cancel_req = test::TestRequest::post()
             .uri("/v1/batches/batch_test/cancel")
             .to_request();
         let cancel_resp = test::call_service(&app, cancel_req).await;
-        assert_eq!(cancel_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(cancel_resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[actix_web::test]

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -441,7 +441,10 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         let body = to_json(response).await;
-        assert_eq!(body["error"]["message"], "Configuration error: Invalid config");
+        assert_eq!(
+            body["error"]["message"],
+            "Configuration error: Invalid config"
+        );
         assert_eq!(body["error"]["type"], "server_error");
         assert_eq!(body["error"]["code"], "internal_error");
     }

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -434,6 +434,19 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn config_error_remains_internal_server_error() {
+        let error = GatewayError::Config("Invalid config".to_string());
+
+        let response = gateway_error_response(&error);
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_json(response).await;
+        assert_eq!(body["error"]["message"], "Configuration error: Invalid config");
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["code"], "internal_error");
+    }
+
+    #[actix_web::test]
     async fn provider_rate_limit_uses_openai_shape_and_retry_after() {
         let error = GatewayError::Provider(ProviderError::RateLimit {
             provider: "openai",

--- a/tests/batches_routes.rs
+++ b/tests/batches_routes.rs
@@ -282,7 +282,7 @@ mod tests {
             .to_request();
         let create_resp = test::call_service(&app, create_req).await;
 
-        assert_eq!(create_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(create_resp.status(), StatusCode::BAD_REQUEST);
         let body: Value = test::read_body_json(create_resp).await;
         assert!(
             body["error"]["message"]
@@ -290,7 +290,8 @@ mod tests {
                 .expect("error message")
                 .contains("Batch API requires")
         );
-        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], "invalid_request");
     }
 
     #[tokio::test]

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -322,7 +322,7 @@ mod tests {
                 .to_request(),
         )
         .await;
-        assert_eq!(edit_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(edit_resp.status(), StatusCode::BAD_REQUEST);
         let edit_body: Value = test::read_body_json(edit_resp).await;
         assert!(
             edit_body["error"]["message"]
@@ -330,7 +330,8 @@ mod tests {
                 .expect("error message")
                 .contains("Image edits and variations API requires")
         );
-        assert_eq!(edit_body["error"]["type"], "server_error");
+        assert_eq!(edit_body["error"]["type"], "invalid_request_error");
+        assert_eq!(edit_body["error"]["code"], "invalid_request");
 
         let variation_resp = test::call_service(
             &app,
@@ -344,7 +345,7 @@ mod tests {
                 .to_request(),
         )
         .await;
-        assert_eq!(variation_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(variation_resp.status(), StatusCode::BAD_REQUEST);
         let variation_body: Value = test::read_body_json(variation_resp).await;
         assert!(
             variation_body["error"]["message"]
@@ -352,6 +353,52 @@ mod tests {
                 .expect("error message")
                 .contains("Image edits and variations API requires")
         );
+        assert_eq!(variation_body["error"]["type"], "invalid_request_error");
+        assert_eq!(variation_body["error"]["code"], "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn image_edit_rejects_unconfigured_model_before_upstream() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![image_route_provider_with_name_and_models(
+            "wrong-model-provider",
+            &mock.base_url,
+            vec!["other-image-model".to_string()],
+        )])
+        .await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let edit_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(edit_resp.status(), StatusCode::NOT_FOUND);
+        let edit_body: Value = test::read_body_json(edit_resp).await;
+        assert_eq!(edit_body["error"]["type"], "invalid_request_error");
+        assert_eq!(edit_body["error"]["code"], "model_not_found");
+        assert!(
+            edit_body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("gpt-image-1-mini")
+        );
+        assert!(mock.requests().is_empty());
+        mock.stop_image_mock().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Return OpenAI-compatible client errors for batch routes when no batch-capable provider is configured.
- Return client errors for image edit/variation routes when no proxy provider is configured or the requested image model is not configured.
- Preserve `GatewayError::Config` as an internal 500 via a regression test.

## SpecRail
- specs/GH835/product.md
- specs/GH835/tech.md
- specs/GH835/tasks.md

Closes #835

## Verification
- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH835"`
- `cargo fmt --all -- --check`
- `cargo test --test batches_routes route_without_batch_provider_fails_closed --all-features -- --nocapture`
- `cargo test --test image_edit_variation_routes image_edit_and_variation_routes_without_provider_fail_closed --all-features -- --nocapture`
- `cargo test --test image_edit_variation_routes image_edit_rejects_unconfigured_model_before_upstream --all-features -- --nocapture`
- `cargo test server::routes::ai::openai_errors --lib --all-features -- --nocapture`
- `cargo test server::routes::ai --all-features -- --nocapture`
- `cargo check --all-features --message-format=short`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `git diff --check origin/main...HEAD`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`