### PR TITLE
fix(openai): preserve legacy functions in upstream payloads

### DIFF
--- a/specs/GH962/product.md
+++ b/specs/GH962/product.md
@@ -1,0 +1,52 @@
+# Product Spec
+
+## Linked Issue
+
+GH-962 / #962
+
+## 用户问题
+
+网关已经接受 legacy OpenAI `functions` 与 `function_call` 字段，并把它们保存在 canonical
+chat request 中，但 OpenAI 与 OpenAI-compatible provider 发往上游的请求会静默丢弃这两个字段。
+调用方看到请求被正常接受，却无法让上游执行所声明的 legacy function contract。
+
+## 目标
+
+- OpenAI 与 OpenAI-compatible provider 都完整转发调用方提交的 legacy function 字段。
+- 缺失字段保持缺失，不向上游伪造 `null`、默认 function 或现代 tool 配置。
+- 修复仅改变此前被静默丢弃的 outbound payload，不改变认证、路由或响应语义。
+
+## 非目标
+
+- 不把 legacy `functions` / `function_call` 自动转换成 `tools` / `tool_choice`。
+- 不改变 HTTP 请求 DTO、canonical chat request 类型或 legacy 字段的校验规则。
+- 不扩展其他 provider、response delta、provider capability 或 supported-parameter 声明。
+- 不承诺所有 OpenAI-compatible 上游都支持 legacy function calling；上游可按其协议返回错误。
+
+## Behavior Invariants
+
+1. `GH962-P1`：调用方提供 `functions` 时，OpenAI outbound JSON 包含同名字段，数组内容与顺序保持不变。
+2. `GH962-P2`：调用方提供 `function_call` 时，OpenAI outbound JSON 保留原始字符串或对象结构。
+3. `GH962-P3`：OpenAI-compatible outbound JSON 对 `functions` 与 `function_call` 满足与 OpenAI 相同的转发契约。
+4. `GH962-P4`：两个字段可同时出现，且不会覆盖或删除现代 `tools` 与 `tool_choice`。
+5. `GH962-P5`：调用方未提供 legacy 字段时，outbound JSON 不包含对应 key。
+6. `GH962-P6`：typed legacy 字段是 canonical 值；同名 provider extra parameter 不得覆盖显式 typed 值。
+
+## 验收标准
+
+- [ ] OpenAI mock upstream 收到与输入完全一致的 `functions` 与 `function_call`。
+- [ ] OpenAI-compatible mock upstream 收到相同字段和值。
+- [ ] 测试覆盖字符串形式与对象形式的 `function_call`，并证明两个字段可同时转发。
+- [ ] 测试证明字段缺失时不会生成对应 key，且 typed 值不会被同名 extra parameter 覆盖。
+- [ ] 聚焦测试、格式、编译、Clippy 与全量测试通过。
+
+## 边界情况
+
+- `functions: []` 是显式空数组，必须保留为 `[]`；它不同于未提供字段。
+- `function_call` 可为 legacy 字符串选择器，也可为命名函数对象；两种 JSON 形状都必须保持。
+- 上游拒绝 legacy 字段时，沿用现有 provider error mapping，不静默删除字段后重试。
+
+## 发布说明
+
+OpenAI 与 OpenAI-compatible chat 请求现在会按调用方输入转发 legacy `functions` 和
+`function_call`；现代 tool calling 与其他 provider 行为不变。

