### PR TITLE
refactor(ai): route image proxy budgets through executor

### DIFF
--- a/src/server/routes/ai/budget_orchestration.rs
+++ b/src/server/routes/ai/budget_orchestration.rs
@@ -119,28 +119,15 @@ impl BudgetContext {
         &self.model
     }
 
-    pub(super) fn ensure_can_spend(&self, amount: f64) -> Result<(), ProviderError> {
-        if !self
-            .budget_limits
-            .providers
-            .can_provider_spend(&self.provider, amount)
-        {
-            return Err(ProviderError::quota_exceeded(
-                "budget",
-                format!("provider '{}' budget exceeded", self.provider),
-            ));
-        }
-        if !self
-            .budget_limits
-            .models
-            .can_model_spend(&self.model, amount)
-        {
-            return Err(ProviderError::quota_exceeded(
-                "budget",
-                format!("model '{}' budget exceeded", self.model),
-            ));
-        }
-        Ok(())
+    pub(super) fn reserve_spend(
+        &self,
+        amount: f64,
+    ) -> Result<UnifiedBudgetReservation, ProviderError> {
+        self.budget_limits
+            .reserve_spend(&self.provider, &self.model, amount)
+            .map_err(|error| {
+                spend::reservation_error_to_provider_error(error, &self.provider, &self.model)
+            })
     }
 }
 
@@ -564,6 +551,46 @@ mod tests {
         assert!(budget.is_none());
         super::spend::settle_api_key_budget_reservation(key, 0.10, "image proxy test");
         assert_eq!(budget_manager.get_current_spend(&scope), 0.10);
+    }
+
+    #[tokio::test]
+    async fn provider_model_reservation_blocks_concurrent_budget_overrun() {
+        let limits = limited_budget();
+
+        let first = BudgetedCall::new(limits.clone(), "openai", "gpt-4")
+            .reserve_call(|context| context.reserve_spend(0.75).map(Some), {
+                let limits = limits.clone();
+                move || async move {
+                    assert!(
+                        limits.reserve_spend("openai", "gpt-4", 0.50).is_err(),
+                        "in-flight reservation must count against remaining budget"
+                    );
+                    Ok::<_, crate::core::providers::ProviderError>(())
+                }
+            })
+            .await;
+        assert!(first.is_ok(), "first reservation should fit the budget");
+        let (_, reservations) = match first {
+            Ok(value) => value,
+            Err(error) => panic!("first reservation failed unexpectedly: {error}"),
+        };
+
+        let (reservation, key_reservation) = reservations.into_parts();
+        assert!(key_reservation.is_none());
+        let Some(reservation) = reservation else {
+            panic!("provider/model reservation should be present");
+        };
+        assert!(
+            reservation.settle(0.75).is_ok(),
+            "settlement should fit reservation"
+        );
+        assert_eq!(
+            limits
+                .providers
+                .get_provider_usage("openai")
+                .map(|usage| usage.current_spend),
+            Some(0.75)
+        );
     }
 
     #[test]

