### PR TITLE
fix(router): apply per-provider retry policy

### DIFF
--- a/specs/GH963/product.md
+++ b/specs/GH963/product.md
@@ -1,0 +1,57 @@
+# Product Spec
+
+## Linked Issue
+
+GH-963 / #963
+
+## 用户问题
+
+网关接受并校验每个 provider 的 `retry.base_delay`、`retry.max_delay`、
+`retry.backoff_multiplier` 和 `retry.jitter`，但 live router 重试仍使用全局固定退避。
+用户以为配置已生效，实际请求延迟和退避节奏却与配置不同，形成声明与执行不一致。
+
+## 目标
+
+- 让每个由 gateway provider 配置创建的 deployment 携带其 retry schedule。
+- 让 unary 请求和首个 chunk 前的 streaming 请求都通过现有 `RetryPolicy` 使用选中 deployment 的 schedule。
+- 用确定性测试证明自定义 base delay、multiplier、cap 和关闭 jitter 后的准确行为。
+- 保持 retry hint、非重试错误、budget fallback、deadline 和已输出 streaming 数据的现有安全语义。
+
+## 非目标
+
+- 不统一或删除 provider 内部 HTTP client 的 retry 配置。
+- 不改变现有 router 总尝试次数或 `ProviderConfig.max_retries` 的 provider-client 语义。
+- 不实现 #964 的 health-check runtime wiring。
+- 不重构 Router、provider factory 或 retry 配置的全部历史类型。
+
+## Behavior Invariants
+
+1. 通过 `GatewayConfig.providers` 创建的每个 deployment 都保留对应 provider 的四个 nested retry 字段，任何字段都不能在 factory/router 边界被静默丢弃。
+2. 选中 deployment 发生可重试错误时，第 1 次 retry 使用 `base_delay`；第 N 次 retry 使用 `base_delay * backoff_multiplier^(N-1)`，结果不得超过 `max_delay`。
+3. `jitter` 表示相对抖动比例；`0.0` 必须产生确定性 delay，非零值只能在未抖动 delay 的 `±jitter` 范围内变化，最终仍受 `max_delay` 硬上限约束。
+4. 上游明确返回 retry-after hint 时，hint 继续优先于配置 schedule。
+5. deployment 没有 provider schedule（例如程序化构造的现有 deployment）时，继续使用现有 `RouterConfig` 全局退避，避免改变 SDK/测试构造行为。
+6. deployment 选择失败、非重试错误、budget/unpriced fallback、deadline 不足，以及 streaming 已输出 chunk 后失败的行为保持不变。
+7. unary 与 streaming 首包前路径必须调用同一个 `RetryPolicy` 决策实现，不允许各自复制 backoff 公式。
+8. 现有配置校验继续拒绝 zero delay、base 大于 max、非正 multiplier 和范围外 jitter。
+
+## 验收标准
+
+- [ ] provider nested retry 配置映射到 deployment runtime schedule。
+- [ ] core router 与 server unary/streaming 的选中 deployment 失败路径都消费该 schedule。
+- [ ] 测试证明自定义 `base_delay=250`、`backoff_multiplier=2`、`max_delay=900` 产生 `250/500/900` 毫秒退避。
+- [ ] 测试证明 `jitter=0` 完全确定，非零 jitter 不突破比例范围和 `max_delay`。
+- [ ] retry-after hint 与现有安全停止条件的测试保持通过。
+- [ ] `cargo fmt --all -- --check`、严格 clippy、全量测试和 SpecRail packet 校验通过。
+
+## 边界情况
+
+- 极大 attempt 不能发生整数溢出或 panic；计算结果必须被 `max_delay` 截断。
+- `backoff_multiplier < 1.0` 按已通过校验的配置执行递减退避。
+- `jitter=1.0` 允许 delay 降到零，但不能超过 `max_delay`。
+- 多 deployment 重试时，每次失败使用实际被选中 deployment 的 schedule。
+
+## 发布说明
+
+这是修复“配置接受但不生效”的行为变更。Gateway YAML 未显式设置 nested retry 时会启用其既有默认值
+（100ms base、5s cap、2x、10% jitter）；程序化构造且未设置 deployment schedule 的调用仍保持旧的全局退避。

