### PR TITLE
fix(auth): redact AuthMethod debug credentials

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -36,7 +36,7 @@ pub struct AuthzResult {
 }
 
 /// Authentication method
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum AuthMethod {
     /// JWT token authentication
     Jwt(String),
@@ -46,6 +46,23 @@ pub enum AuthMethod {
     Session(String),
     /// No authentication
     None,
+}
+
+impl std::fmt::Debug for AuthMethod {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Jwt(_) => formatter.debug_tuple("Jwt").field(&"[REDACTED]").finish(),
+            Self::ApiKey(_) => formatter
+                .debug_tuple("ApiKey")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::Session(_) => formatter
+                .debug_tuple("Session")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::None => formatter.write_str("None"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -353,11 +370,44 @@ mod tests {
     }
 
     #[test]
-    fn test_auth_method_debug() {
-        let method = AuthMethod::ApiKey("secret".to_string());
-        let debug_str = format!("{:?}", method);
+    fn auth_method_debug_exact_output_for_all_variants() {
+        assert_eq!(
+            format!("{:?}", AuthMethod::Jwt("jwt-secret".to_string())),
+            "Jwt(\"[REDACTED]\")"
+        );
+        assert_eq!(
+            format!("{:?}", AuthMethod::ApiKey("api-key-secret".to_string())),
+            "ApiKey(\"[REDACTED]\")"
+        );
+        assert_eq!(
+            format!("{:?}", AuthMethod::Session("session-secret".to_string())),
+            "Session(\"[REDACTED]\")"
+        );
+        assert_eq!(format!("{:?}", AuthMethod::None), "None");
+    }
 
-        assert!(debug_str.contains("ApiKey"));
+    #[test]
+    fn auth_method_debug_exact_output_for_boundary_secrets() {
+        for secret in ["", "jwt-\u{96ea}\nnext", "[REDACTED]"] {
+            assert_eq!(
+                format!("{:?}", AuthMethod::Jwt(secret.to_string())),
+                "Jwt(\"[REDACTED]\")"
+            );
+        }
+
+        for secret in ["", "api-key-\u{03c0}\nnext", "[REDACTED]"] {
+            assert_eq!(
+                format!("{:?}", AuthMethod::ApiKey(secret.to_string())),
+                "ApiKey(\"[REDACTED]\")"
+            );
+        }
+
+        for secret in ["", "session-\u{4f1a}\nnext", "[REDACTED]"] {
+            assert_eq!(
+                format!("{:?}", AuthMethod::Session(secret.to_string())),
+                "Session(\"[REDACTED]\")"
+            );
+        }
     }
 
     // ==================== Integration Tests ====================


### PR DESCRIPTION
## 变更

- 从 `AuthMethod` 移除会输出内部字符串字段的派生 `Debug`
- 添加穷尽式 custom `Debug`：JWT、API key、session 只输出 method kind 与固定 `[REDACTED]`
- 用完整字符串断言覆盖四个变体，并为每个 secret 变体覆盖空串、Unicode/换行和 `[REDACTED]` 输入

## Scope

- 精确 changed-file allowlist：`src/auth/types.rs`
- 不修改认证解析、验证、路由或 HTTP 行为
- 三处直接 session identifier 日志仅 referral 到 GH-969；本 PR 不实现、不验证、不关闭、也不为其提供 coverage

## Red-Green Evidence

- 派生 `Debug` 下，all-variants test 显示 `Jwt("jwt-secret")` 而失败
- 派生 `Debug` 下，boundary test 显示 `Jwt("")` 而失败
- custom formatter 后，两个 exact tests 均通过，T5 后再次运行 T4 也通过
- 规格中的 literal `-- --list | grep -Fqx` 因 `grep -q` 提前关闭 10,280 行 listing 而触发 Rust harness `Broken pipe`；验证改为完整 listing 落文件、精确 grep、立即运行 exact test。独立 reviewer 判定该方式 fail-closed 等价且更强

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
- exact test listing/file assertions与两个 exact runs
- `bash scripts/guards/check_pr_scope.sh origin/main`
- `bash scripts/guards/check_pr_overlap.sh`
- 最新 SpecRail GH957 packet、waiver 与 runtime ledger gates

全部本地通过。全量首个 test binary：10,280 passed、0 failed；后续 integration 和 doc tests 也全部成功。

## Security Review

- AuthMethod scan SHA-256：`9332cb7b2d48dc005801555fa915c9d4e167d3120fe3ddfce69431bfa4c19181`
- Output-sink scan SHA-256：`e4e964d37aa106bdc6438c2af959df762083f93c5458bc1de2ec3cb73a75ae44`
- 独立 reviewer lane `019f5492-3f24-7341-a92a-b60173344c61` 对 head
  `d18dce87cd0ca2f5019ebead38b7bb90ff618837` 返回 `CURRENT_HEAD_APPROVE`，0 findings
- Maintainer waiver 只处置 non-author human `APPROVED` conjunct，不替代 CI、review threads、PR gate、merge state 或 runtime gate

Fixes #957
