### PR TITLE
fix(auth): distinguish infrastructure failures from invalid credentials

### DIFF
--- a/specs/GH960/product.md
+++ b/specs/GH960/product.md
@@ -1,0 +1,53 @@
+# Product Spec
+
+## Linked Issue
+
+GH-960 / #960
+
+## 用户问题
+
+API-key 验证的数据库等基础设施故障当前被 `AuthSystem` 转换成失败的 `AuthResult`，随后 middleware 与 keys management 路由按无效凭证返回 401。部分路径还会把底层 `GatewayError` 文本拼进公开响应，使客户端无法区分凭证无效与认证服务故障，并可能获得数据库或缓存内部详情。
+
+## 目标
+
+- 保持真正无效、inactive、expired 或 owner-invalid API key 的稳定 401 语义。
+- 让 API-key 验证返回的基础设施 `Err` 保持 typed error 边界，并由 HTTP 调用方映射为通用 500。
+- middleware 与 keys management 认证路径使用同一个公开错误消息，且响应不包含底层错误字符串。
+- 在服务端以 `error` 级别记录完整基础设施错误，保留运维诊断能力。
+
+## 非目标
+
+- 不改变 JWT 或 session 的验证与公开错误语义。
+- 不改变 API-key active/expiry/owner 判定；#958 已定义 owner contract。
+- 不改变 Redis snapshot 或 revoke 一致性；#959 已处理 lifecycle authority。
+- 不改变 user 删除、外键或 owner provenance；该工作属于 #961。
+- 不改变成功响应、公开 schema 或数据库 migration。
+
+## Behavior Invariants
+
+1. `P1`：`ApiKeyHandler::verify_key -> Ok(None)` 继续被 `AuthSystem` 表示为失败 `AuthResult`，公开 HTTP 状态为 401，消息保持 `Invalid API key`。
+2. `P2`：`ApiKeyHandler::verify_key -> Err(error)` 必须从 `AuthSystem::authenticate` 传播为 `Err`；不得转换成 conclusively-invalid credential。
+3. `P3`：auth middleware 收到该 `Err` 时释放预留资源、记录完整服务端错误，并返回 500 与固定通用消息；不得计为坏凭证或让重复 outage 触发 auth lockout，公开 body 不得包含数据库、Redis、SQL、连接串或原始 `GatewayError` 文本。
+4. `P4`：keys management 的 direct authentication path 对同一 `Err` 使用相同固定消息和 500 状态，并只在服务端记录原始错误。
+5. `P5`：固定通用消息只有一个 crate-internal 定义，避免 middleware 与 keys route 发生文案或状态语义漂移。
+6. `P6`：OpenAI-compatible middleware 路径保留现有 OpenAI error envelope；非 OpenAI middleware 与 keys route 保留各自现有 envelope，但状态与公开消息一致。
+7. `P7`：认证基础设施错误不得静默降级成 valid、invalid credential、ownerless 或 cache fallback。
+
+## 验收标准
+
+- [ ] API-key verifier 的基础设施错误从 `AuthSystem` 原样传播。
+- [ ] invalid API key 继续返回 401 与稳定的无效凭证消息。
+- [ ] middleware 与 keys route 都把基础设施错误映射为通用 500。
+- [ ] 两个公共响应都使用共享消息且不包含内部错误详情。
+- [ ] 重复认证基础设施故障保持 500，不被 auth failed-attempt limiter 转换成 429。
+- [ ] 聚焦测试、格式、strict clippy、全量测试、scope/overlap guards 与 SpecRail gates 通过。
+
+## 边界情况
+
+- 当前 #959 路径不再读取 Redis，但数据库 key lookup、owner lookup 及未来认证依赖仍可能返回 `GatewayError`；统一按基础设施错误处理。
+- HTTP 调用方必须先记录原始错误，再构造不接受内部详情参数的固定响应 helper。
+- 本 issue 不把基础设施错误细分为 500/503；固定返回 500，避免未声明的可用性分类。
+
+## 发布说明
+
+无效 API key 仍返回 401。API-key 数据库等认证基础设施故障现在返回不含内部详情的通用 500，便于客户端安全地区分凭证问题与服务故障。

