### PR TITLE
refactor(ai): route gemini budgets through executor

### DIFF
--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -364,11 +364,15 @@ async fn gemini_upstream_response_to_http_response(
     let body = response.bytes().await.map_err(gemini_http_error)?;
     if status.is_success() {
         let config = state.config();
+        let budgeted = state.budgeted.clone();
+        let pricing = budgeted.pricing();
+        let budget_limits = budgeted.budget_limits();
+        let key_manager = budgeted.key_manager();
         let spend_state = GeminiSpendState {
-            pricing: state.pricing.as_ref(),
+            pricing: pricing.as_ref(),
             pricing_config: &config.gateway.pricing,
-            budget_limits: &state.budget_limits,
-            key_manager: &state.key_manager,
+            budget_limits: budget_limits.as_ref(),
+            key_manager: &key_manager,
             api_key_id: context.api_key_id(),
         };
         record_gemini_spend(
@@ -410,10 +414,11 @@ fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts)
         stream_lease,
     } = parts;
     let (tx, rx) = mpsc::channel::<Bytes>(8);
-    let pricing = state.pricing.clone();
+    let budgeted = state.budgeted.clone();
+    let pricing = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
-    let budget_limits = state.budget_limits.clone();
-    let key_manager = state.key_manager.clone();
+    let budget_limits = budgeted.budget_limits();
+    let key_manager = budgeted.key_manager();
     let api_key_id = context.api_key_id();
     let should_record_spend = status.is_success();
 

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -14,7 +14,7 @@ use crate::core::providers::{Provider, ProviderError};
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
-use super::super::budgeted::{ApiKeyBudgetPolicy, BudgetedCall};
+use super::super::budgeted::ApiKeyBudgetPolicy;
 use super::{validate_api_version, validate_method, validate_model_segment};
 use uuid::Uuid;
 
@@ -313,37 +313,44 @@ pub(super) async fn send_gemini_request(
     ),
     ProviderError,
 > {
-    let (response, reservations) = BudgetedCall::new(
-        state.budget_limits.clone(),
-        provider.provider_name.clone(),
-        provider.model.clone(),
-    )
-    .with_api_key_budget(
-        state.budget_manager.clone(),
-        api_key_budget_id,
-        ApiKeyBudgetPolicy::FromProviderReservation,
-    )
-    .reserve_call(
-        |_budget| {
-            super::spend::reserve_gemini_budget(state, provider, request)
+    let budgeted = state.budgeted.clone();
+    let pricing = budgeted.pricing();
+    let pricing_config = state.config().gateway.pricing.clone();
+    let budget_limits = budgeted.budget_limits();
+    let (response, reservations) = budgeted
+        .for_selected_with_api_key_budget(
+            provider.provider_name.clone(),
+            provider.model.clone(),
+            api_key_budget_id,
+            ApiKeyBudgetPolicy::FromProviderReservation,
+        )
+        .reserve_call(
+            |_budget| {
+                super::spend::reserve_gemini_budget(
+                    pricing.as_ref(),
+                    &pricing_config,
+                    budget_limits.as_ref(),
+                    provider,
+                    request,
+                )
                 .map_err(gemini_gateway_error_to_provider_error)
-        },
-        || async {
-            let url = gemini_url(provider, api_version, method, stream)
-                .map_err(gemini_gateway_error_to_provider_error)?;
-            let response = apply_gemini_headers(gemini_http_client().post(url), provider)
-                .header(CONTENT_TYPE, "application/json")
-                .json(request)
-                .timeout(provider.timeout)
-                .send()
-                .await
-                .map_err(|error| {
-                    gemini_gateway_error_to_provider_error(gemini_http_error(error))
-                })?;
-            gemini_response_or_provider_error(response, provider).await
-        },
-    )
-    .await?;
+            },
+            || async {
+                let url = gemini_url(provider, api_version, method, stream)
+                    .map_err(gemini_gateway_error_to_provider_error)?;
+                let response = apply_gemini_headers(gemini_http_client().post(url), provider)
+                    .header(CONTENT_TYPE, "application/json")
+                    .json(request)
+                    .timeout(provider.timeout)
+                    .send()
+                    .await
+                    .map_err(|error| {
+                        gemini_gateway_error_to_provider_error(gemini_http_error(error))
+                    })?;
+                gemini_response_or_provider_error(response, provider).await
+            },
+        )
+        .await?;
     let (budget_reservation, key_budget_reservation) = reservations.into_parts();
     Ok((budget_reservation, key_budget_reservation, response))
 }

--- a/src/server/routes/ai/gemini/spend.rs
+++ b/src/server/routes/ai/gemini/spend.rs
@@ -9,7 +9,6 @@ use crate::core::budget::{
 use crate::core::keys::KeyManager;
 use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::ProviderError;
-use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
 use super::provider::GeminiRouteProvider;
@@ -117,13 +116,14 @@ pub(super) async fn record_gemini_spend(
 }
 
 pub(super) fn reserve_gemini_budget(
-    state: &AppState,
+    pricing: &PricingService,
+    pricing_config: &GatewayPricingConfig,
+    budget_limits: &UnifiedBudgetLimits,
     provider: &GeminiRouteProvider,
     request: &Value,
 ) -> Result<Option<UnifiedBudgetReservation>, GatewayError> {
     let usage = estimated_gemini_request_usage(request);
-    let pricing_config = &state.config().gateway.pricing;
-    let estimate = match state.pricing.estimate_loaded_completion_cost_for_provider(
+    let estimate = match pricing.estimate_loaded_completion_cost_for_provider(
         &provider.pricing_provider,
         &provider.model,
         usage.prompt_tokens,
@@ -133,7 +133,7 @@ pub(super) fn reserve_gemini_budget(
         Err(error) => {
             return super::super::spend::reserve_unpriced_usage_budget(
                 pricing_config,
-                &state.budget_limits,
+                budget_limits,
                 &provider.provider_name,
                 &provider.model,
                 &usage,
@@ -144,14 +144,13 @@ pub(super) fn reserve_gemini_budget(
     };
     if estimate.max_cost <= 0.0 {
         super::super::spend::ensure_budget_available(
-            &state.budget_limits,
+            budget_limits,
             &provider.provider_name,
             &provider.model,
         )?;
         return Ok(None);
     }
-    state
-        .budget_limits
+    budget_limits
         .reserve_spend(&provider.provider_name, &provider.model, estimate.max_cost)
         .map(Some)
         .map_err(|error| reservation_error_to_gateway_error(error, provider))


### PR DESCRIPTION
## Summary
- Route Gemini SDK native budget reservations through `AppState::budgeted` / `BudgetedExecutor`.
- Remove Gemini direct captures of `state.budget_manager`, `state.budget_limits`, `state.key_manager`, and `state.pricing`.
- Preserve existing Gemini router fallback, pre-call request usage estimation, non-stream settlement, and stream finalization behavior.

Related: #840

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features --message-format=short`
- `cargo test --all-features gemini`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "$PWD/specs/GH840"`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`