### PR TITLE
refactor(ai): route availability checks through budgeted

### DIFF
--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -17,6 +17,7 @@ use std::future::Future;
 use std::sync::OnceLock;
 use tracing::error;
 
+use super::budgeted::SettlementMode;
 use super::openai_errors;
 use super::provider_config;
 
@@ -194,9 +195,12 @@ where
     for (index, provider_config) in provider_configs.into_iter().enumerate() {
         let is_last_provider = index + 1 == provider_count;
         let provider = batch_proxy_provider_from_config(provider_config)?;
-        if let Err(error) =
-            super::spend::ensure_budget_available(&state.budget_limits, &provider.provider_name, "")
-                .map_err(GatewayError::Provider)
+        if let Err(error) = state
+            .budgeted
+            .for_selected(provider.provider_name.as_str(), "")
+            .with_settlement_mode(SettlementMode::AvailabilityOnly)
+            .ensure_available()
+            .map_err(GatewayError::Provider)
         {
             if !is_last_provider && is_retryable_batch_error(&error) {
                 last_error = Some(error);

--- a/src/server/routes/ai/budget_orchestration.rs
+++ b/src/server/routes/ai/budget_orchestration.rs
@@ -143,6 +143,17 @@ impl BudgetedCall {
         self
     }
 
+    pub(super) fn ensure_available(self) -> Result<(), ProviderError> {
+        if !matches!(self.settlement_mode, SettlementMode::AvailabilityOnly) {
+            return Err(ProviderError::invalid_request(
+                "budget",
+                "availability check requires AvailabilityOnly settlement mode",
+            ));
+        }
+        let context = self.context();
+        spend::ensure_budget_available(context.budget_limits(), context.provider(), context.model())
+    }
+
     pub(super) async fn reserve_call<T, Reserve, Call, CallFuture>(
         self,
         reserve: Reserve,
@@ -447,6 +458,42 @@ mod tests {
             0.0
         );
         assert_eq!(budget_manager.get_current_spend(&scope), 0.0);
+    }
+
+    #[test]
+    fn availability_only_ensure_available_does_not_record_spend() {
+        let limits = limited_budget();
+
+        BudgetedCall::new(limits.clone(), "openai", "gpt-4")
+            .ensure_available()
+            .expect("availability check should pass without recording spend");
+
+        assert_eq!(
+            limits
+                .providers
+                .get_provider_usage("openai")
+                .map(|usage| usage.current_spend)
+                .unwrap_or_default(),
+            0.0
+        );
+        assert_eq!(
+            limits
+                .models
+                .get_model_usage("gpt-4")
+                .map(|usage| usage.current_spend)
+                .unwrap_or_default(),
+            0.0
+        );
+    }
+
+    #[test]
+    fn ensure_available_rejects_metered_mode() {
+        let error = BudgetedCall::new(limited_budget(), "openai", "gpt-4")
+            .with_settlement_mode(ApiKeyBudgetPolicy::FromProviderReservation)
+            .ensure_available()
+            .expect_err("metered budget calls must use reservation settlement");
+
+        assert_eq!(error.http_status(), 400);
     }
 
     #[tokio::test]

--- a/src/server/routes/ai/fine_tuning.rs
+++ b/src/server/routes/ai/fine_tuning.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use tracing::error;
 
+use super::budgeted::SettlementMode;
 use super::openai_errors;
 use super::provider_config;
 
@@ -265,7 +266,11 @@ fn ensure_fine_tuning_budget(
     provider: &str,
     model: &str,
 ) -> Result<(), GatewayError> {
-    super::spend::ensure_budget_available(&state.budget_limits, provider, model)
+    state
+        .budgeted
+        .for_selected(provider, model)
+        .with_settlement_mode(SettlementMode::AvailabilityOnly)
+        .ensure_available()
         .map_err(GatewayError::from)
 }
 

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use std::time::Duration;
 use tracing::error;
 
-use super::budgeted::{BudgetedCall, SettlementMode};
+use super::budgeted::SettlementMode;
 use super::execution::execute_with_selected_deployment;
 use super::openai_errors;
 use super::provider_config;
@@ -102,40 +102,41 @@ async fn proxy_moderation(
                             &resolved_model,
                         )?;
                         let budget_provider = provider.provider_name.clone();
-                        BudgetedCall::new(
-                            state.budget_limits.clone(),
-                            budget_provider,
-                            resolved_model.clone(),
-                        )
-                        .with_settlement_mode(SettlementMode::AvailabilityOnly)
-                        .reserve_call_settle(
-                            |_budget| Ok(None),
-                            || async move {
-                                let url = moderation_url(&provider)
-                                    .map_err(moderation_gateway_error_to_provider_error)?;
-                                let response = provider_config::apply_proxy_headers(
-                                    provider_config::proxy_http_client().post(url),
-                                    &provider.headers,
-                                )
-                                .timeout(provider.timeout)
-                                .json(&request)
-                                .send()
-                                .await
-                                .map_err(|error| {
-                                    ProviderError::network("moderation_proxy", error.to_string())
-                                })?;
-
-                                if !response.status().is_success() {
-                                    return Err(moderation_upstream_error(response).await);
-                                }
-
-                                provider_config::proxy_response_to_http_response(response)
+                        state
+                            .budgeted
+                            .for_selected(budget_provider, resolved_model.clone())
+                            .with_settlement_mode(SettlementMode::AvailabilityOnly)
+                            .reserve_call_settle(
+                                |_budget| Ok(None),
+                                || async move {
+                                    let url = moderation_url(&provider)
+                                        .map_err(moderation_gateway_error_to_provider_error)?;
+                                    let response = provider_config::apply_proxy_headers(
+                                        provider_config::proxy_http_client().post(url),
+                                        &provider.headers,
+                                    )
+                                    .timeout(provider.timeout)
+                                    .json(&request)
+                                    .send()
                                     .await
-                                    .map_err(moderation_gateway_error_to_provider_error)
-                            },
-                            |response, _reservations, _budget| async move { (response, 0) },
-                        )
-                        .await
+                                    .map_err(|error| {
+                                        ProviderError::network(
+                                            "moderation_proxy",
+                                            error.to_string(),
+                                        )
+                                    })?;
+
+                                    if !response.status().is_success() {
+                                        return Err(moderation_upstream_error(response).await);
+                                    }
+
+                                    provider_config::proxy_response_to_http_response(response)
+                                        .await
+                                        .map_err(moderation_gateway_error_to_provider_error)
+                                },
+                                |response, _reservations, _budget| async move { (response, 0) },
+                            )
+                            .await
                     }
                 }
             },

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -14,9 +14,8 @@ use std::time::Duration;
 use tracing::{error, info};
 
 use super::{
-    budgeted::{BudgetedCall, SettlementMode},
-    execution::execute_with_selected_deployment,
-    openai_errors, provider_config,
+    budgeted::SettlementMode, execution::execute_with_selected_deployment, openai_errors,
+    provider_config,
 };
 
 /// Rerank documents against a query.