--- a/specs/GH960/tasks.md
+++ b/specs/GH960/tasks.md
@@ -14,7 +14,7 @@ GH-960 / #960
 - [x] `SP960-T1` Owner: coordinator. Dependencies: none. Done when: GH960 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work、write-spec 与 implement route gates 为 allowed。Verify: packet and route-gate JSON。
 - [x] `SP960-T2` Owner: auth-regression. Dependencies: T1. Done when: 真实关闭 database pool 后，回归测试证明旧 `AuthSystem` 把 API-key storage error 错误折叠成 failed `AuthResult`。Verify: focused red test artifact。
 - [x] `SP960-T3` Owner: auth-implementation. Dependencies: T2. Done when: verifier `Err` 原样传播；middleware 与 keys route 记录内部详情并使用共享固定消息返回通用 500；invalid key 仍为 401，重复 outage 不触发 auth lockout。Verify: focused auth/middleware/keys tests。
-- [ ] `SP960-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
+- [x] `SP960-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
 - [ ] `SP960-T5` Owner: coordinator. Dependencies: T4. Done when: final PR 使用 `Closes #960`，current-head 独立安全 reviewer、CI、review threads、PR gate、runtime gate、merge 与 issue closure 均远端确认。Verify: SpecRail PR evidence and closure audit。
 
 ## 并行拆分

--- a/specs/GH960/tasks.md
+++ b/specs/GH960/tasks.md
@@ -1,0 +1,41 @@
+# Task Plan
+
+## Linked Issue
+
+GH-960 / #960
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [x] `SP960-T1` Owner: coordinator. Dependencies: none. Done when: GH960 product/tech/tasks packet 通过 SpecRail 校验，duplicate-work、write-spec 与 implement route gates 为 allowed。Verify: packet and route-gate JSON。
+- [x] `SP960-T2` Owner: auth-regression. Dependencies: T1. Done when: 真实关闭 database pool 后，回归测试证明旧 `AuthSystem` 把 API-key storage error 错误折叠成 failed `AuthResult`。Verify: focused red test artifact。
+- [x] `SP960-T3` Owner: auth-implementation. Dependencies: T2. Done when: verifier `Err` 原样传播；middleware 与 keys route 记录内部详情并使用共享固定消息返回通用 500；invalid key 仍为 401，重复 outage 不触发 auth lockout。Verify: focused auth/middleware/keys tests。
+- [ ] `SP960-T4` Owner: verification. Dependencies: T3. Done when: fmt、diff、all-features check、strict clippy、串行全量 tests、scope/overlap guards 与 packet validation 全部通过。Verify: commands below。
+- [ ] `SP960-T5` Owner: coordinator. Dependencies: T4. Done when: final PR 使用 `Closes #960`，current-head 独立安全 reviewer、CI、review threads、PR gate、runtime gate、merge 与 issue closure 均远端确认。Verify: SpecRail PR evidence and closure audit。
+
+## 并行拆分
+
+error propagation、两个 HTTP mapping 与其测试共享认证 contract，按 W-14 由 coordinator 串行修改。planner/reviewer lane 只读；共享验证由 coordinator 独占。
+
+## 验证
+
+- closed-pool `AuthSystem` infrastructure-error propagation test
+- middleware and keys generic-500 helper tests
+- existing invalid API-key 401 middleware regression
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- `cargo check --all-features --locked`
+- `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- `cargo test --all-features --locked -- --test-threads=1`
+- `bash scripts/guards/check_pr_scope.sh origin/main`
+- `bash scripts/guards/check_pr_overlap.sh`
+- `python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH960"`
+
+## Handoff Notes
+
+- 不修改 JWT/session、#958 owner contract、#959 cache authority 或 #961 schema semantics。
+- 原始认证错误只进入服务端日志；HTTP helpers 不接受该错误作为输入。

