### PR TITLE
perf(context): share request context extensions

### DIFF
--- a/src/core/types/context.rs
+++ b/src/core/types/context.rs
@@ -1,6 +1,7 @@
 //! Request context types
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
@@ -31,6 +32,9 @@ pub struct RequestContext {
     /// Span ID
     pub span_id: Option<String>,
 }
+
+/// Shared request context handle used between middleware and route handlers.
+pub type SharedRequestContext = Arc<RequestContext>;
 
 impl Default for RequestContext {
     fn default() -> Self {

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -2,7 +2,7 @@
 
 use crate::auth::AuthMethod;
 use crate::core::models::{ApiKey, user::types::User};
-use crate::core::types::context::RequestContext;
+use crate::core::types::context::{RequestContext, SharedRequestContext};
 use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
 use crate::server::middleware::helpers::{
     extract_auth_method_with_api_key_header, is_public_route,
@@ -22,6 +22,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::Arc;
 use tracing::{debug, error, warn};
 
 /// Auth middleware for Actix-web
@@ -94,7 +95,7 @@ where
             let rate_limiter = get_auth_rate_limiter();
 
             if is_public {
-                req.extensions_mut().insert(context);
+                insert_request_context(&mut req, context);
                 return service
                     .call(req)
                     .await
@@ -120,7 +121,7 @@ where
                         ))
                         .map_into_right_body());
                 }
-                req.extensions_mut().insert(context);
+                insert_request_context(&mut req, context);
                 return service
                     .call(req)
                     .await
@@ -266,7 +267,7 @@ where
                         }
                     }
 
-                    req.extensions_mut().insert(result.context.clone());
+                    insert_request_context(&mut req, result.context);
                     if let Some(user) = result.user {
                         req.extensions_mut().insert::<User>(user);
                     }
@@ -354,11 +355,20 @@ fn requires_auth_verification(auth_method: &AuthMethod) -> bool {
 }
 
 /// Extract request context from request