@@ -82,25 +81,23 @@ async fn handle_rerank_with_state(
                         )?;
                         let served_model = served_rerank_model(&requested_model);
                         let budget_provider = selected.provider_name.clone();
-                        BudgetedCall::new(
-                            state.budget_limits.clone(),
-                            budget_provider,
-                            served_model.to_string(),
-                        )
-                        .with_settlement_mode(SettlementMode::AvailabilityOnly)
-                        .reserve_call_settle(
-                            |_budget| Ok(None),
-                            || async move {
-                                let service = build_rerank_service(&selected)
-                                    .map_err(rerank_gateway_error_to_provider_error)?;
-                                service
-                                    .rerank(request)
-                                    .await
-                                    .map_err(rerank_gateway_error_to_provider_error)
-                            },
-                            |response, _reservations, _budget| async move { (response, 0) },
-                        )
-                        .await
+                        state
+                            .budgeted
+                            .for_selected(budget_provider, served_model.to_string())
+                            .with_settlement_mode(SettlementMode::AvailabilityOnly)
+                            .reserve_call_settle(
+                                |_budget| Ok(None),
+                                || async move {
+                                    let service = build_rerank_service(&selected)
+                                        .map_err(rerank_gateway_error_to_provider_error)?;
+                                    service
+                                        .rerank(request)
+                                        .await
+                                        .map_err(rerank_gateway_error_to_provider_error)
+                                },
+                                |response, _reservations, _budget| async move { (response, 0) },
+                            )
+                            .await
                     }
                 }
             },


### PR DESCRIPTION
Refs #840

## Summary
- add `BudgetedCall::ensure_available()` for explicit AvailabilityOnly budget checks
- route moderations, rerank, fine_tuning, and batches availability checks through `state.budgeted`
- keep these paths non-metered: no provider spend or API-key budget usage is recorded by availability checks

## Validation
- `cargo fmt --all`
- `cargo check --all-features --message-format=short`
- `cargo test --all-features budgeted`
- `cargo test --all-features --test moderations_routes --test rerank_routes --test fine_tuning_routes --test batches_routes`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "$PWD/specs/GH840"`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
