### PR TITLE
refactor(ai): route cache pricing through budgeted executor

### DIFF
--- a/src/server/routes/ai/response_cache.rs
+++ b/src/server/routes/ai/response_cache.rs
@@ -134,6 +134,7 @@ pub(super) fn ensure_chat_cache_pricing_gate(
     state: &AppState,
     request: &ChatCompletionRequest,
 ) -> Result<(), GatewayError> {
+    let pricing = state.budgeted.pricing();
     let prompt_tokens = super::spend::estimate_chat_prompt_tokens(
         &request.model,
         &request.messages,
@@ -152,12 +153,11 @@ pub(super) fn ensure_chat_cache_pricing_gate(
         ProviderCapability::ChatCompletion,
         |provider, selected_model| {
             let (pricing_provider, pricing_model) = super::spend::pricing_identity_for_provider(
-                state.pricing.as_ref(),
+                pricing.as_ref(),
                 provider,
                 selected_model,
             );
-            state
-                .pricing
+            pricing
                 .estimate_loaded_completion_cost_for_provider(
                     &pricing_provider,
                     &pricing_model,
@@ -176,6 +176,7 @@ pub(super) fn ensure_embedding_cache_pricing_gate(
     state: &AppState,
     request: &EmbeddingRequest,
 ) -> Result<(), GatewayError> {
+    let pricing = state.budgeted.pricing();
     let usage = PricingUsage::new(1, 0);
     ensure_cache_pricing_gate(
         state,
@@ -183,12 +184,11 @@ pub(super) fn ensure_embedding_cache_pricing_gate(
         ProviderCapability::Embeddings,
         |provider, selected_model| {
             let (pricing_provider, pricing_model) = super::spend::pricing_identity_for_provider(
-                state.pricing.as_ref(),
+                pricing.as_ref(),
                 provider,
                 selected_model,
             );
-            state
-                .pricing
+            pricing
                 .calculate_loaded_usage_cost_for_provider(&pricing_provider, &pricing_model, &usage)
                 .map(|_| ())
                 .map_err(|error| {


### PR DESCRIPTION
## Summary
- Route response-cache pricing gates through `AppState::budgeted` / `BudgetedExecutor` pricing access.
- Remove direct response-cache captures of `state.pricing`.
- Preserve existing cache-hit behavior: cache hits still run before budget orchestration and do not add budget side effects.

Related: #840

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features --message-format=short`
- `cargo test --all-features response_cache`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "$PWD/specs/GH840"`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`