### PR TITLE
fix(azure): enforce native endpoint policy

### DIFF
--- a/src/core/providers/azure/assistants.rs
+++ b/src/core/providers/azure/assistants.rs
@@ -3,6 +3,7 @@
 //! AI assistants with function calling and code interpreter
 
 use async_trait::async_trait;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -249,6 +250,8 @@ impl BaseAssistantHandler for AzureAssistantHandler {
         request: CreateAssistantRequest,
         config: &AssistantApiConfig,
     ) -> Result<CreateAssistantResponse, AssistantError> {
+        self.client
+            .validate_api_base_override(config.api_base.as_deref())?;
         let api_key = config
             .api_key
             .as_deref()
@@ -278,8 +281,7 @@ impl BaseAssistantHandler for AzureAssistantHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(request_headers)
             .json(&request)
             .send()
@@ -287,11 +289,11 @@ impl BaseAssistantHandler for AzureAssistantHandler {
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -308,6 +310,8 @@ impl BaseAssistantHandler for AzureAssistantHandler {
         before: Option<&str>,
         config: &AssistantApiConfig,
     ) -> Result<ListAssistantsResponse, AssistantError> {
+        self.client
+            .validate_api_base_override(config.api_base.as_deref())?;
         let api_key = config
             .api_key
             .as_deref()
@@ -356,19 +360,18 @@ impl BaseAssistantHandler for AzureAssistantHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .get(&url)
+            .request(Method::GET, &url)?
             .headers(request_headers)
             .send()
             .await
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -382,6 +385,8 @@ impl BaseAssistantHandler for AzureAssistantHandler {
         assistant_id: &str,
         config: &AssistantApiConfig,
     ) -> Result<RetrieveAssistantResponse, AssistantError> {
+        self.client
+            .validate_api_base_override(config.api_base.as_deref())?;
         let api_key = config
             .api_key
             .as_deref()
@@ -411,19 +416,18 @@ impl BaseAssistantHandler for AzureAssistantHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .get(&url)
+            .request(Method::GET, &url)?
             .headers(request_headers)
             .send()
             .await
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -438,6 +442,8 @@ impl BaseAssistantHandler for AzureAssistantHandler {
         request: ModifyAssistantRequest,
         config: &AssistantApiConfig,
     ) -> Result<RetrieveAssistantResponse, AssistantError> {
+        self.client
+            .validate_api_base_override(config.api_base.as_deref())?;
         let api_key = config
             .api_key
             .as_deref()
@@ -467,8 +473,7 @@ impl BaseAssistantHandler for AzureAssistantHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(request_headers)
             .json(&request)
             .send()
@@ -476,11 +481,11 @@ impl BaseAssistantHandler for AzureAssistantHandler {
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -494,6 +499,8 @@ impl BaseAssistantHandler for AzureAssistantHandler {
         assistant_id: &str,
         config: &AssistantApiConfig,
     ) -> Result<DeleteAssistantResponse, AssistantError> {
+        self.client
+            .validate_api_base_override(config.api_base.as_deref())?;
         let api_key = config
             .api_key
             .as_deref()
@@ -523,19 +530,18 @@ impl BaseAssistantHandler for AzureAssistantHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .delete(&url)
+            .request(Method::DELETE, &url)?
             .headers(request_headers)
             .send()
             .await
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -543,57 +549,6 @@ impl BaseAssistantHandler for AzureAssistantHandler {
             .await
             .map_err(|e| ProviderError::serialization("azure", e.to_string()))
     }
-
-    // Additional methods not in the trait - commented out for now
-    // NOTE: Methods below not yet part of the trait; kept for reference.
-    /*
-    async fn create_thread(
-        &self,
-        request: CreateThreadRequest,
-        api_key: Option<&str>,
-        _api_base: Option<&str>,
-        headers: Option<HashMap<String, String>>,
-    ) -> Result<CreateThreadResponse, AssistantError> {
-        let api_key = api_key
-            .map(|s| s.to_string())
-            .or_else(|| self.client.get_config().api_key.clone())
-            .ok_or_else(|| ProviderError::authentication("azure","Azure API key required".to_string()))?;
-
-        let url = self.build_threads_url("");
-
-        let mut request_headers = AzureUtils::create_azure_headers(self.client.get_config(), api_key)
-            .map_err(|e| ProviderError::configuration("azure",e.to_string()))?;
-
-        if let Some(custom_headers) = &config.headers {
-            for (key, value) in custom_headers {
-                let header_name = reqwest::header::HeaderName::from_bytes(key.as_bytes())
-                    .map_err(|e| ProviderError::network("azure",format!("Invalid header: {}", e)))?;
-                let header_value = reqwest::header::HeaderValue::from_str(value)
-                    .map_err(|e| ProviderError::network("azure",format!("Invalid header: {}", e)))?;
-                request_headers.insert(header_name, header_value);
-            }
-        }
-
-        let response = self.client.get_http_client()
-            .post(&url)
-            .headers(request_headers)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| ProviderError::network("azure",e.to_string()))?;
-
-        if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
-        }
-
-        response.json().await
-            .map_err(|e| ProviderError::serialization("azure",e.to_string()))
-    }
-    */
 }
 
 pub struct AzureAssistantUtils;

--- a/src/core/providers/azure/batches/mod.rs
+++ b/src/core/providers/azure/batches/mod.rs
@@ -3,6 +3,7 @@
 //! Batch processing for multiple API requests
 
 use async_trait::async_trait;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -98,13 +99,16 @@ impl AzureBatchHandler {
     }
 
     fn build_batches_url(&self, path: &str) -> String {
+        let endpoint = self
+            .client
+            .get_config()
+            .azure_endpoint
+            .as_deref()
+            .unwrap_or("")
+            .trim_end_matches('/');
         format!(
-            "{}openai/batches{}?api-version={}",
-            self.client
-                .get_config()
-                .azure_endpoint
-                .as_deref()
-                .unwrap_or(""),
+            "{}/openai/batches{}?api-version={}",
+            endpoint,
             path,
             self.client.get_config().api_version
         )
@@ -117,9 +121,10 @@ impl BaseBatchHandler for AzureBatchHandler {
         &self,
         request: CreateBatchRequest,
         api_key: Option<&str>,
-        _api_base: Option<&str>,
+        api_base: Option<&str>,
         headers: Option<HashMap<String, String>>,
     ) -> Result<CreateBatchResponse, BatchError> {
+        self.client.validate_api_base_override(api_base)?;
         let api_key = api_key
             .map(|s| s.to_string())
             .or_else(|| self.client.get_config().api_key.clone())
@@ -148,8 +153,7 @@ impl BaseBatchHandler for AzureBatchHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(request_headers)
             .json(&request)
             .send()
@@ -157,11 +161,11 @@ impl BaseBatchHandler for AzureBatchHandler {
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -175,9 +179,10 @@ impl BaseBatchHandler for AzureBatchHandler {
         after: Option<&str>,
         limit: Option<i32>,
         api_key: Option<&str>,
-        _api_base: Option<&str>,
+        api_base: Option<&str>,
         headers: Option<HashMap<String, String>>,
     ) -> Result<ListBatchesResponse, BatchError> {
+        self.client.validate_api_base_override(api_base)?;
         let api_key = api_key
             .map(|s| s.to_string())
             .or_else(|| self.client.get_config().api_key.clone())
@@ -219,19 +224,18 @@ impl BaseBatchHandler for AzureBatchHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .get(&url)
+            .request(Method::GET, &url)?
             .headers(request_headers)
             .send()
             .await
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -244,9 +248,10 @@ impl BaseBatchHandler for AzureBatchHandler {
         &self,
         batch_id: &str,
         api_key: Option<&str>,
-        _api_base: Option<&str>,
+        api_base: Option<&str>,
         headers: Option<HashMap<String, String>>,
     ) -> Result<RetrieveBatchResponse, BatchError> {
+        self.client.validate_api_base_override(api_base)?;
         let api_key = api_key
             .map(|s| s.to_string())
             .or_else(|| self.client.get_config().api_key.clone())
@@ -275,19 +280,18 @@ impl BaseBatchHandler for AzureBatchHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .get(&url)
+            .request(Method::GET, &url)?
             .headers(request_headers)
             .send()
             .await
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response
@@ -300,9 +304,10 @@ impl BaseBatchHandler for AzureBatchHandler {
         &self,
         batch_id: &str,
         api_key: Option<&str>,
-        _api_base: Option<&str>,
+        api_base: Option<&str>,
         headers: Option<HashMap<String, String>>,
     ) -> Result<CancelBatchResponse, BatchError> {
+        self.client.validate_api_base_override(api_base)?;
         let api_key = api_key
             .map(|s| s.to_string())
             .or_else(|| self.client.get_config().api_key.clone())
@@ -331,19 +336,18 @@ impl BaseBatchHandler for AzureBatchHandler {
 
         let response = self
             .client
-            .get_http_client()
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(request_headers)
             .send()
             .await
             .map_err(|e| ProviderError::network("azure", e.to_string()))?;
 
         if !response.status().is_success() {
-            return Err(HttpErrorMapper::map_status_code(
-                "azure",
-                response.status().as_u16(),
-                &response.text().await.unwrap_or_default(),
-            ));
+            let status = response.status().as_u16();
+            let body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
+            return Err(HttpErrorMapper::map_status_code("azure", status, &body));
         }
 
         response

--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -3,9 +3,12 @@
 //! Complete chat completion implementation for Azure OpenAI Service
 
 use futures::{Stream, StreamExt};
+use reqwest::Method;
 use serde_json::{Value, json};
 use std::pin::Pin;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::time::timeout;
 
 use crate::core::types::{
     chat::ChatMessage,
@@ -18,39 +21,33 @@ use crate::core::types::{
     },
 };
 
+use super::client::AzureClient;
 use super::config::AzureConfig;
 use super::error::{azure_api_error, azure_config_error};
 use super::utils::{AzureEndpointType, AzureUtils};
 use crate::core::providers::base::{
-    HeaderPair, apply_headers, header, header_owned, header_static,
+    HeaderPair, apply_provider_headers, header, header_owned, header_static,
+    read_streaming_error_body,
 };
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::streaming::utils::is_done_marker;
-use crate::core::traits::provider::ProviderConfig;
-use crate::utils::net::http::{create_custom_client, create_streaming_client};
 
 /// Azure OpenAI chat handler
 #[derive(Debug, Clone)]
 pub struct AzureChatHandler {
-    config: AzureConfig,
-    client: reqwest::Client,
-    streaming_client: reqwest::Client,
+    client: Box<AzureClient>,
 }
 
 impl AzureChatHandler {
     /// Create new chat handler
     pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
-        let client = create_custom_client(ProviderConfig::timeout(&config))
-            .map_err(|e| azure_config_error(format!("Failed to create HTTP client: {}", e)))?;
-        let streaming_client = create_streaming_client().map_err(|e| {
-            azure_config_error(format!("Failed to create streaming HTTP client: {}", e))
-        })?;
-
         Ok(Self {
-            config,
-            client,
-            streaming_client,
+            client: Box::new(AzureClient::new(config)?),
         })
+    }
+
+    pub(crate) fn policy_client(&self) -> &AzureClient {
+        &self.client
     }
 
     /// Build request headers using the unified HeaderPair pattern.
@@ -58,7 +55,7 @@ impl AzureChatHandler {
         let mut headers = Vec::with_capacity(4);
 
         // Add API key
-        if let Some(api_key) = self.config.get_effective_api_key().await {
+        if let Some(api_key) = self.client.get_config().get_effective_api_key().await {
             headers.push(header("api-key", api_key));
         } else {
             return Err(ProviderError::authentication(
@@ -70,7 +67,7 @@ impl AzureChatHandler {
         headers.push(header_static("Content-Type", "application/json"));
 
         // Add custom headers
-        for (key, value) in &self.config.custom_headers {
+        for (key, value) in &self.client.get_config().custom_headers {
             headers.push(header_owned(key.clone(), value.clone()));
         }
 
@@ -84,11 +81,15 @@ impl AzureChatHandler {
         _context: RequestContext,
     ) -> Result<ChatResponse, ProviderError> {
         // Get deployment name
-        let deployment = self.config.get_effective_deployment_name(&request.model);
+        let deployment = self
+            .client
+            .get_config()
+            .get_effective_deployment_name(&request.model);
 
         // Get Azure endpoint
         let azure_endpoint = self
-            .config
+            .client
+            .get_config()
             .get_effective_azure_endpoint()
             .ok_or_else(|| azure_config_error("Azure endpoint not configured".to_string()))?;
 
@@ -96,7 +97,7 @@ impl AzureChatHandler {
         let url = AzureUtils::build_azure_url(
             &azure_endpoint,
             &deployment,
-            &self.config.api_version,
+            &self.client.get_config().api_version,
             AzureEndpointType::ChatCompletions,
         );
 
@@ -107,17 +108,21 @@ impl AzureChatHandler {
         let headers = self.get_request_headers().await?;
 
         // Execute request
-        let response = apply_headers(self.client.post(&url).json(&azure_request), headers)
-            .send()
-            .await?;
+        let response = apply_provider_headers(
+            self.client
+                .request(Method::POST, &url)?
+                .json(&azure_request),
+            headers,
+        )
+        .send()
+        .await?;
 
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body =
-                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
-                    .await
-                    .map_err(|err| err.into_provider_error("azure"))?;
+            let error_body = read_streaming_error_body(response)
+                .await
+                .map_err(|err| err.into_provider_error("azure"))?;
             return Err(azure_api_error(status, error_body));
         }
 
@@ -139,11 +144,15 @@ impl AzureChatHandler {
         request.stream = true;
 
         // Get deployment name
-        let deployment = self.config.get_effective_deployment_name(&request.model);
+        let deployment = self
+            .client
+            .get_config()
+            .get_effective_deployment_name(&request.model);
 
         // Get Azure endpoint
         let azure_endpoint = self
-            .config
+            .client
+            .get_config()
             .get_effective_azure_endpoint()
             .ok_or_else(|| azure_config_error("Azure endpoint not configured".to_string()))?;
 
@@ -151,7 +160,7 @@ impl AzureChatHandler {
         let url = AzureUtils::build_azure_url(
             &azure_endpoint,
             &deployment,
-            &self.config.api_version,
+            &self.client.get_config().api_version,
             AzureEndpointType::ChatCompletions,
         );
 
@@ -162,22 +171,26 @@ impl AzureChatHandler {
         let headers = self.get_request_headers().await?;
 
         // Execute streaming request
-        let response = crate::core::providers::base::connection_pool::send_streaming_request(
-            apply_headers(
-                self.streaming_client.post(&url).json(&azure_request),
+        let response = timeout(
+            Duration::from_secs(self.client.get_config().timeout),
+            apply_provider_headers(
+                self.client
+                    .streaming_request(Method::POST, &url)?
+                    .json(&azure_request),
                 headers,
-            ),
-            "azure",
+            )
+            .send(),
         )
-        .await?;
+        .await
+        .map_err(|_| ProviderError::network("azure", "Request timeout"))?
+        .map_err(|error| ProviderError::network("azure", error.to_string()))?;
 
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body =
-                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
-                    .await
-                    .map_err(|err| err.into_provider_error("azure"))?;
+            let error_body = read_streaming_error_body(response)
+                .await
+                .map_err(|err| err.into_provider_error("azure"))?;
             return Err(azure_api_error(status, error_body));
         }
 

--- a/src/core/providers/azure/client.rs
+++ b/src/core/providers/azure/client.rs
@@ -2,31 +2,47 @@
 //!
 //! HTTP client wrapper for Azure OpenAI Service
 
-use reqwest::header::HeaderMap;
+use reqwest::{Method, header::HeaderMap};
 use serde::{Deserialize, Serialize};
 
 use super::config::AzureConfig;
 use super::error::azure_config_error;
 use super::utils::{AzureEndpointType, AzureUtils};
+use crate::core::providers::base::{BaseConfig, BaseHttpClient, ProviderRequestBuilder};
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::traits::provider::ProviderConfig as _;
 
 /// Azure OpenAI client
 #[derive(Debug, Clone)]
 pub struct AzureClient {
     config: AzureConfig,
-    http_client: reqwest::Client,
+    http_client: BaseHttpClient,
+    streaming_client: BaseHttpClient,
 }
 
 impl AzureClient {
     /// Create new Azure client
-    pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
-        AzureUtils::validate_config(&config)?;
-
-        let http_client = crate::core::http::outbound::default_outbound_client().clone();
+    pub fn new(mut config: AzureConfig) -> Result<Self, ProviderError> {
+        config
+            .validate()
+            .map_err(|error| azure_config_error(error.to_string()))?;
+        let endpoint = config
+            .get_effective_azure_endpoint()
+            .ok_or_else(|| azure_config_error("Azure endpoint not configured"))?;
+        config.azure_endpoint = Some(endpoint.clone());
+        let base_config = BaseConfig {
+            api_base: Some(endpoint),
+            endpoint_access: config.endpoint_access,
+            timeout: config.timeout,
+            ..Default::default()
+        };
+        let http_client = BaseHttpClient::new_for_provider("azure", base_config.clone())?;
+        let streaming_client = BaseHttpClient::new_for_provider_streaming("azure", base_config)?;
 
         Ok(Self {
             config,
             http_client,
+            streaming_client,
         })
     }
 
@@ -54,9 +70,39 @@ impl AzureClient {
         ))
     }
 
-    /// Get HTTP client
-    pub fn get_http_client(&self) -> &reqwest::Client {
-        &self.http_client
+    pub(crate) fn request(
+        &self,
+        method: Method,
+        url: &str,
+    ) -> Result<ProviderRequestBuilder, ProviderError> {
+        self.http_client.request(method, url)
+    }
+
+    pub(crate) fn streaming_request(
+        &self,
+        method: Method,
+        url: &str,
+    ) -> Result<ProviderRequestBuilder, ProviderError> {
+        self.streaming_client.request(method, url)
+    }
+
+    pub(crate) fn validate_api_base_override(
+        &self,
+        api_base: Option<&str>,
+    ) -> Result<(), ProviderError> {
+        let Some(api_base) = api_base.filter(|value| !value.trim().is_empty()) else {
+            return Ok(());
+        };
+        let configured = self.config.azure_endpoint.as_deref().ok_or_else(|| {
+            ProviderError::configuration("azure", "Azure endpoint not configured")
+        })?;
+        if api_base.trim_end_matches('/') != configured.trim_end_matches('/') {
+            return Err(ProviderError::configuration(
+                "azure",
+                "per-request api_base must match the policy-bound Azure endpoint",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -215,14 +261,33 @@ mod tests {
     }
 
     #[test]
-    fn test_azure_client_get_http_client() {
+    fn test_azure_client_honors_endpoint_access() {
+        let config = AzureConfig::new()
+            .with_api_key("test-key".to_string())
+            .with_azure_endpoint("http://127.0.0.1:18080".to_string());
+
+        assert!(AzureClient::new(config.clone()).is_err());
+        assert!(
+            AzureClient::new(
+                config
+                    .with_endpoint_access(crate::core::net::ProviderEndpointAccess::PrivateNetwork)
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_azure_client_rejects_mismatched_api_base_override() {
         let config = AzureConfig::new()
             .with_api_key("test-key".to_string())
             .with_azure_endpoint("https://test.openai.azure.com".to_string());
 
         let client = AzureClient::new(config).unwrap();
-        let _http_client = client.get_http_client();
-        // Just verify we can get the client without panic
+        assert!(
+            client
+                .validate_api_base_override(Some("https://other.openai.azure.com"))
+                .is_err()
+        );
     }
 
     // ==================== AzureConfigFactory Tests ====================

--- a/src/core/providers/azure/client.rs
+++ b/src/core/providers/azure/client.rs
@@ -2,7 +2,7 @@
 //!
 //! HTTP client wrapper for Azure OpenAI Service
 
-use reqwest::{Method, header::HeaderMap};
+use reqwest::{Method, Url, header::HeaderMap};
 use serde::{Deserialize, Serialize};
 
 use super::config::AzureConfig;
@@ -96,7 +96,16 @@ impl AzureClient {
         let configured = self.config.azure_endpoint.as_deref().ok_or_else(|| {
             ProviderError::configuration("azure", "Azure endpoint not configured")
         })?;
-        if api_base.trim_end_matches('/') != configured.trim_end_matches('/') {
+        let api_base = Url::parse(api_base.trim()).map_err(|error| {
+            ProviderError::configuration("azure", format!("invalid per-request api_base: {error}"))
+        })?;
+        let configured = Url::parse(configured).map_err(|error| {
+            ProviderError::configuration(
+                "azure",
+                format!("invalid policy-bound Azure endpoint: {error}"),
+            )
+        })?;
+        if api_base != configured {
             return Err(ProviderError::configuration(
                 "azure",
                 "per-request api_base must match the policy-bound Azure endpoint",
@@ -287,6 +296,30 @@ mod tests {
             client
                 .validate_api_base_override(Some("https://other.openai.azure.com"))
                 .is_err()
+        );
+        assert!(
+            client
+                .validate_api_base_override(Some("https://test.openai.azure.com/path"))
+                .is_err()
+        );
+        assert!(
+            client
+                .validate_api_base_override(Some("https://test.openai.azure.com?region=eastus"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_azure_client_normalizes_api_base_override_authority() {
+        let config = AzureConfig::new()
+            .with_api_key("test-key".to_string())
+            .with_azure_endpoint("https://test.openai.azure.com".to_string());
+
+        let client = AzureClient::new(config).unwrap();
+        assert!(
+            client
+                .validate_api_base_override(Some("HTTPS://TEST.OPENAI.AZURE.COM/"))
+                .is_ok()
         );
     }
 

--- a/src/core/providers/azure/config.rs
+++ b/src/core/providers/azure/config.rs
@@ -4,6 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use url::Url;
 
 use crate::core::net::{ProviderEndpointAccess, ProviderEndpointPolicy};
 
@@ -149,6 +150,12 @@ impl crate::core::traits::provider::ProviderConfig for AzureConfig {
 
         if self.api_version.is_empty() {
             return Err("API version is required".to_string());
+        }
+
+        let endpoint_url =
+            Url::parse(&endpoint).map_err(|error| format!("Invalid Azure endpoint: {error}"))?;
+        if !matches!(endpoint_url.scheme(), "http" | "https") {
+            return Err("Azure endpoint must use http or https".to_string());
         }
 
         ProviderEndpointPolicy::for_base_url(self.endpoint_access, &endpoint)
@@ -305,6 +312,20 @@ mod tests {
     #[test]
     fn test_azure_config_endpoint_policy() {
         use crate::core::traits::provider::ProviderConfig;
+
+        for endpoint in ["http://example.com", "https://example.com"] {
+            let config = AzureConfig::new().with_azure_endpoint(endpoint.to_string());
+            assert!(config.validate().is_ok(), "{endpoint} should be accepted");
+        }
+
+        for endpoint in ["ws://example.com", "wss://example.com"] {
+            let config = AzureConfig::new().with_azure_endpoint(endpoint.to_string());
+            let error = match config.validate() {
+                Ok(()) => panic!("{endpoint} should be rejected"),
+                Err(error) => error,
+            };
+            assert!(error.contains("http or https"));
+        }
 
         let public = AzureConfig::new().with_azure_endpoint("http://127.0.0.1:18080".to_string());
         assert!(public.validate().is_err());

--- a/src/core/providers/azure/config.rs
+++ b/src/core/providers/azure/config.rs
@@ -5,6 +5,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::core::net::{ProviderEndpointAccess, ProviderEndpointPolicy};
+
 /// Azure OpenAI configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AzureConfig {
@@ -12,6 +14,9 @@ pub struct AzureConfig {
     pub api_key: Option<String>,
     /// Azure endpoint URL
     pub azure_endpoint: Option<String>,
+    /// Network scope allowed for the Azure endpoint.
+    #[serde(default)]
+    pub endpoint_access: ProviderEndpointAccess,
     /// API version
     pub api_version: String,
     /// Azure AD token provider
@@ -45,6 +50,7 @@ impl Default for AzureConfig {
         Self {
             api_key: None,
             azure_endpoint: None,
+            endpoint_access: ProviderEndpointAccess::PublicOnly,
             api_version: "2024-02-01".to_string(),
             azure_ad_token_provider: None,
             deployment_name: None,
@@ -72,6 +78,12 @@ impl AzureConfig {
     /// Set Azure endpoint
     pub fn with_azure_endpoint(mut self, endpoint: String) -> Self {
         self.azure_endpoint = Some(endpoint);
+        self
+    }
+
+    /// Set the endpoint network scope.
+    pub fn with_endpoint_access(mut self, endpoint_access: ProviderEndpointAccess) -> Self {
+        self.endpoint_access = endpoint_access;
         self
     }
 
@@ -131,13 +143,16 @@ impl AzureConfig {
 /// Implement ProviderConfig trait for AzureConfig
 impl crate::core::traits::provider::ProviderConfig for AzureConfig {
     fn validate(&self) -> Result<(), String> {
-        if self.get_effective_azure_endpoint().is_none() {
-            return Err("Azure endpoint is required".to_string());
-        }
+        let endpoint = self
+            .get_effective_azure_endpoint()
+            .ok_or_else(|| "Azure endpoint is required".to_string())?;
 
         if self.api_version.is_empty() {
             return Err("API version is required".to_string());
         }
+
+        ProviderEndpointPolicy::for_base_url(self.endpoint_access, &endpoint)
+            .map_err(|error| format!("Invalid Azure endpoint: {error}"))?;
 
         Ok(())
     }
@@ -156,6 +171,10 @@ impl crate::core::traits::provider::ProviderConfig for AzureConfig {
 
     fn max_retries(&self) -> u32 {
         self.max_retries
+    }
+
+    fn endpoint_access(&self) -> ProviderEndpointAccess {
+        self.endpoint_access
     }
 }
 
@@ -179,6 +198,7 @@ mod tests {
         let config = AzureConfig::default();
         assert!(config.api_key.is_none());
         assert!(config.azure_endpoint.is_none());
+        assert_eq!(config.endpoint_access, ProviderEndpointAccess::PublicOnly);
         assert_eq!(config.api_version, "2024-02-01");
         assert!(config.deployment_name.is_none());
         assert_eq!(config.timeout, 60);
@@ -190,6 +210,7 @@ mod tests {
         let config = AzureConfig::new()
             .with_api_key("test-key".to_string())
             .with_azure_endpoint("https://test.openai.azure.com".to_string())
+            .with_endpoint_access(ProviderEndpointAccess::PrivateNetwork)
             .with_deployment_name("gpt-4".to_string())
             .with_api_version("2024-03-01".to_string());
 
@@ -199,6 +220,10 @@ mod tests {
             Some("https://test.openai.azure.com".to_string())
         );
         assert_eq!(config.deployment_name, Some("gpt-4".to_string()));
+        assert_eq!(
+            config.endpoint_access,
+            ProviderEndpointAccess::PrivateNetwork
+        );
         assert_eq!(config.api_version, "2024-03-01");
     }
 
@@ -251,6 +276,7 @@ mod tests {
         assert_eq!(config.api_base(), Some("https://test.openai.azure.com"));
         assert_eq!(config.timeout(), std::time::Duration::from_secs(60));
         assert_eq!(config.max_retries(), 3);
+        assert_eq!(config.endpoint_access(), ProviderEndpointAccess::PublicOnly);
 
         let mut custom_config = config;
         custom_config.timeout = 12;
@@ -273,6 +299,18 @@ mod tests {
 
         assert_eq!(config.timeout, 60);
         assert_eq!(config.max_retries, 3);
+        assert_eq!(config.endpoint_access, ProviderEndpointAccess::PublicOnly);
+    }
+
+    #[test]
+    fn test_azure_config_endpoint_policy() {
+        use crate::core::traits::provider::ProviderConfig;
+
+        let public = AzureConfig::new().with_azure_endpoint("http://127.0.0.1:18080".to_string());
+        assert!(public.validate().is_err());
+
+        let private = public.with_endpoint_access(ProviderEndpointAccess::PrivateNetwork);
+        assert!(private.validate().is_ok());
     }
 
     #[test]

--- a/src/core/providers/azure/embed.rs
+++ b/src/core/providers/azure/embed.rs
@@ -2,7 +2,7 @@
 //!
 //! Complete embedding functionality for Azure OpenAI Service
 
-use reqwest::header::HeaderMap;
+use reqwest::{Method, header::HeaderMap};
 use serde_json::{Value, json};
 
 use crate::core::types::{
@@ -11,27 +11,24 @@ use crate::core::types::{
     responses::{EmbeddingData, EmbeddingResponse},
 };
 
+use super::client::AzureClient;
 use super::config::AzureConfig;
 use super::error::{azure_api_error, azure_config_error, azure_header_error};
 use super::utils::{AzureEndpointType, AzureUtils};
 use crate::core::providers::unified_provider::ProviderError;
-use crate::core::traits::provider::ProviderConfig;
-use crate::utils::net::http::create_custom_client;
 
 /// Azure OpenAI embedding handler
 #[derive(Debug, Clone)]
 pub struct AzureEmbeddingHandler {
-    config: AzureConfig,
-    client: reqwest::Client,
+    client: Box<AzureClient>,
 }
 
 impl AzureEmbeddingHandler {
     /// Create new embedding handler
     pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
-        let client = create_custom_client(ProviderConfig::timeout(&config))
-            .map_err(|e| azure_config_error(format!("Failed to create HTTP client: {}", e)))?;
-
-        Ok(Self { config, client })
+        Ok(Self {
+            client: Box::new(AzureClient::new(config)?),
+        })
     }
 
     /// Build request headers
@@ -39,7 +36,7 @@ impl AzureEmbeddingHandler {
         let mut headers = HeaderMap::new();
 
         // Add API key
-        if let Some(api_key) = self.config.get_effective_api_key().await {
+        if let Some(api_key) = self.client.get_config().get_effective_api_key().await {
             headers.insert(
                 "api-key",
                 api_key
@@ -61,7 +58,7 @@ impl AzureEmbeddingHandler {
         );
 
         // Add custom headers
-        for (key, value) in &self.config.custom_headers {
+        for (key, value) in &self.client.get_config().custom_headers {
             let header_name = reqwest::header::HeaderName::from_bytes(key.as_bytes())
                 .map_err(|e| azure_header_error(format!("Invalid header name: {}", e)))?;
             let header_value = value
@@ -83,11 +80,15 @@ impl AzureEmbeddingHandler {
         AzureEmbeddingUtils::validate_request(&request)?;
 
         // Get deployment name (Azure uses deployment names for embeddings too)
-        let deployment = self.config.get_effective_deployment_name(&request.model);
+        let deployment = self
+            .client
+            .get_config()
+            .get_effective_deployment_name(&request.model);
 
         // Get Azure endpoint
         let azure_endpoint = self
-            .config
+            .client
+            .get_config()
             .get_effective_azure_endpoint()
             .ok_or_else(|| azure_config_error("Azure endpoint not configured"))?;
 
@@ -95,7 +96,7 @@ impl AzureEmbeddingHandler {
         let url = AzureUtils::build_azure_url(
             &azure_endpoint,
             &deployment,
-            &self.config.api_version,
+            &self.client.get_config().api_version,
             AzureEndpointType::Embeddings,
         );
 
@@ -108,7 +109,7 @@ impl AzureEmbeddingHandler {
         // Execute request
         let response = self
             .client
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(headers)
             .json(&azure_request)
             .send()
@@ -117,10 +118,9 @@ impl AzureEmbeddingHandler {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
             return Err(azure_api_error(status, error_body));
         }
 

--- a/src/core/providers/azure/image.rs
+++ b/src/core/providers/azure/image.rs
@@ -2,7 +2,7 @@
 //!
 //! Complete image generation functionality for Azure OpenAI Service (DALL-E)
 
-use reqwest::header::HeaderMap;
+use reqwest::{Method, header::HeaderMap};
 use serde_json::{Value, json};
 
 use crate::core::types::{
@@ -11,27 +11,24 @@ use crate::core::types::{
     responses::{ImageData, ImageGenerationResponse},
 };
 
+use super::client::AzureClient;
 use super::config::AzureConfig;
 use super::error::{azure_api_error, azure_config_error, azure_header_error};
 use super::utils::{AzureEndpointType, AzureUtils};
 use crate::core::providers::unified_provider::ProviderError;
-use crate::core::traits::provider::ProviderConfig;
-use crate::utils::net::http::create_custom_client;
 
 /// Azure OpenAI image generation handler
 #[derive(Debug, Clone)]
 pub struct AzureImageHandler {
-    config: AzureConfig,
-    client: reqwest::Client,
+    client: Box<AzureClient>,
 }
 
 impl AzureImageHandler {
     /// Create new image generation handler
     pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
-        let client = create_custom_client(ProviderConfig::timeout(&config))
-            .map_err(|e| azure_config_error(format!("Failed to create HTTP client: {}", e)))?;
-
-        Ok(Self { config, client })
+        Ok(Self {
+            client: Box::new(AzureClient::new(config)?),
+        })
     }
 
     /// Build request headers
@@ -39,7 +36,7 @@ impl AzureImageHandler {
         let mut headers = HeaderMap::new();
 
         // Add API key
-        if let Some(api_key) = self.config.get_effective_api_key().await {
+        if let Some(api_key) = self.client.get_config().get_effective_api_key().await {
             headers.insert(
                 "api-key",
                 api_key
@@ -61,7 +58,7 @@ impl AzureImageHandler {
         );
 
         // Add custom headers
-        for (key, value) in &self.config.custom_headers {
+        for (key, value) in &self.client.get_config().custom_headers {
             let header_name = reqwest::header::HeaderName::from_bytes(key.as_bytes())
                 .map_err(|e| azure_header_error(format!("Invalid header name: {}", e)))?;
             let header_value = value
@@ -84,11 +81,15 @@ impl AzureImageHandler {
 
         // Get deployment name (for DALL-E models)
         let model_name = request.model.as_deref().unwrap_or("dall-e-3");
-        let deployment = self.config.get_effective_deployment_name(model_name);
+        let deployment = self
+            .client
+            .get_config()
+            .get_effective_deployment_name(model_name);
 
         // Get Azure endpoint
         let azure_endpoint = self
-            .config
+            .client
+            .get_config()
             .get_effective_azure_endpoint()
             .ok_or_else(|| azure_config_error("Azure endpoint not configured"))?;
 
@@ -96,7 +97,7 @@ impl AzureImageHandler {
         let url = AzureUtils::build_azure_url(
             &azure_endpoint,
             &deployment,
-            &self.config.api_version,
+            &self.client.get_config().api_version,
             AzureEndpointType::Images,
         );
 
@@ -109,7 +110,7 @@ impl AzureImageHandler {
         // Execute request
         let response = self
             .client
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(headers)
             .json(&azure_request)
             .send()
@@ -118,10 +119,9 @@ impl AzureImageHandler {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
             return Err(azure_api_error(status, error_body));
         }
 
@@ -140,11 +140,15 @@ impl AzureImageHandler {
     ) -> Result<ImageGenerationResponse, ProviderError> {
         // Get deployment name
         let model_name = request.model.as_str();
-        let deployment = self.config.get_effective_deployment_name(model_name);
+        let deployment = self
+            .client
+            .get_config()
+            .get_effective_deployment_name(model_name);
 
         // Get Azure endpoint
         let azure_endpoint = self
-            .config
+            .client
+            .get_config()
             .get_effective_azure_endpoint()
             .ok_or_else(|| azure_config_error("Azure endpoint not configured"))?;
 
@@ -152,7 +156,7 @@ impl AzureImageHandler {
         let url = AzureUtils::build_azure_url(
             &azure_endpoint,
             &deployment,
-            &self.config.api_version,
+            &self.client.get_config().api_version,
             AzureEndpointType::ImageEdits,
         );
 
@@ -177,7 +181,7 @@ impl AzureImageHandler {
         // Execute request
         let response = self
             .client
-            .post(&url)
+            .request(Method::POST, &url)?
             .headers(headers)
             .multipart(form)
             .send()
@@ -186,10 +190,9 @@ impl AzureImageHandler {
         // Check status
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+            let error_body = response.text().await.map_err(|error| {
+                ProviderError::network("azure", format!("failed to read error body: {error}"))
+            })?;
             return Err(azure_api_error(status, error_body));
         }
 

--- a/src/core/providers/azure/mod.rs
+++ b/src/core/providers/azure/mod.rs
@@ -47,6 +47,7 @@ pub use image::{AzureImageHandler, AzureImageUtils};
 pub use responses::{AzureResponseHandler, AzureResponseProcessor, AzureResponseUtils};
 
 use futures::Stream;
+use reqwest::Method;
 use serde_json::Value;
 use std::pin::Pin;
 
@@ -77,7 +78,8 @@ pub struct AzureOpenAIProvider {
 impl AzureOpenAIProvider {
     /// Create new Azure OpenAI provider
     pub fn new(config: AzureConfig) -> Result<Self, ProviderError> {
-        let chat_handler = AzureChatHandler::new(config.clone())?;
+        let chat_handler = AzureChatHandler::new(config)?;
+        let config = chat_handler.policy_client().get_config().clone();
         let embedding_handler = AzureEmbeddingHandler::new(config.clone())?;
         let image_handler = AzureImageHandler::new(config.clone())?;
         let cost_calculator = AzureCostCalculator::new();
@@ -275,23 +277,27 @@ impl LLMProvider for AzureOpenAIProvider {
     }
 
     async fn health_check(&self) -> HealthStatus {
-        let endpoint = match self.config.get_effective_azure_endpoint() {
+        let client = self.chat_handler.policy_client();
+        let config = client.get_config();
+        let endpoint = match config.get_effective_azure_endpoint() {
             Some(endpoint) => endpoint,
             None => return HealthStatus::Unhealthy,
         };
-        if self.config.api_version.is_empty() {
+        if config.api_version.is_empty() {
             return HealthStatus::Unhealthy;
         }
 
-        let api_key = match self.config.get_effective_api_key().await {
+        let api_key = match config.get_effective_api_key().await {
             Some(api_key) => api_key,
             None => return HealthStatus::Unhealthy,
         };
 
-        let url = build_azure_models_health_url(&endpoint, &self.config.api_version);
-        let client = crate::core::http::outbound::default_outbound_client().clone();
-        let mut request = client.get(url).header("api-key", api_key);
-        for (key, value) in &self.config.custom_headers {
+        let url = build_azure_models_health_url(&endpoint, &config.api_version);
+        let mut request = match client.request(Method::GET, &url) {
+            Ok(request) => request.header("api-key", api_key),
+            Err(_) => return HealthStatus::Unhealthy,
+        };
+        for (key, value) in &config.custom_headers {
             request = request.header(key.as_str(), value.as_str());
         }
 
@@ -337,6 +343,7 @@ mod tests {
         AzureConfig::new()
             .with_api_key("test-key".to_string())
             .with_azure_endpoint(endpoint)
+            .with_endpoint_access(crate::core::net::ProviderEndpointAccess::PrivateNetwork)
             .with_api_version("2024-02-01".to_string())
     }
 

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -11,6 +11,7 @@ const ALLOWED_BASE_SYMBOLS: &[&str] = &[
     "HttpErrorMapper",
     "HttpMethod",
     "OpenAIRequestTransformer",
+    "ProviderRequestBuilder",
     "UrlBuilder",
     "apply_provider_headers",
     "create_provider_sse_stream",
@@ -237,7 +238,7 @@ fn boundary_violations(source: &str, module_path: &[&str]) -> Result<Vec<String>
     Ok(visitor.violations)
 }
 
-fn collect_bedrock_sources(
+fn collect_provider_sources(
     root: &FsPath,
     directory: &FsPath,
     module_path: &[String],
@@ -253,7 +254,7 @@ fn collect_bedrock_sources(
             }
             let mut child_module = module_path.to_vec();
             child_module.push(entry.file_name().to_string_lossy().into_owned());
-            collect_bedrock_sources(root, &path, &child_module, output)?;
+            collect_provider_sources(root, &path, &child_module, output)?;
             continue;
         }
         if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
@@ -359,7 +360,7 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
     }
     let bedrock_root = FsPath::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers/bedrock");
     let mut bedrock_sources = Vec::new();
-    collect_bedrock_sources(
+    collect_provider_sources(
         &bedrock_root,
         &bedrock_root,
         &[
@@ -379,6 +380,31 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
         assert!(
             violations.is_empty(),
             "bedrock/{path}: {}",
+            violations.join("; ")
+        );
+    }
+    let azure_root = FsPath::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers/azure");
+    let mut azure_sources = Vec::new();
+    collect_provider_sources(
+        &azure_root,
+        &azure_root,
+        &[
+            "crate".to_string(),
+            "core".to_string(),
+            "providers".to_string(),
+            "azure".to_string(),
+        ],
+        &mut azure_sources,
+    )
+    .unwrap_or_else(|error| panic!("Azure source inventory failed: {error}"));
+    assert!(!azure_sources.is_empty());
+    for (path, module_path, source) in azure_sources {
+        let module_path: Vec<_> = module_path.iter().map(String::as_str).collect();
+        let violations = boundary_violations(&source, &module_path)
+            .unwrap_or_else(|error| panic!("azure/{path} must parse: {error}"));
+        assert!(
+            violations.is_empty(),
+            "azure/{path}: {}",
             violations.join("; ")
         );
     }

--- a/src/core/providers/base/mod.rs
+++ b/src/core/providers/base/mod.rs
@@ -10,6 +10,7 @@ pub mod pricing;
 pub mod sse;
 
 pub use crate::core::pricing::{PricingDatabase, get_pricing_db};
+pub use crate::utils::net::http::ProviderRequestBuilder;
 pub use config::BaseConfig;
 pub use connection_pool::{
     ConnectionPool, GlobalPoolManager, HeaderPair, HttpMethod, PoolConfig,

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -491,6 +491,7 @@ pub(super) fn build_azure_config_from_factory(
     let mut azure_config = azure::AzureConfig::new()
         .with_api_key(api_key.to_string())
         .with_azure_endpoint(api_base.to_string());
+    azure_config.endpoint_access = config_endpoint_access(config, "azure")?;
 
     if let Some(api_version) = config_str(config, "api_version") {
         azure_config.api_version = api_version.to_string();

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -581,6 +581,7 @@ fn test_build_azure_config_from_factory_maps_native_fields() {
     let config = serde_json::json!({
         "api_key": "azure-key",
         "azure_endpoint": "https://example-resource.openai.azure.com",
+        "endpoint_access": "private_network",
         "deployment_name": "gpt-4o-prod",
         "api_version": "2024-03-01",
         "timeout": 31,
@@ -605,6 +606,10 @@ fn test_build_azure_config_from_factory_maps_native_fields() {
     assert_eq!(azure_config.api_version, "2024-03-01");
     assert_eq!(azure_config.timeout, 31);
     assert_eq!(azure_config.max_retries, 6);
+    assert_eq!(
+        azure_config.endpoint_access,
+        ProviderEndpointAccess::PrivateNetwork
+    );
     assert_eq!(
         azure_config
             .custom_headers


### PR DESCRIPTION
## 变更

- 将 Azure chat ordinary/streaming、embedding、image generation/edit 与 health 请求迁移到统一 policy client
- 删除 AzureClient 公开 raw client getter，并让 batch/assistant 的 9 个请求路径使用安全 request builder
- 冻结 effective Azure endpoint，传播 typed endpoint access；per-call api_base 不一致时 fail closed
- 规范化比较 per-call api_base，同时保持 path/query 敏感；Azure 配置仅接受 http/https
- 修正 batch endpoint 尾斜杠拼接，移除 assistant 中保留 raw escape 的死代码
- 扩展 AST source guard 递归覆盖 Azure production 树，保持 Gateway private access staged 到 T9R

Refs #968

Spec packet: `specs/GH968/`
Task: `SP968-T11B`

## 验证

- [x] Azure focused: 500 passed
- [x] factory builder focused: 20 passed
- [x] Azure recursive AST source boundary guard
- [x] `cargo check --all-targets --all-features --locked`
- [x] Rust 1.96 CI-equivalent strict Clippy
- [x] `cargo test --all-features --locked -- --test-threads=1`: main library 10340 passed, 0 failed, 1 ignored；后续集成测试全部通过
- [x] SpecRail GH968 packet check
- [x] 12 non-doc files / 644 changed lines scope gate
- [x] independent current-head security rereview

## 后续

本 PR 是局部实现，不关闭 #968；SP968-T11C-E、T9R、T11F、T12、T13 仍待完成。
