### PR TITLE
perf(chat): share chat request budget views

### DIFF
--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -19,6 +19,7 @@ use crate::utils::data::validation::RequestValidator;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde_json::json;
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
@@ -65,21 +66,12 @@ pub async fn chat_completions(
         return Ok(openai_errors::gateway_error_response(&error));
     }
 
+    let request = Arc::new(request.into_inner());
+
     if request.stream.unwrap_or(false) {
-        chat_streaming::handle_streaming_chat_completion(
-            state.get_ref(),
-            request.into_inner(),
-            context,
-        )
-        .await
+        chat_streaming::handle_streaming_chat_completion(state.get_ref(), request, context).await
     } else {
-        match handle_chat_completion_with_shared_state(
-            state.get_ref(),
-            request.into_inner(),
-            context,
-        )
-        .await
-        {
+        match handle_chat_completion_with_shared_state(state.get_ref(), request, context).await {
             Ok(response) => Ok(HttpResponse::Ok().json(response)),
             Err(e) => {
                 error!("Chat completion error: {}", e);
@@ -95,12 +87,12 @@ pub async fn handle_chat_completion_with_state(
     request: ChatCompletionRequest,
     context: RequestContext,
 ) -> Result<ChatCompletionResponse, GatewayError> {
-    handle_chat_completion_with_shared_state(state, request, std::sync::Arc::new(context)).await
+    handle_chat_completion_with_shared_state(state, Arc::new(request), Arc::new(context)).await
 }
 
 pub async fn handle_chat_completion_with_shared_state(
     state: &AppState,
-    request: ChatCompletionRequest,
+    request: Arc<ChatCompletionRequest>,
     context: SharedRequestContext,
 ) -> Result<ChatCompletionResponse, GatewayError> {
     handle_chat_completion_internal(state, request, context).await
@@ -108,22 +100,21 @@ pub async fn handle_chat_completion_with_shared_state(
 
 async fn handle_chat_completion_internal(
     state: &AppState,
-    request: ChatCompletionRequest,
+    request: Arc<ChatCompletionRequest>,
     context: SharedRequestContext,
 ) -> Result<ChatCompletionResponse, GatewayError> {
     let unified_router = &state.unified_router;
     let requested_model = request.model.clone();
-    let request_for_budget = request.clone();
-    let request_for_cache = request.clone();
-    let core_request = build_core_chat_request(request, requested_model, false)?;
+    let core_request = build_core_chat_request(request.as_ref(), requested_model, false)?;
     if let Some(cached) =
-        super::response_cache::lookup_chat(state, &request_for_cache, context.as_ref()).await?
+        super::response_cache::lookup_chat(state, request.as_ref(), context.as_ref()).await?
     {
-        super::response_cache::ensure_chat_cache_pricing_gate(state, &request_for_cache)?;
+        super::response_cache::ensure_chat_cache_pricing_gate(state, request.as_ref())?;
         return Ok(cached);
     }
     let requested_model = core_request.model.clone();
-    let context_for_execution = std::sync::Arc::clone(&context);
+    let context_for_execution = Arc::clone(&context);
+    let request_for_execution = Arc::clone(&request);
 
     // Owned handles captured into the (retryable) execution closure so that the
     // successful attempt records budget spend and per-key usage.
@@ -140,11 +131,11 @@ async fn handle_chat_completion_internal(
         ProviderCapability::ChatCompletion,
         move |provider, selected_model, _deployment_id| {
             let core_request = core_request.clone();
-            let context = std::sync::Arc::clone(&context_for_execution);
+            let context = Arc::clone(&context_for_execution);
+            let original_request = Arc::clone(&request_for_execution);
             let pricing_service = pricing_service.clone();
             let key_manager = key_manager.clone();
             let budgeted = budgeted.clone();
-            let request_for_budget = request_for_budget.clone();
             let pricing_config = pricing_config.clone();
             async move {
                 let provider_name = provider.name().to_string();
@@ -153,14 +144,18 @@ async fn handle_chat_completion_internal(
                     &provider,
                     &selected_model,
                 );
-                let (request_for_provider, request_for_budget) =
-                    super::token_policy::prepare_chat_request_for_provider(
-                        context.api_key_max_tokens_per_request(),
-                        &provider_name,
-                        &selected_model,
-                        core_request.clone(),
-                        request_for_budget,
-                    )?;
+                let request_for_provider = super::token_policy::prepare_chat_request_for_provider(
+                    context.api_key_max_tokens_per_request(),
+                    &provider_name,
+                    &selected_model,
+                    core_request.clone(),
+                )?;
+                let request_for_budget =
+                    super::spend::ChatCompletionBudgetRequest::from(original_request.as_ref())
+                        .with_output_limits(
+                            request_for_provider.max_tokens,
+                            request_for_provider.max_completion_tokens,
+                        );
                 let provider_context = context.as_ref().clone();
                 let reserve_pricing_service = pricing_service.clone();
                 let settle_pricing_service = pricing_service.clone();
@@ -188,7 +183,7 @@ async fn handle_chat_completion_internal(
                                 budget.model(),
                                 &reserve_pricing_provider,
                                 &reserve_pricing_model,
-                                &request_for_budget,
+                                request_for_budget,
                             )
                         },
                         || provider.chat_completion(request_for_provider, provider_context),
@@ -228,23 +223,31 @@ async fn handle_chat_completion_internal(
     .await?;
 
     let response = convert_core_chat_response(core_response);
-    super::response_cache::store_chat(state, &request_for_cache, &response, context.as_ref())
-        .await?;
+    super::response_cache::store_chat(state, request.as_ref(), &response, context.as_ref()).await?;
     Ok(response)
 }
 
 pub(crate) fn build_core_chat_request(
-    request: ChatCompletionRequest,
+    request: &ChatCompletionRequest,
     model: String,
     stream: bool,
+) -> Result<CoreChatRequest, GatewayError> {
+    build_core_chat_request_with_stream_usage(request, model, stream, None)
+}
+
+pub(crate) fn build_core_chat_request_with_stream_usage(
+    request: &ChatCompletionRequest,
+    model: String,
+    stream: bool,
+    include_usage_override: Option<bool>,
 ) -> Result<CoreChatRequest, GatewayError> {
     // This is the OpenAI transport DTO -> internal provider request boundary.
     // Keep field forwarding explicit so new OpenAI-compatible parameters cannot
     // disappear silently while routing through the canonical ChatRequest tree.
-    let tools = match request.tools {
+    let tools = match request.tools.as_ref() {
         Some(tools) => {
             let mut converted = Vec::with_capacity(tools.len());
-            for tool in tools {
+            for tool in tools.iter().cloned() {
                 converted.push(convert_tool(tool)?);
             }
             Some(converted)
@@ -252,9 +255,9 @@ pub(crate) fn build_core_chat_request(
         None => None,
     };
 
-    let tool_choice = request.tool_choice.map(convert_tool_choice);
+    let tool_choice = request.tool_choice.clone().map(convert_tool_choice);
 
-    let functions = match request.functions {
+    let functions = match request.functions.as_ref() {
         Some(funcs) => {
             let mut values = Vec::with_capacity(funcs.len());
             for function in funcs {
@@ -267,20 +270,22 @@ pub(crate) fn build_core_chat_request(
         None => None,
     };
 
-    let function_call = match request.function_call {
+    let function_call = match request.function_call.as_ref() {
         Some(call) => Some(serde_json::to_value(call).map_err(|e| {
             GatewayError::internal(format!("Failed to serialize function call: {}", e))
         })?),
         None => None,
     };
 
-    let response_format = request
-        .response_format
-        .map(|format| types::tools::ResponseFormat {
-            format_type: format.format_type,
-            json_schema: format.json_schema,
-            response_type: format.response_type,
-        });
+    let response_format =
+        request
+            .response_format
+            .as_ref()
+            .map(|format| types::tools::ResponseFormat {
+                format_type: format.format_type.clone(),
+                json_schema: format.json_schema.clone(),
+                response_type: format.response_type.clone(),
+            });
 
     let seed = request
         .seed
@@ -295,58 +300,65 @@ pub(crate) fn build_core_chat_request(
         })
         .transpose()?;
 
-    let mut extra_params = request.extra_body;
-    if let Some(modalities) = request.modalities {
+    let mut extra_params = request.extra_body.clone();
+    if let Some(modalities) = request.modalities.as_ref() {
         extra_params.insert("modalities".to_string(), json!(modalities));
     }
-    if let Some(audio) = request.audio {
+    if let Some(audio) = request.audio.as_ref() {
         extra_params.insert("audio".to_string(), json!(audio));
     }
-    if let Some(prediction) = request.prediction {
-        extra_params.insert("prediction".to_string(), prediction);
+    if let Some(prediction) = request.prediction.as_ref() {
+        extra_params.insert("prediction".to_string(), prediction.clone());
     }
-    if let Some(safety_settings) = request.safety_settings {
-        extra_params.insert("safety_settings".to_string(), safety_settings);
+    if let Some(safety_settings) = request.safety_settings.as_ref() {
+        extra_params.insert("safety_settings".to_string(), safety_settings.clone());
     }
-    if let Some(cache_control) = request.cache_control {
-        extra_params.insert("cache_control".to_string(), cache_control);
+    if let Some(cache_control) = request.cache_control.as_ref() {
+        extra_params.insert("cache_control".to_string(), cache_control.clone());
     }
 
-    let stream_options = request
-        .stream_options
-        .map(|so| crate::core::types::chat::StreamOptions {
-            include_usage: so.include_usage,
-        });
+    let stream_options = match (request.stream_options.as_ref(), include_usage_override) {
+        (Some(_), Some(include_usage)) => Some(crate::core::types::chat::StreamOptions {
+            include_usage: Some(include_usage),
+        }),
+        (None, Some(include_usage)) => Some(crate::core::types::chat::StreamOptions {
+            include_usage: Some(include_usage),
+        }),
+        (Some(options), None) => Some(crate::core::types::chat::StreamOptions {
+            include_usage: options.include_usage,
+        }),
+        (None, None) => None,
+    };
 
     Ok(CoreChatRequest {
         model,
-        messages: request.messages.into_iter().map(Into::into).collect(),
+        messages: request.messages.iter().cloned().map(Into::into).collect(),
         temperature: request.temperature,
         max_tokens: request.max_tokens,
         max_completion_tokens: request.max_completion_tokens,
         top_p: request.top_p,
         frequency_penalty: request.frequency_penalty,
         presence_penalty: request.presence_penalty,
-        stop: request.stop,
+        stop: request.stop.clone(),
         stream,
         stream_options,
         tools,
         tool_choice,
         parallel_tool_calls: request.parallel_tool_calls,
         response_format,
-        user: request.user,
+        user: request.user.clone(),
         seed,
         n: request.n,
-        logit_bias: request.logit_bias,
+        logit_bias: request.logit_bias.clone(),
         functions,
         function_call,
         logprobs: request.logprobs,
         top_logprobs: request.top_logprobs,
         thinking: None,
-        reasoning_effort: request.reasoning_effort,
+        reasoning_effort: request.reasoning_effort.clone(),
         store: request.store,
-        metadata: request.metadata,
-        service_tier: request.service_tier,
+        metadata: request.metadata.clone(),
+        service_tier: request.service_tier.clone(),
         extra_params,
     })
 }

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -4,10 +4,11 @@ use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use actix_web::{HttpResponse, Result as ActixResult};
 use bytes::Bytes;
 use futures::StreamExt;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use crate::core::models::openai::{ChatCompletionRequest, StreamOptions};
+use crate::core::models::openai::ChatCompletionRequest;
 use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
 use crate::core::types::{context::SharedRequestContext, model::ProviderCapability};
@@ -19,7 +20,7 @@ use super::super::{spend, token_policy};
 
 pub(super) async fn handle_streaming_chat_completion(
     state: &AppState,
-    mut request: ChatCompletionRequest,
+    request: Arc<ChatCompletionRequest>,
     context: SharedRequestContext,
 ) -> ActixResult<HttpResponse> {
     info!(
@@ -28,25 +29,24 @@ pub(super) async fn handle_streaming_chat_completion(
     );
 
     let requested_model = request.model.clone();
-    let request_for_budget = request.clone();
     let client_requested_usage = request
         .stream_options
         .as_ref()
         .and_then(|options| options.include_usage)
         .unwrap_or(false);
-    request
-        .stream_options
-        .get_or_insert(StreamOptions {
-            include_usage: None,
-        })
-        .include_usage = Some(true);
-    let core_request = match super::build_core_chat_request(request, requested_model, true) {
+    let core_request = match super::build_core_chat_request_with_stream_usage(
+        request.as_ref(),
+        requested_model,
+        true,
+        Some(true),
+    ) {
         Ok(req) => req,
         Err(e) => return Ok(openai_errors::gateway_error_response(&e)),
     };
 
     let requested_model = core_request.model.clone();
-    let context_for_execution = std::sync::Arc::clone(&context);
+    let context_for_execution = Arc::clone(&context);
+    let request_for_execution = Arc::clone(&request);
     let budgeted = state.budgeted.clone();
     let pricing_service = state.budgeted.pricing();
     let budget_limits = state.budgeted.budget_limits();
@@ -60,12 +60,12 @@ pub(super) async fn handle_streaming_chat_completion(
         ProviderCapability::ChatCompletionStream,
         move |provider, selected_model, _selected_deployment_id| {
             let core_request = core_request.clone();
-            let context = std::sync::Arc::clone(&context_for_execution);
+            let context = Arc::clone(&context_for_execution);
+            let original_request = Arc::clone(&request_for_execution);
             let budgeted = budgeted.clone();
             let pricing_service = pricing_service.clone();
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
-            let request_for_budget = request_for_budget.clone();
             let pricing_config = pricing_config.clone();
             async move {
                 let provider_name = provider.name().to_string();
@@ -74,14 +74,18 @@ pub(super) async fn handle_streaming_chat_completion(
                     &provider,
                     &selected_model,
                 );
-                let (request_for_provider, request_for_budget) =
-                    token_policy::prepare_chat_request_for_provider(
-                        context.api_key_max_tokens_per_request(),
-                        &provider_name,
-                        &selected_model,
-                        core_request.clone(),
-                        request_for_budget,
-                    )?;
+                let request_for_provider = token_policy::prepare_chat_request_for_provider(
+                    context.api_key_max_tokens_per_request(),
+                    &provider_name,
+                    &selected_model,
+                    core_request.clone(),
+                )?;
+                let request_for_budget =
+                    spend::ChatCompletionBudgetRequest::from(original_request.as_ref())
+                        .with_output_limits(
+                            request_for_provider.max_tokens,
+                            request_for_provider.max_completion_tokens,
+                        );
                 let provider_context = context.as_ref().clone();
                 let reserve_pricing_service = pricing_service.clone();
                 let reserve_pricing_config = pricing_config.clone();
@@ -104,7 +108,7 @@ pub(super) async fn handle_streaming_chat_completion(
                                 budget.model(),
                                 &reserve_pricing_provider,
                                 &reserve_pricing_model,
-                                &request_for_budget,
+                                request_for_budget,
                             )
                         },
                         || provider.chat_completion_stream(request_for_provider, provider_context),

--- a/src/server/routes/ai/chat_tests.rs
+++ b/src/server/routes/ai/chat_tests.rs
@@ -291,7 +291,7 @@ fn test_build_core_chat_request_minimal() {
         ..Default::default()
     };
 
-    let core_request = build_core_chat_request(request, "gpt-4".to_string(), false).unwrap();
+    let core_request = build_core_chat_request(&request, "gpt-4".to_string(), false).unwrap();
     assert_eq!(core_request.model, "gpt-4");
     assert_eq!(core_request.messages.len(), 1);
 }
@@ -363,7 +363,7 @@ fn test_build_core_chat_request_preserves_transport_fields() {
         ..Default::default()
     };
 
-    let core_request = build_core_chat_request(request, "gpt-4".to_string(), false).unwrap();
+    let core_request = build_core_chat_request(&request, "gpt-4".to_string(), false).unwrap();
     assert_eq!(core_request.parallel_tool_calls, Some(false));
     assert_eq!(core_request.seed, Some(123));
     assert_eq!(
@@ -440,6 +440,51 @@ fn test_build_core_chat_request_preserves_transport_fields() {
 }
 
 #[test]
+fn test_build_core_chat_request_usage_override_does_not_mutate_original() {
+    let request = ChatCompletionRequest {
+        model: "gpt-4".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Hello".to_string())),
+            name: None,
+            function_call: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: None,
+        }],
+        stream_options: Some(crate::core::models::openai::StreamOptions {
+            include_usage: Some(false),
+        }),
+        ..Default::default()
+    };
+
+    let core_request = match build_core_chat_request_with_stream_usage(
+        &request,
+        "gpt-4".to_string(),
+        true,
+        Some(true),
+    ) {
+        Ok(core_request) => core_request,
+        Err(error) => panic!("valid stream request should build: {error}"),
+    };
+
+    assert_eq!(
+        core_request
+            .stream_options
+            .as_ref()
+            .and_then(|options| options.include_usage),
+        Some(true)
+    );
+    assert_eq!(
+        request
+            .stream_options
+            .as_ref()
+            .and_then(|options| options.include_usage),
+        Some(false)
+    );
+}
+
+#[test]
 fn test_build_core_chat_request_rejects_seed_overflow() {
     let request = ChatCompletionRequest {
         model: "gpt-4".to_string(),
@@ -456,6 +501,6 @@ fn test_build_core_chat_request_rejects_seed_overflow() {
         ..Default::default()
     };
 
-    let err = build_core_chat_request(request, "gpt-4".to_string(), false).unwrap_err();
+    let err = build_core_chat_request(&request, "gpt-4".to_string(), false).unwrap_err();
     assert!(format!("{err}").contains("seed"));
 }

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -4,6 +4,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{error, warn};
 
 use crate::core::models::openai::{
@@ -101,7 +102,7 @@ async fn completions_inner(
 
     match super::chat::handle_chat_completion_with_shared_state(
         state.get_ref(),
-        adapter_request.chat_request,
+        Arc::new(adapter_request.chat_request),
         context,
     )
     .await

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -4,10 +4,10 @@ use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use actix_web::{HttpResponse, Result as ActixResult};
 use bytes::Bytes;
 use futures::StreamExt;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use crate::core::models::openai::StreamOptions;
 use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
 use crate::core::types::{context::SharedRequestContext, model::ProviderCapability};
@@ -28,22 +28,21 @@ pub(super) async fn handle_streaming_completion(
         adapter_request.chat_request.model
     );
 
-    let mut request = adapter_request.chat_request;
+    let request = Arc::new(adapter_request.chat_request);
     let requested_model = request.model.clone();
-    let request_for_budget = request.clone();
-    request
-        .stream_options
-        .get_or_insert(StreamOptions {
-            include_usage: None,
-        })
-        .include_usage = Some(true);
 
-    let core_request = match chat::build_core_chat_request(request, requested_model.clone(), true) {
+    let core_request = match chat::build_core_chat_request_with_stream_usage(
+        request.as_ref(),
+        requested_model.clone(),
+        true,
+        Some(true),
+    ) {
         Ok(request) => request,
         Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
     };
 
-    let context_for_execution = std::sync::Arc::clone(&context);
+    let context_for_execution = Arc::clone(&context);
+    let request_for_execution = Arc::clone(&request);
     let budgeted = state.budgeted.clone();
     let pricing_service = state.budgeted.pricing();
     let budget_limits = state.budgeted.budget_limits();
@@ -58,12 +57,12 @@ pub(super) async fn handle_streaming_completion(
         ProviderCapability::ChatCompletionStream,
         move |provider, selected_model, _selected_deployment_id| {
             let core_request = core_request.clone();
-            let context = std::sync::Arc::clone(&context_for_execution);
+            let context = Arc::clone(&context_for_execution);
+            let original_request = Arc::clone(&request_for_execution);
             let budgeted = budgeted.clone();
             let pricing_service = pricing_service.clone();
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
-            let request_for_budget = request_for_budget.clone();
             let pricing_config = pricing_config.clone();
             async move {
                 let provider_name = provider.name().to_string();
@@ -72,14 +71,18 @@ pub(super) async fn handle_streaming_completion(
                     &provider,
                     &selected_model,
                 );
-                let (request_for_provider, request_for_budget) =
-                    token_policy::prepare_chat_request_for_provider(
-                        context.api_key_max_tokens_per_request(),
-                        &provider_name,
-                        &selected_model,
-                        core_request.clone(),
-                        request_for_budget,
-                    )?;
+                let request_for_provider = token_policy::prepare_chat_request_for_provider(
+                    context.api_key_max_tokens_per_request(),
+                    &provider_name,
+                    &selected_model,
+                    core_request.clone(),
+                )?;
+                let request_for_budget =
+                    spend::ChatCompletionBudgetRequest::from(original_request.as_ref())
+                        .with_output_limits(
+                            request_for_provider.max_tokens,
+                            request_for_provider.max_completion_tokens,
+                        );
                 let provider_context = context.as_ref().clone();
                 let reserve_pricing_config = pricing_config.clone();
                 let reserve_pricing_provider = pricing_provider.clone();
@@ -101,7 +104,7 @@ pub(super) async fn handle_streaming_completion(
                                 budget.model(),
                                 &reserve_pricing_provider,
                                 &reserve_pricing_model,
-                                &request_for_budget,
+                                request_for_budget,
                             )
                         },
                         || provider.chat_completion_stream(request_for_provider, provider_context),

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -25,6 +25,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -61,20 +62,22 @@ pub(crate) async fn handle_streaming_response(
     chat_request.stream_options = Some(StreamOptions {
         include_usage: Some(true),
     });
-    let request_for_budget = chat_request.clone();
+    let chat_request = Arc::new(chat_request);
     let model_name = chat_request.model.clone();
     let resp_id = format!("resp_{}", uuid_v4_hex());
     let created_at = current_unix_ts();
 
-    let core_request = match build_core_chat_request(chat_request, model_name.clone(), true) {
-        Ok(r) => r,
-        Err(e) => {
-            return Ok(openai_errors::gateway_error_response(&e));
-        }
-    };
+    let core_request =
+        match build_core_chat_request(chat_request.as_ref(), model_name.clone(), true) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(openai_errors::gateway_error_response(&e));
+            }
+        };
 
     let requested_model = core_request.model.clone();
-    let context_clone = std::sync::Arc::clone(&context);
+    let context_clone = Arc::clone(&context);
+    let request_for_execution = Arc::clone(&chat_request);
     let budgeted = state.budgeted.clone();
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
@@ -88,11 +91,11 @@ pub(crate) async fn handle_streaming_response(
         ProviderCapability::ChatCompletionStream,
         move |provider, selected_model, _selected_deployment_id| {
             let core_request = core_request.clone();
-            let ctx = std::sync::Arc::clone(&context_clone);
+            let ctx = Arc::clone(&context_clone);
+            let original_request = Arc::clone(&request_for_execution);
             let budgeted = budgeted.clone();
             let pricing_service = pricing_service.clone();
             let pricing_config = pricing_config.clone();
-            let request_for_budget = request_for_budget.clone();
             async move {
                 let provider_name = provider.name().to_string();
                 let (pricing_provider, pricing_model) = spend::pricing_identity_for_provider(
@@ -100,14 +103,15 @@ pub(crate) async fn handle_streaming_response(
                     &provider,
                     &selected_model,
                 );
-                let (req, request_for_budget) =
-                    super::token_policy::prepare_chat_request_for_provider(
-                        ctx.api_key_max_tokens_per_request(),
-                        &provider_name,
-                        &selected_model,
-                        core_request.clone(),
-                        request_for_budget,
-                    )?;
+                let req = super::token_policy::prepare_chat_request_for_provider(
+                    ctx.api_key_max_tokens_per_request(),
+                    &provider_name,
+                    &selected_model,
+                    core_request.clone(),
+                )?;
+                let request_for_budget =
+                    spend::ChatCompletionBudgetRequest::from(original_request.as_ref())
+                        .with_output_limits(req.max_tokens, req.max_completion_tokens);
                 let provider_context = ctx.as_ref().clone();
                 let reserve_pricing_service = pricing_service.clone();
                 let reserve_pricing_config = pricing_config.clone();
@@ -130,7 +134,7 @@ pub(crate) async fn handle_streaming_response(
                                 budget.model(),
                                 &reserve_pricing_provider,
                                 &reserve_pricing_model,
-                                &request_for_budget,
+                                request_for_budget,
                             )
                         },
                         || provider.chat_completion_stream(req, provider_context),

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -22,15 +22,16 @@ use crate::core::types::responses::Usage;
 #[cfg(test)]
 use std::sync::LazyLock;
 
+pub(super) use completion::{
+    ChatCompletionBudgetRequest, estimate_chat_prompt_tokens,
+    reserve_chat_completion_budget_with_split_pricing,
+};
 #[cfg(test)]
 pub(super) use completion::{
     IMAGE_HIGH_DETAIL_PROMPT_TOKENS, catalog_max_output_tokens,
     provider_effective_max_output_tokens, reserve_chat_completion_budget,
     reserve_completion_budget, reserve_completion_budget_with_policy,
     reserve_completion_budget_with_pricing,
-};
-pub(super) use completion::{
-    estimate_chat_prompt_tokens, reserve_chat_completion_budget_with_split_pricing,
 };
 pub(in crate::server::routes::ai) use key_budget::{
     reserve_api_key_budget, reserve_api_key_budget_for_reservation,

--- a/src/server/routes/ai/spend/completion.rs
+++ b/src/server/routes/ai/spend/completion.rs
@@ -15,6 +15,45 @@ const DOCUMENT_PROMPT_BASE_TOKENS: u32 = 1_000;
 const TOOL_RESULT_BASE_TOKENS: u32 = 50;
 const TOOL_USE_BASE_TOKENS: u32 = 100;
 
+#[derive(Clone, Copy)]
+pub(in crate::server::routes::ai) struct ChatCompletionBudgetRequest<'a> {
+    messages: &'a [ChatMessage],
+    tools: Option<&'a [Tool]>,
+    functions: Option<&'a [Function]>,
+    function_call: Option<&'a FunctionCall>,
+    response_format: Option<&'a ResponseFormat>,
+    max_tokens: Option<u32>,
+    max_completion_tokens: Option<u32>,
+    n: Option<u32>,
+}
+
+impl<'a> ChatCompletionBudgetRequest<'a> {
+    pub(in crate::server::routes::ai) fn with_output_limits(
+        mut self,
+        max_tokens: Option<u32>,
+        max_completion_tokens: Option<u32>,
+    ) -> Self {
+        self.max_tokens = max_tokens;
+        self.max_completion_tokens = max_completion_tokens;
+        self
+    }
+}
+
+impl<'a> From<&'a ChatCompletionRequest> for ChatCompletionBudgetRequest<'a> {
+    fn from(request: &'a ChatCompletionRequest) -> Self {
+        Self {
+            messages: &request.messages,
+            tools: request.tools.as_deref(),
+            functions: request.functions.as_deref(),
+            function_call: request.function_call.as_ref(),
+            response_format: request.response_format.as_ref(),
+            max_tokens: request.max_tokens,
+            max_completion_tokens: request.max_completion_tokens,
+            n: request.n,
+        }
+    }
+}
+
 #[cfg(test)]
 pub(in crate::server::routes::ai) fn reserve_completion_budget(
     budget_limits: &UnifiedBudgetLimits,
@@ -182,7 +221,7 @@ pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_policy(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_split_pricing(
+pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_split_pricing<'a>(
     pricing_service: &PricingService,
     pricing_config: &GatewayPricingConfig,
     budget_limits: &UnifiedBudgetLimits,
@@ -190,15 +229,16 @@ pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_split_p
     budget_model: &str,
     pricing_provider: &str,
     pricing_model: &str,
-    request: &ChatCompletionRequest,
+    request: impl Into<ChatCompletionBudgetRequest<'a>>,
 ) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
+    let request = request.into();
     let prompt_tokens = estimate_chat_prompt_tokens(
         pricing_model,
-        &request.messages,
-        request.tools.as_deref(),
-        request.functions.as_deref(),
-        request.function_call.as_ref(),
-        request.response_format.as_ref(),
+        request.messages,
+        request.tools,
+        request.functions,
+        request.function_call,
+        request.response_format,
     );
     reserve_completion_budget_with_split_pricing(
         pricing_service,
@@ -214,7 +254,7 @@ pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_split_p
             pricing_provider,
             pricing_model,
             prompt_tokens,
-            provider_effective_max_output_tokens(budget_provider, budget_model, request),
+            provider_effective_max_output_tokens_for_budget(budget_provider, budget_model, request),
             request.n.unwrap_or(1),
         ),
     )
@@ -325,10 +365,19 @@ fn catalog_max_output_tokens_with_pricing(
     pricing_service.max_output_tokens_for_provider(provider, model)
 }
 
+#[cfg(test)]
 pub(in crate::server::routes::ai) fn provider_effective_max_output_tokens(
     provider: &str,
     model: &str,
     request: &ChatCompletionRequest,
+) -> Option<u32> {
+    provider_effective_max_output_tokens_for_budget(provider, model, request.into())
+}
+
+fn provider_effective_max_output_tokens_for_budget(
+    provider: &str,
+    model: &str,
+    request: ChatCompletionBudgetRequest<'_>,
 ) -> Option<u32> {
     let provider = crate::core::pricing::normalize_pricing_provider(provider);
     match provider.as_str() {
@@ -346,7 +395,7 @@ pub(in crate::server::routes::ai) fn provider_effective_max_output_tokens(
 
 fn bedrock_effective_max_output_tokens(
     model: &str,
-    request: &ChatCompletionRequest,
+    request: ChatCompletionBudgetRequest<'_>,
 ) -> Option<u32> {
     use crate::core::providers::bedrock::BedrockApiType;
 
@@ -467,4 +516,48 @@ fn fallback_message_tokens(messages: &[ChatMessage]) -> u32 {
         .sum::<usize>();
     let overhead = messages.len().saturating_mul(4).saturating_add(8);
     u32::try_from(chars.div_ceil(4).saturating_add(overhead)).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod budget_request_tests {
+    use super::*;
+
+    #[test]
+    fn budget_request_view_borrows_large_request_parts() {
+        let request = ChatCompletionRequest {
+            messages: vec![ChatMessage {
+                role: crate::core::models::openai::MessageRole::User,
+                content: Some(MessageContent::Text("x".repeat(64 * 1024))),
+                name: None,
+                function_call: None,
+                tool_calls: None,
+                tool_call_id: None,
+                audio: None,
+            }],
+            tools: Some(vec![Tool {
+                tool_type: "function".to_string(),
+                function: crate::core::models::openai::Function {
+                    name: "lookup".to_string(),
+                    description: None,
+                    parameters: Some(serde_json::json!({"type": "object"})),
+                },
+            }]),
+            max_tokens: Some(1024),
+            ..Default::default()
+        };
+
+        let view =
+            ChatCompletionBudgetRequest::from(&request).with_output_limits(Some(128), Some(64));
+
+        assert!(std::ptr::eq(
+            view.messages.as_ptr(),
+            request.messages.as_ptr()
+        ));
+        assert!(std::ptr::eq(
+            view.tools.expect("tools").as_ptr(),
+            request.tools.as_ref().expect("tools").as_ptr()
+        ));
+        assert_eq!(view.max_tokens, Some(128));
+        assert_eq!(view.max_completion_tokens, Some(64));
+    }
 }

--- a/src/server/routes/ai/token_policy.rs
+++ b/src/server/routes/ai/token_policy.rs
@@ -82,13 +82,10 @@ pub(super) fn prepare_chat_request_for_provider(
     provider: &str,
     model: &str,
     mut core_request: ChatRequest,
-    mut budget_request: ChatCompletionRequest,
-) -> Result<(ChatRequest, ChatCompletionRequest), ProviderError> {
+) -> Result<ChatRequest, ProviderError> {
     core_request.model = model.to_string();
     apply_api_key_output_token_limit(max_tokens_per_request, provider, model, &mut core_request)?;
-    budget_request.max_tokens = core_request.max_tokens;
-    budget_request.max_completion_tokens = core_request.max_completion_tokens;
-    Ok((core_request, budget_request))
+    Ok(core_request)
 }
 
 fn provider_effective_output_cap(


### PR DESCRIPTION
Refs #842

## Summary
- Wrap inbound chat requests in shared `Arc<ChatCompletionRequest>` handles for chat, legacy completions, and Responses streaming paths.
- Replace budget/cache `ChatCompletionRequest` clones with borrowed budget views plus provider-adjusted token caps.
- Keep provider execution ownership unchanged: each retry still gets an owned `ChatRequest`, while budget/cache use the original request view.
- Preserve stream usage behavior by injecting internal `include_usage=true` only while building provider requests, without mutating the original request.

## Verification
- `SPEC_RAIL=/Users/apple/Desktop/code/AI/tool/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH842"`
- static clone guard: no `request_for_budget/cache = request.clone()` hits in chat stream/non-stream routes
- `cargo check --all-features`
- `cargo test server::routes::ai::chat --lib --all-features`
- `cargo test server::routes::ai::spend --lib --all-features`
- `cargo test server::routes::ai::token_policy --lib --all-features`
- `cargo test server::middleware::auth --lib --all-features`
- `cargo test server::routes::ai::context --lib --all-features`
- `cargo test core::keys --lib --all-features`
- `cargo test --all-features`