-pub fn get_request_context(req: &HttpRequest) -> Result<RequestContext, actix_web::Error> {
+pub fn get_request_context(req: &HttpRequest) -> Result<SharedRequestContext, actix_web::Error> {
+    if let Some(context) = req.extensions().get::<SharedRequestContext>() {
+        return Ok(Arc::clone(context));
+    }
+
     req.extensions()
         .get::<RequestContext>()
-        .cloned()
+        .map(|context| Arc::new(context.clone()))
         .ok_or_else(|| actix_web::error::ErrorInternalServerError("Missing request context"))
+}
+
+fn insert_request_context(req: &mut ServiceRequest, context: RequestContext) {
+    req.extensions_mut()
+        .insert::<SharedRequestContext>(Arc::new(context));
 }
 
 /// Extract a client identifier for rate limiting

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -2,7 +2,7 @@
 
 use super::rate_limit_key_policy::effective_requests_per_minute;
 use crate::core::rate_limiter::{RateLimitReservation, get_global_rate_limiter};
-use crate::core::types::context::RequestContext;
+use crate::core::types::context::{RequestContext, SharedRequestContext};
 use crate::server::state::AppState;
 use actix_web::body::EitherBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
@@ -433,8 +433,15 @@ fn extract_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> Strin
 
 fn authenticated_client_key(req: &ServiceRequest) -> Option<String> {
     let extensions = req.extensions();
-    let context = extensions.get::<RequestContext>()?;
+    if let Some(context) = extensions.get::<SharedRequestContext>() {
+        return client_key_from_context(context.as_ref());
+    }
 
+    let context = extensions.get::<RequestContext>()?;
+    client_key_from_context(context)
+}
+
+fn client_key_from_context(context: &RequestContext) -> Option<String> {
     if let Some(api_key_id) = context.api_key_id() {
         return Some(format!("api_key:{}", api_key_id));
     }

--- a/src/server/routes/ai/context.rs
+++ b/src/server/routes/ai/context.rs
@@ -2,11 +2,12 @@
 
 use crate::core::models::ApiKey;
 use crate::core::models::user::types::User;
-use crate::core::types::context::RequestContext;
+use crate::core::types::context::{RequestContext, SharedRequestContext};
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result as ActixResult};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
+use std::sync::Arc;
 use tracing::{debug, error};
 
 const CORE_KEYS_EXTRA_NAMESPACE: &str = "__core_keys";
@@ -26,9 +27,13 @@ struct RuntimeKeyPermissions {
 }
 
 /// Get request context from headers and middleware extensions
-pub fn get_request_context(req: &HttpRequest) -> ActixResult<RequestContext> {
+pub fn get_shared_request_context(req: &HttpRequest) -> ActixResult<SharedRequestContext> {
+    if let Some(context) = req.extensions().get::<SharedRequestContext>() {
+        return Ok(Arc::clone(context));
+    }
+
     if let Some(context) = req.extensions().get::<RequestContext>() {
-        return Ok(context.clone());
+        return Ok(Arc::new(context.clone()));
     }
 
     let mut context = RequestContext::new();
@@ -49,7 +54,11 @@ pub fn get_request_context(req: &HttpRequest) -> ActixResult<RequestContext> {
 
     context.client_ip = req.connection_info().peer_addr().map(|ip| ip.to_string());
 
-    Ok(context)
+    Ok(Arc::new(context))
+}
+
+pub fn get_request_context(req: &HttpRequest) -> ActixResult<RequestContext> {
+    Ok(get_shared_request_context(req)?.as_ref().clone())
 }
 
 /// Extract user from request extensions
@@ -565,6 +574,23 @@ mod tests {
         assert!(enforce_api_key_model_and_token_limits(&req, "gpt-4o", Some(128)).is_ok());
         assert!(enforce_api_key_model_and_token_limits(&req, "gpt-4o-mini", Some(128)).is_err());
         assert!(enforce_api_key_model_and_token_limits(&req, "gpt-4o", Some(129)).is_err());
+    }
+
+    #[test]
+    fn test_get_request_context_reuses_shared_extension_handle() {
+        let api_key_id = uuid::Uuid::new_v4();
+        let context = Arc::new(RequestContext::new().with_api_key(api_key_id));
+        let req = actix_web::test::TestRequest::default().to_http_request();
+        req.extensions_mut()
+            .insert::<SharedRequestContext>(Arc::clone(&context));
+
+        let extracted = match get_shared_request_context(&req) {
+            Ok(context) => context,
+            Err(error) => panic!("shared context should be present: {error}"),
+        };
+
+        assert!(Arc::ptr_eq(&context, &extracted));
+        assert_eq!(extracted.api_key_id(), Some(api_key_id));
     }
 
     // ==================== get_authenticated_user Tests ====================

--- a/src/server/routes/teams.rs
+++ b/src/server/routes/teams.rs
@@ -19,7 +19,7 @@ use crate::core::teams::{
     AddMemberRequest, CreateTeamRequest, Team, TeamManager, TeamRole, TeamStatus,
     UpdateRoleRequest, UpdateTeamRequest,
 };
-use crate::core::types::context::RequestContext;
+use crate::core::types::context::{RequestContext, SharedRequestContext};
 use crate::server::routes::{ApiResponse, PaginatedResponse, PaginationQuery, errors};
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
@@ -129,6 +129,10 @@ fn get_request_caller(req: &HttpRequest) -> Option<RequestCaller> {
         return Some(RequestCaller::User(Box::new(user.clone())));
     }
 
+    if let Some(ctx) = req.extensions().get::<SharedRequestContext>() {
+        return ctx.team_id().map(RequestCaller::Team);
+    }
+
     req.extensions()
         .get::<RequestContext>()
         .and_then(|ctx| ctx.team_id())
@@ -213,6 +217,13 @@ async fn authorize_team_operation(
 fn resolve_invited_by(req: &HttpRequest) -> Option<Uuid> {
     if let Some(user) = req.extensions().get::<User>() {
         return Some(user.id());
+    }
+
+    if let Some(ctx) = req.extensions().get::<SharedRequestContext>() {
+        return ctx
+            .user_id
+            .as_deref()
+            .and_then(|user_id| Uuid::parse_str(user_id).ok());
     }
 
     req.extensions()

--- a/tests/integration/auth_middleware_tests_parts/mod.rs
+++ b/tests/integration/auth_middleware_tests_parts/mod.rs
@@ -3,7 +3,7 @@ use actix_web::{App, HttpMessage, HttpRequest, HttpResponse, test, web};
 use litellm_rs::Config;
 use litellm_rs::core::models::user::types::{User, UserRole, UserStatus};
 use litellm_rs::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
-use litellm_rs::core::types::context::RequestContext;
+use litellm_rs::core::types::context::{RequestContext, SharedRequestContext};
 use litellm_rs::server::http::HttpServer;
 use litellm_rs::server::middleware::{AuthMiddleware, RateLimitMiddleware};
 use litellm_rs::server::state::AppState;
@@ -35,7 +35,15 @@ struct AuthProbePayload {
 async fn auth_probe(req: HttpRequest, hit_counter: web::Data<Arc<AtomicUsize>>) -> HttpResponse {
     hit_counter.fetch_add(1, Ordering::SeqCst);
 
-    let context = req.extensions().get::<RequestContext>().cloned();
+    let context = req
+        .extensions()
+        .get::<SharedRequestContext>()
+        .cloned()
+        .or_else(|| {
+            req.extensions()
+                .get::<RequestContext>()
+                .map(|context| Arc::new(context.clone()))
+        });
     let user = req.extensions().get::<User>().cloned();
     let api_key = req.extensions().get::<ApiKey>().cloned();
 


### PR DESCRIPTION
## Summary
- store request context in Actix extensions as `Arc<RequestContext>` from auth middleware
- add a shared AI context helper that reuses the same allocation while preserving the existing owned-context helper for legacy call sites
- update rate-limit and teams readers to prefer the shared context handle with owned-context fallback compatibility

Related issue: https://github.com/majiayu000/litellm-rs/issues/842

## SpecRail
- Spec: `specs/GH842`
- Task: SP842-T5 partial tranche for shared RequestContext extension/handler access
- Human gate: https://github.com/majiayu000/litellm-rs/issues/842#issuecomment-4880608753
- Completion mode: partial; do not close GH842

## Verification
- `cargo fmt --all -- --check`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir /private/tmp/litellm-rs-gh842-request-context-arc/specs/GH842`
- `cargo check --all-features --message-format=short`
- `cargo test server::routes::ai::context --lib --all-features`
- `cargo test server::middleware::auth --lib --all-features`
- `cargo test server::middleware::rate_limit --lib --all-features`
- `cargo test server::routes::teams --lib --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `SPEC_RAIL=/Users/lifcc/Desktop/code/AI/tools/specrail python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`
- `git diff --check origin/main...HEAD`
