### PR TITLE
fix(providers): derive Tier-1 capabilities from catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,13 +183,13 @@ A provider belongs in Tier 1 when **all** of the following are true:
 - No custom streaming logic is needed (standard SSE with `data: [DONE]`)
 - No provider-specific model metadata is required at runtime
 
-**How to add a Tier 1 provider**: add a single `def()` entry in
+**How to add a Tier 1 provider**: add a single `def_chat()` entry in
 `src/core/providers/registry/catalog.rs` and a commented annotation in
 `src/core/providers/mod.rs`:
 
 ```rust
 // in catalog.rs
-def("myprovider", "My Provider", "https://api.myprovider.com/v1", "MYPROVIDER_API_KEY"),
+def_chat("myprovider", "My Provider", "https://api.myprovider.com/v1", "MYPROVIDER_API_KEY"),
 
 // in mod.rs
 // myprovider: Tier 1 -> registry/catalog.rs
@@ -226,7 +226,7 @@ If `git status` shows `DU` (deleted-by-us, unresolved) files under `src/core/pro
 
 ## Common Development Patterns
 
-1. **Adding a Tier 1 provider**: add a `def()` entry in `src/core/providers/registry/catalog.rs`
+1. **Adding a Tier 1 provider**: add a `def_chat()` entry in `src/core/providers/registry/catalog.rs`
 2. **Adding a Tier 2 provider**: create a provider directory in `src/core/providers/<name>/`
 3. **New API endpoints**: add routes in `src/server/routes/`
 4. **Authentication**: extend auth modules in `src/auth/`

--- a/specs/GH967/product.md
+++ b/specs/GH967/product.md
@@ -1,0 +1,76 @@
+# Product Spec
+
+## Linked Issue
+
+GH-967 / #967
+
+## 用户问题
+
+所有 Tier-1 catalog provider 都由 `OpenAILikeProvider` 执行，但当前 provider instance 返回同一份
+静态 capability 列表，其中包含 `ImageEdit`、`ImageVariation` 和 `Moderation`。Tier-1 catalog selector
+没有这些 endpoint 的执行路径，route selection 因而可能选择一个随后无法映射到配置的 deployment。
+显式 `openai_compatible` selector 则不同：gateway 的 image/moderation server routes 为它提供独立 proxy
+执行面。当前单一列表无法表达两种事实。与此同时，现有 provider support matrix 已把通用 catalog
+provider 限定为 HTTP chat/stream，形成互相矛盾的能力真值源。
+
+## 目标
+
+- 每个 Tier-1 catalog entry 必须显式选择 capability profile，不能继承隐式全局过度声明。
+- catalog factory 创建的 runtime provider 必须携带并返回该 entry 的 capability 列表。
+- capability 声明必须是 OpenAI-like 可执行 surface 的子集；不合法声明必须在构造阶段 fail closed。
+- route selection 不得选择没有目标执行方法的 Tier-1 provider。
+- 显式 `openai_compatible` 必须保留 image edit/variation/moderation proxy 的既有可执行能力。
+- conformance tests 必须遍历全部 catalog entry，阻止 capability 与执行面再次漂移。
+
+## 非目标
+
+- 不新增 image edit、image variation、moderation 或其他 endpoint 实现；只保留已有显式 proxy surface。
+- 不探测第三方上游或按模型动态推断 capability。
+- 不修改 `LLMProvider::capabilities()` 的全局签名，也不重开 #729 的 sub-trait 方案。
+- 不重写 `ProviderSurfaceSupport` 或合并 #965 的 router/provider 架构工作。
+- 不保证所有第三方模型都支持 tools；本 issue 只约束 gateway 是否存在可执行方法。
+
+## Behavior Invariants
+
+1. 每个 Tier-1 catalog entry 必须通过命名明确的 capability profile 声明其 endpoint 能力；新增 entry
+   缺少 profile 时不能编译或不能通过 catalog conformance test。
+2. catalog factory 生成的 `OpenAILikeProvider` 必须返回该 `ProviderDefinition` 的 exact capability
+   slice；alias 与 canonical selector 必须解析到同一份声明。
+3. Tier-1 catalog profile 只包含它实际可执行的方法组：chat completion、chat stream，以及由 chat
+   passthrough 执行的 tool/function calling。
+4. `ImageEdit`、`ImageVariation`、`Moderation` 不得由默认或 Tier-1 profile 声明；显式
+   `openai_compatible` factory 必须选择包含这三项的 proxy profile，因为 server routes 有对应执行路径。
+5. 传入包含不可执行 capability 的 instance profile 必须返回 configuration error；不得删除字段、
+   回退到默认列表或只记录 warning。
+6. router/server 已有 canonical capability predicate 必须消费 instance 声明；请求目标 capability
+   不受支持时返回 `UnsupportedCapability`，且不得执行该 deployment。
+7. 直接构造的通用 `OpenAILikeProvider` 必须采用保守的可执行 profile，保持 chat/stream/tool/function
+   行为，同时不重新引入 image/moderation 过度声明。
+8. conformance test 必须遍历每个 catalog definition，证明其声明非空、无重复、属于可执行 surface，
+   并证明 factory instance 与 definition 一致。
+9. exported completion `DefaultRouter` 的环境变量注册路径也必须传递 definition slice；构造失败必须传播，
+   不能静默跳过。
+
+## 验收标准
+
+- [ ] Tier-1 catalog 明确声明各 entry 的 capability profile。
+- [ ] catalog 与直接构造的 OpenAI-like instance 都只返回可执行 capability。
+- [ ] route selection 对 Tier-1 `ImageEdit`/`ImageVariation`/`Moderation` 返回 unsupported，chat 仍可选。
+- [ ] 显式 `openai_compatible` 的既有 image edit/variation/moderation proxy route 保持可用。
+- [ ] conformance test 覆盖全部 catalog entry 和非法声明 fail-closed 路径。
+- [ ] alias、factory registry 与主 gateway factory 使用同一 capability 数据。
+- [ ] 格式、PR scope/overlap guards、strict clippy、全量测试与 SpecRail packet 校验通过。
+
+## 边界情况
+
+- catalog alias 不得复制或覆盖 capability；它只解析到 canonical definition。
+- capability slice 中的重复项属于无效 catalog 数据，必须被 conformance gate 拒绝。
+- support matrix 的 public surface 可比 provider method surface 更窄，但不能把不存在的方法标为可用。
+- custom OpenAI-compatible base URL 不构成新增 capability 的证据。
+- capability 是否可执行按 selector/runtime route 判断，不能只检查 `LLMProvider` trait 方法。
+
+## 发布说明
+
+这是 fail-closed 的 provider routing 修复。Tier-1 chat/stream 与 tool/function passthrough 保持可用；
+image edit、image variation 和 moderation 不再由 Tier-1 参与 route selection，同时显式
+`openai_compatible` 的既有 proxy route 保持可用。

