### PR TITLE
fix(azure-ai): enforce native endpoint policy

### DIFF
--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -6,7 +6,6 @@ use futures::Stream;
 use reqwest::Method;
 use serde_json::{Value, json};
 use std::pin::Pin;
-use std::time::Duration;
 use tokio::time::timeout;
 
 // Type system imports
@@ -114,7 +113,7 @@ impl AzureAIChatHandler {
             .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
         // Execute streaming request
         let response = timeout(
-            Duration::from_secs(self.client.get_config().base.timeout),
+            self.client.get_config().timeout(),
             self.client
                 .streaming_request(Method::POST, &url)?
                 .json(&azure_request)

--- a/src/core/providers/azure_ai/chat.rs
+++ b/src/core/providers/azure_ai/chat.rs
@@ -3,9 +3,11 @@
 //! Complete chat completion implementation for Azure AI Foundry
 
 use futures::Stream;
-use reqwest::header::HeaderMap;
+use reqwest::Method;
 use serde_json::{Value, json};
 use std::pin::Pin;
+use std::time::Duration;
+use tokio::time::timeout;
 
 // Type system imports
 use crate::core::types::{
@@ -17,55 +19,27 @@ use crate::core::types::{
     responses::{ChatChoice, ChatChunk, ChatResponse, FinishReason, Usage},
 };
 
+use super::client::AzureAIClient;
 use super::config::{AzureAIConfig, AzureAIEndpointType};
-use crate::core::providers::base::HttpErrorMapper;
-use crate::core::providers::base::sse::{SSETransformer, UnifiedSSEStream};
+use crate::core::providers::base::{
+    HttpErrorMapper, SSETransformer, UnifiedSSEStream, read_streaming_error_body,
+};
 use crate::core::providers::unified_provider::ProviderError;
-use crate::utils::net::http::{create_custom_client_with_headers, create_streaming_client};
 
 /// Azure AI chat handler - complete implementation
 #[derive(Debug, Clone)]
 pub struct AzureAIChatHandler {
-    config: AzureAIConfig,
-    client: reqwest::Client,
-    streaming_client: reqwest::Client,
+    client: AzureAIClient,
 }
 
 impl AzureAIChatHandler {
     /// Create new chat handler
     pub fn new(config: AzureAIConfig) -> Result<Self, ProviderError> {
-        // Create headers for the client
-        let mut headers = HeaderMap::new();
-        let default_headers = config
-            .create_default_headers()
-            .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
+        Self::from_client(AzureAIClient::new(config)?)
+    }
 
-        for (key, value) in default_headers {
-            let header_name =
-                reqwest::header::HeaderName::from_bytes(key.as_bytes()).map_err(|e| {
-                    ProviderError::configuration("azure_ai", format!("Invalid header name: {}", e))
-                })?;
-            let header_value = reqwest::header::HeaderValue::from_str(&value).map_err(|e| {
-                ProviderError::configuration("azure_ai", format!("Invalid header value: {}", e))
-            })?;
-            headers.insert(header_name, header_value);
-        }
-
-        let client = create_custom_client_with_headers(config.timeout(), headers).map_err(|e| {
-            ProviderError::configuration("azure_ai", format!("Failed to create HTTP client: {}", e))
-        })?;
-        let streaming_client = create_streaming_client().map_err(|e| {
-            ProviderError::configuration(
-                "azure_ai",
-                format!("Failed to create streaming HTTP client: {}", e),
-            )
-        })?;
-
-        Ok(Self {
-            config,
-            client,
-            streaming_client,
-        })
+    pub(crate) fn from_client(client: AzureAIClient) -> Result<Self, ProviderError> {
+        Ok(Self { client })
     }
 
     /// Create chat completion
@@ -82,14 +56,15 @@ impl AzureAIChatHandler {
 
         // Build URL
         let url = self
-            .config
+            .client
+            .get_config()
             .build_endpoint_url(AzureAIEndpointType::ChatCompletions.as_path())
             .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
 
         // Execute request
         let response = self
             .client
-            .post(&url)
+            .request(Method::POST, &url)?
             .json(&azure_request)
             .send()
             .await
@@ -98,10 +73,9 @@ impl AzureAIChatHandler {
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body =
-                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
-                    .await
-                    .map_err(|err| err.into_provider_error("azure_ai"))?;
+            let error_body = read_streaming_error_body(response)
+                .await
+                .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,
@@ -134,32 +108,28 @@ impl AzureAIChatHandler {
 
         // Build URL
         let url = self
-            .config
+            .client
+            .get_config()
             .build_endpoint_url(AzureAIEndpointType::ChatCompletions.as_path())
             .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
-        let headers = self
-            .config
-            .create_default_headers()
-            .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
-
         // Execute streaming request
-        let mut request_builder = self.streaming_client.post(&url).json(&azure_request);
-        for (key, value) in headers {
-            request_builder = request_builder.header(key, value);
-        }
-        let response = crate::core::providers::base::connection_pool::send_streaming_request(
-            request_builder,
-            "azure_ai",
+        let response = timeout(
+            Duration::from_secs(self.client.get_config().base.timeout),
+            self.client
+                .streaming_request(Method::POST, &url)?
+                .json(&azure_request)
+                .send(),
         )
-        .await?;
+        .await
+        .map_err(|_| ProviderError::timeout("azure_ai", "Streaming response header timeout"))?
+        .map_err(|error| ProviderError::network("azure_ai", error.to_string()))?;
 
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body =
-                crate::core::providers::base::connection_pool::read_streaming_error_body(response)
-                    .await
-                    .map_err(|err| err.into_provider_error("azure_ai"))?;
+            let error_body = read_streaming_error_body(response)
+                .await
+                .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,

--- a/src/core/providers/azure_ai/client.rs
+++ b/src/core/providers/azure_ai/client.rs
@@ -1,0 +1,91 @@
+//! Policy-aware HTTP client for Azure AI Foundry.
+
+use std::sync::Arc;
+
+use reqwest::{Method, header::HeaderMap};
+
+use super::config::AzureAIConfig;
+use crate::core::providers::base::{BaseHttpClient, ProviderRequestBuilder};
+use crate::core::providers::unified_provider::ProviderError;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AzureAIClient {
+    inner: Arc<AzureAIClientInner>,
+}
+
+#[derive(Debug)]
+struct AzureAIClientInner {
+    config: AzureAIConfig,
+    headers: HeaderMap,
+    http_client: BaseHttpClient,
+    streaming_client: BaseHttpClient,
+}
+
+impl AzureAIClient {
+    pub(crate) fn new(config: AzureAIConfig) -> Result<Self, ProviderError> {
+        config
+            .validate_policy_client_settings()
+            .map_err(|error| ProviderError::configuration("azure_ai", error))?;
+        let headers = build_headers(&config)?;
+        let http_client = BaseHttpClient::new_for_provider("azure_ai", config.base.clone())?;
+        let streaming_client =
+            BaseHttpClient::new_for_provider_streaming("azure_ai", config.base.clone())?;
+
+        Ok(Self {
+            inner: Arc::new(AzureAIClientInner {
+                config,
+                headers,
+                http_client,
+                streaming_client,
+            }),
+        })
+    }
+
+    pub(crate) fn get_config(&self) -> &AzureAIConfig {
+        &self.inner.config
+    }
+
+    pub(crate) fn request(
+        &self,
+        method: Method,
+        url: &str,
+    ) -> Result<ProviderRequestBuilder, ProviderError> {
+        Ok(self
+            .inner
+            .http_client
+            .request(method, url)?
+            .headers(self.inner.headers.clone()))
+    }
+
+    pub(crate) fn streaming_request(
+        &self,
+        method: Method,
+        url: &str,
+    ) -> Result<ProviderRequestBuilder, ProviderError> {
+        Ok(self
+            .inner
+            .streaming_client
+            .request(method, url)?
+            .headers(self.inner.headers.clone()))
+    }
+}
+
+fn build_headers(config: &AzureAIConfig) -> Result<HeaderMap, ProviderError> {
+    let mut headers = HeaderMap::new();
+    for (key, value) in config
+        .create_default_headers()
+        .map_err(|error| ProviderError::configuration("azure_ai", error))?
+    {
+        let name = reqwest::header::HeaderName::from_bytes(key.as_bytes()).map_err(|error| {
+            ProviderError::configuration("azure_ai", format!("invalid header name {key}: {error}"))
+        })?;
+        let value = reqwest::header::HeaderValue::from_str(&value).map_err(|error| {
+            ProviderError::configuration(
+                "azure_ai",
+                format!("invalid header value for {key}: {error}"),
+            )
+        })?;
+        headers.insert(name, value);
+    }
+    Ok(headers)
+}

--- a/src/core/providers/azure_ai/config.rs
+++ b/src/core/providers/azure_ai/config.rs
@@ -4,7 +4,9 @@
 
 // use serde::{Deserialize, Serialize};  // Not needed with the macro
 use std::collections::HashMap;
+use url::Url;
 
+use crate::core::net::{ProviderEndpointAccess, ProviderEndpointPolicy};
 use crate::core::traits::provider::ProviderConfig;
 use crate::define_provider_config;
 
@@ -119,14 +121,31 @@ impl AzureAIConfig {
 
     /// Configuration
     pub fn validate(&self) -> Result<(), String> {
-        self.base.validate("azure_ai")
+        self.validate_policy_client_settings()
+    }
+
+    pub(crate) fn validate_policy_client_settings(&self) -> Result<(), String> {
+        self.base.validate("azure_ai")?;
+        let endpoint = self
+            .base
+            .api_base
+            .as_deref()
+            .ok_or_else(|| "Azure AI API base URL not set".to_string())?;
+        let endpoint_url =
+            Url::parse(endpoint).map_err(|error| format!("Invalid Azure AI endpoint: {error}"))?;
+        if !matches!(endpoint_url.scheme(), "http" | "https") {
+            return Err("Azure AI endpoint must use http or https".to_string());
+        }
+        ProviderEndpointPolicy::for_base_url(self.base.endpoint_access, endpoint)
+            .map(|_| ())
+            .map_err(|error| format!("Invalid Azure AI endpoint policy: {error}"))
     }
 }
 
 // Implementation of ProviderConfig trait
 impl ProviderConfig for AzureAIConfig {
     fn validate(&self) -> Result<(), String> {
-        self.base.validate("azure_ai")
+        self.validate_policy_client_settings()
     }
 
     fn api_key(&self) -> Option<&str> {
@@ -143,6 +162,10 @@ impl ProviderConfig for AzureAIConfig {
 
     fn max_retries(&self) -> u32 {
         self.base.max_retries
+    }
+
+    fn endpoint_access(&self) -> ProviderEndpointAccess {
+        self.base.endpoint_access
     }
 }
 
@@ -327,6 +350,31 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_endpoint_policy_and_scheme() {
+        let mut config = AzureAIConfig::new("azure_ai");
+        config.base.api_key = Some("test-key".to_string());
+
+        for endpoint in ["http://example.com", "https://example.com"] {
+            config.base.api_base = Some(endpoint.to_string());
+            assert!(config.validate().is_ok(), "{endpoint} should be accepted");
+        }
+
+        for endpoint in ["ws://example.com", "wss://example.com"] {
+            config.base.api_base = Some(endpoint.to_string());
+            assert!(config.validate().is_err(), "{endpoint} should be rejected");
+        }
+
+        config.base.api_base = Some("http://127.0.0.1:18080".to_string());
+        config.base.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        assert!(config.validate().is_err());
+        config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        assert!(config.validate().is_ok());
+
+        config.base.api_base = Some("http://169.254.169.254".to_string());
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
     fn test_validate_missing_api_key() {
         let mut config = AzureAIConfig::new("azure_ai");
         config.base.api_base = Some("https://test.com".to_string());
@@ -366,5 +414,6 @@ mod tests {
             std::time::Duration::from_secs(60)
         );
         assert_eq!(config.max_retries(), 3);
+        assert_eq!(config.endpoint_access(), ProviderEndpointAccess::PublicOnly);
     }
 }

--- a/src/core/providers/azure_ai/embed.rs
+++ b/src/core/providers/azure_ai/embed.rs
@@ -2,51 +2,33 @@
 //!
 //! Complete embedding functionality for Azure AI services following unified architecture
 
-use reqwest::header::HeaderMap;
+use reqwest::Method;
 use serde_json::{Value, json};
 
+use super::client::AzureAIClient;
 use super::config::{AzureAIConfig, AzureAIEndpointType};
-use crate::core::providers::base::HttpErrorMapper;
+use crate::core::providers::base::{HttpErrorMapper, read_streaming_error_body};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::{
     context::RequestContext,
     embedding::EmbeddingRequest,
     responses::{EmbeddingData, EmbeddingResponse},
 };
-use crate::utils::net::http::create_custom_client_with_headers;
 
 /// Azure AI embedding handler following unified architecture
 #[derive(Debug, Clone)]
 pub struct AzureAIEmbeddingHandler {
-    config: AzureAIConfig,
-    client: reqwest::Client,
+    client: AzureAIClient,
 }
 
 impl AzureAIEmbeddingHandler {
     /// Create a new embedding handler
     pub fn new(config: AzureAIConfig) -> Result<Self, ProviderError> {
-        // Create headers for the client
-        let mut headers = HeaderMap::new();
-        let default_headers = config
-            .create_default_headers()
-            .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
+        Self::from_client(AzureAIClient::new(config)?)
+    }
 
-        for (key, value) in default_headers {
-            let header_name =
-                reqwest::header::HeaderName::from_bytes(key.as_bytes()).map_err(|e| {
-                    ProviderError::configuration("azure_ai", format!("Invalid header name: {}", e))
-                })?;
-            let header_value = reqwest::header::HeaderValue::from_str(&value).map_err(|e| {
-                ProviderError::configuration("azure_ai", format!("Invalid header value: {}", e))
-            })?;
-            headers.insert(header_name, header_value);
-        }
-
-        let client = create_custom_client_with_headers(config.timeout(), headers).map_err(|e| {
-            ProviderError::configuration("azure_ai", format!("Failed to create HTTP client: {}", e))
-        })?;
-
-        Ok(Self { config, client })
+    pub(crate) fn from_client(client: AzureAIClient) -> Result<Self, ProviderError> {
+        Ok(Self { client })
     }
 
     /// Handle embedding request
@@ -64,11 +46,13 @@ impl AzureAIEmbeddingHandler {
         // Build URL
         let url = if self.is_multimodal_embedding_model(&request.model) {
             // Use image embeddings endpoint for multimodal models
-            self.config
+            self.client
+                .get_config()
                 .build_endpoint_url(AzureAIEndpointType::ImageEmbeddings.as_path())
         } else {
             // Use regular embeddings endpoint
-            self.config
+            self.client
+                .get_config()
                 .build_endpoint_url(AzureAIEndpointType::Embeddings.as_path())
         }
         .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
@@ -76,7 +60,7 @@ impl AzureAIEmbeddingHandler {
         // Execute request
         let response = self
             .client
-            .post(&url)
+            .request(Method::POST, &url)?
             .json(&azure_request)
             .send()
             .await
@@ -85,10 +69,9 @@ impl AzureAIEmbeddingHandler {
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
+            let error_body = read_streaming_error_body(response)
                 .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+                .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,

--- a/src/core/providers/azure_ai/image_generation.rs
+++ b/src/core/providers/azure_ai/image_generation.rs
@@ -2,11 +2,12 @@
 //!
 //! Basic image generation functionality for Azure AI using FLUX models
 
-// use reqwest::header::HeaderMap;  // Not used in simplified version
+use reqwest::Method;
 use serde_json::{Value, json};
 
+use super::client::AzureAIClient;
 use super::config::{AzureAIConfig, AzureAIEndpointType};
-use crate::core::providers::base::HttpErrorMapper;
+use crate::core::providers::base::{HttpErrorMapper, read_streaming_error_body};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::{
     context::RequestContext,
@@ -17,15 +18,17 @@ use crate::core::types::{
 /// Azure AI image generation handler
 #[derive(Debug, Clone)]
 pub struct AzureAIImageHandler {
-    config: AzureAIConfig,
-    client: reqwest::Client,
+    client: AzureAIClient,
 }
 
 impl AzureAIImageHandler {
     /// Create a new image generation handler
     pub fn new(config: AzureAIConfig) -> Result<Self, ProviderError> {
-        let client = crate::core::http::outbound::default_outbound_client().clone();
-        Ok(Self { config, client })
+        Self::from_client(AzureAIClient::new(config)?)
+    }
+
+    pub(crate) fn from_client(client: AzureAIClient) -> Result<Self, ProviderError> {
+        Ok(Self { client })
     }
 
     /// Generate image
@@ -53,24 +56,15 @@ impl AzureAIImageHandler {
 
         // Build URL
         let url = self
-            .config
+            .client
+            .get_config()
             .build_endpoint_url(AzureAIEndpointType::ImageGeneration.as_path())
             .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
 
         // Execute request
         let response = self
             .client
-            .post(&url)
-            .header(
-                "Authorization",
-                format!(
-                    "Bearer {}",
-                    self.config.base.api_key.as_ref().ok_or_else(|| {
-                        ProviderError::authentication("azure_ai", "API key not set")
-                    })?
-                ),
-            )
-            .header("Content-Type", "application/json")
+            .request(Method::POST, &url)?
             .json(&azure_request)
             .send()
             .await
@@ -79,10 +73,9 @@ impl AzureAIImageHandler {
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
+            let error_body = read_streaming_error_body(response)
                 .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+                .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,

--- a/src/core/providers/azure_ai/mod.rs
+++ b/src/core/providers/azure_ai/mod.rs
@@ -4,11 +4,14 @@
 
 // Complete Azure AI modules
 pub mod chat;
+mod client;
 pub mod config;
 pub mod embed;
 pub mod error;
 pub mod image_generation;
 pub mod models;
+#[cfg(test)]
+mod policy_tests;
 pub mod rerank;
 
 // Re-export main components
@@ -21,6 +24,7 @@ pub use models::{AzureAIModelRegistry, AzureAIModelSpec, AzureAIModelType, get_a
 pub use rerank::{AzureAIRerankHandler, AzureAIRerankUtils, RerankRequest, RerankResponse};
 
 use futures::Stream;
+use reqwest::Method;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -38,11 +42,12 @@ use crate::core::types::{
     model::ProviderCapability,
     responses::{ChatChunk, ChatResponse, EmbeddingResponse, ImageGenerationResponse},
 };
+use client::AzureAIClient;
 
 /// Main Azure AI provider following unified architecture
 #[derive(Debug, Clone)]
 pub struct AzureAIProvider {
-    config: AzureAIConfig,
+    client: AzureAIClient,
     chat_handler: AzureAIChatHandler,
     embedding_handler: AzureAIEmbeddingHandler,
     image_handler: AzureAIImageHandler,
@@ -53,23 +58,19 @@ pub struct AzureAIProvider {
 impl AzureAIProvider {
     /// Create new Azure AI provider
     pub fn new(config: AzureAIConfig) -> Result<Self, ProviderError> {
-        // Configuration
-        config
-            .validate()
-            .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
-
-        let chat_handler = AzureAIChatHandler::new(config.clone())
+        let client = AzureAIClient::new(config)?;
+        let chat_handler = AzureAIChatHandler::from_client(client.clone())
             .map_err(|e| ProviderError::configuration("azure_ai", e.to_string()))?;
-        let embedding_handler = AzureAIEmbeddingHandler::new(config.clone())
+        let embedding_handler = AzureAIEmbeddingHandler::from_client(client.clone())
             .map_err(|e| ProviderError::configuration("azure_ai", e.to_string()))?;
-        let image_handler = AzureAIImageHandler::new(config.clone())
+        let image_handler = AzureAIImageHandler::from_client(client.clone())
             .map_err(|e| ProviderError::configuration("azure_ai", e.to_string()))?;
-        let rerank_handler = AzureAIRerankHandler::new(config.clone())
+        let rerank_handler = AzureAIRerankHandler::from_client(client.clone())
             .map_err(|e| ProviderError::configuration("azure_ai", e.to_string()))?;
         let model_registry = get_azure_ai_registry();
 
         Ok(Self {
-            config,
+            client,
             chat_handler,
             embedding_handler,
             image_handler,
@@ -80,7 +81,7 @@ impl AzureAIProvider {
 
     /// Get Azure AI configuration
     pub fn get_config(&self) -> &AzureAIConfig {
-        &self.config
+        self.client.get_config()
     }
 
     /// Create from environment variables
@@ -240,24 +241,18 @@ impl LLMProvider for AzureAIProvider {
 
     async fn health_check(&self) -> HealthStatus {
         // Validate configuration first
-        if self.config.validate().is_err() {
+        if self.client.get_config().validate().is_err() {
             return HealthStatus::Unhealthy;
         }
 
-        let url = match self.config.build_endpoint_url("models") {
+        let url = match self.client.get_config().build_endpoint_url("models") {
             Ok(url) => url,
             Err(_) => return HealthStatus::Unhealthy,
         };
-        let headers = match self.config.create_default_headers() {
-            Ok(headers) => headers,
+        let request = match self.client.request(Method::GET, &url) {
+            Ok(request) => request,
             Err(_) => return HealthStatus::Unhealthy,
         };
-
-        let client = crate::core::http::outbound::default_outbound_client().clone();
-        let mut request = client.get(url);
-        for (key, value) in headers {
-            request = request.header(key, value);
-        }
 
         match request.send().await {
             Ok(response) if response.status().is_success() => HealthStatus::Healthy,
@@ -597,6 +592,7 @@ mod tests {
             Ok(url) => url,
             Err(error) => panic!("test server should start: {error}"),
         });
+        config.base.endpoint_access = crate::core::net::ProviderEndpointAccess::PrivateNetwork;
         let provider = match AzureAIProvider::new(config) {
             Ok(provider) => provider,
             Err(error) => panic!("provider should be created: {error}"),
@@ -615,6 +611,7 @@ mod tests {
                 Err(error) => panic!("test server should start: {error}"),
             },
         );
+        config.base.endpoint_access = crate::core::net::ProviderEndpointAccess::PrivateNetwork;
         let provider = match AzureAIProvider::new(config) {
             Ok(provider) => provider,
             Err(error) => panic!("provider should be created: {error}"),

--- a/src/core/providers/azure_ai/policy_tests.rs
+++ b/src/core/providers/azure_ai/policy_tests.rs
@@ -1,0 +1,92 @@
+use reqwest::Method;
+
+use super::{
+    AzureAIChatHandler, AzureAIEmbeddingHandler, AzureAIImageHandler, AzureAIProvider,
+    AzureAIRerankHandler, client::AzureAIClient, config::AzureAIConfig,
+};
+use crate::core::net::ProviderEndpointAccess;
+
+fn policy_config(endpoint: &str, access: ProviderEndpointAccess) -> AzureAIConfig {
+    let mut config = AzureAIConfig::new("azure_ai");
+    config.base.api_key = Some("test-key".to_string());
+    config.base.api_base = Some(endpoint.to_string());
+    config.base.endpoint_access = access;
+    config
+}
+
+#[test]
+fn public_loopback_is_rejected_by_every_native_consumer() {
+    let config = policy_config("http://127.0.0.1:18080", ProviderEndpointAccess::PublicOnly);
+
+    assert!(AzureAIChatHandler::new(config.clone()).is_err());
+    assert!(AzureAIEmbeddingHandler::new(config.clone()).is_err());
+    assert!(AzureAIImageHandler::new(config.clone()).is_err());
+    assert!(AzureAIRerankHandler::new(config.clone()).is_err());
+    assert!(AzureAIProvider::new(config).is_err());
+}
+
+#[test]
+fn private_loopback_is_accepted_by_every_native_consumer() {
+    let config = policy_config(
+        "http://127.0.0.1:18080",
+        ProviderEndpointAccess::PrivateNetwork,
+    );
+
+    assert!(AzureAIChatHandler::new(config.clone()).is_ok());
+    assert!(AzureAIEmbeddingHandler::new(config.clone()).is_ok());
+    assert!(AzureAIImageHandler::new(config.clone()).is_ok());
+    assert!(AzureAIRerankHandler::new(config.clone()).is_ok());
+    assert!(AzureAIProvider::new(config).is_ok());
+}
+
+#[test]
+fn metadata_is_rejected_even_with_private_access() {
+    let config = policy_config(
+        "http://169.254.169.254",
+        ProviderEndpointAccess::PrivateNetwork,
+    );
+
+    assert!(AzureAIClient::new(config).is_err());
+}
+
+#[test]
+fn private_client_rejects_cross_authority_requests() {
+    let config = policy_config(
+        "http://127.0.0.1:18080",
+        ProviderEndpointAccess::PrivateNetwork,
+    );
+    let client = match AzureAIClient::new(config) {
+        Ok(client) => client,
+        Err(error) => panic!("private policy client should initialize: {error}"),
+    };
+
+    assert!(
+        client
+            .request(
+                Method::POST,
+                "http://127.0.0.1:18080/models/chat/completions"
+            )
+            .is_ok()
+    );
+    assert!(
+        client
+            .streaming_request(
+                Method::POST,
+                "http://127.0.0.1:18080/models/chat/completions",
+            )
+            .is_ok()
+    );
+    assert!(
+        client
+            .request(Method::GET, "http://127.0.0.1:18081/models")
+            .is_err()
+    );
+    assert!(
+        client
+            .streaming_request(
+                Method::POST,
+                "http://127.0.0.1:18081/models/chat/completions",
+            )
+            .is_err()
+    );
+}

--- a/src/core/providers/azure_ai/rerank.rs
+++ b/src/core/providers/azure_ai/rerank.rs
@@ -2,47 +2,29 @@
 //!
 //! Complete Cohere-compatible reranking functionality for Azure AI services following unified architecture
 
-use reqwest::header::HeaderMap;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use super::client::AzureAIClient;
 use super::config::{AzureAIConfig, AzureAIEndpointType};
-use crate::core::providers::base::HttpErrorMapper;
+use crate::core::providers::base::{HttpErrorMapper, read_streaming_error_body};
 use crate::core::providers::unified_provider::ProviderError;
-use crate::utils::net::http::create_custom_client_with_headers;
 
 /// Azure AI rerank handler following unified architecture
 #[derive(Debug, Clone)]
 pub struct AzureAIRerankHandler {
-    config: AzureAIConfig,
-    client: reqwest::Client,
+    client: AzureAIClient,
 }
 
 impl AzureAIRerankHandler {
     /// Create a new rerank handler
     pub fn new(config: AzureAIConfig) -> Result<Self, ProviderError> {
-        // Create headers for the client
-        let mut headers = HeaderMap::new();
-        let default_headers = config
-            .create_default_headers()
-            .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
+        Self::from_client(AzureAIClient::new(config)?)
+    }
 
-        for (key, value) in default_headers {
-            let header_name =
-                reqwest::header::HeaderName::from_bytes(key.as_bytes()).map_err(|e| {
-                    ProviderError::configuration("azure_ai", format!("Invalid header name: {}", e))
-                })?;
-            let header_value = reqwest::header::HeaderValue::from_str(&value).map_err(|e| {
-                ProviderError::configuration("azure_ai", format!("Invalid header value: {}", e))
-            })?;
-            headers.insert(header_name, header_value);
-        }
-
-        let client = create_custom_client_with_headers(config.timeout(), headers).map_err(|e| {
-            ProviderError::configuration("azure_ai", format!("Failed to create HTTP client: {}", e))
-        })?;
-
-        Ok(Self { config, client })
+    pub(crate) fn from_client(client: AzureAIClient) -> Result<Self, ProviderError> {
+        Ok(Self { client })
     }
 
     /// Handle rerank request
@@ -55,14 +37,15 @@ impl AzureAIRerankHandler {
 
         // Build URL
         let url = self
-            .config
+            .client
+            .get_config()
             .build_endpoint_url(AzureAIEndpointType::Rerank.as_path())
             .map_err(|e| ProviderError::configuration("azure_ai", &e))?;
 
         // Execute request
         let response = self
             .client
-            .post(&url)
+            .request(Method::POST, &url)?
             .json(&azure_request)
             .send()
             .await
@@ -71,10 +54,9 @@ impl AzureAIRerankHandler {
         // Handle error responses
         if !response.status().is_success() {
             let status = response.status().as_u16();
-            let error_body = response
-                .text()
+            let error_body = read_streaming_error_body(response)
                 .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
+                .map_err(|err| err.into_provider_error("azure_ai"))?;
             return Err(HttpErrorMapper::map_status_code(
                 "azure_ai",
                 status,

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -12,6 +12,8 @@ const ALLOWED_BASE_SYMBOLS: &[&str] = &[
     "HttpMethod",
     "OpenAIRequestTransformer",
     "ProviderRequestBuilder",
+    "SSETransformer",
+    "UnifiedSSEStream",
     "UrlBuilder",
     "apply_provider_headers",
     "create_provider_sse_stream",
@@ -405,6 +407,31 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
         assert!(
             violations.is_empty(),
             "azure/{path}: {}",
+            violations.join("; ")
+        );
+    }
+    let azure_ai_root = FsPath::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers/azure_ai");
+    let mut azure_ai_sources = Vec::new();
+    collect_provider_sources(
+        &azure_ai_root,
+        &azure_ai_root,
+        &[
+            "crate".to_string(),
+            "core".to_string(),
+            "providers".to_string(),
+            "azure_ai".to_string(),
+        ],
+        &mut azure_ai_sources,
+    )
+    .unwrap_or_else(|error| panic!("AzureAI source inventory failed: {error}"));
+    assert!(!azure_ai_sources.is_empty());
+    for (path, module_path, source) in azure_ai_sources {
+        let module_path: Vec<_> = module_path.iter().map(String::as_str).collect();
+        let violations = boundary_violations(&source, &module_path)
+            .unwrap_or_else(|error| panic!("azure_ai/{path} must parse: {error}"));
+        assert!(
+            violations.is_empty(),
+            "azure_ai/{path}: {}",
             violations.join("; ")
         );
     }

--- a/src/core/providers/factory/azure_ai_builder_tests.rs
+++ b/src/core/providers/factory/azure_ai_builder_tests.rs
@@ -1,0 +1,45 @@
+use super::builder::build_azure_ai_config_from_factory;
+use crate::core::net::ProviderEndpointAccess;
+
+fn azure_ai_config() -> serde_json::Value {
+    serde_json::json!({
+        "api_key": "azure-ai-key",
+        "azure_ai_endpoint": "https://example-resource.services.ai.azure.com"
+    })
+}
+
+#[test]
+fn azure_ai_factory_defaults_endpoint_access_to_public_only() {
+    let config = match build_azure_ai_config_from_factory(&azure_ai_config()) {
+        Ok(config) => config,
+        Err(error) => panic!("AzureAI config should build: {error}"),
+    };
+
+    assert_eq!(
+        config.base.endpoint_access,
+        ProviderEndpointAccess::PublicOnly
+    );
+}
+
+#[test]
+fn azure_ai_factory_maps_private_endpoint_access() {
+    let mut input = azure_ai_config();
+    input["endpoint_access"] = serde_json::json!("private_network");
+    let config = match build_azure_ai_config_from_factory(&input) {
+        Ok(config) => config,
+        Err(error) => panic!("AzureAI private config should build: {error}"),
+    };
+
+    assert_eq!(
+        config.base.endpoint_access,
+        ProviderEndpointAccess::PrivateNetwork
+    );
+}
+
+#[test]
+fn azure_ai_factory_rejects_invalid_endpoint_access() {
+    let mut input = azure_ai_config();
+    input["endpoint_access"] = serde_json::json!("internal_only");
+
+    assert!(build_azure_ai_config_from_factory(&input).is_err());
+}

--- a/src/core/providers/factory/builder.rs
+++ b/src/core/providers/factory/builder.rs
@@ -459,6 +459,7 @@ pub(super) fn build_azure_ai_config_from_factory(
     let mut azure_ai_config = azure_ai::AzureAIConfig::new("azure_ai");
     azure_ai_config.base.api_key = Some(api_key.to_string());
     azure_ai_config.base.api_base = Some(api_base.to_string());
+    azure_ai_config.base.endpoint_access = config_endpoint_access(config, "azure_ai")?;
 
     if let Some(api_version) = config_str(config, "api_version") {
         azure_ai_config.base.api_version = Some(api_version.to_string());

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -5,6 +5,8 @@
 //! - `builder`: per-provider config builders and extraction helpers
 //! - `registry`: `Provider::from_config_async` dispatch table
 
+#[cfg(all(test, feature = "providers-extra"))]
+mod azure_ai_builder_tests;
 mod builder;
 #[cfg(test)]
 mod builder_tests;


### PR DESCRIPTION
## 变更

- 为 Azure AI Foundry 建立单一、策略绑定的普通与流式 HTTP 客户端
- 将 chat、embedding、image generation、rerank 与 health 全部接入 endpoint policy，移除 raw/default client 绕过
- 在工厂层传播 endpoint_access，并对 http/https、loopback、metadata 与 authority 绑定执行 fail-closed 校验
- 扩展递归源码边界守卫，防止 AzureAI 后续重新暴露原始客户端

Refs #968

Spec packet: `specs/GH968/`
Task: `SP968-T11C`
Depends on merged PR #1001

## 验证

- [x] `cargo check --locked --no-default-features --features providers-extra`
- [x] `cargo check --all-targets --all-features --locked`
- [x] AzureAI focused tests: 95 passed
- [x] AzureAI factory endpoint-access tests: 3 passed
- [x] recursive source-boundary guard
- [x] Rust 1.96 CI-equivalent strict Clippy
- [x] `cargo test --all-features --locked -- --test-threads=1`
- [x] `cargo fmt --check` and `git diff --check`
- [x] SpecRail GH968 packet check
- [x] scope guard: 12 files / 572 changed lines
- [x] overlap guard: no overlap with open PRs

## 已知基线

`cargo clippy --all-targets --all-features --locked -- -D warnings` 会在全 feature 组合中暴露既有 `Provider` 大枚举尺寸告警（VertexAI 624B / OpenAILike 344B）。仓库 CI 实际 feature 集合下的严格 clippy 已通过；本 PR 不扩大到全局 Provider 枚举重构。

## 后续

本 PR 只完成 SP968-T11C，不关闭 #968；后续原生 provider slices 与最终收口仍待完成。
