### PR TITLE
feat(pricing): add usage-aware dry run

### DIFF
--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -194,6 +194,7 @@ fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
         cache_creation_tokens: None,
         cache_read_tokens: None,
         audio_tokens: usage.audio_tokens,
+        output_audio_tokens: None,
         image_tokens: usage.image_tokens,
         reasoning_tokens: usage.reasoning_tokens,
         output_image_count: None,

--- a/src/core/cost/calculator/tests/edge_case_tests.rs
+++ b/src/core/cost/calculator/tests/edge_case_tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 
-// Tests for cost breakdown calculation with all features
+// Usage-aware pricing must fail closed when a priced text model lacks
+// modality-specific prices for requested usage.
 #[test]
-fn test_generic_cost_per_token_all_features() {
+fn test_generic_cost_per_token_fails_closed_for_unpriced_modal_usage() {
     let mut usage = create_usage(5000, 2000);
     usage.cached_tokens = Some(1000);
     usage.audio_tokens = Some(500);
@@ -10,18 +11,10 @@ fn test_generic_cost_per_token_all_features() {
     usage.reasoning_tokens = Some(200);
 
     let result = generic_cost_per_token("gpt-4o", &usage, "openai");
-    assert!(result.is_ok());
-    let breakdown = result.unwrap();
-
-    // Verify total is sum of all components
-    let calculated_total = breakdown.input_cost
-        + breakdown.output_cost
-        + breakdown.cache_cost
-        + breakdown.audio_cost
-        + breakdown.image_cost
-        + breakdown.reasoning_cost;
-
-    assert!((breakdown.total_cost - calculated_total).abs() < 1e-10);
+    assert!(matches!(
+        result,
+        Err(CostError::MissingPricing { ref model }) if model == "gpt-4o"
+    ));
 }
 
 // Edge case tests

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -540,7 +540,7 @@ fn calculate_usage_cost_with_pricing(
         model_info,
         model,
         usage.audio_tokens,
-        "input_cost_per_audio_token",
+        &["input_cost_per_audio_token", "output_cost_per_audio_token"],
         "audio pricing",
     )?;
     let image_cost_per_token =
@@ -587,7 +587,7 @@ fn priced_extra_units(
     pricing: &LiteLLMModelInfo,
     model: &str,
     units: Option<u32>,
-    key: &str,
+    keys: &[&str],
     pricing_type: &str,
 ) -> Result<f64> {
     let units = units.unwrap_or(0);
@@ -595,12 +595,20 @@ fn priced_extra_units(
         return Ok(0.0);
     }
 
-    let unit_price = pricing
-        .extra
-        .get(key)
-        .and_then(serde_json::Value::as_f64)
+    let (key, unit_price) = keys
+        .iter()
+        .find_map(|key| {
+            pricing
+                .extra
+                .get(*key)
+                .and_then(serde_json::Value::as_f64)
+                .map(|price| (*key, price))
+        })
         .ok_or_else(|| {
-            GatewayError::Config(format!("Missing {pricing_type} for model {model}: {key}"))
+            GatewayError::Config(format!(
+                "Missing {pricing_type} for model {model}: {}",
+                keys.join(", ")
+            ))
         })?;
     if unit_price < 0.0 || unit_price.is_nan() {
         return Err(GatewayError::Config(format!(

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -112,6 +112,21 @@ impl PricingService {
         calculate_usage_cost_with_pricing(provider, &resolved_model, &model_info, usage)
     }
 
+    /// Validate and estimate an arbitrary usage shape without mutating spend
+    /// or budget state.
+    ///
+    /// Request-time gates should use this instead of checking only whether a
+    /// provider/model row exists, because modality-specific usage can require
+    /// additional pricing fields.
+    pub fn dry_run_loaded_usage_cost_for_provider(
+        &self,
+        provider: &str,
+        model: &str,
+        usage: &PricingUsage,
+    ) -> Result<PricingCostBreakdown> {
+        self.calculate_loaded_usage_cost_for_provider(provider, model, usage)
+    }
+
     /// Estimate reservation cost from the same authority used for completed
     /// spend settlement.
     pub fn estimate_loaded_completion_cost_for_provider(
@@ -124,8 +139,8 @@ impl PricingService {
         let estimated_output_tokens = max_output_tokens.unwrap_or(100);
         let input_only = PricingUsage::new(input_tokens, 0);
         let full_usage = PricingUsage::new(input_tokens, estimated_output_tokens);
-        let input = self.calculate_loaded_usage_cost_for_provider(provider, model, &input_only)?;
-        let full = self.calculate_loaded_usage_cost_for_provider(provider, model, &full_usage)?;
+        let input = self.dry_run_loaded_usage_cost_for_provider(provider, model, &input_only)?;
+        let full = self.dry_run_loaded_usage_cost_for_provider(provider, model, &full_usage)?;
 
         Ok(PricingCostEstimate {
             min_cost: input.total_cost,
@@ -521,8 +536,13 @@ fn calculate_usage_cost_with_pricing(
     let output_cost = usage.completion_tokens as f64 * output_cost_per_token;
     let cache_cost = cache_creation_tokens as f64 * cache_creation_cost_per_token
         + cache_read_tokens as f64 * cache_read_cost_per_token;
-    let audio_cost = usage.audio_tokens.unwrap_or(0) as f64
-        * extra_f64(model_info, "input_cost_per_audio_token");
+    let audio_cost = priced_extra_units(
+        model_info,
+        model,
+        usage.audio_tokens,
+        "input_cost_per_audio_token",
+        "audio pricing",
+    )?;
     let image_cost_per_token =
         super::image_pricing::image_token_unit_price(model_info).unwrap_or(0.0);
     let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
@@ -563,6 +583,34 @@ fn extra_f64(pricing: &LiteLLMModelInfo, key: &str) -> f64 {
         .unwrap_or(0.0)
 }
 
+fn priced_extra_units(
+    pricing: &LiteLLMModelInfo,
+    model: &str,
+    units: Option<u32>,
+    key: &str,
+    pricing_type: &str,
+) -> Result<f64> {
+    let units = units.unwrap_or(0);
+    if units == 0 {
+        return Ok(0.0);
+    }
+
+    let unit_price = pricing
+        .extra
+        .get(key)
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| {
+            GatewayError::Config(format!("Missing {pricing_type} for model {model}: {key}"))
+        })?;
+    if unit_price < 0.0 || unit_price.is_nan() {
+        return Err(GatewayError::Config(format!(
+            "Invalid {pricing_type} for model {model}: {key} ({unit_price})"
+        )));
+    }
+
+    Ok(units as f64 * unit_price)
+}
+
 fn tiered_cost_per_token(
     pricing: &LiteLLMModelInfo,
     base_cost: f64,
@@ -598,197 +646,5 @@ fn extract_tier_threshold(key: &str) -> Option<u32> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_model_info(provider: &str) -> LiteLLMModelInfo {
-        LiteLLMModelInfo {
-            max_tokens: Some(4096),
-            max_input_tokens: Some(4096),
-            max_output_tokens: Some(4096),
-            input_cost_per_token: Some(0.00001),
-            output_cost_per_token: Some(0.00003),
-            input_cost_per_character: None,
-            output_cost_per_character: None,
-            cost_per_second: None,
-            litellm_provider: provider.to_string(),
-            mode: "chat".to_string(),
-            supports_function_calling: Some(true),
-            supports_vision: Some(false),
-            supports_streaming: Some(true),
-            supports_parallel_function_calling: Some(true),
-            supports_system_message: Some(true),
-            extra: HashMap::new(),
-        }
-    }
-
-    #[test]
-    fn provider_aware_authority_uses_loaded_custom_model() {
-        let service = PricingService::new(None);
-        service.add_custom_model(
-            "runtime-only-priced-model".to_string(),
-            test_model_info("runtime_provider"),
-        );
-
-        let cost = match service.calculate_loaded_usage_cost_for_provider(
-            "runtime_provider",
-            "runtime-only-priced-model",
-            &PricingUsage::new(1000, 500),
-        ) {
-            Ok(cost) => cost,
-            Err(error) => panic!("runtime-loaded pricing should calculate cost: {error}"),
-        };
-
-        assert_eq!(cost.model, "runtime-only-priced-model");
-        assert_eq!(cost.provider, "runtime_provider");
-        assert_eq!(cost.input_cost, 0.01);
-        assert!((cost.output_cost - 0.015).abs() < f64::EPSILON);
-        assert!((cost.total_cost - 0.025).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn provider_aware_authority_resolves_anthropic_mimo_alias() {
-        let service = match PricingService::with_embedded_default() {
-            Ok(service) => service,
-            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
-        };
-
-        let cost = match service.calculate_loaded_usage_cost_for_provider(
-            "anthropic",
-            "mimo-v2.5-pro",
-            &PricingUsage::new(1000, 500),
-        ) {
-            Ok(cost) => cost,
-            Err(error) => {
-                panic!("Anthropic-compatible MiMo should resolve through Xiaomi pricing: {error}")
-            }
-        };
-
-        assert_eq!(cost.model, "mimo-v2.5-pro");
-        assert_eq!(cost.provider, "anthropic");
-        assert!(cost.total_cost > 0.0);
-    }
-
-    #[test]
-    fn provider_aware_authority_resolves_loaded_openai_like_model_without_prefix() {
-        let service = PricingService::new(None);
-        service.add_custom_model(
-            "runtime-openai-like-model".to_string(),
-            test_model_info("openai_like"),
-        );
-
-        let cost = match service.calculate_loaded_usage_cost_for_provider(
-            "openai_like",
-            "runtime-openai-like-model",
-            &PricingUsage::new(1000, 500),
-        ) {
-            Ok(cost) => cost,
-            Err(error) => panic!("loaded OpenAI-like pricing should calculate cost: {error}"),
-        };
-
-        assert_eq!(cost.model, "runtime-openai-like-model");
-        assert_eq!(cost.provider, "openai_like");
-        assert!((cost.total_cost - 0.025).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn provider_aware_authority_resolves_xai_openai_like_prefix() {
-        let service = match PricingService::with_embedded_default() {
-            Ok(service) => service,
-            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
-        };
-
-        let cost = match service.calculate_loaded_usage_cost_for_provider(
-            "openai_like",
-            "xai/grok-4.3",
-            &PricingUsage::new(1000, 500),
-        ) {
-            Ok(cost) => cost,
-            Err(error) => panic!("xAI OpenAI-like prefixed model should resolve: {error}"),
-        };
-
-        assert_eq!(cost.model, "xai/grok-4.3-latest");
-        assert_eq!(cost.provider, "openai_like");
-        assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
-    }
-
-    #[cfg(feature = "providers-extended")]
-    #[test]
-    fn provider_aware_authority_resolves_amazon_nova_short_alias() {
-        let service = match PricingService::with_embedded_default() {
-            Ok(service) => service,
-            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
-        };
-
-        let cost = match service.calculate_loaded_usage_cost_for_provider(
-            "amazon_nova",
-            "nova-2-lite",
-            &PricingUsage::new(1000, 500),
-        ) {
-            Ok(cost) => cost,
-            Err(error) => panic!("Amazon Nova short alias should resolve: {error}"),
-        };
-
-        assert_eq!(cost.model, "amazon.nova-2-lite-v1:0");
-        assert_eq!(cost.provider, "amazon_nova");
-        assert!((cost.total_cost - 0.00155).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn provider_aware_authority_preserves_core_pricing_tiers() {
-        let service = match PricingService::with_embedded_default() {
-            Ok(service) => service,
-            Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
-        };
-
-        let cost = match service.calculate_loaded_usage_cost_for_provider(
-            "azure",
-            "gpt-5.5",
-            &PricingUsage::new(300_000, 1_000),
-        ) {
-            Ok(cost) => cost,
-            Err(error) => panic!("Azure tiered fallback pricing should resolve: {error}"),
-        };
-
-        assert_eq!(cost.model, "azure/gpt-5.5-2026-04-23");
-        assert_eq!(cost.provider, "azure");
-        assert!((cost.input_cost - 3.0).abs() < 1e-12);
-        assert!((cost.output_cost - 0.045).abs() < 1e-12);
-        assert!((cost.total_cost - 3.045).abs() < 1e-12);
-    }
-
-    #[test]
-    fn tier_threshold_ignores_named_price_variants() {
-        assert_eq!(
-            extract_tier_threshold("input_cost_per_token_above_272k_tokens"),
-            Some(272_000)
-        );
-        assert_eq!(
-            extract_tier_threshold("input_cost_per_token_above_272k_tokens_priority"),
-            None
-        );
-        assert_eq!(
-            extract_tier_threshold("input_cost_per_token_above_272k_tokens_flex"),
-            None
-        );
-    }
-
-    #[test]
-    fn provider_aware_authority_rejects_missing_token_pricing() {
-        let service = PricingService::new(None);
-        let mut model_info = test_model_info("runtime_provider");
-        model_info.output_cost_per_token = None;
-        service.add_custom_model("partial-priced-model".to_string(), model_info);
-
-        let error = match service.calculate_loaded_usage_cost_for_provider(
-            "runtime_provider",
-            "partial-priced-model",
-            &PricingUsage::new(1000, 500),
-        ) {
-            Ok(_) => panic!("incomplete pricing must fail closed"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("output_cost_per_token"));
-    }
-}
+#[path = "authority_tests.rs"]
+mod tests;

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -112,6 +112,38 @@ impl PricingService {
         calculate_usage_cost_with_pricing(provider, &resolved_model, &model_info, usage)
     }
 
+    /// Calculate settlement cost for an already-successful request.
+    ///
+    /// Request-time dry runs fail closed on missing modality-specific pricing.
+    /// Settlement must not convert that error into free spend when text tokens
+    /// are still priced, so it falls back to the text/cache/reasoning portion.
+    pub fn calculate_loaded_settlement_cost_for_provider(
+        &self,
+        provider: &str,
+        model: &str,
+        usage: &PricingUsage,
+    ) -> Result<PricingCostBreakdown> {
+        match self.calculate_loaded_usage_cost_for_provider(provider, model, usage) {
+            Ok(breakdown) => Ok(breakdown),
+            Err(error) => {
+                let Some(text_usage) = text_only_usage_for_modal_settlement(usage) else {
+                    return Err(error);
+                };
+                match self.calculate_loaded_usage_cost_for_provider(provider, model, &text_usage) {
+                    Ok(mut breakdown) => {
+                        tracing::error!(
+                            "modal cost calculation failed for '{provider}'/'{model}': {error}; \
+                             settling text/token cost only"
+                        );
+                        breakdown.usage = usage.clone();
+                        Ok(breakdown)
+                    }
+                    Err(_) => Err(error),
+                }
+            }
+        }
+    }
+
     /// Validate and estimate an arbitrary usage shape without mutating spend
     /// or budget state.
     ///
@@ -488,6 +520,23 @@ fn alias_suffix_matches(suffix: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
 }
 
+fn text_only_usage_for_modal_settlement(usage: &PricingUsage) -> Option<PricingUsage> {
+    let has_modal_usage = usage.audio_token_count() > 0
+        || usage.image_tokens.unwrap_or(0) > 0
+        || usage.output_image_count.unwrap_or(0) > 0;
+    if !has_modal_usage {
+        return None;
+    }
+
+    let mut text_usage = usage.clone();
+    text_usage.audio_tokens = None;
+    text_usage.output_audio_tokens = None;
+    text_usage.image_tokens = None;
+    text_usage.output_image_count = None;
+    text_usage.output_image_pricing_keys.clear();
+    Some(text_usage)
+}
+
 fn calculate_usage_cost_with_pricing(
     requested_provider: &str,
     model: &str,
@@ -540,11 +589,17 @@ fn calculate_usage_cost_with_pricing(
         model_info,
         model,
         usage.audio_tokens,
-        &["input_cost_per_audio_token", "output_cost_per_audio_token"],
+        &["input_cost_per_audio_token"],
         "audio pricing",
+    )? + priced_extra_units(
+        model_info,
+        model,
+        usage.output_audio_tokens,
+        &["output_cost_per_audio_token"],
+        "output audio pricing",
     )?;
     let image_cost_per_token =
-        super::image_pricing::image_token_unit_price(model_info).unwrap_or(0.0);
+        super::image_pricing::image_token_unit_price(model_info, usage).unwrap_or(0.0);
     let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
         + super::image_pricing::output_image_cost(model, model_info, usage)?;
     let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -1,0 +1,192 @@
+use super::*;
+
+fn test_model_info(provider: &str) -> LiteLLMModelInfo {
+    LiteLLMModelInfo {
+        max_tokens: Some(4096),
+        max_input_tokens: Some(4096),
+        max_output_tokens: Some(4096),
+        input_cost_per_token: Some(0.00001),
+        output_cost_per_token: Some(0.00003),
+        input_cost_per_character: None,
+        output_cost_per_character: None,
+        cost_per_second: None,
+        litellm_provider: provider.to_string(),
+        mode: "chat".to_string(),
+        supports_function_calling: Some(true),
+        supports_vision: Some(false),
+        supports_streaming: Some(true),
+        supports_parallel_function_calling: Some(true),
+        supports_system_message: Some(true),
+        extra: HashMap::new(),
+    }
+}
+
+#[test]
+fn provider_aware_authority_uses_loaded_custom_model() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "runtime-only-priced-model".to_string(),
+        test_model_info("runtime_provider"),
+    );
+
+    let cost = match service.calculate_loaded_usage_cost_for_provider(
+        "runtime_provider",
+        "runtime-only-priced-model",
+        &PricingUsage::new(1000, 500),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => panic!("runtime-loaded pricing should calculate cost: {error}"),
+    };
+
+    assert_eq!(cost.model, "runtime-only-priced-model");
+    assert_eq!(cost.provider, "runtime_provider");
+    assert_eq!(cost.input_cost, 0.01);
+    assert!((cost.output_cost - 0.015).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.025).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_aware_authority_resolves_anthropic_mimo_alias() {
+    let service = match PricingService::with_embedded_default() {
+        Ok(service) => service,
+        Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+    };
+
+    let cost = match service.calculate_loaded_usage_cost_for_provider(
+        "anthropic",
+        "mimo-v2.5-pro",
+        &PricingUsage::new(1000, 500),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => {
+            panic!("Anthropic-compatible MiMo should resolve through Xiaomi pricing: {error}")
+        }
+    };
+
+    assert_eq!(cost.model, "mimo-v2.5-pro");
+    assert_eq!(cost.provider, "anthropic");
+    assert!(cost.total_cost > 0.0);
+}
+
+#[test]
+fn provider_aware_authority_resolves_loaded_openai_like_model_without_prefix() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "runtime-openai-like-model".to_string(),
+        test_model_info("openai_like"),
+    );
+
+    let cost = match service.calculate_loaded_usage_cost_for_provider(
+        "openai_like",
+        "runtime-openai-like-model",
+        &PricingUsage::new(1000, 500),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => panic!("loaded OpenAI-like pricing should calculate cost: {error}"),
+    };
+
+    assert_eq!(cost.model, "runtime-openai-like-model");
+    assert_eq!(cost.provider, "openai_like");
+    assert!((cost.total_cost - 0.025).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_aware_authority_resolves_xai_openai_like_prefix() {
+    let service = match PricingService::with_embedded_default() {
+        Ok(service) => service,
+        Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+    };
+
+    let cost = match service.calculate_loaded_usage_cost_for_provider(
+        "openai_like",
+        "xai/grok-4.3",
+        &PricingUsage::new(1000, 500),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => panic!("xAI OpenAI-like prefixed model should resolve: {error}"),
+    };
+
+    assert_eq!(cost.model, "xai/grok-4.3-latest");
+    assert_eq!(cost.provider, "openai_like");
+    assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
+}
+
+#[cfg(feature = "providers-extended")]
+#[test]
+fn provider_aware_authority_resolves_amazon_nova_short_alias() {
+    let service = match PricingService::with_embedded_default() {
+        Ok(service) => service,
+        Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+    };
+
+    let cost = match service.calculate_loaded_usage_cost_for_provider(
+        "amazon_nova",
+        "nova-2-lite",
+        &PricingUsage::new(1000, 500),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => panic!("Amazon Nova short alias should resolve: {error}"),
+    };
+
+    assert_eq!(cost.model, "amazon.nova-2-lite-v1:0");
+    assert_eq!(cost.provider, "amazon_nova");
+    assert!((cost.total_cost - 0.00155).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_aware_authority_preserves_core_pricing_tiers() {
+    let service = match PricingService::with_embedded_default() {
+        Ok(service) => service,
+        Err(error) => panic!("embedded pricing service should initialize for tests: {error}"),
+    };
+
+    let cost = match service.calculate_loaded_usage_cost_for_provider(
+        "azure",
+        "gpt-5.5",
+        &PricingUsage::new(300_000, 1_000),
+    ) {
+        Ok(cost) => cost,
+        Err(error) => panic!("Azure tiered fallback pricing should resolve: {error}"),
+    };
+
+    assert_eq!(cost.model, "azure/gpt-5.5-2026-04-23");
+    assert_eq!(cost.provider, "azure");
+    assert!((cost.input_cost - 3.0).abs() < 1e-12);
+    assert!((cost.output_cost - 0.045).abs() < 1e-12);
+    assert!((cost.total_cost - 3.045).abs() < 1e-12);
+}
+
+#[test]
+fn tier_threshold_ignores_named_price_variants() {
+    assert_eq!(
+        extract_tier_threshold("input_cost_per_token_above_272k_tokens"),
+        Some(272_000)
+    );
+    assert_eq!(
+        extract_tier_threshold("input_cost_per_token_above_272k_tokens_priority"),
+        None
+    );
+    assert_eq!(
+        extract_tier_threshold("input_cost_per_token_above_272k_tokens_flex"),
+        None
+    );
+}
+
+#[test]
+fn provider_aware_authority_rejects_missing_token_pricing() {
+    let service = PricingService::new(None);
+    let mut model_info = test_model_info("runtime_provider");
+    model_info.output_cost_per_token = None;
+    service.add_custom_model("partial-priced-model".to_string(), model_info);
+
+    let error = match service.calculate_loaded_usage_cost_for_provider(
+        "runtime_provider",
+        "partial-priced-model",
+        &PricingUsage::new(1000, 500),
+    ) {
+        Ok(_) => panic!("incomplete pricing must fail closed"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("output_cost_per_token"));
+}

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -36,7 +36,11 @@ pub(super) fn output_image_cost(
     model_info: &LiteLLMModelInfo,
     usage: &PricingUsage,
 ) -> Result<f64> {
-    if usage.image_tokens.is_some() && image_token_unit_price(model_info).is_some() {
+    let image_tokens = usage.image_tokens.unwrap_or(0);
+    if image_tokens == 0 && usage.output_image_count.unwrap_or(0) == 0 {
+        return Ok(0.0);
+    }
+    if image_tokens > 0 && image_token_unit_price(model_info).is_some() {
         return Ok(0.0);
     }
 
@@ -46,6 +50,12 @@ pub(super) fn output_image_cost(
         .and_then(serde_json::Value::as_f64)
     {
         Some(price) => price,
+        None if image_tokens > 0 => {
+            return Err(GatewayError::Config(format!(
+                "Missing image pricing for model {}: image_cost_per_token or output_cost_per_image",
+                model
+            )));
+        }
         None if model_info.input_cost_per_token.is_some()
             || model_info.output_cost_per_token.is_some() =>
         {

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -40,7 +40,7 @@ pub(super) fn output_image_cost(
     if image_tokens == 0 && usage.output_image_count.unwrap_or(0) == 0 {
         return Ok(0.0);
     }
-    if image_tokens > 0 && image_token_unit_price(model_info).is_some() {
+    if image_tokens > 0 && image_token_unit_price(model_info, usage).is_some() {
         return Ok(0.0);
     }
 
@@ -96,17 +96,23 @@ pub(super) fn output_image_cost(
     Ok(count as f64 * price)
 }
 
-pub(super) fn image_token_unit_price(model_info: &LiteLLMModelInfo) -> Option<f64> {
-    [
-        "image_cost_per_token",
-        "input_cost_per_image_token",
-        "output_cost_per_image_token",
-    ]
-    .into_iter()
-    .find_map(|key| {
+pub(super) fn image_token_unit_price(
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+) -> Option<f64> {
+    let keys: &[&str] = if usage.output_image_count.unwrap_or(0) > 0 {
+        &["image_cost_per_token", "output_cost_per_image_token"]
+    } else {
+        &[
+            "image_cost_per_token",
+            "input_cost_per_image_token",
+            "output_cost_per_image_token",
+        ]
+    };
+    keys.iter().find_map(|key| {
         model_info
             .extra
-            .get(key)
+            .get(*key)
             .and_then(serde_json::Value::as_f64)
     })
 }

--- a/src/core/pricing_service/image_pricing.rs
+++ b/src/core/pricing_service/image_pricing.rs
@@ -52,7 +52,7 @@ pub(super) fn output_image_cost(
         Some(price) => price,
         None if image_tokens > 0 => {
             return Err(GatewayError::Config(format!(
-                "Missing image pricing for model {}: image_cost_per_token or output_cost_per_image",
+                "Missing image pricing for model {}: image_cost_per_token, input_cost_per_image_token, output_cost_per_image_token, or output_cost_per_image",
                 model
             )));
         }
@@ -97,14 +97,18 @@ pub(super) fn output_image_cost(
 }
 
 pub(super) fn image_token_unit_price(model_info: &LiteLLMModelInfo) -> Option<f64> {
-    ["image_cost_per_token", "output_cost_per_image_token"]
-        .into_iter()
-        .find_map(|key| {
-            model_info
-                .extra
-                .get(key)
-                .and_then(serde_json::Value::as_f64)
-        })
+    [
+        "image_cost_per_token",
+        "input_cost_per_image_token",
+        "output_cost_per_image_token",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        model_info
+            .extra
+            .get(key)
+            .and_then(serde_json::Value::as_f64)
+    })
 }
 
 fn flat_image_pricing_key_matches(model: &str, usage: &PricingUsage) -> bool {

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -267,6 +267,27 @@ fn provider_pricing_dry_run_charges_audio_tokens_with_audio_price() {
 }
 
 #[test]
+fn provider_pricing_dry_run_charges_audio_tokens_with_output_audio_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.mode = "audio_transcription".to_string();
+    model_info.extra.insert(
+        "output_cost_per_audio_token".to_string(),
+        serde_json::Value::from(0.003),
+    );
+    service.add_custom_model("output-audio-priced-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.audio_tokens = Some(200);
+
+    let cost = service
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "output-audio-priced-model", &usage)
+        .unwrap();
+
+    assert_eq!(cost.audio_cost, 0.6);
+    assert_eq!(cost.total_cost, 0.6);
+}
+
+#[test]
 fn provider_pricing_dry_run_fails_closed_for_missing_audio_price() {
     let service = PricingService::new(None);
     let mut model_info = flat_image_model_info(None);
@@ -280,6 +301,7 @@ fn provider_pricing_dry_run_fails_closed_for_missing_audio_price() {
         .unwrap_err();
 
     assert!(error.to_string().contains("input_cost_per_audio_token"));
+    assert!(error.to_string().contains("output_cost_per_audio_token"));
 }
 
 #[test]
@@ -461,6 +483,26 @@ fn provider_pricing_charges_output_image_token_price() {
 
     assert!((cost.image_cost - 0.12).abs() < f64::EPSILON);
     assert!((cost.total_cost - 0.12).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_pricing_charges_input_image_token_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.extra.insert(
+        "input_cost_per_image_token".to_string(),
+        serde_json::Value::from(0.05),
+    );
+    service.add_custom_model("image-token-input-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.image_tokens = Some(4);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider("bedrock", "image-token-input-model", &usage)
+        .unwrap();
+
+    assert!((cost.image_cost - 0.2).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.2).abs() < f64::EPSILON);
 }
 
 #[test]

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -272,12 +272,16 @@ fn provider_pricing_dry_run_charges_audio_tokens_with_output_audio_price() {
     let mut model_info = flat_image_model_info(None);
     model_info.mode = "audio_transcription".to_string();
     model_info.extra.insert(
+        "input_cost_per_audio_token".to_string(),
+        serde_json::Value::from(0.001),
+    );
+    model_info.extra.insert(
         "output_cost_per_audio_token".to_string(),
         serde_json::Value::from(0.003),
     );
     service.add_custom_model("output-audio-priced-model".to_string(), model_info);
     let mut usage = PricingUsage::new(0, 0);
-    usage.audio_tokens = Some(200);
+    usage.output_audio_tokens = Some(200);
 
     let cost = service
         .dry_run_loaded_usage_cost_for_provider("bedrock", "output-audio-priced-model", &usage)
@@ -285,6 +289,26 @@ fn provider_pricing_dry_run_charges_audio_tokens_with_output_audio_price() {
 
     assert_eq!(cost.audio_cost, 0.6);
     assert_eq!(cost.total_cost, 0.6);
+}
+
+#[test]
+fn provider_pricing_dry_run_fails_closed_for_missing_output_audio_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.mode = "audio_transcription".to_string();
+    model_info.extra.insert(
+        "input_cost_per_audio_token".to_string(),
+        serde_json::Value::from(0.001),
+    );
+    service.add_custom_model("missing-output-audio-price".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.output_audio_tokens = Some(200);
+
+    let error = service
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "missing-output-audio-price", &usage)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("output_cost_per_audio_token"));
 }
 
 #[test]
@@ -301,7 +325,6 @@ fn provider_pricing_dry_run_fails_closed_for_missing_audio_price() {
         .unwrap_err();
 
     assert!(error.to_string().contains("input_cost_per_audio_token"));
-    assert!(error.to_string().contains("output_cost_per_audio_token"));
 }
 
 #[test]
@@ -483,6 +506,35 @@ fn provider_pricing_charges_output_image_token_price() {
 
     assert!((cost.image_cost - 0.12).abs() < f64::EPSILON);
     assert!((cost.total_cost - 0.12).abs() < f64::EPSILON);
+}
+
+#[test]
+fn provider_pricing_prefers_output_image_token_price_for_generated_images() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.extra.insert(
+        "input_cost_per_image_token".to_string(),
+        serde_json::Value::from(0.01),
+    );
+    model_info.extra.insert(
+        "output_cost_per_image_token".to_string(),
+        serde_json::Value::from(0.05),
+    );
+    service.add_custom_model("image-token-bidirectional-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.image_tokens = Some(4);
+    usage.output_image_count = Some(1);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider(
+            "bedrock",
+            "image-token-bidirectional-model",
+            &usage,
+        )
+        .unwrap();
+
+    assert!((cost.image_cost - 0.2).abs() < f64::EPSILON);
+    assert!((cost.total_cost - 0.2).abs() < f64::EPSILON);
 }
 
 #[test]

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -246,6 +246,43 @@ fn flat_image_model_info(output_cost_per_image: Option<f64>) -> LiteLLMModelInfo
 }
 
 #[test]
+fn provider_pricing_dry_run_charges_audio_tokens_with_audio_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.mode = "audio_transcription".to_string();
+    model_info.extra.insert(
+        "input_cost_per_audio_token".to_string(),
+        serde_json::Value::from(0.002),
+    );
+    service.add_custom_model("audio-priced-model".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.audio_tokens = Some(250);
+
+    let cost = service
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "audio-priced-model", &usage)
+        .unwrap();
+
+    assert_eq!(cost.audio_cost, 0.5);
+    assert_eq!(cost.total_cost, 0.5);
+}
+
+#[test]
+fn provider_pricing_dry_run_fails_closed_for_missing_audio_price() {
+    let service = PricingService::new(None);
+    let mut model_info = flat_image_model_info(None);
+    model_info.mode = "audio_transcription".to_string();
+    service.add_custom_model("missing-audio-price".to_string(), model_info);
+    let mut usage = PricingUsage::new(0, 0);
+    usage.audio_tokens = Some(250);
+
+    let error = service
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "missing-audio-price", &usage)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("input_cost_per_audio_token"));
+}
+
+#[test]
 fn provider_pricing_charges_flat_output_image_cost_without_token_prices() {
     let service = PricingService::new(None);
     service.add_custom_model(
@@ -253,10 +290,11 @@ fn provider_pricing_charges_flat_output_image_cost_without_token_prices() {
         flat_image_model_info(Some(0.06)),
     );
     let mut usage = PricingUsage::new(25, 0);
+    usage.image_tokens = Some(300);
     usage.output_image_count = Some(3);
 
     let cost = service
-        .calculate_loaded_usage_cost_for_provider("bedrock", "flat-image-model", &usage)
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "flat-image-model", &usage)
         .unwrap();
 
     assert_eq!(cost.input_cost, 0.0);
@@ -275,7 +313,7 @@ fn provider_pricing_fails_closed_for_missing_flat_output_image_price() {
     usage.output_image_count = Some(1);
 
     let error = service
-        .calculate_loaded_usage_cost_for_provider("bedrock", "missing-image-price", &usage)
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "missing-image-price", &usage)
         .unwrap_err();
 
     assert!(error.to_string().contains("output_cost_per_image"));
@@ -341,7 +379,7 @@ fn provider_pricing_treats_explicit_zero_image_token_price_as_present() {
 }
 
 #[test]
-fn provider_pricing_does_not_require_flat_price_for_token_priced_image_model() {
+fn provider_pricing_fails_closed_for_token_priced_image_usage_without_image_price() {
     let service = PricingService::new(None);
     let mut model_info = flat_image_model_info(None);
     model_info.input_cost_per_token = Some(0.01);
@@ -351,12 +389,13 @@ fn provider_pricing_does_not_require_flat_price_for_token_priced_image_model() {
     usage.image_tokens = Some(100);
     usage.output_image_count = Some(1);
 
-    let cost = service
-        .calculate_loaded_usage_cost_for_provider("bedrock", "token-priced-image-model", &usage)
-        .unwrap();
+    let error = service
+        .dry_run_loaded_usage_cost_for_provider("bedrock", "token-priced-image-model", &usage)
+        .unwrap_err();
 
-    assert!((cost.input_cost - 0.02).abs() < f64::EPSILON);
-    assert_eq!(cost.image_cost, 0.0);
+    let error = error.to_string();
+    assert!(error.contains("image_cost_per_token"));
+    assert!(error.contains("output_cost_per_image"));
 }
 
 #[test]

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -81,6 +81,7 @@ pub struct PricingUsage {
     pub cache_creation_tokens: Option<u32>,
     pub cache_read_tokens: Option<u32>,
     pub audio_tokens: Option<u32>,
+    pub output_audio_tokens: Option<u32>,
     pub image_tokens: Option<u32>,
     pub reasoning_tokens: Option<u32>,
     pub output_image_count: Option<u32>,
@@ -97,6 +98,7 @@ impl PricingUsage {
             cache_creation_tokens: None,
             cache_read_tokens: None,
             audio_tokens: None,
+            output_audio_tokens: None,
             image_tokens: None,
             reasoning_tokens: None,
             output_image_count: None,
@@ -118,11 +120,18 @@ impl PricingUsage {
                 .saturating_add(self.cache_read_token_count()),
         )
     }
+
+    pub fn audio_token_count(&self) -> u32 {
+        self.audio_tokens
+            .unwrap_or(0)
+            .saturating_add(self.output_audio_tokens.unwrap_or(0))
+    }
 }
 
 impl From<&crate::core::types::responses::Usage> for PricingUsage {
     fn from(usage: &crate::core::types::responses::Usage) -> Self {
         let prompt_details = usage.prompt_tokens_details.as_ref();
+        let completion_details = usage.completion_tokens_details.as_ref();
         Self {
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens,
@@ -131,6 +140,7 @@ impl From<&crate::core::types::responses::Usage> for PricingUsage {
             cache_creation_tokens: prompt_details.and_then(|details| details.cache_creation_tokens),
             cache_read_tokens: prompt_details.and_then(|details| details.cache_read_tokens),
             audio_tokens: prompt_details.and_then(|details| details.audio_tokens),
+            output_audio_tokens: completion_details.and_then(|details| details.audio_tokens),
             image_tokens: None,
             reasoning_tokens: usage
                 .completion_tokens_details

--- a/src/server/routes/ai/audio/budgeting.rs
+++ b/src/server/routes/ai/audio/budgeting.rs
@@ -249,9 +249,7 @@ async fn record_key_usage(
     cost: f64,
 ) {
     if let Some(key_id) = api_key_id {
-        let total_tokens = usage
-            .total_tokens
-            .saturating_add(usage.audio_tokens.unwrap_or(0));
+        let total_tokens = usage.total_tokens.saturating_add(usage.audio_token_count());
         if let Err(error) = key_manager
             .record_usage(key_id, u64::from(total_tokens), cost)
             .await

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -529,7 +529,7 @@ pub(super) async fn record_completion_spend_with_reservation_with_pricing(
     let total_tokens = u64::from(usage.total_tokens);
     let usage_tokens = PricingUsage::from(usage);
 
-    let cost = match pricing_service.calculate_loaded_usage_cost_for_provider(
+    let cost = match pricing_service.calculate_loaded_settlement_cost_for_provider(
         provider,
         model,
         &usage_tokens,

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -143,7 +143,7 @@ pub(in crate::server::routes::ai) async fn record_pricing_usage_spend_with_reser
     budget_reservation: Option<UnifiedBudgetReservation>,
     key_budget_reservation: Option<BudgetReservation>,
 ) {
-    let cost = match pricing_service.calculate_loaded_usage_cost_for_provider(
+    let cost = match pricing_service.calculate_loaded_settlement_cost_for_provider(
         pricing_provider,
         pricing_model,
         usage,
@@ -180,7 +180,7 @@ pub(in crate::server::routes::ai) async fn record_pricing_usage_spend_with_reser
     if let Some(key_id) = api_key_id {
         let total_tokens = usage
             .total_tokens
-            .saturating_add(usage.audio_tokens.unwrap_or(0))
+            .saturating_add(usage.audio_token_count())
             .saturating_add(usage.image_tokens.unwrap_or(0));
         if let Err(error) = key_manager
             .record_usage(key_id, u64::from(total_tokens), cost.unwrap_or(0.0))

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
 use crate::core::keys::InMemoryKeyRepository;
 use crate::core::pricing_service::LiteLLMModelInfo;
-use crate::core::types::responses::Usage;
+use crate::core::types::responses::{PromptTokensDetails, Usage};
 use std::collections::HashMap;
 
 fn response_usage(prompt: u32, completion: u32) -> Usage {
@@ -169,6 +169,58 @@ async fn record_completion_spend_uses_runtime_pricing_service() {
                 "runtime_provider",
                 "runtime-only-priced-model",
                 Some(&response_usage(1000, 500)),
+            ),
+            None,
+            None,
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        budget
+            .providers
+            .get_provider_usage("runtime_provider")
+            .map(|usage| usage.current_spend),
+        Some(0.025)
+    );
+    assert_eq!(
+        budget
+            .models
+            .get_model_usage("runtime-only-priced-model")
+            .map(|usage| usage.current_spend),
+        Some(0.025)
+    );
+}
+
+#[tokio::test]
+async fn record_completion_spend_settles_text_cost_when_modal_price_is_missing() {
+    let pricing = runtime_test_pricing_service("runtime_provider");
+    let budget = UnifiedBudgetLimits::new();
+    budget.providers.set_provider_limit(
+        "runtime_provider",
+        ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    budget.models.set_model_limit(
+        "runtime-only-priced-model",
+        ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+    );
+    let keys = KeyManager::new(InMemoryKeyRepository::new());
+    let mut usage = response_usage(1000, 500);
+    usage.prompt_tokens_details = Some(PromptTokensDetails {
+        cached_tokens: None,
+        cache_creation_tokens: None,
+        cache_read_tokens: None,
+        audio_tokens: Some(250),
+    });
+
+    record_completion_spend_with_reservation_with_pricing(
+        &pricing,
+        usage_spend_settlement(
+            (&budget, &keys, None),
+            (
+                "runtime_provider",
+                "runtime-only-priced-model",
+                Some(&usage),
             ),
             None,
             None,

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -598,7 +598,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn image_generation_allows_token_priced_image_model_without_flat_price() {
+    async fn image_generation_rejects_token_priced_image_model_without_image_price() {
         let mock = MockImageServer::start().await;
         let state = build_test_state(vec![openai_image_provider_with_mapping(
             "openai-primary",
@@ -636,14 +636,14 @@ mod tests {
         )
         .await;
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(mock.paths(), vec!["/v1/images/generations".to_string()]);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(mock.paths().is_empty());
         let spent = budget_limits
             .providers
             .get_provider_usage("openai-primary")
             .map(|usage| usage.current_spend)
             .unwrap_or_default();
-        assert!((spent - 0.03).abs() < f64::EPSILON);
+        assert_eq!(spent, 0.0);
         mock.stop().await;
     }
 


### PR DESCRIPTION
## Summary

- Adds `PricingService::dry_run_loaded_usage_cost_for_provider` so request gates can validate full `PricingUsage` shapes instead of checking only provider/model presence.
- Makes audio usage fail closed when `input_cost_per_audio_token` is missing.
- Makes image-token usage fail closed unless an image-token price or flat output image price is available.
- Splits `authority.rs` inline tests into `authority_tests.rs` to keep the production file under the repo hard line limit.

Closes #898.
Refs #831.

## Notes

- This PR implements `SP831-T3` only. Parent issue #831 remains open for later request-time router rejection and settlement changes.
- `specs/GH831/tasks.md` is not edited here to avoid overlapping with the parallel config-surface PR #897; task status can be reconciled after #897 lands.

## Validation

- `python3 /tmp/specrail-pr51/checks/check_workflow.py --repo /tmp/specrail-pr51 --spec-dir "$PWD/specs/GH831"`
- `cargo fmt --all -- --check`
- `cargo test core::pricing_service --lib --all-features -- --nocapture`
- `cargo test core::cost::calculator::tests::edge_case_tests::test_generic_cost_per_token_fails_closed_for_unpriced_modal_usage --lib --all-features -- --nocapture`
- `cargo test --test image_router_fallback_routes --all-features -- --nocapture`
- `cargo check --all-features --message-format=short`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet --all-features`
- `git diff --check`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