--- a/specs/GH960/tech.md
+++ b/specs/GH960/tech.md
@@ -1,0 +1,96 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-960 / #960
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Required boundary |
+| --- | --- | --- | --- |
+| API-key auth core | `src/auth/system.rs` | `verify_key` errors become failed `AuthResult` with formatted internal detail | preserve `Ok(None)` invalid semantics but propagate `Err` |
+| Shared public contract | `src/auth/mod.rs` | no common generic authentication-service message | define one crate-internal constant |
+| Middleware mapping | `src/server/middleware/auth.rs` | propagated auth errors are formatted into `ErrorInternalServerError`, exposing detail | log original error and return generic 500 through existing envelope helper |
+| Keys direct mapping | `src/server/routes/keys/access.rs` | propagated auth errors are logged but returned as generic 401 | log original error and return generic 500 |
+| Core regression | `src/auth/tests.rs` | no real storage failure proves `AuthSystem` preserves `Err` | close the in-memory DB pool and assert API-key auth returns storage error |
+
+## 设计方案
+
+1. 在 `crate::auth` 定义 `pub(crate)` 固定消息 `Authentication service temporarily unavailable`，仅供服务端映射复用，不新增 public API。
+2. `AuthSystem::authenticate_api_key` 保留成功与 `Ok(None)` 分支，将 verifier 的 `Err(error)` 直接返回。该层不构造 HTTP 状态或公开消息。
+3. auth middleware 的 `Err` 分支：
+   - 释放已有 auth rate-limit reservation，保持现有资源语义；
+   - 不调用 failed-credential `record_failure`，避免 outage 触发 lockout/429；
+   - 以 `error!(error = %error, ...)` 在服务端记录完整错误；
+   - 调用私有 `authentication_unavailable_response`，用共享消息构造 500；
+   - OpenAI-compatible path 继续经 `middleware_gateway_error_response` 生成 OpenAI envelope，其他路径使用 Actix 500。
+4. keys access 的 `Err` 分支同样记录完整错误，并调用私有 helper，以 `KeyErrorResponse::internal` 与共享消息构造 500 `ApiResponse`。
+5. 不让 response helper 接收原始 error 或任意 message，结构上阻止内部详情误传。
+6. 回归测试：
+   - real in-memory SQLite pool `close_by_ref` 后调用 API-key authentication，旧代码应返回 `Ok(AuthResult)`，新代码必须返回 `GatewayError::Storage`；
+   - middleware 关闭 DB 后连续请求仍返回 500、包含共享通用消息且不包含 storage/Redis sentinel，不转成 429；
+   - keys direct auth 先证明 invalid credential 为 401，再关闭 DB 证明同一路径返回通用 500；
+   - 现有 invalid API-key middleware 回归继续证明 401 与 `Invalid API key`。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 | unchanged `Ok(None)` branch | existing invalid API-key middleware 401 regression |
+| P2/P7 | `AuthSystem::authenticate_api_key` | closed database pool returns `Err(GatewayError::Storage)` |
+| P3/P6 | middleware private response helper and integration path | helper 500/generic body plus repeated closed-DB requests never become 429 |
+| P4 | keys direct authentication path | invalid credential 401 followed by closed-DB generic 500 |
+| P5 | crate-internal shared constant | both helpers import the same constant; code review and body assertions |
+
+## 数据流
+
+Invalid credential: `verify_key -> Ok(None)` -> failed `AuthResult` -> caller 401。
+
+Infrastructure failure: `verify_key -> Err(GatewayError)` -> `AuthSystem::authenticate -> Err` -> caller logs full error -> fixed generic 500 response。
+
+## 受影响文件与规模
+
+- `src/auth/mod.rs`
+- `src/auth/system.rs`
+- `src/auth/tests.rs`
+- `src/server/middleware/auth.rs`
+- `src/server/routes/keys/access.rs`
+- `tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs`
+- `specs/GH960/product.md`
+- `specs/GH960/tech.md`
+- `specs/GH960/tasks.md`
+
+预计 6 个 code/test 文件、少于 300 行 code diff，满足仓库 scope 限制；所有文件保持在 800 行以内。
+
+## 备选方案
+
+- 在 `AuthResult` 增加 error kind：已有 `Result<AuthResult, GatewayError>` 已能表达基础设施失败，增加第二套分类会重复建模，拒绝。
+- 直接返回 `GatewayError::error_response()`：当前通用 error serializer 会使用原始 `to_string()`，仍可能泄露 storage detail，拒绝。
+- 所有认证失败统一 500：破坏无效凭证 401 contract，拒绝。
+- 同时修正 JWT database/error disclosure：不在 issue 的 API-key 证据与验收范围，留作独立工作，拒绝。
+
+## 风险
+
+- Security: 原始 error 只能进入服务端日志，不能传给任一 response constructor。
+- Compatibility: 依赖“数据库故障也返回 401”的客户端将看到 500；这是预期纠正。
+- Observability: 两个 HTTP 调用点必须保留 error-level full-detail log。
+- Availability: 基础设施故障不计入 credential lockout；gateway 全局 rate limit 若独立启用仍保持其现有语义。
+- Envelope: middleware OpenAI path 与 keys `ApiResponse` 结构不同，只共享状态/消息 contract，不强行统一 schema。
+- Testing: 关闭 in-memory pool 的测试必须确认真实 query 失败，而不是构造 synthetic `GatewayError`。
+
+## 测试计划
+
+- Red phase: closed-pool AuthSystem test 先证明旧代码把 storage error 折叠为 `AuthResult`。
+- Focused: AuthSystem propagation、middleware generic 500、keys generic 500、existing invalid-key 401。
+- Deterministic: `cargo fmt --all -- --check`、`git diff --check`、all-features check、strict clippy。
+- Repository: `cargo test --all-features --locked -- --test-threads=1`。
+- Guards: `bash scripts/guards/check_pr_scope.sh origin/main`、`bash scripts/guards/check_pr_overlap.sh`。
+- SpecRail: GH960 packet、implement route、current-head security reviewer、PR gate 与 runtime gate。
+
+## 回滚方案
+
+回滚 GH960 PR 即恢复旧 401/error-detail 行为；没有 schema、数据 migration 或 cache 格式变更。

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -27,4 +27,7 @@ pub use crate::core::models::ApiKey;
 pub use system::AuthSystem;
 pub use types::{AuthMethod, AuthResult};
 
