### PR TITLE
fix(router): honor provider health check config

### DIFF
--- a/specs/GH964/product.md
+++ b/specs/GH964/product.md
@@ -1,0 +1,78 @@
+# Product Spec
+
+## Linked Issue
+
+GH-964 / #964
+
+## 用户问题
+
+网关接受并校验每个 provider 的 `health_check.interval`、`failure_threshold`、
+`recovery_timeout`、`endpoint` 和 `expected_codes`，但 live router 不调度这些检查，
+也不根据结果更新 deployment 健康状态。用户配置看似有效，实际路由行为完全不变。
+
+## 目标
+
+- 让 gateway provider 配置创建的 deployment 参与真实、持续的健康探测。
+- 让五个公开字段都具有明确、可测试的运行时或拒绝语义。
+- 让探测结果直接影响 live router 的 deployment 可选状态。
+- 保持 provider-native health check、请求失败 circuit breaker 与程序化 Router 的兼容边界。
+
+## 非目标
+
+- 不接入当前使用随机模拟结果的 `core::health::HealthMonitor`。
+- 不重写各 provider 已有的 native `health_check()` 实现。
+- 不为自定义 health endpoint 推断或注入 provider 密钥、签名或私有请求头。
+- 不实现 gateway 配置热重载后的动态 probe 重建。
+- 不改变请求错误触发的全局 circuit-breaker 阈值与 cooldown 配置。
+
+## Behavior Invariants
+
+1. 当全局 `router.load_balancer.health_check_enabled=true` 且 provider health 配置偏离 schema
+   默认值时，该 `ProviderConfig` 必须启动一个 live probe loop；任一公开 health 字段 override
+   都会激活 policy。同一 provider 的多个 model deployment 共享一次 probe 结果，不得重复发起
+   每模型探测。完全默认的 health 配置保持既有无主动流量行为。
+2. probe loop 启动后立即执行首次检查，之后按该 provider 的 `interval` 秒调度；关闭全局
+   health check 时不得启动后台 probe。
+3. active policy 的 `endpoint=None` 时必须调用该 provider 现有的 native `health_check()`；完全
+   默认的 gateway health 配置以及程序化构造且没有 provider health policy 的 deployment 不得自动
+   启动 probe。
+4. 配置 `endpoint` 时，绝对 URL 或基于显式 `base_url` 解析出的相对 path 必须执行无认证
+   HTTP GET；只有响应状态位于 `expected_codes` 时才算成功。相对 endpoint 缺少 `base_url`、
+   不安全 URL、空 endpoint 或非法 status code 必须在配置校验阶段拒绝。
+5. 未配置 `endpoint` 时只允许默认 `expected_codes=[200]`；自定义 expected codes 必须同时
+   配置 endpoint，避免接受后忽略。partial `health_check:` 配置省略 expected codes 时仍默认为
+   `[200]`。
+6. 连续失败数小于 `failure_threshold` 时，相关 deployment 变为 `Degraded`；达到阈值时变为
+   `Unhealthy` 并从路由选择中排除。一次成功 probe 必须清零连续失败计数。
+7. deployment 达到失败阈值后，下一次 probe 必须等待 `recovery_timeout` 秒；恢复窗口后的成功
+   probe 将其恢复为 `Healthy`，失败则保持 `Unhealthy` 并再次等待恢复窗口。
+8. health probe 不得覆盖仍有效的请求级 `Cooldown`。并发中的请求失败也不得把 probe 已标记的
+   `Unhealthy` deployment 降级回可路由的 `Degraded`。
+9. provider probe task 必须随 Router drop 被取消；probe 错误不得 panic、泄漏密钥或静默停止
+   整个 loop。
+10. provider 配置在进入 runtime mapping 前必须再次通过现有 `Validate` 契约，直接调用
+    `Router::from_gateway_config` 也不能绕过字段校验。
+
+## 验收标准
+
+- [ ] 五个 per-provider health-check 字段均有 live consumer 或显式拒绝规则。
+- [ ] 自定义 interval/threshold/recovery 改变 probe 调度和 deployment 状态迁移。
+- [ ] provider-native 与自定义 endpoint 两条 probe 路径都有确定性测试。
+- [ ] 多模型 provider 只运行一个 probe，结果同步到其全部 deployment。
+- [ ] 全局关闭、程序化 deployment、active cooldown 与 Router drop 的兼容行为有测试。
+- [ ] 格式、严格 clippy、全量测试与 SpecRail packet 校验通过。
+
+## 边界情况
+
+- `failure_threshold=1` 时首次失败立即标记 `Unhealthy`。
+- `expected_codes` 可以包含多个不同的合法 HTTP 状态，但不得为空、重复或超出 `100..=599`。
+- endpoint 返回非预期状态、连接失败或超过 deployment timeout 都按一次失败处理。
+- provider-native 返回 `Degraded`、`Unhealthy` 或 `Unknown` 都按失败处理。
+- probe 执行时间不计入 interval；下一次延迟从本次结果处理完成后开始。
+
+## 发布说明
+
+这是修复“自定义配置接受但不生效”的行为变更。默认开启 health check 且 provider 配置了任一
+health override 的 gateway 会开始主动探测；完全默认配置不新增上游流量。自定义 endpoint 是
+无认证 GET，需认证的 provider 应保留 `endpoint=None` 并通过 interval/threshold/recovery override
+激活 native health check。程序化 Router 不受影响，除非 deployment 显式携带 health policy 并启动检查。

--- a/specs/GH964/product.md
+++ b/specs/GH964/product.md
@@ -38,7 +38,8 @@ GH-964 / #964
    启动 probe。
 4. 配置 `endpoint` 时，绝对 URL 或基于显式 `base_url` 解析出的相对 path 必须执行无认证
    HTTP GET；只有响应状态位于 `expected_codes` 时才算成功。相对 endpoint 缺少 `base_url`、
-   不安全 URL、空 endpoint 或非法 status code 必须在配置校验阶段拒绝。
+   不安全 URL、空 endpoint 或非法 status code 必须在配置校验阶段拒绝。probe 不跟随 redirect，
+   因此配置的 3xx expected code 必须按原始响应判断，且不得请求 `Location` target。
 5. 未配置 `endpoint` 时只允许默认 `expected_codes=[200]`；自定义 expected codes 必须同时
    配置 endpoint，避免接受后忽略。partial `health_check:` 配置省略 expected codes 时仍默认为
    `[200]`。
@@ -66,6 +67,7 @@ GH-964 / #964
 
 - `failure_threshold=1` 时首次失败立即标记 `Unhealthy`。
 - `expected_codes` 可以包含多个不同的合法 HTTP 状态，但不得为空、重复或超出 `100..=599`。
+- endpoint 返回 3xx 时直接按该状态判断，不跟随 redirect。
 - endpoint 返回非预期状态、连接失败或超过 deployment timeout 都按一次失败处理。
 - provider-native 返回 `Degraded`、`Unhealthy` 或 `Unknown` 都按失败处理。
 - probe 执行时间不计入 interval；下一次延迟从本次结果处理完成后开始。

--- a/specs/GH964/tasks.md
+++ b/specs/GH964/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-964 / #964
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP964-T1` Owner: coordinator. Dependencies: none. Done when: GH964 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work 与 implement route gate 为 allowed。Verify: packet check and route gate JSON。
+- [x] `SP964-T2` Owner: config-contract. Dependencies: T1. Done when: partial expected codes 默认一致，endpoint 使用 URL API 解析并通过 SSRF/跨字段/status code 校验，direct factory 不能绕过 Validate。Verify: focused provider config and validation tests。
+- [x] `SP964-T3` Owner: runtime-mapping. Dependencies: T2. Done when: `DeploymentConfig` 可选保存 normalized health policy，同 provider 的所有 model deployment 获得同一 policy，程序化默认保持 None。Verify: focused gateway mapping/deployment tests。
+- [x] `SP964-T4` Owner: probe-engine. Dependencies: T3. Done when: 每 provider 一个 live task 执行 native 或 custom endpoint probe，interval/threshold/recovery/expected codes 均被消费，global disabled 不 spawn，Drop 取消 task。Verify: focused health-probe tests。
+- [x] `SP964-T5` Owner: state-safety. Dependencies: T4. Done when: probe success/failure驱动 Healthy/Degraded/Unhealthy，active Cooldown 和 probe Unhealthy 不被并发请求路径错误覆盖。Verify: transition and existing cooldown/router suites。
+- [x] `SP964-T6` Owner: verification. Dependencies: T2-T5. Done when: focused、fmt、check、strict clippy、串行全量 tests 和 packet validation 全部通过。Verify: commands below。
+- [ ] `SP964-T7` Owner: coordinator. Dependencies: T6. Done when: one implementation PR 使用 `Closes #964`，current-head CI、独立 reviewer、review threads、PR gate 与 runtime gate 全部通过并远端确认合并。Verify: SpecRail PR evidence and closure audit。
+
+## 并行拆分
+
+T2-T5 共享 config -> policy -> task -> state contract，按 W-14 串行实现。只读 reviewer 在 focused
+verification 后启动；共享全量验证由 coordinator 独占。
+
+## 验证
+
+- `cargo fmt --all -- --check`
+- `cargo check --all-features --locked`
+- `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- focused provider config/validation tests
+- focused `core::router::health_probe` and cooldown tests
+- `cargo test --all-features --locked -- --test-threads=1`
+- `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH964"`
+
+## Handoff Notes
+
+- custom endpoint 是经过 SSRF 校验的无认证 GET；需要 provider 认证时使用 native path。
+- 不接入使用随机模拟的 `core::health::checker::perform_health_check`。
+- one task per provider config name，结果应用到该 provider 的全部 model deployment。
+- reviewer 必须检查 task 生命周期、endpoint/expected code、threshold/recovery 和 Cooldown race。

