### PR TITLE
fix(auth): make API key lifecycle database authoritative

### DIFF
--- a/specs/GH959/product.md
+++ b/specs/GH959/product.md
@@ -11,8 +11,8 @@ API-key 认证当前优先读取 Redis 中的完整 key 快照。撤销或权限
 ## 目标
 
 - 让数据库成为 API-key active/revoked 生命周期的单一认证权威来源。
-- 保证数据库成功撤销后，任何旧 Redis 快照都不能继续通过普通或详细验证。
-- 保留 cache invalidation 作为兼容性清理，但其失败不再影响认证正确性。
+- 保证数据库成功撤销后，任何旧 Redis 快照都不能继续通过本版本的普通或详细验证。
+- 保留撤销前后的 cache invalidation 作为兼容性清理，但其失败不再影响已升级实例的认证正确性。
 - 用真实 cache 删除拒绝场景证明 stale active 快照仍存在时认证会 fail closed。
 
 ## 非目标
@@ -27,25 +27,28 @@ API-key 认证当前优先读取 Redis 中的完整 key 快照。撤销或权限
 
 1. `P1`：`verify_key` 与 `verify_key_detailed` 每次都从数据库读取当前 API-key 记录；Redis 快照不参与认证决定。
 2. `P2`：数据库中的 `is_active = false` 一旦可见，两条验证入口都必须拒绝该 key，即使 Redis 仍保存同一 key 的旧 active 快照。
-3. `P3`：cache 删除失败可记录诊断信息并允许数据库撤销成功，但不能通过 warning、TTL 或后台清理延迟授权失效。
+3. `P3`：cache 删除失败可记录诊断信息并允许数据库撤销成功，但已升级验证入口不能通过 warning、TTL 或后台清理延迟授权失效。
 4. `P4`：数据库查找错误必须继续传播为系统错误；不得回退到 Redis、旧快照或普通 invalid credential。
 5. `P5`：数据库返回的 active、expiry、owner 与权限数据保持现有验证语义；本变更只调整数据权威边界。
 6. `P6`：遗留 Redis API-key 快照可以继续被 best-effort invalidation 清理，但新认证读取不得填充或消费该快照。
+7. `P7`：撤销流程在数据库 commit 后再次执行 best-effort invalidation，以缩小滚动部署时旧实例回填快照的窗口；即时撤销保证要求先排空所有旧 cache-first 实例。
 
 ## 验收标准
 
 - [ ] 两条 API-key 验证入口只使用数据库中的当前 key 记录。
 - [ ] 回归测试真实制造 cache `DEL` 权限失败，并确认数据库撤销成功、旧 active 快照仍存在、两条验证入口均拒绝。
 - [ ] cache warning 与 TTL 不再构成撤销安全保证。
+- [ ] 撤销在数据库 mutation 前后都尝试清理遗留快照，并明确记录滚动部署边界。
 - [ ] owner、expiry、last-used 与详细 invalid reason 的现有行为保持不变。
 - [ ] 聚焦测试、格式、strict clippy、全量测试、scope/overlap guards 与 SpecRail gates 通过。
 
 ## 边界情况
 
 - Redis 不可用或返回损坏数据时，认证不读取 Redis，因此结果只取决于数据库查询。
-- 旧部署留下的 `api_key:hash:*` 快照不需要迁移；它们不再位于授权路径。
+- 旧部署留下的 `api_key:hash:*` 快照不需要迁移；已升级实例不再把它们放入授权路径。
+- 滚动升级期间，旧 cache-first 实例仍可能消费或回填 stale snapshot；必须先排空这些实例，才能依赖本版本的即时撤销保证。
 - 数据库撤销失败时仍返回错误，不能仅凭 cache 删除成功声称 key 已撤销。
 
 ## 发布说明
 
-这是 fail-closed 的认证安全修复。API key 撤销以数据库状态即时生效，不再受 Redis stale snapshot 或五分钟 TTL 影响；代价是每次 key 验证都执行权威数据库读取。
+这是 fail-closed 的认证安全修复。所有实例升级并排空旧 cache-first 副本后，API key 撤销以数据库状态即时生效，不再受 Redis stale snapshot 或五分钟 TTL 影响；代价是每次 key 验证都执行权威数据库读取。