+pub(crate) const AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE: &str =
+    "Authentication service temporarily unavailable";
+
 // Re-export OAuth types for convenience

--- a/src/auth/system.rs
+++ b/src/auth/system.rs
@@ -190,14 +190,7 @@ impl AuthSystem {
                 error: Some("Invalid API key".to_string()),
                 context,
             }),
-            Err(e) => Ok(AuthResult {
-                success: false,
-                user: None,
-                api_key: None,
-                session: None,
-                error: Some(format!("API key verification failed: {}", e)),
-                context,
-            }),
+            Err(error) => Err(error),
         }
     }
 

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -203,3 +203,39 @@ async fn test_session_auth_always_rejected() {
         "session auth error message must match expected value"
     );
 }
+
+#[tokio::test]
+async fn api_key_storage_error_propagates_from_auth_system() {
+    let mut config = crate::config::Config::default();
+    config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+
+    let storage = std::sync::Arc::new(
+        crate::storage::StorageLayer::new(&config.gateway.storage)
+            .await
+            .expect("storage should initialize before the failure is injected"),
+    );
+    let auth_system = super::system::AuthSystem::new(&config.gateway.auth, storage.clone())
+        .await
+        .expect("AuthSystem should initialize before the failure is injected");
+    storage
+        .db()
+        .connection()
+        .close_by_ref()
+        .await
+        .expect("test should close the database pool");
+
+    let error = auth_system
+        .authenticate(
+            AuthMethod::ApiKey("gw-infrastructure-failure".to_string()),
+            RequestContext::new(),
+        )
+        .await
+        .expect_err("database failure must not become an invalid-credential AuthResult");
+
+    assert!(matches!(
+        error,
+        crate::utils::error::gateway_error::GatewayError::Storage(_)
+    ));
+}

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -1,6 +1,6 @@
 //! Authentication middleware
 
-use crate::auth::AuthMethod;
+use crate::auth::{AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE, AuthMethod};
 use crate::core::models::{ApiKey, user::types::User};
 use crate::core::types::context::{RequestContext, SharedRequestContext};
 use crate::server::middleware::auth_rate_limiter::get_auth_rate_limiter;
@@ -289,11 +289,8 @@ where
                     if let Some(reservation) = auth_rate_limit_reservation.take() {
                         reservation.release().await;
                     }
-                    rate_limiter.record_failure(&client_id);
-                    Err(actix_web::error::ErrorInternalServerError(format!(
-                        "Authentication error: {}",
-                        err
-                    )))
+                    error!(error = %err, "Authentication infrastructure failure");
+                    Ok(authentication_unavailable_response(req))
                 }
             }
         })
@@ -354,6 +351,14 @@ fn forbidden_response<B>(
         req,
         actix_web::error::ErrorForbidden(message.clone()),
         GatewayError::Forbidden(message),
+    )
+}
+
+fn authentication_unavailable_response<B>(req: ServiceRequest) -> ServiceResponse<EitherBody<B>> {
+    middleware_gateway_error_response(
+        req,
+        actix_web::error::ErrorInternalServerError(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE),
+        GatewayError::Internal(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE.to_string()),
     )
 }
 
@@ -608,5 +613,29 @@ mod tests {
         );
         assert!(!context.headers.contains_key("authorization"));
         assert!(!context.headers.contains_key("x-api-key"));