--- a/specs/GH967/tasks.md
+++ b/specs/GH967/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-967 / #967
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP967-T1` Owner: coordinator. Dependencies: none. Done when: GH967 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work 与 write-spec/implement route gates 为 allowed。Verify: packet and route-gate JSON。
+- [x] `SP967-T2` Owner: catalog-contract. Dependencies: T1. Done when: `ProviderDefinition` 持有显式 static capability slice，所有 Tier-1 entry 选择命名 profile，alias 仍解析到 canonical definition。Verify: full-catalog conformance tests。
+- [x] `SP967-T3` Owner: runtime-instance. Dependencies: T2. Done when: OpenAI-like instance 保存 exact slice，constructor 拒绝空、重复或不属于当前 profile 的 capability，三条 catalog 构造路径传递声明，direct constructor 使用保守 profile，显式 `openai_compatible` 使用 proxy profile。Verify: provider/factory/default-router tests。
+- [x] `SP967-T4` Owner: route-conformance. Dependencies: T3. Done when: catalog deployment 的 chat route 可选，`ImageEdit`、`ImageVariation`、`Moderation` 在执行前返回 `UnsupportedCapability`；显式 proxy route 保持可用；每个 declared capability 都通过 method-surface conformance。Verify: focused router 与 image/moderation integration tests。
+- [x] `SP967-T5` Owner: verification. Dependencies: T2-T4. Done when: fmt、diff、all-features check、strict clippy、scope/overlap guards、串行全量 tests 和 packet validation 全部通过。Verify: commands below。
+- [ ] `SP967-T6` Owner: coordinator. Dependencies: T5. Done when: one implementation PR 使用 `Closes #967`，current-head CI、独立 reviewer、review threads、PR gate 与 runtime gate 全部通过并远端确认合并。Verify: SpecRail PR evidence and closure audit。
+
+## 并行拆分
+
+T2-T4 共享 definition -> factory -> instance -> route contract，按 W-14 串行实现。planner/reviewer lane
+只读；共享全量验证由 coordinator 独占。
+
+## 验证
+
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- focused catalog/provider/factory/router capability tests
+- `cargo check --all-features --locked`
+- `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- `bash scripts/guards/check_pr_scope.sh`
+- `bash scripts/guards/check_pr_overlap.sh`
+- `cargo test --all-features --locked -- --test-threads=1`
+- `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH967"`
+
+## Handoff Notes
+
+- 不修改全局 trait lifetime，不使用 `Any`/downcast。
+- support matrix 是 public route surface，不替代 provider method capability。
+- 不根据第三方文档猜测 image/moderation support；当前 profile 只声明 gateway 已实现的 surface。