--- a/specs/GH962/tasks.md
+++ b/specs/GH962/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-962 / #962
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP962-T1` Owner: coordinator. Dependencies: none. Done when: `specs/GH962/` 三件套与 issue、代码证据和 stable IDs 一致，并通过 SpecRail packet check. Verify: `python3 /Users/lifcc/Desktop/code/AI/tools/specrail/checks/check_workflow.py --repo /Users/lifcc/Desktop/code/AI/tools/specrail --spec-dir "$PWD/specs/GH962"`。
+- [x] `SP962-T2` Owner: implementation worker. Dependencies: `SP962-T1`. Done when: mock upstream contract tests 通过 live `chat_completion` 路径捕获 OpenAI 与 OpenAI-compatible outbound JSON，并在生产修复前以缺失 `functions` / `function_call` 失败. Verify: `cargo test --test openai_legacy_function_forwarding --all-features --locked`，red 与 green 输出分别保存为 artifact。
+- [x] `SP962-T3` Owner: implementation worker. Dependencies: `SP962-T2`. Done when: OpenAI transform 精确转发 typed `functions` 与 `function_call`，且 typed 值优先于同名 `extra_params`. Verify: mock upstream OpenAI case + focused transform assertions。
+- [x] `SP962-T4` Owner: implementation worker. Dependencies: `SP962-T2`. Done when: OpenAI-compatible transform 满足相同契约并保留既有 serialization error mapping. Verify: mock upstream OpenAI-compatible case + focused transform assertions。
+- [ ] `SP962-T5` Owner: reviewer. Dependencies: `SP962-T3`, `SP962-T4`. Done when: 独立 reviewer 对当前 head 比较 issue、三件套、diff 与测试，且无 blocking finding. Verify: reviewer evidence 记录 current head SHA 与 verdict。
+
+## 并行拆分
+
+- `SP962-T3` 与 `SP962-T4` 修改不同生产文件，理论上可并行；本 tranche 使用单一 implementation owner 串行完成，避免共享 integration test 文件。
+- reviewer lane 只读，只在 implementation head 固定后启动。
+- 禁止修改 `AGENTS.md`、`CLAUDE.md`、`.github/workflows/**`、provider capability 与 supported-parameter 列表。
+
+## 验证
+
+- [ ] `SP962-T6` Owner: verification owner. Dependencies: `SP962-T3`, `SP962-T4`, `SP962-T5`. Done when: focused test、format、check、strict Clippy、全量 test、scope/overlap guards 与 PR gate 都绑定最终 head 并通过. Verify: `cargo test --test openai_legacy_function_forwarding --all-features --locked`; `cargo fmt --all -- --check`; `cargo check --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked`; `bash scripts/guards/check_pr_scope.sh`; `bash scripts/guards/check_pr_overlap.sh`。
+
+## Handoff Notes
+
+- `pr_kind: mixed_impl`；spec 与实现放在同一 issue PR，不计为 spec-only progress。
+- `completion_mode: final`；只有全部验收标准满足后，PR 才使用 `Fixes #962`。
+- 本 issue 不修改 modern tools、response delta、其他 provider、capability 或 supported-parameter 声明。
+- `auth_mode: auto` 提供 merge authorization，但仍需 current-head CI、独立 reviewer、review threads、clean merge state 与 PR gate 全部通过。

--- a/specs/GH962/tech.md
+++ b/specs/GH962/tech.md
@@ -1,0 +1,79 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-962 / #962
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Canonical request | `src/core/types/chat.rs` | `ChatRequest` 已声明 typed `functions` 与 `function_call` | 字段在 provider 前仍存在 |
+| HTTP boundary | `src/server/routes/ai/chat.rs` | transport DTO 已转换并保存两个 legacy 字段 | 证明丢失发生在 outbound serializer |
+| OpenAI serializer | `src/core/providers/openai/client.rs` | `transform_chat_request` 手工插入 optional fields，但遗漏两个 legacy 字段 | OpenAI live 请求根因 |
+| OpenAI-compatible serializer | `src/core/providers/openai_like/provider.rs` | 独立手工映射同样遗漏两个字段 | catalog/Tier-1 OpenAI-like live 请求根因 |
+| Contract tests | `tests/openai_legacy_function_forwarding.rs` | 尚无 mock upstream 对两个 provider outbound body 的共同契约测试 | 需要锁定实际发送边界 |
+
+## 设计方案
+
+1. 保留现有 `ChatRequest` 与 provider-specific JSON transform 结构。
+2. 在 OpenAI `transform_chat_request` 的 typed optional parameter 映射中插入 `functions` 与
+   `function_call`，复用现有 fallible `serde_json::to_value` 路径。
+3. 在 OpenAI-compatible transform 中做同样插入，并沿用该 provider 的
+   `OpenAILikeError::serialization` 映射。
+4. 两条路径都先写 typed fields，再用 `entry(...).or_insert(...)` 合并 `extra_params`，保持 canonical
+   typed 值优先的既有规则。
+5. 新增一个独立 integration test 文件，启动本地 mock HTTP upstream，分别通过
+   `OpenAIProvider` 与 `OpenAILikeProvider` 的 live `chat_completion` 路径发送请求并捕获 JSON body。
+   测试直接构造 canonical `ChatRequest`；字符串形式 `function_call` 只证明 provider contract，
+   不声明扩展当前 HTTP DTO 的输入形状。
+6. 不修改 `get_supported_openai_params`、capability matrix、transport DTO 或 response transformer；这些
+   不属于本 issue 的 outbound field-loss 根因。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| `GH962-P1/P2` | OpenAI request transform | OpenAI mock upstream 精确 body 断言 |
+| `GH962-P3` | OpenAI-compatible request transform | OpenAI-compatible mock upstream 精确 body 断言 |
+| `GH962-P4` | 两个 transform | 同一请求同时携带 legacy 与 modern fields |
+| `GH962-P5` | optional insertion | 无 legacy fields 的 transform 聚焦断言 |
+| `GH962-P6` | typed insertion before `extra_params` merge | 同名 extra parameter 冲突测试 |
+
+## 数据流
+
+HTTP `functions` / `function_call` -> canonical `ChatRequest` -> selected OpenAI or OpenAI-compatible
+provider -> provider `transform_chat_request` -> outbound JSON body -> upstream `/chat/completions`。
+
+没有新增持久化、缓存、共享状态或外部协议转换。
+
+## 备选方案
+
+- 直接序列化整个 `ChatRequest`：会绕过 model mapping、provider-specific reasoning 处理和现有字段白名单，范围过大，拒绝。
+- 把 legacy fields 放回 `extra_params`：继续保留两套来源并允许语义漂移，拒绝。
+- 自动转换成现代 tool fields：会改变调用方选择的 OpenAI 协议，且无法保证完全等价，拒绝。
+- 只添加 transform unit tests：能覆盖映射函数，但不能证明 live provider 发送边界，保留为补充而不替代 mock upstream contract test。
+
+## 风险
+
+- Security: 不新增 secret 或日志；测试使用固定假 API key，本地 upstream 仅绑定 loopback。
+- Compatibility: 以前被静默丢弃的字段现在会到达上游；不支持 legacy contract 的上游可能显式返回 4xx，这是预期修复行为。
+- Performance: 仅多序列化两个已存在的 optional JSON 字段，开销与 payload 大小线性一致。
+- Maintenance: OpenAI 与 OpenAI-compatible 仍有两套手工 serializer；本 issue 只保持二者契约一致，不做架构合并。
+
+## 测试计划
+
+- [x] Red test: mock upstream 先证明当前两个 live provider body 都缺少 legacy fields。
+- [x] Integration: 两个 provider 分别精确断言 `functions`、字符串/对象 `function_call` 与 typed precedence。
+- [ ] Focused: `cargo test --test openai_legacy_function_forwarding --all-features --locked`。
+- [ ] Repository: `cargo fmt --all -- --check`; `cargo check --all-features --locked`;
+  `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked`。
+
+## 回滚方案
+
+该变更无 schema 或数据迁移。若出现 provider compatibility 回归，可回退两个 optional insertion 与对应
+contract tests；回退会重新暴露字段静默丢失，因此优先通过 provider-specific 显式校验或错误映射 forward-fix。

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -283,6 +283,8 @@ impl OpenAIProvider {
         insert_optional_param!(metadata);
         insert_optional_param!(service_tier);
         insert_optional_param!(parallel_tool_calls);
+        insert_optional_param!(functions);
+        insert_optional_param!(function_call);
 
         if let Some(obj) = openai_request.as_object_mut() {
             for (key, value) in request.extra_params {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -284,6 +284,8 @@ impl OpenAILikeProvider {
         insert_optional_param!(metadata);
         insert_optional_param!(service_tier);
         insert_optional_param!(parallel_tool_calls);
+        insert_optional_param!(functions);
+        insert_optional_param!(function_call);
 
         if let Some(effort) = reasoning_effort {
             self.insert_reasoning_effort(&mut openai_request, &model, effort)?;

--- a/tests/openai_legacy_function_forwarding.rs
+++ b/tests/openai_legacy_function_forwarding.rs
@@ -1,0 +1,235 @@
+use litellm_rs::core::providers::openai::{OpenAIConfig, OpenAIProvider};
+use litellm_rs::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
+use litellm_rs::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use litellm_rs::core::types::chat::{ChatMessage, ChatRequest};
+use litellm_rs::core::types::context::RequestContext;
+use litellm_rs::core::types::message::{MessageContent, MessageRole};
+use litellm_rs::core::types::tools::{FunctionDefinition, Tool, ToolChoice, ToolType};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::error::Error;
+use std::io;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const CHAT_RESPONSE: &str = r#"{"id":"chatcmpl-test","object":"chat.completion","created":1,"model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+
+struct MockUpstream {
+    api_base: String,
+    body: oneshot::Receiver<Value>,
+    task: JoinHandle<io::Result<()>>,
+}
+
+impl MockUpstream {
+    async fn captured_body(self) -> TestResult<Value> {
+        let body = self.body.await?;
+        self.task.await??;
+        Ok(body)
+    }
+}
+
+async fn read_json_body(socket: &mut TcpStream) -> io::Result<Value> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 2048];
+
+    loop {
+        let bytes_read = socket.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "mock upstream received an incomplete HTTP request",
+            ));
+        }
+        request.extend_from_slice(&buffer[..bytes_read]);
+
+        let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "mock upstream request is missing content-length",
+                )
+            })?;
+        let body_start = header_end + 4;
+        if request.len() < body_start + content_length {
+            continue;
+        }
+
+        return serde_json::from_slice(&request[body_start..body_start + content_length])
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+    }
+}
+
+async fn start_mock_upstream() -> io::Result<MockUpstream> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let address = listener.local_addr()?;
+    let (body_sender, body) = oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await?;
+        let request_body = read_json_body(&mut socket).await?;
+        body_sender.send(request_body).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "mock upstream request receiver was dropped",
+            )
+        })?;
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            CHAT_RESPONSE.len(),
+            CHAT_RESPONSE
+        );
+        socket.write_all(response.as_bytes()).await
+    });
+
+    Ok(MockUpstream {
+        api_base: format!("http://{address}/v1"),
+        body,
+        task,
+    })
+}
+
+fn legacy_functions() -> Vec<Value> {
+    vec![json!({
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    })]
+}
+
+fn modern_weather_tool() -> Tool {
+    Tool {
+        tool_type: ToolType::Function,
+        function: FunctionDefinition {
+            name: "get_forecast".to_string(),
+            description: Some("Get a weather forecast".to_string()),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {"city": {"type": "string"}}
+            })),
+        },
+    }
+}
+
+fn legacy_function_request(function_call: Value) -> ChatRequest {
+    ChatRequest {
+        model: "gpt-4".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Weather?".to_string())),
+            ..Default::default()
+        }],
+        functions: Some(legacy_functions()),
+        function_call: Some(function_call),
+        tools: Some(vec![modern_weather_tool()]),
+        tool_choice: Some(ToolChoice::String("auto".to_string())),
+        extra_params: HashMap::from([
+            ("functions".to_string(), json!([{"name": "wrong"}])),
+            ("function_call".to_string(), json!("none")),
+        ]),
+        ..Default::default()
+    }
+}
+
+fn request_without_legacy_fields() -> ChatRequest {
+    ChatRequest {
+        model: "gpt-4".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Hello".to_string())),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+async fn openai_request_body(request: ChatRequest) -> TestResult<Value> {
+    let upstream = start_mock_upstream().await?;
+    let mut config = OpenAIConfig::default();
+    config.base.api_key = Some("sk-test-legacy-functions".to_string());
+    config.base.api_base = Some(upstream.api_base.clone());
+    let provider = OpenAIProvider::new(config).await?;
+
+    LLMProvider::chat_completion(&provider, request, RequestContext::default()).await?;
+    upstream.captured_body().await
+}
+
+async fn openai_like_request_body(request: ChatRequest) -> TestResult<Value> {
+    let upstream = start_mock_upstream().await?;
+    let config = OpenAILikeConfig::new(upstream.api_base.clone()).with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await?;
+
+    LLMProvider::chat_completion(&provider, request, RequestContext::default()).await?;
+    upstream.captured_body().await
+}
+
+#[tokio::test]
+async fn openai_forwards_legacy_functions_and_string_function_call() -> TestResult {
+    let body = openai_request_body(legacy_function_request(json!("auto"))).await?;
+
+    assert_eq!(body["functions"], json!(legacy_functions()));
+    assert_eq!(body["function_call"], json!("auto"));
+    assert_eq!(body["tools"][0]["function"]["name"], "get_forecast");
+    assert_eq!(body["tool_choice"], "auto");
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_like_forwards_legacy_functions_and_object_function_call() -> TestResult {
+    let function_call = json!({"name": "get_weather"});
+    let body = openai_like_request_body(legacy_function_request(function_call.clone())).await?;
+
+    assert_eq!(body["functions"], json!(legacy_functions()));
+    assert_eq!(body["function_call"], function_call);
+    assert_eq!(body["tools"][0]["function"]["name"], "get_forecast");
+    assert_eq!(body["tool_choice"], "auto");
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_fields_remain_absent_when_not_provided() -> TestResult {
+    let openai_body = openai_request_body(request_without_legacy_fields()).await?;
+    let openai_like_body = openai_like_request_body(request_without_legacy_fields()).await?;
+
+    for body in [openai_body, openai_like_body] {
+        assert!(body.get("functions").is_none());
+        assert!(body.get("function_call").is_none());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn explicit_empty_functions_remain_present() -> TestResult {
+    let mut openai_request = request_without_legacy_fields();
+    openai_request.functions = Some(Vec::new());
+    let mut openai_like_request = request_without_legacy_fields();
+    openai_like_request.functions = Some(Vec::new());
+
+    let openai_body = openai_request_body(openai_request).await?;
+    let openai_like_body = openai_like_request_body(openai_like_request).await?;
+
+    for body in [openai_body, openai_like_body] {
+        assert_eq!(body["functions"], json!([]));
+        assert!(body.get("function_call").is_none());
+    }
+    Ok(())
+}

--- a/tests/openai_legacy_function_forwarding.rs
+++ b/tests/openai_legacy_function_forwarding.rs
@@ -26,9 +26,9 @@ struct MockUpstream {
 
 impl MockUpstream {
     async fn captured_body(self) -> TestResult<Value> {
-        let body = self.body.await?;
+        let body = self.body.await;
         self.task.await??;
-        Ok(body)
+        Ok(body?)
     }
 }
 


### PR DESCRIPTION
## What

- 在 OpenAI 与 OpenAI-compatible live serializer 中转发 typed legacy `functions` / `function_call`。
- 新增 mock upstream contract tests，覆盖两个 provider、string/object selector、typed precedence、modern tools 共存、字段缺失与显式空数组。
- 新增 `specs/GH962/` product、tech、task packet。

## Why

HTTP -> core 边界已经保留 legacy function fields，但两个 outbound serializer 会静默丢弃它们；合法请求因此在无错误提示的情况下改变语义。

## Linked Work

- Issue: Fixes #962
- Spec packet: `specs/GH962/`
- `pr_kind: mixed_impl`
- `completion_mode: final`

## Test Plan

- [x] `cargo test --test openai_legacy_function_forwarding --all-features --locked`（4 passed）
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-features --locked`
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --all-features --locked -- --test-threads=1`（20 suites，10,990 passed，0 failed，51 ignored）
- [x] SpecRail packet check、`git diff --check`、scope/overlap guards

并行 full-suite 的前两次运行分别有 2/1 个实时 DNS SSRF 用例失败；同一用例单独运行通过，串行 full-suite 全绿。当前系统 resolver 由本地代理返回 fake IP，因此远端 CI 作为最终并行环境真值。

## Review And Merge Gate

- [ ] current-head independent reviewer verdict
- [ ] current-head CI/check rollup
- [ ] GraphQL review threads clean
- [ ] SpecRail PR gate allowed
- [ ] clean merge state

## Agent Disclosure

- [x] Agent assisted
- [ ] Human author reviewed the full diff