--- a/specs/GH963/tasks.md
+++ b/specs/GH963/tasks.md
@@ -1,0 +1,41 @@
+# Task Plan
+
+## Linked Issue
+
+GH-963 / #963
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP963-T1` Owner: coordinator. Dependencies: none. Done when: GH963 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work 与 implement route gate 为 allowed。Verify: `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH963"`; `python3 "$SPEC_RAIL/checks/route_gate.py" --repo "$SPEC_RAIL" --route implement --issue 963 --state ready_to_implement --duplicate-evidence "$EVIDENCE" --json`。
+- [x] `SP963-T2` Owner: runtime-config. Dependencies: T1. Done when: `DeploymentConfig` 可选保存 normalized retry schedule，gateway provider mapping 保留 `base_delay`、`max_delay`、`backoff_multiplier`、`jitter`，程序化 deployment 的默认值保持 global fallback。Verify: focused `gateway_config` 与 `deployment` unit tests。
+- [x] `SP963-T3` Owner: retry-policy. Dependencies: T2. Done when: 唯一 `RetryPolicy` 支持 selected-deployment schedule，公式、jitter、cap、retry-after precedence 与 global fallback 都有确定性测试。Verify: `cargo test core::router::retry_policy --lib --all-features --locked`; `cargo test core::router::execution --lib --all-features --locked`。
+- [x] `SP963-T4` Owner: live-callers. Dependencies: T3. Done when: core router unary/capability 与 server unary/streaming-pre-output 的 selected-deployment failure 调用新 policy；selection error 仍走 global policy。Verify: source scan plus focused router/server execution tests。
+- [x] `SP963-T5` Owner: verification. Dependencies: T2-T4. Done when: mapping、250/500/900 backoff、jitter bounds、global fallback、hint precedence 和现有安全停止条件均通过。Verify: focused tests and fresh full checks。
+- [ ] `SP963-T6` Owner: coordinator. Dependencies: T5. Done when: one mixed implementation PR 使用 `Closes #963`，current-head CI、独立 reviewer、review threads 和 PR gate 全部通过。Verify: SpecRail PR evidence and gate artifacts。
+
+## 并行拆分
+
+T2-T4 共享 `DeploymentConfig`、`RetryPolicy` 与 caller contract，按 W-14 串行执行，避免跨 lane 修改同一 API。
+只读 reviewer 在实现和 focused verification 完成后启动；共享全量验证由 coordinator 独占。
+
+## 验证
+
+- `cargo fmt --all -- --check`
+- `cargo check --all-features --locked`
+- `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- `cargo test core::router --lib --all-features --locked`
+- `cargo test server::routes::ai::execution --lib --all-features --locked`
+- `cargo test --all-features --locked -- --test-threads=1`
+- `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH963"`
+
+## Handoff Notes
+
+- `ProviderConfig.max_retries` 与 provider client retry 不在本 issue 内重构。
+- Provider factory 不拥有 router schedule；消费边在 `gateway_config` → `DeploymentConfig`。
+- `RetrySchedule::None` 是程序化 deployment 的兼容路径，不得默认为 provider YAML schedule。
+- reviewer 必须重点检查所有 selected-deployment call site、retry-after precedence、jitter hard cap 和 streaming 已输出后的禁止 retry。

--- a/specs/GH963/tech.md
+++ b/specs/GH963/tech.md
@@ -1,0 +1,87 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-963 / #963
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Provider config | `src/config/models/provider.rs` | `ProviderConfig.retry` 声明四个 schedule 字段并有默认值 | 用户输入与兼容边界 |
+| Validation | `src/config/validation/config_validators.rs` | 校验 delay、cap、multiplier 和 jitter | 保证 runtime schedule 合法 |
+| Provider factory | `src/core/providers/factory/mod.rs` | 只把 top-level `max_retries` 交给 provider client；nested retry 不属于 provider construction | 不应把 router schedule 塞进每个 provider builder |
+| Gateway mapping | `src/core/router/gateway_config.rs` | provider 变成 deployment，但 `DeploymentConfig` 没有 retry schedule | 声明到执行的缺失边 |
+| Deployment runtime | `src/core/router/deployment.rs` | 只保存 limits、timeout、weight、priority | 需要保存按 deployment 选择的 schedule |
+| Retry engine | `src/core/router/retry_policy.rs`, `src/core/router/execution.rs` | `RetryPolicy` 对 global `RouterConfig` 使用 1s/2x/30s 固定退避 | 唯一 retry 决策和 delay 公式 |
+| Live callers | `src/core/router/execute_impl.rs`, `src/server/routes/ai/execution.rs` | 选中 deployment 后仍把 global router config 传给 policy | unary 与 streaming 的实际消费点 |
+
+## 设计方案
+
+1. 在 `deployment.rs` 增加小型 runtime value object `RetrySchedule`，字段使用明确单位：
+   `base_delay_ms`、`max_delay_ms`、`backoff_multiplier`、`jitter_ratio`。
+   `DeploymentConfig.retry_schedule` 使用 `Option<RetrySchedule>`；`None` 表示保持旧的 global fallback。
+2. 在 `gateway_config.rs` 提取纯映射 helper，把 `ProviderConfig.max_retries` 之外的 nested retry
+   schedule 写入每个 deployment。Provider factory 继续只负责 provider construction，不复制 router retry 逻辑。
+3. 在 `execution.rs` 增加 schedule delay 计算：
+   - exponent 使用 retry attempt 的饱和减法；
+   - 先计算指数退避，再应用对称 jitter，最后用 `max_delay_ms` 硬截断；
+   - production helper 从 `rand` 取得 `[-1, 1]` sample；内部纯函数接受显式 sample 供测试使用；
+   - 现有 `calculate_retry_delay(&RouterConfig, ...)` 保留，作为无 deployment schedule 时的兼容路径。
+4. 在 `RetryPolicy` 增加 `decide_for_deployment`，与现有 `decide` 共用一个私有决策核心。
+   retry-after hint 仍优先；只有缺少 hint 时才选择 deployment schedule 或 global fallback。
+5. 只替换“已经选中 deployment 且 operation 返回错误”的四类调用：core unary/capability 和 server
+   unary/streaming-pre-output。选择 deployment 之前的 router 错误仍用 global policy。
+6. 不改变外层 `num_retries`/`max_attempts`。本 issue 修复 nested schedule 的执行，不混入 provider-client
+   retry 次数与 router retry budget 的架构收敛。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 config 不丢失 | `gateway_config.rs`, `deployment.rs` | pure mapping test asserts all four fields |
+| P2/P3 formula + jitter/cap | `execution.rs` | deterministic sample tests for 250/500/900 and jitter bounds |
+| P4 retry hint precedence | `retry_policy.rs` | existing retry-after test plus deployment schedule regression |
+| P5 compatibility fallback | `retry_policy.rs`, `DeploymentConfig::default` | `None` schedule matches existing global delay |
+| P6 safety stops unchanged | existing retry policy/route tests | focused router and server execution suites |
+| P7 one policy | `retry_policy.rs`, four live call sites | source inspection + selected-deployment regression tests |
+| P8 validation unchanged | `config_validators.rs` | existing retry validation suite |
+
+## 数据流
+
+`gateway.yaml ProviderConfig.retry` → validation → `gateway_config` mapping →
+`DeploymentConfig.retry_schedule` → selected deployment failure → `RetryPolicy::decide_for_deployment` →
+retry-after hint or computed `Duration` → existing `tokio::time::sleep`.
+
+没有新增持久化、网络 API 或外部数据格式。Machine-facing YAML keys 保持不变。
+
+## 备选方案
+
+- 把第一个 provider 的 retry 写入 global `RouterConfig`：多 provider 配置会互相覆盖，拒绝。
+- 把 nested retry 传进所有 provider builder：会形成 provider 内部 retry 与 router retry 的重复执行，拒绝。
+- 直接复用 `config/models/retry.rs::RetryConfig`：其字段语义（bool jitter、retryable error list、内含 max retries）
+  与现有 provider YAML 不同，会扩大兼容面，拒绝本 issue 内合并。
+- 为 unary/streaming 各写一套 backoff：违反唯一 policy，拒绝。
+
+## 风险
+
+- Security: 无新增输入面；继续依赖现有严格配置校验。
+- Compatibility: gateway-config deployment 的默认 retry delay 从旧 global 1s/2x/30s 转为已声明的 100ms/2x/5s/10% jitter；这是预期修复。程序化 deployment 保持旧行为。
+- Performance: 每次实际 retry 增加一次轻量随机采样；无 retry 时无额外 I/O。
+- Maintenance: 新 runtime value object 只表达 normalized schedule，公式仍唯一存在于 router execution/policy。
+
+## 测试计划
+
+- [ ] Unit tests: provider-to-deployment mapping、指数公式、cap、jitter sample、global fallback、hint precedence。
+- [ ] Integration tests: core router 与 server selected-deployment retry helper 使用自定义 schedule。
+- [ ] Manual verification: `rg` 确认四个 selected-deployment failure call site 使用 `decide_for_deployment`，selection-error call site 保留 `decide`。
+- [ ] Deterministic checks: `cargo fmt --all -- --check`; `cargo check --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked`。
+
+## 回滚方案
+
+回滚 GH963 PR 即恢复 global retry delay。没有 schema 或数据迁移；移除 `retry_schedule` 与新 policy overload 后，
+现有 `RetryPolicy::decide` 和 global `RouterConfig` 兼容路径仍在。

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -87,6 +87,10 @@ pub fn default_backoff_multiplier() -> f64 {
     2.0
 }
 
