### PR TITLE
refactor(ai): route audio budgets through executor

### DIFF
--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -7,7 +7,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde::Deserialize;
 use tracing::{error, info};
 
-use super::super::budgeted::{ApiKeyBudgetPolicy, BudgetedCall};
+use super::super::budgeted::ApiKeyBudgetPolicy;
 use super::super::execution::execute_with_selected_deployment;
 use crate::server::routes::ai::context::{
     enforce_api_key_model_and_token_limits, get_request_context,
@@ -79,10 +79,9 @@ pub async fn audio_speech(
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
-    let budget_manager = state.budget_manager.clone();
-    let budget_limits = state.budget_limits.clone();
-    let key_manager = state.key_manager.clone();
-    let pricing_service = state.pricing.clone();
+    let budgeted = state.budgeted.clone();
+    let key_manager = budgeted.key_manager();
+    let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
 
     match execute_with_selected_deployment(
@@ -92,8 +91,7 @@ pub async fn audio_speech(
         move |provider, selected_model, _deployment_id| {
             let mut request = speech_request.clone();
             let context = context_for_execution.clone();
-            let budget_manager = budget_manager.clone();
-            let budget_limits = budget_limits.clone();
+            let budgeted = budgeted.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
             let pricing_config = pricing_config.clone();
@@ -118,57 +116,54 @@ pub async fn audio_speech(
                 let reserve_usage = usage.clone();
                 let settle_usage = usage;
                 let settle_key_manager = key_manager.clone();
-                BudgetedCall::new(
-                    budget_limits.clone(),
-                    budget_provider.clone(),
-                    selected_model.clone(),
-                )
-                .with_api_key_budget(
-                    budget_manager.clone(),
-                    api_key_budget_id,
-                    ApiKeyBudgetPolicy::FromProviderReservation,
-                )
-                .reserve_call_settle(
-                    |budget| {
-                        super::budgeting::reserve_audio_provider_budget_with_pricing(
-                            reserve_pricing_service.as_ref(),
-                            &reserve_pricing_config,
-                            budget.budget_limits(),
-                            budget.provider(),
-                            budget.model(),
-                            &reserve_pricing_provider,
-                            &reserve_pricing_model,
-                            None,
-                            &reserve_usage,
-                        )
-                    },
-                    || provider.text_to_speech(request, context),
-                    |response, reservations, budget| {
-                        let (budget_reservation, key_budget_reservation) =
-                            reservations.into_parts();
-                        async move {
-                            let tokens_used = u64::from(settle_usage.total_tokens);
-                            super::budgeting::record_audio_spend(
-                                settle_pricing_service.as_ref(),
-                                &settle_pricing_config,
+                budgeted
+                    .for_selected_with_api_key_budget(
+                        budget_provider.clone(),
+                        selected_model.clone(),
+                        api_key_budget_id,
+                        ApiKeyBudgetPolicy::FromProviderReservation,
+                    )
+                    .reserve_call_settle(
+                        |budget| {
+                            super::budgeting::reserve_audio_provider_budget_with_pricing(
+                                reserve_pricing_service.as_ref(),
+                                &reserve_pricing_config,
                                 budget.budget_limits(),
-                                &settle_key_manager,
-                                api_key_id,
                                 budget.provider(),
                                 budget.model(),
-                                &settle_pricing_provider,
-                                &settle_pricing_model,
+                                &reserve_pricing_provider,
+                                &reserve_pricing_model,
                                 None,
-                                &settle_usage,
-                                budget_reservation,
-                                key_budget_reservation,
+                                &reserve_usage,
                             )
-                            .await;
-                            (response, tokens_used)
-                        }
-                    },
-                )
-                .await
+                        },
+                        || provider.text_to_speech(request, context),
+                        |response, reservations, budget| {
+                            let (budget_reservation, key_budget_reservation) =
+                                reservations.into_parts();
+                            async move {
+                                let tokens_used = u64::from(settle_usage.total_tokens);
+                                super::budgeting::record_audio_spend(
+                                    settle_pricing_service.as_ref(),
+                                    &settle_pricing_config,
+                                    budget.budget_limits(),
+                                    &settle_key_manager,
+                                    api_key_id,
+                                    budget.provider(),
+                                    budget.model(),
+                                    &settle_pricing_provider,
+                                    &settle_pricing_model,
+                                    None,
+                                    &settle_usage,
+                                    budget_reservation,
+                                    key_budget_reservation,
+                                )
+                                .await;
+                                (response, tokens_used)
+                            }
+                        },
+                    )
+                    .await
             }
         },
     )

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -8,7 +8,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
-use super::super::budgeted::{ApiKeyBudgetPolicy, BudgetedCall};
+use super::super::budgeted::ApiKeyBudgetPolicy;
 use super::super::execution::execute_with_selected_deployment;
 use super::upload::{
     drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
@@ -151,10 +151,9 @@ pub async fn audio_transcriptions(
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
-    let budget_manager = state.budget_manager.clone();
-    let budget_limits = state.budget_limits.clone();
-    let key_manager = state.key_manager.clone();
-    let pricing_service = state.pricing.clone();
+    let budgeted = state.budgeted.clone();
+    let key_manager = budgeted.key_manager();
+    let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
 
     match execute_with_selected_deployment(
@@ -164,8 +163,7 @@ pub async fn audio_transcriptions(
         move |provider, selected_model, _deployment_id| {
             let mut request = transcription_request.clone();
             let context = context_for_execution.clone();
-            let budget_manager = budget_manager.clone();
-            let budget_limits = budget_limits.clone();
+            let budgeted = budgeted.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
             let pricing_config = pricing_config.clone();
@@ -193,57 +191,54 @@ pub async fn audio_transcriptions(
                 let reserve_usage = usage.clone();
                 let settle_usage = usage;
                 let settle_key_manager = key_manager.clone();
-                BudgetedCall::new(
-                    budget_limits.clone(),
-                    budget_provider.clone(),
-                    selected_model.clone(),
-                )
-                .with_api_key_budget(
-                    budget_manager.clone(),
-                    api_key_budget_id,
-                    ApiKeyBudgetPolicy::FromProviderReservation,
-                )
-                .reserve_call_settle(
-                    |budget| {
-                        super::budgeting::reserve_audio_provider_budget_with_pricing(
-                            reserve_pricing_service.as_ref(),
-                            &reserve_pricing_config,
-                            budget.budget_limits(),
-                            budget.provider(),
-                            budget.model(),
-                            &reserve_pricing_provider,
-                            &reserve_pricing_model,
-                            Some(total_time_seconds),
-                            &reserve_usage,
-                        )
-                    },
-                    || provider.audio_transcription(request, context),
-                    |response, reservations, budget| {
-                        let (budget_reservation, key_budget_reservation) =
-                            reservations.into_parts();
-                        async move {
-                            let tokens_used = u64::from(settle_usage.total_tokens);
-                            super::budgeting::record_audio_spend(
-                                settle_pricing_service.as_ref(),
-                                &settle_pricing_config,
+                budgeted
+                    .for_selected_with_api_key_budget(
+                        budget_provider.clone(),
+                        selected_model.clone(),
+                        api_key_budget_id,
+                        ApiKeyBudgetPolicy::FromProviderReservation,
+                    )
+                    .reserve_call_settle(
+                        |budget| {
+                            super::budgeting::reserve_audio_provider_budget_with_pricing(
+                                reserve_pricing_service.as_ref(),
+                                &reserve_pricing_config,
                                 budget.budget_limits(),
-                                &settle_key_manager,
-                                api_key_id,
                                 budget.provider(),
                                 budget.model(),
-                                &settle_pricing_provider,
-                                &settle_pricing_model,
+                                &reserve_pricing_provider,
+                                &reserve_pricing_model,
                                 Some(total_time_seconds),
-                                &settle_usage,
-                                budget_reservation,
-                                key_budget_reservation,
+                                &reserve_usage,
                             )
-                            .await;
-                            (response, tokens_used)
-                        }
-                    },
-                )
-                .await
+                        },
+                        || provider.audio_transcription(request, context),
+                        |response, reservations, budget| {
+                            let (budget_reservation, key_budget_reservation) =
+                                reservations.into_parts();
+                            async move {
+                                let tokens_used = u64::from(settle_usage.total_tokens);
+                                super::budgeting::record_audio_spend(
+                                    settle_pricing_service.as_ref(),
+                                    &settle_pricing_config,
+                                    budget.budget_limits(),
+                                    &settle_key_manager,
+                                    api_key_id,
+                                    budget.provider(),
+                                    budget.model(),
+                                    &settle_pricing_provider,
+                                    &settle_pricing_model,
+                                    Some(total_time_seconds),
+                                    &settle_usage,
+                                    budget_reservation,
+                                    key_budget_reservation,
+                                )
+                                .await;
+                                (response, tokens_used)
+                            }
+                        },
+                    )
+                    .await
             }
         },
     )

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -8,7 +8,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
-use super::super::budgeted::{ApiKeyBudgetPolicy, BudgetedCall};
+use super::super::budgeted::ApiKeyBudgetPolicy;
 use super::super::execution::execute_with_selected_deployment;
 use super::upload::{
     drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
@@ -139,10 +139,9 @@ pub async fn audio_translations(
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
-    let budget_manager = state.budget_manager.clone();
-    let budget_limits = state.budget_limits.clone();
-    let key_manager = state.key_manager.clone();
-    let pricing_service = state.pricing.clone();
+    let budgeted = state.budgeted.clone();
+    let key_manager = budgeted.key_manager();
+    let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
 
     match execute_with_selected_deployment(
@@ -152,8 +151,7 @@ pub async fn audio_translations(
         move |provider, selected_model, _deployment_id| {
             let mut request = translation_request.clone();
             let context = context_for_execution.clone();
-            let budget_manager = budget_manager.clone();
-            let budget_limits = budget_limits.clone();
+            let budgeted = budgeted.clone();
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
             let pricing_config = pricing_config.clone();
@@ -181,57 +179,54 @@ pub async fn audio_translations(
                 let reserve_usage = usage.clone();
                 let settle_usage = usage;
                 let settle_key_manager = key_manager.clone();
-                BudgetedCall::new(
-                    budget_limits.clone(),
-                    budget_provider.clone(),
-                    selected_model.clone(),
-                )
-                .with_api_key_budget(
-                    budget_manager.clone(),
-                    api_key_budget_id,
-                    ApiKeyBudgetPolicy::FromProviderReservation,
-                )
-                .reserve_call_settle(
-                    |budget| {
-                        super::budgeting::reserve_audio_provider_budget_with_pricing(
-                            reserve_pricing_service.as_ref(),
-                            &reserve_pricing_config,
-                            budget.budget_limits(),
-                            budget.provider(),
-                            budget.model(),
-                            &reserve_pricing_provider,
-                            &reserve_pricing_model,
-                            Some(total_time_seconds),
-                            &reserve_usage,
-                        )
-                    },
-                    || provider.audio_translation(request, context),
-                    |response, reservations, budget| {
-                        let (budget_reservation, key_budget_reservation) =
-                            reservations.into_parts();
-                        async move {
-                            let tokens_used = u64::from(settle_usage.total_tokens);
-                            super::budgeting::record_audio_spend(
-                                settle_pricing_service.as_ref(),
-                                &settle_pricing_config,
+                budgeted
+                    .for_selected_with_api_key_budget(
+                        budget_provider.clone(),
+                        selected_model.clone(),
+                        api_key_budget_id,
+                        ApiKeyBudgetPolicy::FromProviderReservation,
+                    )
+                    .reserve_call_settle(
+                        |budget| {
+                            super::budgeting::reserve_audio_provider_budget_with_pricing(
+                                reserve_pricing_service.as_ref(),
+                                &reserve_pricing_config,
                                 budget.budget_limits(),
-                                &settle_key_manager,
-                                api_key_id,
                                 budget.provider(),
                                 budget.model(),
-                                &settle_pricing_provider,
-                                &settle_pricing_model,
+                                &reserve_pricing_provider,
+                                &reserve_pricing_model,
                                 Some(total_time_seconds),
-                                &settle_usage,
-                                budget_reservation,
-                                key_budget_reservation,
+                                &reserve_usage,
                             )
-                            .await;
-                            (response, tokens_used)
-                        }
-                    },
-                )
-                .await
+                        },
+                        || provider.audio_translation(request, context),
+                        |response, reservations, budget| {
+                            let (budget_reservation, key_budget_reservation) =
+                                reservations.into_parts();
+                            async move {
+                                let tokens_used = u64::from(settle_usage.total_tokens);
+                                super::budgeting::record_audio_spend(
+                                    settle_pricing_service.as_ref(),
+                                    &settle_pricing_config,
+                                    budget.budget_limits(),
+                                    &settle_key_manager,
+                                    api_key_id,
+                                    budget.provider(),
+                                    budget.model(),
+                                    &settle_pricing_provider,
+                                    &settle_pricing_model,
+                                    Some(total_time_seconds),
+                                    &settle_usage,
+                                    budget_reservation,
+                                    key_budget_reservation,
+                                )
+                                .await;
+                                (response, tokens_used)
+                            }
+                        },
+                    )
+                    .await
             }
         },
     )


### PR DESCRIPTION
## Summary
- Route audio speech, transcription, and translation budget reservations through `AppState::budgeted` / `BudgetedExecutor`.
- Remove direct audio-route captures of `state.budget_manager`, `state.budget_limits`, `state.key_manager`, and `state.pricing`.
- Preserve existing audio reserve, upstream call, and settle behavior; no provider behavior change intended.

Related: #840

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features --message-format=short`
- `cargo test --all-features audio`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "$PWD/specs/GH840"`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`