### PR TITLE
fix(auth): reject API keys with invalid owners

### DIFF
--- a/specs/GH958/product.md
+++ b/specs/GH958/product.md
@@ -1,0 +1,51 @@
+# Product Spec
+
+## Linked Issue
+
+GH-958 / #958
+
+## 用户问题
+
+API key 自身为 active 且未过期时，实时验证路径会接受其数据库记录，即使该 key 明确绑定的 user 已不存在或不是 active。详细验证路径只拒绝 inactive owner，仍会接受 missing owner。两条入口因此可能为已经失去有效 owner 的凭证授权。
+
+## 目标
+
+- 明确 user-owned API key 的 owner 存在性与 active 状态是认证成功的必要条件。
+- 普通验证与详细验证使用同一个 owner 判定契约。
+- 保持 `user_id = None` 的 ownerless/global key 现有有效性语义。
+- owner 查询基础设施错误继续作为系统错误传播，不伪装成无效凭证。
+
+## 非目标
+
+- 不改变 API-key Redis cache 的读取或失效策略；该工作属于 #959。
+- 不改变 user 删除、外键 `ON DELETE SET NULL` 或 owner provenance；该工作属于 #961。
+- 不改变 key hash、创建、撤销、过期或权限语义。
+- 不新增公开 API 或数据库 migration。
+
+## Behavior Invariants
+
+1. `P1`：`user_id = Some(id)` 的 key 只有在 owner 查询返回 user 且 `user.is_active()` 为 true 时才有效。
+2. `P2`：`user_id = Some(id)` 且 owner 不存在时，普通验证返回无效，详细验证返回 `is_valid = false`，且两者都不得更新 `last_used_at`。
+3. `P3`：owner 为 inactive、suspended、pending 或 deleted 时按同一规则拒绝；只有 `Active` 状态通过。
+4. `P4`：`user_id = None` 的 ownerless/global key 不触发 owner 查询，也不因缺少 owner 被拒绝。
+5. `P5`：普通验证和详细验证调用同一 owner predicate；任一入口新增或修改 owner 状态时不能发生语义漂移。
+6. `P6`：owner repository 查询返回错误时，两条验证入口传播系统错误；不得降级为 valid、ownerless 或普通 invalid credential。
+7. `P7`：普通认证入口对 missing 与 inactive owner 都保持通用 `Invalid API key` 结果，不向客户端披露 owner 存在性。
+
+## 验收标准
+
+- [ ] missing owner 的 user-owned key 被普通与详细验证拒绝。
+- [ ] non-active owner 的 key 被普通与详细验证拒绝。
+- [ ] ownerless/global key 的成功语义有明确回归测试。
+- [ ] 两条验证入口共享一个 owner 判定函数，且 owner 有效前不更新 last-used。
+- [ ] 聚焦测试、格式、strict clippy、全量测试、scope/overlap guards 与 SpecRail gates 通过。
+
+## 边界情况
+
+- `UserStatus` 中除 `Active` 外的所有状态均视为 non-active。
+- 当前 schema 删除 owner 后可能把 `user_id` 置为 `None`；本 issue 无法恢复已丢失的 owner provenance，不把该情况重新解释为 missing owner。
+- owner 查询成功返回 `None` 是 credential lifecycle invalid；查询本身返回 `Err` 是基础设施失败。
+
+## 发布说明
+
+这是 fail-closed 的认证修复。仍绑定 owner 但 owner missing/non-active 的 API key 将不再认证成功；显式 ownerless/global key 保持不变。