--- a/specs/GH959/product.md
+++ b/specs/GH959/product.md
@@ -1,0 +1,51 @@
+# Product Spec
+
+## Linked Issue
+
+GH-959 / #959
+
+## 用户问题
+
+API-key 认证当前优先读取 Redis 中的完整 key 快照。撤销或权限更新即使已经成功写入数据库，只要 cache invalidation 失败，旧的 active 快照仍可在 TTL 内继续授权，导致安全撤销结果取决于 best-effort cache 删除。
+
+## 目标
+
+- 让数据库成为 API-key active/revoked 生命周期的单一认证权威来源。
+- 保证数据库成功撤销后，任何旧 Redis 快照都不能继续通过普通或详细验证。
+- 保留 cache invalidation 作为兼容性清理，但其失败不再影响认证正确性。
+- 用真实 cache 删除拒绝场景证明 stale active 快照仍存在时认证会 fail closed。
+
+## 非目标
+
+- 不改变 owner 存在性或状态判定；该契约已由 #958 处理。
+- 不改变认证基础设施错误的公开响应；该工作属于 #960。
+- 不改变 user 删除、API-key 外键或 owner provenance；该工作属于 #961。
+- 不改变 key hash、创建、权限、过期、last-used 或公开 API。
+- 不新增数据库 migration 或新的 cache backend。
+
+## Behavior Invariants
+
+1. `P1`：`verify_key` 与 `verify_key_detailed` 每次都从数据库读取当前 API-key 记录；Redis 快照不参与认证决定。
+2. `P2`：数据库中的 `is_active = false` 一旦可见，两条验证入口都必须拒绝该 key，即使 Redis 仍保存同一 key 的旧 active 快照。
+3. `P3`：cache 删除失败可记录诊断信息并允许数据库撤销成功，但不能通过 warning、TTL 或后台清理延迟授权失效。
+4. `P4`：数据库查找错误必须继续传播为系统错误；不得回退到 Redis、旧快照或普通 invalid credential。
+5. `P5`：数据库返回的 active、expiry、owner 与权限数据保持现有验证语义；本变更只调整数据权威边界。
+6. `P6`：遗留 Redis API-key 快照可以继续被 best-effort invalidation 清理，但新认证读取不得填充或消费该快照。
+
+## 验收标准
+
+- [ ] 两条 API-key 验证入口只使用数据库中的当前 key 记录。
+- [ ] 回归测试真实制造 cache `DEL` 权限失败，并确认数据库撤销成功、旧 active 快照仍存在、两条验证入口均拒绝。
+- [ ] cache warning 与 TTL 不再构成撤销安全保证。
+- [ ] owner、expiry、last-used 与详细 invalid reason 的现有行为保持不变。
+- [ ] 聚焦测试、格式、strict clippy、全量测试、scope/overlap guards 与 SpecRail gates 通过。
+
+## 边界情况
+
+- Redis 不可用或返回损坏数据时，认证不读取 Redis，因此结果只取决于数据库查询。
+- 旧部署留下的 `api_key:hash:*` 快照不需要迁移；它们不再位于授权路径。
+- 数据库撤销失败时仍返回错误，不能仅凭 cache 删除成功声称 key 已撤销。
+
+## 发布说明
+
+这是 fail-closed 的认证安全修复。API key 撤销以数据库状态即时生效，不再受 Redis stale snapshot 或五分钟 TTL 影响；代价是每次 key 验证都执行权威数据库读取。

--- a/specs/GH959/tasks.md
+++ b/specs/GH959/tasks.md
@@ -14,7 +14,7 @@ GH-959 / #959
 - [x] `SP959-T1` Owner: coordinator. Dependencies: none. Done when: GH959 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work、write-spec 与 implement route gates 为 allowed。Verify: packet and route-gate JSON。
 - [x] `SP959-T2` Owner: auth-regression. Dependencies: T1. Done when: Redis ACL 测试真实拒绝 cache `DEL`，数据库撤销成功且 readable stale active snapshot 让旧认证实现失败。Verify: focused red test artifact。
 - [x] `SP959-T3` Owner: auth-implementation. Dependencies: T2. Done when: live/detailed verification 只读取数据库权威 key 记录，cache 不再参与认证读取或填充，现有 owner/expiry/last-used 语义保持。Verify: focused API-key tests。
-- [ ] `SP959-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
+- [x] `SP959-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
 - [ ] `SP959-T5` Owner: coordinator. Dependencies: T4. Done when: final PR 使用 `Closes #959`，current-head 独立安全 reviewer、CI、review threads、PR gate、runtime gate、merge 与 issue closure 均远端确认。Verify: SpecRail PR evidence and closure audit。
 
 ## 并行拆分

--- a/specs/GH959/tasks.md
+++ b/specs/GH959/tasks.md
@@ -1,0 +1,40 @@
+# Task Plan
+
+## Linked Issue
+
+GH-959 / #959
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP959-T1` Owner: coordinator. Dependencies: none. Done when: GH959 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work、write-spec 与 implement route gates 为 allowed。Verify: packet and route-gate JSON。
+- [x] `SP959-T2` Owner: auth-regression. Dependencies: T1. Done when: Redis ACL 测试真实拒绝 cache `DEL`，数据库撤销成功且 readable stale active snapshot 让旧认证实现失败。Verify: focused red test artifact。
+- [x] `SP959-T3` Owner: auth-implementation. Dependencies: T2. Done when: live/detailed verification 只读取数据库权威 key 记录，cache 不再参与认证读取或填充，现有 owner/expiry/last-used 语义保持。Verify: focused API-key tests。
+- [ ] `SP959-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
+- [ ] `SP959-T5` Owner: coordinator. Dependencies: T4. Done when: final PR 使用 `Closes #959`，current-head 独立安全 reviewer、CI、review threads、PR gate、runtime gate、merge 与 issue closure 均远端确认。Verify: SpecRail PR evidence and closure audit。
+
+## 并行拆分
+
+认证 lookup 与回归测试共享 API-key module，按 W-14 由 coordinator 串行修改。planner/reviewer lane 只读；共享验证由 coordinator 独占。
+
+## 验证
+
+- `REDIS_URL=redis://127.0.0.1:<isolated-port> cargo test --all-features --locked revoked_key_is_rejected_when_cache_delete_fails -- --exact --nocapture`
+- focused API-key module tests
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- `cargo check --all-features --locked`
+- `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- `cargo test --all-features --locked -- --test-threads=1`
+- `bash scripts/guards/check_pr_scope.sh origin/main`
+- `bash scripts/guards/check_pr_overlap.sh`
+- `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH959"`
+
+## Handoff Notes
+
+- 不修改 #958 owner contract、#960 public infrastructure error mapping 或 #961 schema semantics。
+- Redis cache invalidation 继续用于兼容性清理，但不再是认证安全保证。