--- a/specs/GH964/tech.md
+++ b/specs/GH964/tech.md
@@ -1,0 +1,100 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-964 / #964
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Provider config | `src/config/models/provider.rs` | 声明五个 health 字段；partial block 的 `expected_codes` 会 serde 成空数组 | 输入与默认值边界 |
+| Validation | `src/config/validation/config_validators.rs` | 只校验非零/非空，不解析 endpoint、不校验 status 范围或跨字段组合 | 必须 fail closed |
+| Provider probes | `src/core/providers/mod.rs`, provider implementations | `Provider::health_check()` 可调用各 provider 已认证的 native probe | 默认 probe 执行路径 |
+| Gateway mapping | `src/core/router/gateway_config.rs` | provider 变成 deployment，但丢弃整个 health config | 声明到执行的缺失边 |
+| Router runtime | `src/core/router/deployment.rs`, `unified.rs` | health 状态参与选择，但没有 active probe task | live 状态消费点 |
+| Legacy health monitor | `src/core/health/*` | 未接入 router，实际 checker 使用随机模拟 | 明确不复用 |
+
+## 设计方案
+
+1. 在 provider config 中增加唯一 `default_health_expected_codes()`，让 serde partial block 与
+   `Default` 都产生 `[200]`。增加结构化 endpoint resolver：绝对 URL 直接解析；相对 path 只允许
+   基于显式 `base_url` 用 URL API 解析。`ProviderConfig::validate` 对最终 URL 执行既有 SSRF 校验，
+   并校验 expected code 范围、重复项和 endpoint/expected_codes 组合。
+2. 在 `deployment.rs` 增加 runtime `HealthCheckPolicy`：`provider_name`、`interval_secs`、
+   `failure_threshold`、`recovery_timeout_secs`、normalized endpoint URL 和 expected codes。
+   `DeploymentConfig.health_check_policy: Option<HealthCheckPolicy>` 默认 `None`；gateway 只在 provider
+   health 配置偏离 schema 默认值时创建 policy，保证默认 gateway 与程序化构造都不新增主动流量。
+3. `gateway_config.rs` 在 create-provider 前显式调用与完整 `ProviderConfig::validate` 共用的 health
+   runtime validator，把 endpoint 解析错误转成 `RouterError::InvalidConfiguration`。direct factory
+   不重跑 base URL 等已有全局校验，以保留自托管/private upstream 的程序化构造边界。每个由 provider
+   config 创建的 deployment 保存相同 policy；完成所有 deployment 后调用
+   `Router::start_configured_health_checks()`。
+4. 新建 `src/core/router/health_probe.rs` 作为唯一 active probe engine：
+   - 按 `provider_name` 分组 deployment，每个 provider 只 spawn 一个 task；
+   - endpoint 缺失时调用组内 provider clone 的 native `health_check()`；
+   - endpoint 存在时用按 deployment timeout 缓存的 SSRF-safe client 发无认证 GET，并按 expected
+     codes 判定；该 client 在每次连接 DNS 解析时过滤 private/reserved IP，并校验 redirect target；
+   - 用 deployment `timeout_secs` 包裹单次 probe；
+   - 首次立即执行，普通结果后 sleep interval，达到失败阈值后 sleep recovery timeout；
+   - task handle 保存在 Router，`Drop` 中 abort，错误仅影响当前 provider loop。
+5. probe task 局部保存连续失败计数，结果原子更新同 provider 的全部 deployment：
+   - success: 清零并将非 Cooldown 状态设为 Healthy；
+   - failure below threshold: 将非 Cooldown/Unhealthy 状态设为 Degraded；
+   - failure at/above threshold: 将非 Cooldown 状态设为 Unhealthy；Cooldown 期间记录 probe-unhealthy
+     标记，使 cooldown 到期后恢复为 Unhealthy 而不是提前进入 Degraded。
+   请求路径 `Deployment::record_failure` 改为只把 Healthy/Unknown 转为 Degraded，不覆盖 Unhealthy/Cooldown。
+6. 全局 `RouterConfig.enable_pre_call_checks=false` 时 start 方法直接返回且不 spawn task。动态
+   `add_deployment`/`set_model_list` 不自动重建任务，作为本 issue 明确非目标；gateway startup 是唯一
+   自动启动边界。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P2 one task + interval/global switch | `health_probe.rs`, `gateway_config.rs` | grouping/start tests and deterministic next-delay assertions |
+| P3 native path/programmatic compatibility | `HealthCheckPolicy::None`, native probe helper | native-provider mock HTTP test; default deployment has no task |
+| P4/P5 endpoint + expected codes | config resolver/validator, custom HTTP probe | partial YAML, URL validation, local HTTP 204/500 tests |
+| P6/P7 threshold + recovery | probe transition helper | table tests for Degraded/Unhealthy/Healthy and next delay |
+| P8 cooldown/request race | deployment transition helpers | tests prove Cooldown/Unhealthy are not overwritten |
+| P9 lifecycle/error isolation | Router task registry + Drop | abort/drop and failed-probe loop tests |
+| P10 direct factory validation | `from_gateway_config` | invalid config rejected before provider creation |
+
+## 数据流
+
+`gateway.yaml ProviderConfig.health_check` -> full provider validation -> normalized
+`HealthCheckPolicy` -> deployment group -> one Tokio probe loop -> provider-native status or custom HTTP status ->
+atomic router `HealthStatus` transition -> existing deployment selection excludes `Unhealthy`.
+
+没有新增持久化或外部 API。自定义 endpoint 不携带 provider credential；URL 和错误日志不得包含密钥。
+
+## 备选方案
+
+- 接入 `core::health::HealthMonitor`：其 checker 仍是随机模拟且状态不驱动 UnifiedRouter，拒绝。
+- 每个 model deployment 启动 task：会对同一 provider 重复探测，拒绝。
+- 把 endpoint 注入所有 provider trait 实现：需要跨全部 provider 复制认证与 URL 逻辑，超出本 issue。
+- 对自定义 endpoint 自动附加 `api_key`：不同 provider 的认证协议不同且可能泄密，拒绝。
+- 只映射 threshold 到全局 RouterConfig：多 provider 策略互相覆盖，拒绝。
+
+## 风险
+
+- Security: endpoint 是新的出站 URL 面；必须复用 SSRF 校验，禁止隐式凭据，并避免 URL/secret 日志。
+- Compatibility: 默认 gateway health checks 从声明但无效变成真实主动请求；这是预期修复。
+- Performance: 每 provider 一个低频 task；多模型不放大请求数。
+- Maintenance: 新 engine 只负责 UnifiedRouter，不与未接线的 legacy HealthMonitor 共享状态。
+
+## 测试计划
+
+- Unit tests: 默认值、URL resolver、status code/跨字段校验、mapping、状态迁移、delay 选择。
+- Integration tests: native provider probe、自定义 endpoint expected code、全局开关、provider 分组与 task 取消。
+- Manual verification: `rg` 确认五字段 mapping 与唯一 startup 调用，legacy random checker 未被引用。
+- Deterministic checks: fmt、all-features check、strict clippy、focused router/config tests、串行全量 tests。
+
+## 回滚方案
+
+回滚 GH964 PR 即恢复无 active provider probe 的旧行为。没有 schema migration 或持久化状态；删除
+`HealthCheckPolicy`、probe module 与 gateway startup 调用后，现有请求级 health/cooldown 路径保持可用。

--- a/specs/GH964/tech.md
+++ b/specs/GH964/tech.md
@@ -37,8 +37,9 @@ Link to `product.md`.
 4. 新建 `src/core/router/health_probe.rs` 作为唯一 active probe engine：
    - 按 `provider_name` 分组 deployment，每个 provider 只 spawn 一个 task；
    - endpoint 缺失时调用组内 provider clone 的 native `health_check()`；
-   - endpoint 存在时用按 deployment timeout 缓存的 SSRF-safe client 发无认证 GET，并按 expected
-     codes 判定；该 client 在每次连接 DNS 解析时过滤 private/reserved IP，并校验 redirect target；
+   - endpoint 存在时用按 deployment timeout 缓存的 SSRF-safe/no-redirect client 发无认证 GET，
+     并按 expected codes 判定；该 client 在初始连接 DNS 解析时过滤 private/reserved IP，且不请求
+     redirect target，因此 3xx 状态可被直接消费；
    - 用 deployment `timeout_secs` 包裹单次 probe；
    - 首次立即执行，普通结果后 sleep interval，达到失败阈值后 sleep recovery timeout；
    - task handle 保存在 Router，`Drop` 中 abort，错误仅影响当前 provider loop。
@@ -58,7 +59,7 @@ Link to `product.md`.
 | --- | --- | --- |
 | P1/P2 one task + interval/global switch | `health_probe.rs`, `gateway_config.rs` | grouping/start tests and deterministic next-delay assertions |
 | P3 native path/programmatic compatibility | `HealthCheckPolicy::None`, native probe helper | native-provider mock HTTP test; default deployment has no task |
-| P4/P5 endpoint + expected codes | config resolver/validator, custom HTTP probe | partial YAML, URL validation, local HTTP 204/500 tests |
+| P4/P5 endpoint + expected codes | config resolver/validator, custom HTTP probe | partial YAML, URL validation, local HTTP 204/302/500 tests |
 | P6/P7 threshold + recovery | probe transition helper | table tests for Degraded/Unhealthy/Healthy and next delay |
 | P8 cooldown/request race | deployment transition helpers | tests prove Cooldown/Unhealthy are not overwritten |
 | P9 lifecycle/error isolation | Router task registry + Drop | abort/drop and failed-probe loop tests |