--- a/specs/GH958/tasks.md
+++ b/specs/GH958/tasks.md
@@ -1,0 +1,40 @@
+# Task Plan
+
+## Linked Issue
+
+GH-958 / #958
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP958-T1` Owner: coordinator. Dependencies: none. Done when: GH958 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work、write-spec 与 implement route gates 为 allowed。Verify: packet and route-gate JSON。
+- [x] `SP958-T2` Owner: auth-contract. Dependencies: T1. Done when: 回归测试先证明 missing owner 与 inactive owner 在 live/detailed 两入口均被错误接受或语义漂移，并固定 ownerless 成功语义。Verify: focused failing tests。
+- [x] `SP958-T3` Owner: auth-implementation. Dependencies: T2. Done when: 两条验证入口在 last-used 更新前调用同一 owner predicate；missing/non-active 拒绝，active/ownerless 通过，repository error 不被吞掉。Verify: focused auth API-key tests。
+- [x] `SP958-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards与 packet validation 全部通过。Verify: commands below。
+- [ ] `SP958-T5` Owner: coordinator. Dependencies: T4. Done when: final PR 使用 `Closes #958`，current-head 独立安全 reviewer、10/10 CI、review threads、PR gate、runtime gate、merge 与 issue closure 均远端确认。Verify: SpecRail PR evidence and closure audit。
+
+## 并行拆分
+
+owner tests 与 helper/call sites 位于同一 `creation.rs`，按 W-14 串行修改。planner/reviewer lane 只读；共享验证由 coordinator 独占。
+
+## 验证
+
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- focused missing/inactive/ownerless live/detailed tests
+- `cargo check --all-features --locked`
+- `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- `cargo test --all-features --locked -- --test-threads=1`
+- `bash scripts/guards/check_pr_scope.sh origin/main`
+- `bash scripts/guards/check_pr_overlap.sh`
+- `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH958"`
+
+## Handoff Notes
+
+- 不修改 Redis authorization cache；见 #959。
+- 不修改 user deletion 或 API-key FK；见 #961。
+- 普通认证结果保持通用 invalid key，不暴露 owner missing/inactive。

