### PR TITLE
refactor(ai): route execution through budgeted entrypoints

### DIFF
--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -7,8 +7,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde::Deserialize;
 use tracing::{error, info};
 
-use super::super::budgeted::ApiKeyBudgetPolicy;
-use super::super::execution::execute_with_selected_deployment;
+use super::super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use crate::server::routes::ai::context::{
     enforce_api_key_model_and_token_limits, get_request_context,
 };
@@ -84,7 +83,7 @@ pub async fn audio_speech(
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
 
-    match execute_with_selected_deployment(
+    match run_unary(
         &state.unified_router,
         &requested_model,
         ProviderCapability::TextToSpeech,

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -8,8 +8,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
-use super::super::budgeted::ApiKeyBudgetPolicy;
-use super::super::execution::execute_with_selected_deployment;
+use super::super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use super::upload::{
     drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
     read_text_field, upload_error_response,
@@ -156,7 +155,7 @@ pub async fn audio_transcriptions(
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
 
-    match execute_with_selected_deployment(
+    match run_unary(
         &state.unified_router,
         &requested_model,
         ProviderCapability::AudioTranscription,

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -8,8 +8,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use futures::StreamExt;
 use tracing::{error, info};
 
-use super::super::budgeted::ApiKeyBudgetPolicy;
-use super::super::execution::execute_with_selected_deployment;
+use super::super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use super::upload::{
     drain_field, parse_optional_f32_field, raw_response_format_error, read_audio_file,
     read_text_field, upload_error_response,
@@ -144,7 +143,7 @@ pub async fn audio_translations(
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
 
-    match execute_with_selected_deployment(
+    match run_unary(
         &state.unified_router,
         &requested_model,
         ProviderCapability::AudioTranslation,

--- a/src/server/routes/ai/budgeted.rs
+++ b/src/server/routes/ai/budgeted.rs
@@ -10,8 +10,13 @@ use crate::core::budget::{
 use crate::core::keys::KeyManager;
 use crate::core::models::openai::Usage;
 use crate::core::pricing_service::PricingService;
-use crate::core::providers::ProviderError;
+use crate::core::providers::{Provider, ProviderError};
+use crate::core::router::UnifiedRouter;
+use crate::core::types::model::ProviderCapability;
+use crate::utils::error::gateway_error::GatewayError;
 
+use super::execution;
+pub(super) use super::execution::StreamingDeploymentLease;
 use super::spend;
 
 #[derive(Clone, Copy)]
@@ -87,6 +92,39 @@ impl BudgetedExecutor {
     pub(super) fn key_manager(&self) -> KeyManager {
         self.key_manager.clone()
     }
+}
+
+pub(super) async fn run_unary<T, F, Fut>(
+    router: &UnifiedRouter,
+    requested_model: &str,
+    capability: ProviderCapability,
+    operation: F,
+) -> Result<T, GatewayError>
+where
+    F: Fn(Provider, String, String) -> Fut + Clone,
+    Fut: Future<Output = Result<(T, u64), ProviderError>>,
+{
+    execution::execute_with_selected_deployment(router, requested_model, capability, operation)
+        .await
+}
+
+pub(super) async fn run_stream<T, F, Fut>(
+    router: Arc<UnifiedRouter>,
+    requested_model: &str,
+    capability: ProviderCapability,
+    operation: F,
+) -> Result<(T, StreamingDeploymentLease), GatewayError>
+where
+    F: Fn(Provider, String, String) -> Fut + Clone,
+    Fut: Future<Output = Result<T, ProviderError>>,
+{
+    execution::execute_stream_with_selected_deployment(
+        router,
+        requested_model,
+        capability,
+        operation,
+    )
+    .await
 }
 
 pub(super) struct BudgetedCall {

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -18,9 +18,8 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde_json::json;
 use tracing::{error, info, warn};
 
-use super::budgeted::ApiKeyBudgetPolicy;
+use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use super::context::get_request_context;
-use super::execution::execute_with_selected_deployment;
 use super::openai_errors;
 #[path = "chat_delta.rs"]
 mod chat_delta;
@@ -119,7 +118,7 @@ async fn handle_chat_completion_internal(
     let api_key_budget_id = context.api_key_budget_id();
     let budgeted = state.budgeted.clone();
 
-    let core_response = execute_with_selected_deployment(
+    let core_response = run_unary(
         unified_router,
         &requested_model,
         ProviderCapability::ChatCompletion,

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -13,8 +13,7 @@ use crate::core::streaming::types::Event;
 use crate::core::types::{context::RequestContext, model::ProviderCapability};
 use crate::server::state::AppState;
 
-use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream};
-use super::super::execution::execute_stream_with_selected_deployment;
+use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream, run_stream};
 use super::super::openai_errors;
 use super::super::{spend, token_policy};
 
@@ -55,7 +54,7 @@ pub(super) async fn handle_streaming_chat_completion(
     let pricing_config = state.config().gateway.pricing.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
-    match execute_stream_with_selected_deployment(
+    match run_stream(
         state.unified_router.clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -13,8 +13,7 @@ use crate::core::streaming::types::Event;
 use crate::core::types::{context::RequestContext, model::ProviderCapability};
 use crate::server::state::AppState;
 
-use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream};
-use super::super::execution::execute_stream_with_selected_deployment;
+use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream, run_stream};
 use super::super::{chat, openai_errors, spend, token_policy};
 use super::completions_sse::send_stream_error;
 use super::{CompletionAdapterRequest, chunk_has_text_delta, completion_chunk_from_core};
@@ -53,7 +52,7 @@ pub(super) async fn handle_streaming_completion(
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
 
-    match execute_stream_with_selected_deployment(
+    match run_stream(
         state.unified_router.clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -11,9 +11,8 @@ use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use tracing::info;
 
-use super::budgeted::ApiKeyBudgetPolicy;
+use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use super::context::handle_ai_request;
-use super::execution::execute_with_selected_deployment;
 
 fn parse_embedding_input(input: &serde_json::Value) -> Result<EmbeddingInput, GatewayError> {
     match input {
@@ -116,7 +115,7 @@ async fn handle_embedding_internal(
     let key_manager = budgeted.key_manager();
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
-    let core_response = execute_with_selected_deployment(
+    let core_response = run_unary(
         &state.unified_router,
         &requested_model,
         ProviderCapability::Embeddings,

--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -14,10 +14,7 @@ use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
-use super::execution::{
-    StreamingDeploymentLease, execute_stream_with_selected_deployment,
-    execute_with_selected_deployment,
-};
+use super::budgeted::{StreamingDeploymentLease, run_stream, run_unary};
 use super::openai_errors;
 
 mod provider;
@@ -150,7 +147,7 @@ async fn proxy_gemini_route_inner(
 
     let mut last_router_error = None;
     for router_model in router_models {
-        let result = execute_with_selected_deployment(
+        let result = run_unary(
             &state.unified_router,
             &router_model,
             gemini_route_capability(stream),
@@ -233,7 +230,7 @@ async fn proxy_gemini_stream_route_inner(
     let api_key_budget_id = context.api_key_budget_id();
     let mut last_router_error = None;
     for router_model in router_models {
-        let result = execute_stream_with_selected_deployment(
+        let result = run_stream(
             state.unified_router.clone(),
             &router_model,
             gemini_route_capability(true),

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -23,9 +23,8 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::{error, info};
 
-use super::budgeted::ApiKeyBudgetPolicy;
+use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use super::context::handle_ai_request;
-use super::execution::execute_with_selected_deployment;
 use super::{openai_errors, provider_config};
 use proxy_spend::{image_proxy_cost, record_image_proxy_spend};
 
@@ -174,7 +173,7 @@ async fn proxy_image_multipart_endpoint(
 
     let mut last_router_error = None;
     for router_model in router_models {
-        let result = execute_with_selected_deployment(
+        let result = run_unary(
             &state.unified_router,
             &router_model,
             endpoint.capability(),

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -6,8 +6,7 @@ use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
-use super::super::budgeted::ApiKeyBudgetPolicy;
-use super::super::execution::execute_with_selected_deployment;
+use super::super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 
 /// Handle image generation with app state (UnifiedRouter only)
 pub async fn handle_image_generation_with_state(
@@ -41,7 +40,7 @@ pub async fn handle_image_generation_with_state(
     let key_manager = budgeted.key_manager();
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
-    let core_response = execute_with_selected_deployment(
+    let core_response = run_unary(
         &state.unified_router,
         &requested_model,
         ProviderCapability::ImageGeneration,

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -5,7 +5,6 @@
 // Module declarations
 mod audio;
 mod batches;
-#[path = "budget_orchestration.rs"]
 pub(crate) mod budgeted;
 mod chat;
 mod completions;

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -12,8 +12,7 @@ use serde_json::Value;
 use std::time::Duration;
 use tracing::error;
 
-use super::budgeted::SettlementMode;
-use super::execution::execute_with_selected_deployment;
+use super::budgeted::{SettlementMode, run_unary};
 use super::openai_errors;
 use super::provider_config;
 
@@ -83,17 +82,20 @@ async fn proxy_moderation(
         moderation_router_models(state.config().gateway.providers.as_slice(), &resolved_model);
 
     let mut last_router_error = None;
+    let budgeted = state.budgeted.clone();
     for router_model in router_models {
-        let result = execute_with_selected_deployment(
+        let result = run_unary(
             &state.unified_router,
             &router_model,
             ProviderCapability::Moderation,
             {
                 let request = request.clone();
                 let resolved_model = resolved_model.clone();
+                let budgeted = budgeted.clone();
                 move |selected_provider, selected_model, _deployment_id| {
                     let request = request.clone();
                     let resolved_model = resolved_model.clone();
+                    let budgeted = budgeted.clone();
                     async move {
                         let provider = selected_moderation_proxy_provider(
                             state.config().gateway.providers.as_slice(),
@@ -102,8 +104,7 @@ async fn proxy_moderation(
                             &resolved_model,
                         )?;
                         let budget_provider = provider.provider_name.clone();
-                        state
-                            .budgeted
+                        budgeted
                             .for_selected(budget_provider, resolved_model.clone())
                             .with_settlement_mode(SettlementMode::AvailabilityOnly)
                             .reserve_call_settle(

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 use tracing::{error, info};
 
 use super::{
-    budgeted::SettlementMode, execution::execute_with_selected_deployment, openai_errors,
-    provider_config,
+    budgeted::{SettlementMode, run_unary},
+    openai_errors, provider_config,
 };
 
 /// Rerank documents against a query.
@@ -60,17 +60,20 @@ async fn handle_rerank_with_state(
     );
 
     let mut last_router_error = None;
+    let budgeted = state.budgeted.clone();
     for router_model in router_models {
-        let result = execute_with_selected_deployment(
+        let result = run_unary(
             &state.unified_router,
             &router_model,
             ProviderCapability::Rerank,
             {
                 let request = request.clone();
                 let requested_model = requested_model.clone();
+                let budgeted = budgeted.clone();
                 move |selected_provider, selected_model, selected_deployment_id| {
                     let request = request.clone();
                     let requested_model = requested_model.clone();
+                    let budgeted = budgeted.clone();
                     async move {
                         let selected = selected_rerank_provider(
                             state.config().gateway.providers.as_slice(),
@@ -81,8 +84,7 @@ async fn handle_rerank_with_state(
                         )?;
                         let served_model = served_rerank_model(&requested_model);
                         let budget_provider = selected.provider_name.clone();
-                        state
-                            .budgeted
+                        budgeted
                             .for_selected(budget_provider, served_model.to_string())
                             .with_settlement_mode(SettlementMode::AvailabilityOnly)
                             .reserve_call_settle(

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -14,7 +14,6 @@ use crate::core::streaming::types::Event;
 use crate::core::types::responses::Usage as ChatUsage;
 use crate::core::types::{context::RequestContext, model::ProviderCapability};
 use crate::server::routes::ai::chat::build_core_chat_request;
-use crate::server::routes::ai::execution::execute_stream_with_selected_deployment;
 use crate::server::routes::ai::responses::{
     ResponseOwner, current_unix_ts, finish_reason_enum_to_status, store_response_if_requested,
     uuid_v4_hex,
@@ -30,7 +29,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use super::budgeted::ApiKeyBudgetPolicy;
+use super::budgeted::{ApiKeyBudgetPolicy, run_stream};
 use super::{openai_errors, spend};
 #[path = "responses_stream_budget.rs"]
 mod responses_stream_budget;
@@ -83,7 +82,7 @@ pub(crate) async fn handle_streaming_response(
     let api_key_budget_id = context.api_key_budget_id();
     let settlement_budgeted = state.budgeted.clone();
 
-    match execute_stream_with_selected_deployment(
+    match run_stream(
         state.unified_router.clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,


### PR DESCRIPTION
## Summary
- Related: #840
- Rename the budget orchestration module to the visible `budgeted` entrypoint.
- Route AI HTTP handlers through `budgeted::run_unary` / `budgeted::run_stream` instead of direct execution helper calls.
- Keep direct budget state access inside the budgeted layer while preserving existing provider callbacks and settlement behavior.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-features --message-format=short`
- `cargo test server::routes::ai::budgeted --lib --all-features`
- `cargo test --test audio_routes --test image_edit_variation_routes --test image_router_fallback_routes --test gemini_sdk_routes --test gemini_router_fallback_routes --test moderations_routes --test rerank_routes --test responses_routes --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "$PWD/specs/GH840"`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
- `rg -n "state\.(budget_limits|pricing|key_manager|budget_manager)\b" src/server/routes/ai --glob '!budgeted.rs' --glob '!budgeted/**' --glob '!spend.rs' --glob '!spend/**' --glob '!*_tests.rs'` (no matches)
- `rg -n "(execution::execute_|execute_with_selected_deployment\(|execute_stream_with_selected_deployment\()" src/server/routes/ai --glob '!budgeted.rs' --glob '!budgeted/**' --glob '!execution.rs' --glob '!*_tests.rs'` (no matches)

## Guard Evidence
- Scope guard: 15 files / 123 lines, within the 15 file / 800 line limit.
- Overlap guard: no open PRs at the time of check.
