### PR TITLE
test(azure): bound full policy operation matrix

### DIFF
--- a/src/core/providers/azure/policy_tests.rs
+++ b/src/core/providers/azure/policy_tests.rs
@@ -114,19 +114,20 @@ async fn azure_core_operation_matrix_uses_policy_client() {
     let batch = AzureBatchHandler::new(config.clone()).expect("batch should build");
     let assistant = AzureAssistantHandler::new(config).expect("assistant should build");
     let assistant_api = AssistantApiConfig::new(None, Some(endpoint.as_str()), None);
-    assert_errors!(assert_request_error;
-        chat.create_chat_completion(policy_chat_request(), RequestContext::default()),
-        chat.create_chat_completion_stream(policy_chat_request(), RequestContext::default()),
-        embeddings.create_embeddings(request, RequestContext::default()),
-        images.generate_image(generation, RequestContext::default()),
-        images.edit_image(edit, RequestContext::default()),
-        batch.create_batch(create_batch_request(), None, Some(endpoint.as_str()), None),
-        assistant.create_assistant(create_assistant_request(), &assistant_api),
-    );
-    let requests = tokio::time::timeout(Duration::from_secs(5), capture)
-        .await
-        .expect("all policy requests should arrive within five seconds")
-        .expect("capture task should finish");
+    let requests = tokio::time::timeout(Duration::from_secs(5), async {
+        assert_errors!(assert_request_error;
+            chat.create_chat_completion(policy_chat_request(), RequestContext::default()),
+            chat.create_chat_completion_stream(policy_chat_request(), RequestContext::default()),
+            embeddings.create_embeddings(request, RequestContext::default()),
+            images.generate_image(generation, RequestContext::default()),
+            images.edit_image(edit, RequestContext::default()),
+            batch.create_batch(create_batch_request(), None, Some(endpoint.as_str()), None),
+            assistant.create_assistant(create_assistant_request(), &assistant_api),
+        );
+        capture.await.expect("capture task should finish")
+    })
+    .await
+    .expect("policy operation matrix should finish within five seconds");
     let paths = [
         "/openai/deployments/deployment/chat/completions",
         "/openai/deployments/deployment/chat/completions",


### PR DESCRIPTION
## 根因

PR #1002 的 5 秒 timeout 只在 7 个网络操作全部返回后才开始等待 capture；因此请求若在 DNS、连接、发送或响应读取阶段停滞，测试仍可能按每个 Azure 请求的默认超时长时间挂起。

## 修复

- 将 7 个 policy consumer 操作与 capture join 放入同一个 5 秒 deadline
- 保留顺序执行、完整 request-line 捕获、路径矩阵及 PublicOnly fail-closed 覆盖
- 仅修改测试，不改变生产行为

Refs #968
Follow-up to #1002

Spec packet: `specs/GH968/`
Task: `SP968-T11B` post-merge reviewer correction

## 验证

- [x] `cargo test azure_core_operation_matrix_uses_policy_client --lib --all-features --locked`
- [x] `cargo check --all-targets --all-features --locked`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] scope guard: 1 file / 27 changed lines
- [x] overlap guard: no open PRs

## 后续

本 PR 只修复 #1002 的测试 deadline 缺口，不关闭 #968。