--- a/specs/GH967/tech.md
+++ b/specs/GH967/tech.md
@@ -1,0 +1,118 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-967 / #967
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Required boundary |
+| --- | --- | --- | --- |
+| Tier-1 catalog | `src/core/providers/registry/definition.rs`, `catalog.rs` | Definition has URL/auth/model metadata but no capability data | Definition owns an explicit static capability slice |
+| OpenAI-like runtime | `src/core/providers/openai_like/provider.rs` | Every instance returns one overbroad static list | Instance stores the selected static slice and validates it |
+| Provider factories | `src/core/providers/factory/mod.rs`, `factory/registry.rs` | Catalog metadata becomes config, then capability identity is lost | Both catalog paths pass definition capabilities into the instance |
+| Exported completion router | `src/core/completion/default_router/mod.rs` | Environment registration uses the default profile and silently ignores construction errors | Pass the definition slice and propagate profile errors |
+| Capability selection | `src/core/providers/capability_dispatch.rs`, `src/core/router/selection.rs` | Existing canonical predicate already filters deployments | Preserve this path; correct the instance truth it consumes |
+| Explicit proxy routes | `src/server/routes/ai/images.rs`, `moderations.rs` | `openai_compatible` has callable image/moderation proxy paths outside `LLMProvider` | Preserve these capabilities only for the explicit selector profile |
+| Public support matrix | `src/core/providers/registry/support_matrix.rs` | Generic Tier-1 is HTTP chat/stream only | Keep unchanged and add consistency coverage where useful |
+
+## 设计方案
+
+1. 在 `ProviderDefinition` 增加 `capabilities: &'static [ProviderCapability]`。catalog 使用命名明确的
+   `def_chat` / `def_local_chat` profile helper，使每个 entry 的选择在调用点可见。当前 profile 包含
+   `ChatCompletion`、`ChatCompletionStream`、`ToolCalling` 和 `FunctionCalling`；不声明 image 或
+   moderation capability。
+2. 在 `OpenAILikeProvider` 定义 `OPENAI_LIKE_CATALOG_CAPABILITIES` 与
+   `OPENAI_COMPATIBLE_PROXY_CAPABILITIES` 两个命名 profile，并增加 instance 字段
+   `capabilities: &'static [ProviderCapability]`。现有 `new(config)` 使用保守 catalog profile；crate
+   内部 catalog constructor 接收 definition slice；显式 `openai_compatible` constructor 使用 proxy profile。
+3. constructor 在建立 HTTP pool 前验证：slice 非空、无重复、每个值都属于该 constructor 的允许集合。
+   catalog constructor 因此拒绝 image/moderation；失败返回 `OpenAILikeError::configuration`，不 fallback。
+4. `LLMProvider::capabilities()` 返回 instance 字段。主 gateway factory、registry factory 与 exported
+   completion `DefaultRouter` 的 catalog 分支都调用 catalog constructor；显式 `openai_compatible` factory
+   调用 proxy constructor。`DefaultRouter` 只对缺少 env key 跳过，profile 构造错误向启动调用者传播。
+5. 不修改 router selection 算法。`Provider::supports_capability_for_model()` 已经委托 canonical
+   `supports_capability()`；instance 真值修正后，unsupported deployment 会在 reservation/执行前被排除。
+6. conformance tests：
+   - 遍历 `PROVIDER_CATALOG`，校验每个 slice 非空、无重复且属于 executable surface；
+   - 通过 factory 构造代表性 canonical/alias provider，断言 instance 与 definition exact match；
+   - 注入静态非法 profile，断言 constructor configuration error；
+   - router 同时验证 Tier-1 chat 可选择、`ImageEdit`/`ImageVariation`/`Moderation` 返回
+     `UnsupportedCapability`；既有 explicit proxy integration tests 必须继续通过。
+
+## Executable Surface Mapping
+
+| Capability | Runtime method | Status |
+| --- | --- | --- |
+| `ChatCompletion` | `OpenAILikeProvider::chat_completion` | implemented |
+| `ChatCompletionStream` | `OpenAILikeProvider::chat_completion_stream` | implemented |
+| `ToolCalling` | chat request/response passthrough | implemented through chat |
+| `FunctionCalling` | legacy function fields through chat passthrough | implemented through chat |
+| `ImageEdit` | explicit `openai_compatible` image proxy route | explicit proxy profile only |
+| `ImageVariation` | explicit `openai_compatible` image proxy route | explicit proxy profile only |
+| `Moderation` | explicit `openai_compatible` moderation proxy route | explicit proxy profile only |
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P2/P9 catalog ownership | definition, catalog, all three catalog factories | full-catalog and factory/default-router identity tests |
+| P3/P4 executable surface | OpenAI-like provider and explicit proxy routes | exact catalog/proxy profiles plus existing integration tests |
+| P5 fail closed | capability-aware constructor | invalid static profile returns configuration error |
+| P6 route exclusion | existing router selection | catalog deployment chat succeeds; image/moderation unsupported |
+| P7 direct construction | `OpenAILikeProvider::new` | default instance exact capability test |
+| P8 conformance | catalog/provider tests | iteration over every catalog definition |
+
+## 数据流
+
+`ProviderDefinition.capabilities` -> catalog factory -> `OpenAILikeProvider.capabilities` ->
+`Provider::supports_capability_for_model` -> router candidate filter -> selected executable deployment。
+
+没有新增持久化、外部 API、配置字段或动态网络探测。capability slice 全部是编译期静态数据。
+
+## 受影响文件与规模
+
+- `src/core/providers/registry/definition.rs`
+- `src/core/providers/registry/catalog.rs`
+- `src/core/providers/openai_like/provider.rs`
+- `src/core/providers/openai_like/provider/tests.rs`
+- `src/core/providers/factory/mod.rs`
+- `src/core/providers/factory/registry.rs`
+- `src/core/completion/default_router/mod.rs`
+- `src/core/router/tests/selection_tests.rs`
+- `CLAUDE.md`
+- `specs/GH967/*`
+
+预计不超过 10 个文件、500 行 production/test diff（docs 不计），满足仓库 PR scope guard。
+
+## 备选方案
+
+- 只删除三个 capability：能修眼前症状，但 catalog 仍没有真值，未来会再次漂移，拒绝。
+- 修改 trait 为 instance-borrowed `&[ProviderCapability]`：会触及全部 provider 实现，超出本 issue。
+- 从 support matrix 运行时反推 capability：surface matrix 与 provider method surface 语义不同，拒绝。
+- 用 `Any`/downcast 检查方法：违反 provider dispatch contract，拒绝。
+
+## 风险
+
+- Compatibility: Tier-1 的错误 image/moderation 宣称会更早返回 unsupported；显式 proxy route 必须保持。
+- Logic: 三条 catalog 构造路径都必须传递 capability，否则行为会因入口不同而漂移。
+- Data integrity: static slice 的重复/越界声明必须 fail closed，不能 warning 后继续。
+- Performance: capability 查询仍是很短的静态 slice scan，无额外分配。
+- Security: 不改变 URL、认证、header 或请求执行。
+
+## 测试计划
+
+- Focused: catalog definition、OpenAI-like provider、三条 factory/router capability tests、现有 image/moderation proxy integration tests。
+- Deterministic: `cargo fmt --all -- --check`、`git diff --check`、all-features check、strict clippy。
+- Repository: `cargo test --all-features --locked -- --test-threads=1`。
+- Guards: `bash scripts/guards/check_pr_scope.sh`、`bash scripts/guards/check_pr_overlap.sh`。
+- SpecRail: GH967 packet check、implementation route gate、current-head PR gate。
+
+## 回滚方案
+
+回滚 GH967 PR 即恢复旧静态 capability 列表。没有 migration 或持久化状态；但回滚会重新允许 route
+选择没有执行方法的 Tier-1 provider，因此只应在发现真实 chat/stream 回归时执行。

--- a/src/core/completion/default_router/mod.rs
+++ b/src/core/completion/default_router/mod.rs
@@ -24,6 +24,25 @@ pub struct DefaultRouter {
 }
 
 impl DefaultRouter {
+    async fn build_catalog_provider(
+        def: &crate::core::providers::registry::ProviderDefinition,
+        api_key: &str,
+    ) -> Result<Provider> {
+        let config = def.to_openai_like_config(Some(api_key), None);
+        let provider = crate::core::providers::openai_like::OpenAILikeProvider::new_for_catalog(
+            config,
+            def.capabilities,
+        )
+        .await
+        .map_err(|error| {
+            GatewayError::Config(format!(
+                "Failed to initialize catalog provider '{}': {error}",
+                def.name
+            ))
+        })?;
+        Ok(Provider::OpenAILike(provider))
+    }
+
     /// Helper function to find and select a provider by name with model prefix stripping
     fn select_provider_by_name<'a>(
         providers: &'a [&'a crate::core::providers::Provider],
