### PR TITLE
fix(routes): enforce endpoint policy for remaining AI proxies

### DIFF
--- a/src/core/fine_tuning/config.rs
+++ b/src/core/fine_tuning/config.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::core::net::ProviderEndpointAccess;
+
 /// Fine-tuning configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FineTuningConfig {
@@ -96,6 +98,10 @@ pub struct ProviderFineTuningConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_base: Option<String>,
 
+    /// Network access allowed for the configured API base.
+    #[serde(default)]
+    pub endpoint_access: ProviderEndpointAccess,
+
     /// Organization ID (for OpenAI)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization_id: Option<String>,
@@ -123,6 +129,7 @@ impl Default for ProviderFineTuningConfig {
             enabled: true,
             api_key: None,
             api_base: None,
+            endpoint_access: ProviderEndpointAccess::PublicOnly,
             organization_id: None,
             supported_models: vec![],
             timeout_seconds: default_timeout(),
@@ -143,6 +150,11 @@ impl ProviderFineTuningConfig {
 
     pub fn api_base(mut self, base: impl Into<String>) -> Self {
         self.api_base = Some(base.into());
+        self
+    }
+
+    pub fn endpoint_access(mut self, access: ProviderEndpointAccess) -> Self {
+        self.endpoint_access = access;
         self
     }
 
@@ -177,6 +189,36 @@ mod tests {
         assert!(config.enabled);
         assert!(config.default_provider.is_none());
         assert_eq!(config.max_concurrent_jobs, 5);
+    }
+
+    #[test]
+    fn provider_endpoint_access_defaults_public_and_accepts_private() {
+        let default = ProviderFineTuningConfig::default();
+        assert_eq!(default.endpoint_access, ProviderEndpointAccess::PublicOnly);
+
+        let private =
+            ProviderFineTuningConfig::new().endpoint_access(ProviderEndpointAccess::PrivateNetwork);
+        assert_eq!(
+            private.endpoint_access,
+            ProviderEndpointAccess::PrivateNetwork
+        );
+    }
+
+    #[test]
+    fn provider_endpoint_access_serde_is_strict() {
+        let private: ProviderFineTuningConfig = serde_json::from_value(serde_json::json!({
+            "endpoint_access": "private_network"
+        }))
+        .unwrap_or_else(|error| panic!("private endpoint access should deserialize: {error}"));
+        assert_eq!(
+            private.endpoint_access,
+            ProviderEndpointAccess::PrivateNetwork
+        );
+
+        let invalid = serde_json::from_value::<ProviderFineTuningConfig>(serde_json::json!({
+            "endpoint_access": "internal"
+        }));
+        assert!(invalid.is_err());
     }
 
     #[test]

--- a/src/core/fine_tuning/providers/openai.rs
+++ b/src/core/fine_tuning/providers/openai.rs
@@ -3,12 +3,10 @@
 //! Implementation of fine-tuning for OpenAI API.
 
 use async_trait::async_trait;
-use reqwest::{Client, Method, Url, header::RETRY_AFTER};
+use reqwest::{Method, Url, header::RETRY_AFTER};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
 use tracing::{debug, warn};
 
 use super::{FineTuningError, FineTuningProvider, FineTuningResult};
@@ -17,51 +15,67 @@ use crate::core::fine_tuning::types::{
     CreateJobRequest, FineTuningCheckpoint, FineTuningJob, ListEventsParams, ListEventsResponse,
     ListJobsParams, ListJobsResponse,
 };
-use crate::utils::net::http::create_custom_client;
-
-static CLIENTS_BY_TIMEOUT: OnceLock<Mutex<HashMap<u64, Client>>> = OnceLock::new();
+use crate::core::providers::base::{BaseConfig, BaseHttpClient};
 
 /// OpenAI fine-tuning provider
 pub struct OpenAIFineTuningProvider {
     config: ProviderFineTuningConfig,
-    client: Client,
+    client: BaseHttpClient,
     api_base: String,
     provider_name: String,
 }
 
 impl OpenAIFineTuningProvider {
     /// Create a new OpenAI fine-tuning provider
-    pub fn new(config: ProviderFineTuningConfig) -> Self {
+    pub fn new(config: ProviderFineTuningConfig) -> FineTuningResult<Self> {
         Self::new_named(config, "openai")
     }
 
     /// Create a new OpenAI-compatible fine-tuning provider with a gateway provider name.
-    pub fn new_named(config: ProviderFineTuningConfig, provider_name: impl Into<String>) -> Self {
-        let client = shared_client(config.timeout_seconds);
-
+    pub fn new_named(
+        config: ProviderFineTuningConfig,
+        provider_name: impl Into<String>,
+    ) -> FineTuningResult<Self> {
         let api_base = config
             .api_base
             .clone()
             .unwrap_or_else(|| "https://api.openai.com/v1".to_string())
             .trim_end_matches('/')
             .to_string();
+        let client = BaseHttpClient::new_for_provider(
+            "openai_fine_tuning",
+            BaseConfig {
+                api_base: Some(api_base.clone()),
+                endpoint_access: config.endpoint_access,
+                timeout: config.timeout_seconds,
+                ..BaseConfig::default()
+            },
+        )
+        .map_err(|error| {
+            FineTuningError::provider(format!(
+                "Failed to create policy-aware fine-tuning client: {error}"
+            ))
+        })?;
 
-        Self {
+        Ok(Self {
             config,
             client,
             api_base,
             provider_name: provider_name.into(),
-        }
+        })
     }
 
     /// Create from API key
-    pub fn from_api_key(api_key: impl Into<String>) -> Self {
+    pub fn from_api_key(api_key: impl Into<String>) -> FineTuningResult<Self> {
         Self::new(ProviderFineTuningConfig::new().api_key(api_key))
     }
 
     /// Create from environment variable
-    pub fn from_env() -> Option<Self> {
-        std::env::var("OPENAI_API_KEY").ok().map(Self::from_api_key)
+    pub fn from_env() -> FineTuningResult<Option<Self>> {
+        std::env::var("OPENAI_API_KEY")
+            .ok()
+            .map(Self::from_api_key)
+            .transpose()
     }
 
     /// Build authorization header
@@ -102,6 +116,9 @@ impl OpenAIFineTuningProvider {
         let mut request = self
             .client
             .request(method, url)
+            .map_err(|error| {
+                FineTuningError::network(format!("Request policy rejected URL: {error}"))
+            })?
             .header("Authorization", auth);
 
         // Add organization header if configured
@@ -140,13 +157,11 @@ impl OpenAIFineTuningProvider {
                 .and_then(|value| value.to_str().ok())
                 .and_then(|value| value.parse::<u64>().ok())
                 .unwrap_or(60);
-            let error_text = response.text().await.unwrap_or_else(|e| {
-                warn!(
-                    "Failed to read OpenAI fine-tuning error response payload: {}",
-                    e
-                );
-                String::new()
-            });
+            let error_text = response.text().await.map_err(|error| {
+                FineTuningError::network(format!(
+                    "Failed to read OpenAI fine-tuning error response payload: {error}"
+                ))
+            })?;
             let response_bytes = error_text.len();
             let safe_error_message = extract_openai_error_message(&error_text);
             warn!(
@@ -179,26 +194,6 @@ impl OpenAIFineTuningProvider {
         job.provider = Some(self.provider_name.clone());
         job
     }
-}
-
-fn shared_client(timeout_seconds: u64) -> Client {
-    let clients = CLIENTS_BY_TIMEOUT.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut clients = clients
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-
-    clients
-        .entry(timeout_seconds)
-        .or_insert_with(|| {
-            create_custom_client(Duration::from_secs(timeout_seconds)).unwrap_or_else(|error| {
-                warn!(
-                    "Failed to create custom fine-tuning HTTP client, using default client: {}",
-                    error
-                );
-                Client::new()
-            })
-        })
-        .clone()
 }
 
 fn extract_openai_error_message(error_text: &str) -> Option<String> {
@@ -369,7 +364,9 @@ mod tests {
 
     #[test]
     fn test_provider_creation() {
-        let provider = OpenAIFineTuningProvider::from_api_key("sk-test");
+        let Ok(provider) = OpenAIFineTuningProvider::from_api_key("sk-test") else {
+            panic!("official provider should build");
+        };
         assert_eq!(provider.name(), "openai");
     }
 
@@ -404,16 +401,42 @@ mod tests {
 
     #[test]
     fn test_auth_header() {
-        let provider = OpenAIFineTuningProvider::from_api_key("sk-test");
+        let Ok(provider) = OpenAIFineTuningProvider::from_api_key("sk-test") else {
+            panic!("official provider should build");
+        };
         let header = provider.auth_header().unwrap();
         assert_eq!(header, "Bearer sk-test");
     }
 
     #[test]
     fn test_auth_header_missing() {
-        let provider = OpenAIFineTuningProvider::new(ProviderFineTuningConfig::new());
+        let Ok(provider) = OpenAIFineTuningProvider::new(ProviderFineTuningConfig::new()) else {
+            panic!("official provider should build without an API key");
+        };
         let result = provider.auth_header();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn policy_constructor_rejects_public_loopback_and_private_metadata() {
+        let public = OpenAIFineTuningProvider::new(
+            ProviderFineTuningConfig::new().api_base("http://127.0.0.1:11434/v1"),
+        );
+        assert!(public.is_err());
+
+        let private = OpenAIFineTuningProvider::new(
+            ProviderFineTuningConfig::new()
+                .api_base("http://127.0.0.1:11434/v1")
+                .endpoint_access(crate::core::net::ProviderEndpointAccess::PrivateNetwork),
+        );
+        assert!(private.is_ok());
+
+        let metadata = OpenAIFineTuningProvider::new(
+            ProviderFineTuningConfig::new()
+                .api_base("http://169.254.169.254/latest")
+                .endpoint_access(crate::core::net::ProviderEndpointAccess::PrivateNetwork),
+        );
+        assert!(metadata.is_err());
     }
 
     #[test]

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -286,7 +286,7 @@ fn collect_provider_sources(
 #[test]
 fn migrated_shared_providers_have_no_raw_client_escape() {
     let base_source = include_str!("../http.rs");
-    let provider_sources: [(&str, &[&str], &str); 12] = [
+    let provider_sources: [(&str, &[&str], &str); 19] = [
         (
             "mistral/mod.rs",
             &["crate", "core", "providers", "mistral"],
@@ -346,6 +346,41 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
             "server/routes/ai/images.rs",
             &["crate", "server", "routes", "ai", "images"],
             include_str!("../../../../server/routes/ai/images.rs"),
+        ),
+        (
+            "server/routes/ai/provider_config.rs",
+            &["crate", "server", "routes", "ai", "provider_config"],
+            include_str!("../../../../server/routes/ai/provider_config.rs"),
+        ),
+        (
+            "server/routes/ai/moderations.rs",
+            &["crate", "server", "routes", "ai", "moderations"],
+            include_str!("../../../../server/routes/ai/moderations.rs"),
+        ),
+        (
+            "server/routes/ai/fine_tuning.rs",
+            &["crate", "server", "routes", "ai", "fine_tuning"],
+            include_str!("../../../../server/routes/ai/fine_tuning.rs"),
+        ),
+        (
+            "server/routes/ai/rerank.rs",
+            &["crate", "server", "routes", "ai", "rerank"],
+            include_str!("../../../../server/routes/ai/rerank.rs"),
+        ),
+        (
+            "core/fine_tuning/providers/openai.rs",
+            &["crate", "core", "fine_tuning", "providers", "openai"],
+            include_str!("../../../fine_tuning/providers/openai.rs"),
+        ),
+        (
+            "core/rerank/providers/cohere.rs",
+            &["crate", "core", "rerank", "providers", "cohere"],
+            include_str!("../../../rerank/providers/cohere.rs"),
+        ),
+        (
+            "core/rerank/providers/jina.rs",
+            &["crate", "core", "rerank", "providers", "jina"],
+            include_str!("../../../rerank/providers/jina.rs"),
         ),
     ];
     let allowed = boundary_violations(

--- a/src/core/rerank/providers/cohere.rs
+++ b/src/core/rerank/providers/cohere.rs
@@ -1,6 +1,8 @@
 //! Cohere rerank provider implementation
 
 use super::rerank_upstream_error;
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::base::{BaseConfig, BaseHttpClient};
 use crate::core::rerank::service::RerankProvider;
 use crate::core::rerank::types::{RerankRequest, RerankResponse, RerankResult, RerankUsage};
 use crate::utils::error::gateway_error::{GatewayError, Result};
@@ -13,24 +15,57 @@ pub struct CohereRerankProvider {
     api_key: String,
     /// API base URL
     base_url: String,
-    /// HTTP client
-    client: reqwest::Client,
+    /// Policy-aware HTTP client.
+    client: BaseHttpClient,
+    endpoint_access: ProviderEndpointAccess,
+    timeout_seconds: u64,
 }
 
 impl CohereRerankProvider {
     /// Create a new Cohere rerank provider
-    pub fn new(api_key: impl Into<String>) -> Self {
-        Self {
-            api_key: api_key.into(),
-            base_url: "https://api.cohere.ai/v1".to_string(),
-            client: crate::core::http::outbound::default_outbound_client().clone(),
-        }
+    pub fn new(api_key: impl Into<String>) -> Result<Self> {
+        Self::new_with_endpoint(
+            api_key,
+            "https://api.cohere.ai/v1",
+            ProviderEndpointAccess::PublicOnly,
+            30,
+        )
     }
 
     /// Set custom base URL
-    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
-        self.base_url = url.into();
-        self
+    pub fn with_base_url(self, url: impl Into<String>) -> Result<Self> {
+        Self::new_with_endpoint(
+            self.api_key,
+            url,
+            self.endpoint_access,
+            self.timeout_seconds,
+        )
+    }
+
+    /// Create a provider bound to an exact endpoint policy and authority.
+    pub fn new_with_endpoint(
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+        endpoint_access: ProviderEndpointAccess,
+        timeout_seconds: u64,
+    ) -> Result<Self> {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        let client = BaseHttpClient::new_for_provider(
+            "cohere_rerank",
+            BaseConfig {
+                api_base: Some(base_url.clone()),
+                endpoint_access,
+                timeout: timeout_seconds,
+                ..BaseConfig::default()
+            },
+        )?;
+        Ok(Self {
+            api_key: api_key.into(),
+            base_url,
+            client,
+            endpoint_access,
+            timeout_seconds,
+        })
     }
 }
 
@@ -72,7 +107,7 @@ impl RerankProvider for CohereRerankProvider {
         // Send request
         let response = self
             .client
-            .post(format!("{}/rerank", self.base_url))
+            .post(format!("{}/rerank", self.base_url))?
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
@@ -82,7 +117,11 @@ impl RerankProvider for CohereRerankProvider {
 
         if !response.status().is_success() {
             let status = response.status();
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = response.text().await.map_err(|error| {
+                GatewayError::Network(format!(
+                    "Failed to read Cohere rerank error response: {error}"
+                ))
+            })?;
             return Err(rerank_upstream_error("cohere", status, error_text));
         }
 
@@ -159,5 +198,38 @@ impl RerankProvider for CohereRerankProvider {
             "rerank-english-v2.0",
             "rerank-multilingual-v2.0",
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_constructor_binds_private_cohere_authority() {
+        let public = CohereRerankProvider::new_with_endpoint(
+            "test-key",
+            "http://127.0.0.1:11434/v1",
+            ProviderEndpointAccess::PublicOnly,
+            30,
+        );
+        assert!(public.is_err());
+
+        let Ok(private) = CohereRerankProvider::new_with_endpoint(
+            "test-key",
+            "http://127.0.0.1:11434/v1",
+            ProviderEndpointAccess::PrivateNetwork,
+            30,
+        ) else {
+            panic!("private Cohere endpoint should build");
+        };
+        let Some(error) = private
+            .client
+            .post("http://127.0.0.1:11435/v1/rerank")
+            .err()
+        else {
+            panic!("cross-authority Cohere request should fail");
+        };
+        assert!(error.to_string().contains("does not match"));
     }
 }

--- a/src/core/rerank/providers/jina.rs
+++ b/src/core/rerank/providers/jina.rs
@@ -1,6 +1,8 @@
 //! Jina AI rerank provider implementation
 
 use super::rerank_upstream_error;
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::base::{BaseConfig, BaseHttpClient};
 use crate::core::rerank::service::RerankProvider;
 use crate::core::rerank::types::{RerankRequest, RerankResponse, RerankResult, RerankUsage};
 use crate::utils::error::gateway_error::{GatewayError, Result};
@@ -13,24 +15,57 @@ pub struct JinaRerankProvider {
     api_key: String,
     /// API base URL
     base_url: String,
-    /// HTTP client
-    client: reqwest::Client,
+    /// Policy-aware HTTP client.
+    client: BaseHttpClient,
+    endpoint_access: ProviderEndpointAccess,
+    timeout_seconds: u64,
 }
 
 impl JinaRerankProvider {
     /// Create a new Jina rerank provider
-    pub fn new(api_key: impl Into<String>) -> Self {
-        Self {
-            api_key: api_key.into(),
-            base_url: "https://api.jina.ai/v1".to_string(),
-            client: crate::core::http::outbound::default_outbound_client().clone(),
-        }
+    pub fn new(api_key: impl Into<String>) -> Result<Self> {
+        Self::new_with_endpoint(
+            api_key,
+            "https://api.jina.ai/v1",
+            ProviderEndpointAccess::PublicOnly,
+            30,
+        )
     }
 
     /// Set custom base URL
-    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
-        self.base_url = url.into();
-        self
+    pub fn with_base_url(self, url: impl Into<String>) -> Result<Self> {
+        Self::new_with_endpoint(
+            self.api_key,
+            url,
+            self.endpoint_access,
+            self.timeout_seconds,
+        )
+    }
+
+    /// Create a provider bound to an exact endpoint policy and authority.
+    pub fn new_with_endpoint(
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+        endpoint_access: ProviderEndpointAccess,
+        timeout_seconds: u64,
+    ) -> Result<Self> {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        let client = BaseHttpClient::new_for_provider(
+            "jina_rerank",
+            BaseConfig {
+                api_base: Some(base_url.clone()),
+                endpoint_access,
+                timeout: timeout_seconds,
+                ..BaseConfig::default()
+            },
+        )?;
+        Ok(Self {
+            api_key: api_key.into(),
+            base_url,
+            client,
+            endpoint_access,
+            timeout_seconds,
+        })
     }
 }
 
@@ -65,7 +100,7 @@ impl RerankProvider for JinaRerankProvider {
 
         let response = self
             .client
-            .post(format!("{}/rerank", self.base_url))
+            .post(format!("{}/rerank", self.base_url))?
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
@@ -75,7 +110,11 @@ impl RerankProvider for JinaRerankProvider {
 
         if !response.status().is_success() {
             let status = response.status();
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = response.text().await.map_err(|error| {
+                GatewayError::Network(format!(
+                    "Failed to read Jina rerank error response: {error}"
+                ))
+            })?;
             return Err(rerank_upstream_error("jina", status, error_text));
         }
 
@@ -146,5 +185,38 @@ impl RerankProvider for JinaRerankProvider {
             "jina-reranker-v1-base-en",
             "jina-reranker-v1-turbo-en",
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_constructor_binds_private_jina_authority() {
+        let metadata = JinaRerankProvider::new_with_endpoint(
+            "test-key",
+            "http://169.254.169.254/latest",
+            ProviderEndpointAccess::PrivateNetwork,
+            30,
+        );
+        assert!(metadata.is_err());
+
+        let Ok(private) = JinaRerankProvider::new_with_endpoint(
+            "test-key",
+            "http://127.0.0.1:11434/v1",
+            ProviderEndpointAccess::PrivateNetwork,
+            30,
+        ) else {
+            panic!("private Jina endpoint should build");
+        };
+        let Some(error) = private
+            .client
+            .post("http://127.0.0.1:11435/v1/rerank")
+            .err()
+        else {
+            panic!("cross-authority Jina request should fail");
+        };
+        assert!(error.to_string().contains("does not match"));
     }
 }

--- a/src/core/rerank/tests.rs
+++ b/src/core/rerank/tests.rs
@@ -104,7 +104,9 @@ fn test_rerank_service_validation() {
 
 #[test]
 fn test_cohere_provider_supports_model() {
-    let provider = CohereRerankProvider::new("test-key");
+    let Ok(provider) = CohereRerankProvider::new("test-key") else {
+        panic!("official Cohere provider should build");
+    };
 
     assert!(provider.supports_model("rerank-english-v3.0"));
     assert!(provider.supports_model("cohere/rerank-english-v3.0"));
@@ -114,7 +116,9 @@ fn test_cohere_provider_supports_model() {
 
 #[test]
 fn test_jina_provider_supports_model() {
-    let provider = JinaRerankProvider::new("test-key");
+    let Ok(provider) = JinaRerankProvider::new("test-key") else {
+        panic!("official Jina provider should build");
+    };
 
     assert!(provider.supports_model("jina-reranker-v2-base-multilingual"));
     assert!(provider.supports_model("jina/jina-reranker-v2-base-multilingual"));

--- a/src/server/routes/ai/fine_tuning.rs
+++ b/src/server/routes/ai/fine_tuning.rs
@@ -243,7 +243,8 @@ where
         let route_provider =
             fine_tuning_route_provider(provider_config).map_err(FineTuningRouteError::Gateway)?;
         let provider =
-            OpenAIFineTuningProvider::new_named(route_provider.config, route_provider.name);
+            OpenAIFineTuningProvider::new_named(route_provider.config, route_provider.name)
+                .map_err(FineTuningRouteError::FineTuning)?;
         match operation(provider).await {
             Ok(response) => return Ok(response),
             Err(error) => {
@@ -340,6 +341,7 @@ fn fine_tuning_route_provider(
             enabled: true,
             api_key: Some(provider.api_key.clone()),
             api_base: Some(fine_tuning_api_base(provider)?),
+            endpoint_access: provider.endpoint_access,
             organization_id: provider.organization.clone(),
             supported_models: provider.models.clone(),
             timeout_seconds: provider.timeout,

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -1,6 +1,7 @@
 //! OpenAI-compatible moderation API route.
 
 use crate::config::models::provider::ProviderConfig;
+use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::{Provider, ProviderError};
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
@@ -14,7 +15,7 @@ use tracing::error;
 
 use super::budgeted::{SettlementMode, run_unary};
 use super::openai_errors;
-use super::provider_config;
+use super::{provider_config, route_http::RouteHttpClient};
 
 const DEFAULT_MODERATION_MODEL: &str = "omni-moderation-latest";
 const OPENAI_MODERATION_BASE_URL: &str = "https://api.openai.com/v1";
@@ -25,6 +26,7 @@ struct ModerationProxyProvider {
     base_url: String,
     headers: Vec<(HeaderName, HeaderValue)>,
     timeout: Duration,
+    endpoint_access: ProviderEndpointAccess,
 }
 
 /// Create a moderation request.
@@ -112,11 +114,20 @@ async fn proxy_moderation(
                                 || async move {
                                     let url = moderation_url(&provider)
                                         .map_err(moderation_gateway_error_to_provider_error)?;
+                                    let client = RouteHttpClient::new(
+                                        "moderation_proxy",
+                                        provider.base_url.clone(),
+                                        provider.endpoint_access,
+                                        provider.timeout.as_secs(),
+                                    )
+                                    .map_err(moderation_gateway_error_to_provider_error)?;
+                                    let request_builder = client
+                                        .ordinary_post(url)
+                                        .map_err(moderation_gateway_error_to_provider_error)?;
                                     let response = provider_config::apply_proxy_headers(
-                                        provider_config::proxy_http_client().post(url),
+                                        request_builder,
                                         &provider.headers,
                                     )
-                                    .timeout(provider.timeout)
                                     .json(&request)
                                     .send()
                                     .await
@@ -309,6 +320,7 @@ fn moderation_proxy_provider_from_config(
         base_url: moderation_base_url(provider)?,
         headers: moderation_provider_headers(provider)?,
         timeout: Duration::from_secs(provider.timeout),
+        endpoint_access: provider.endpoint_access,
     })
 }
 

--- a/src/server/routes/ai/provider_config.rs
+++ b/src/server/routes/ai/provider_config.rs
@@ -1,14 +1,11 @@
 //! Shared helpers for OpenAI-compatible provider route configuration.
 
 use crate::config::models::provider::ProviderConfig;
+use crate::core::providers::base::ProviderRequestBuilder;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::HttpResponse;
 use actix_web::http::{StatusCode, header};
 use reqwest::header::{HeaderName, HeaderValue};
-use reqwest::{Client, RequestBuilder};
-use std::sync::OnceLock;
-
-static PROXY_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 
 pub(super) fn append_string_header_map(
     provider: &ProviderConfig,
@@ -35,10 +32,6 @@ pub(super) fn normalize_provider_selector(value: &str) -> String {
     value.trim().to_ascii_lowercase().replace(['_', '-'], "")
 }
 
-pub(super) fn proxy_http_client() -> &'static Client {
-    PROXY_HTTP_CLIENT.get_or_init(Client::new)
-}
-
 pub(super) async fn proxy_response_to_http_response(
     response: reqwest::Response,
 ) -> Result<HttpResponse, GatewayError> {
@@ -58,9 +51,9 @@ pub(super) async fn proxy_response_to_http_response(
 }
 
 pub(super) fn apply_proxy_headers(
-    mut request: RequestBuilder,
+    mut request: ProviderRequestBuilder,
     headers: &[(HeaderName, HeaderValue)],
-) -> RequestBuilder {
+) -> ProviderRequestBuilder {
     for (name, value) in headers {
         request = request.header(name.clone(), value.clone());
     }

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -149,17 +149,27 @@ fn build_rerank_service(provider: &SelectedRerankProvider) -> Result<RerankServi
 
     match provider.kind {
         RerankProviderKind::Cohere => {
-            let mut rerank_provider = CohereRerankProvider::new(provider.api_key.clone());
-            if let Some(base_url) = provider.base_url.as_deref() {
-                rerank_provider = rerank_provider.with_base_url(base_url.trim_end_matches('/'));
-            }
+            let rerank_provider = CohereRerankProvider::new_with_endpoint(
+                provider.api_key.clone(),
+                provider
+                    .base_url
+                    .as_deref()
+                    .unwrap_or("https://api.cohere.ai/v1"),
+                provider.endpoint_access,
+                provider.timeout.as_secs(),
+            )?;
             service.register_provider("cohere", Arc::new(rerank_provider));
         }
         RerankProviderKind::Jina => {
-            let mut rerank_provider = JinaRerankProvider::new(provider.api_key.clone());
-            if let Some(base_url) = provider.base_url.as_deref() {
-                rerank_provider = rerank_provider.with_base_url(base_url.trim_end_matches('/'));
-            }
+            let rerank_provider = JinaRerankProvider::new_with_endpoint(
+                provider.api_key.clone(),
+                provider
+                    .base_url
+                    .as_deref()
+                    .unwrap_or("https://api.jina.ai/v1"),
+                provider.endpoint_access,
+                provider.timeout.as_secs(),
+            )?;
             service.register_provider("jina", Arc::new(rerank_provider));
         }
     }
@@ -222,6 +232,7 @@ fn selected_rerank_provider_from_config(
         api_key: provider.api_key.clone(),
         base_url: provider.base_url.clone(),
         timeout: Duration::from_secs(provider.timeout),
+        endpoint_access: provider.endpoint_access,
     })
 }
 
@@ -465,6 +476,7 @@ struct SelectedRerankProvider {
     api_key: String,
     base_url: Option<String>,
     timeout: Duration,
+    endpoint_access: crate::core::net::ProviderEndpointAccess,
 }
 
 #[cfg(test)]

--- a/tests/fine_tuning_routes.rs
+++ b/tests/fine_tuning_routes.rs
@@ -4,7 +4,7 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{
         App, HttpRequest, HttpResponse, HttpServer,
         http::{Method, StatusCode},
@@ -14,6 +14,7 @@ mod tests {
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
     use std::collections::HashMap;
@@ -278,13 +279,17 @@ mod tests {
         config.gateway.auth.allow_anonymous = true;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn fine_tuning_provider(base_url: &str) -> ProviderConfig {
@@ -312,6 +317,7 @@ mod tests {
                 }),
             ),
         ]);
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
         provider
     }
 
@@ -323,6 +329,9 @@ mod tests {
         provider.settings.clear();
         provider
     }
+
+    #[path = "fine_tuning_routes_policy_tests.rs"]
+    mod policy_tests;
 
     #[tokio::test]
     async fn fine_tuning_route_without_provider_fails_closed() {

--- a/tests/moderations_routes.rs
+++ b/tests/moderations_routes.rs
@@ -4,7 +4,7 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
     use actix_web::{HttpMessage, dev::Service};
     use bytes::Bytes;
@@ -12,6 +12,7 @@ mod tests {
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
     use std::collections::HashMap;
@@ -155,13 +156,17 @@ mod tests {
         config.gateway.auth.allow_anonymous = allow_anonymous;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn moderation_provider(base_url: &str) -> ProviderConfig {
@@ -209,6 +214,7 @@ mod tests {
                 }),
             ),
         ]);
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
         provider
     }
 
@@ -227,6 +233,49 @@ mod tests {
             last_used_at: None,
             usage_stats: UsageStats::default(),
         }
+    }
+
+    #[tokio::test]
+    async fn public_only_moderation_route_rejects_loopback_before_connect() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let mut provider = moderation_provider(&format!("http://{address}/v1"));
+        provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        let state = build_test_app_state(vec![provider]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/moderations")
+                .set_json(json!({
+                    "model": "omni-moderation-latest",
+                    "input": "listener must remain untouched"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert!(!response.status().is_success());
+        let body: Value = test::read_body_json(response).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("SSRF protection"))
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "public-only moderation route must not connect to loopback listener"
+        );
     }
 
     #[path = "moderations_routes_auth_validation_tests.rs"]

--- a/tests/rerank_routes.rs
+++ b/tests/rerank_routes.rs
@@ -4,7 +4,7 @@ pub mod provider_fixtures;
 
 #[cfg(all(test, feature = "gateway", feature = "storage"))]
 mod tests {
-    use super::provider_fixtures::mock_provider_config;
+    use super::provider_fixtures::{mock_provider_config, route_policy_bootstrap_providers};
     use actix_web::{App, HttpRequest, HttpResponse, HttpServer, http::StatusCode, test, web};
     use actix_web::{HttpMessage, dev::Service};
     use bytes::Bytes;
@@ -13,6 +13,7 @@ mod tests {
     use litellm_rs::config::models::router::RoutingStrategyConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
+    use litellm_rs::core::net::ProviderEndpointAccess;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
     use std::collections::HashMap;
@@ -177,13 +178,17 @@ mod tests {
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.router.strategy = RoutingStrategyConfig::RoundRobin;
-        config.gateway.providers = providers;
+        config.gateway.providers = route_policy_bootstrap_providers(&providers);
 
-        GatewayHttpServer::new(&config)
+        let state = GatewayHttpServer::new(&config)
             .await
             .expect("gateway server should initialize")
             .state()
-            .clone()
+            .clone();
+        let mut runtime_config = state.config().as_ref().clone();
+        runtime_config.gateway.providers = providers;
+        state.config.store(runtime_config);
+        state
     }
 
     fn cohere_rerank_provider(base_url: &str) -> ProviderConfig {
@@ -199,17 +204,22 @@ mod tests {
         base_url: &str,
         models: Vec<String>,
     ) -> ProviderConfig {
-        mock_provider_config(name, "openai_compatible", "sk-test", base_url, models)
+        let mut provider =
+            mock_provider_config(name, "openai_compatible", "sk-test", base_url, models);
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        provider
     }
 
     fn jina_rerank_provider_with_models(base_url: &str, models: Vec<String>) -> ProviderConfig {
-        mock_provider_config(
+        let mut provider = mock_provider_config(
             "mock-jina-rerank",
             "openai_compatible",
             "sk-test",
             base_url,
             models,
-        )
+        );
+        provider.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        provider
     }
 
     fn authenticated_api_key() -> ApiKey {
@@ -241,6 +251,9 @@ mod tests {
             "return_documents": true
         })
     }
+
+    #[path = "rerank_routes_policy_tests.rs"]
+    mod policy_tests;
 
     #[tokio::test]
     async fn rerank_route_without_provider_fails_closed() {

--- a/tests/tests/fine_tuning_routes_policy_tests.rs
+++ b/tests/tests/fine_tuning_routes_policy_tests.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[tokio::test]
+async fn public_only_fine_tuning_route_rejects_loopback_before_connect() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let address = listener.local_addr().expect("listener should have address");
+    let mut provider = fine_tuning_provider(&format!("http://{address}/v1"));
+    provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+    let state = build_test_state(vec![provider]).await;
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(litellm_rs::server::routes::ai::configure_routes),
+    )
+    .await;
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/fine_tuning/jobs")
+            .set_json(json!({
+                "model": "gpt-4o-mini",
+                "training_file": "file-train"
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert!(!response.status().is_success());
+    let body: Value = test::read_body_json(response).await;
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("SSRF protection"))
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err(),
+        "public-only fine-tuning route must not connect to loopback listener"
+    );
+}

--- a/tests/tests/rerank_routes_policy_tests.rs
+++ b/tests/tests/rerank_routes_policy_tests.rs
@@ -1,0 +1,70 @@
+use super::*;
+
+async fn assert_public_only_rerank_rejects_loopback(mut provider: ProviderConfig, request: Value) {
+    provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+    let state = build_test_app_state(vec![provider]).await;
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(litellm_rs::server::routes::ai::configure_routes),
+    )
+    .await;
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/rerank")
+            .set_json(request)
+            .to_request(),
+    )
+    .await;
+
+    assert!(!response.status().is_success());
+    let body: Value = test::read_body_json(response).await;
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("SSRF protection"))
+    );
+}
+
+#[tokio::test]
+async fn public_only_cohere_rerank_rejects_loopback_before_connect() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let address = listener.local_addr().expect("listener should have address");
+    let provider = cohere_rerank_provider(&format!("http://{address}/v1"));
+
+    assert_public_only_rerank_rejects_loopback(provider, rerank_body()).await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err(),
+        "public-only Cohere rerank route must not connect to loopback listener"
+    );
+}
+
+#[tokio::test]
+async fn public_only_jina_rerank_rejects_loopback_before_connect() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let address = listener.local_addr().expect("listener should have address");
+    let provider = jina_rerank_provider_with_models(
+        &format!("http://{address}/v1"),
+        vec!["jina-reranker-v3".to_string()],
+    );
+    let mut request = rerank_body();
+    request["model"] = json!("jina-reranker-v3");
+
+    assert_public_only_rerank_rejects_loopback(provider, request).await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err(),
+        "public-only Jina rerank route must not connect to loopback listener"
+    );
+}


### PR DESCRIPTION
## Summary

- preserve configured endpoint access and exact authority for moderation, fine-tuning, and rerank routes
- replace the fine-tuning timeout-only raw-client cache and Cohere/Jina default clients with fallible policy-aware clients
- make policy construction and upstream error-body failures explicit, with no ordinary-client fallback
- add private-network route fixtures, four public-only loopback listener negatives, and AST source-boundary coverage

## Verification

- cargo check --all-targets --all-features --locked
- CI-equivalent strict Clippy
- moderations/fine-tuning/rerank integration matrix: 52 passed
- core fine-tuning/rerank policy suites: 77 passed
- AST source guard and constructor/config policy tests
- cargo test --all-features --locked -- --test-threads=1
- six CI feature-matrix checks
- scope guard: 15 files / 678 changed lines
- overlap guard: no open PR overlap

Partial implementation of SP968-T11E; issue remains open for T9R, T11F, T12, and T13.

Refs #968