--- a/specs/GH959/tasks.md
+++ b/specs/GH959/tasks.md
@@ -14,7 +14,7 @@ GH-959 / #959
 - [x] `SP959-T1` Owner: coordinator. Dependencies: none. Done when: GH959 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work、write-spec 与 implement route gates 为 allowed。Verify: packet and route-gate JSON。
 - [x] `SP959-T2` Owner: auth-regression. Dependencies: T1. Done when: Redis ACL 测试真实拒绝 cache `DEL`，数据库撤销成功且 readable stale active snapshot 让旧认证实现失败。Verify: focused red test artifact。
 - [x] `SP959-T3` Owner: auth-implementation. Dependencies: T2. Done when: live/detailed verification 只读取数据库权威 key 记录，cache 不再参与认证读取或填充，现有 owner/expiry/last-used 语义保持。Verify: focused API-key tests。
-- [x] `SP959-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
+- [ ] `SP959-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
 - [ ] `SP959-T5` Owner: coordinator. Dependencies: T4. Done when: final PR 使用 `Closes #959`，current-head 独立安全 reviewer、CI、review threads、PR gate、runtime gate、merge 与 issue closure 均远端确认。Verify: SpecRail PR evidence and closure audit。
 
 ## 并行拆分
@@ -23,7 +23,7 @@ GH-959 / #959
 
 ## 验证
 
-- `REDIS_URL=redis://127.0.0.1:<isolated-port> cargo test --all-features --locked revoked_key_is_rejected_when_cache_delete_fails -- --exact --nocapture`
+- `REDIS_URL=redis://127.0.0.1:<isolated-port> cargo test --all-features --locked --lib auth::api_key::tests::revoked_key_is_rejected_when_cache_delete_fails -- --exact --nocapture`
 - focused API-key module tests
 - `cargo fmt --all -- --check`
 - `git diff --check`
@@ -38,3 +38,4 @@ GH-959 / #959
 
 - 不修改 #958 owner contract、#960 public infrastructure error mapping 或 #961 schema semantics。
 - Redis cache invalidation 继续用于兼容性清理，但不再是认证安全保证。
+- 所有旧 cache-first 实例必须排空后，才能依赖即时撤销保证。

--- a/specs/GH959/tech.md
+++ b/specs/GH959/tech.md
@@ -15,14 +15,14 @@ Link to `product.md`.
 | API-key lookup | `src/auth/api_key/creation.rs` | `find_api_key_cached` trusts a complete Redis snapshot before the database and writes DB hits with a five-minute TTL | replace the authentication lookup with an authoritative database read |
 | Live verification | `src/auth/api_key/creation.rs` | active/expiry/owner checks run against the cached snapshot | preserve checks but feed them only the database record |
 | Detailed verification | `src/auth/api_key/creation.rs` | same stale-cache exposure through the detailed path | use the same authoritative lookup boundary |
-| Mutation cleanup | `src/auth/api_key/management.rs` | revoke/update operations delete cache best effort and log failures | keep cleanup compatibility; correctness must not depend on it |
+| Mutation cleanup | `src/auth/api_key/management.rs` | revoke deletes only before the DB mutation, leaving a legacy refill window | invalidate before and after commit while keeping upgraded-instance correctness independent of cache |
 | Regression tests | `src/auth/api_key/tests.rs` | no test leaves a readable active snapshot after a denied cache delete | add a live Redis ACL test that denies `DEL` while allowing `GET`/`SET` |
 
 ## 设计方案
 
 1. 删除认证专用的 `API_KEY_CACHE_TTL` 和 `find_api_key_cached` cache-aside 实现，增加私有 `find_api_key_authoritative`，仅调用 `database.find_api_key_by_hash`。
 2. `verify_key` 与 `verify_key_detailed` 保持各自现有返回契约，但都通过 `find_api_key_authoritative` 获取 key；active、expiry、owner 和 last-used 的顺序不变。
-3. 保留 `api_key_cache_key`、`invalidate_api_key_cache` 和 management 中的 invalidation 调用，用于清理旧版本或并行部署留下的快照。删除失败仍可诊断，但不再位于授权可信边界。
+3. 保留 `api_key_cache_key` 与 `invalidate_api_key_cache`。`revoke_key` 在数据库 mutation 前后各执行一次 best-effort invalidation，以缩小旧 cache-first 副本的回填窗口；删除失败仍可诊断，但不再位于已升级实例的授权可信边界。
 4. 不在数据库错误时读取 Redis。`find_api_key_by_hash(...).await?` 原样传播错误，避免 silent degradation。
 5. 在现有 `src/auth/api_key/tests.rs` 中增加 Redis ACL 回归：
    - 通过 `REDIS_URL` 建立管理连接，并创建唯一的受限测试用户；
@@ -32,6 +32,7 @@ Link to `product.md`.
    - 确认 live/detailed verification 都从数据库拒绝该 key；
    - 用管理连接清理 key 与 ACL 用户。
 6. 本地 Redis 不可达时沿用仓库既有 live-Redis 测试约定跳过；CI 设置 `CI` 与 `REDIS_URL`，Redis 不可达则测试必须失败。协调器在本地隔离 Redis 实例上执行一次非跳过验证。
+7. 部署要求：在依赖即时撤销保证前，排空所有仍运行 cache-first 认证代码的旧副本。双 invalidation 不能阻止已经在 DB commit 前读到 active row 的旧请求于第二次删除后回填。
 
 ## Product-to-Test Mapping
 