--- a/specs/GH958/tech.md
+++ b/specs/GH958/tech.md
@@ -1,0 +1,83 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-958 / #958
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Required boundary |
+| --- | --- | --- | --- |
+| Live verification | `src/auth/api_key/creation.rs` | 查询 optional owner 后直接成功，missing/non-active owner 均未拒绝 | 在 last-used 更新前调用共享 owner predicate |
+| Detailed verification | `src/auth/api_key/creation.rs` | 只拒绝返回的 inactive owner；missing owner 被当成 ownerless | 使用同一 predicate 并保留详细 invalid reason |
+| Authentication caller | `src/auth/system.rs` | `verify_key -> None` 映射为通用 `Invalid API key` | 保持不变，避免 owner existence disclosure |
+| Owner model | `src/core/models/user/types.rs` | `is_active()` 仅对 `UserStatus::Active` 返回 true | 复用该方法，不复制状态枚举 |
+| Schema | `src/storage/database/migration/m20240101_000005_create_api_keys_table.rs` | owner FK 使用 `ON DELETE SET NULL` | 不改；provenance/delete semantics 留给 #961 |
+
+## 设计方案
+
+1. 在 `creation.rs` 增加私有纯函数 `api_key_owner_invalid_reason(api_key, user)`：
+   - `api_key.user_id == None` 返回 `None`，表示 ownerless key 不需要 owner；
+   - `user_id != None` 且 `user == None` 返回 missing-owner reason；
+   - user 存在但 `!user.is_active()` 返回 inactive-owner reason；
+   - active user 返回 `None`。
+2. `verify_key` 与 `verify_key_detailed` 保留现有 key lookup、active、expiry 与 owner repository query，但在 `update_last_used` 前都调用该函数。
+3. live 入口只把 invalid owner 映射成 `Ok(None)`，不把具体 reason 写入公开认证结果。detailed 入口把同一 reason 写入 `invalid_reason`，用于内部诊断与测试。
+4. repository 的 `Err` 继续由 `?` 传播；helper 只处理成功查询后的 `Option<User>`，不吞掉基础设施错误。
+5. 保留 `find_api_key_cached` 和 cache invalidation 行为，避免混入 #959。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P3 | shared owner predicate | active 与 inactive user matrix |
+| P2/P5 | both verifier call sites | missing owner 通过 live/detailed 双入口均拒绝 |
+| P4 | ownerless branch | ownerless key 双入口成功且 user 为 `None` |
+| P6 | existing `find_user_by_id(...).await?` boundary | code review plus existing storage-error propagation contract |
+| P7 | existing `AuthSystem::authenticate_api_key` mapping | no caller change; live verifier returns `None` for both owner failures |
+
+## 数据流
+
+`raw_key` -> hash -> existing key lookup -> key active/expiry checks -> optional owner DB lookup -> shared owner predicate -> reject or update last-used -> verification result。
+
+不新增持久化或网络调用。user-owned key 仍执行一次现有 owner DB lookup；ownerless key 不查询 owner。
+
+## 受影响文件与规模
+
+- `src/auth/api_key/creation.rs`
+- `specs/GH958/product.md`
+- `specs/GH958/tech.md`
+- `specs/GH958/tasks.md`
+
+预计 1 个 code/test 文件、少于 250 行 code diff，满足仓库 scope 限制。
+
+## 备选方案
+
+- 让 `verify_key` 直接调用 `verify_key_detailed`：会连带合并 key lookup/debug/result 构造，超过 owner 判定的最小范围，拒绝。
+- 把 missing owner 当作 ownerless：违反 `user_id = Some(id)` 的数据契约，拒绝。
+- 在本 issue 修改 FK 或删除流程：需要 #961 的维护者决策，拒绝。
+- 同时移除 Redis 认证缓存：属于 #959，拒绝。
+
+## 风险
+
+- Security: 必须 fail closed，且 live 客户端不能区分 missing 与 inactive owner。
+- Compatibility: 仅此前错误成功的 orphaned/non-active-owner keys 会被拒绝。
+- Data integrity: `ON DELETE SET NULL` 后已成为 ownerless 的记录不在本 issue 可识别范围内。
+- Performance: 不增加查询；只增加一个纯函数分支。
+- Maintenance: 两条入口仍各自构造结果，但 owner 规则只有一个真值源。
+
+## 测试计划
+
+- Unit/in-memory storage: missing owner、inactive owner、ownerless key 的 live/detailed matrix。
+- Deterministic: `cargo fmt --all -- --check`、`git diff --check`、all-features check、strict clippy。
+- Repository: `cargo test --all-features --locked -- --test-threads=1`。
+- Guards: `bash scripts/guards/check_pr_scope.sh origin/main`、`bash scripts/guards/check_pr_overlap.sh`。
+- SpecRail: GH958 packet、implement route、current-head reviewer、PR gate 与 runtime gate。
+
+## 回滚方案
+
+回滚 GH958 PR 即恢复旧 owner 判定。没有 schema、数据 migration 或 cache 格式变更。

--- a/src/auth/api_key/creation.rs
+++ b/src/auth/api_key/creation.rs
@@ -77,6 +77,9 @@ const LAST_USED_THROTTLE: Duration = Duration::from_secs(5 * 60);
 /// TTL for cached API keys in Redis (seconds).
 const API_KEY_CACHE_TTL: u64 = 300;
 