@@ -78,30 +97,31 @@ impl DefaultRouter {
     async fn register_openai_like_provider_from_env(
         provider_registry: &mut ProviderRegistry,
         provider_name: &str,
-    ) {
-        let Some(def) = crate::core::providers::registry::get_definition(provider_name) else {
-            return;
-        };
+    ) -> Result<()> {
+        let def =
+            crate::core::providers::registry::get_definition(provider_name).ok_or_else(|| {
+                GatewayError::Config(format!(
+                    "Default catalog provider '{provider_name}' has no definition"
+                ))
+            })?;
         let Some(api_key) = def.resolve_api_key(None) else {
-            return;
+            return Ok(());
         };
 
-        let config = def.to_openai_like_config(Some(&api_key), None);
-        if let Ok(provider) =
-            crate::core::providers::openai_like::OpenAILikeProvider::new(config).await
-        {
-            provider_registry.register(Provider::OpenAILike(provider));
-        }
+        let provider = Self::build_catalog_provider(def, &api_key).await?;
+        provider_registry.register(provider);
+        Ok(())
     }
 
     async fn register_default_openai_like_providers_from_env(
         provider_registry: &mut ProviderRegistry,
-    ) {
+    ) -> Result<()> {
         for provider_name in
             crate::core::providers::registry::default_catalog_runtime_provider_names()
         {
-            Self::register_openai_like_provider_from_env(provider_registry, provider_name).await;
+            Self::register_openai_like_provider_from_env(provider_registry, provider_name).await?;
         }
+        Ok(())
     }
 
     pub async fn new() -> Result<Self> {
@@ -135,7 +155,7 @@ impl DefaultRouter {
             }
         }
 
-        Self::register_default_openai_like_providers_from_env(&mut provider_registry).await;
+        Self::register_default_openai_like_providers_from_env(&mut provider_registry).await?;
 
         // Add Anthropic provider if API key is available
         if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
@@ -259,5 +279,55 @@ fn convert_chat_chunk_to_completion_chunk(
                 finish_reason: c.finish_reason,
             })
             .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::model::ProviderCapability;
+
+    #[tokio::test]
+    async fn catalog_builder_preserves_definition_capabilities() {
+        let definition = crate::core::providers::registry::get_definition("perplexity")
+            .expect("Perplexity catalog definition should exist");
+
+        let provider = DefaultRouter::build_catalog_provider(definition, "test-key")
+            .await
+            .expect("catalog provider should build");
+
+        assert_eq!(provider.capabilities(), definition.capabilities);
+    }
+
+    #[tokio::test]
+    async fn catalog_builder_propagates_invalid_profile_errors() {
+        static INVALID: &[ProviderCapability] = &[ProviderCapability::ImageEdit];
+        let mut definition = crate::core::providers::registry::get_definition("perplexity")
+            .expect("Perplexity catalog definition should exist")
+            .clone();
+        definition.capabilities = INVALID;
+
+        let error = DefaultRouter::build_catalog_provider(&definition, "test-key")
+            .await
+            .expect_err("invalid catalog profile must fail startup");
+
+        assert!(
+            error
+                .to_string()
+                .contains("not executable for this OpenAI-like profile"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_catalog_registration_rejects_missing_definition() {
+        let mut registry = ProviderRegistry::new();
+
+        let error =
+            DefaultRouter::register_openai_like_provider_from_env(&mut registry, "missing-catalog")
+                .await
+                .expect_err("missing catalog definition must fail startup");
+
+        assert!(error.to_string().contains("has no definition"));
     }
 }

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -112,9 +112,10 @@ pub async fn create_provider(
             );
         }
 
-        let provider = openai_like::OpenAILikeProvider::new(oai_config)
-            .await
-            .map_err(|e| ProviderError::initialization(def.name, e.to_string()))?;
+        let provider =
+            openai_like::OpenAILikeProvider::new_for_catalog(oai_config, def.capabilities)
+                .await
+                .map_err(|e| ProviderError::initialization(def.name, e.to_string()))?;
         return Ok(Provider::OpenAILike(provider));
     }
 
@@ -232,10 +233,11 @@ mod tests {
             });
 
             assert!(
-                matches!(provider, Provider::OpenAILike(_)),
+                matches!(&provider, Provider::OpenAILike(_)),
                 "Catalog provider '{}' must create OpenAILike variant",
                 name
             );
+            assert_eq!(provider.capabilities(), def.capabilities);
         }
     }
 
@@ -291,7 +293,10 @@ mod tests {
         let provider = create_provider(config)
             .await
             .expect("Tier 1 provider should succeed");
-        assert!(matches!(provider, Provider::OpenAILike(_)));
+        assert!(matches!(&provider, Provider::OpenAILike(_)));
+        let definition = provider_registry::get_definition("perplexity")
+            .expect("Perplexity definition should exist");
+        assert_eq!(provider.capabilities(), definition.capabilities);
     }
 
     #[tokio::test]