--- a/src/config/models/defaults.rs
+++ b/src/config/models/defaults.rs
@@ -24,6 +24,10 @@ pub fn default_recovery_timeout() -> u64 {
     60
 }
 
+pub fn default_health_expected_codes() -> Vec<u16> {
+    vec![200]
+}
+
 pub fn default_initial_delay_ms() -> u64 {
     100
 }
@@ -67,6 +71,11 @@ mod tests {
     #[test]
     fn test_default_recovery_timeout() {
         assert_eq!(default_recovery_timeout(), 60);
+    }
+
+    #[test]
+    fn test_default_health_expected_codes() {
+        assert_eq!(default_health_expected_codes(), vec![200]);
     }
 
     #[test]

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -10,7 +10,8 @@ pub mod retry;
 // Re-export shared default functions so submodules using `use super::*` get them
 pub use self::defaults::{
     default_api_key_header, default_failure_threshold, default_health_check_interval,
-    default_jwt_expiration, default_max_retries, default_recovery_timeout, default_true,
+    default_health_expected_codes, default_jwt_expiration, default_max_retries,
+    default_recovery_timeout, default_true,
 };
 
 pub mod auth;

--- a/src/config/models/provider.rs
+++ b/src/config/models/provider.rs
@@ -136,12 +136,22 @@ impl ProviderConfig {
                         self.name
                     )
                 })?;
