### PR TITLE
fix(routes): enforce endpoint policy for direct AI proxies

### DIFF
--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -286,7 +286,7 @@ fn collect_provider_sources(
 #[test]
 fn migrated_shared_providers_have_no_raw_client_escape() {
     let base_source = include_str!("../http.rs");
-    let provider_sources: [(&str, &[&str], &str); 8] = [
+    let provider_sources: [(&str, &[&str], &str); 12] = [
         (
             "mistral/mod.rs",
             &["crate", "core", "providers", "mistral"],
@@ -326,6 +326,26 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
             "router/health_probe.rs",
             &["crate", "core", "router", "health_probe"],
             include_str!("../../../router/health_probe.rs"),
+        ),
+        (
+            "server/routes/ai/route_http.rs",
+            &["crate", "server", "routes", "ai", "route_http"],
+            include_str!("../../../../server/routes/ai/route_http.rs"),
+        ),
+        (
+            "server/routes/ai/batches.rs",
+            &["crate", "server", "routes", "ai", "batches"],
+            include_str!("../../../../server/routes/ai/batches.rs"),
+        ),
+        (
+            "server/routes/ai/gemini/provider.rs",
+            &["crate", "server", "routes", "ai", "gemini", "provider"],
+            include_str!("../../../../server/routes/ai/gemini/provider.rs"),
+        ),
+        (
+            "server/routes/ai/images.rs",
+            &["crate", "server", "routes", "ai", "images"],
+            include_str!("../../../../server/routes/ai/images.rs"),
         ),
     ];
     let allowed = boundary_violations(

--- a/src/server/routes/ai/batches.rs
+++ b/src/server/routes/ai/batches.rs
@@ -5,25 +5,25 @@
 
 use crate::config::models::provider::ProviderConfig;
 use crate::core::providers::ProviderError;
+use crate::core::providers::base::ProviderRequestBuilder;
 use crate::core::router::execution::is_retryable_error;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpResponse, Result as ActixResult, http::StatusCode, http::header, web};
 use bytes::Bytes;
+use reqwest::Url;
 use reqwest::header::{HeaderName, HeaderValue};
-use reqwest::{Client, RequestBuilder, Url};
 use serde::Deserialize;
 use serde_json::Value;
 use std::future::Future;
-use std::sync::OnceLock;
 use tracing::error;
 
 use super::budgeted::SettlementMode;
 use super::openai_errors;
 use super::provider_config;
+use super::route_http::RouteHttpClient;
 
 const OPENAI_BATCH_BASE_URL: &str = "https://api.openai.com/v1";
-static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 
 #[derive(Debug, Deserialize)]
 pub struct ListBatchesQuery {
@@ -31,12 +31,12 @@ pub struct ListBatchesQuery {
     limit: Option<u32>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 struct BatchProxyProvider {
     provider_name: String,
-    api_key: String,
     base_url: String,
     headers: Vec<(HeaderName, HeaderValue)>,
+    client: RouteHttpClient,
 }
 
 /// Create a batch request.
@@ -104,7 +104,7 @@ async fn proxy_batch_create(
         let request = request.clone();
         async move {
             let url = batch_url(&provider, None, None)?;
-            apply_provider_headers(http_client().post(url), &provider)
+            apply_provider_headers(provider.client.ordinary_post(url)?, &provider)
                 .json(&request)
                 .send()
                 .await
@@ -135,7 +135,7 @@ async fn proxy_batch_list(
                 }
             }
 
-            apply_provider_headers(http_client().get(url), &provider)
+            apply_provider_headers(provider.client.ordinary_get(url)?, &provider)
                 .send()
                 .await
                 .map_err(GatewayError::from)
@@ -150,7 +150,7 @@ async fn proxy_batch_get(state: &AppState, batch_id: &str) -> Result<HttpRespons
         let batch_id = batch_id.clone();
         async move {
             let url = batch_url(&provider, Some(&batch_id), None)?;
-            apply_provider_headers(http_client().get(url), &provider)
+            apply_provider_headers(provider.client.ordinary_get(url)?, &provider)
                 .send()
                 .await
                 .map_err(GatewayError::from)
@@ -168,7 +168,7 @@ async fn proxy_batch_cancel(
         let batch_id = batch_id.clone();
         async move {
             let url = batch_url(&provider, Some(&batch_id), Some("cancel"))?;
-            apply_provider_headers(http_client().post(url), &provider)
+            apply_provider_headers(provider.client.ordinary_post(url)?, &provider)
                 .send()
                 .await
                 .map_err(GatewayError::from)
@@ -317,11 +317,18 @@ fn batch_proxy_provider_from_config(
         )));
     }
 
+    let base_url = batch_base_url(provider)?;
+    let client = RouteHttpClient::new(
+        "batch_proxy",
+        base_url.clone(),
+        provider.endpoint_access,
+        provider.timeout,
+    )?;
     Ok(BatchProxyProvider {
         provider_name: provider.name.clone(),
-        api_key: provider.api_key.clone(),
-        base_url: batch_base_url(provider)?,
+        base_url,
         headers: batch_provider_headers(provider)?,
+        client,
     })
 }
 
@@ -378,14 +385,10 @@ fn missing_batch_provider_error() -> GatewayError {
     )
 }
 
-fn http_client() -> &'static Client {
-    HTTP_CLIENT.get_or_init(Client::new)
-}
-
 fn apply_provider_headers(
-    mut request: RequestBuilder,
+    mut request: ProviderRequestBuilder,
     provider: &BatchProxyProvider,
-) -> RequestBuilder {
+) -> ProviderRequestBuilder {
     for (name, value) in &provider.headers {
         request = request.header(name.clone(), value.clone());
     }
@@ -516,7 +519,6 @@ mod tests {
             .expect("provider should select");
 
         assert_eq!(selected.base_url, "https://batch.example.test/v1");
-        assert_eq!(selected.api_key, "sk-test");
         assert_eq!(selected.provider_name, "primary");
     }
 
@@ -571,7 +573,7 @@ mod tests {
     fn no_batch_provider_is_explicitly_unconfigured() {
         let selected = select_batch_proxy_provider(&[]);
 
-        assert_eq!(selected.unwrap(), None);
+        assert!(selected.unwrap().is_none());
         assert!(
             missing_batch_provider_error()
                 .to_string()
@@ -583,9 +585,15 @@ mod tests {
     fn builds_batch_urls() {
         let provider = BatchProxyProvider {
             provider_name: "openai".to_string(),
-            api_key: "sk-test".to_string(),
             base_url: "https://batch.example.test/v1".to_string(),
             headers: Vec::new(),
+            client: RouteHttpClient::new(
+                "batch_proxy",
+                "https://batch.example.test/v1".to_string(),
+                crate::core::net::ProviderEndpointAccess::PublicOnly,
+                30,
+            )
+            .expect("route client should build"),
         };
 
         assert_eq!(

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use crate::config::models::provider::ProviderConfig;
 use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
-use crate::core::providers::base::ProviderRequestBuilder;
+use crate::core::providers::base::{ProviderRequestBuilder, read_streaming_error_body};
 use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::{Provider, ProviderError};
 use crate::server::state::AppState;
@@ -400,11 +400,10 @@ async fn gemini_response_or_provider_error(
         .get(RETRY_AFTER)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.trim().parse::<u64>().ok());
-    let body = response
-        .bytes()
+    let body = read_streaming_error_body(response)
         .await
-        .map_err(|error| gemini_gateway_error_to_provider_error(gemini_http_error(error)))?;
-    let body = sanitize_gemini_error_body(body, provider);
+        .map_err(|error| error.into_provider_error("gemini_proxy"))?;
+    let body = sanitize_gemini_error_body(Bytes::from(body), provider);
     let body_text = String::from_utf8_lossy(&body).to_string();
     Err(gemini_upstream_status_provider_error(
         status,
@@ -501,4 +500,85 @@ fn sanitize_gemini_error_body(body: Bytes, provider: &GeminiRouteProvider) -> By
         sanitized = sanitized.replace(&encoded_key, "[REDACTED]");
     }
     Bytes::from(sanitized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::providers::base::STREAMING_ERROR_BODY_MAX_BYTES;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn raw_error_response(
+        body: Vec<u8>,
+        content_length: usize,
+        stall: bool,
+    ) -> (reqwest::Response, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("error server should bind");
+        let address = listener.local_addr().expect("error server address");
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("request should connect");
+            let mut request = [0_u8; 4096];
+            let request_bytes = socket
+                .read(&mut request)
+                .await
+                .expect("request should be readable");
+            assert!(request_bytes > 0, "request should not be empty");
+            let headers = format!(
+                "HTTP/1.1 500 Internal Server Error\r\ncontent-length: {content_length}\r\nconnection: close\r\n\r\n"
+            );
+            socket
+                .write_all(headers.as_bytes())
+                .await
+                .expect("headers should write");
+            socket
+                .write_all(&body)
+                .await
+                .expect("error body should write");
+            if stall {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }
+        });
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .expect("response headers should arrive");
+        (response, task)
+    }
+
+    #[tokio::test]
+    async fn gemini_streaming_error_body_stall_times_out() {
+        let (response, task) = raw_error_response(b"partial".to_vec(), 4096, true).await;
+        let provider = test_gemini_route_provider("gemini", "gemini", "model");
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(12),
+            gemini_response_or_provider_error(response, &provider),
+        )
+        .await
+        .expect("bounded error reader should return")
+        .expect_err("stalled error body must fail");
+
+        assert!(matches!(error, ProviderError::Timeout { .. }));
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn gemini_streaming_error_body_is_capped() {
+        let mut body = vec![b'a'; STREAMING_ERROR_BODY_MAX_BYTES];
+        body.extend_from_slice(b"TAIL_MARKER");
+        let (response, task) = raw_error_response(body.clone(), body.len(), false).await;
+        let provider = test_gemini_route_provider("gemini", "gemini", "model");
+
+        let error = gemini_response_or_provider_error(response, &provider)
+            .await
+            .expect_err("upstream error must fail");
+        let message = error.to_string();
+
+        assert!(!message.contains("TAIL_MARKER"));
+        assert!(message.len() < STREAMING_ERROR_BODY_MAX_BYTES + 256);
+        task.await.expect("error server should finish");
+    }
 }

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -1,26 +1,25 @@
 use bytes::Bytes;
 use reqwest::{
-    Client, Url,
+    Url,
     header::{CONTENT_TYPE, HeaderName, HeaderValue, RETRY_AFTER},
 };
 use serde_json::Value;
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::config::models::provider::ProviderConfig;
 use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
+use crate::core::providers::base::ProviderRequestBuilder;
 use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::{Provider, ProviderError};
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
 use super::super::budgeted::ApiKeyBudgetPolicy;
+use super::super::route_http::RouteHttpClient;
 use super::{validate_api_version, validate_method, validate_model_segment};
 use uuid::Uuid;
 
 const GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com";
-
-static GEMINI_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub(super) struct GeminiRouteProvider {
@@ -31,6 +30,7 @@ pub(super) struct GeminiRouteProvider {
     base_url: String,
     headers: Vec<(HeaderName, HeaderValue)>,
     timeout: Duration,
+    client: RouteHttpClient,
 }
 
 #[cfg(test)]
@@ -39,14 +39,22 @@ pub(super) fn test_gemini_route_provider(
     pricing_provider: impl Into<String>,
     model: impl Into<String>,
 ) -> GeminiRouteProvider {
+    let base_url = GEMINI_BASE_URL.to_string();
     GeminiRouteProvider {
         provider_name: provider_name.into(),
         pricing_provider: pricing_provider.into(),
         model: model.into(),
         api_key: String::new(),
-        base_url: String::new(),
+        base_url: base_url.clone(),
         headers: Vec::new(),
         timeout: Duration::from_secs(1),
+        client: RouteHttpClient::new(
+            "gemini_proxy",
+            base_url,
+            crate::core::net::ProviderEndpointAccess::PublicOnly,
+            1,
+        )
+        .expect("test Gemini route client should build"),
     }
 }
 
@@ -178,14 +186,22 @@ fn gemini_route_provider_from_config(
         )));
     }
 
+    let base_url = gemini_base_url(provider);
+    let client = RouteHttpClient::new(
+        "gemini_proxy",
+        base_url.clone(),
+        provider.endpoint_access,
+        provider.timeout,
+    )?;
     Ok(GeminiRouteProvider {
         provider_name: provider.name.clone(),
         pricing_provider: "gemini".to_string(),
         model: requested_model.to_string(),
         api_key: provider.api_key.clone(),
-        base_url: gemini_base_url(provider),
+        base_url,
         headers: gemini_provider_headers(provider)?,
         timeout: Duration::from_secs(provider.timeout),
+        client,
     })
 }
 
@@ -338,15 +354,30 @@ pub(super) async fn send_gemini_request(
             || async {
                 let url = gemini_url(provider, api_version, method, stream)
                     .map_err(gemini_gateway_error_to_provider_error)?;
-                let response = apply_gemini_headers(gemini_http_client().post(url), provider)
+                let builder = if stream {
+                    provider.client.streaming_post(url)
+                } else {
+                    provider.client.ordinary_post(url)
+                }
+                .map_err(gemini_gateway_error_to_provider_error)?;
+                let builder = apply_gemini_headers(builder, provider)
                     .header(CONTENT_TYPE, "application/json")
-                    .json(request)
-                    .timeout(provider.timeout)
-                    .send()
-                    .await
-                    .map_err(|error| {
-                        gemini_gateway_error_to_provider_error(gemini_http_error(error))
-                    })?;
+                    .json(request);
+                let response = if stream {
+                    tokio::time::timeout(provider.timeout, builder.send())
+                        .await
+                        .map_err(|_| {
+                            ProviderError::timeout(
+                                "gemini_proxy",
+                                "Gemini streaming response header timeout",
+                            )
+                        })?
+                } else {
+                    builder.send().await
+                }
+                .map_err(|error| {
+                    gemini_gateway_error_to_provider_error(gemini_http_error(error))
+                })?;
                 gemini_response_or_provider_error(response, provider).await
             },
         )
@@ -443,14 +474,10 @@ pub(super) fn gemini_gateway_error_to_provider_error(error: GatewayError) -> Pro
     }
 }
 
-fn gemini_http_client() -> &'static Client {
-    GEMINI_HTTP_CLIENT.get_or_init(Client::new)
-}
-
 fn apply_gemini_headers(
-    mut request: reqwest::RequestBuilder,
+    mut request: ProviderRequestBuilder,
     provider: &GeminiRouteProvider,
-) -> reqwest::RequestBuilder {
+) -> ProviderRequestBuilder {
     for (name, value) in &provider.headers {
         request = request.header(name.clone(), value.clone());
     }

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -7,6 +7,7 @@ mod proxy_spend;
 
 use crate::core::models::openai::ImageGenerationRequest;
 use crate::core::pricing_service::PricingUsage;
+use crate::core::providers::base::ProviderRequestBuilder;
 use crate::core::providers::{Provider, ProviderError};
 use crate::core::types::context::RequestContext;
 use crate::core::types::model::ProviderCapability;
@@ -17,33 +18,30 @@ use actix_web::{
 };
 use bytes::Bytes;
 use futures::StreamExt;
+use reqwest::Url;
 use reqwest::header::{HeaderName, HeaderValue};
-use reqwest::{Client, RequestBuilder, Url};
-use std::sync::OnceLock;
-use std::time::Duration;
 use tracing::{error, info};
 
 use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
 use super::context::handle_ai_request;
+use super::route_http::RouteHttpClient;
 use super::{openai_errors, provider_config};
 use proxy_spend::{image_proxy_cost, record_image_proxy_spend};
 
 const OPENAI_IMAGE_BASE_URL: &str = "https://api.openai.com/v1";
 const MAX_IMAGE_MULTIPART_BYTES: usize = 64 * 1024 * 1024;
-static IMAGE_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
-
 #[derive(Debug, Clone, Copy)]
 enum ImageProxyEndpoint {
     Edits,
     Variations,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 struct ImageProxyProvider {
     provider_name: String,
     base_url: String,
     headers: Vec<(HeaderName, HeaderValue)>,
-    timeout: Duration,
+    client: RouteHttpClient,
 }
 
 #[derive(Debug, Clone)]
@@ -214,18 +212,22 @@ async fn proxy_image_multipart_endpoint(
                                 || async move {
                                     let url = image_proxy_url(&provider_for_call, endpoint)
                                         .map_err(image_proxy_gateway_error_to_provider_error)?;
-                                    let response = apply_image_proxy_headers(
-                                        image_http_client().post(url),
-                                        &provider_for_call,
-                                    )
-                                    .header(reqwest::header::CONTENT_TYPE, content_type)
-                                    .body(body)
-                                    .timeout(provider_for_call.timeout)
-                                    .send()
-                                    .await
-                                    .map_err(|error| {
-                                        ProviderError::network("image_proxy", error.to_string())
-                                    })?;
+                                    let request = provider_for_call
+                                        .client
+                                        .ordinary_post(url)
+                                        .map_err(image_proxy_gateway_error_to_provider_error)?;
+                                    let response =
+                                        apply_image_proxy_headers(request, &provider_for_call)
+                                            .header(reqwest::header::CONTENT_TYPE, content_type)
+                                            .body(body)
+                                            .send()
+                                            .await
+                                            .map_err(|error| {
+                                                ProviderError::network(
+                                                    "image_proxy",
+                                                    error.to_string(),
+                                                )
+                                            })?;
 
                                     if !response.status().is_success() {
                                         return Err(image_proxy_upstream_error(response).await);
@@ -511,11 +513,18 @@ fn image_proxy_provider_from_config(
         )));
     }
 
+    let base_url = image_proxy_base_url(provider)?;
+    let client = RouteHttpClient::new(
+        "image_proxy",
+        base_url.clone(),
+        provider.endpoint_access,
+        provider.timeout,
+    )?;
     Ok(ImageProxyProvider {
         provider_name: provider.name.clone(),
-        base_url: image_proxy_base_url(provider)?,
+        base_url,
         headers: image_proxy_provider_headers(provider)?,
-        timeout: Duration::from_secs(provider.timeout),
+        client,
     })
 }
 
@@ -687,14 +696,10 @@ fn missing_image_proxy_provider_error() -> GatewayError {
     )
 }
 
-fn image_http_client() -> &'static Client {
-    IMAGE_HTTP_CLIENT.get_or_init(Client::new)
-}
-
 fn apply_image_proxy_headers(
-    mut request: RequestBuilder,
+    mut request: ProviderRequestBuilder,
     provider: &ImageProxyProvider,
-) -> RequestBuilder {
+) -> ProviderRequestBuilder {
     for (name, value) in &provider.headers {
         request = request.header(name.clone(), value.clone());
     }

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -25,6 +25,7 @@ mod rerank;
 mod response_cache;
 mod responses;
 mod responses_stream;
+mod route_http;
 mod spend;
 mod token_policy;
 

--- a/src/server/routes/ai/route_http.rs
+++ b/src/server/routes/ai/route_http.rs
@@ -1,0 +1,111 @@
+//! Policy-aware HTTP client used by configurable AI route proxies.
+
+use reqwest::IntoUrl;
+
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::base::{BaseConfig, BaseHttpClient, ProviderRequestBuilder};
+use crate::utils::error::gateway_error::GatewayError;
+
+#[derive(Debug, Clone)]
+pub(super) struct RouteHttpClient {
+    ordinary: BaseHttpClient,
+    streaming: BaseHttpClient,
+}
+
+impl RouteHttpClient {
+    pub(super) fn new(
+        provider: &'static str,
+        base_url: String,
+        endpoint_access: ProviderEndpointAccess,
+        timeout: u64,
+    ) -> Result<Self, GatewayError> {
+        let config = BaseConfig {
+            api_base: Some(base_url),
+            endpoint_access,
+            timeout,
+            ..BaseConfig::default()
+        };
+        let ordinary = BaseHttpClient::new_for_provider(provider, config.clone())?;
+        let streaming = BaseHttpClient::new_for_provider_streaming(provider, config)?;
+        Ok(Self {
+            ordinary,
+            streaming,
+        })
+    }
+
+    pub(super) fn ordinary_get<U: IntoUrl>(
+        &self,
+        url: U,
+    ) -> Result<ProviderRequestBuilder, GatewayError> {
+        self.ordinary.get(url).map_err(GatewayError::from)
+    }
+
+    pub(super) fn ordinary_post<U: IntoUrl>(
+        &self,
+        url: U,
+    ) -> Result<ProviderRequestBuilder, GatewayError> {
+        self.ordinary.post(url).map_err(GatewayError::from)
+    }
+
+    pub(super) fn streaming_post<U: IntoUrl>(
+        &self,
+        url: U,
+    ) -> Result<ProviderRequestBuilder, GatewayError> {
+        self.streaming.post(url).map_err(GatewayError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_route_client_rejects_loopback_base() {
+        let error = RouteHttpClient::new(
+            "route_test",
+            "http://127.0.0.1:11434/v1".to_string(),
+            ProviderEndpointAccess::PublicOnly,
+            30,
+        )
+        .expect_err("public-only route client must reject loopback");
+
+        assert!(error.to_string().contains("SSRF protection"));
+    }
+
+    #[test]
+    fn private_route_client_pins_ordinary_and_streaming_authority() {
+        let client = RouteHttpClient::new(
+            "route_test",
+            "http://127.0.0.1:11434/v1".to_string(),
+            ProviderEndpointAccess::PrivateNetwork,
+            30,
+        )
+        .expect("private route client should build");
+
+        for error in [
+            client
+                .ordinary_post("http://127.0.0.1:11435/v1/request")
+                .err()
+                .unwrap_or_else(|| panic!("ordinary request must reject cross-authority URL")),
+            client
+                .streaming_post("http://127.0.0.1:11435/v1/request")
+                .err()
+                .unwrap_or_else(|| panic!("streaming request must reject cross-authority URL")),
+        ] {
+            assert!(error.to_string().contains("does not match"));
+        }
+    }
+
+    #[test]
+    fn private_route_client_still_rejects_metadata() {
+        let error = RouteHttpClient::new(
+            "route_test",
+            "http://169.254.169.254/latest".to_string(),
+            ProviderEndpointAccess::PrivateNetwork,
+            30,
+        )
+        .expect_err("private route client must reject metadata");
+
+        assert!(error.to_string().contains("SSRF protection"));
+    }
+}

--- a/tests/batches_routes.rs
+++ b/tests/batches_routes.rs
@@ -4,7 +4,7 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{
         App, HttpRequest, HttpResponse, HttpServer,
         http::{Method, StatusCode},
@@ -14,6 +14,7 @@ mod tests {
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use litellm_rs::server::state::AppState;
     use serde_json::{Value, json};
@@ -213,13 +214,17 @@ mod tests {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn batch_route_provider_with_headers(base_url: &str) -> ProviderConfig {
@@ -247,6 +252,7 @@ mod tests {
                 }),
             ),
         ]);
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
         provider
     }
 
@@ -554,5 +560,49 @@ mod tests {
         assert_eq!(primary_requests[0].path, "/v1/batches");
 
         primary.stop_batch_mock().await;
+    }
+
+    #[tokio::test]
+    async fn public_only_batch_route_rejects_loopback_before_connect() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let mut provider = batch_route_provider("public-batch", &format!("http://{address}/v1"));
+        provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        let state = build_test_app_state(vec![provider]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/batches")
+                .set_json(json!({
+                    "input_file_id": "file_123",
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(response).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("SSRF protection"))
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "public-only batch route must not connect to loopback listener"
+        );
     }
 }

--- a/tests/common/providers.rs
+++ b/tests/common/providers.rs
@@ -6,6 +6,7 @@
 use std::env;
 
 use litellm_rs::config::models::provider::ProviderConfig;
+use litellm_rs::core::net::ProviderEndpointAccess;
 use litellm_rs::core::providers::openai::OpenAIConfig;
 use litellm_rs::core::providers::openai_like::OpenAILikeConfig;
 
@@ -25,6 +26,19 @@ pub fn mock_provider_config(
         models,
         ..ProviderConfig::default()
     }
+}
+
+/// Build startup-safe copies for direct-route tests that activate private runtime policy later.
+pub fn route_policy_bootstrap_providers(providers: &[ProviderConfig]) -> Vec<ProviderConfig> {
+    providers
+        .iter()
+        .cloned()
+        .map(|mut provider| {
+            provider.base_url = Some("https://example.com/v1".to_string());
+            provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+            provider
+        })
+        .collect()
 }
 
 pub fn mock_openai_runtime_config(

--- a/tests/gemini_router_fallback_routes.rs
+++ b/tests/gemini_router_fallback_routes.rs
@@ -4,12 +4,13 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
     use bytes::Bytes;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use litellm_rs::server::state::AppState;
     use serde_json::{Value, json};
@@ -158,23 +159,29 @@ mod tests {
         config.gateway.auth.allow_anonymous = true;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn gemini_provider(name: &str, base_url: &str) -> ProviderConfig {
-        mock_provider_config(
+        let mut provider = mock_provider_config(
             name,
             "openai_compatible",
             GEMINI_API_KEY,
             base_url,
             vec![GEMINI_MODEL.to_string()],
-        )
+        );
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        provider
     }
 
     fn gemini_body() -> Value {

--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -9,16 +9,18 @@ mod support;
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
     use super::support::{
-        BrokenGeminiStreamServer, MockGeminiServer, api_key_with_invalid_runtime_permissions,
-        api_key_with_max_tokens_per_request, build_auth_required_state, build_test_state,
-        gemini_body, gemini_body_without_generation_config, gemini_provider,
-        gemini_upstream_error_body,
+        BrokenGeminiStreamServer, DelayedGeminiStreamServer, MockGeminiServer,
+        api_key_with_invalid_runtime_permissions, api_key_with_max_tokens_per_request,
+        build_auth_required_state, build_test_state, gemini_body,
+        gemini_body_without_generation_config, gemini_provider, gemini_upstream_error_body,
     };
     use actix_web::{App, HttpMessage, dev::Service};
     use actix_web::{http::StatusCode, test, web};
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::ApiKey;
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use serde_json::{Value, json};
+    use std::time::{Duration, Instant};
 
     #[tokio::test]
     async fn gemini_sdk_routes_without_provider_fail_closed() {
@@ -610,5 +612,87 @@ mod tests {
         assert_eq!(model_usage.current_spend, 0.0);
 
         broken.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn gemini_sdk_stream_body_is_not_cut_off_by_ordinary_timeout() {
+        let delayed = DelayedGeminiStreamServer::launch(Duration::from_millis(1_200)).await;
+        let mut provider = gemini_provider(
+            "gemini",
+            &delayed.base_url,
+            vec!["gemini-3.1-flash-lite".to_string()],
+        );
+        provider.timeout = 1;
+        let state = build_test_state(vec![provider]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let started = Instant::now();
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:streamGenerateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = tokio::time::timeout(Duration::from_secs(3), test::read_body(response))
+            .await
+            .expect("delayed SSE body should complete")
+            .to_vec();
+        let body = String::from_utf8(body).expect("stream body should be utf8");
+        assert!(body.contains("delayed"));
+        assert!(started.elapsed() >= Duration::from_millis(1_100));
+        delayed.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn public_only_gemini_route_rejects_loopback_before_connect() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let mut provider = gemini_provider(
+            "gemini",
+            &format!("http://{address}"),
+            vec!["gemini-3.1-flash-lite".to_string()],
+        );
+        provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        let state = build_test_state(vec![provider]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+                .set_json(gemini_body())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(response).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("SSRF protection"))
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "public-only Gemini route must not connect to loopback listener"
+        );
     }
 }

--- a/tests/gemini_sdk_routes/support.rs
+++ b/tests/gemini_sdk_routes/support.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 use litellm_rs::Config;
 use litellm_rs::config::models::provider::ProviderConfig;
 use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+use litellm_rs::core::net::ProviderEndpointAccess;
 use litellm_rs::server::HttpServer as GatewayHttpServer;
 use litellm_rs::server::state::AppState;
 use serde_json::{Value, json};
@@ -11,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use super::provider_fixtures::mock_provider_config;
+use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
 
 #[derive(Clone, Debug)]
 pub(crate) struct CapturedGeminiRequest {
@@ -123,6 +124,62 @@ impl BrokenGeminiStreamServer {
     }
 }
 
+pub(crate) struct DelayedGeminiStreamServer {
+    pub(crate) base_url: String,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl DelayedGeminiStreamServer {
+    pub(crate) async fn launch(delay: Duration) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("delayed stream server should bind");
+        let address = listener
+            .local_addr()
+            .expect("delayed stream server should have address");
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("delayed stream server should accept");
+            let mut buffer = [0_u8; 4096];
+            let _ = socket.read(&mut buffer).await;
+            socket
+                .write_all(
+                    concat!(
+                        "HTTP/1.1 200 OK\r\n",
+                        "content-type: text/event-stream\r\n",
+                        "transfer-encoding: chunked\r\n",
+                        "connection: close\r\n",
+                        "\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("delayed stream server should write headers");
+            tokio::time::sleep(delay).await;
+            let body =
+                "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"delayed\"}]}}]}\n\n";
+            socket
+                .write_all(format!("{:x}\r\n{body}\r\n0\r\n\r\n", body.len()).as_bytes())
+                .await
+                .expect("delayed stream server should write body");
+            let _ = socket.shutdown().await;
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            task,
+        }
+    }
+
+    pub(crate) async fn shutdown(self) {
+        self.task
+            .await
+            .expect("delayed stream server task should join");
+    }
+}
+
 async fn wait_for_server(address: std::net::SocketAddr) {
     for _ in 0..20 {
         if tokio::net::TcpStream::connect(address).await.is_ok() {
@@ -218,26 +275,34 @@ pub(crate) async fn build_test_state(providers: Vec<ProviderConfig>) -> AppState
     config.gateway.auth.allow_anonymous = true;
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
-    config.gateway.providers = providers;
+    config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-    GatewayHttpServer::new(&config)
+    let state = GatewayHttpServer::new(&config)
         .await
         .expect("gateway server should initialize")
         .state()
-        .clone()
+        .clone();
+    let mut runtime_config = state.config().as_ref().clone();
+    runtime_config.gateway.providers = providers;
+    state.config.store(runtime_config);
+    state
 }
 
 pub(crate) async fn build_auth_required_state(providers: Vec<ProviderConfig>) -> AppState {
     let mut config = Config::default();
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
-    config.gateway.providers = providers;
+    config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-    GatewayHttpServer::new(&config)
+    let state = GatewayHttpServer::new(&config)
         .await
         .expect("gateway server should initialize")
         .state()
-        .clone()
+        .clone();
+    let mut runtime_config = state.config().as_ref().clone();
+    runtime_config.gateway.providers = providers;
+    state.config.store(runtime_config);
+    state
 }
 
 pub(crate) fn gemini_provider(name: &str, base_url: &str, models: Vec<String>) -> ProviderConfig {
@@ -263,6 +328,7 @@ pub(crate) fn gemini_provider(name: &str, base_url: &str, models: Vec<String>) -
             }),
         ),
     ]);
+    provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
     provider
 }
 

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -4,12 +4,13 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
     use bytes::Bytes;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::core::pricing_service::PricingUsage;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
@@ -152,13 +153,17 @@ mod tests {
         config.gateway.auth.allow_anonymous = true;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     async fn build_auth_required_state(
@@ -167,13 +172,17 @@ mod tests {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn image_route_provider(base_url: &str) -> ProviderConfig {
@@ -204,6 +213,7 @@ mod tests {
                 }),
             ),
         ]);
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
         provider
     }
 
@@ -648,6 +658,51 @@ mod tests {
         );
 
         mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn public_only_image_route_rejects_loopback_before_connect() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let mut provider = image_route_provider(&format!("http://{address}/v1"));
+        provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        let state = build_test_state(vec![provider]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: Value = test::read_body_json(response).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("SSRF protection"))
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "public-only image route must not connect to loopback listener"
+        );
     }
 
     #[path = "image_edit_variation_routes_budget_tests.rs"]

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -4,7 +4,7 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
     use actix_web::{HttpMessage, dev::Service};
     use bytes::Bytes;
@@ -12,6 +12,7 @@ mod tests {
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::core::pricing_service::{LiteLLMModelInfo, PricingUsage};
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
@@ -127,6 +128,31 @@ mod tests {
             .expect("gateway server should initialize")
             .state()
             .clone()
+    }
+
+    async fn build_route_policy_test_state(
+        mut providers: Vec<ProviderConfig>,
+    ) -> litellm_rs::server::state::AppState {
+        for provider in &mut providers {
+            provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        }
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
+
+        let state = GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway server should initialize")
+            .state()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn api_key_with_allowed_models(allowed_models: &[&str]) -> ApiKey {

--- a/tests/tests/image_router_fallback_routes_edit_fallback_tests.rs
+++ b/tests/tests/image_router_fallback_routes_edit_fallback_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[tokio::test]
 async fn image_edit_records_flat_output_image_spend_after_success() {
     let mock = MockImageServer::start().await;
-    let state = build_test_state(vec![image_provider(
+    let state = build_route_policy_test_state(vec![image_provider(
         "openai-primary",
         "openai",
         &mock.base_url,
@@ -58,7 +58,7 @@ async fn image_edit_records_flat_output_image_spend_after_success() {
 async fn native_openai_image_edit_uses_selected_provider_config_after_budget_fallback() {
     let exhausted = MockImageServer::start().await;
     let fallback = MockImageServer::start().await;
-    let state = build_test_state(vec![
+    let state = build_route_policy_test_state(vec![
         image_provider(
             "openai-primary",
             "openai",
@@ -123,7 +123,7 @@ async fn native_openai_image_edit_uses_selected_provider_config_after_budget_fal
 async fn wildcard_openai_compatible_image_edit_tries_next_provider_name_key() {
     let exhausted = MockImageServer::start().await;
     let fallback = MockImageServer::start().await;
-    let state = build_test_state(vec![
+    let state = build_route_policy_test_state(vec![
         image_provider(
             "wild-primary",
             "openai_compatible",
@@ -188,7 +188,7 @@ async fn wildcard_openai_compatible_image_edit_tries_next_provider_name_key() {
 async fn explicit_image_provider_falls_back_to_wildcard_provider() {
     let exhausted = MockImageServer::start().await;
     let fallback = MockImageServer::start().await;
-    let state = build_test_state(vec![
+    let state = build_route_policy_test_state(vec![
         image_provider(
             "explicit-primary",
             "openai_compatible",


### PR DESCRIPTION
## Summary

- replace the batches, Gemini SDK-compatible, and image multipart route-level raw clients with one policy-aware route client
- preserve each selected provider endpoint access mode and pin ordinary, streaming, and multipart requests to its configured authority
- bound Gemini non-2xx response bodies to 10 seconds / 64 KiB while keeping successful SSE bodies unbounded
- add listener negatives, delayed SSE and bounded-error coverage, private-route fixtures, and an AST source guard against raw client regressions

## Verification

- `cargo check --all-targets --all-features --locked`
- CI-equivalent strict Clippy
- batches/Gemini/images route matrices
- `cargo test --all-features --locked -- --test-threads=1`
- scope guard: 14 files / 764 changed lines
- overlap guard: no open PR overlap

Partial implementation of SP968-T11D; issue remains open for later SpecRail tasks.

Refs #968