@@ -51,12 +52,13 @@ Redis invalidation remains a side-effect of mutation paths only. There is no Red
 ## 受影响文件与规模
 
 - `src/auth/api_key/creation.rs`
+- `src/auth/api_key/management.rs`
 - `src/auth/api_key/tests.rs`
 - `specs/GH959/product.md`
 - `specs/GH959/tech.md`
 - `specs/GH959/tasks.md`
 
-预计 2 个 code/test 文件、少于 250 行 code diff，满足仓库 scope 限制；现有文件均保持在 800 行以内。
+预计 3 个 code/test 文件、少于 350 行 code diff，满足仓库 scope 限制；现有文件均保持在 800 行以内。
 
 ## 备选方案
 
@@ -69,8 +71,8 @@ Redis invalidation remains a side-effect of mutation paths only. There is no Red
 
 - Security: 任何后续优化都不得把完整 Redis key 快照重新引入授权路径。
 - Performance: 每次 API-key 验证增加或恢复一次数据库读取；这是即时撤销一致性的明确代价。
-- Compatibility: cache invalidation API 保留，因此滚动部署期间旧实例仍可清理快照。
-- Test isolation: Redis ACL user、key 与密码都使用唯一随机值；清理使用管理连接，不依赖受限用户的 `DEL` 权限。
+- Compatibility: pre/post invalidation 缩小滚动部署窗口，但旧 cache-first 实例必须排空；不能把双删除描述成分布式一致性保证。
+- Test isolation: Redis ACL user、key 与密码都使用唯一随机值；场景逻辑通过 finally-style 路径在断言前调用管理连接清理，不依赖受限用户的 `DEL` 权限。
 - Error handling: Redis 测试不可用在 CI 中必须失败，数据库错误在生产中必须传播。
 
 ## 测试计划

--- a/specs/GH959/tech.md
+++ b/specs/GH959/tech.md
@@ -1,0 +1,87 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-959 / #959
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Required boundary |
+| --- | --- | --- | --- |
+| API-key lookup | `src/auth/api_key/creation.rs` | `find_api_key_cached` trusts a complete Redis snapshot before the database and writes DB hits with a five-minute TTL | replace the authentication lookup with an authoritative database read |
+| Live verification | `src/auth/api_key/creation.rs` | active/expiry/owner checks run against the cached snapshot | preserve checks but feed them only the database record |
+| Detailed verification | `src/auth/api_key/creation.rs` | same stale-cache exposure through the detailed path | use the same authoritative lookup boundary |
+| Mutation cleanup | `src/auth/api_key/management.rs` | revoke/update operations delete cache best effort and log failures | keep cleanup compatibility; correctness must not depend on it |
+| Regression tests | `src/auth/api_key/tests.rs` | no test leaves a readable active snapshot after a denied cache delete | add a live Redis ACL test that denies `DEL` while allowing `GET`/`SET` |
+
+## 设计方案
+
+1. 删除认证专用的 `API_KEY_CACHE_TTL` 和 `find_api_key_cached` cache-aside 实现，增加私有 `find_api_key_authoritative`，仅调用 `database.find_api_key_by_hash`。
+2. `verify_key` 与 `verify_key_detailed` 保持各自现有返回契约，但都通过 `find_api_key_authoritative` 获取 key；active、expiry、owner 和 last-used 的顺序不变。
+3. 保留 `api_key_cache_key`、`invalidate_api_key_cache` 和 management 中的 invalidation 调用，用于清理旧版本或并行部署留下的快照。删除失败仍可诊断，但不再位于授权可信边界。
+4. 不在数据库错误时读取 Redis。`find_api_key_by_hash(...).await?` 原样传播错误，避免 silent degradation。
+5. 在现有 `src/auth/api_key/tests.rs` 中增加 Redis ACL 回归：
+   - 通过 `REDIS_URL` 建立管理连接，并创建唯一的受限测试用户；
+   - 仅允许该用户对唯一 cache key 执行 `GET`/`SET`，明确拒绝 `DEL`；
+   - 写入 active `ApiKey` 快照后调用真实 `revoke_key`；
+   - 确认数据库记录 inactive、受限连接仍能读到 active stale snapshot；
+   - 确认 live/detailed verification 都从数据库拒绝该 key；
+   - 用管理连接清理 key 与 ACL 用户。
+6. 本地 Redis 不可达时沿用仓库既有 live-Redis 测试约定跳过；CI 设置 `CI` 与 `REDIS_URL`，Redis 不可达则测试必须失败。协调器在本地隔离 Redis 实例上执行一次非跳过验证。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1/P4 | `find_api_key_authoritative` and both callers | code review plus existing DB error propagation |
+| P2/P3 | revoke path plus authoritative verification | ACL-denied `DEL` regression with readable stale active snapshot |
+| P5 | unchanged live/detailed checks | existing active/inactive/expiry/owner tests and full suite |
+| P6 | retained invalidation helpers, removed auth cache read/write | diff inspection and stale snapshot assertion |
+
+## 数据流
+
+`raw_key` -> hash -> authoritative database lookup -> active/expiry checks -> optional owner database lookup -> owner predicate -> reject or update last-used -> verification result。
+
+Redis invalidation remains a side-effect of mutation paths only. There is no Redis-to-authentication edge after this change.
+
+## 受影响文件与规模
+
+- `src/auth/api_key/creation.rs`
+- `src/auth/api_key/tests.rs`
+- `specs/GH959/product.md`
+- `specs/GH959/tech.md`
+- `specs/GH959/tasks.md`
+
+预计 2 个 code/test 文件、少于 250 行 code diff，满足仓库 scope 限制；现有文件均保持在 800 行以内。
+
+## 备选方案
+
+- 缩短 TTL：仍存在授权窗口，不满足即时撤销，拒绝。
+- cache 删除失败时让撤销 API 失败：数据库可能已经提交，且多实例/网络分区仍不能证明所有快照已删除，拒绝。
+- 在 Redis 中只缓存 active flag 并做版本校验：仍引入双权威与分布式一致性协议，超过本 issue 的最小安全修复，拒绝。
+- 每次认证先读 Redis 再向数据库确认 lifecycle：没有收益且仍增加复杂度，拒绝。
+
+## 风险
+
+- Security: 任何后续优化都不得把完整 Redis key 快照重新引入授权路径。
+- Performance: 每次 API-key 验证增加或恢复一次数据库读取；这是即时撤销一致性的明确代价。
+- Compatibility: cache invalidation API 保留，因此滚动部署期间旧实例仍可清理快照。
+- Test isolation: Redis ACL user、key 与密码都使用唯一随机值；清理使用管理连接，不依赖受限用户的 `DEL` 权限。
+- Error handling: Redis 测试不可用在 CI 中必须失败，数据库错误在生产中必须传播。
+
+## 测试计划
+
+- Red phase: 在隔离 Redis 上运行 ACL-denied deletion 测试，确认旧实现读取 stale active snapshot 而失败。
+- Focused: 修复后重复同一测试并运行 API-key 模块测试。
+- Deterministic: `cargo fmt --all -- --check`、`git diff --check`、all-features check、strict clippy。
+- Repository: `cargo test --all-features --locked -- --test-threads=1`。
+- Guards: `bash scripts/guards/check_pr_scope.sh origin/main`、`bash scripts/guards/check_pr_overlap.sh`。
+- SpecRail: GH959 packet、implement route、current-head security reviewer、PR gate 与 runtime gate。
+
+## 回滚方案
+
+代码回滚会重新引入 stale-cache 撤销窗口，只能作为安全风险已明确接受的紧急回滚；没有 schema、数据 migration 或 cache 格式回滚步骤。

