### PR TITLE
fix(build): pin Rust toolchain

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -46,8 +46,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
         with:
+          toolchain: 1.96.1
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -33,8 +33,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
         with:
+          toolchain: 1.96.1
           targets: ${{ matrix.target }}
 
       - name: Cache

--- a/.github/workflows/ci-disabled-modules.yml
+++ b/.github/workflows/ci-disabled-modules.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/ci-disabled-modules.yml
+++ b/.github/workflows/ci-disabled-modules.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/ci-main-full.yml
+++ b/.github/workflows/ci-main-full.yml
@@ -25,8 +25,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
         with:
+          toolchain: 1.96.1
           components: rustfmt, clippy
 
       - name: Cache
@@ -84,7 +85,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Cache
         uses: actions/cache@v4
@@ -115,7 +118,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -130,7 +135,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/ci-main-full.yml
+++ b/.github/workflows/ci-main-full.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache
         uses: actions/cache@v4
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
         with:
+          toolchain: 1.96.1
           components: rustfmt, clippy
 
       - name: Cache
@@ -87,7 +88,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Cache
         uses: actions/cache@v4
@@ -132,7 +135,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Cache
         uses: actions/cache@v4
@@ -163,7 +168,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache
         uses: actions/cache@v4
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache
         uses: actions/cache@v4
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.95.0
       with:
         targets: ${{ matrix.target }}
 
@@ -242,7 +242,7 @@ jobs:
 
     - name: Install Rust
       if: steps.crates_token.outputs.available == 'true'
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.95.0
 
     - name: Cache dependencies
       if: steps.crates_token.outputs.available == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
+      uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
       with:
+        toolchain: 1.96.1
         targets: ${{ matrix.target }}
 
     - name: Cache dependencies
@@ -242,7 +243,9 @@ jobs:
 
     - name: Install Rust
       if: steps.crates_token.outputs.available == 'true'
-      uses: dtolnay/rust-toolchain@1.95.0
+      uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+      with:
+        toolchain: 1.96.1
 
     - name: Cache dependencies
       if: steps.crates_token.outputs.available == 'true'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## 变更

- 将 `rust-toolchain.toml` 从浮动的 `stable` 固定为已完整验证且包含近期 Cargo/libssh2 安全修复的 `1.96.1`
- 显式声明 `rustfmt` 与 `clippy` components
- 将 CI、coverage、cross-platform 与 release 的 13 个 Rust setup steps 固定到不可变 action commit `4be7066a...`，并显式选择 `toolchain: 1.96.1`
- 确保非 host targets 与 Cargo 使用同一工具链

## 根因

PR #954 的 Lint job 在 2026-07-09 自动升级到 Rust 1.97.0，并因 5 个 origin/main 既有新 lint 失败。仓库事后文档已经明确要求固定版本，但当前配置实际上仍会漂移。

## 验证

使用 `rustup run 1.96.1` 通过：

- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- 6 个变更 workflow 均通过 YAML 解析
- `bash scripts/guards/check_pr_scope.sh`（7 文件 / 50 行）
- `bash scripts/guards/check_pr_overlap.sh`

独立 reviewer 提出的 cross-target 错配、1.95 安全补丁滞后和 action ref 可变性均已修复。

Fixes #955