@@ -528,6 +533,9 @@ mod tests {
                 let provider = create_provider(config).await.unwrap_or_else(|e| {
                     panic!("Expected '{selector}' provider to be creatable: {e}")
                 });
+                let definition = provider_registry::get_definition(selector)
+                    .expect("alias should resolve to a catalog definition");
+                assert_eq!(provider.capabilities(), definition.capabilities);
                 let Provider::OpenAILike(provider) = provider else {
                     panic!("Expected '{selector}' to create OpenAILike provider");
                 };
@@ -736,6 +744,10 @@ mod tests {
         let provider = create_provider(config)
             .await
             .expect("openai_compatible provider should be creatable");
-        assert!(matches!(provider, Provider::OpenAILike(_)));
+        assert!(matches!(&provider, Provider::OpenAILike(_)));
+        assert_eq!(
+            provider.capabilities(),
+            openai_like::provider::OPENAI_COMPATIBLE_PROXY_CAPABILITIES
+        );
     }
 }

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -95,7 +95,7 @@ impl Provider {
             }
             ProviderType::OpenAICompatible => {
                 let oai_like = build_openai_like_config_from_factory(&config)?;
-                let provider = openai_like::OpenAILikeProvider::new(oai_like)
+                let provider = openai_like::OpenAILikeProvider::new_openai_compatible(oai_like)
                     .await
                     .map_err(|e| {
                         ProviderError::initialization("openai_compatible", e.to_string())
@@ -250,9 +250,10 @@ impl Provider {
                     let _ignored_settings =
                         apply_tier1_openai_like_overrides(&mut oai_config, &settings);
                 }
-                let provider = openai_like::OpenAILikeProvider::new(oai_config)
-                    .await
-                    .map_err(|e| ProviderError::initialization(name, e.to_string()))?;
+                let provider =
+                    openai_like::OpenAILikeProvider::new_for_catalog(oai_config, def.capabilities)
+                        .await
+                        .map_err(|e| ProviderError::initialization(name, e.to_string()))?;
                 Ok(Provider::OpenAILike(provider))
             }
         }
@@ -768,6 +769,10 @@ mod tests {
             ProviderType::GitHub,
             ProviderType::Custom("together".to_string()),
         ] {
+            let expected_capabilities =
+                provider_registry::catalog_definition_for_provider_type(&provider_type)
+                    .expect("catalogified provider should have a definition")
+                    .capabilities;
             let provider = Provider::from_config_async(
                 provider_type.clone(),
                 serde_json::json!({
@@ -783,6 +788,7 @@ mod tests {
 
             assert!(matches!(provider, Provider::OpenAILike(_)));
             assert_eq!(provider.name(), provider_type.to_string());
+            assert_eq!(provider.capabilities(), expected_capabilities);
         }
     }
 }

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -30,6 +30,23 @@ use super::{
 };
 use crate::core::providers::unified_provider::ProviderError;
 
+pub(crate) static OPENAI_LIKE_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
+    ProviderCapability::ChatCompletion,
+    ProviderCapability::ChatCompletionStream,
+    ProviderCapability::ToolCalling,
+    ProviderCapability::FunctionCalling,
+];
+
+pub(crate) static OPENAI_COMPATIBLE_PROXY_CAPABILITIES: &[ProviderCapability] = &[
+    ProviderCapability::ChatCompletion,
+    ProviderCapability::ChatCompletionStream,
+    ProviderCapability::ImageEdit,
+    ProviderCapability::ImageVariation,
+    ProviderCapability::Moderation,
+    ProviderCapability::ToolCalling,
+    ProviderCapability::FunctionCalling,
+];
+
 /// OpenAI-Like Provider implementation
 ///
 /// Connects to any OpenAI-compatible API endpoint.
@@ -43,14 +60,48 @@ pub struct OpenAILikeProvider {
     model_registry: &'static OpenAILikeModelRegistry,
     /// Provider name returned by the LLM provider trait.
     provider_name: String,
+    /// Catalog or instance capability profile, validated against executable methods.
+    capabilities: &'static [ProviderCapability],
 }
 
 impl OpenAILikeProvider {
     /// Create a new OpenAI-like provider
     pub async fn new(config: OpenAILikeConfig) -> Result<Self, OpenAILikeError> {
+        Self::new_with_profile(
+            config,
+            OPENAI_LIKE_CATALOG_CAPABILITIES,
+            OPENAI_LIKE_CATALOG_CAPABILITIES,
+        )
+        .await
+    }
+
+    pub(crate) async fn new_for_catalog(
+        config: OpenAILikeConfig,
+        capabilities: &'static [ProviderCapability],
+    ) -> Result<Self, OpenAILikeError> {
+        Self::new_with_profile(config, capabilities, OPENAI_LIKE_CATALOG_CAPABILITIES).await
+    }
+
+    pub(crate) async fn new_openai_compatible(
+        config: OpenAILikeConfig,
+    ) -> Result<Self, OpenAILikeError> {
+        Self::new_with_profile(
+            config,
+            OPENAI_COMPATIBLE_PROXY_CAPABILITIES,
+            OPENAI_COMPATIBLE_PROXY_CAPABILITIES,
+        )
+        .await
+    }
+
+    async fn new_with_profile(
+        config: OpenAILikeConfig,
+        capabilities: &'static [ProviderCapability],
+        allowed_capabilities: &'static [ProviderCapability],
+    ) -> Result<Self, OpenAILikeError> {
         config
             .validate()
             .map_err(|e| OpenAILikeError::configuration(PROVIDER_NAME, e))?;
+        Self::validate_capability_profile(capabilities, allowed_capabilities)?;
 
         let pool_manager = Arc::new(
             GlobalPoolManager::new()
@@ -64,7 +115,39 @@ impl OpenAILikeProvider {
             config,
             model_registry,
             provider_name,
+            capabilities,
         })
+    }
+
+    fn validate_capability_profile(
+        capabilities: &'static [ProviderCapability],
+        allowed_capabilities: &'static [ProviderCapability],
+    ) -> Result<(), OpenAILikeError> {
+        if capabilities.is_empty() {
+            return Err(OpenAILikeError::configuration(
+                PROVIDER_NAME,
+                "capability profile cannot be empty",
+            ));
+        }
+
+        for (index, capability) in capabilities.iter().enumerate() {
+            if capabilities[..index].contains(capability) {
+                return Err(OpenAILikeError::configuration(
+                    PROVIDER_NAME,
+                    format!("capability profile contains duplicate {capability:?}"),
+                ));
+            }
+            if !allowed_capabilities.contains(capability) {
+                return Err(OpenAILikeError::configuration(
+                    PROVIDER_NAME,
+                    format!(
+                        "capability {capability:?} is not executable for this OpenAI-like profile"
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     /// Create provider with just an API base URL (no API key required)
@@ -492,16 +575,7 @@ impl LLMProvider for OpenAILikeProvider {
     }
 
     fn capabilities(&self) -> &'static [ProviderCapability] {
-        static CAPABILITIES: &[ProviderCapability] = &[
-            ProviderCapability::ChatCompletion,
-            ProviderCapability::ChatCompletionStream,
-            ProviderCapability::ImageEdit,
-            ProviderCapability::ImageVariation,
-            ProviderCapability::Moderation,
-            ProviderCapability::ToolCalling,
-            ProviderCapability::FunctionCalling,
-        ];
-        CAPABILITIES
+        self.capabilities
     }
 
     fn models(&self) -> &[ModelInfo] {

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -81,6 +81,65 @@ async fn test_provider_creation_with_api_base() {
 }
 
 #[tokio::test]
+async fn generic_openai_like_declares_only_catalog_executable_capabilities() {
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    let provider = OpenAILikeProvider::with_api_base("http://localhost:8000/v1")
+        .await
+        .expect("OpenAI-like provider should build");
+
+    assert_eq!(
+        provider.capabilities(),
+        &[
+            ProviderCapability::ChatCompletion,
+            ProviderCapability::ChatCompletionStream,
+            ProviderCapability::ToolCalling,
+            ProviderCapability::FunctionCalling,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn openai_compatible_declares_executable_proxy_capabilities() {
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    let config = OpenAILikeConfig::new("http://localhost:8000/v1").with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new_openai_compatible(config)
+        .await
+        .expect("OpenAI-compatible provider should build");
+
+    assert_eq!(
+        provider.capabilities(),
+        OPENAI_COMPATIBLE_PROXY_CAPABILITIES
+    );
+}
+
+#[tokio::test]
+async fn openai_like_catalog_rejects_invalid_capability_profiles() {
+    static EMPTY: &[ProviderCapability] = &[];
+    static DUPLICATE: &[ProviderCapability] = &[
+        ProviderCapability::ChatCompletion,
+        ProviderCapability::ChatCompletion,
+    ];
+    static UNIMPLEMENTED: &[ProviderCapability] = &[ProviderCapability::ImageEdit];
+
+    let config = OpenAILikeConfig::new("http://localhost:8000/v1").with_skip_api_key(true);
+    for (profile, expected) in [
+        (EMPTY, "cannot be empty"),
+        (DUPLICATE, "duplicate ChatCompletion"),
+        (UNIMPLEMENTED, "not executable for this OpenAI-like profile"),
+    ] {
+        let error = OpenAILikeProvider::new_for_catalog(config.clone(), profile)
+            .await
+            .expect_err("invalid capability profile must fail closed");
+        assert!(
+            error.to_string().contains(expected),
+            "expected {expected:?} in {error}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_openai_like_streaming_maps_non_success_status_before_sse()
 -> Result<(), Box<dyn std::error::Error>> {
     use crate::core::providers::unified_provider::ProviderError;

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use super::definition::{AuthType, ProviderDefinition};
+use crate::core::providers::openai_like::provider::OPENAI_LIKE_CATALOG_CAPABILITIES;
 
 /// Global provider catalog, keyed by provider name.
 pub static PROVIDER_CATALOG: LazyLock<HashMap<&'static str, ProviderDefinition>> =
@@ -43,7 +44,7 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
     let defs: Vec<ProviderDefinition> = vec![
         // ===== Group 1b: Cloud OpenAI-compatible =====
         // ===== Group 1b: Cloud OpenAI-compatible =====
-        def(
+        def_chat(
             "groq",
             "Groq",
             "https://api.groq.com/openai/v1",
@@ -55,7 +56,7 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
                 "TOGETHERAI_API_KEY",
                 "TOGETHER_AI_TOKEN",
             ],
-            ..def(
+            ..def_chat(
                 "together",
                 "Together AI",
                 "https://api.together.xyz/v1",
@@ -68,7 +69,7 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
                 "TOGETHERAI_API_KEY",
                 "TOGETHER_AI_TOKEN",
             ],
-            ..def(
+            ..def_chat(
                 "together_ai",
                 "Together AI",
                 "https://api.together.xyz/v1",
@@ -81,7 +82,7 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
                 "FIREWORKSAI_API_KEY",
                 "FIREWORKS_AI_TOKEN",
             ],
-            ..def(
+            ..def_chat(
                 "fireworks",
                 "Fireworks AI",
                 "https://api.fireworks.ai/inference/v1",
@@ -94,117 +95,117 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
                 "FIREWORKSAI_API_KEY",
                 "FIREWORKS_AI_TOKEN",
             ],
-            ..def(
+            ..def_chat(
                 "fireworks_ai",
                 "Fireworks AI",
                 "https://api.fireworks.ai/inference/v1",
                 "FIREWORKS_API_KEY",
             )
         },
-        def(
+        def_chat(
             "perplexity",
             "Perplexity AI",
             "https://api.perplexity.ai",
             "PERPLEXITY_API_KEY",
         ),
-        def(
+        def_chat(
             "cerebras",
             "Cerebras",
             "https://api.cerebras.ai/v1",
             "CEREBRAS_API_KEY",
         ),
-        def(
+        def_chat(
             "openrouter",
             "OpenRouter",
             "https://openrouter.ai/api/v1",
             "OPENROUTER_API_KEY",
         ),
-        def(
+        def_chat(
             "deepinfra",
             "DeepInfra",
             "https://api.deepinfra.com/v1/openai",
             "DEEPINFRA_API_KEY",
         ),
-        def(
+        def_chat(
             "deepseek",
             "DeepSeek",
             "https://api.deepseek.com",
             "DEEPSEEK_API_KEY",
         ),
-        def(
+        def_chat(
             "novita",
             "Novita AI",
             "https://api.novita.ai/v3/openai",
             "NOVITA_API_KEY",
         ),
-        def(
+        def_chat(
             "nvidia_nim",
             "NVIDIA NIM",
             "https://integrate.api.nvidia.com/v1",
             "NVIDIA_NIM_API_KEY",
         ),
-        def(
+        def_chat(
             "nebius",
             "Nebius AI",
             "https://api.studio.nebius.ai/v1",
             "NEBIUS_API_KEY",
         ),
-        def(
+        def_chat(
             "nscale",
             "Nscale",
             "https://inference.api.nscale.ai/v1",
             "NSCALE_API_KEY",
         ),
-        def(
+        def_chat(
             "hyperbolic",
             "Hyperbolic",
             "https://api.hyperbolic.xyz/v1",
             "HYPERBOLIC_API_KEY",
         ),
-        def(
+        def_chat(
             "featherless",
             "Featherless AI",
             "https://api.featherless.ai/v1",
             "FEATHERLESS_API_KEY",
         ),
-        def(
+        def_chat(
             "galadriel",
             "Galadriel",
             "https://api.galadriel.com/v1",
             "GALADRIEL_API_KEY",
         ),
-        def(
+        def_chat(
             "sambanova",
             "SambaNova",
             "https://api.sambanova.ai/v1",
             "SAMBANOVA_API_KEY",
         ),
-        def(
+        def_chat(
             "heroku",
             "Heroku",
             "https://us.inference.heroku.com/v1",
             "HEROKU_API_KEY",
         ),
-        def(
+        def_chat(
             "friendliai",
             "FriendliAI",
             "https://api.friendli.ai/v1",
             "FRIENDLIAI_API_KEY",
         ),
-        def(
+        def_chat(
             "meta_llama",
             "Meta Llama API",
             "https://api.llama.com/compat/v1",
             "META_LLAMA_API_KEY",
         ),
-        def("v0", "Vercel v0", "https://api.v0.dev/v1", "V0_API_KEY"),
-        def(
+        def_chat("v0", "Vercel v0", "https://api.v0.dev/v1", "V0_API_KEY"),
+        def_chat(
             "amazon_nova",
             "Amazon Nova",
             "https://api.nova.amazon.com/v1",
             "AMAZON_NOVA_API_KEY",
         ),
-        def(
+        def_chat(
             "github",
             "GitHub Models",
             "https://models.inference.ai.azure.com",
@@ -214,53 +215,53 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
         // passed through instead of enumerated in this static provider catalog.
         ProviderDefinition {
             model_prefix: Some("xai/"),
-            ..def("xai", "xAI", "https://api.x.ai/v1", "XAI_API_KEY")
+            ..def_chat("xai", "xAI", "https://api.x.ai/v1", "XAI_API_KEY")
         },
         // ===== Group 1c: Local inference (no API key) =====
-        def_local("vllm", "vLLM", "http://localhost:8000/v1"),
-        def_local("hosted_vllm", "Hosted vLLM", "http://localhost:8000/v1"),
-        def_local("lm_studio", "LM Studio", "http://localhost:1234/v1"),
-        def_local("llamafile", "Llamafile", "http://localhost:8080/v1"),
-        def_local(
+        def_local_chat("vllm", "vLLM", "http://localhost:8000/v1"),
+        def_local_chat("hosted_vllm", "Hosted vLLM", "http://localhost:8000/v1"),
+        def_local_chat("lm_studio", "LM Studio", "http://localhost:1234/v1"),
+        def_local_chat("llamafile", "Llamafile", "http://localhost:8080/v1"),
+        def_local_chat(
             "docker_model_runner",
             "Docker Model Runner",
             "http://localhost:12434/engines/llama.cpp/v1",
         ),
-        def_local("xinference", "Xinference", "http://localhost:9997/v1"),
-        def_local("infinity", "Infinity", "http://localhost:7997/v1"),
-        def_local("oobabooga", "Oobabooga", "http://localhost:5000/v1"),
+        def_local_chat("xinference", "Xinference", "http://localhost:9997/v1"),
+        def_local_chat("infinity", "Infinity", "http://localhost:7997/v1"),
+        def_local_chat("oobabooga", "Oobabooga", "http://localhost:5000/v1"),
         // ===== Group 1d: Chinese OpenAI-compatible =====
-        def(
+        def_chat(
             "moonshot",
             "Moonshot AI",
             "https://api.moonshot.cn/v1",
             "MOONSHOT_API_KEY",
         ),
-        def(
+        def_chat(
             "dashscope",
             "Dashscope",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
             "DASHSCOPE_API_KEY",
         ),
-        def(
+        def_chat(
             "qwen",
             "Qwen",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
             "DASHSCOPE_API_KEY",
         ),
-        def(
+        def_chat(
             "baichuan",
             "Baichuan",
             "https://api.baichuan-ai.com/v1",
             "BAICHUAN_API_KEY",
         ),
-        def(
+        def_chat(
             "minimax",
             "MiniMax",
             "https://api.minimax.chat/v1",
             "MINIMAX_API_KEY",
         ),
-        def(
+        def_chat(
             "volcengine",
             "Volcengine",
             "https://ark.cn-beijing.volces.com/api/v3",
@@ -268,41 +269,41 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
         ),
         ProviderDefinition {
             alternate_auth_env_vars: &["XIAOMI_API_KEY"],
-            ..def(
+            ..def_chat(
                 "xiaomi_mimo",
                 "Xiaomi MiMo",
                 "https://api.xiaomimimo.com/v1",
                 "MIMO_API_KEY",
             )
         },
-        def(
+        def_chat(
             "zhipu",
             "Zhipu AI",
             "https://open.bigmodel.cn/api/paas/v4",
             "ZHIPU_API_KEY",
         ),
-        def("zai", "ZAI", "https://api.z.ai/api/paas/v4", "ZAI_API_KEY"),
+        def_chat("zai", "ZAI", "https://api.z.ai/api/paas/v4", "ZAI_API_KEY"),
         // ===== Group 1e: Other OpenAI-compatible =====
-        def(
+        def_chat(
             "lemonade",
             "Lemonade",
             "https://api.lemonade.social/v1",
             "LEMONADE_API_KEY",
         ),
-        def(
+        def_chat(
             "linkup",
             "Linkup",
             "https://api.linkup.so/v1",
             "LINKUP_API_KEY",
         ),
-        def("poe", "Poe", "https://api.poe.com/v1", "POE_API_KEY"),
-        def(
+        def_chat("poe", "Poe", "https://api.poe.com/v1", "POE_API_KEY"),
+        def_chat(
             "wandb",
             "Weights & Biases",
             "https://api.wandb.ai/v1",
             "WANDB_API_KEY",
         ),
-        def(
+        def_chat(
             "nanogpt",
             "NanoGPT",
             "https://api.nanogpt.com/v1",
@@ -311,7 +312,7 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
         // ===== Group 1a: Previously macro-based =====
         ProviderDefinition {
             alternate_auth_env_vars: &["AIMLAPI_KEY"],
-            ..def(
+            ..def_chat(
                 "aiml_api",
                 "AIML API",
                 "https://api.aimlapi.com/v1",
@@ -320,63 +321,63 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
         },
         ProviderDefinition {
             alternate_auth_env_vars: &["AIMLAPI_KEY"],
-            ..def(
+            ..def_chat(
                 "aiml",
                 "AIML API",
                 "https://api.aimlapi.com/v1",
                 "AIML_API_KEY",
             )
         },
-        def(
+        def_chat(
             "aleph_alpha",
             "Aleph Alpha",
             "https://api.aleph-alpha.com/v1",
             "ALEPH_ALPHA_API_KEY",
         ),
-        def(
+        def_chat(
             "anyscale",
             "Anyscale",
             "https://api.endpoints.anyscale.com/v1",
             "ANYSCALE_API_KEY",
         ),
-        def(
+        def_chat(
             "bytez",
             "Bytez",
             "https://api.bytez.com/v1",
             "BYTEZ_API_KEY",
         ),
-        def(
+        def_chat(
             "comet_api",
             "Comet API",
             "https://api.comet.com/v1",
             "COMET_API_KEY",
         ),
-        def(
+        def_chat(
             "compactifai",
             "CompactifAI",
             "https://api.compactif.ai/v1",
             "COMPACTIFAI_API_KEY",
         ),
-        def(
+        def_chat(
             "maritalk",
             "MariTalk",
             "https://chat.maritaca.ai/api",
             "MARITALK_API_KEY",
         ),
-        def(
+        def_chat(
             "siliconflow",
             "SiliconFlow",
             "https://api.siliconflow.cn/v1",
             "SILICONFLOW_API_KEY",
         ),
-        def("yi", "Yi", "https://api.lingyiwanwu.com/v1", "YI_API_KEY"),
-        def(
+        def_chat("yi", "Yi", "https://api.lingyiwanwu.com/v1", "YI_API_KEY"),
+        def_chat(
             "lambda_ai",
             "Lambda AI",
             "https://api.lambdalabs.com/v1",
             "LAMBDA_API_KEY",
         ),
-        def(
+        def_chat(
             "ovhcloud",
             "OVHcloud",
             "https://api.ai.cloud.ovh.net/v1",
@@ -392,7 +393,7 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
 }
 
 /// Helper: standard Bearer-auth cloud provider
-fn def(
+fn def_chat(
     name: &'static str,
     display_name: &'static str,
     base_url: &'static str,
@@ -407,11 +408,12 @@ fn def(
         auth_type: AuthType::Bearer,
         skip_api_key: false,
         model_prefix: None,
+        capabilities: OPENAI_LIKE_CATALOG_CAPABILITIES,
     }
 }
 
 /// Helper: local provider (no API key required)
-fn def_local(
+fn def_local_chat(
     name: &'static str,
     display_name: &'static str,
     base_url: &'static str,
@@ -425,12 +427,36 @@ fn def_local(
         auth_type: AuthType::None,
         skip_api_key: true,
         model_prefix: None,
+        capabilities: OPENAI_LIKE_CATALOG_CAPABILITIES,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_catalog_capability_is_executable_and_unique() {
+        for definition in PROVIDER_CATALOG.values() {
+            assert!(
+                !definition.capabilities.is_empty(),
+                "{} must declare a capability profile",
+                definition.name
+            );
+            for (index, capability) in definition.capabilities.iter().enumerate() {
+                assert!(
+                    !definition.capabilities[..index].contains(capability),
+                    "{} declares duplicate capability {capability:?}",
+                    definition.name
+                );
+                assert!(
+                    OPENAI_LIKE_CATALOG_CAPABILITIES.contains(capability),
+                    "{} declares non-executable capability {capability:?}",
+                    definition.name
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_xai_openai_compatible_pass_through_definition() {
@@ -500,6 +526,9 @@ mod tests {
             assert_eq!(definition.base_url, base_url);
             assert_eq!(canonical_catalog_name(alias), Some(canonical));
             assert!(is_tier1_provider(alias));
+            let canonical_definition =
+                get_definition(canonical).expect("canonical catalog definition should exist");
+            assert_eq!(definition.capabilities, canonical_definition.capabilities);
         }
     }
 

--- a/src/core/providers/registry/definition.rs
+++ b/src/core/providers/registry/definition.rs
@@ -4,6 +4,8 @@
 //! base_url, auth, and supported models. Instead of maintaining separate
 //! implementations, they are defined as static data entries.
 
+use crate::core::types::model::ProviderCapability;
+
 /// How the provider authenticates requests
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthType {
@@ -37,6 +39,8 @@ pub struct ProviderDefinition {
     pub skip_api_key: bool,
     /// Model name prefix to strip, if any (e.g. "groq/")
     pub model_prefix: Option<&'static str>,
+    /// Runtime methods this catalog provider is allowed to advertise.
+    pub capabilities: &'static [ProviderCapability],
 }
 
 impl ProviderDefinition {

--- a/src/core/router/tests/selection_tests.rs
+++ b/src/core/router/tests/selection_tests.rs
@@ -6,8 +6,10 @@
 #![allow(deprecated)]
 
 use super::router_tests::create_test_deployment;
+use crate::config::models::provider::ProviderConfig;
+use crate::core::providers::factory::create_provider;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
-use crate::core::router::deployment::HealthStatus;
+use crate::core::router::deployment::{Deployment, HealthStatus};
 use crate::core::router::error::RouterError;
 use crate::core::router::unified::Router;
 use crate::core::types::model::ProviderCapability;
@@ -154,6 +156,49 @@ async fn test_capability_selection_reports_unsupported_capability() {
         RouterError::UnsupportedCapability { model, capability }
             if model == "shared-model" && capability == "CodeExecution"
     ));
+}
+
+#[tokio::test]
+async fn openai_like_route_selection_rejects_unimplemented_surfaces() {
+    let provider = create_provider(ProviderConfig {
+        name: "perplexity".to_string(),
+        api_key: "sk-test".to_string(),
+        ..Default::default()
+    })
+    .await
+    .expect("Tier-1 catalog provider should build");
+    let deployment = Deployment::new(
+        "catalog-test".to_string(),
+        provider,
+        "shared-model".to_string(),
+        "shared-model".to_string(),
+    );
+    deployment
+        .state
+        .health
+        .store(HealthStatus::Healthy as u8, Relaxed);
+    let router = Router::default();
+    router.add_deployment(deployment);
+
+    let selected = router
+        .select_deployment_for_capability("shared-model", &ProviderCapability::ChatCompletion)
+        .expect("OpenAI-like provider should remain selectable for chat");
+    assert_eq!(selected, "catalog-test");
+
+    for capability in [
+        ProviderCapability::ImageEdit,
+        ProviderCapability::ImageVariation,
+        ProviderCapability::Moderation,
+    ] {
+        let err = router
+            .select_deployment_for_capability("shared-model", &capability)
+            .expect_err("OpenAI-like provider must not be selected without an executable method");
+        assert!(matches!(
+            err,
+            RouterError::UnsupportedCapability { model, capability: reported }
+                if model == "shared-model" && reported == format!("{capability:?}")
+        ));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add explicit capability profiles to every Tier-1 catalog definition and preserve them across all catalog construction paths
- keep generic catalog providers on chat surfaces while preserving explicit openai_compatible image and moderation proxy routes
- fail closed on invalid profiles and add catalog, factory, router, proxy, and DefaultRouter conformance coverage

## Verification
- cargo fmt --all -- --check
- cargo check --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked -- --test-threads=1
- bash scripts/guards/check_pr_scope.sh origin/main
- bash scripts/guards/check_pr_overlap.sh
- SpecRail GH967 packet and runtime gates

Closes #967