--- a/src/auth/api_key/creation.rs
+++ b/src/auth/api_key/creation.rs
@@ -74,9 +74,6 @@ fn validate_create_key_input(name: &str, permissions: &[String]) -> Result<()> {
 /// Minimum interval between DB writes for the same key's last_used timestamp.
 const LAST_USED_THROTTLE: Duration = Duration::from_secs(5 * 60);
 
-/// TTL for cached API keys in Redis (seconds).
-const API_KEY_CACHE_TTL: u64 = 300;
-
 const MISSING_OWNER_REASON: &str = "Associated user was not found";
 const INACTIVE_OWNER_REASON: &str = "Associated user is inactive";
 
@@ -189,54 +186,12 @@ impl ApiKeyHandler {
         Ok((stored_key, raw_key))
     }
 
-    /// Look up an API key by hash, checking Redis cache first and falling back
-    /// to PostgreSQL. On a cache miss the result is populated into Redis with a
-    /// 5-minute TTL.
-    async fn find_api_key_cached(&self, key_hash: &str) -> Result<Option<ApiKey>> {
-        let cache_key = api_key_cache_key(key_hash);
-
-        // 1. Try Redis cache
-        match self.storage.cache_get(&cache_key).await {
-            Ok(Some(cached)) => {
-                debug!("API key cache hit");
-                match serde_json::from_str::<ApiKey>(&cached) {
-                    Ok(api_key) => return Ok(Some(api_key)),
-                    Err(e) => {
-                        warn!(
-                            "Failed to deserialize cached API key, falling back to DB: {}",
-                            e
-                        );
-                        // Stale/corrupt entry – delete and continue to DB
-                        if let Err(del_err) = self.storage.cache_delete(&cache_key).await {
-                            warn!("Failed to delete corrupt API key cache entry: {}", del_err);
-                        }
-                    }
-                }
-            }
-            Ok(None) => {
-                debug!("API key cache miss");
-            }
-            Err(e) => {
-                // Redis unavailable – degrade gracefully
-                warn!("Redis cache_get failed, falling back to DB: {}", e);
-            }
-        }
-
-        // 2. Fall back to PostgreSQL
-        let api_key = self.storage.db().find_api_key_by_hash(key_hash).await?;
-
-        // 3. Populate cache on DB hit
-        if let Some(ref key) = api_key
-            && let Ok(serialized) = serde_json::to_string(key)
-            && let Err(e) = self
-                .storage
-                .cache_set(&cache_key, &serialized, Some(API_KEY_CACHE_TTL))
-                .await
-        {
-            warn!("Failed to populate API key cache: {}", e);
-        }
-
-        Ok(api_key)
+    /// Look up an API key from the authoritative lifecycle store.
+    ///
+    /// Authentication must not consume Redis snapshots because a stale active
+    /// value could otherwise outlive a committed database revoke.
+    async fn find_api_key_authoritative(&self, key_hash: &str) -> Result<Option<ApiKey>> {
+        self.storage.db().find_api_key_by_hash(key_hash).await
     }
 
     /// Invalidate the Redis cache entry for the given key hash.
@@ -257,8 +212,7 @@ impl ApiKeyHandler {
         // Hash the provided key
         let key_hash = hash_api_key(raw_key, self.hmac_secret());
 
-        // Find API key (cache-aside: Redis → PostgreSQL → populate Redis)
-        let api_key = match self.find_api_key_cached(&key_hash).await? {
+        let api_key = match self.find_api_key_authoritative(&key_hash).await? {
             Some(key) => key,
             None => {
                 debug!("API key not found");
@@ -303,7 +257,7 @@ impl ApiKeyHandler {
     pub async fn verify_key_detailed(&self, raw_key: &str) -> Result<ApiKeyVerification> {
         let key_hash = hash_api_key(raw_key, self.hmac_secret());
 
-        let api_key = match self.find_api_key_cached(&key_hash).await? {
+        let api_key = match self.find_api_key_authoritative(&key_hash).await? {
             Some(key) => key,
             None => {
                 return Ok(ApiKeyVerification {

--- a/src/auth/api_key/management.rs
+++ b/src/auth/api_key/management.rs
@@ -35,6 +35,11 @@ impl ApiKeyHandler {
 
         self.storage.db().deactivate_api_key(key_id).await?;
 
+        // Narrow the refill window for cache-first replicas during a rolling
+        // deployment. Operators must still drain those older replicas because
+        // an in-flight legacy lookup can write after this best-effort delete.
+        self.invalidate_cache_for_key_id(key_id).await;
+
         info!("API key revoked successfully: {}", key_id);
         Ok(())
     }

--- a/src/auth/api_key/tests.rs
+++ b/src/auth/api_key/tests.rs
@@ -561,77 +561,87 @@ async fn revoked_key_is_rejected_when_cache_delete_fails() {
     let cache_key = format!("api_key:hash:{}", api_key.key_hash);
     let username = format!("gh959_{}", Uuid::new_v4().simple());
     let password = format!("gh959-{}", Uuid::new_v4().simple());
+    let restricted_config = restricted_redis_config(&redis_url, &username, &password);
 
     configure_delete_denied_user(&admin_pool, &username, &password, &cache_key).await;
-    let restricted_pool =
-        RedisPool::new(&restricted_redis_config(&redis_url, &username, &password))
+    let scenario = async {
+        let restricted_pool = RedisPool::new(&restricted_config)
             .await
-            .expect("restricted Redis user should connect");
-    let handler = handler_with_redis(&base_handler, restricted_pool).await;
-    handler
-        .storage
-        .cache_set(
-            &cache_key,
-            &serde_json::to_string(&api_key).expect("active snapshot should serialize"),
-            None,
-        )
-        .await
-        .expect("restricted user should populate the stale snapshot");
-    let delete_error = handler
-        .storage
-        .cache_delete(&cache_key)
-        .await
-        .expect_err("restricted user must not delete the cache key");
-    assert!(
-        delete_error.to_string().contains("NoPerm"),
-        "cache deletion should fail because Redis denied DEL: {delete_error}"
-    );
+            .map_err(|error| error.to_string())?;
+        let handler = handler_with_redis(&base_handler, restricted_pool)
+            .await
+            .map_err(|error| error.to_string())?;
+        let serialized = serde_json::to_string(&api_key).map_err(|error| error.to_string())?;
+        handler
+            .storage
+            .cache_set(&cache_key, &serialized, None)
+            .await
+            .map_err(|error| error.to_string())?;
+        let delete_error = handler
+            .storage
+            .cache_delete(&cache_key)
+            .await
+            .err()
+            .ok_or_else(|| "restricted user unexpectedly deleted the cache key".to_string())?;
 
-    handler
-        .revoke_key(api_key.metadata.id)
-        .await
-        .expect("database revoke must not depend on cache deletion");
-    let stored = handler
-        .storage
-        .db()
-        .find_api_key_by_hash(&api_key.key_hash)
-        .await
-        .expect("revoked key lookup should succeed")
-        .expect("revoked key should remain stored");
-    let stale_snapshot: ApiKey = serde_json::from_str(
-        &handler
+        handler
+            .revoke_key(api_key.metadata.id)
+            .await
+            .map_err(|error| error.to_string())?;
+        let stored = handler
+            .storage
+            .db()
+            .find_api_key_by_hash(&api_key.key_hash)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "revoked key was not stored".to_string())?;
+        let cached = handler
             .storage
             .cache_get(&cache_key)
             .await
-            .expect("restricted user should still read the cache")
-            .expect("denied deletion must leave the stale snapshot"),
-    )
-    .expect("stale snapshot should deserialize");
-    let live_result = handler
-        .verify_key(&raw_key)
-        .await
-        .expect("live verification should read the database");
-    let detailed_result = handler
-        .verify_key_detailed(&raw_key)
-        .await
-        .expect("detailed verification should read the database");
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "denied deletion removed the stale snapshot".to_string())?;
+        let stale_snapshot: ApiKey =
+            serde_json::from_str(&cached).map_err(|error| error.to_string())?;
+        let live_result = handler
+            .verify_key(&raw_key)
+            .await
+            .map_err(|error| error.to_string())?;
+        let detailed_result = handler
+            .verify_key_detailed(&raw_key)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        Ok::<_, String>((
+            delete_error.to_string(),
+            stored.is_active,
+            stale_snapshot.is_active,
+            live_result.is_some(),
+            detailed_result.is_valid,
+            detailed_result.invalid_reason,
+        ))
+    }
+    .await;
 
     cleanup_delete_denied_user(&admin_pool, &username, &cache_key).await;
 
-    assert!(!stored.is_active, "database revoke must be committed");
+    let (delete_error, stored_active, stale_active, live_valid, detailed_valid, invalid_reason) =
+        scenario.expect("revocation scenario should complete before cleanup");
     assert!(
-        stale_snapshot.is_active,
+        delete_error.to_ascii_lowercase().contains("noperm"),
+        "cache deletion should fail because Redis denied DEL: {delete_error}"
+    );
+    assert!(!stored_active, "database revoke must be committed");
+    assert!(
+        stale_active,
         "the denied cache deletion must leave the old active snapshot readable"
     );
     assert!(
-        live_result.is_none(),
+        !live_valid,
         "live authentication must ignore the stale active snapshot"
     );
-    assert!(!detailed_result.is_valid);
-    assert_eq!(
-        detailed_result.invalid_reason.as_deref(),
-        Some("API key is inactive")
-    );
+    assert!(!detailed_valid);
+    assert_eq!(invalid_reason.as_deref(), Some("API key is inactive"));
 }
 
 #[cfg(test)]
@@ -648,13 +658,14 @@ async fn test_api_key_handler() -> ApiKeyHandler {
 }
 
 #[cfg(test)]
-async fn handler_with_redis(base_handler: &ApiKeyHandler, redis: RedisPool) -> ApiKeyHandler {
+async fn handler_with_redis(
+    base_handler: &ApiKeyHandler,
+    redis: RedisPool,
+) -> crate::utils::error::gateway_error::Result<ApiKeyHandler> {
     let mut storage = (*base_handler.storage).clone();
     storage.redis = Arc::new(redis);
     storage.redis_status = DependencyStatus::Healthy;
-    ApiKeyHandler::new(Arc::new(storage), None)
-        .await
-        .expect("API key handler should accept the restricted Redis pool")
+    ApiKeyHandler::new(Arc::new(storage), None).await
 }
 
 #[cfg(test)]

--- a/src/auth/api_key/tests.rs
+++ b/src/auth/api_key/tests.rs
@@ -3,9 +3,17 @@
 //! This module contains unit tests for API key management.
 
 #[cfg(test)]
+use super::creation::ApiKeyHandler;
+#[cfg(test)]
 use crate::auth::api_key::types::{ApiKeyVerification, CreateApiKeyRequest};
+#[cfg(test)]
+use crate::config::models::storage::{RedisConfig, StorageConfig};
 use crate::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
+#[cfg(test)]
+use crate::storage::{DependencyStatus, StorageLayer, redis::RedisPool};
 use chrono::{Duration, Utc};
+#[cfg(test)]
+use std::sync::Arc;
 use uuid::Uuid;
 
 // ==================== CreateApiKeyRequest Tests ====================
@@ -531,4 +539,225 @@ fn test_key_prefix_different_formats() {
 
         assert_eq!(api_key.key_prefix, prefix);
     }
+}
+
+// ==================== Revocation Consistency Tests ====================
+
+#[tokio::test]
+async fn revoked_key_is_rejected_when_cache_delete_fails() {
+    let Some((admin_pool, redis_url)) = live_redis_pool().await else {
+        return;
+    };
+    let base_handler = test_api_key_handler().await;
+    let (api_key, raw_key) = base_handler
+        .create_key(
+            None,
+            None,
+            "acl-denied-cache-delete".to_string(),
+            vec!["api.chat".to_string()],
+        )
+        .await
+        .expect("test API key should be stored");
+    let cache_key = format!("api_key:hash:{}", api_key.key_hash);
+    let username = format!("gh959_{}", Uuid::new_v4().simple());
+    let password = format!("gh959-{}", Uuid::new_v4().simple());
+
+    configure_delete_denied_user(&admin_pool, &username, &password, &cache_key).await;
+    let restricted_pool =
+        RedisPool::new(&restricted_redis_config(&redis_url, &username, &password))
+            .await
+            .expect("restricted Redis user should connect");
+    let handler = handler_with_redis(&base_handler, restricted_pool).await;
+    handler
+        .storage
+        .cache_set(
+            &cache_key,
+            &serde_json::to_string(&api_key).expect("active snapshot should serialize"),
+            None,
+        )
+        .await
+        .expect("restricted user should populate the stale snapshot");
+    let delete_error = handler
+        .storage
+        .cache_delete(&cache_key)
+        .await
+        .expect_err("restricted user must not delete the cache key");
+    assert!(
+        delete_error.to_string().contains("NoPerm"),
+        "cache deletion should fail because Redis denied DEL: {delete_error}"
+    );
+
+    handler
+        .revoke_key(api_key.metadata.id)
+        .await
+        .expect("database revoke must not depend on cache deletion");
+    let stored = handler
+        .storage
+        .db()
+        .find_api_key_by_hash(&api_key.key_hash)
+        .await
+        .expect("revoked key lookup should succeed")
+        .expect("revoked key should remain stored");
+    let stale_snapshot: ApiKey = serde_json::from_str(
+        &handler
+            .storage
+            .cache_get(&cache_key)
+            .await
+            .expect("restricted user should still read the cache")
+            .expect("denied deletion must leave the stale snapshot"),
+    )
+    .expect("stale snapshot should deserialize");
+    let live_result = handler
+        .verify_key(&raw_key)
+        .await
+        .expect("live verification should read the database");
+    let detailed_result = handler
+        .verify_key_detailed(&raw_key)
+        .await
+        .expect("detailed verification should read the database");
+
+    cleanup_delete_denied_user(&admin_pool, &username, &cache_key).await;
+
+    assert!(!stored.is_active, "database revoke must be committed");
+    assert!(
+        stale_snapshot.is_active,
+        "the denied cache deletion must leave the old active snapshot readable"
+    );
+    assert!(
+        live_result.is_none(),
+        "live authentication must ignore the stale active snapshot"
+    );
+    assert!(!detailed_result.is_valid);
+    assert_eq!(
+        detailed_result.invalid_reason.as_deref(),
+        Some("API key is inactive")
+    );
+}
+
+#[cfg(test)]
+async fn test_api_key_handler() -> ApiKeyHandler {
+    let mut config = StorageConfig::default();
+    config.database.enabled = false;
+    config.redis.enabled = false;
+    let storage = StorageLayer::new(&config)
+        .await
+        .expect("test storage should initialize");
+    ApiKeyHandler::new(Arc::new(storage), None)
+        .await
+        .expect("API key handler should initialize")
+}
+
+#[cfg(test)]
+async fn handler_with_redis(base_handler: &ApiKeyHandler, redis: RedisPool) -> ApiKeyHandler {
+    let mut storage = (*base_handler.storage).clone();
+    storage.redis = Arc::new(redis);
+    storage.redis_status = DependencyStatus::Healthy;
+    ApiKeyHandler::new(Arc::new(storage), None)
+        .await
+        .expect("API key handler should accept the restricted Redis pool")
+}
+
+#[cfg(test)]
+async fn live_redis_pool() -> Option<(RedisPool, String)> {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let config = RedisConfig {
+        url: redis_url.clone(),
+        enabled: true,
+        max_connections: 2,
+        connection_timeout: 1,
+        cluster: false,
+        allow_degraded: false,
+    };
+
+    match RedisPool::new(&config).await {
+        Ok(pool) => match pool.health_check().await {
+            Ok(()) => Some((pool, redis_url)),
+            Err(error) => unavailable_live_redis(&redis_url, error),
+        },
+        Err(error) => unavailable_live_redis(&redis_url, error),
+    }
+}
+
+#[cfg(test)]
+fn unavailable_live_redis(
+    redis_url: &str,
+    error: crate::utils::error::gateway_error::GatewayError,
+) -> Option<(RedisPool, String)> {
+    if std::env::var("CI").is_ok() {
+        panic!("Redis should be reachable in CI at {redis_url}: {error}");
+    }
+    eprintln!("Skipping API-key revocation Redis test: {error}");
+    None
+}
+
+#[cfg(test)]
+fn restricted_redis_config(redis_url: &str, username: &str, password: &str) -> RedisConfig {
+    let mut url = url::Url::parse(redis_url).expect("REDIS_URL should be valid");
+    url.set_username(username)
+        .expect("Redis ACL username should be valid");
+    url.set_password(Some(password))
+        .expect("Redis ACL password should be valid");
+    RedisConfig {
+        url: url.to_string(),
+        enabled: true,
+        max_connections: 2,
+        connection_timeout: 1,
+        cluster: false,
+        allow_degraded: false,
+    }
+}
+
+#[cfg(test)]
+async fn configure_delete_denied_user(
+    admin_pool: &RedisPool,
+    username: &str,
+    password: &str,
+    cache_key: &str,
+) {
+    let mut connection = admin_pool
+        .get_connection()
+        .await
+        .expect("admin Redis connection should be available");
+    let connection = connection
+        .conn
+        .as_mut()
+        .expect("live Redis connection should not be no-op");
+    let _: () = redis::cmd("ACL")
+        .arg("SETUSER")
+        .arg(username)
+        .arg("reset")
+        .arg("on")
+        .arg(format!(">{password}"))
+        .arg(format!("~{cache_key}"))
+        .arg("+@connection")
+        .arg("+get")
+        .arg("+set")
+        .arg("-del")
+        .query_async(connection)
+        .await
+        .expect("test should create a Redis user that cannot delete the cache key");
+}
+
+#[cfg(test)]
+async fn cleanup_delete_denied_user(admin_pool: &RedisPool, username: &str, cache_key: &str) {
+    let mut connection = admin_pool
+        .get_connection()
+        .await
+        .expect("admin Redis cleanup connection should be available");
+    let connection = connection
+        .conn
+        .as_mut()
+        .expect("live Redis cleanup connection should not be no-op");
+    let _: i64 = redis::cmd("DEL")
+        .arg(cache_key)
+        .query_async(&mut *connection)
+        .await
+        .expect("admin should remove the stale test cache key");
+    let _: i64 = redis::cmd("ACL")
+        .arg("DELUSER")
+        .arg(username)
+        .query_async(connection)
+        .await
+        .expect("admin should remove the restricted test user");
 }


### PR DESCRIPTION
## Summary

- make the database the authoritative API-key lifecycle source for both verification paths
- invalidate Redis before and after database revoke as best-effort rolling-deployment cleanup without trusting cached authorization snapshots
- add a Redis ACL regression that proves a revoked key is rejected when `DEL` is denied and the stale active snapshot remains readable
- document that old cache-first replicas must be drained before relying on immediate revocation

## Verification

- `REDIS_URL=redis://127.0.0.1:6389 cargo test --all-features --locked --lib auth::api_key::tests::revoked_key_is_rejected_when_cache_delete_fails -- --exact --nocapture`
- `REDIS_URL=redis://127.0.0.1:6389 cargo test --all-features --locked --lib auth::api_key:: -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `REDIS_URL=redis://127.0.0.1:6389 cargo test --all-features --locked -- --test-threads=1`
- `bash scripts/guards/check_pr_scope.sh origin/main`
- `bash scripts/guards/check_pr_overlap.sh`
- SpecRail GH959 packet check

Closes #959
