### PR TITLE
fix(auth): harden credential lifecycle

### DIFF
--- a/specs/GH953/product.md
+++ b/specs/GH953/product.md
@@ -1,0 +1,43 @@
+# GH953 产品规格：认证凭证与 API-key 生命周期加固
+
+关联 issue：`GH953`
+
+## 目标
+
+确保认证边界不会泄露凭证，也不会在 key 或其 owner 失效后继续接受缓存中的旧状态。
+
+## 非目标
+
+- 不改变 JWT、session 或 API-key 的编码与哈希算法。
+- 不替换数据库、Redis 或现有 repository 抽象。
+- 不调整权限、轮换策略或公开成功响应格式。
+
+## 行为不变量
+
+- `GH953-B1`：`AuthMethod` 的 `Debug`/日志输出只能显示认证方式，不能包含 JWT、API key 或 session ID 的任何字节。
+- `GH953-B2`：有关联 owner 的 API key 仅在 owner 存在且为 active 时有效；无 owner 的系统/团队 key 保持现有语义。
+- `GH953-B3`：普通验证和详细验证对 key 状态、过期时间、owner 缺失与 owner inactive 使用同一判定规则。
+- `GH953-B4`：认证路径不读取 API-key 缓存快照；数据库状态变化后，旧缓存不得继续授权。
+- `GH953-B5`：无效凭证返回稳定的认证失败；存储等基础设施错误使用不同的通用失败消息，客户端不获得内部错误细节。
+
+## 验收标准
+
+- `GH953-AC1`：回归测试证明三类凭证均被完整遮蔽。
+- `GH953-AC2`：回归测试证明 inactive owner 与 missing owner 在两种验证入口中均被拒绝。
+- `GH953-AC3`：回归测试证明不执行缓存失效时，数据库中已撤销的 key 仍会被两种验证入口拒绝。
+- `GH953-AC4`：基础设施错误与 invalid credential 可区分，但公开错误不包含底层错误字符串。
+- `GH953-AC5`：聚焦测试、格式检查和 Rust 编译检查通过。
+
+## 边界情况
+
+- `user_id = None` 的 key 不因缺少 owner 被拒绝。
+- owner 查询失败属于基础设施错误，不得伪装成“key 无效”。
+- 既有 Redis 快照只做兼容性清理，认证路径不读取其内容。
+
+## 后续 schema 决策
+
+现有外键在 canonical user 删除时会把 `api_keys.user_id` 置空，无法再区分“原本有 owner”与“创建时无 owner”。当前没有 canonical user 删除的应用入口；若未来增加该能力，必须先由维护者选择 `CASCADE`、`RESTRICT` 或显式撤销迁移，不能继续沿用 `SET NULL`。
+
+## 开放问题
+
+无。

--- a/specs/GH953/tasks.md
+++ b/specs/GH953/tasks.md
@@ -1,0 +1,13 @@
+# GH953 任务计划
+
+- [x] `SP953-T1` Owner: auth worker. Dependencies: none. Done when: `AuthMethod` 的 `Debug` 与认证入口日志不包含凭证字节。Verify: `cargo test auth_method --lib --all-features`。
+- [x] `SP953-T2` Owner: auth worker. Dependencies: `SP953-T1`. Done when: 普通/详细 API-key 验证共享 owner 判定，missing/inactive owner 均被拒绝，基础设施错误仍为 `Err`。Verify: `cargo test api_key --lib --all-features`。
+- [x] `SP953-T3` Owner: auth worker. Dependencies: `SP953-T2`. Done when: 认证只读取数据库权威状态，缓存失效失败不影响已撤销 key 的拒绝结果。Verify: 不调用缓存失效、直接撤销数据库后的双入口回归测试。
+- [x] `SP953-T4` Owner: auth worker. Dependencies: `SP953-T2`. Done when: 客户端能区分 invalid key 与 verification unavailable，且看不到底层错误详情。Verify: 聚焦 auth 测试与代码检查。
+- [x] `SP953-T5` Owner: verification owner. Dependencies: `SP953-T1..T4`. Done when: 格式、编译、clippy、全量测试和 PR scope guard 通过。Verify: `cargo fmt --all -- --check`; `cargo check --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`; `bash scripts/guards/check_pr_scope.sh`。
+
+## Handoff
+
+- `pr_kind: mixed_impl`
+- `completion_mode: final`
+- PR 使用 `Refs #953`；canonical-user 删除的 FK 策略需要维护者决定，不能在当前 tranche 中声称完整关闭 issue。