+const MISSING_OWNER_REASON: &str = "Associated user was not found";
+const INACTIVE_OWNER_REASON: &str = "Associated user is inactive";
+
 /// Build the Redis cache key for an API key hash.
 fn api_key_cache_key(key_hash: &str) -> String {
     format!("api_key:hash:{}", key_hash)
@@ -284,6 +287,11 @@ impl ApiKeyHandler {
             None
         };
 
+        if api_key_owner_invalid_reason(&api_key, user.as_ref()).is_some() {
+            debug!("API key owner is invalid");
+            return Ok(None);
+        }
+
         // Update last used timestamp
         self.update_last_used(api_key.metadata.id).await?;
 
@@ -349,15 +357,12 @@ impl ApiKeyHandler {
             None
         };
 
-        // Check if user is active (if associated)
-        if let Some(ref user) = user
-            && !user.is_active()
-        {
+        if let Some(reason) = api_key_owner_invalid_reason(&api_key, user.as_ref()) {
             return Ok(ApiKeyVerification {
                 api_key,
-                user: Some(user.clone()),
+                user,
                 is_valid: false,
-                invalid_reason: Some("Associated user is inactive".to_string()),
+                invalid_reason: Some(reason.to_string()),
             });
         }
 
@@ -397,9 +402,56 @@ impl ApiKeyHandler {
     }
 }
 
+fn api_key_owner_invalid_reason(api_key: &ApiKey, user: Option<&User>) -> Option<&'static str> {
+    api_key.user_id?;
+    match user {
+        None => Some(MISSING_OWNER_REASON),
+        Some(user) if !user.is_active() => Some(INACTIVE_OWNER_REASON),
+        Some(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::models::storage::StorageConfig;
+    use crate::core::models::user::types::UserStatus;
+    use crate::storage::database::entities::user as user_entity;
+    use sea_orm::{ConnectionTrait, EntityTrait};
+
+    async fn test_handler() -> ApiKeyHandler {
+        let mut config = StorageConfig::default();
+        config.database.enabled = false;
+        config.redis.enabled = false;
+        let storage = StorageLayer::new(&config)
+            .await
+            .expect("test storage should initialize");
+        ApiKeyHandler::new(Arc::new(storage), None)
+            .await
+            .expect("API key handler should initialize")
+    }
+
+    async fn remove_owner_without_nulling_key(handler: &ApiKeyHandler, user_id: Uuid) {
+        handler
+            .storage
+            .db()
+            .delete_user(&user_id.to_string())
+            .await
+            .expect("legacy owner should be deleted");
+        let connection = handler.storage.db().connection();
+        connection
+            .execute_unprepared("PRAGMA foreign_keys = OFF")
+            .await
+            .expect("test fixture should disable SQLite foreign keys");
+        user_entity::Entity::delete_by_id(user_id)
+            .exec(connection)
+            .await
+            .expect("canonical owner should be deleted");
+        connection
+            .execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("test fixture should restore SQLite foreign keys");
+    }
 
     // ==================== validate_create_key_input ====================
 
@@ -490,5 +542,175 @@ mod tests {
         let perms = vec!["api.chat".to_string(), "not.a.perm".to_string()];
         let result = validate_create_key_input("My Key", &perms);
         assert!(matches!(result, Err(GatewayError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn live_and_detailed_verification_reject_missing_owner() {
+        let handler = test_handler().await;
+        let mut user = User::new(
+            format!("missing-{}", Uuid::new_v4()),
+            format!("missing-{}@example.com", Uuid::new_v4()),
+            "unused-hash".to_string(),
+        );
+        user.status = UserStatus::Active;
+        handler
+            .storage
+            .db()
+            .create_user(&user)
+            .await
+            .expect("owner should be stored before creating the key");
+        let (api_key, raw_key) = handler
+            .create_key(
+                Some(user.id()),
+                None,
+                "missing-owner".to_string(),
+                vec!["api.chat".to_string()],
+            )
+            .await
+            .expect("owned key should be stored");
+        remove_owner_without_nulling_key(&handler, user.id()).await;
+
+        assert!(
+            handler
+                .storage
+                .db()
+                .find_user_by_id(user.id())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            handler
+                .storage
+                .db()
+                .find_api_key_by_hash(&api_key.key_hash)
+                .await
+                .unwrap()
+                .and_then(|stored| stored.user_id),
+            Some(user.id())
+        );
+        assert!(handler.verify_key(&raw_key).await.unwrap().is_none());
+        assert!(!handler.last_used_cache.contains_key(&api_key.metadata.id));
+        let detailed = handler.verify_key_detailed(&raw_key).await.unwrap();
+        assert!(!detailed.is_valid);
+        assert_eq!(
+            detailed.invalid_reason.as_deref(),
+            Some(MISSING_OWNER_REASON)
+        );
+        assert!(!handler.last_used_cache.contains_key(&api_key.metadata.id));
+        let stored = handler
+            .storage
+            .db()
+            .find_api_key_by_hash(&api_key.key_hash)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(stored.last_used_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn live_and_detailed_verification_reject_inactive_owner() {
+        let handler = test_handler().await;
+        let mut user = User::new(
+            format!("inactive-{}", Uuid::new_v4()),
+            format!("inactive-{}@example.com", Uuid::new_v4()),
+            "unused-hash".to_string(),
+        );
+        user.status = UserStatus::Inactive;
+        handler
+            .storage
+            .db()
+            .create_user(&user)
+            .await
+            .expect("inactive user should be stored");
+        let (api_key, raw_key) = handler
+            .create_key(
+                Some(user.id()),
+                None,
+                "inactive-owner".to_string(),
+                vec!["api.chat".to_string()],
+            )
+            .await
+            .expect("key creation should succeed");
+
+        assert!(handler.verify_key(&raw_key).await.unwrap().is_none());
+        assert!(!handler.last_used_cache.contains_key(&api_key.metadata.id));
+        let detailed = handler.verify_key_detailed(&raw_key).await.unwrap();
+        assert!(!detailed.is_valid);
+        assert_eq!(
+            detailed.invalid_reason.as_deref(),
+            Some(INACTIVE_OWNER_REASON)
+        );
+        assert!(!handler.last_used_cache.contains_key(&api_key.metadata.id));
+        let stored = handler
+            .storage
+            .db()
+            .find_api_key_by_hash(&api_key.key_hash)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(stored.last_used_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn live_and_detailed_verification_accept_ownerless_key() {
+        let handler = test_handler().await;
+        let (_, raw_key) = handler
+            .create_key(
+                None,
+                None,
+                "ownerless".to_string(),
+                vec!["api.chat".to_string()],
+            )
+            .await
+            .expect("ownerless key creation should succeed");
+
+        let (_, live_user) = handler
+            .verify_key(&raw_key)
+            .await
+            .unwrap()
+            .expect("ownerless key should remain valid");
+        assert!(live_user.is_none());
+        let detailed = handler.verify_key_detailed(&raw_key).await.unwrap();
+        assert!(detailed.is_valid);
+        assert!(detailed.user.is_none());
+        assert!(detailed.invalid_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn live_and_detailed_verification_accept_active_owner() {
+        let handler = test_handler().await;
+        let mut user = User::new(
+            format!("active-{}", Uuid::new_v4()),
+            format!("active-{}@example.com", Uuid::new_v4()),
+            "unused-hash".to_string(),
+        );
+        user.status = UserStatus::Active;
+        handler
+            .storage
+            .db()
+            .create_user(&user)
+            .await
+            .expect("active user should be stored");
+        let (_, raw_key) = handler
+            .create_key(
+                Some(user.id()),
+                None,
+                "active-owner".to_string(),
+                vec!["api.chat".to_string()],
+            )
+            .await
+            .expect("key creation should succeed");
+
+        let (_, live_user) = handler
+            .verify_key(&raw_key)
+            .await
+            .unwrap()
+            .expect("active owner key should remain valid");
+        assert_eq!(live_user.as_ref().map(User::id), Some(user.id()));
+        let detailed = handler.verify_key_detailed(&raw_key).await.unwrap();
+        assert!(detailed.is_valid);
+        assert_eq!(detailed.user.as_ref().map(User::id), Some(user.id()));
+        assert!(detailed.invalid_reason.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- require user-owned API keys to resolve to an active owner in both live and detailed verification
- preserve ownerless/global key behavior and propagate owner repository failures
- prevent invalid owner paths from updating last-used state
- add real missing-owner, inactive-owner, ownerless, and active-owner verification coverage

## Scope
- does not change Redis authorization caching tracked by #959
- does not change user deletion or API-key foreign-key semantics tracked by #961

## Verification
- cargo fmt --all -- --check
- cargo check --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked -- --test-threads=1
- bash scripts/guards/check_pr_scope.sh origin/main
- bash scripts/guards/check_pr_overlap.sh
- SpecRail GH958 packet and runtime gates
- independent security reviewer approved after one resolved finding

Closes #958