+pub fn default_retry_jitter() -> f64 {
+    0.1
+}
+
 pub fn default_max_connections() -> u32 {
     10
 }

--- a/src/config/models/provider.rs
+++ b/src/config/models/provider.rs
@@ -126,7 +126,7 @@ pub struct RetryConfig {
     #[serde(default = "default_backoff_multiplier")]
     pub backoff_multiplier: f64,
     /// Jitter factor (0.0 to 1.0)
-    #[serde(default)]
+    #[serde(default = "default_retry_jitter")]
     pub jitter: f64,
 }
 
@@ -136,7 +136,7 @@ impl Default for RetryConfig {
             base_delay: default_base_delay(),
             max_delay: default_max_delay(),
             backoff_multiplier: default_backoff_multiplier(),
-            jitter: 0.1,
+            jitter: default_retry_jitter(),
         }
     }
 }
@@ -220,6 +220,18 @@ mod tests {
         let config: RetryConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.base_delay, 1500);
         assert!((config.backoff_multiplier - 2.5).abs() < f64::EPSILON);
+        assert!((config.jitter - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_partial_yaml_retry_config_preserves_jitter_default() {
+        let config: RetryConfig = serde_yml::from_str("base_delay: 250\nmax_delay: 900\n")
+            .expect("partial retry YAML should deserialize");
+
+        assert_eq!(config.base_delay, 250);
+        assert_eq!(config.max_delay, 900);
+        assert!((config.backoff_multiplier - 2.0).abs() < f64::EPSILON);
+        assert!((config.jitter - 0.1).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -240,12 +240,19 @@ impl Validate for RetryConfig {
             return Err("Retry base delay cannot be greater than max delay".to_string());
         }
 
+        if !self.backoff_multiplier.is_finite() {
+            return Err("Retry backoff multiplier must be finite".to_string());
+        }
+
         if self.backoff_multiplier <= 0.0 {
             return Err("Retry backoff multiplier must be greater than 0".to_string());
         }
 
-        // Validate jitter is between 0.0 and 1.0
-        if self.jitter < 0.0 || self.jitter > 1.0 {
+        if !self.jitter.is_finite() {
+            return Err("Retry jitter must be finite".to_string());
+        }
+
+        if !(0.0..=1.0).contains(&self.jitter) {
             return Err("Retry jitter must be between 0.0 and 1.0".to_string());
         }
 

--- a/src/config/validation/router_validators.rs
+++ b/src/config/validation/router_validators.rs
@@ -257,6 +257,46 @@ mod tests {
         assert!(validate_config(&config).is_ok());
     }
 
+    #[test]
+    fn test_retry_backoff_multiplier_nan() {
+        let mut config = create_valid_retry_config();
+        config.backoff_multiplier = f64::NAN;
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be finite"));
+    }
+
+    #[test]
+    fn test_retry_backoff_multiplier_infinite() {
+        let mut config = create_valid_retry_config();
+        config.backoff_multiplier = f64::INFINITY;
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be finite"));
+    }
+
+    #[test]
+    fn test_retry_jitter_nan() {
+        let mut config = create_valid_retry_config();
+        config.jitter = f64::NAN;
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be finite"));
+    }
+
+    #[test]
+    fn test_retry_jitter_out_of_range() {
+        let mut config = create_valid_retry_config();
+        config.jitter = 1.1;
+
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("between 0.0 and 1.0"));
+    }
+
     // ==================== RouterConfig Validation Tests ====================
 
     #[test]

--- a/src/core/router/deployment.rs
+++ b/src/core/router/deployment.rs
@@ -29,6 +29,22 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Deployment identifier (unique within router)
 pub type DeploymentId = String;
 
+/// Normalized retry timing for a gateway-configured deployment.
+///
+/// Retry eligibility and retry-after precedence remain owned by `RetryPolicy`;
+/// this value only carries the provider-specific fallback schedule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetrySchedule {
+    /// Delay before the first retry, in milliseconds.
+    pub base_delay_ms: u64,
+    /// Hard upper bound for any configured retry delay, in milliseconds.
+    pub max_delay_ms: u64,
+    /// Exponential multiplier applied for each subsequent retry.
+    pub backoff_multiplier: f64,
+    /// Symmetric jitter ratio in the inclusive range `0.0..=1.0`.
+    pub jitter_ratio: f64,
+}
+
 /// Health status enumeration for deployments
 ///
 /// Maps to AtomicU8 values for lock-free updates:
@@ -88,6 +104,9 @@ pub struct DeploymentConfig {
 
     /// Priority (lower value = higher priority)
     pub priority: u32,
+
+    /// Provider-specific retry schedule, or `None` to use router defaults.
+    pub retry_schedule: Option<RetrySchedule>,
 }
 
 impl Default for DeploymentConfig {
@@ -99,6 +118,7 @@ impl Default for DeploymentConfig {
             weight: 1,
             timeout_secs: 60,
             priority: 0,
+            retry_schedule: None,
         }
     }
 }
@@ -498,6 +518,7 @@ mod tests {
             weight: 2,
             timeout_secs: 120,
             priority: 1,
+            retry_schedule: None,
         };
         assert_eq!(config.tpm_limit, Some(100_000));
         assert_eq!(config.rpm_limit, Some(500));

--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -137,8 +137,9 @@ impl Router {
                         continue;
                     }
 
-                    let retry_decision = RetryPolicy.decide(
+                    let retry_decision = RetryPolicy.decide_for_deployment(
                         &self.config,
+                        &selected_deployment.config,
                         &err,
                         RetryContext::unary(attempt, max_attempts),
                     );
@@ -255,8 +256,9 @@ impl Router {
                         continue;
                     }
 
-                    let retry_decision = RetryPolicy.decide(
+                    let retry_decision = RetryPolicy.decide_for_deployment(
                         &self.config,
+                        &selected_deployment.config,
                         &err,
                         RetryContext::unary(attempt, max_attempts),
                     );

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -4,10 +4,11 @@
 //! with retry and fallback support.
 
 use super::config::RouterConfig;
-use super::deployment::DeploymentId;
+use super::deployment::{DeploymentId, RetrySchedule};
 use super::error::{CooldownReason, RouterError};
 use super::fallback::{ExecutionResult, FallbackType};
 use crate::core::providers::unified_provider::ProviderError;
+use rand::Rng;
 use std::time::Duration;
 
 /// Check if an error is retryable
@@ -52,6 +53,45 @@ pub fn calculate_retry_delay(config: &RouterConfig, attempt: u32) -> Duration {
     let base = config.retry_after_secs.max(1);
     let delay = base * (2_u64.pow(attempt.saturating_sub(1)));
     Duration::from_secs(delay.min(30)) // Cap at 30 seconds
+}
+
+/// Calculate retry delay from a deployment-specific schedule.
+pub(crate) fn calculate_retry_delay_for_schedule(
+    schedule: &RetrySchedule,
+    attempt: u32,
+) -> Duration {
+    let jitter_sample = if schedule.jitter_ratio == 0.0 {
+        0.0
+    } else {
+        rand::rng().random_range(-1.0..=1.0)
+    };
+
+    calculate_retry_delay_for_schedule_with_sample(schedule, attempt, jitter_sample)
+}
+
+fn calculate_retry_delay_for_schedule_with_sample(
+    schedule: &RetrySchedule,
+    attempt: u32,
+    jitter_sample: f64,
+) -> Duration {
+    let jitter_multiplier = 1.0 + schedule.jitter_ratio * jitter_sample.clamp(-1.0, 1.0);
+    if jitter_multiplier <= 0.0 {
+        return Duration::ZERO;
+    }
+
+    let exponent = f64::from(attempt.saturating_sub(1));
+    let base_delay = schedule.base_delay_ms as f64 * schedule.backoff_multiplier.powf(exponent);
+    let delay_ms = base_delay * jitter_multiplier;
+    let max_delay = Duration::from_millis(schedule.max_delay_ms);
+
+    if !delay_ms.is_finite() || delay_ms >= schedule.max_delay_ms as f64 {
+        return max_delay;
+    }
+    if delay_ms <= 0.0 {
+        return Duration::ZERO;
+    }
+
+    Duration::from_secs_f64(delay_ms / 1_000.0).min(max_delay)
 }
 
 /// Infer fallback type from a ProviderError
@@ -164,5 +204,135 @@ pub fn build_execution_result<T>(
         model_used,
         used_fallback,
         latency_us,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schedule(jitter_ratio: f64) -> RetrySchedule {
+        RetrySchedule {
+            base_delay_ms: 250,
+            max_delay_ms: 900,
+            backoff_multiplier: 2.0,
+            jitter_ratio,
+        }
+    }
+
+    #[test]
+    fn deployment_retry_schedule_applies_backoff_and_cap() {
+        let schedule = schedule(0.0);
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, 1),
+            Duration::from_millis(250)
+        );
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, 2),
+            Duration::from_millis(500)
+        );
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, 3),
+            Duration::from_millis(900)
+        );
+    }
+
+    #[test]
+    fn deployment_retry_schedule_bounds_jitter_before_hard_cap() {
+        let schedule = RetrySchedule {
+            base_delay_ms: 1_000,
+            max_delay_ms: 1_100,
+            backoff_multiplier: 1.0,
+            jitter_ratio: 0.2,
+        };
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule_with_sample(&schedule, 1, -1.0),
+            Duration::from_millis(800)
+        );
+        assert_eq!(
+            calculate_retry_delay_for_schedule_with_sample(&schedule, 1, 1.0),
+            Duration::from_millis(1_100)
+        );
+    }
+
+    #[test]
+    fn deployment_retry_schedule_saturates_large_attempts() {
+        let schedule = schedule(0.0);
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, u32::MAX),
+            Duration::from_millis(900)
+        );
+    }
+
+    #[test]
+    fn deployment_retry_schedule_keeps_exact_integer_cap_after_float_conversion() {
+        let max_delay_ms = 9_007_199_254_740_995;
+        let schedule = RetrySchedule {
+            base_delay_ms: max_delay_ms,
+            max_delay_ms,
+            backoff_multiplier: 1.0,
+            jitter_ratio: 0.0,
+        };
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, 1),
+            Duration::from_millis(max_delay_ms)
+        );
+    }
+
+    #[test]
+    fn deployment_retry_schedule_preserves_fractional_backoff() {
+        let schedule = RetrySchedule {
+            base_delay_ms: 1,
+            max_delay_ms: 10,
+            backoff_multiplier: 0.5,
+            jitter_ratio: 0.0,
+        };
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, 2),
+            Duration::from_micros(500)
+        );
+        assert_eq!(
+            calculate_retry_delay_for_schedule(&schedule, 3),
+            Duration::from_micros(250)
+        );
+    }
+
+    #[test]
+    fn deployment_retry_schedule_preserves_fractional_jitter_bounds() {
+        let schedule = RetrySchedule {
+            base_delay_ms: 3,
+            max_delay_ms: 10,
+            backoff_multiplier: 1.0,
+            jitter_ratio: 0.2,
+        };
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule_with_sample(&schedule, 1, -1.0),
+            Duration::from_micros(2_400)
+        );
+        assert_eq!(
+            calculate_retry_delay_for_schedule_with_sample(&schedule, 1, 1.0),
+            Duration::from_micros(3_600)
+        );
+    }
+
+    #[test]
+    fn deployment_retry_schedule_zero_jitter_endpoint_wins_before_overflow() {
+        let schedule = RetrySchedule {
+            base_delay_ms: 250,
+            max_delay_ms: 900,
+            backoff_multiplier: 2.0,
+            jitter_ratio: 1.0,
+        };
+
+        assert_eq!(
+            calculate_retry_delay_for_schedule_with_sample(&schedule, u32::MAX, -1.0),
+            Duration::ZERO
+        );
     }
 }

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -4,7 +4,7 @@
 //! a Router from gateway configuration.
 
 use super::config::RouterConfig;
