### PR TITLE
perf(keys): share hmac secret across key manager clones

### DIFF
--- a/src/core/keys/manager.rs
+++ b/src/core/keys/manager.rs
@@ -29,7 +29,7 @@ pub struct KeyManager {
     /// Tracks when each key's `last_used_at` was last persisted.
     last_used_cache: Arc<DashMap<Uuid, Instant>>,
     /// Optional HMAC secret for key hashing.
-    hmac_secret: Option<String>,
+    hmac_secret: Option<Arc<str>>,
 }
 
 impl std::fmt::Debug for KeyManager {
@@ -66,7 +66,7 @@ impl KeyManager {
 
     /// Set the HMAC secret for key hashing
     pub fn with_hmac_secret(mut self, secret: Option<String>) -> Self {
-        self.hmac_secret = secret;
+        self.hmac_secret = secret.map(Arc::from);
         self
     }
 
@@ -435,6 +435,21 @@ mod manager_tests {
         manager.prune_last_used_cache(now);
 
         assert!(manager.last_used_cache.len() < LAST_USED_CACHE_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn test_clone_reuses_hmac_secret_allocation() {
+        let manager = create_manager().with_hmac_secret(Some("shared-secret".to_string()));
+        let cloned = manager.clone();
+
+        let (Some(original_secret), Some(cloned_secret)) =
+            (manager.hmac_secret.as_ref(), cloned.hmac_secret.as_ref())
+        else {
+            panic!("secret should be set on both managers");
+        };
+
+        assert!(Arc::ptr_eq(original_secret, cloned_secret));
+        assert_eq!(cloned.hmac_secret(), Some("shared-secret"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- store `KeyManager` HMAC secret as `Arc<str>` internally
- keep `with_hmac_secret(Option<String>)` unchanged for callers
- add a regression test proving cloned managers share the same secret allocation

## SpecRail
Refs #842

Tranche: partial `SP842-T6` for KeyManager/HMAC-secret sharing. T2 approval for this tranche is recorded in https://github.com/majiayu000/litellm-rs/issues/842#issuecomment-4880519193.

This does not complete #842; request/context/chat body sharing and allocation benchmark work remain for later tranches.

## Verification
- `cargo fmt --all -- --check`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir /private/tmp/litellm-rs-gh842-key-manager-arc/specs/GH842`
- `cargo test core::keys --lib --all-features`
- `cargo check --all-features --message-format=short`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
- `git diff --check origin/main...HEAD`