+    }
+
+    #[actix_web::test]
+    async fn authentication_unavailable_response_is_generic_server_error() {
+        let req = TestRequest::with_uri("/v1/chat/completions").to_srv_request();
+        let response = authentication_unavailable_response::<actix_web::body::BoxBody>(req);
+
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("generic authentication error body should render");
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE));
+        for internal_detail in [
+            "Storage error",
+            "Database error",
+            "Redis error",
+            "Connection closed",
+        ] {
+            assert!(!body.contains(internal_detail));
+        }
     }
 }

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -355,11 +355,18 @@ fn forbidden_response<B>(
 }
 
 fn authentication_unavailable_response<B>(req: ServiceRequest) -> ServiceResponse<EitherBody<B>> {
-    middleware_gateway_error_response(
-        req,
-        actix_web::error::ErrorInternalServerError(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE),
-        GatewayError::Internal(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE.to_string()),
-    )
+    if ai::is_openai_compatible_path(req.path()) {
+        return req
+            .into_response(ai::openai_internal_error_response(
+                AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE,
+            ))
+            .map_into_right_body();
+    }
+
+    req.error_response(actix_web::error::ErrorInternalServerError(
+        AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE,
+    ))
+    .map_into_right_body()
 }
 
 fn rate_limit_response<B>(
@@ -627,8 +634,13 @@ mod tests {
         let body = actix_web::body::to_bytes(response.into_body())
             .await
             .expect("generic authentication error body should render");
-        let body = String::from_utf8_lossy(&body);
-        assert!(body.contains(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE));
+        let body: serde_json::Value = serde_json::from_slice(&body)
+            .expect("generic authentication error body should be valid JSON");
+        assert_eq!(
+            body["error"]["message"],
+            AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE
+        );
+        let body = body.to_string();
         for internal_detail in [
             "Storage error",
             "Database error",

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -310,6 +310,10 @@ pub(crate) fn openai_gateway_error_response(error: &GatewayError) -> HttpRespons
     openai_errors::gateway_error_response(error)
 }
 
+pub(crate) fn openai_internal_error_response(message: impl Into<String>) -> HttpResponse {
+    openai_errors::internal_error(message)
+}
+
 fn openai_json_error_config() -> web::JsonConfig {
     web::JsonConfig::default().error_handler(|error, _req| {
         let response =

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -66,6 +66,15 @@ pub(crate) fn unauthorized_error(message: impl Into<String>) -> HttpResponse {
     ))
 }
 
+pub(crate) fn internal_error(message: impl Into<String>) -> HttpResponse {
+    build_response(spec(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        message.into(),
+        "server_error",
+        "internal_error",
+    ))
+}
+
 pub(crate) fn gateway_error_response(error: &GatewayError) -> HttpResponse {
     let spec = openai_error_spec(error);
     let mut builder = HttpResponse::build(spec.status);

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -277,8 +277,10 @@ mod tests {
         let body = actix_web::body::to_bytes(outage_response.into_body())
             .await
             .expect("generic key-route authentication error should render");
-        let body = String::from_utf8_lossy(&body);
-        assert!(body.contains(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE));
+        let body: serde_json::Value = serde_json::from_slice(&body)
+            .expect("generic key-route authentication error should be valid JSON");
+        assert_eq!(body["error"], AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE);
+        let body = body.to_string();
         for internal_detail in [
             "Storage error",
             "Database error",

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -1,5 +1,5 @@
 use super::types::{CreateKeyRequest, KeyErrorResponse, UpdateKeyRequest};
-use crate::auth::{AuthMethod, AuthResult};
+use crate::auth::{AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE, AuthMethod, AuthResult};
 use crate::core::keys::{KeyInfo, KeyPermissions, KeyRateLimits, KeyStatus};
 use crate::core::models::user::types::{User, UserRole};
 use crate::core::types::context::RequestContext;
@@ -102,12 +102,16 @@ pub(super) async fn authenticate_request(
             let error_response = KeyErrorResponse::unauthorized(msg);
             Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
         }
-        Err(e) => {
-            error!("Authentication error: {}", e);
-            let error_response = KeyErrorResponse::unauthorized("Authentication error");
-            Err(HttpResponse::Unauthorized().json(ApiResponse::<()>::error(error_response.error)))
+        Err(error) => {
+            error!(error = %error, "Authentication infrastructure failure");
+            Err(authentication_unavailable_response())
         }
     }
+}
+
+fn authentication_unavailable_response() -> HttpResponse {
+    let error_response = KeyErrorResponse::internal(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE);
+    HttpResponse::InternalServerError().json(ApiResponse::<()>::error(error_response.error))
 }
 
 pub(super) fn resolve_create_key_scope(
@@ -227,6 +231,63 @@ pub(super) fn filter_and_paginate_keys(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[actix_web::test]
+    async fn direct_auth_distinguishes_invalid_credentials_from_storage_failure() {
+        let mut config = crate::config::Config::default();
+        config.gateway.auth.enable_jwt = true;
+        config.gateway.auth.enable_api_key = true;
+        config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        let server = crate::server::http::HttpServer::new(&config)
+            .await
+            .expect("key-route test server should initialize");
+        let state = web::Data::new(server.state().clone());
+
+        let invalid_request = actix_web::test::TestRequest::default()
+            .insert_header(("x-api-key", "gw-invalid-key-route-credential"))
+            .to_http_request();
+        let invalid_response = authenticate_request(&invalid_request, &state)
+            .await
+            .expect_err("invalid credentials should return an HTTP response");
+        assert_eq!(
+            invalid_response.status(),
+            actix_web::http::StatusCode::UNAUTHORIZED
+        );
+
+        state
+            .storage
+            .db()
+            .connection()
+            .close_by_ref()
+            .await
+            .expect("test should close the authentication database pool");
+        let outage_request = actix_web::test::TestRequest::default()
+            .insert_header(("x-api-key", "gw-key-route-infrastructure-failure"))
+            .to_http_request();
+        let outage_response = authenticate_request(&outage_request, &state)
+            .await
+            .expect_err("storage failure should return a generic HTTP response");
+        assert_eq!(
+            outage_response.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body = actix_web::body::to_bytes(outage_response.into_body())
+            .await
+            .expect("generic key-route authentication error should render");
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains(AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE));
+        for internal_detail in [
+            "Storage error",
+            "Database error",
+            "Redis error",
+            "Connection closed",
+        ] {
+            assert!(!body.contains(internal_detail));
+        }
+    }
 
     #[test]
     fn accepts_unset_or_rpm_only_key_rate_limits() {

--- a/tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs
+++ b/tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs
@@ -182,6 +182,49 @@ async fn test_auth_middleware_rejects_invalid_auth() {
 }
 
 #[tokio::test]
+async fn test_auth_infrastructure_failures_stay_generic_500_without_lockout() {
+    let state = build_test_state(true, true).await;
+    state
+        .storage
+        .db()
+        .connection()
+        .close_by_ref()
+        .await
+        .expect("test should close the authentication database pool");
+    let hit_counter = Arc::new(AtomicUsize::new(0));
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .app_data(web::Data::new(hit_counter.clone()))
+            .wrap(AuthMiddleware)
+            .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
+    )
+    .await;
+
+    for port in 1000..1006 {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(AUTH_PROBE_PATH)
+                .peer_addr(format!("203.0.113.196:{port}").parse().unwrap())
+                .insert_header(("x-api-key", "gw-auth-infrastructure-failure-960"))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = test::read_body(response).await;
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("Authentication service temporarily unavailable"));
+        for internal_detail in ["Storage error", "Database error", "Connection closed"] {
+            assert!(!body.contains(internal_detail));
+        }
+    }
+
+    assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn test_missing_auth_hits_gateway_rate_limit_before_auth_short_circuit() {
     let state = build_test_state_with_rate_limit(true, true, false, Some(1)).await;
     let hit_counter = Arc::new(AtomicUsize::new(0));

--- a/tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs
+++ b/tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs
@@ -215,7 +215,7 @@ async fn test_auth_infrastructure_failures_stay_generic_500_without_lockout() {
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         let body = test::read_body(response).await;
         let body = String::from_utf8_lossy(&body);
-        assert!(body.contains("Authentication service temporarily unavailable"));
+        assert_eq!(body, "Authentication service temporarily unavailable");
         for internal_detail in ["Storage error", "Database error", "Connection closed"] {
             assert!(!body.contains(internal_detail));
         }


### PR DESCRIPTION
Closes #960

## Summary
- propagate API-key verification infrastructure errors instead of classifying them as invalid credentials
- return a shared generic 500 response from auth middleware and key-management authentication paths
- keep invalid credentials at 401 and prevent infrastructure outages from consuming failed-auth lockout state

## Verification
- cargo fmt --all -- --check
- cargo check --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked -- --test-threads=1
- bash scripts/guards/check_log_pii.sh
- bash scripts/guards/check_pr_scope.sh origin/main
- bash scripts/guards/check_pr_overlap.sh
- SpecRail GH960 packet validation