-use super::deployment::{Deployment, DeploymentConfig};
+use super::deployment::{Deployment, DeploymentConfig, RetrySchedule};
 use super::error::RouterError;
 use super::unified::Router;
 use crate::config::Validate;
@@ -103,7 +103,20 @@ fn create_deployment_from_config(
     model: &str,
     config: &ProviderConfig,
 ) -> Deployment {
-    let deployment_config = DeploymentConfig {
+    let deployment_config = deployment_config_from_provider(config);
+
+    Deployment::new(
+        deployment_id.to_string(),
+        provider,
+        model.to_string(),
+        model.to_string(),
+    )
+    .with_config(deployment_config)
+    .with_tags(config.tags.clone())
+}
+
+fn deployment_config_from_provider(config: &ProviderConfig) -> DeploymentConfig {
+    DeploymentConfig {
         tpm_limit: if config.tpm > 0 {
             Some(config.tpm as u64)
         } else {
@@ -122,21 +135,19 @@ fn create_deployment_from_config(
         weight: (config.weight.max(1.0)).round() as u32,
         timeout_secs: config.timeout,
         priority: 0,
-    };
-
-    Deployment::new(
-        deployment_id.to_string(),
-        provider,
-        model.to_string(),
-        model.to_string(),
-    )
-    .with_config(deployment_config)
-    .with_tags(config.tags.clone())
+        retry_schedule: Some(RetrySchedule {
+            base_delay_ms: config.retry.base_delay,
+            max_delay_ms: config.retry.max_delay,
+            backoff_multiplier: config.retry.backoff_multiplier,
+            jitter_ratio: config.retry.jitter,
+        }),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::models::provider::RetryConfig as ProviderRetryConfig;
     use crate::config::models::router::{
         CircuitBreakerConfig, GatewayRouterConfig, LoadBalancerConfig, RoutingStrategyConfig,
     };
@@ -212,5 +223,28 @@ mod tests {
 
         let err = runtime_router_config_from_gateway(&gateway).unwrap_err();
         assert!(err.contains("session_timeout"));
+    }
+
+    #[test]
+    fn test_provider_retry_schedule_maps_to_deployment_config() {
+        let provider = ProviderConfig {
+            retry: ProviderRetryConfig {
+                base_delay: 250,
+                max_delay: 900,
+                backoff_multiplier: 2.0,
+                jitter: 0.0,
+            },
+            ..ProviderConfig::default()
+        };
+
+        let deployment = deployment_config_from_provider(&provider);
+        let retry = deployment
+            .retry_schedule
+            .expect("gateway provider retry schedule should be preserved");
+
+        assert_eq!(retry.base_delay_ms, 250);
+        assert_eq!(retry.max_delay_ms, 900);
+        assert!((retry.backoff_multiplier - 2.0).abs() < f64::EPSILON);
+        assert!((retry.jitter_ratio - 0.0).abs() < f64::EPSILON);
     }
 }

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -36,7 +36,9 @@ pub mod unified;
 mod tests;
 
 // Re-exports from deployment module
-pub use deployment::{Deployment, DeploymentConfig, DeploymentId, DeploymentState, HealthStatus};
+pub use deployment::{
+    Deployment, DeploymentConfig, DeploymentId, DeploymentState, HealthStatus, RetrySchedule,
+};
 
 // Re-exports from new modular router (UnifiedRouter)
 pub use budget_routing::{BudgetAwareRouter, BudgetAwareRouting, RequestBudgetCheck};

--- a/src/core/router/retry_policy.rs
+++ b/src/core/router/retry_policy.rs
@@ -1,7 +1,8 @@
 //! Contextual retry policy for router execution.
 
 use super::config::RouterConfig;
-use super::execution::calculate_retry_delay;
+use super::deployment::DeploymentConfig;
+use super::execution::{calculate_retry_delay, calculate_retry_delay_for_schedule};
 use crate::core::providers::ProviderError;
 use crate::core::providers::failure::{ProviderFailureFacts, ProviderFailureKind};
 use std::time::Duration;
@@ -137,6 +138,36 @@ impl RetryPolicy {
         error: &ProviderError,
         context: RetryContext,
     ) -> RetryDecision {
+        self.decide_with_fallback_delay(error, context, || {
+            calculate_retry_delay(config, context.attempt)
+        })
+    }
+
+    pub fn decide_for_deployment(
+        &self,
+        router_config: &RouterConfig,
+        deployment_config: &DeploymentConfig,
+        error: &ProviderError,
+        context: RetryContext,
+    ) -> RetryDecision {
+        self.decide_with_fallback_delay(error, context, || {
+            deployment_config
+                .retry_schedule
+                .as_ref()
+                .map(|schedule| calculate_retry_delay_for_schedule(schedule, context.attempt))
+                .unwrap_or_else(|| calculate_retry_delay(router_config, context.attempt))
+        })
+    }
+
+    fn decide_with_fallback_delay<F>(
+        &self,
+        error: &ProviderError,
+        context: RetryContext,
+        fallback_delay: F,
+    ) -> RetryDecision
+    where
+        F: FnOnce() -> Duration,
+    {
         let facts = ProviderFailureFacts::from_error(error);
 
         if context.attempt >= context.max_attempts {
@@ -159,10 +190,7 @@ impl RetryPolicy {
             return RetryDecision::stop(RetryDecisionReason::NonRetryableFailure);
         }
 
-        let delay = facts
-            .retry_hint
-            .retry_after
-            .unwrap_or_else(|| calculate_retry_delay(config, context.attempt));
+        let delay = facts.retry_hint.retry_after.unwrap_or_else(fallback_delay);
 
         if let Some(deadline_remaining) = context.deadline_remaining
             && delay > deadline_remaining
@@ -195,6 +223,80 @@ fn failure_is_retryable(facts: ProviderFailureFacts, context: RetryContext) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::router::deployment::RetrySchedule;
+
+    fn deployment_config_with_schedule() -> DeploymentConfig {
+        DeploymentConfig {
+            retry_schedule: Some(RetrySchedule {
+                base_delay_ms: 250,
+                max_delay_ms: 900,
+                backoff_multiplier: 2.0,
+                jitter_ratio: 0.0,
+            }),
+            ..DeploymentConfig::default()
+        }
+    }
+
+    #[test]
+    fn deployment_schedule_controls_retry_delay() {
+        let error = ProviderError::rate_limit("openai", None);
+        let deployment = deployment_config_with_schedule();
+
+        let first = RetryPolicy.decide_for_deployment(
+            &RouterConfig::default(),
+            &deployment,
+            &error,
+            RetryContext::unary(1, 4),
+        );
+        let second = RetryPolicy.decide_for_deployment(
+            &RouterConfig::default(),
+            &deployment,
+            &error,
+            RetryContext::unary(2, 4),
+        );
+        let capped = RetryPolicy.decide_for_deployment(
+            &RouterConfig::default(),
+            &deployment,
+            &error,
+            RetryContext::unary(3, 4),
+        );
+
+        assert_eq!(first.delay, Some(Duration::from_millis(250)));
+        assert_eq!(second.delay, Some(Duration::from_millis(500)));
+        assert_eq!(capped.delay, Some(Duration::from_millis(900)));
+    }
+
+    #[test]
+    fn deployment_without_schedule_uses_router_delay() {
+        let router = RouterConfig {
+            retry_after_secs: 5,
+            ..RouterConfig::default()
+        };
+        let error = ProviderError::rate_limit("openai", None);
+
+        let decision = RetryPolicy.decide_for_deployment(
+            &router,
+            &DeploymentConfig::default(),
+            &error,
+            RetryContext::unary(1, 2),
+        );
+
+        assert_eq!(decision.delay, Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn retry_after_hint_overrides_deployment_schedule() {
+        let error = ProviderError::rate_limit("openai", Some(60));
+
+        let decision = RetryPolicy.decide_for_deployment(
+            &RouterConfig::default(),
+            &deployment_config_with_schedule(),
+            &error,
+            RetryContext::unary(1, 2),
+        );
+
+        assert_eq!(decision.delay, Some(Duration::from_secs(60)));
+    }
 
     #[test]
     fn streaming_error_after_emitted_chunks_is_not_retried() {

--- a/src/core/router/tests/execution_tests.rs
+++ b/src/core/router/tests/execution_tests.rs
@@ -4,6 +4,7 @@
 
 use super::router_tests::create_test_deployment;
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::router::RetrySchedule;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::error::RouterError;
 use crate::core::router::execution::is_retryable_error;
@@ -195,6 +196,89 @@ async fn test_execute_with_retry_success_second_attempt() {
     assert!(result.is_ok());
     let (_value, _deployment_id, attempts, _latency) = result.unwrap();
     assert_eq!(attempts, 2);
+}
+
+fn one_millisecond_retry_schedule() -> RetrySchedule {
+    RetrySchedule {
+        base_delay_ms: 1,
+        max_delay_ms: 1,
+        backoff_multiplier: 2.0,
+        jitter_ratio: 0.0,
+    }
+}
+
+#[tokio::test]
+async fn test_execute_with_retry_uses_selected_deployment_schedule() {
+    let router = Router::new(RouterConfig {
+        num_retries: 1,
+        retry_after_secs: 30,
+        ..Default::default()
+    });
+    let mut deployment = create_test_deployment("scheduled-retry", "gpt-4").await;
+    deployment.config.retry_schedule = Some(one_millisecond_retry_schedule());
+    router.add_deployment(deployment);
+    let attempts = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let execution = router.execute_with_selected_deployment_retry("gpt-4", {
+        let attempts = attempts.clone();
+        move |_deployment| {
+            let attempts = attempts.clone();
+            async move {
+                if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(ProviderError::timeout("test", "first attempt"))
+                } else {
+                    Ok(("success", 0))
+                }
+            }
+        }
+    });
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(1), execution)
+        .await
+        .expect("deployment schedule should replace the 30-second router delay")
+        .expect("second attempt should succeed");
+
+    assert_eq!(result.0, "success");
+    assert_eq!(result.2, 2);
+}
+
+#[tokio::test]
+async fn test_execute_with_capability_retry_uses_selected_deployment_schedule() {
+    let router = Router::new(RouterConfig {
+        num_retries: 1,
+        retry_after_secs: 30,
+        ..Default::default()
+    });
+    let mut deployment = create_test_deployment("scheduled-capability-retry", "gpt-4").await;
+    deployment.config.retry_schedule = Some(one_millisecond_retry_schedule());
+    router.add_deployment(deployment);
+    let attempts = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let execution = router.execute_with_selected_deployment_capability_retry(
+        "gpt-4",
+        &ProviderCapability::ChatCompletion,
+        {
+            let attempts = attempts.clone();
+            move |_deployment| {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                        Err(ProviderError::timeout("test", "first attempt"))
+                    } else {
+                        Ok(("success", 0))
+                    }
+                }
+            }
+        },
+    );
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(1), execution)
+        .await
+        .expect("deployment schedule should replace the 30-second router delay")
+        .expect("second attempt should succeed");
+
+    assert_eq!(result.0, "success");
+    assert_eq!(result.2, 2);
 }
 
 #[tokio::test]

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -10,10 +10,8 @@ use std::sync::Arc;
 #[cfg(test)]
 use std::time::Duration;
 use std::time::Instant;
-
 #[path = "execution_observability.rs"]
 pub(super) mod observability;
-
 pub(super) struct StreamingDeploymentLease {
     router: Arc<UnifiedRouter>,
     deployment: Arc<Deployment>,
@@ -137,8 +135,9 @@ where
                     continue;
                 }
 
-                let retry_decision = RetryPolicy.decide(
+                let retry_decision = RetryPolicy.decide_for_deployment(
                     router.config(),
+                    &deployment_lease.deployment().config,
                     &err,
                     RetryContext::unary(attempt, max_attempts),
                 );
@@ -272,8 +271,9 @@ where
                     continue;
                 }
 
-                let retry_decision = RetryPolicy.decide(
+                let retry_decision = RetryPolicy.decide_for_deployment(
                     router.config(),
+                    &deployment_lease.deployment().config,
                     &err,
                     RetryContext::stream_pre_output(attempt, max_attempts),
                 );

--- a/src/server/routes/ai/execution_retry_delay_tests.rs
+++ b/src/server/routes/ai/execution_retry_delay_tests.rs
@@ -2,8 +2,11 @@ use super::*;
 use crate::core::providers::Provider;
 use crate::core::providers::openai::OpenAIProvider;
 use crate::core::router::config::RouterConfig;
-use crate::core::router::{Deployment, DeploymentConfig, UnifiedRouter, UnifiedRoutingStrategy};
+use crate::core::router::{
+    Deployment, DeploymentConfig, RetrySchedule, UnifiedRouter, UnifiedRoutingStrategy,
+};
 use crate::core::types::model::ProviderCapability;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[test]
@@ -24,6 +27,106 @@ fn budget_retry_fallbacks_skip_retry_delay() {
         retry_delay_for_error(&config, 1, &rate_limit),
         Some(std::time::Duration::from_secs(60))
     );
+}
+
+async fn build_selected_retry_schedule_router() -> UnifiedRouter {
+    let router = UnifiedRouter::new(RouterConfig {
+        num_retries: 1,
+        retry_after_secs: 30,
+        ..Default::default()
+    });
+    let provider = Provider::OpenAI(
+        OpenAIProvider::with_api_key("sk-test-key")
+            .await
+            .expect("test provider should build"),
+    );
+
+    router.add_deployment(
+        Deployment::new(
+            "scheduled-retry".to_string(),
+            provider,
+            "gpt-4o-mini".to_string(),
+            "shared-model".to_string(),
+        )
+        .with_config(DeploymentConfig {
+            retry_schedule: Some(RetrySchedule {
+                base_delay_ms: 1,
+                max_delay_ms: 1,
+                backoff_multiplier: 2.0,
+                jitter_ratio: 0.0,
+            }),
+            ..Default::default()
+        }),
+    );
+
+    router
+}
+
+#[tokio::test]
+async fn selected_unary_retry_uses_deployment_schedule() {
+    let router = build_selected_retry_schedule_router().await;
+    let attempts = Arc::new(AtomicU32::new(0));
+
+    let execution = execute_with_selected_deployment(
+        &router,
+        "shared-model",
+        ProviderCapability::ChatCompletion,
+        {
+            let attempts = attempts.clone();
+            move |_provider, model, _deployment_id| {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                        Err(ProviderError::timeout("test", "first attempt"))
+                    } else {
+                        Ok((model, 0))
+                    }
+                }
+            }
+        },
+    );
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(1), execution)
+        .await
+        .expect("deployment schedule should replace the 30-second router delay")
+        .expect("second attempt should succeed");
+
+    assert_eq!(result, "gpt-4o-mini");
+    assert_eq!(attempts.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn selected_stream_retry_uses_deployment_schedule() {
+    let router = Arc::new(build_selected_retry_schedule_router().await);
+    let attempts = Arc::new(AtomicU32::new(0));
+
+    let execution = execute_stream_with_selected_deployment(
+        router,
+        "shared-model",
+        ProviderCapability::ChatCompletionStream,
+        {
+            let attempts = attempts.clone();
+            move |_provider, model, _deployment_id| {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                        Err(ProviderError::timeout("test", "first attempt"))
+                    } else {
+                        Ok(model)
+                    }
+                }
+            }
+        },
+    );
+
+    let (model, lease) = tokio::time::timeout(std::time::Duration::from_secs(1), execution)
+        .await
+        .expect("deployment schedule should replace the 30-second router delay")
+        .expect("second attempt should succeed");
+
+    assert_eq!(model, "gpt-4o-mini");
+    assert_eq!(attempts.load(Ordering::Relaxed), 2);
+    lease.finish_success(0);
 }
 
 async fn build_same_provider_budget_fallback_router(num_retries: u32) -> UnifiedRouter {


### PR DESCRIPTION
## What

- carry validated provider retry schedules into runtime deployments
- apply the selected deployment schedule through the shared retry policy for core and server unary/streaming paths
- preserve retry-after precedence and global fallback for programmatic deployments
- reject non-finite retry multipliers and jitter, with fractional and overflow edge coverage
- add the SpecRail GH963 product, technical, and task packet

## Why

Provider retry timing was accepted and validated but dropped before runtime, so configured backoff and jitter never affected router retries.

Closes #963

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-features --locked`
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test retry_schedule --lib --all-features --locked` (8 passed)
- [x] retry validation tests (14 passed)
- [x] `cargo test --all-features --locked -- --test-threads=1` (main library: 10,242 passed; all integration and doctest suites passed)
- [x] SpecRail packet validation
- [x] independent current-head review: no blocking findings