--- a/specs/GH953/tech.md
+++ b/specs/GH953/tech.md
@@ -1,0 +1,48 @@
+# GH953 技术规格：认证凭证与 API-key 生命周期加固
+
+## 当前行为与根因
+
+| 区域 | 当前行为 | 风险 |
+|---|---|---|
+| `src/auth/types.rs`、`src/auth/system.rs` | `AuthMethod` 派生 `Debug`，认证入口记录完整值 | 日志泄露凭证 |
+| `src/auth/api_key/creation.rs` | `verify_key` 不拒绝 missing/inactive owner；详细入口仅拒绝 inactive | 两个 live 入口语义漂移 |
+| `src/auth/api_key/creation.rs` | cache hit 直接作为 key 真值 | revoke 后可继续信任旧 active 快照 |
+| `src/auth/api_key/management.rs`、key handler | 缓存删除错误只告警 | 缓存若参与认证，成功撤销不能证明状态已收敛 |
+| `src/auth/system.rs` | 将底层验证错误拼入公开 `AuthResult.error` | 内部错误泄露，invalid 与 outage 混淆 |
+
+## 设计
+
+1. 手写 `AuthMethod::Debug`，只输出 variant 与固定 `[REDACTED]`，认证日志继续保留方式级可观测性。
+2. 在 API-key handler 内建立共享验证函数，统一检查 active、expiry、owner 存在性与 owner active 状态；普通入口由详细入口派生成功/失败结果。
+3. API-key 认证直接读取数据库权威状态，不再读取或刷新 Redis snapshot。既有缓存失效保留为 best-effort 兼容性清理；即使 cache delete 失败，旧 active 快照也不会参与授权。
+4. 撤销仍以数据库 mutation 成功为准；Redis 故障不把已完成的安全 mutation 伪装成失败，也不影响后续认证结果。
+5. `AuthSystem` 服务端记录底层验证错误，公开结果使用固定的“verification unavailable”，与“Invalid API key”区分且不带内部详情。
+
+## 不变范围
+
+- 不修改 API-key hash、TTL、数据库 schema 或 Redis key 格式。
+- 不修改 JWT/session 验证流程。
+- 不改变未绑定 owner 的 key 语义。
+
+## 映射
+
+| invariant | 实现 | 验证 |
+|---|---|---|
+| `GH953-B1` | `AuthMethod` 手写 `Debug` | 三个 variant 的 redaction 单测 |
+| `GH953-B2/B3` | 共享 key/owner 判定 | inactive/missing owner 集成测试 |
+| `GH953-B4` | 认证只读 DB authoritative state | 不调用缓存失效，直接撤销 DB 后验证两种入口均拒绝 |
+| `GH953-B5` | 固定公开消息、内部 `error!` | `AuthSystem` 聚焦测试/静态断言 |
+
+## 风险与回滚
+
+- 风险：每次 API-key 验证需要一次权威 DB 查询；这是保证跨实例 revoke 正确性的有意安全取舍，并移除了无效的 Redis GET/SET 往返。
+- 回滚：可整体回退本 tranche；无 schema 或数据迁移。
+
+## 验证计划
+
+- `cargo test auth_method --lib --all-features`
+- `cargo test api_key --lib --all-features`
+- `cargo fmt --all -- --check`
+- `cargo check --all-features`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --all-features`

--- a/src/auth/api_key/creation.rs
+++ b/src/auth/api_key/creation.rs
@@ -74,9 +74,6 @@ fn validate_create_key_input(name: &str, permissions: &[String]) -> Result<()> {
 /// Minimum interval between DB writes for the same key's last_used timestamp.
 const LAST_USED_THROTTLE: Duration = Duration::from_secs(5 * 60);
 
-/// TTL for cached API keys in Redis (seconds).
-const API_KEY_CACHE_TTL: u64 = 300;
-
 /// Build the Redis cache key for an API key hash.
 fn api_key_cache_key(key_hash: &str) -> String {
     format!("api_key:hash:{}", key_hash)
@@ -186,54 +183,12 @@ impl ApiKeyHandler {
         Ok((stored_key, raw_key))
     }
 
-    /// Look up an API key by hash, checking Redis cache first and falling back
-    /// to PostgreSQL. On a cache miss the result is populated into Redis with a
-    /// 5-minute TTL.
-    async fn find_api_key_cached(&self, key_hash: &str) -> Result<Option<ApiKey>> {
-        let cache_key = api_key_cache_key(key_hash);
-
-        // 1. Try Redis cache
-        match self.storage.cache_get(&cache_key).await {
-            Ok(Some(cached)) => {
-                debug!("API key cache hit");
-                match serde_json::from_str::<ApiKey>(&cached) {
-                    Ok(api_key) => return Ok(Some(api_key)),
-                    Err(e) => {
-                        warn!(
-                            "Failed to deserialize cached API key, falling back to DB: {}",
-                            e
-                        );
-                        // Stale/corrupt entry – delete and continue to DB
-                        if let Err(del_err) = self.storage.cache_delete(&cache_key).await {
-                            warn!("Failed to delete corrupt API key cache entry: {}", del_err);
-                        }
-                    }
-                }
-            }
-            Ok(None) => {
-                debug!("API key cache miss");
-            }
-            Err(e) => {
-                // Redis unavailable – degrade gracefully
-                warn!("Redis cache_get failed, falling back to DB: {}", e);
-            }
-        }
-
-        // 2. Fall back to PostgreSQL
-        let api_key = self.storage.db().find_api_key_by_hash(key_hash).await?;
-
-        // 3. Populate cache on DB hit
-        if let Some(ref key) = api_key
-            && let Ok(serialized) = serde_json::to_string(key)
-            && let Err(e) = self
-                .storage
-                .cache_set(&cache_key, &serialized, Some(API_KEY_CACHE_TTL))
-                .await
-        {
-            warn!("Failed to populate API key cache: {}", e);
-        }
-
-        Ok(api_key)
+    /// Look up an API key from the authoritative lifecycle store.
+    ///
+    /// Authentication intentionally does not read Redis snapshots: a stale
+    /// active value must not outlive a database revoke or owner-state change.
+    async fn find_api_key_authoritative(&self, key_hash: &str) -> Result<Option<ApiKey>> {
+        self.storage.db().find_api_key_by_hash(key_hash).await
     }
 
     /// Invalidate the Redis cache entry for the given key hash.
@@ -250,52 +205,21 @@ impl ApiKeyHandler {
     /// Verify an API key
     pub async fn verify_key(&self, raw_key: &str) -> Result<Option<(ApiKey, Option<User>)>> {
         debug!("Verifying API key");
-
-        // Hash the provided key
-        let key_hash = hash_api_key(raw_key, self.hmac_secret());
-
-        // Find API key (cache-aside: Redis → PostgreSQL → populate Redis)
-        let api_key = match self.find_api_key_cached(&key_hash).await? {
-            Some(key) => key,
-            None => {
-                debug!("API key not found");
-                return Ok(None);
-            }
-        };
-
-        // Check if key is active
-        if !api_key.is_active {
-            debug!("API key is inactive");
-            return Ok(None);
-        }
-
-        // Check if key is expired
-        if let Some(expires_at) = api_key.expires_at
-            && Utc::now() > expires_at
-        {
-            debug!("API key is expired");
-            return Ok(None);
-        }
-
-        // Get associated user if any
-        let user = if let Some(user_id) = api_key.user_id {
-            self.storage.db().find_user_by_id(user_id).await?
+        let verification = self.verify_key_detailed(raw_key).await?;
+        if verification.is_valid {
+            debug!("API key verified successfully");
+            Ok(Some((verification.api_key, verification.user)))
         } else {
-            None
-        };
-
-        // Update last used timestamp
-        self.update_last_used(api_key.metadata.id).await?;
-
-        debug!("API key verified successfully");
-        Ok(Some((api_key, user)))
+            debug!(reason = ?verification.invalid_reason, "API key rejected");
+            Ok(None)
+        }
     }
 
     /// Verify API key with detailed result
     pub async fn verify_key_detailed(&self, raw_key: &str) -> Result<ApiKeyVerification> {
         let key_hash = hash_api_key(raw_key, self.hmac_secret());
 
-        let api_key = match self.find_api_key_cached(&key_hash).await? {
+        let api_key = match self.find_api_key_authoritative(&key_hash).await? {
             Some(key) => key,
             None => {
                 return Ok(ApiKeyVerification {
@@ -349,15 +273,12 @@ impl ApiKeyHandler {
             None
         };
 
-        // Check if user is active (if associated)
-        if let Some(ref user) = user
-            && !user.is_active()
-        {
+        if let Some(reason) = api_key_owner_invalid_reason(&api_key, user.as_ref()) {
             return Ok(ApiKeyVerification {
                 api_key,
-                user: Some(user.clone()),
+                user,
                 is_valid: false,
-                invalid_reason: Some("Associated user is inactive".to_string()),
+                invalid_reason: Some(reason.to_string()),
             });
         }
 
@@ -397,9 +318,32 @@ impl ApiKeyHandler {
     }
 }
 
+fn api_key_owner_invalid_reason(api_key: &ApiKey, user: Option<&User>) -> Option<&'static str> {
+    api_key.user_id?;
+    match user {
+        None => Some("Associated user was not found"),
+        Some(user) if !user.is_active() => Some("Associated user is inactive"),
+        Some(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::models::storage::StorageConfig;
+    use crate::core::models::user::types::UserStatus;
+
+    async fn test_handler() -> ApiKeyHandler {
+        let mut config = StorageConfig::default();
+        config.database.enabled = false;
+        config.redis.enabled = false;
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("test storage should initialize");
+        ApiKeyHandler::new(Arc::new(storage), None)
+            .await
+            .expect("API key handler should initialize")
+    }
 
     // ==================== validate_create_key_input ====================
 
@@ -490,5 +434,91 @@ mod tests {
         let perms = vec!["api.chat".to_string(), "not.a.perm".to_string()];
         let result = validate_create_key_input("My Key", &perms);
         assert!(matches!(result, Err(GatewayError::Validation(_))));
+    }
+
+    #[test]
+    fn owner_validation_rejects_missing_owner() {
+        let api_key = ApiKey {
+            metadata: Metadata::new(),
+            name: "missing-owner".to_string(),
+            key_hash: "hash".to_string(),
+            key_prefix: "gw-test".to_string(),
+            user_id: Some(Uuid::new_v4()),
+            team_id: None,
+            permissions: vec![],
+            rate_limits: None,
+            expires_at: None,
+            is_active: true,
+            last_used_at: None,
+            usage_stats: UsageStats::default(),
+        };
+
+        assert_eq!(
+            api_key_owner_invalid_reason(&api_key, None),
+            Some("Associated user was not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn live_and_detailed_verification_reject_inactive_owner() {
+        let handler = test_handler().await;
+        let mut user = User::new(
+            format!("inactive-{}", Uuid::new_v4()),
+            format!("inactive-{}@example.com", Uuid::new_v4()),
+            "unused-hash".to_string(),
+        );
+        user.status = UserStatus::Inactive;
+        handler
+            .storage
+            .db()
+            .create_user(&user)
+            .await
+            .expect("inactive user should be stored");
+        let (_, raw_key) = handler
+            .create_key(
+                Some(user.id()),
+                None,
+                "inactive-owner".to_string(),
+                vec!["api.chat".to_string()],
+            )
+            .await
+            .expect("key creation should succeed");
+
+        assert!(handler.verify_key(&raw_key).await.unwrap().is_none());
+        let detailed = handler.verify_key_detailed(&raw_key).await.unwrap();
+        assert!(!detailed.is_valid);
+        assert_eq!(
+            detailed.invalid_reason.as_deref(),
+            Some("Associated user is inactive")
+        );
+    }
+
+    #[tokio::test]
+    async fn database_revoke_is_authoritative_without_cache_invalidation() {
+        let handler = test_handler().await;
+        let (api_key, raw_key) = handler
+            .create_key(
+                None,
+                None,
+                "revoked-without-invalidation".to_string(),
+                vec!["api.chat".to_string()],
+            )
+            .await
+            .expect("key creation should succeed");
+
+        handler
+            .storage
+            .db()
+            .deactivate_api_key(api_key.metadata.id)
+            .await
+            .expect("database revoke should succeed");
+
+        assert!(handler.verify_key(&raw_key).await.unwrap().is_none());
+        let detailed = handler.verify_key_detailed(&raw_key).await.unwrap();
+        assert!(!detailed.is_valid);
+        assert_eq!(
+            detailed.invalid_reason.as_deref(),
+            Some("API key is inactive")
+        );
     }
 }

--- a/src/auth/system.rs
+++ b/src/auth/system.rs
@@ -190,14 +190,7 @@ impl AuthSystem {
                 error: Some("Invalid API key".to_string()),
                 context,
             }),
-            Err(e) => Ok(AuthResult {
-                success: false,
-                user: None,
-                api_key: None,
-                session: None,
-                error: Some(format!("API key verification failed: {}", e)),
-                context,
-            }),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -36,7 +36,7 @@ pub struct AuthzResult {
 }
 
 /// Authentication method
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum AuthMethod {
     /// JWT token authentication
     Jwt(String),
@@ -46,6 +46,23 @@ pub enum AuthMethod {
     Session(String),
     /// No authentication
     None,
+}
+
+impl std::fmt::Debug for AuthMethod {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Jwt(_) => formatter.debug_tuple("Jwt").field(&"[REDACTED]").finish(),
+            Self::ApiKey(_) => formatter
+                .debug_tuple("ApiKey")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::Session(_) => formatter
+                .debug_tuple("Session")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::None => formatter.write_str("None"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -354,10 +371,17 @@ mod tests {
 
     #[test]
     fn test_auth_method_debug() {
-        let method = AuthMethod::ApiKey("secret".to_string());
-        let debug_str = format!("{:?}", method);
+        let credentials = [
+            AuthMethod::Jwt("jwt-secret-bytes".to_string()),
+            AuthMethod::ApiKey("api-key-secret-bytes".to_string()),
+            AuthMethod::Session("session-secret-bytes".to_string()),
+        ];
 
-        assert!(debug_str.contains("ApiKey"));
+        for method in credentials {
+            let debug_str = format!("{method:?}");
+            assert!(debug_str.contains("[REDACTED]"));
+            assert!(!debug_str.contains("secret-bytes"));
+        }
     }
 
     // ==================== Integration Tests ====================

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -290,10 +290,8 @@ where
                         reservation.release().await;
                     }
                     rate_limiter.record_failure(&client_id);
-                    Err(actix_web::error::ErrorInternalServerError(format!(
-                        "Authentication error: {}",
-                        err
-                    )))
+                    error!(error = %err, "Authentication infrastructure failure");
+                    Ok(authentication_unavailable_response(req))
                 }
             }
         })
@@ -354,6 +352,15 @@ fn forbidden_response<B>(
         req,
         actix_web::error::ErrorForbidden(message.clone()),
         GatewayError::Forbidden(message),
+    )
+}
+
+fn authentication_unavailable_response<B>(req: ServiceRequest) -> ServiceResponse<EitherBody<B>> {
+    const MESSAGE: &str = "Authentication service temporarily unavailable";
+    middleware_gateway_error_response(
+        req,
+        actix_web::error::ErrorInternalServerError(MESSAGE),
+        GatewayError::Internal(MESSAGE.to_string()),
     )
 }
 
@@ -608,5 +615,23 @@ mod tests {
         );
         assert!(!context.headers.contains_key("authorization"));
         assert!(!context.headers.contains_key("x-api-key"));
+    }
+
+    #[actix_web::test]
+    async fn authentication_unavailable_response_is_generic_server_error() {
+        let req = TestRequest::with_uri("/v1/chat/completions").to_srv_request();
+        let response = authentication_unavailable_response::<actix_web::body::BoxBody>(req);
+
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("generic authentication error body should render");
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("Authentication service temporarily unavailable"));
+        assert!(!body.contains("Storage error"));
+        assert!(!body.contains("Redis error"));
     }
 }

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -104,10 +104,15 @@ pub(super) async fn authenticate_request(
         }
         Err(e) => {
             error!("Authentication error: {}", e);
-            let error_response = KeyErrorResponse::unauthorized("Authentication error");
-            Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
+            Err(authentication_unavailable_response())
         }
     }
+}
+
+fn authentication_unavailable_response() -> HttpResponse {
+    let error_response =
+        KeyErrorResponse::internal("Authentication service temporarily unavailable");
+    HttpResponse::InternalServerError().json(ApiResponse::<()>::error(error_response.error))
 }
 
 pub(super) fn resolve_create_key_scope(
@@ -227,6 +232,23 @@ pub(super) fn filter_and_paginate_keys(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[actix_web::test]
+    async fn authentication_unavailable_response_is_generic_server_error() {
+        let response = authentication_unavailable_response();
+
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("generic key-route authentication error should render");
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("Authentication service temporarily unavailable"));
+        assert!(!body.contains("Storage error"));
+        assert!(!body.contains("Redis error"));
+    }
 
     #[test]
     fn accepts_unset_or_rpm_only_key_rate_limits() {


### PR DESCRIPTION
## 变更

- 为 `AuthMethod` 提供凭证安全的 `Debug`，JWT、API key、session 都只输出 `[REDACTED]`
- 让普通与详细 API-key 验证共享 owner 存在/active 判定
- 认证路径只读取数据库权威状态，不再信任或刷新可能过期的 Redis key 快照
- 将 API-key 存储故障与 invalid credential 区分，对客户端只返回通用 500
- 增加产品、技术和任务规格：`specs/GH953/`

## 验证

- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `bash scripts/guards/check_pr_scope.sh`
- `bash scripts/guards/check_pr_overlap.sh`

全部通过。Scope guard：5 个代码文件、322 行；无开放 PR 重叠。

## 人工安全审查门

这是认证安全改动，合并前必须由维护者真人审查。

独立审查还发现一个既有 schema 边界：canonical `users` 外键为 `ON DELETE SET NULL`，未来若增加 canonical-user 删除入口，会丢失 key 原本是否有 owner 的 provenance。当前没有该应用入口，且正确修复需要维护者在 `CASCADE`、`RESTRICT` 或显式撤销迁移之间做选择，因此本 PR 不擅自修改数据库语义，也不声称完整关闭 issue。

Refs #953