### PR TITLE
test(routes): avoid graceful mock server hangs

### DIFF
--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -72,7 +72,7 @@ mod tests {
         }
 
         async fn stop_image_mock(self) {
-            self.handle.stop(true).await;
+            self.handle.stop(false).await;
             let result = self.task.await.expect("mock server task should join");
             if let Err(error) = result {
                 panic!("mock server should stop cleanly: {error}");

--- a/tests/rerank_routes.rs
+++ b/tests/rerank_routes.rs
@@ -70,7 +70,7 @@ mod tests {
         }
 
         async fn stop_rerank_mock(self) {
-            self.handle.stop(true).await;
+            self.handle.stop(false).await;
             let result = self.task.await.expect("mock server task should join");
             if let Err(error) = result {
                 panic!("mock server should stop cleanly: {error}");


### PR DESCRIPTION
# Summary
Splits the test-stability fix out of #932 so the GH837 provider deletion PR can stay focused.

## Scope
- Uses non-graceful stop for the test-only Actix mock server in `tests/rerank_routes.rs`.
- Uses non-graceful stop for the test-only Actix mock server in `tests/image_edit_variation_routes.rs`.

## Why
Default parallel `cargo test --all-features` hung in these route suites while the mock server awaited graceful shutdown with active keep-alive connections. This keeps production shutdown unchanged; only test mock server teardown changes.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test rerank_routes --all-features`
- `cargo test --test image_edit_variation_routes --all-features`
- `cargo check --all-features`
- `git diff --check`

## Agent Disclosure
- [ ] No agent was used.
- [x] Agent assisted; human author should review before merge.