-                let base = Url::parse(base_url).map_err(|error| {
+                let mut base = Url::parse(base_url).map_err(|error| {
                     format!(
                         "Provider {} base_url cannot resolve health check endpoint: {}",
                         self.name, error
                     )
                 })?;
+                if !base.path().ends_with('/') {
+                    base.path_segments_mut()
+                        .map_err(|()| {
+                            format!(
+                                "Provider {} base_url cannot resolve a relative health check endpoint",
+                                self.name
+                            )
+                        })?
+                        .push("");
+                }
                 base.join(endpoint).map(Some).map_err(|error| {
                     format!(
                         "Provider {} has invalid health check endpoint: {}",

--- a/src/config/models/provider.rs
+++ b/src/config/models/provider.rs
@@ -3,6 +3,7 @@
 use super::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use url::Url;
 
 /// Provider configuration
 #[derive(Clone, Serialize, Deserialize)]
@@ -112,6 +113,50 @@ impl Default for ProviderConfig {
     }
 }
 
+impl ProviderConfig {
+    /// Resolve a configured custom health endpoint to an absolute URL.
+    pub(crate) fn resolved_health_check_endpoint(&self) -> Result<Option<Url>, String> {
+        let Some(endpoint) = self.health_check.endpoint.as_deref() else {
+            return Ok(None);
+        };
+        let endpoint = endpoint.trim();
+        if endpoint.is_empty() {
+            return Err(format!(
+                "Provider {} health check endpoint cannot be empty",
+                self.name
+            ));
+        }
+
+        match Url::parse(endpoint) {
+            Ok(url) => Ok(Some(url)),
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                let base_url = self.base_url.as_deref().ok_or_else(|| {
+                    format!(
+                        "Provider {} relative health check endpoint requires base_url",
+                        self.name
+                    )
+                })?;
+                let base = Url::parse(base_url).map_err(|error| {
+                    format!(
+                        "Provider {} base_url cannot resolve health check endpoint: {}",
+                        self.name, error
+                    )
+                })?;
+                base.join(endpoint).map(Some).map_err(|error| {
+                    format!(
+                        "Provider {} has invalid health check endpoint: {}",
+                        self.name, error
+                    )
+                })
+            }
+            Err(error) => Err(format!(
+                "Provider {} has invalid health check endpoint: {}",
+                self.name, error
+            )),
+        }
+    }
+}
+
 /// Retry configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -142,7 +187,7 @@ impl Default for RetryConfig {
 }
 
 /// Health check configuration for provider-level health monitoring
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProviderHealthCheckConfig {
     /// Health check interval in seconds
@@ -157,7 +202,7 @@ pub struct ProviderHealthCheckConfig {
     /// Health check endpoint path
     pub endpoint: Option<String>,
     /// Expected status codes for healthy response
-    #[serde(default)]
+    #[serde(default = "default_health_expected_codes")]
     pub expected_codes: Vec<u16>,
 }
 
@@ -168,8 +213,14 @@ impl Default for ProviderHealthCheckConfig {
             failure_threshold: default_failure_threshold(),
             recovery_timeout: default_recovery_timeout(),
             endpoint: None,
-            expected_codes: vec![200],
+            expected_codes: default_health_expected_codes(),
         }
+    }
+}
+
+impl ProviderHealthCheckConfig {
+    pub(crate) fn has_runtime_overrides(&self) -> bool {
+        self != &Self::default()
     }
 }
 
@@ -288,6 +339,17 @@ mod tests {
         let config: ProviderHealthCheckConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.interval, 20);
         assert_eq!(config.failure_threshold, 2);
+    }
+
+    #[test]
+    fn test_partial_health_check_yaml_preserves_expected_code_default() {
+        let config: ProviderHealthCheckConfig =
+            serde_yml::from_str("interval: 15\nfailure_threshold: 2\n")
+                .expect("partial health check YAML should deserialize");
+
+        assert_eq!(config.interval, 15);
+        assert_eq!(config.failure_threshold, 2);
+        assert_eq!(config.expected_codes, vec![200]);
     }
 
     #[test]

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -219,8 +219,28 @@ impl Validate for ProviderConfig {
         // Validate retry configuration
         self.retry.validate()?;
 
-        // Validate health check configuration
+        self.validate_health_check_runtime()?;
+
+        Ok(())
+    }
+}
+
+impl ProviderConfig {
+    /// Validate health settings at every runtime construction boundary.
+    pub(crate) fn validate_health_check_runtime(&self) -> Result<(), String> {
         self.health_check.validate()?;
+        if let Some(endpoint) = self.resolved_health_check_endpoint()? {
+            if !endpoint.username().is_empty() || endpoint.password().is_some() {
+                return Err(format!(
+                    "Provider {} health check endpoint cannot contain URL credentials",
+                    self.name
+                ));
+            }
+            validate_url_against_ssrf(
+                endpoint.as_str(),
+                &format!("Provider {} health check endpoint", self.name),
+            )?;
+        }
 
         Ok(())
     }
@@ -276,6 +296,37 @@ impl Validate for ProviderHealthCheckConfig {
 
         if self.expected_codes.is_empty() {
             return Err("Health check expected codes cannot be empty".to_string());
+        }
+
+        let mut unique_codes = HashSet::with_capacity(self.expected_codes.len());
+        for code in &self.expected_codes {
+            if !(100..=599).contains(code) {
+                return Err(format!(
+                    "Health check expected status code {code} must be between 100 and 599"
+                ));
+            }
+            if !unique_codes.insert(*code) {
+                return Err(format!(
+                    "Health check expected status code {code} cannot be duplicated"
+                ));
+            }
+        }
+
+        if self.endpoint.is_none()
+            && self.expected_codes != crate::config::models::default_health_expected_codes()
+        {
+            return Err(
+                "Health check expected_codes requires a custom endpoint; provider-native checks do not expose HTTP status codes"
+                    .to_string(),
+            );
+        }
+
+        if self
+            .endpoint
+            .as_deref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err("Health check endpoint cannot be empty".to_string());
         }
 
         Ok(())

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -155,7 +155,7 @@ fn test_provider_health_check_resolves_relative_endpoint() {
         name: "test".to_string(),
         provider_type: "openai".to_string(),
         api_key: "test-key".to_string(),
-        base_url: Some("https://8.8.8.8/v1/".to_string()),
+        base_url: Some("https://8.8.8.8/v1".to_string()),
         health_check: crate::config::models::provider::ProviderHealthCheckConfig {
             endpoint: Some("health".to_string()),
             expected_codes: vec![200, 204],
@@ -172,6 +172,28 @@ fn test_provider_health_check_resolves_relative_endpoint() {
             .expect("endpoint should be present")
             .as_str(),
         "https://8.8.8.8/v1/health"
+    );
+
+    let mut trailing_slash = config.clone();
+    trailing_slash.base_url = Some("https://8.8.8.8/v1/".to_string());
+    assert_eq!(
+        trailing_slash
+            .resolved_health_check_endpoint()
+            .expect("endpoint should resolve")
+            .expect("endpoint should be present")
+            .as_str(),
+        "https://8.8.8.8/v1/health"
+    );
+
+    let mut root_relative = config;
+    root_relative.health_check.endpoint = Some("/health".to_string());
+    assert_eq!(
+        root_relative
+            .resolved_health_check_endpoint()
+            .expect("endpoint should resolve")
+            .expect("endpoint should be present")
+            .as_str(),
+        "https://8.8.8.8/health"
     );
 }
 

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -149,6 +149,99 @@ fn test_provider_config_empty_name() {
     assert!(config.validate().is_err());
 }
 
+#[test]
+fn test_provider_health_check_resolves_relative_endpoint() {
+    let config = ProviderConfig {
+        name: "test".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "test-key".to_string(),
+        base_url: Some("https://8.8.8.8/v1/".to_string()),
+        health_check: crate::config::models::provider::ProviderHealthCheckConfig {
+            endpoint: Some("health".to_string()),
+            expected_codes: vec![200, 204],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    assert!(config.validate().is_ok());
+    assert_eq!(
+        config
+            .resolved_health_check_endpoint()
+            .expect("endpoint should resolve")
+            .expect("endpoint should be present")
+            .as_str(),
+        "https://8.8.8.8/v1/health"
+    );
+}
+
+#[test]
+fn test_provider_health_check_rejects_unsupported_combinations() {
+    let mut config = ProviderConfig {
+        name: "test".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "test-key".to_string(),
+        ..Default::default()
+    };
+
+    config.health_check.endpoint = Some("/health".to_string());
+    assert!(config.validate().unwrap_err().contains("requires base_url"));
+
+    config.health_check.endpoint = None;
+    config.health_check.expected_codes = vec![204];
+    assert!(
+        config
+            .validate()
+            .unwrap_err()
+            .contains("requires a custom endpoint")
+    );
+
+    config.health_check.endpoint = Some("https://8.8.8.8/health".to_string());
+    config.health_check.expected_codes = vec![200, 200];
+    assert!(config.validate().unwrap_err().contains("duplicated"));
+
+    config.health_check.expected_codes = vec![99];
+    assert!(
+        config
+            .validate()
+            .unwrap_err()
+            .contains("between 100 and 599")
+    );
+
+    config.health_check.expected_codes = vec![600];
+    assert!(
+        config
+            .validate()
+            .unwrap_err()
+            .contains("between 100 and 599")
+    );
+
+    config.health_check.endpoint = Some("https://user:secret@8.8.8.8/health".to_string());
+    config.health_check.expected_codes = vec![200];
+    assert!(
+        config
+            .validate()
+            .unwrap_err()
+            .contains("cannot contain URL credentials")
+    );
+}
+
+#[test]
+fn test_provider_health_check_endpoint_uses_ssrf_validation() {
+    let config = ProviderConfig {
+        name: "test".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "test-key".to_string(),
+        health_check: crate::config::models::provider::ProviderHealthCheckConfig {
+            endpoint: Some("http://127.0.0.1/health".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    assert!(config.validate().unwrap_err().contains("SSRF protection"));
+}
+
 // ==================== Auth Config Validation ====================
 
 #[test]

--- a/src/core/router/deployment.rs
+++ b/src/core/router/deployment.rs
@@ -23,8 +23,9 @@
 use crate::core::providers::Provider;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+use url::Url;
 
 /// Deployment identifier (unique within router)
 pub type DeploymentId = String;
@@ -43,6 +44,23 @@ pub struct RetrySchedule {
     pub backoff_multiplier: f64,
     /// Symmetric jitter ratio in the inclusive range `0.0..=1.0`.
     pub jitter_ratio: f64,
+}
+
+/// Runtime policy for an active provider health probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthCheckPolicy {
+    /// Gateway provider name used to group model deployments into one probe task.
+    pub provider_name: String,
+    /// Delay between ordinary probe attempts.
+    pub interval_secs: u64,
+    /// Consecutive failures required before marking deployments unhealthy.
+    pub failure_threshold: u32,
+    /// Delay after reaching the failure threshold.
+    pub recovery_timeout_secs: u64,
+    /// Normalized custom unauthenticated GET endpoint, or native provider probe when absent.
+    pub endpoint: Option<Url>,
+    /// HTTP statuses accepted by a custom endpoint probe.
+    pub expected_codes: Vec<u16>,
 }
 
 /// Health status enumeration for deployments
@@ -107,6 +125,9 @@ pub struct DeploymentConfig {
 
     /// Provider-specific retry schedule, or `None` to use router defaults.
     pub retry_schedule: Option<RetrySchedule>,
+
+    /// Active health probe policy for gateway-created deployments.
+    pub health_check_policy: Option<HealthCheckPolicy>,
 }
 
 impl Default for DeploymentConfig {
@@ -119,6 +140,7 @@ impl Default for DeploymentConfig {
             timeout_secs: 60,
             priority: 0,
             retry_schedule: None,
+            health_check_policy: None,
         }
     }
 }
@@ -153,6 +175,9 @@ impl Deref for DeploymentState {
 pub struct DeploymentStateInner {
     /// Health status (0=unknown, 1=healthy, 2=degraded, 3=unhealthy, 4=cooldown)
     pub health: AtomicU8,
+
+    /// Whether the active probe remains unhealthy while request cooldown owns `health`.
+    pub probe_unhealthy: AtomicBool,
 
     /// Current minute TPM usage
     pub tpm_current: AtomicU64,
@@ -198,6 +223,7 @@ impl DeploymentState {
         Self {
             inner: Arc::new(DeploymentStateInner {
                 health: AtomicU8::new(HealthStatus::Healthy as u8),
+                probe_unhealthy: AtomicBool::new(false),
                 tpm_current: AtomicU64::new(0),
                 rpm_current: AtomicU64::new(0),
                 active_requests: AtomicU32::new(0),
@@ -346,14 +372,19 @@ impl Deployment {
         if cooldown_until > now {
             return true;
         }
-        // Cooldown expired: reset health from Cooldown to Degraded so
-        // `is_healthy()` returns true and the deployment is selectable.
+        // Cooldown expiry restores probe-owned Unhealthy when the provider did
+        // not recover during cooldown; otherwise it enters request half-open.
+        let next = if self.state.probe_unhealthy.load(Ordering::Relaxed) {
+            HealthStatus::Unhealthy
+        } else {
+            HealthStatus::Degraded
+        };
         // CAS failure means another thread already transitioned the state -- safe to ignore.
         self.state
             .health
             .compare_exchange(
                 HealthStatus::Cooldown as u8,
-                HealthStatus::Degraded as u8,
+                next as u8,
                 Ordering::Relaxed,
                 Ordering::Relaxed,
             )
@@ -413,10 +444,38 @@ impl Deployment {
         // Reset consecutive success counter on failure
         self.state.consecutive_successes.store(0, Ordering::Relaxed);
 
-        // Mark as degraded (caller can escalate to Unhealthy/Cooldown if needed)
-        self.state
-            .health
-            .store(HealthStatus::Degraded as u8, Ordering::Relaxed);
+        // Request failures may degrade an available deployment, but must not
+        // overwrite a stronger state owned by health probes or cooldown logic.
+        let mut current = self.state.health.load(Ordering::Relaxed);
+        while matches!(
+            HealthStatus::from(current),
+            HealthStatus::Healthy | HealthStatus::Unknown
+        ) {
+            match self.state.health.compare_exchange_weak(
+                current,
+                HealthStatus::Degraded as u8,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub(crate) fn promote_to_healthy_if_degraded(&self) {
+        let mut current = self.state.health.load(Ordering::Relaxed);
+        while current == HealthStatus::Degraded as u8 {
+            match self.state.health.compare_exchange_weak(
+                current,
+                HealthStatus::Healthy as u8,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     /// Enter cooldown state
@@ -431,9 +490,19 @@ impl Deployment {
         self.state
             .cooldown_until
             .store(cooldown_until, Ordering::Relaxed);
-        self.state
-            .health
-            .store(HealthStatus::Cooldown as u8, Ordering::Relaxed);
+
+        let mut current = self.state.health.load(Ordering::Relaxed);
+        while HealthStatus::from(current) != HealthStatus::Cooldown {
+            match self.state.health.compare_exchange_weak(
+                current,
+                HealthStatus::Cooldown as u8,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
     }
 }
 
@@ -507,6 +576,7 @@ mod tests {
         assert_eq!(config.weight, 1);
         assert_eq!(config.timeout_secs, 60);
         assert_eq!(config.priority, 0);
+        assert!(config.health_check_policy.is_none());
     }
 
     #[test]
@@ -519,6 +589,7 @@ mod tests {
             timeout_secs: 120,
             priority: 1,
             retry_schedule: None,
+            health_check_policy: None,
         };
         assert_eq!(config.tpm_limit, Some(100_000));
         assert_eq!(config.rpm_limit, Some(500));

--- a/src/core/router/error.rs
+++ b/src/core/router/error.rs
@@ -30,6 +30,10 @@ pub enum CooldownReason {
 /// Defines errors that can occur during routing operations.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RouterError {
+    /// Gateway configuration cannot be represented safely by the runtime router.
+    #[error("Invalid router configuration: {0}")]
+    InvalidConfiguration(String),
+
     /// Model not found in router configuration
     #[error("Model not found: {0}")]
     ModelNotFound(String),
@@ -170,6 +174,15 @@ mod tests {
     }
 
     #[test]
+    fn test_router_error_invalid_configuration() {
+        let error = RouterError::InvalidConfiguration("bad health endpoint".to_string());
+        assert_eq!(
+            error.to_string(),
+            "Invalid router configuration: bad health endpoint"
+        );
+    }
+
+    #[test]
     fn test_router_error_no_available_deployment() {
         let error = RouterError::NoAvailableDeployment("gpt-4".to_string());
         assert_eq!(
@@ -259,6 +272,7 @@ mod tests {
     #[test]
     fn test_router_error_all_variants() {
         let errors = vec![
+            RouterError::InvalidConfiguration("config".to_string()),
             RouterError::ModelNotFound("a".to_string()),
             RouterError::NoAvailableDeployment("b".to_string()),
             RouterError::UnsupportedCapability {
@@ -272,7 +286,7 @@ mod tests {
             RouterError::FallbackCycle("g".to_string()),
         ];
 
-        assert_eq!(errors.len(), 8);
+        assert_eq!(errors.len(), 9);
         for error in errors {
             assert!(!error.to_string().is_empty());
         }

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -149,6 +149,10 @@ pub fn infer_cooldown_reason(error: &ProviderError) -> CooldownReason {
 /// Convert RouterError to ProviderError for consistency
 pub fn router_error_to_provider_error(err: RouterError) -> ProviderError {
     match err {
+        RouterError::InvalidConfiguration(msg) => ProviderError::Configuration {
+            provider: "router",
+            message: msg,
+        },
         RouterError::ModelNotFound(msg) => ProviderError::model_not_found("router", msg),
         RouterError::NoAvailableDeployment(msg) => ProviderError::ProviderUnavailable {
             provider: "router",

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -4,7 +4,7 @@
 //! a Router from gateway configuration.
 
 use super::config::RouterConfig;
-use super::deployment::{Deployment, DeploymentConfig, RetrySchedule};
+use super::deployment::{Deployment, DeploymentConfig, HealthCheckPolicy, RetrySchedule};
 use super::error::RouterError;
 use super::unified::Router;
 use crate::config::Validate;
@@ -42,6 +42,14 @@ impl Router {
         let router = Self::new(config);
 
         for provider_config in providers {
+            provider_config
+                .validate_health_check_runtime()
+                .map_err(|error| {
+                    RouterError::InvalidConfiguration(format!(
+                        "provider '{}': {error}",
+                        provider_config.name
+                    ))
+                })?;
             if !provider_config.enabled {
                 continue;
             }
@@ -75,7 +83,7 @@ impl Router {
                     provider.clone(),
                     &provider_config.name,
                     provider_config,
-                );
+                )?;
                 router.add_deployment(deployment);
             } else {
                 // Create one deployment per model
@@ -86,12 +94,13 @@ impl Router {
                         provider.clone(),
                         &model,
                         provider_config,
-                    );
+                    )?;
                     router.add_deployment(deployment);
                 }
             }
         }
 
+        router.start_configured_health_checks()?;
         Ok(router)
     }
 }
@@ -102,21 +111,27 @@ fn create_deployment_from_config(
     provider: Provider,
     model: &str,
     config: &ProviderConfig,
-) -> Deployment {
-    let deployment_config = deployment_config_from_provider(config);
+) -> Result<Deployment, RouterError> {
+    let deployment_config = deployment_config_from_provider(config)?;
 
-    Deployment::new(
+    Ok(Deployment::new(
         deployment_id.to_string(),
         provider,
         model.to_string(),
         model.to_string(),
     )
     .with_config(deployment_config)
-    .with_tags(config.tags.clone())
+    .with_tags(config.tags.clone()))
 }
 
-fn deployment_config_from_provider(config: &ProviderConfig) -> DeploymentConfig {
-    DeploymentConfig {
+fn deployment_config_from_provider(
+    config: &ProviderConfig,
+) -> Result<DeploymentConfig, RouterError> {
+    let endpoint = config.resolved_health_check_endpoint().map_err(|error| {
+        RouterError::InvalidConfiguration(format!("provider '{}': {error}", config.name))
+    })?;
+
+    Ok(DeploymentConfig {
         tpm_limit: if config.tpm > 0 {
             Some(config.tpm as u64)
         } else {
@@ -141,7 +156,17 @@ fn deployment_config_from_provider(config: &ProviderConfig) -> DeploymentConfig 
             backoff_multiplier: config.retry.backoff_multiplier,
             jitter_ratio: config.retry.jitter,
         }),
-    }
+        health_check_policy: config.health_check.has_runtime_overrides().then(|| {
+            HealthCheckPolicy {
+                provider_name: config.name.clone(),
+                interval_secs: config.health_check.interval,
+                failure_threshold: config.health_check.failure_threshold,
+                recovery_timeout_secs: config.health_check.recovery_timeout,
+                endpoint,
+                expected_codes: config.health_check.expected_codes.clone(),
+            }
+        }),
+    })
 }
 
 #[cfg(test)]
@@ -237,7 +262,7 @@ mod tests {
             ..ProviderConfig::default()
         };
 
-        let deployment = deployment_config_from_provider(&provider);
+        let deployment = deployment_config_from_provider(&provider).unwrap();
         let retry = deployment
             .retry_schedule
             .expect("gateway provider retry schedule should be preserved");
@@ -246,5 +271,64 @@ mod tests {
         assert_eq!(retry.max_delay_ms, 900);
         assert!((retry.backoff_multiplier - 2.0).abs() < f64::EPSILON);
         assert!((retry.jitter_ratio - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_provider_health_policy_maps_every_runtime_field() {
+        let provider = ProviderConfig {
+            name: "openai-primary".to_string(),
+            base_url: Some("https://8.8.8.8/v1/".to_string()),
+            health_check: crate::config::models::provider::ProviderHealthCheckConfig {
+                interval: 11,
+                failure_threshold: 3,
+                recovery_timeout: 47,
+                endpoint: Some("health".to_string()),
+                expected_codes: vec![200, 204],
+            },
+            ..ProviderConfig::default()
+        };
+
+        let deployment = deployment_config_from_provider(&provider).unwrap();
+        let policy = deployment
+            .health_check_policy
+            .expect("gateway deployment should carry health policy");
+
+        assert_eq!(policy.provider_name, "openai-primary");
+        assert_eq!(policy.interval_secs, 11);
+        assert_eq!(policy.failure_threshold, 3);
+        assert_eq!(policy.recovery_timeout_secs, 47);
+        assert_eq!(
+            policy.endpoint.expect("endpoint should resolve").as_str(),
+            "https://8.8.8.8/v1/health"
+        );
+        assert_eq!(policy.expected_codes, vec![200, 204]);
+    }
+
+    #[test]
+    fn test_default_provider_health_config_preserves_no_probe_behavior() {
+        let deployment = deployment_config_from_provider(&ProviderConfig::default()).unwrap();
+
+        assert!(deployment.health_check_policy.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_direct_factory_rejects_invalid_provider_health_config() {
+        let provider = ProviderConfig {
+            name: "disabled-invalid".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test-key".to_string(),
+            enabled: false,
+            health_check: crate::config::models::provider::ProviderHealthCheckConfig {
+                endpoint: Some("/health".to_string()),
+                ..Default::default()
+            },
+            ..ProviderConfig::default()
+        };
+
+        let error = Router::from_gateway_config(&[provider], None)
+            .await
+            .expect_err("direct factory must validate disabled providers too");
+        assert!(matches!(error, RouterError::InvalidConfiguration(_)));
+        assert!(error.to_string().contains("requires base_url"));
     }
 }

--- a/src/core/router/health_probe.rs
+++ b/src/core/router/health_probe.rs
@@ -5,7 +5,7 @@ use super::error::RouterError;
 use super::unified::Router;
 use crate::core::providers::Provider;
 use crate::core::types::health::HealthStatus as ProviderHealthStatus;
-use crate::utils::net::http::get_ssrf_safe_client_with_timeout_fallible;
+use crate::utils::net::http::get_ssrf_safe_no_redirect_client_with_timeout_fallible;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -49,7 +49,7 @@ impl Router {
                     let timeout = Duration::from_secs(deployment.config.timeout_secs);
                     let custom_client = if policy.endpoint.is_some() {
                         Some(
-                            get_ssrf_safe_client_with_timeout_fallible(timeout).map_err(
+                            get_ssrf_safe_no_redirect_client_with_timeout_fallible(timeout).map_err(
                                 |error| {
                                     RouterError::InvalidConfiguration(format!(
                                         "provider '{}' health probe client failed to initialize: {error}",
@@ -229,6 +229,9 @@ fn update_probe_health(deployment: &Deployment, target: HealthStatus) {
             | (HealthStatus::Unhealthy, _) => target,
             (HealthStatus::Unknown | HealthStatus::Cooldown, _) => return,
         };
+        if current_status == next {
+            return;
+        }
 
         match deployment.state.health.compare_exchange_weak(
             current,
@@ -366,10 +369,79 @@ mod tests {
         (endpoint, request_rx, task)
     }
 
+    async fn redirect_server() -> (
+        Url,
+        tokio::task::JoinHandle<()>,
+        tokio::task::JoinHandle<bool>,
+    ) {
+        let target_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("redirect target should bind");
+        let target_address = target_listener
+            .local_addr()
+            .expect("redirect target address should be available");
+        let redirect_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("redirect server should bind");
+        let redirect_address = redirect_listener
+            .local_addr()
+            .expect("redirect address should be available");
+
+        let redirect_task = tokio::spawn(async move {
+            let (mut stream, _) = redirect_listener
+                .accept()
+                .await
+                .expect("redirect request should connect");
+            let mut request = [0_u8; 2048];
+            let bytes_read = stream
+                .read(&mut request)
+                .await
+                .expect("redirect request should be readable");
+            assert!(bytes_read > 0, "redirect request should not be empty");
+            let response = format!(
+                "HTTP/1.1 302 Found\r\nLocation: http://{target_address}/target\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("redirect response should be writable");
+        });
+
+        let target_task = tokio::spawn(async move {
+            let Ok(Ok((mut stream, _))) =
+                tokio::time::timeout(Duration::from_millis(500), target_listener.accept()).await
+            else {
+                return false;
+            };
+            let mut request = [0_u8; 2048];
+            let bytes_read = stream
+                .read(&mut request)
+                .await
+                .expect("redirected request should be readable");
+            assert!(bytes_read > 0, "redirected request should not be empty");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .await
+                .expect("redirect target response should be writable");
+            true
+        });
+
+        let endpoint = Url::parse(&format!("http://{redirect_address}/health"))
+            .expect("redirect endpoint should parse");
+        (endpoint, redirect_task, target_task)
+    }
+
     fn local_probe_client() -> Client {
         Client::builder()
             .build()
             .expect("local probe client should build")
+    }
+
+    fn local_no_redirect_probe_client() -> Client {
+        Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("local no-redirect probe client should build")
     }
 
     async fn wait_for_health(deployment: &Deployment, expected: HealthStatus) {
@@ -429,6 +501,33 @@ mod tests {
             Err(ProbeFailure::UnexpectedStatus(500))
         );
         failed_server.await.expect("test server should stop");
+    }
+
+    #[tokio::test]
+    async fn custom_endpoint_observes_redirect_status_without_following_it() {
+        let provider = test_provider(None).await;
+        let client = local_no_redirect_probe_client();
+        let (endpoint, redirect_task, redirect_target) = redirect_server().await;
+        let mut policy = test_policy(Some(endpoint));
+        policy.expected_codes = vec![302];
+
+        let result = execute_probe(&provider, &policy, Some(&client)).await;
+        redirect_task.await.expect("redirect server should stop");
+        let target_was_requested = redirect_target.await.expect("redirect target should stop");
+
+        assert_eq!(result, Ok(()));
+        assert!(!target_was_requested);
+
+        let (endpoint, redirect_task, redirect_target) = redirect_server().await;
+        policy.endpoint = Some(endpoint);
+        policy.expected_codes = vec![200];
+
+        let result = execute_probe(&provider, &policy, Some(&client)).await;
+        redirect_task.await.expect("redirect server should stop");
+        let target_was_requested = redirect_target.await.expect("redirect target should stop");
+
+        assert_eq!(result, Err(ProbeFailure::UnexpectedStatus(302)));
+        assert!(!target_was_requested);
     }
 
     #[tokio::test]
@@ -500,6 +599,31 @@ mod tests {
         deployment.state.cooldown_until.store(1, Ordering::Relaxed);
         assert!(!deployment.is_in_cooldown());
         assert_eq!(deployment.state.health_status(), HealthStatus::Degraded);
+    }
+
+    #[tokio::test]
+    async fn same_probe_health_update_keeps_stable_states() {
+        let provider = test_provider(None).await;
+
+        for status in [
+            HealthStatus::Healthy,
+            HealthStatus::Degraded,
+            HealthStatus::Unhealthy,
+        ] {
+            let deployment = test_deployment("stable", provider.clone(), test_policy(None)).await;
+            deployment
+                .state
+                .health
+                .store(status as u8, Ordering::Relaxed);
+
+            update_probe_health(&deployment, status);
+
+            assert_eq!(deployment.state.health_status(), status);
+            assert_eq!(
+                deployment.state.probe_unhealthy.load(Ordering::Relaxed),
+                status == HealthStatus::Unhealthy
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/core/router/health_probe.rs
+++ b/src/core/router/health_probe.rs
@@ -1,0 +1,584 @@
+//! Active health probes for gateway-configured router deployments.
+
+use super::deployment::{Deployment, HealthCheckPolicy, HealthStatus};
+use super::error::RouterError;
+use super::unified::Router;
+use crate::core::providers::Provider;
+use crate::core::types::health::HealthStatus as ProviderHealthStatus;
+use crate::utils::net::http::get_ssrf_safe_client_with_timeout_fallible;
+use reqwest::Client;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+#[derive(Debug)]
+struct ProbeGroup {
+    policy: HealthCheckPolicy,
+    provider: Provider,
+    deployments: Vec<Arc<Deployment>>,
+    timeout_secs: u64,
+    custom_client: Option<Arc<Client>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProbeFailure {
+    Request,
+    ClientUnavailable,
+    Timeout,
+    UnexpectedStatus(u16),
+    ProviderStatus(ProviderHealthStatus),
+}
+
+impl Router {
+    pub(crate) fn start_configured_health_checks(&self) -> Result<usize, RouterError> {
+        if !self.config.enable_pre_call_checks {
+            return Ok(0);
+        }
+
+        let snapshot = self.routing_snapshot.load_full();
+        let mut groups: HashMap<String, ProbeGroup> = HashMap::new();
+        for deployment in snapshot.deployments.values() {
+            let Some(policy) = deployment.config.health_check_policy.clone() else {
+                continue;
+            };
+
+            match groups.entry(policy.provider_name.clone()) {
+                Entry::Vacant(entry) => {
+                    let timeout = Duration::from_secs(deployment.config.timeout_secs);
+                    let custom_client = if policy.endpoint.is_some() {
+                        Some(
+                            get_ssrf_safe_client_with_timeout_fallible(timeout).map_err(
+                                |error| {
+                                    RouterError::InvalidConfiguration(format!(
+                                        "provider '{}' health probe client failed to initialize: {error}",
+                                        policy.provider_name
+                                    ))
+                                },
+                            )?,
+                        )
+                    } else {
+                        None
+                    };
+                    entry.insert(ProbeGroup {
+                        policy,
+                        provider: deployment.provider.clone(),
+                        deployments: vec![deployment.clone()],
+                        timeout_secs: deployment.config.timeout_secs,
+                        custom_client,
+                    });
+                }
+                Entry::Occupied(mut entry) => {
+                    let group = entry.get_mut();
+                    if group.policy != policy
+                        || group.timeout_secs != deployment.config.timeout_secs
+                    {
+                        return Err(RouterError::InvalidConfiguration(format!(
+                            "provider '{}' has conflicting health probe policies",
+                            policy.provider_name
+                        )));
+                    }
+                    group.deployments.push(deployment.clone());
+                }
+            }
+        }
+
+        if groups.is_empty() {
+            return Ok(0);
+        }
+        tokio::runtime::Handle::try_current().map_err(|_| {
+            RouterError::InvalidConfiguration(
+                "health probes require an active Tokio runtime".to_string(),
+            )
+        })?;
+
+        let mut tasks = self.health_probe_tasks.lock();
+        if !tasks.is_empty() {
+            return Err(RouterError::InvalidConfiguration(
+                "health probes have already been started for this router".to_string(),
+            ));
+        }
+
+        for (provider_name, group) in groups {
+            tasks.insert(provider_name, tokio::spawn(run_probe_loop(group)));
+        }
+        Ok(tasks.len())
+    }
+
+    #[cfg(test)]
+    fn health_probe_task_count(&self) -> usize {
+        self.health_probe_tasks.lock().len()
+    }
+}
+
+async fn run_probe_loop(group: ProbeGroup) {
+    let mut consecutive_failures = 0_u32;
+
+    loop {
+        let result = match tokio::time::timeout(
+            Duration::from_secs(group.timeout_secs),
+            execute_probe(
+                &group.provider,
+                &group.policy,
+                group.custom_client.as_deref(),
+            ),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(ProbeFailure::Timeout),
+        };
+
+        let delay = match result {
+            Ok(()) => {
+                if consecutive_failures > 0 {
+                    tracing::info!(
+                        provider = %group.policy.provider_name,
+                        "provider health probe recovered"
+                    );
+                }
+                apply_probe_result(&group, true, &mut consecutive_failures)
+            }
+            Err(failure) => {
+                let delay = apply_probe_result(&group, false, &mut consecutive_failures);
+                log_probe_failure(&group.policy, consecutive_failures, &failure);
+                delay
+            }
+        };
+
+        tokio::time::sleep(delay).await;
+    }
+}
+
+async fn execute_probe(
+    provider: &Provider,
+    policy: &HealthCheckPolicy,
+    custom_client: Option<&Client>,
+) -> Result<(), ProbeFailure> {
+    if let Some(endpoint) = &policy.endpoint {
+        let client = custom_client.ok_or(ProbeFailure::ClientUnavailable)?;
+        let response = client
+            .get(endpoint.clone())
+            .send()
+            .await
+            .map_err(|_| ProbeFailure::Request)?;
+        let status = response.status().as_u16();
+        if policy.expected_codes.contains(&status) {
+            Ok(())
+        } else {
+            Err(ProbeFailure::UnexpectedStatus(status))
+        }
+    } else {
+        match provider.health_check().await {
+            ProviderHealthStatus::Healthy => Ok(()),
+            status => Err(ProbeFailure::ProviderStatus(status)),
+        }
+    }
+}
+
+fn apply_probe_result(
+    group: &ProbeGroup,
+    succeeded: bool,
+    consecutive_failures: &mut u32,
+) -> Duration {
+    if succeeded {
+        *consecutive_failures = 0;
+        for deployment in &group.deployments {
+            update_probe_health(deployment, HealthStatus::Healthy);
+        }
+        return Duration::from_secs(group.policy.interval_secs);
+    }
+
+    *consecutive_failures = consecutive_failures.saturating_add(1);
+    let threshold_reached = *consecutive_failures >= group.policy.failure_threshold;
+    let target = if threshold_reached {
+        HealthStatus::Unhealthy
+    } else {
+        HealthStatus::Degraded
+    };
+    for deployment in &group.deployments {
+        update_probe_health(deployment, target);
+    }
+
+    let delay_secs = if threshold_reached {
+        group.policy.recovery_timeout_secs
+    } else {
+        group.policy.interval_secs
+    };
+    Duration::from_secs(delay_secs)
+}
+
+fn update_probe_health(deployment: &Deployment, target: HealthStatus) {
+    deployment
+        .state
+        .probe_unhealthy
+        .store(target == HealthStatus::Unhealthy, Ordering::Relaxed);
+    if deployment.is_in_cooldown() {
+        return;
+    }
+
+    let mut current = deployment.state.health.load(Ordering::Relaxed);
+    loop {
+        let current_status = HealthStatus::from(current);
+        let next = match (target, current_status) {
+            (_, HealthStatus::Cooldown) => return,
+            (HealthStatus::Degraded, HealthStatus::Unhealthy) => return,
+            (HealthStatus::Healthy, _)
+            | (HealthStatus::Degraded, _)
+            | (HealthStatus::Unhealthy, _) => target,
+            (HealthStatus::Unknown | HealthStatus::Cooldown, _) => return,
+        };
+
+        match deployment.state.health.compare_exchange_weak(
+            current,
+            next as u8,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+fn log_probe_failure(
+    policy: &HealthCheckPolicy,
+    consecutive_failures: u32,
+    failure: &ProbeFailure,
+) {
+    if consecutive_failures >= policy.failure_threshold {
+        tracing::error!(
+            provider = %policy.provider_name,
+            consecutive_failures,
+            failure = ?failure,
+            "provider health probe marked deployments unhealthy"
+        );
+    } else {
+        tracing::warn!(
+            provider = %policy.provider_name,
+            consecutive_failures,
+            failure = ?failure,
+            "provider health probe failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::providers::openai::{OpenAIConfig, OpenAIProvider};
+    use crate::core::router::config::RouterConfig;
+    use crate::core::router::deployment::{DeploymentConfig, DeploymentState};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use url::Url;
+
+    async fn test_provider(base_url: Option<String>) -> Provider {
+        let mut config = OpenAIConfig::default();
+        config.base.api_key = Some("sk-health-probe-test".to_string());
+        if let Some(base_url) = base_url {
+            config.base.api_base = Some(base_url);
+        }
+        Provider::OpenAI(
+            OpenAIProvider::new(config)
+                .await
+                .expect("test provider should be valid"),
+        )
+    }
+
+    fn test_policy(endpoint: Option<Url>) -> HealthCheckPolicy {
+        HealthCheckPolicy {
+            provider_name: "openai-primary".to_string(),
+            interval_secs: 30,
+            failure_threshold: 2,
+            recovery_timeout_secs: 60,
+            endpoint,
+            expected_codes: vec![204],
+        }
+    }
+
+    async fn status_server(status: u16) -> (Url, tokio::task::JoinHandle<Vec<u8>>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let address = listener.local_addr().expect("address should be available");
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("request should connect");
+            let mut request = [0_u8; 2048];
+            let bytes_read = stream
+                .read(&mut request)
+                .await
+                .expect("request should be readable");
+            let reason = if status == 204 {
+                "No Content"
+            } else {
+                "Internal Server Error"
+            };
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("response should be writable");
+            request[..bytes_read].to_vec()
+        });
+        let endpoint =
+            Url::parse(&format!("http://{address}/health")).expect("test endpoint should parse");
+        (endpoint, task)
+    }
+
+    async fn sequence_server(
+        statuses: Vec<u16>,
+    ) -> (
+        Url,
+        mpsc::UnboundedReceiver<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let address = listener.local_addr().expect("address should be available");
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
+        let task = tokio::spawn(async move {
+            for status in statuses {
+                let (mut stream, _) = listener.accept().await.expect("request should connect");
+                let mut request = [0_u8; 2048];
+                let bytes_read = stream
+                    .read(&mut request)
+                    .await
+                    .expect("request should be readable");
+                assert!(bytes_read > 0, "request should not be empty");
+                request_tx.send(()).expect("request should be observable");
+                let response = format!(
+                    "HTTP/1.1 {status} Test\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("response should be writable");
+            }
+        });
+        let endpoint =
+            Url::parse(&format!("http://{address}/health")).expect("test endpoint should parse");
+        (endpoint, request_rx, task)
+    }
+
+    fn local_probe_client() -> Client {
+        Client::builder()
+            .build()
+            .expect("local probe client should build")
+    }
+
+    async fn wait_for_health(deployment: &Deployment, expected: HealthStatus) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while deployment.state.health_status() != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("health transition should complete");
+    }
+
+    async fn test_deployment(
+        id: &str,
+        provider: Provider,
+        policy: HealthCheckPolicy,
+    ) -> Deployment {
+        Deployment::new(
+            id.to_string(),
+            provider,
+            "gpt-test".to_string(),
+            "gpt-test".to_string(),
+        )
+        .with_config(DeploymentConfig {
+            timeout_secs: 2,
+            health_check_policy: Some(policy),
+            ..DeploymentConfig::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn custom_endpoint_uses_expected_status_codes() {
+        let provider = test_provider(None).await;
+        let client = local_probe_client();
+        let (healthy_endpoint, healthy_server) = status_server(204).await;
+        assert_eq!(
+            execute_probe(
+                &provider,
+                &test_policy(Some(healthy_endpoint)),
+                Some(&client),
+            )
+            .await,
+            Ok(())
+        );
+        let request = healthy_server.await.expect("test server should stop");
+        let request = String::from_utf8_lossy(&request).to_ascii_lowercase();
+        assert!(!request.contains("authorization:"));
+
+        let (failed_endpoint, failed_server) = status_server(500).await;
+        assert_eq!(
+            execute_probe(
+                &provider,
+                &test_policy(Some(failed_endpoint)),
+                Some(&client),
+            )
+            .await,
+            Err(ProbeFailure::UnexpectedStatus(500))
+        );
+        failed_server.await.expect("test server should stop");
+    }
+
+    #[tokio::test]
+    async fn native_probe_calls_provider_health_check() {
+        let (endpoint, server) = status_server(204).await;
+        let base_url = endpoint
+            .join("/v1")
+            .expect("base URL should resolve")
+            .to_string();
+        let provider = test_provider(Some(base_url)).await;
+        let mut policy = test_policy(None);
+        policy.expected_codes = vec![200];
+
+        assert_eq!(execute_probe(&provider, &policy, None).await, Ok(()));
+        server.await.expect("test server should stop");
+    }
+
+    #[tokio::test]
+    async fn threshold_recovery_and_cooldown_transitions_are_enforced() {
+        let provider = test_provider(None).await;
+        let deployment =
+            Arc::new(test_deployment("one", provider.clone(), test_policy(None)).await);
+        let second = Arc::new(test_deployment("two", provider.clone(), test_policy(None)).await);
+        let group = ProbeGroup {
+            policy: test_policy(None),
+            provider,
+            deployments: vec![deployment.clone(), second.clone()],
+            timeout_secs: 2,
+            custom_client: None,
+        };
+        let mut failures = 0;
+
+        assert_eq!(
+            apply_probe_result(&group, false, &mut failures),
+            Duration::from_secs(30)
+        );
+        assert_eq!(deployment.state.health_status(), HealthStatus::Degraded);
+        assert_eq!(second.state.health_status(), HealthStatus::Degraded);
+        assert_eq!(
+            apply_probe_result(&group, false, &mut failures),
+            Duration::from_secs(60)
+        );
+        assert_eq!(deployment.state.health_status(), HealthStatus::Unhealthy);
+        assert_eq!(second.state.health_status(), HealthStatus::Unhealthy);
+
+        deployment.record_failure();
+        assert_eq!(deployment.state.health_status(), HealthStatus::Unhealthy);
+        assert_eq!(
+            apply_probe_result(&group, true, &mut failures),
+            Duration::from_secs(30)
+        );
+        assert_eq!(failures, 0);
+        assert_eq!(deployment.state.health_status(), HealthStatus::Healthy);
+        assert_eq!(second.state.health_status(), HealthStatus::Healthy);
+
+        deployment.enter_cooldown(60);
+        apply_probe_result(&group, false, &mut failures);
+        apply_probe_result(&group, false, &mut failures);
+        assert_eq!(deployment.state.health_status(), HealthStatus::Cooldown);
+        assert!(deployment.state.probe_unhealthy.load(Ordering::Relaxed));
+        deployment.state.cooldown_until.store(1, Ordering::Relaxed);
+        assert!(!deployment.is_in_cooldown());
+        assert_eq!(deployment.state.health_status(), HealthStatus::Unhealthy);
+
+        deployment.enter_cooldown(60);
+        apply_probe_result(&group, true, &mut failures);
+        assert_eq!(deployment.state.health_status(), HealthStatus::Cooldown);
+        assert!(!deployment.state.probe_unhealthy.load(Ordering::Relaxed));
+        deployment.state.cooldown_until.store(1, Ordering::Relaxed);
+        assert!(!deployment.is_in_cooldown());
+        assert_eq!(deployment.state.health_status(), HealthStatus::Degraded);
+    }
+
+    #[tokio::test]
+    async fn probe_loop_runs_immediately_and_continues_after_failure() {
+        let provider = test_provider(None).await;
+        let (endpoint, mut requests, server) = sequence_server(vec![500, 204]).await;
+        let mut policy = test_policy(Some(endpoint));
+        policy.failure_threshold = 1;
+        policy.interval_secs = 1;
+        policy.recovery_timeout_secs = 1;
+        let deployment = Arc::new(test_deployment("one", provider.clone(), policy.clone()).await);
+        let group = ProbeGroup {
+            policy,
+            provider,
+            deployments: vec![deployment.clone()],
+            timeout_secs: 2,
+            custom_client: Some(Arc::new(local_probe_client())),
+        };
+
+        let probe_task = tokio::spawn(run_probe_loop(group));
+        tokio::time::timeout(Duration::from_millis(500), requests.recv())
+            .await
+            .expect("first probe should run immediately")
+            .expect("first probe should be observed");
+        wait_for_health(&deployment, HealthStatus::Unhealthy).await;
+        tokio::time::timeout(Duration::from_secs(2), requests.recv())
+            .await
+            .expect("probe loop should continue after failure")
+            .expect("second probe should be observed");
+        wait_for_health(&deployment, HealthStatus::Healthy).await;
+
+        probe_task.abort();
+        server.await.expect("test server should stop");
+    }
+
+    #[tokio::test]
+    async fn router_groups_probe_tasks_and_aborts_them_on_drop() {
+        let provider = test_provider(None).await;
+        let endpoint = Url::parse("http://127.0.0.1:9/health").expect("test endpoint should parse");
+        let policy = test_policy(Some(endpoint));
+        let router = Router::new(RouterConfig::default());
+        router.add_deployment(test_deployment("one", provider.clone(), policy.clone()).await);
+        router.add_deployment(test_deployment("two", provider, policy).await);
+
+        assert_eq!(router.start_configured_health_checks().unwrap(), 1);
+        assert_eq!(router.health_probe_task_count(), 1);
+        let abort_handle = router
+            .health_probe_tasks
+            .lock()
+            .values()
+            .next()
+            .expect("probe task should exist")
+            .abort_handle();
+
+        drop(router);
+        tokio::task::yield_now().await;
+        assert!(abort_handle.is_finished());
+    }
+
+    #[tokio::test]
+    async fn global_switch_disables_probe_tasks() {
+        let provider = test_provider(None).await;
+        let config = RouterConfig {
+            enable_pre_call_checks: false,
+            ..RouterConfig::default()
+        };
+        let router = Router::new(config);
+        router.add_deployment(test_deployment("one", provider, test_policy(None)).await);
+
+        assert_eq!(router.start_configured_health_checks().unwrap(), 0);
+        assert_eq!(router.health_probe_task_count(), 0);
+    }
+
+    #[test]
+    fn programmatic_deployment_has_no_probe_policy() {
+        assert!(DeploymentConfig::default().health_check_policy.is_none());
+        assert_eq!(
+            DeploymentState::default().health_status(),
+            HealthStatus::Healthy
+        );
+    }
+}

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -27,6 +27,7 @@ pub mod execute_impl;
 pub mod execution;
 pub mod fallback;
 pub mod gateway_config;
+mod health_probe;
 pub mod retry_policy;
 pub mod selection;
 pub mod strategy_impl;
@@ -37,7 +38,8 @@ mod tests;
 
 // Re-exports from deployment module
 pub use deployment::{
-    Deployment, DeploymentConfig, DeploymentId, DeploymentState, HealthStatus, RetrySchedule,
+    Deployment, DeploymentConfig, DeploymentId, DeploymentState, HealthCheckPolicy, HealthStatus,
+    RetrySchedule,
 };
 
 // Re-exports from new modular router (UnifiedRouter)

--- a/src/core/router/tests/cooldown_tests.rs
+++ b/src/core/router/tests/cooldown_tests.rs
@@ -43,6 +43,36 @@ async fn test_record_failure_triggers_cooldown() {
 }
 
 #[tokio::test]
+async fn test_request_cooldown_does_not_override_probe_unhealthy() {
+    let config = RouterConfig {
+        cooldown_time_secs: 60,
+        ..Default::default()
+    };
+    let router = Router::new(config);
+    let deployment = create_test_deployment("test-1", "gpt-4").await;
+    deployment
+        .state
+        .probe_unhealthy
+        .store(true, Ordering::Relaxed);
+    deployment
+        .state
+        .health
+        .store(HealthStatus::Unhealthy as u8, Ordering::Relaxed);
+    router.add_deployment(deployment);
+
+    router.record_failure_with_reason("test-1", CooldownReason::RateLimit);
+
+    let deployment = router
+        .get_deployment("test-1")
+        .expect("deployment should remain registered");
+    assert!(deployment.is_in_cooldown());
+    assert_eq!(deployment.state.health_status(), HealthStatus::Cooldown);
+    deployment.state.cooldown_until.store(1, Ordering::Relaxed);
+    assert!(!deployment.is_in_cooldown());
+    assert_eq!(deployment.state.health_status(), HealthStatus::Unhealthy);
+}
+
+#[tokio::test]
 async fn test_cooldown_on_rate_limit() {
     let config = RouterConfig {
         allowed_fails: 3,

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -201,6 +201,9 @@ pub struct Router {
 
     /// Atomic counter: number of fallback model attempts.
     pub(crate) fallback_triggered_count: AtomicU64,
+
+    /// One active health probe task per gateway provider.
+    pub(crate) health_probe_tasks: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
 }
 
 impl Router {
@@ -215,6 +218,7 @@ impl Router {
             provider_selected_count: AtomicU64::new(0),
             strategy_used_count: AtomicU64::new(0),
             fallback_triggered_count: AtomicU64::new(0),
+            health_probe_tasks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -451,10 +455,7 @@ impl Router {
         if current_health == super::deployment::HealthStatus::Degraded as u8 {
             let consec = deployment.state.consecutive_successes.load(Relaxed);
             if consec >= self.config.success_threshold {
-                deployment
-                    .state
-                    .health
-                    .store(super::deployment::HealthStatus::Healthy as u8, Relaxed);
+                deployment.promote_to_healthy_if_degraded();
             }
         }
     }
@@ -600,6 +601,14 @@ impl Router {
                 self.reset_minute_counters();
             }
         })
+    }
+}
+
+impl Drop for Router {
+    fn drop(&mut self) {
+        for (_, task) in self.health_probe_tasks.get_mut().drain() {
+            task.abort();
+        }
     }
 }
 

--- a/src/utils/net/http.rs
+++ b/src/utils/net/http.rs
@@ -119,6 +119,10 @@ static TIMEOUT_CLIENT_CACHE: OnceLock<DashMap<u64, Arc<Client>>> = OnceLock::new
 /// Timeout-specific SSRF-safe client cache (keyed by milliseconds)
 static SSRF_SAFE_TIMEOUT_CLIENT_CACHE: OnceLock<DashMap<u64, Arc<Client>>> = OnceLock::new();
 
+/// Timeout-specific SSRF-safe client cache for requests that must observe redirects.
+static SSRF_SAFE_NO_REDIRECT_TIMEOUT_CLIENT_CACHE: OnceLock<DashMap<u64, Arc<Client>>> =
+    OnceLock::new();
+
 /// Create a reqwest client builder with unified pool/timeout defaults.
 pub fn create_client_builder_with_config(
     timeout: Duration,
@@ -252,15 +256,39 @@ pub fn get_ssrf_safe_client_with_timeout_fallible(
         return Ok(existing.clone());
     }
 
-    let client = Arc::new(
-        create_client_builder_with_config(timeout, &HttpClientPoolConfig::default())
-            .no_proxy()
-            .dns_resolver(Arc::new(SsrfSafeDnsResolver))
-            .redirect(ssrf_safe_redirect_policy())
-            .build()?,
-    );
+    let client = Arc::new(create_ssrf_safe_client(
+        timeout,
+        ssrf_safe_redirect_policy(),
+    )?);
     cache.insert(timeout_millis, client.clone());
     Ok(client)
+}
+
+/// Get or create an SSRF-safe HTTP client that returns redirect responses unchanged.
+pub(crate) fn get_ssrf_safe_no_redirect_client_with_timeout_fallible(
+    timeout: Duration,
+) -> Result<Arc<Client>, reqwest::Error> {
+    let cache = SSRF_SAFE_NO_REDIRECT_TIMEOUT_CLIENT_CACHE.get_or_init(DashMap::new);
+    let timeout_millis = timeout.as_millis().min(u64::MAX as u128) as u64;
+
+    if let Some(existing) = cache.get(&timeout_millis) {
+        return Ok(existing.clone());
+    }
+
+    let client = Arc::new(create_ssrf_safe_client(timeout, redirect::Policy::none())?);
+    cache.insert(timeout_millis, client.clone());
+    Ok(client)
+}
+
+fn create_ssrf_safe_client(
+    timeout: Duration,
+    redirect_policy: redirect::Policy,
+) -> Result<Client, reqwest::Error> {
+    create_client_builder_with_config(timeout, &HttpClientPoolConfig::default())
+        .no_proxy()
+        .dns_resolver(Arc::new(SsrfSafeDnsResolver))
+        .redirect(redirect_policy)
+        .build()
 }
 
 /// Create a custom HTTP client with specific timeout and default headers
@@ -357,6 +385,24 @@ mod tests {
         {
             Ok(client) => client,
             Err(error) => panic!("SSRF-safe client should build: {error}"),
+        };
+
+        assert!(Arc::ptr_eq(&client1, &client2));
+    }
+
+    #[test]
+    fn test_ssrf_safe_no_redirect_client_with_timeout_fallible_caching() {
+        let client1 = match get_ssrf_safe_no_redirect_client_with_timeout_fallible(
+            Duration::from_millis(1500),
+        ) {
+            Ok(client) => client,
+            Err(error) => panic!("SSRF-safe no-redirect client should build: {error}"),
+        };
+        let client2 = match get_ssrf_safe_no_redirect_client_with_timeout_fallible(
+            Duration::from_millis(1500),
+        ) {
+            Ok(client) => client,
+            Err(error) => panic!("SSRF-safe no-redirect client should build: {error}"),
         };
 
         assert!(Arc::ptr_eq(&client1, &client2));


### PR DESCRIPTION
## Summary

- validate and map every provider health-check field into router runtime policy
- run one lifecycle-managed native or SSRF-safe custom probe per provider
- preserve request cooldown and probe health state across concurrent transitions
- document the GH964 product, technical, and task contract

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
- GH964 SpecRail packet check
- independent reviewer lane: APPROVE

Closes #964