--- a/src/server/routes/ai/budget_orchestration.rs
+++ b/src/server/routes/ai/budget_orchestration.rs
@@ -118,6 +118,30 @@ impl BudgetContext {
     pub(super) fn model(&self) -> &str {
         &self.model
     }
+
+    pub(super) fn ensure_can_spend(&self, amount: f64) -> Result<(), ProviderError> {
+        if !self
+            .budget_limits
+            .providers
+            .can_provider_spend(&self.provider, amount)
+        {
+            return Err(ProviderError::quota_exceeded(
+                "budget",
+                format!("provider '{}' budget exceeded", self.provider),
+            ));
+        }
+        if !self
+            .budget_limits
+            .models
+            .can_model_spend(&self.model, amount)
+        {
+            return Err(ProviderError::quota_exceeded(
+                "budget",
+                format!("model '{}' budget exceeded", self.model),
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl BudgetedCall {

--- a/src/server/routes/ai/budget_orchestration.rs
+++ b/src/server/routes/ai/budget_orchestration.rs
@@ -93,6 +93,7 @@ pub(super) struct BudgetedCall {
     budget_limits: Arc<UnifiedBudgetLimits>,
     budget_manager: Option<Arc<BudgetManager>>,
     api_key_budget_id: Option<Uuid>,
+    api_key_estimated_cost: Option<f64>,
     provider: String,
     model: String,
     settlement_mode: SettlementMode,
@@ -129,6 +130,7 @@ impl BudgetedCall {
             budget_limits,
             budget_manager: None,
             api_key_budget_id: None,
+            api_key_estimated_cost: None,
             provider: provider.into(),
             model: model.into(),
             settlement_mode: SettlementMode::AvailabilityOnly,
@@ -154,6 +156,14 @@ impl BudgetedCall {
         self.budget_manager = Some(budget_manager);
         self.api_key_budget_id = api_key_budget_id;
         self.settlement_mode = mode;
+        self
+    }
+
+    pub(super) fn with_precomputed_api_key_budget_cost(
+        mut self,
+        estimated_cost: Option<f64>,
+    ) -> Self {
+        self.api_key_estimated_cost = estimated_cost;
         self
     }
 
@@ -239,12 +249,15 @@ impl BudgetedCall {
                         "API key budget manager is required for budget reservation",
                     )
                 })?;
+                let estimated_cost = self.api_key_estimated_cost.or_else(|| {
+                    budget
+                        .as_ref()
+                        .map(UnifiedBudgetReservation::reserved_amount)
+                });
                 spend::reserve_api_key_budget(
                     budget_manager.as_ref(),
                     self.api_key_budget_id,
-                    budget
-                        .as_ref()
-                        .map(UnifiedBudgetReservation::reserved_amount),
+                    estimated_cost,
                 )?
             }
         };
@@ -472,6 +485,61 @@ mod tests {
             0.0
         );
         assert_eq!(budget_manager.get_current_spend(&scope), 0.0);
+    }
+
+    #[tokio::test]
+    async fn key_reservation_mode_uses_precomputed_cost_without_provider_model_reservation() {
+        let limits = limited_budget();
+        let budget_manager = Arc::new(BudgetManager::new());
+        let scope = BudgetScope::ApiKey("image-proxy-key-budget".to_string());
+        let budget = budget_manager
+            .create_budget(
+                scope.clone(),
+                BudgetConfig::new("image proxy key budget", 1.0),
+            )
+            .await
+            .expect("key budget should be created");
+        let budget_id = uuid::Uuid::parse_str(&budget.id).expect("budget id should be UUID");
+
+        let ((), reservations) = BudgetedCall::new(limits.clone(), "openai", "gpt-image-1-mini")
+            .with_api_key_budget(
+                budget_manager.clone(),
+                Some(budget_id),
+                ApiKeyBudgetPolicy::RequirePricedReservation,
+            )
+            .with_precomputed_api_key_budget_cost(Some(0.25))
+            .reserve_call(|_context| Ok(None), {
+                let limits = limits.clone();
+                let budget_manager = budget_manager.clone();
+                let scope = scope.clone();
+                move || async move {
+                    assert_eq!(
+                        limits
+                            .providers
+                            .get_provider_usage("openai")
+                            .map(|usage| usage.current_spend)
+                            .unwrap_or_default(),
+                        0.0
+                    );
+                    assert_eq!(
+                        limits
+                            .models
+                            .get_model_usage("gpt-image-1-mini")
+                            .map(|usage| usage.current_spend)
+                            .unwrap_or_default(),
+                        0.0
+                    );
+                    assert_eq!(budget_manager.get_current_spend(&scope), 0.25);
+                    Ok::<_, crate::core::providers::ProviderError>(())
+                }
+            })
+            .await
+            .expect("precomputed key budget should reserve without provider/model reservation");
+
+        let (budget, key) = reservations.into_parts();
+        assert!(budget.is_none());
+        super::spend::settle_api_key_budget_reservation(key, 0.10, "image proxy test");
+        assert_eq!(budget_manager.get_current_spend(&scope), 0.10);
     }
 
     #[test]

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -211,10 +211,7 @@ async fn proxy_image_multipart_endpoint(
                             )
                             .with_precomputed_api_key_budget_cost(Some(estimated_cost))
                             .reserve_call(
-                                |context| {
-                                    context.ensure_can_spend(estimated_cost)?;
-                                    Ok(None)
-                                },
+                                |context| context.reserve_spend(estimated_cost).map(Some),
                                 || async move {
                                     let url = image_proxy_url(&provider_for_call, endpoint)
                                         .map_err(image_proxy_gateway_error_to_provider_error)?;

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -211,7 +211,10 @@ async fn proxy_image_multipart_endpoint(
                             )
                             .with_precomputed_api_key_budget_cost(Some(estimated_cost))
                             .reserve_call(
-                                |_context| Ok(None),
+                                |context| {
+                                    context.ensure_can_spend(estimated_cost)?;
+                                    Ok(None)
+                                },
                                 || async move {
                                     let url = image_proxy_url(&provider_for_call, endpoint)
                                         .map_err(image_proxy_gateway_error_to_provider_error)?;

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -23,6 +23,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::{error, info};
 
+use super::budgeted::ApiKeyBudgetPolicy;
 use super::context::handle_ai_request;
 use super::execution::execute_with_selected_deployment;
 use super::{openai_errors, provider_config};
@@ -140,10 +141,14 @@ async fn proxy_image_multipart_endpoint(
         state.config().gateway.providers.as_slice(),
         requested_model,
     )?;
+    let budgeted = state.budgeted.clone();
+    let pricing_service = budgeted.pricing();
+    let budget_limits = budgeted.budget_limits();
+    let key_manager = budgeted.key_manager();
     let router_models =
         image_proxy_router_models(state.config().gateway.providers.as_slice(), requested_model);
     let pricing_model = pricing_keys::resolve_image_pricing_model(
-        state.pricing.as_ref(),
+        pricing_service.as_ref(),
         "openai",
         requested_model,
         form_fields.size.as_deref(),
@@ -153,7 +158,7 @@ async fn proxy_image_multipart_endpoint(
     let usage = estimated_image_proxy_usage(&form_fields, "openai", &pricing_model);
     let pricing_config = state.config().gateway.pricing.clone();
     let (estimated_cost, unpriced) = image_proxy_cost(
-        state.pricing.as_ref(),
+        pricing_service.as_ref(),
         &pricing_config,
         "openai",
         &pricing_model,
@@ -174,10 +179,18 @@ async fn proxy_image_multipart_endpoint(
             &router_model,
             endpoint.capability(),
             {
+                let budgeted = budgeted.clone();
+                let budget_limits = budget_limits.clone();
+                let key_manager = key_manager.clone();
+                let pricing_config = pricing_config.clone();
                 let body = body.clone();
                 let content_type = content_type.clone();
                 let usage = usage.clone();
                 move |selected_provider, selected_model, _deployment_id| {
+                    let budgeted = budgeted.clone();
+                    let budget_limits = budget_limits.clone();
+                    let key_manager = key_manager.clone();
+                    let pricing_config = pricing_config.clone();
                     let body = body.clone();
                     let content_type = content_type.clone();
                     let usage = usage.clone();
@@ -188,81 +201,56 @@ async fn proxy_image_multipart_endpoint(
                             &selected_model,
                             requested_model,
                         )?;
-                        let mut budget_reservation = if estimated_cost > 0.0 {
-                            state
-                                .budget_limits
-                                .reserve_spend(
-                                    &provider.provider_name,
-                                    requested_model,
-                                    estimated_cost,
-                                )
-                                .map(Some)
-                                .map_err(|error| {
-                                    super::spend::reservation_error_to_provider_error(
-                                        error,
-                                        &provider.provider_name,
-                                        requested_model,
-                                    )
-                                })?
-                        } else {
-                            super::spend::ensure_budget_available(
-                                &state.budget_limits,
-                                &provider.provider_name,
-                                requested_model,
-                            )?;
-                            None
-                        };
-                        let mut key_budget_reservation =
-                            super::spend::reserve_api_key_budget_for_reservation(
-                                &state.budget_manager,
+                        let provider_for_call = provider.clone();
+                        let (response, reservations) = budgeted
+                            .for_selected_with_api_key_budget(
+                                provider.provider_name.clone(),
+                                requested_model.to_string(),
                                 api_key_budget_id,
-                                budget_reservation.as_ref(),
-                            )?;
-                        let url = image_proxy_url(&provider, endpoint)
-                            .map_err(image_proxy_gateway_error_to_provider_error)?;
-                        let response_result =
-                            apply_image_proxy_headers(image_http_client().post(url), &provider)
-                                .header(reqwest::header::CONTENT_TYPE, content_type)
-                                .body(body)
-                                .timeout(provider.timeout)
-                                .send()
-                                .await;
-                        let response = match response_result {
-                            Ok(response) => response,
-                            Err(error) => {
-                                if let Some(reservation) = budget_reservation.take() {
-                                    reservation.cancel();
-                                }
-                                if let Some(reservation) = key_budget_reservation.take() {
-                                    reservation.cancel();
-                                }
-                                return Err(ProviderError::network(
-                                    "image_proxy",
-                                    error.to_string(),
-                                ));
-                            }
-                        };
+                                ApiKeyBudgetPolicy::RequirePricedReservation,
+                            )
+                            .with_precomputed_api_key_budget_cost(Some(estimated_cost))
+                            .reserve_call(
+                                |_context| Ok(None),
+                                || async move {
+                                    let url = image_proxy_url(&provider_for_call, endpoint)
+                                        .map_err(image_proxy_gateway_error_to_provider_error)?;
+                                    let response = apply_image_proxy_headers(
+                                        image_http_client().post(url),
+                                        &provider_for_call,
+                                    )
+                                    .header(reqwest::header::CONTENT_TYPE, content_type)
+                                    .body(body)
+                                    .timeout(provider_for_call.timeout)
+                                    .send()
+                                    .await
+                                    .map_err(|error| {
+                                        ProviderError::network("image_proxy", error.to_string())
+                                    })?;
 
-                        if !response.status().is_success() {
-                            if let Some(reservation) = budget_reservation.take() {
-                                reservation.cancel();
-                            }
-                            if let Some(reservation) = key_budget_reservation.take() {
-                                reservation.cancel();
-                            }
-                            return Err(image_proxy_upstream_error(response).await);
-                        }
+                                    if !response.status().is_success() {
+                                        return Err(image_proxy_upstream_error(response).await);
+                                    }
+
+                                    Ok(response)
+                                },
+                            )
+                            .await?;
+                        let (budget_reservation, key_budget_reservation) =
+                            reservations.into_parts();
 
                         record_image_proxy_spend(
-                            state,
+                            &pricing_config,
+                            budget_limits.as_ref(),
+                            &key_manager,
                             &provider,
                             requested_model,
                             &usage,
                             estimated_cost,
                             unpriced,
-                            budget_reservation.take(),
+                            budget_reservation,
                             api_key_id,
-                            key_budget_reservation.take(),
+                            key_budget_reservation,
                         )
                         .await;
                         let tokens_used = image_proxy_tokens_used(&usage);

--- a/src/server/routes/ai/images/proxy_spend.rs
+++ b/src/server/routes/ai/images/proxy_spend.rs
@@ -1,7 +1,7 @@
 use crate::config::models::gateway::{GatewayPricingConfig, UnpricedModelPolicy};
-use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
+use crate::core::budget::{BudgetReservation, UnifiedBudgetLimits, UnifiedBudgetReservation};
+use crate::core::keys::KeyManager;
 use crate::core::pricing_service::{PricingService, PricingUsage};
-use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use tracing::error;
 
@@ -9,7 +9,9 @@ use super::ImageProxyProvider;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn record_image_proxy_spend(
-    state: &AppState,
+    pricing_config: &GatewayPricingConfig,
+    budget_limits: &UnifiedBudgetLimits,
+    key_manager: &KeyManager,
     provider: &ImageProxyProvider,
     model: &str,
     usage: &PricingUsage,
@@ -20,11 +22,10 @@ pub(super) async fn record_image_proxy_spend(
     key_budget_reservation: Option<BudgetReservation>,
 ) {
     if unpriced {
-        let config = state.config();
         super::super::spend::settle_unpriced_usage(
-            &config.gateway.pricing,
-            &state.budget_limits,
-            &state.key_manager,
+            pricing_config,
+            budget_limits,
+            key_manager,
             api_key_id,
             &provider.provider_name,
             model,
@@ -45,9 +46,7 @@ pub(super) async fn record_image_proxy_spend(
             );
         }
     } else {
-        state
-            .budget_limits
-            .record_spend(&provider.provider_name, model, cost);
+        budget_limits.record_spend(&provider.provider_name, model, cost);
     }
     if let Some(api_key_id) = api_key_id {
         let total_tokens = u64::from(
@@ -55,8 +54,7 @@ pub(super) async fn record_image_proxy_spend(
                 .total_tokens
                 .saturating_add(usage.image_tokens.unwrap_or(0)),
         );
-        if let Err(error) = state
-            .key_manager
+        if let Err(error) = key_manager
             .record_usage(api_key_id, total_tokens, cost)
             .await
         {

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -785,6 +785,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn image_edit_rejects_provider_budget_that_cannot_cover_estimated_cost_before_upstream() {
+        let mock = MockImageServer::start_image_mock().await;
+        let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;
+        let mut usage = PricingUsage::new(4, 0);
+        usage.image_tokens = Some(1024);
+        let estimated_cost = state
+            .pricing
+            .calculate_loaded_usage_cost_for_provider("openai", "gpt-image-1-mini", &usage)
+            .expect("image pricing should be available")
+            .total_cost;
+        assert!(estimated_cost > 0.0);
+        state.budget_limits.providers.set_provider_limit(
+            "mock-openai-compatible",
+            ProviderLimitConfig::new(estimated_cost / 2.0, ResetPeriod::Monthly),
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "insufficient_quota");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("provider 'mock-openai-compatible' budget exceeded")
+        );
+        assert!(
+            mock.requests().is_empty(),
+            "estimated-cost budget rejection must happen before upstream call"
+        );
+
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
     async fn image_edit_rejects_exhausted_model_budget_before_upstream() {
         let mock = MockImageServer::start_image_mock().await;
         let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;


### PR DESCRIPTION
## Summary
- route image edit/variation proxy budget checks through BudgetedExecutor special key-reservation mode
- add precomputed API-key budget cost support without provider/model pre-call reservation
- pass budgeted pricing, budget limits, and key manager into image proxy settlement instead of direct AppState budget field access

## Behavior notes
- image proxy still prices request-level OpenAI image usage before router execution
- provider/model budget uses availability check before upstream and records spend after upstream success status, before response body conversion
- API-key budget pre-reserves the precomputed cost and is canceled automatically on provider/upstream errors

## Verification
- cargo fmt --all -- --check
- cargo check --all-features --message-format=short
- cargo test --all-features key_reservation_mode_uses_precomputed_cost_without_provider_model_reservation
- cargo test --test image_edit_variation_routes --all-features
- cargo test --test image_router_fallback_routes --all-features
- cargo test server::routes::ai::budgeted --lib --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "/private/tmp/litellm-rs-gh840-image-proxy-budgeted/specs/GH840"
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh

Related: #840