### PR TITLE
fix(providers): activate endpoint policy runtime

### DIFF
--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -166,9 +166,19 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
-        let has_configured_endpoint = self.base_url.is_some()
-            || self.settings.contains_key("base_url")
-            || self.settings.contains_key("api_base");
+        let setting_url = |key| {
+            self.settings
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .filter(|url| !url.trim().is_empty())
+        };
+        let configured_endpoint = self
+            .base_url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+            .or_else(|| setting_url("base_url"))
+            .or_else(|| setting_url("api_base"));
+        let has_configured_endpoint = configured_endpoint.is_some();
         if (self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
             || has_configured_endpoint)
             && !crate::core::providers::factory::is_provider_endpoint_access_supported(
@@ -181,7 +191,7 @@ impl Validate for ProviderConfig {
             ));
         }
         if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
-            && self.base_url.is_none()
+            && !has_configured_endpoint
             && !crate::core::providers::factory::selector_allows_implicit_private_endpoint(
                 provider_selector,
             )
@@ -230,7 +240,7 @@ impl Validate for ProviderConfig {
         }
 
         // Validate base URL if present (with SSRF protection)
-        if let Some(base_url) = &self.base_url {
+        if let Some(base_url) = configured_endpoint {
             let endpoint = url::Url::parse(base_url)
                 .map_err(|error| format!("Provider {} base URL is invalid: {error}", self.name))?;
             if !matches!(endpoint.scheme(), "http" | "https") {

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -182,7 +182,9 @@ impl Validate for ProviderConfig {
         }
         if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
             && self.base_url.is_none()
-            && !crate::core::providers::factory::selector_uses_catalog_endpoint(provider_selector)
+            && !crate::core::providers::factory::selector_allows_implicit_private_endpoint(
+                provider_selector,
+            )
         {
             return Err(format!(
                 "Provider {} private_network endpoint access requires a base URL",
@@ -409,6 +411,11 @@ mod endpoint_access_tests {
         config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
         assert!(Validate::validate(&config).is_ok());
 
+        config.base_url = None;
+        for (provider_type, allowed) in [("bedrock", true), ("vllm", true), ("openrouter", false)] {
+            config.provider_type = provider_type.to_string();
+            assert_eq!(Validate::validate(&config).is_ok(), allowed);
+        }
         config.provider_type = "cloudflare".to_string();
         assert!(
             Validate::validate(&config)
@@ -417,6 +424,7 @@ mod endpoint_access_tests {
         );
 
         config.provider_type = "openai_compatible".to_string();
+        config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
         config.endpoint_access = ProviderEndpointAccess::PublicOnly;
         assert!(Validate::validate(&config).is_err());
         config.base_url = Some("https://8.8.8.8/v1".to_string());

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -166,13 +166,14 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
-        if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
+        if (self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
+            || self.base_url.is_some())
             && !crate::core::providers::factory::is_provider_endpoint_access_supported(
                 provider_selector,
             )
         {
             return Err(format!(
-                "Provider {} private_network is unavailable because provider type '{}' is not policy-wired",
+                "Provider {} configurable endpoint access is unavailable because provider type '{}' is not policy-wired",
                 self.name, self.provider_type
             ));
         }

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -10,6 +10,7 @@ use crate::config::models::server::ServerConfig;
 use crate::core::net::{
     validate_provider_endpoint_url, validate_provider_endpoint_url_without_resolution,
 };
+use crate::core::providers::factory::invalid_endpoint;
 use std::collections::HashSet;
 use tracing::debug;
 
@@ -166,6 +167,12 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
+        if ["base_url", "api_base"]
+            .into_iter()
+            .any(|key| invalid_endpoint(self.settings.get(key)))
+        {
+            return Err(format!("Provider {} endpoint must be a string", self.name));
+        }
         let setting_url = |key| {
             self.settings
                 .get(key)
@@ -181,7 +188,7 @@ impl Validate for ProviderConfig {
         let has_configured_endpoint = configured_endpoint.is_some();
         if (self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
             || has_configured_endpoint)
-            && !crate::core::providers::factory::is_provider_endpoint_access_supported(
+            && !crate::core::providers::factory::selector_supports_endpoint_access(
                 provider_selector,
             )
         {
@@ -192,9 +199,7 @@ impl Validate for ProviderConfig {
         }
         if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
             && !has_configured_endpoint
-            && !crate::core::providers::factory::selector_allows_implicit_private_endpoint(
-                provider_selector,
-            )
+            && !crate::core::providers::factory::selector_allows_implicit_private(provider_selector)
         {
             return Err(format!(
                 "Provider {} private_network endpoint access requires a base URL",
@@ -402,7 +407,7 @@ mod endpoint_access_tests {
 
     fn public_provider() -> ProviderConfig {
         ProviderConfig {
-            name: "endpoint-policy".to_string(),
+            name: "staged".to_string(),
             provider_type: "openai_compatible".to_string(),
             api_key: "sk-test".to_string(),
             base_url: Some("https://8.8.8.8/v1".to_string()),
@@ -437,7 +442,6 @@ mod endpoint_access_tests {
         config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
         config.endpoint_access = ProviderEndpointAccess::PublicOnly;
         assert!(Validate::validate(&config).is_err());
-        config.base_url = Some("https://8.8.8.8/v1".to_string());
         config.base_url = Some("wss://8.8.8.8/v1".to_string());
         assert!(Validate::validate(&config).is_err());
         config.base_url = Some("https://8.8.8.8/v1".to_string());

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -166,8 +166,11 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
+        let has_configured_endpoint = self.base_url.is_some()
+            || self.settings.contains_key("base_url")
+            || self.settings.contains_key("api_base");
         if (self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
-            || self.base_url.is_some())
+            || has_configured_endpoint)
             && !crate::core::providers::factory::is_provider_endpoint_access_supported(
                 provider_selector,
             )
@@ -179,6 +182,7 @@ impl Validate for ProviderConfig {
         }
         if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
             && self.base_url.is_none()
+            && !crate::core::providers::factory::selector_uses_catalog_endpoint(provider_selector)
         {
             return Err(format!(
                 "Provider {} private_network endpoint access requires a base URL",
@@ -227,6 +231,12 @@ impl Validate for ProviderConfig {
         if let Some(base_url) = &self.base_url {
             let endpoint = url::Url::parse(base_url)
                 .map_err(|error| format!("Provider {} base URL is invalid: {error}", self.name))?;
+            if !matches!(endpoint.scheme(), "http" | "https") {
+                return Err(format!(
+                    "Provider {} base URL must use http:// or https:// scheme",
+                    self.name
+                ));
+            }
             validate_provider_endpoint_url_without_resolution(&endpoint, self.endpoint_access)
                 .map_err(|error| format!("Provider {} base URL is invalid: {error}", self.name))?;
         }
@@ -408,6 +418,9 @@ mod endpoint_access_tests {
 
         config.provider_type = "openai_compatible".to_string();
         config.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        assert!(Validate::validate(&config).is_err());
+        config.base_url = Some("https://8.8.8.8/v1".to_string());
+        config.base_url = Some("wss://8.8.8.8/v1".to_string());
         assert!(Validate::validate(&config).is_err());
         config.base_url = Some("https://8.8.8.8/v1".to_string());
         config.settings.insert(

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -3,12 +3,13 @@
 //! This module provides validation implementations for the main gateway configuration
 //! structures including GatewayConfig, ServerConfig, and ProviderConfig.
 
-use super::ssrf::validate_url_against_ssrf;
 use super::trait_def::Validate;
 use crate::config::models::gateway::{GatewayConfig, GatewayPricingConfig};
 use crate::config::models::provider::{ProviderConfig, ProviderHealthCheckConfig, RetryConfig};
 use crate::config::models::server::ServerConfig;
-use crate::core::net::validate_provider_endpoint_url;
+use crate::core::net::{
+    validate_provider_endpoint_url, validate_provider_endpoint_url_without_resolution,
+};
 use std::collections::HashSet;
 use tracing::debug;
 
@@ -165,9 +166,21 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
-        if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork {
+        if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
+            && !crate::core::providers::factory::is_provider_endpoint_access_supported(
+                provider_selector,
+            )
+        {
             return Err(format!(
-                "Provider {} private_network is staged until all provider routes are policy-wired",
+                "Provider {} private_network is unavailable because provider type '{}' is not policy-wired",
+                self.name, self.provider_type
+            ));
+        }
+        if self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
+            && self.base_url.is_none()
+        {
+            return Err(format!(
+                "Provider {} private_network endpoint access requires a base URL",
                 self.name
             ));
         }
@@ -211,7 +224,10 @@ impl Validate for ProviderConfig {
 
         // Validate base URL if present (with SSRF protection)
         if let Some(base_url) = &self.base_url {
-            validate_url_against_ssrf(base_url, &format!("Provider {} base URL", self.name))?;
+            let endpoint = url::Url::parse(base_url)
+                .map_err(|error| format!("Provider {} base URL is invalid: {error}", self.name))?;
+            validate_provider_endpoint_url_without_resolution(&endpoint, self.endpoint_access)
+                .map_err(|error| format!("Provider {} base URL is invalid: {error}", self.name))?;
         }
 
         // Validate rate limits
@@ -363,7 +379,7 @@ mod endpoint_access_tests {
 
     fn public_provider() -> ProviderConfig {
         ProviderConfig {
-            name: "staged".to_string(),
+            name: "endpoint-policy".to_string(),
             provider_type: "openai_compatible".to_string(),
             api_key: "sk-test".to_string(),
             base_url: Some("https://8.8.8.8/v1".to_string()),
@@ -372,14 +388,27 @@ mod endpoint_access_tests {
     }
 
     #[test]
-    fn endpoint_access_is_top_level_and_private_is_staged() {
+    fn endpoint_access_is_top_level_and_private_is_provider_gated() {
         let mut config = public_provider();
         assert!(Validate::validate(&config).is_ok());
 
         config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-        assert!(Validate::validate(&config).unwrap_err().contains("staged"));
+        assert!(Validate::validate(&config).is_ok());
 
+        config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
+        assert!(Validate::validate(&config).is_ok());
+
+        config.provider_type = "cloudflare".to_string();
+        assert!(
+            Validate::validate(&config)
+                .unwrap_err()
+                .contains("not policy-wired")
+        );
+
+        config.provider_type = "openai_compatible".to_string();
         config.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        assert!(Validate::validate(&config).is_err());
+        config.base_url = Some("https://8.8.8.8/v1".to_string());
         config.settings.insert(
             "endpoint_access".to_string(),
             serde_json::json!("private_network"),

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -167,9 +167,14 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
-        if ["base_url", "api_base"]
-            .into_iter()
-            .any(|key| invalid_endpoint(self.settings.get(key)))
+        let blank_base = self
+            .base_url
+            .as_ref()
+            .is_some_and(|url| url.trim().is_empty());
+        if blank_base
+            || ["base_url", "api_base"]
+                .into_iter()
+                .any(|key| invalid_endpoint(self.settings.get(key)))
         {
             return Err(format!("Provider {} endpoint must be a string", self.name));
         }
@@ -443,6 +448,8 @@ mod endpoint_access_tests {
         config.endpoint_access = ProviderEndpointAccess::PublicOnly;
         assert!(Validate::validate(&config).is_err());
         config.base_url = Some("wss://8.8.8.8/v1".to_string());
+        assert!(Validate::validate(&config).is_err());
+        config.base_url = Some(" ".to_string());
         assert!(Validate::validate(&config).is_err());
         config.base_url = Some("https://8.8.8.8/v1".to_string());
         config.settings.insert(

--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -456,13 +456,12 @@ impl GlobalPoolManager {
     ) -> Result<reqwest::Response, ProviderError> {
         if let Some(policy) = &self.policy {
             let request = apply_provider_headers(policy.streaming.post(url)?, headers).json(&body);
-            let response = tokio::time::timeout(policy.streaming_header_timeout, request.send())
+            let timeout = policy.streaming_header_timeout;
+            let response = tokio::time::timeout(timeout, request.send())
                 .await
                 .map_err(|_| {
-                    StreamingRequestError::HeaderTimeout {
-                        timeout: policy.streaming_header_timeout,
-                    }
-                    .into_provider_error(policy.provider)
+                    StreamingRequestError::HeaderTimeout { timeout }
+                        .into_provider_error(policy.provider)
                 })?;
             return response.map_err(|error| {
                 StreamingRequestError::Request(error).into_provider_error(policy.provider)
@@ -629,10 +628,8 @@ mod tests {
             .unwrap()
             .policy
             .unwrap();
-        assert_eq!(
-            policy.streaming_header_timeout,
-            Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS)
-        );
+        let expected = Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS);
+        assert_eq!(policy.streaming_header_timeout, expected);
     }
 
     #[tokio::test]

--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -7,6 +7,8 @@ use futures::StreamExt;
 use reqwest::{Client, RequestBuilder, Response};
 use serde_json;
 
+use super::config::BaseConfig;
+use super::http::{BaseHttpClient, apply_provider_headers};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::net::http::{
     HttpClientPoolConfig, create_custom_client_with_config, create_streaming_client,
@@ -333,6 +335,15 @@ impl ConnectionPool {
 #[derive(Debug, Clone)]
 pub struct GlobalPoolManager {
     pool: Arc<ConnectionPool>,
+    policy: Option<ProviderPool>,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderPool {
+    provider: &'static str,
+    ordinary: BaseHttpClient,
+    streaming: BaseHttpClient,
+    streaming_header_timeout: Duration,
 }
 
 impl GlobalPoolManager {
@@ -343,6 +354,26 @@ impl GlobalPoolManager {
     pub fn new() -> Result<Self, ProviderError> {
         Ok(Self {
             pool: Arc::new(ConnectionPool::new()?),
+            policy: None,
+        })
+    }
+
+    /// Create a manager whose ordinary and streaming clients are bound to one provider policy.
+    pub fn new_for_provider(
+        provider: &'static str,
+        config: BaseConfig,
+    ) -> Result<Self, ProviderError> {
+        let streaming_header_timeout = Duration::from_secs(config.timeout);
+        let ordinary = BaseHttpClient::new_for_provider(provider, config.clone())?;
+        let streaming = BaseHttpClient::new_for_provider_streaming(provider, config)?;
+        Ok(Self {
+            pool: Arc::new(ConnectionPool::new()?),
+            policy: Some(ProviderPool {
+                provider,
+                ordinary,
+                streaming,
+                streaming_header_timeout,
+            }),
         })
     }
 
@@ -356,6 +387,7 @@ impl GlobalPoolManager {
             pool: Arc::new(ConnectionPool {
                 client: global_client(),
             }),
+            policy: None,
         }
     }
 
@@ -370,6 +402,26 @@ impl GlobalPoolManager {
         headers: Vec<HeaderPair>,
         body: Option<serde_json::Value>,
     ) -> Result<reqwest::Response, ProviderError> {
+        if let Some(policy) = &self.policy {
+            let method = match method {
+                HttpMethod::GET => reqwest::Method::GET,
+                HttpMethod::POST => reqwest::Method::POST,
+                HttpMethod::PUT => reqwest::Method::PUT,
+                HttpMethod::DELETE => reqwest::Method::DELETE,
+            };
+            let mut request_builder = policy.ordinary.request(method, url)?;
+            request_builder = apply_provider_headers(request_builder, headers);
+            if let Some(body_data) = body {
+                request_builder = request_builder
+                    .header("Content-Type", "application/json")
+                    .json(&body_data);
+            }
+            return request_builder
+                .send()
+                .await
+                .map_err(|error| ProviderError::network(policy.provider, error.to_string()));
+        }
+
         let client = self.pool.client();
 
         let mut request_builder = match method {
@@ -395,6 +447,34 @@ impl GlobalPoolManager {
             .send()
             .await
             .map_err(|e| ProviderError::network("common", e.to_string()))
+    }
+
+    /// Execute a policy-bound request while bounding only the response-header phase.
+    pub async fn execute_streaming_request(
+        &self,
+        url: &str,
+        headers: Vec<HeaderPair>,
+        body: serde_json::Value,
+        legacy_provider: &'static str,
+    ) -> Result<reqwest::Response, ProviderError> {
+        if let Some(policy) = &self.policy {
+            let request = apply_provider_headers(policy.streaming.post(url)?, headers).json(&body);
+            return match tokio::time::timeout(policy.streaming_header_timeout, request.send()).await
+            {
+                Ok(Ok(response)) => Ok(response),
+                Ok(Err(error)) => Err(ProviderError::network(policy.provider, error.to_string())),
+                Err(_) => Err(ProviderError::timeout(
+                    policy.provider,
+                    format!(
+                        "streaming request did not receive response headers within {:?}",
+                        policy.streaming_header_timeout
+                    ),
+                )),
+            };
+        }
+
+        let request = apply_headers(streaming_unbounded_client().post(url).json(&body), headers);
+        send_streaming_request(request, legacy_provider).await
     }
 
     /// Get the underlying client for direct use

--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -462,7 +462,9 @@ impl GlobalPoolManager {
             return match tokio::time::timeout(policy.streaming_header_timeout, request.send()).await
             {
                 Ok(Ok(response)) => Ok(response),
-                Ok(Err(error)) => Err(ProviderError::network(policy.provider, error.to_string())),
+                Ok(Err(error)) => {
+                    Err(StreamingRequestError::Request(error).into_provider_error(policy.provider))
+                }
                 Err(_) => Err(ProviderError::timeout(
                     policy.provider,
                     format!(

--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -363,16 +363,13 @@ impl GlobalPoolManager {
         provider: &'static str,
         config: BaseConfig,
     ) -> Result<Self, ProviderError> {
-        let streaming_header_timeout = Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS);
-        let ordinary = BaseHttpClient::new_for_provider(provider, config.clone())?;
-        let streaming = BaseHttpClient::new_for_provider_streaming(provider, config)?;
         Ok(Self {
             pool: Arc::new(ConnectionPool::new()?),
             policy: Some(ProviderPool {
                 provider,
-                ordinary,
-                streaming,
-                streaming_header_timeout,
+                ordinary: BaseHttpClient::new_for_provider(provider, config.clone())?,
+                streaming: BaseHttpClient::new_for_provider_streaming(provider, config)?,
+                streaming_header_timeout: Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS),
             }),
         })
     }
@@ -459,20 +456,17 @@ impl GlobalPoolManager {
     ) -> Result<reqwest::Response, ProviderError> {
         if let Some(policy) = &self.policy {
             let request = apply_provider_headers(policy.streaming.post(url)?, headers).json(&body);
-            return match tokio::time::timeout(policy.streaming_header_timeout, request.send()).await
-            {
-                Ok(Ok(response)) => Ok(response),
-                Ok(Err(error)) => {
-                    Err(StreamingRequestError::Request(error).into_provider_error(policy.provider))
-                }
-                Err(_) => Err(ProviderError::timeout(
-                    policy.provider,
-                    format!(
-                        "streaming request did not receive response headers within {:?}",
-                        policy.streaming_header_timeout
-                    ),
-                )),
-            };
+            let response = tokio::time::timeout(policy.streaming_header_timeout, request.send())
+                .await
+                .map_err(|_| {
+                    StreamingRequestError::HeaderTimeout {
+                        timeout: policy.streaming_header_timeout,
+                    }
+                    .into_provider_error(policy.provider)
+                })?;
+            return response.map_err(|error| {
+                StreamingRequestError::Request(error).into_provider_error(policy.provider)
+            });
         }
 
         let request = apply_headers(streaming_unbounded_client().post(url).json(&body), headers);

--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -363,7 +363,7 @@ impl GlobalPoolManager {
         provider: &'static str,
         config: BaseConfig,
     ) -> Result<Self, ProviderError> {
-        let streaming_header_timeout = Duration::from_secs(config.timeout);
+        let streaming_header_timeout = Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS);
         let ordinary = BaseHttpClient::new_for_provider(provider, config.clone())?;
         let streaming = BaseHttpClient::new_for_provider_streaming(provider, config)?;
         Ok(Self {
@@ -627,6 +627,18 @@ mod tests {
     async fn test_global_manager() {
         let manager = GlobalPoolManager::new();
         assert!(manager.is_ok());
+        let config = BaseConfig {
+            timeout: 1,
+            ..Default::default()
+        };
+        let policy = GlobalPoolManager::new_for_provider("test", config)
+            .unwrap()
+            .policy
+            .unwrap();
+        assert_eq!(
+            policy.streaming_header_timeout,
+            Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS)
+        );
     }
 
     #[tokio::test]

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -425,26 +425,12 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
         let violations = boundary_violations(source, module_path)
             .unwrap_or_else(|error| panic!("{path} must parse: {error}"));
         assert!(violations.is_empty(), "{path}: {}", violations.join("; "));
-    }
-    for (path, source) in [
-        ("openai/client.rs", include_str!("../../openai/client.rs")),
-        (
-            "openai_like/provider.rs",
-            include_str!("../../openai_like/provider.rs"),
-        ),
-    ] {
-        let compact = source.split_whitespace().collect::<String>();
-        assert!(
-            compact.contains("GlobalPoolManager::new_for_provider"),
-            "{path}"
-        );
-        for forbidden in [
-            "GlobalPoolManager::new()",
-            "streaming_unbounded_client",
-            "default_outbound_client",
-            ".client()",
-        ] {
-            assert!(!compact.contains(forbidden), "{path}: {forbidden}");
+        if matches!(path, "openai/client.rs" | "openai_like/provider.rs") {
+            let compact = source.split_whitespace().collect::<String>();
+            assert!(compact.contains("GlobalPoolManager::new_for_provider"));
+            for forbidden in ["GlobalPoolManager::new()", ".client()"] {
+                assert!(!compact.contains(forbidden), "{path}: {forbidden}");
+            }
         }
     }
     let bedrock_root = FsPath::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers/bedrock");

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -433,13 +433,10 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
             include_str!("../../openai_like/provider.rs"),
         ),
     ] {
-        let compact: String = source
-            .chars()
-            .filter(|character| !character.is_whitespace())
-            .collect();
+        let compact = source.split_whitespace().collect::<String>();
         assert!(
             compact.contains("GlobalPoolManager::new_for_provider"),
-            "{path} must construct a provider-policy pool"
+            "{path}"
         );
         for forbidden in [
             "GlobalPoolManager::new()",
@@ -447,10 +444,7 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
             "default_outbound_client",
             ".client()",
         ] {
-            assert!(
-                !compact.contains(forbidden),
-                "{path} retains forbidden runtime bypass {forbidden}"
-            );
+            assert!(!compact.contains(forbidden), "{path}: {forbidden}");
         }
     }
     let bedrock_root = FsPath::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers/bedrock");

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -7,6 +7,7 @@ use syn::{ExprMethodCall, ItemExternCrate, ItemMacro, ItemMod, ItemUse, Path, Us
 const ALLOWED_BASE_SYMBOLS: &[&str] = &[
     "BaseConfig",
     "BaseHttpClient",
+    "GlobalPoolManager",
     "HeaderPair",
     "HttpErrorMapper",
     "HttpMethod",
@@ -286,7 +287,7 @@ fn collect_provider_sources(
 #[test]
 fn migrated_shared_providers_have_no_raw_client_escape() {
     let base_source = include_str!("../http.rs");
-    let provider_sources: [(&str, &[&str], &str); 19] = [
+    let provider_sources: [(&str, &[&str], &str); 21] = [
         (
             "mistral/mod.rs",
             &["crate", "core", "providers", "mistral"],
@@ -321,6 +322,16 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
             "openai/api_methods.rs",
             &["crate", "core", "providers", "openai", "api_methods"],
             include_str!("../../openai/api_methods.rs"),
+        ),
+        (
+            "openai/client.rs",
+            &["crate", "core", "providers", "openai", "client"],
+            include_str!("../../openai/client.rs"),
+        ),
+        (
+            "openai_like/provider.rs",
+            &["crate", "core", "providers", "openai_like", "provider"],
+            include_str!("../../openai_like/provider.rs"),
         ),
         (
             "router/health_probe.rs",
@@ -414,6 +425,33 @@ fn migrated_shared_providers_have_no_raw_client_escape() {
         let violations = boundary_violations(source, module_path)
             .unwrap_or_else(|error| panic!("{path} must parse: {error}"));
         assert!(violations.is_empty(), "{path}: {}", violations.join("; "));
+    }
+    for (path, source) in [
+        ("openai/client.rs", include_str!("../../openai/client.rs")),
+        (
+            "openai_like/provider.rs",
+            include_str!("../../openai_like/provider.rs"),
+        ),
+    ] {
+        let compact: String = source
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .collect();
+        assert!(
+            compact.contains("GlobalPoolManager::new_for_provider"),
+            "{path} must construct a provider-policy pool"
+        );
+        for forbidden in [
+            "GlobalPoolManager::new()",
+            "streaming_unbounded_client",
+            "default_outbound_client",
+            ".client()",
+        ] {
+            assert!(
+                !compact.contains(forbidden),
+                "{path} retains forbidden runtime bypass {forbidden}"
+            );
+        }
     }
     let bedrock_root = FsPath::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers/bedrock");
     let mut bedrock_sources = Vec::new();

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -5,6 +5,7 @@ use super::builder::*;
 use super::cohere_builder::build_cohere_config_from_factory;
 #[cfg(feature = "providers-extended")]
 use super::gemini_builder::build_gemini_config_from_factory;
+use super::{Provider, ProviderType, create_provider};
 use crate::core::net::ProviderEndpointAccess;
 use std::sync::Mutex;
 
@@ -419,6 +420,65 @@ fn test_factory_endpoint_access_defaults_and_rejects_invalid_values() {
             .unwrap_or_else(|| panic!("invalid endpoint_access must fail"));
         assert!(error.to_string().contains("invalid endpoint_access"));
     }
+}
+
+#[tokio::test]
+async fn test_gateway_and_direct_registry_endpoint_access_contract() {
+    let mut config = crate::config::models::provider::ProviderConfig {
+        name: "test-openai-like".to_string(),
+        provider_type: "openai_compatible".to_string(),
+        base_url: Some("https://api.example.com/v1".to_string()),
+        ..Default::default()
+    };
+    config
+        .settings
+        .insert("skip_api_key".to_string(), serde_json::json!(true));
+
+    let provider = create_provider(config.clone())
+        .await
+        .unwrap_or_else(|error| panic!("public-only Gateway config should work: {error}"));
+    let Provider::OpenAILike(provider) = provider else {
+        panic!("expected OpenAILike provider");
+    };
+    assert_eq!(
+        provider.config().base.endpoint_access,
+        ProviderEndpointAccess::PublicOnly
+    );
+
+    config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+    config.base_url = Some("http://127.0.0.1/v1".to_string());
+    assert!(create_provider(config).await.is_ok());
+
+    let mut settings_override = crate::config::models::provider::ProviderConfig {
+        name: "openai".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        ..Default::default()
+    };
+    settings_override.settings.insert(
+        "endpoint_access".to_string(),
+        serde_json::json!("private_network"),
+    );
+    let error = create_provider(settings_override)
+        .await
+        .err()
+        .unwrap_or_else(|| panic!("settings must not override endpoint access"));
+    assert!(error.to_string().contains("top-level"));
+
+    let provider = Provider::from_config_async(
+        ProviderType::Custom("together".to_string()),
+        serde_json::json!({"api_key": "x", "base_url": "http://127.0.0.1/v1",
+            "endpoint_access": "private_network"}),
+    )
+    .await
+    .unwrap_or_else(|error| panic!("catalog-backed custom type should activate: {error}"));
+    let Provider::OpenAILike(provider) = provider else {
+        panic!("expected catalog-backed OpenAILike provider");
+    };
+    assert_eq!(
+        provider.config().base.endpoint_access,
+        ProviderEndpointAccess::PrivateNetwork
+    );
 }
 
 #[cfg(not(feature = "providers-extra"))]

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -421,19 +421,15 @@ fn test_factory_endpoint_access_defaults_and_rejects_invalid_values() {
         assert!(error.to_string().contains("invalid endpoint_access"));
     }
 }
-
 #[tokio::test]
 async fn test_gateway_and_direct_registry_endpoint_access_contract() {
     let mut config = crate::config::models::provider::ProviderConfig {
-        name: "test-openai-like".to_string(),
+        name: "openai-compatible-test".to_string(),
         provider_type: "openai_compatible".to_string(),
+        api_key: "test-key".to_string(),
         base_url: Some("https://api.example.com/v1".to_string()),
         ..Default::default()
     };
-    config
-        .settings
-        .insert("skip_api_key".to_string(), serde_json::json!(true));
-
     let provider = create_provider(config.clone())
         .await
         .unwrap_or_else(|error| panic!("public-only Gateway config should work: {error}"));
@@ -444,11 +440,20 @@ async fn test_gateway_and_direct_registry_endpoint_access_contract() {
         provider.config().base.endpoint_access,
         ProviderEndpointAccess::PublicOnly
     );
-
     config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-    config.base_url = Some("http://127.0.0.1/v1".to_string());
+    config.base_url = None;
+    config
+        .settings
+        .insert("api_base".into(), serde_json::json!("http://127.0.0.1/v1"));
+    assert!(crate::config::Validate::validate(&config).is_ok());
+    config
+        .settings
+        .insert("api_base".into(), serde_json::json!("wss://127.0.0.1/v1"));
+    assert!(crate::config::Validate::validate(&config).is_err());
+    config
+        .settings
+        .insert("api_base".into(), serde_json::json!("http://127.0.0.1/v1"));
     assert!(create_provider(config).await.is_ok());
-
     let mut settings_override = crate::config::models::provider::ProviderConfig {
         name: "openai".to_string(),
         provider_type: "openai".to_string(),
@@ -456,7 +461,7 @@ async fn test_gateway_and_direct_registry_endpoint_access_contract() {
         ..Default::default()
     };
     settings_override.settings.insert(
-        "endpoint_access".to_string(),
+        "endpoint_access".into(),
         serde_json::json!("private_network"),
     );
     let error = create_provider(settings_override)
@@ -464,7 +469,6 @@ async fn test_gateway_and_direct_registry_endpoint_access_contract() {
         .err()
         .unwrap_or_else(|| panic!("settings must not override endpoint access"));
     assert!(error.to_string().contains("top-level"));
-
     let provider = Provider::from_config_async(
         ProviderType::Custom("together".to_string()),
         serde_json::json!({"api_key": "x", "base_url": "http://127.0.0.1/v1",

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -5,7 +5,6 @@ use super::builder::*;
 use super::cohere_builder::build_cohere_config_from_factory;
 #[cfg(feature = "providers-extended")]
 use super::gemini_builder::build_gemini_config_from_factory;
-use super::{Provider, ProviderType, create_provider};
 use crate::core::net::ProviderEndpointAccess;
 use std::sync::Mutex;
 
@@ -419,69 +418,6 @@ fn test_factory_endpoint_access_defaults_and_rejects_invalid_values() {
             .err()
             .unwrap_or_else(|| panic!("invalid endpoint_access must fail"));
         assert!(error.to_string().contains("invalid endpoint_access"));
-    }
-}
-
-#[tokio::test]
-async fn test_gateway_and_direct_registry_endpoint_access_contract() {
-    let mut config = crate::config::models::provider::ProviderConfig {
-        name: "test-openai-like".to_string(),
-        provider_type: "openai_compatible".to_string(),
-        base_url: Some("https://api.example.com/v1".to_string()),
-        ..Default::default()
-    };
-    config
-        .settings
-        .insert("skip_api_key".to_string(), serde_json::json!(true));
-
-    let provider = create_provider(config.clone())
-        .await
-        .unwrap_or_else(|error| panic!("public-only Gateway config should work: {error}"));
-    let Provider::OpenAILike(provider) = provider else {
-        panic!("expected OpenAILike provider");
-    };
-    assert_eq!(
-        provider.config().base.endpoint_access,
-        ProviderEndpointAccess::PublicOnly
-    );
-
-    config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-    let error = create_provider(config)
-        .await
-        .err()
-        .unwrap_or_else(|| panic!("private access must remain staged"));
-    assert!(error.to_string().contains("staged"));
-
-    let mut settings_override = crate::config::models::provider::ProviderConfig {
-        name: "openai".to_string(),
-        provider_type: "openai".to_string(),
-        api_key: "sk-test".to_string(),
-        ..Default::default()
-    };
-    settings_override.settings.insert(
-        "endpoint_access".to_string(),
-        serde_json::json!("private_network"),
-    );
-    let error = create_provider(settings_override)
-        .await
-        .err()
-        .unwrap_or_else(|| panic!("settings must not override endpoint access"));
-    assert!(error.to_string().contains("top-level"));
-
-    for explicit in [
-        serde_json::json!("public_only"),
-        serde_json::json!("private_network"),
-        serde_json::json!("invalid"),
-        serde_json::json!(true),
-    ] {
-        let error = Provider::from_config_async(
-            ProviderType::OpenAICompatible,
-            serde_json::json!({"endpoint_access": explicit}),
-        )
-        .await
-        .err()
-        .unwrap_or_else(|| panic!("direct configs must reject explicit endpoint_access"));
-        assert!(error.to_string().contains("staged"));
     }
 }
 

--- a/src/core/providers/factory/builder_tests.rs
+++ b/src/core/providers/factory/builder_tests.rs
@@ -424,7 +424,7 @@ fn test_factory_endpoint_access_defaults_and_rejects_invalid_values() {
 #[tokio::test]
 async fn test_gateway_and_direct_registry_endpoint_access_contract() {
     let mut config = crate::config::models::provider::ProviderConfig {
-        name: "openai-compatible-test".to_string(),
+        name: "test-openai-like".to_string(),
         provider_type: "openai_compatible".to_string(),
         api_key: "test-key".to_string(),
         base_url: Some("https://api.example.com/v1".to_string()),
@@ -461,7 +461,7 @@ async fn test_gateway_and_direct_registry_endpoint_access_contract() {
         ..Default::default()
     };
     settings_override.settings.insert(
-        "endpoint_access".into(),
+        "endpoint_access".to_string(),
         serde_json::json!("private_network"),
     );
     let error = create_provider(settings_override)

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -1,0 +1,140 @@
+use super::create_provider;
+use crate::config::models::provider::ProviderConfig;
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::{Provider, ProviderType};
+
+#[tokio::test]
+async fn gateway_and_direct_registry_activate_wired_endpoint_access() {
+    let mut config = ProviderConfig {
+        name: "test-openai-like".to_string(),
+        provider_type: "openai_compatible".to_string(),
+        base_url: Some("https://api.example.com/v1".to_string()),
+        ..Default::default()
+    };
+    config
+        .settings
+        .insert("skip_api_key".to_string(), serde_json::json!(true));
+
+    let provider = create_provider(config.clone())
+        .await
+        .unwrap_or_else(|error| panic!("public-only Gateway config should work: {error}"));
+    let Provider::OpenAILike(provider) = provider else {
+        panic!("expected OpenAILike provider");
+    };
+    assert_eq!(
+        provider.config().base.endpoint_access,
+        ProviderEndpointAccess::PublicOnly
+    );
+
+    config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+    config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
+    let provider = create_provider(config)
+        .await
+        .unwrap_or_else(|error| panic!("private Gateway access should activate: {error}"));
+    let Provider::OpenAILike(provider) = provider else {
+        panic!("expected OpenAILike provider");
+    };
+    assert_eq!(
+        provider.config().base.endpoint_access,
+        ProviderEndpointAccess::PrivateNetwork
+    );
+
+    for (explicit, base_url, expected) in [
+        (
+            "public_only",
+            "https://api.example.test/v1",
+            ProviderEndpointAccess::PublicOnly,
+        ),
+        (
+            "private_network",
+            "http://127.0.0.1:18081/v1",
+            ProviderEndpointAccess::PrivateNetwork,
+        ),
+    ] {
+        let provider = Provider::from_config_async(
+            ProviderType::OpenAICompatible,
+            serde_json::json!({
+                "endpoint_access": explicit,
+                "base_url": base_url,
+                "skip_api_key": true
+            }),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("wired direct config should activate: {error}"));
+        let Provider::OpenAILike(provider) = provider else {
+            panic!("expected OpenAILike provider");
+        };
+        assert_eq!(provider.config().base.endpoint_access, expected);
+    }
+}
+
+#[tokio::test]
+async fn endpoint_access_alias_and_unwired_direct_provider_fail_closed() {
+    let mut settings_override = ProviderConfig {
+        name: "openai".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        ..Default::default()
+    };
+    settings_override.settings.insert(
+        "endpoint_access".to_string(),
+        serde_json::json!("private_network"),
+    );
+    let error = create_provider(settings_override)
+        .await
+        .err()
+        .unwrap_or_else(|| panic!("settings must not override endpoint access"));
+    assert!(error.to_string().contains("top-level"));
+
+    let error = Provider::from_config_async(
+        ProviderType::Cloudflare,
+        serde_json::json!({"endpoint_access": "public_only"}),
+    )
+    .await
+    .err()
+    .unwrap_or_else(|| panic!("unwired direct config must fail closed"));
+    assert!(error.to_string().contains("not policy-wired"));
+}
+
+#[tokio::test]
+async fn catalog_local_providers_require_explicit_private_access() {
+    for (name, definition) in super::provider_registry::PROVIDER_CATALOG.iter() {
+        let is_local = url::Url::parse(definition.base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_owned))
+            .is_some_and(|host| host == "localhost");
+        let config = ProviderConfig {
+            name: (*name).to_string(),
+            provider_type: (*name).to_string(),
+            api_key: if definition.skip_api_key {
+                String::new()
+            } else {
+                "test-key".to_string()
+            },
+            endpoint_access: if is_local {
+                ProviderEndpointAccess::PrivateNetwork
+            } else {
+                ProviderEndpointAccess::PublicOnly
+            },
+            ..Default::default()
+        };
+
+        if is_local {
+            let mut public_config = config.clone();
+            public_config.endpoint_access = ProviderEndpointAccess::PublicOnly;
+            let error = create_provider(public_config)
+                .await
+                .expect_err("Local catalog providers must require explicit private access");
+            assert!(
+                error.to_string().contains("private or reserved"),
+                "Local catalog provider '{name}' returned an unexpected error: {error}"
+            );
+        }
+
+        let provider = create_provider(config)
+            .await
+            .unwrap_or_else(|error| panic!("Catalog provider '{name}' should work: {error}"));
+        assert!(matches!(&provider, Provider::OpenAILike(_)));
+        assert_eq!(provider.capabilities(), definition.capabilities);
+    }
+}

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -1,6 +1,6 @@
 use super::create_provider;
 use crate::config::models::provider::ProviderConfig;
-use crate::core::net::ProviderEndpointAccess::{PrivateNetwork, PublicOnly};
+use crate::core::net::ProviderEndpointAccess::PrivateNetwork;
 use crate::core::providers::{Provider, ProviderType};
 #[cfg(not(feature = "providers-extra"))]
 #[tokio::test]
@@ -68,35 +68,35 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
     let result = create_provider(config).await;
     let error = result.expect_err("must reject before construction");
     assert!(error.to_string().contains("not policy-wired"));
-    assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
-            .await
-            .is_err(),
-        "unwired endpoint gate must not connect to the listener"
-    );
+    let accepted =
+        tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept()).await;
+    assert!(accepted.is_err(), "unwired endpoint gate must not connect");
 }
 #[tokio::test]
-async fn catalog_local_providers_require_explicit_private_access() {
-    for (name, definition) in super::provider_registry::PROVIDER_CATALOG.iter() {
-        let is_local = definition.base_url.contains("localhost");
-        let config = ProviderConfig {
-            name: (*name).to_string(),
-            provider_type: (*name).to_string(),
-            api_key: "test-key".into(),
-            endpoint_access: if is_local { PrivateNetwork } else { PublicOnly },
-            ..Default::default()
-        };
-        let mut opposite = config.clone();
-        opposite.endpoint_access = if is_local { PublicOnly } else { PrivateNetwork };
-        if is_local {
-            assert!(create_provider(opposite).await.is_err());
-        } else {
-            assert!(crate::config::Validate::validate(&opposite).is_err());
-        }
-        assert!(crate::config::Validate::validate(&config).is_ok());
-        let provider = create_provider(config)
+async fn invalid_or_implicit_private_endpoints_fail_closed() {
+    let mut gateway = ProviderConfig {
+        name: "openai-test".into(),
+        provider_type: "openai".into(),
+        api_key: "sk-test".into(),
+        ..Default::default()
+    };
+    gateway.settings.insert("api_base".into(), 42.into());
+    let error = crate::config::Validate::validate(&gateway).expect_err("must reject");
+    assert!(error.contains("must be a string"), "{error}");
+    let result = create_provider(gateway.clone()).await;
+    let error = result.expect_err("must reject");
+    assert!(error.to_string().contains("must be a string"), "{error}");
+    gateway.settings.clear();
+    gateway.endpoint_access = PrivateNetwork;
+    let error = create_provider(gateway).await.expect_err("must reject");
+    assert!(error.to_string().contains("requires a base URL"), "{error}");
+    for config in [
+        serde_json::json!({"api_key": "sk-test", "api_base": 42}),
+        serde_json::json!({"api_key": "sk-test", "endpoint_access": "private_network"}),
+    ] {
+        let error = Provider::from_config_async(ProviderType::OpenAI, config)
             .await
-            .unwrap_or_else(|error| panic!("Catalog provider '{name}' should work: {error}"));
-        assert_eq!(provider.capabilities(), definition.capabilities);
+            .expect_err("must reject");
+        assert!(error.to_string().contains("endpoint"), "{error}");
     }
 }

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -43,16 +43,18 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
             base_url: Some("https://x.test".to_string()),
             ..Default::default()
         };
-        let result = create_provider(gateway_config.clone()).await;
-        let error = result.expect_err("must reject");
+        let error = create_provider(gateway_config.clone())
+            .await
+            .expect_err("must reject");
         assert!(error.to_string().contains("not policy-wired"));
         for key in ["base_url", "api_base"] {
             let mut settings_config = gateway_config.clone();
             settings_config.base_url = None;
             let settings = &mut settings_config.settings;
             settings.insert(key.into(), "https://x.test".into());
-            let result = create_provider(settings_config).await;
-            let error = result.expect_err("must reject");
+            let error = create_provider(settings_config)
+                .await
+                .expect_err("must reject");
             assert!(error.to_string().contains("not policy-wired"));
         }
     }
@@ -65,8 +67,9 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
         base_url: Some(format!("http://localhost:{port}")),
         ..Default::default()
     };
-    let result = create_provider(config).await;
-    let error = result.expect_err("must reject before construction");
+    let error = create_provider(config)
+        .await
+        .expect_err("must reject before construction");
     assert!(error.to_string().contains("not policy-wired"));
     let accepted =
         tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept()).await;
@@ -83,15 +86,20 @@ async fn invalid_or_implicit_private_endpoints_fail_closed() {
     gateway.settings.insert("api_base".into(), 42.into());
     let error = crate::config::Validate::validate(&gateway).expect_err("must reject");
     assert!(error.contains("must be a string"), "{error}");
-    let result = create_provider(gateway.clone()).await;
-    let error = result.expect_err("must reject");
+    let error = create_provider(gateway.clone())
+        .await
+        .expect_err("must reject");
     assert!(error.to_string().contains("must be a string"), "{error}");
+    gateway.settings.insert("api_base".into(), " ".into());
+    assert!(crate::config::Validate::validate(&gateway).is_err());
+    assert!(create_provider(gateway.clone()).await.is_err());
     gateway.settings.clear();
     gateway.endpoint_access = PrivateNetwork;
     let error = create_provider(gateway).await.expect_err("must reject");
     assert!(error.to_string().contains("requires a base URL"), "{error}");
     for config in [
         serde_json::json!({"api_key": "sk-test", "api_base": 42}),
+        serde_json::json!({"api_key": "sk-test", "api_base": " "}),
         serde_json::json!({"api_key": "sk-test", "endpoint_access": "private_network"}),
     ] {
         let error = Provider::from_config_async(ProviderType::OpenAI, config)

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -3,12 +3,6 @@ use crate::config::models::provider::ProviderConfig;
 use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::{Provider, ProviderType};
 use tokio::net::TcpListener;
-fn openai_like_access(provider: Provider) -> ProviderEndpointAccess {
-    let Provider::OpenAILike(provider) = provider else {
-        panic!("expected OpenAILike provider")
-    };
-    provider.config().base.endpoint_access
-}
 #[cfg(not(feature = "providers-extra"))]
 #[tokio::test]
 async fn azure_fallbacks_propagate_private_endpoint_access() {
@@ -23,48 +17,13 @@ async fn azure_fallbacks_propagate_private_endpoint_access() {
         )
         .await
         .unwrap_or_else(|error| panic!("Azure fallback must propagate access: {error}"));
+        let Provider::OpenAILike(provider) = provider else {
+            panic!("Azure fallback should use OpenAILike")
+        };
         assert_eq!(
-            openai_like_access(provider),
+            provider.config().base.endpoint_access,
             ProviderEndpointAccess::PrivateNetwork
         );
-    }
-}
-#[tokio::test]
-async fn gateway_and_direct_registry_activate_wired_endpoint_access() {
-    let mut config = ProviderConfig {
-        name: "test-openai-like".to_string(),
-        provider_type: "openai_compatible".to_string(),
-        ..Default::default()
-    };
-    config
-        .settings
-        .insert("skip_api_key".to_string(), serde_json::json!(true));
-    for (explicit, base_url, expected) in [
-        (
-            "public_only",
-            "https://example.test/v1",
-            ProviderEndpointAccess::PublicOnly,
-        ),
-        (
-            "private_network",
-            "http://127.0.0.1/v1",
-            ProviderEndpointAccess::PrivateNetwork,
-        ),
-    ] {
-        config.endpoint_access = expected;
-        config.base_url = Some(base_url.to_string());
-        let gateway = create_provider(config.clone())
-            .await
-            .unwrap_or_else(|error| panic!("Gateway access should activate: {error}"));
-        assert_eq!(openai_like_access(gateway), expected);
-        let direct = Provider::from_config_async(
-            ProviderType::OpenAICompatible,
-            serde_json::json!({"endpoint_access": explicit, "base_url": base_url,
-                "skip_api_key": true}),
-        )
-        .await
-        .unwrap_or_else(|error| panic!("wired direct config should activate: {error}"));
-        assert_eq!(openai_like_access(direct), expected);
     }
 }
 #[tokio::test]
@@ -157,6 +116,10 @@ async fn catalog_local_providers_require_explicit_private_access() {
             let mut public_config = config.clone();
             public_config.endpoint_access = ProviderEndpointAccess::PublicOnly;
             assert!(create_provider(public_config).await.is_err());
+        } else {
+            let mut private_config = config.clone();
+            private_config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+            assert!(crate::config::Validate::validate(&private_config).is_err());
         }
         assert!(crate::config::Validate::validate(&config).is_ok());
         let provider = create_provider(config)

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -3,72 +3,70 @@ use crate::config::models::provider::ProviderConfig;
 use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::{Provider, ProviderType};
 use tokio::net::TcpListener;
-
+fn openai_like_access(provider: Provider) -> ProviderEndpointAccess {
+    let Provider::OpenAILike(provider) = provider else {
+        panic!("expected OpenAILike provider")
+    };
+    provider.config().base.endpoint_access
+}
+#[cfg(not(feature = "providers-extra"))]
+#[tokio::test]
+async fn azure_fallbacks_propagate_private_endpoint_access() {
+    for (provider_type, base_url) in [
+        (ProviderType::Azure, "http://127.0.0.1/openai/deployments/x"),
+        (ProviderType::AzureAI, "http://127.0.0.1/models"),
+    ] {
+        let provider = Provider::from_config_async(
+            provider_type,
+            serde_json::json!({"api_key": "x", "base_url": base_url,
+                "endpoint_access": "private_network"}),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("Azure fallback must propagate access: {error}"));
+        assert_eq!(
+            openai_like_access(provider),
+            ProviderEndpointAccess::PrivateNetwork
+        );
+    }
+}
 #[tokio::test]
 async fn gateway_and_direct_registry_activate_wired_endpoint_access() {
     let mut config = ProviderConfig {
         name: "test-openai-like".to_string(),
         provider_type: "openai_compatible".to_string(),
-        base_url: Some("https://api.example.com/v1".to_string()),
         ..Default::default()
     };
     config
         .settings
         .insert("skip_api_key".to_string(), serde_json::json!(true));
-
-    let provider = create_provider(config.clone())
-        .await
-        .unwrap_or_else(|error| panic!("public-only Gateway config should work: {error}"));
-    let Provider::OpenAILike(provider) = provider else {
-        panic!("expected OpenAILike provider");
-    };
-    assert_eq!(
-        provider.config().base.endpoint_access,
-        ProviderEndpointAccess::PublicOnly
-    );
-
-    config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-    config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
-    let provider = create_provider(config)
-        .await
-        .unwrap_or_else(|error| panic!("private Gateway access should activate: {error}"));
-    let Provider::OpenAILike(provider) = provider else {
-        panic!("expected OpenAILike provider");
-    };
-    assert_eq!(
-        provider.config().base.endpoint_access,
-        ProviderEndpointAccess::PrivateNetwork
-    );
-
     for (explicit, base_url, expected) in [
         (
             "public_only",
-            "https://api.example.test/v1",
+            "https://example.test/v1",
             ProviderEndpointAccess::PublicOnly,
         ),
         (
             "private_network",
-            "http://127.0.0.1:18081/v1",
+            "http://127.0.0.1/v1",
             ProviderEndpointAccess::PrivateNetwork,
         ),
     ] {
-        let provider = Provider::from_config_async(
+        config.endpoint_access = expected;
+        config.base_url = Some(base_url.to_string());
+        let gateway = create_provider(config.clone())
+            .await
+            .unwrap_or_else(|error| panic!("Gateway access should activate: {error}"));
+        assert_eq!(openai_like_access(gateway), expected);
+        let direct = Provider::from_config_async(
             ProviderType::OpenAICompatible,
-            serde_json::json!({
-                "endpoint_access": explicit,
-                "base_url": base_url,
-                "skip_api_key": true
-            }),
+            serde_json::json!({"endpoint_access": explicit, "base_url": base_url,
+                "skip_api_key": true}),
         )
         .await
         .unwrap_or_else(|error| panic!("wired direct config should activate: {error}"));
-        let Provider::OpenAILike(provider) = provider else {
-            panic!("expected OpenAILike provider");
-        };
-        assert_eq!(provider.config().base.endpoint_access, expected);
+        assert_eq!(openai_like_access(direct), expected);
     }
 }
-
 #[tokio::test]
 async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
     for (provider_type, selector) in [
@@ -87,7 +85,6 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
                 .expect_err("unwired direct endpoint config must fail closed");
             assert!(error.to_string().contains("not policy-wired"));
         }
-
         let gateway_config = ProviderConfig {
             name: format!("unwired-{selector}"),
             provider_type: selector.to_string(),
@@ -111,7 +108,6 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
             assert!(error.to_string().contains("not policy-wired"));
         }
     }
-
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .expect("listener must bind");
@@ -124,7 +120,6 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
         )),
         ..Default::default()
     };
-
     let error = create_provider(config)
         .await
         .expect_err("unwired hostname endpoint must fail closed before construction");
@@ -136,7 +131,6 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
         "unwired endpoint gate must not connect to the listener"
     );
 }
-
 #[tokio::test]
 async fn catalog_local_providers_require_explicit_private_access() {
     for (name, definition) in super::provider_registry::PROVIDER_CATALOG.iter() {
@@ -159,13 +153,11 @@ async fn catalog_local_providers_require_explicit_private_access() {
             },
             ..Default::default()
         };
-
         if is_local {
             let mut public_config = config.clone();
             public_config.endpoint_access = ProviderEndpointAccess::PublicOnly;
             assert!(create_provider(public_config).await.is_err());
         }
-
         assert!(crate::config::Validate::validate(&config).is_ok());
         let provider = create_provider(config)
             .await

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -2,6 +2,7 @@ use super::create_provider;
 use crate::config::models::provider::ProviderConfig;
 use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::{Provider, ProviderType};
+use tokio::net::TcpListener;
 
 #[tokio::test]
 async fn gateway_and_direct_registry_activate_wired_endpoint_access() {
@@ -86,14 +87,61 @@ async fn endpoint_access_alias_and_unwired_direct_provider_fail_closed() {
         .unwrap_or_else(|| panic!("settings must not override endpoint access"));
     assert!(error.to_string().contains("top-level"));
 
-    let error = Provider::from_config_async(
-        ProviderType::Cloudflare,
-        serde_json::json!({"endpoint_access": "public_only"}),
-    )
-    .await
-    .err()
-    .unwrap_or_else(|| panic!("unwired direct config must fail closed"));
+    for (provider_type, selector) in [
+        (ProviderType::Cloudflare, "cloudflare"),
+        (ProviderType::FalAI, "fal_ai"),
+        (ProviderType::Replicate, "replicate"),
+        (ProviderType::GitHubCopilot, "github_copilot"),
+    ] {
+        for direct_config in [
+            serde_json::json!({"endpoint_access": "public_only"}),
+            serde_json::json!({"base_url": "https://unwired.example.test"}),
+            serde_json::json!({"api_base": "https://unwired.example.test"}),
+        ] {
+            let error = Provider::from_config_async(provider_type.clone(), direct_config)
+                .await
+                .expect_err("unwired direct endpoint config must fail closed");
+            assert!(error.to_string().contains("not policy-wired"));
+        }
+
+        let gateway_config = ProviderConfig {
+            name: format!("unwired-{selector}"),
+            provider_type: selector.to_string(),
+            base_url: Some("https://unwired.example.test".to_string()),
+            ..Default::default()
+        };
+        let error = create_provider(gateway_config)
+            .await
+            .expect_err("unwired Gateway endpoint config must fail closed");
+        assert!(error.to_string().contains("not policy-wired"));
+    }
+}
+
+#[tokio::test]
+async fn unwired_hostname_endpoint_is_rejected_without_connecting() {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("loopback listener must bind");
+    let config = ProviderConfig {
+        name: "unwired-cloudflare".to_string(),
+        provider_type: "cloudflare".to_string(),
+        base_url: Some(format!(
+            "http://localhost:{}",
+            listener.local_addr().unwrap().port()
+        )),
+        ..Default::default()
+    };
+
+    let error = create_provider(config)
+        .await
+        .expect_err("unwired hostname endpoint must fail closed before construction");
     assert!(error.to_string().contains("not policy-wired"));
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
+            .await
+            .is_err(),
+        "unwired endpoint gate must not connect to the listener"
+    );
 }
 
 #[tokio::test]

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -70,23 +70,7 @@ async fn gateway_and_direct_registry_activate_wired_endpoint_access() {
 }
 
 #[tokio::test]
-async fn endpoint_access_alias_and_unwired_direct_provider_fail_closed() {
-    let mut settings_override = ProviderConfig {
-        name: "openai".to_string(),
-        provider_type: "openai".to_string(),
-        api_key: "sk-test".to_string(),
-        ..Default::default()
-    };
-    settings_override.settings.insert(
-        "endpoint_access".to_string(),
-        serde_json::json!("private_network"),
-    );
-    let error = create_provider(settings_override)
-        .await
-        .err()
-        .unwrap_or_else(|| panic!("settings must not override endpoint access"));
-    assert!(error.to_string().contains("top-level"));
-
+async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
     for (provider_type, selector) in [
         (ProviderType::Cloudflare, "cloudflare"),
         (ProviderType::FalAI, "fal_ai"),
@@ -110,18 +94,27 @@ async fn endpoint_access_alias_and_unwired_direct_provider_fail_closed() {
             base_url: Some("https://unwired.example.test".to_string()),
             ..Default::default()
         };
-        let error = create_provider(gateway_config)
+        let error = create_provider(gateway_config.clone())
             .await
             .expect_err("unwired Gateway endpoint config must fail closed");
         assert!(error.to_string().contains("not policy-wired"));
+        for key in ["base_url", "api_base"] {
+            let mut settings_config = gateway_config.clone();
+            settings_config.base_url = None;
+            settings_config.settings.insert(
+                key.to_string(),
+                serde_json::json!("https://unwired.example.test"),
+            );
+            let error = create_provider(settings_config)
+                .await
+                .expect_err("unwired Gateway settings endpoint must fail closed");
+            assert!(error.to_string().contains("not policy-wired"));
+        }
     }
-}
 
-#[tokio::test]
-async fn unwired_hostname_endpoint_is_rejected_without_connecting() {
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
-        .expect("loopback listener must bind");
+        .expect("listener must bind");
     let config = ProviderConfig {
         name: "unwired-cloudflare".to_string(),
         provider_type: "cloudflare".to_string(),
@@ -170,19 +163,13 @@ async fn catalog_local_providers_require_explicit_private_access() {
         if is_local {
             let mut public_config = config.clone();
             public_config.endpoint_access = ProviderEndpointAccess::PublicOnly;
-            let error = create_provider(public_config)
-                .await
-                .expect_err("Local catalog providers must require explicit private access");
-            assert!(
-                error.to_string().contains("private or reserved"),
-                "Local catalog provider '{name}' returned an unexpected error: {error}"
-            );
+            assert!(create_provider(public_config).await.is_err());
         }
 
+        assert!(crate::config::Validate::validate(&config).is_ok());
         let provider = create_provider(config)
             .await
             .unwrap_or_else(|error| panic!("Catalog provider '{name}' should work: {error}"));
-        assert!(matches!(&provider, Provider::OpenAILike(_)));
         assert_eq!(provider.capabilities(), definition.capabilities);
     }
 }

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -1,8 +1,7 @@
 use super::create_provider;
 use crate::config::models::provider::ProviderConfig;
-use crate::core::net::ProviderEndpointAccess;
+use crate::core::net::ProviderEndpointAccess::{PrivateNetwork, PublicOnly};
 use crate::core::providers::{Provider, ProviderType};
-use tokio::net::TcpListener;
 #[cfg(not(feature = "providers-extra"))]
 #[tokio::test]
 async fn azure_fallbacks_propagate_private_endpoint_access() {
@@ -17,13 +16,8 @@ async fn azure_fallbacks_propagate_private_endpoint_access() {
         )
         .await
         .unwrap_or_else(|error| panic!("Azure fallback must propagate access: {error}"));
-        let Provider::OpenAILike(provider) = provider else {
-            panic!("Azure fallback should use OpenAILike")
-        };
-        assert_eq!(
-            provider.config().base.endpoint_access,
-            ProviderEndpointAccess::PrivateNetwork
-        );
+        assert!(matches!(provider, Provider::OpenAILike(provider)
+            if provider.config().base.endpoint_access == PrivateNetwork));
     }
 }
 #[tokio::test]
@@ -36,52 +30,43 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
     ] {
         for direct_config in [
             serde_json::json!({"endpoint_access": "public_only"}),
-            serde_json::json!({"base_url": "https://unwired.example.test"}),
-            serde_json::json!({"api_base": "https://unwired.example.test"}),
+            serde_json::json!({"base_url": "https://x.test"}),
+            serde_json::json!({"api_base": "https://x.test"}),
         ] {
             let error = Provider::from_config_async(provider_type.clone(), direct_config)
                 .await
-                .expect_err("unwired direct endpoint config must fail closed");
+                .expect_err("must reject unwired endpoint");
             assert!(error.to_string().contains("not policy-wired"));
         }
         let gateway_config = ProviderConfig {
-            name: format!("unwired-{selector}"),
             provider_type: selector.to_string(),
-            base_url: Some("https://unwired.example.test".to_string()),
+            base_url: Some("https://x.test".to_string()),
             ..Default::default()
         };
-        let error = create_provider(gateway_config.clone())
-            .await
-            .expect_err("unwired Gateway endpoint config must fail closed");
+        let result = create_provider(gateway_config.clone()).await;
+        let error = result.expect_err("must reject");
         assert!(error.to_string().contains("not policy-wired"));
         for key in ["base_url", "api_base"] {
             let mut settings_config = gateway_config.clone();
             settings_config.base_url = None;
-            settings_config.settings.insert(
-                key.to_string(),
-                serde_json::json!("https://unwired.example.test"),
-            );
-            let error = create_provider(settings_config)
-                .await
-                .expect_err("unwired Gateway settings endpoint must fail closed");
+            let settings = &mut settings_config.settings;
+            settings.insert(key.into(), "https://x.test".into());
+            let result = create_provider(settings_config).await;
+            let error = result.expect_err("must reject");
             assert!(error.to_string().contains("not policy-wired"));
         }
     }
-    let listener = TcpListener::bind(("127.0.0.1", 0))
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await
         .expect("listener must bind");
+    let port = listener.local_addr().unwrap().port();
     let config = ProviderConfig {
-        name: "unwired-cloudflare".to_string(),
         provider_type: "cloudflare".to_string(),
-        base_url: Some(format!(
-            "http://localhost:{}",
-            listener.local_addr().unwrap().port()
-        )),
+        base_url: Some(format!("http://localhost:{port}")),
         ..Default::default()
     };
-    let error = create_provider(config)
-        .await
-        .expect_err("unwired hostname endpoint must fail closed before construction");
+    let result = create_provider(config).await;
+    let error = result.expect_err("must reject before construction");
     assert!(error.to_string().contains("not policy-wired"));
     assert!(
         tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
@@ -93,33 +78,20 @@ async fn unwired_gateway_and_direct_endpoint_config_fail_closed() {
 #[tokio::test]
 async fn catalog_local_providers_require_explicit_private_access() {
     for (name, definition) in super::provider_registry::PROVIDER_CATALOG.iter() {
-        let is_local = url::Url::parse(definition.base_url)
-            .ok()
-            .and_then(|url| url.host_str().map(str::to_owned))
-            .is_some_and(|host| host == "localhost");
+        let is_local = definition.base_url.contains("localhost");
         let config = ProviderConfig {
             name: (*name).to_string(),
             provider_type: (*name).to_string(),
-            api_key: if definition.skip_api_key {
-                String::new()
-            } else {
-                "test-key".to_string()
-            },
-            endpoint_access: if is_local {
-                ProviderEndpointAccess::PrivateNetwork
-            } else {
-                ProviderEndpointAccess::PublicOnly
-            },
+            api_key: "test-key".into(),
+            endpoint_access: if is_local { PrivateNetwork } else { PublicOnly },
             ..Default::default()
         };
+        let mut opposite = config.clone();
+        opposite.endpoint_access = if is_local { PublicOnly } else { PrivateNetwork };
         if is_local {
-            let mut public_config = config.clone();
-            public_config.endpoint_access = ProviderEndpointAccess::PublicOnly;
-            assert!(create_provider(public_config).await.is_err());
+            assert!(create_provider(opposite).await.is_err());
         } else {
-            let mut private_config = config.clone();
-            private_config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-            assert!(crate::config::Validate::validate(&private_config).is_err());
+            assert!(crate::config::Validate::validate(&opposite).is_err());
         }
         assert!(crate::config::Validate::validate(&config).is_ok());
         let provider = create_provider(config)

--- a/src/core/providers/factory/endpoint_policy.rs
+++ b/src/core/providers/factory/endpoint_policy.rs
@@ -1,0 +1,73 @@
+use super::{builder, catalog_definition_for_supported_selector, provider_diagnostic_name};
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::providers::{ProviderType, registry as provider_registry};
+
+pub(super) fn provider_type_supports(provider_type: &ProviderType) -> bool {
+    use ProviderType::*;
+    match provider_type {
+        OpenAI | OpenAICompatible | Anthropic | Mistral | Cohere | Azure | AzureAI | Bedrock
+        | VertexAI | Gemini => true,
+        Cloudflare | FalAI | Replicate | GitHubCopilot => false,
+        _ => provider_registry::catalog_definition_for_provider_type(provider_type).is_some(),
+    }
+}
+
+pub(crate) fn selector_supports_endpoint_access(selector: &str) -> bool {
+    catalog_definition_for_supported_selector(selector).is_some()
+        || selector
+            .parse::<ProviderType>()
+            .is_ok_and(|provider_type| provider_type_supports(&provider_type))
+}
+
+pub(crate) fn selector_allows_implicit_private(selector: &str) -> bool {
+    selector
+        .parse::<ProviderType>()
+        .is_ok_and(|provider_type| matches!(provider_type, ProviderType::Bedrock))
+        || catalog_definition_for_supported_selector(selector)
+            .and_then(|definition| url::Url::parse(definition.base_url).ok())
+            .is_some_and(|url| url.host_str() == Some("localhost"))
+}
+
+pub(crate) fn invalid_endpoint(value: Option<&serde_json::Value>) -> bool {
+    value.is_some_and(|value| !value.is_null() && !value.is_string())
+}
+
+pub(super) fn validate_direct_endpoint_policy(
+    provider_type: &ProviderType,
+    config: &serde_json::Value,
+) -> Result<(), ProviderError> {
+    let provider = provider_diagnostic_name(provider_type);
+    let fail = |message| ProviderError::configuration(provider, message);
+    if ["base_url", "api_base"]
+        .into_iter()
+        .any(|key| invalid_endpoint(config.get(key)))
+    {
+        return Err(fail("endpoint must be a string"));
+    }
+    let has_endpoint = ["base_url", "api_base"].into_iter().any(|key| {
+        config
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    });
+    let access = builder::config_endpoint_access(config, provider)?;
+    let selector = provider_type.to_string();
+    if access == ProviderEndpointAccess::PrivateNetwork
+        && !has_endpoint
+        && !selector_allows_implicit_private(&selector)
+    {
+        return Err(fail("private_network endpoint access requires a base URL"));
+    }
+    if !provider_type_supports(provider_type)
+        && (config
+            .get("endpoint_access")
+            .is_some_and(|value| !value.is_null())
+            || has_endpoint)
+    {
+        return Err(fail(
+            "configurable endpoint access is unavailable because this provider runtime is not policy-wired",
+        ));
+    }
+    Ok(())
+}

--- a/src/core/providers/factory/endpoint_policy.rs
+++ b/src/core/providers/factory/endpoint_policy.rs
@@ -1,7 +1,6 @@
 use super::{builder, catalog_definition_for_supported_selector, provider_diagnostic_name};
 use crate::core::net::ProviderEndpointAccess;
-use crate::core::providers::unified_provider::ProviderError;
-use crate::core::providers::{ProviderType, registry as provider_registry};
+use crate::core::providers::{ProviderError, ProviderType, registry as provider_registry};
 
 pub(super) fn provider_type_supports(provider_type: &ProviderType) -> bool {
     use ProviderType::*;
@@ -30,7 +29,27 @@ pub(crate) fn selector_allows_implicit_private(selector: &str) -> bool {
 }
 
 pub(crate) fn invalid_endpoint(value: Option<&serde_json::Value>) -> bool {
-    value.is_some_and(|value| !value.is_null() && !value.is_string())
+    value.is_some_and(|value| {
+        !value.is_null() && value.as_str().is_none_or(|url| url.trim().is_empty())
+    })
+}
+
+fn is_native_default_endpoint(
+    provider_type: &ProviderType,
+    config: &serde_json::Value,
+    access: ProviderEndpointAccess,
+) -> bool {
+    let endpoint = config.get("api_base").and_then(serde_json::Value::as_str);
+    let default = match provider_type {
+        ProviderType::FalAI => "https://fal.run",
+        ProviderType::Replicate => "https://api.replicate.com/v1",
+        _ => return false,
+    };
+    access == ProviderEndpointAccess::PublicOnly
+        && config
+            .get("base_url")
+            .is_none_or(serde_json::Value::is_null)
+        && endpoint == Some(default)
 }
 
 pub(super) fn validate_direct_endpoint_policy(
@@ -64,6 +83,7 @@ pub(super) fn validate_direct_endpoint_policy(
             .get("endpoint_access")
             .is_some_and(|value| !value.is_null())
             || has_endpoint)
+        && !is_native_default_endpoint(provider_type, config, access)
     {
         return Err(fail(
             "configurable endpoint access is unavailable because this provider runtime is not policy-wired",

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -95,6 +95,18 @@ pub(crate) fn selector_allows_implicit_private_endpoint(selector: &str) -> bool 
         .is_some_and(|url| url.host_str() == Some("localhost"))
 }
 
+pub(crate) fn config_has_explicit_endpoint(config: &serde_json::Value) -> bool {
+    let has_url = |key| {
+        config
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    config.get("endpoint_access").is_some_and(|v| !v.is_null())
+        || has_url("base_url")
+        || has_url("api_base")
+}
+
 /// Create a provider from configuration
 ///
 /// This is the main factory function for creating providers
@@ -114,7 +126,7 @@ pub async fn create_provider(
         project,
         timeout,
         max_retries,
-        settings,
+        mut settings,
         models,
         ..
     } = config;
@@ -124,7 +136,12 @@ pub async fn create_provider(
     } else {
         provider_type.as_str()
     };
-    let settings_endpoint = settings.contains_key("base_url") || settings.contains_key("api_base");
+    let settings_endpoint = ["base_url", "api_base"].into_iter().any(|key| {
+        settings
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    });
     if settings.contains_key("endpoint_access") {
         return Err(ProviderError::configuration(
             "provider",
@@ -137,8 +154,19 @@ pub async fn create_provider(
         } else {
             Some(api_key.clone())
         };
-        let mut oai_config =
-            def.to_openai_like_config(effective_key.as_deref(), base_url.as_deref());
+        let settings_base_url = ["base_url", "api_base"]
+            .into_iter()
+            .filter_map(|key| settings.remove(key))
+            .find_map(|value| {
+                value
+                    .as_str()
+                    .filter(|url| !url.trim().is_empty())
+                    .map(str::to_owned)
+            });
+        let mut oai_config = def.to_openai_like_config(
+            effective_key.as_deref(),
+            base_url.as_deref().or(settings_base_url.as_deref()),
+        );
         oai_config.base.endpoint_access = endpoint_access;
         oai_config.base.timeout = timeout;
         oai_config.base.max_retries = max_retries;

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -12,6 +12,8 @@ mod builder;
 mod builder_tests;
 #[cfg(feature = "providers-extended")]
 mod cohere_builder;
+#[cfg(test)]
+mod endpoint_access_tests;
 #[cfg(feature = "providers-extended")]
 mod fal_ai_builder;
 #[cfg(feature = "providers-extended")]
@@ -52,6 +54,36 @@ fn catalog_definition_for_supported_selector(
     }
 }
 
+pub(crate) fn provider_type_supports_endpoint_access(provider_type: &ProviderType) -> bool {
+    match provider_type {
+        ProviderType::OpenAI
+        | ProviderType::OpenAICompatible
+        | ProviderType::Anthropic
+        | ProviderType::Mistral
+        | ProviderType::Cohere
+        | ProviderType::Azure
+        | ProviderType::AzureAI
+        | ProviderType::Bedrock
+        | ProviderType::VertexAI
+        | ProviderType::Gemini => true,
+        ProviderType::Cloudflare
+        | ProviderType::FalAI
+        | ProviderType::Replicate
+        | ProviderType::GitHubCopilot
+        | ProviderType::Custom(_) => false,
+        _ => provider_registry::catalog_definition_for_provider_type(provider_type).is_some(),
+    }
+}
+
+pub(crate) fn is_provider_endpoint_access_supported(selector: &str) -> bool {
+    if catalog_definition_for_supported_selector(selector).is_some() {
+        return true;
+    }
+    selector
+        .parse::<ProviderType>()
+        .is_ok_and(|provider_type| provider_type_supports_endpoint_access(&provider_type))
+}
+
 /// Create a provider from configuration
 ///
 /// This is the main factory function for creating providers
@@ -85,12 +117,6 @@ pub async fn create_provider(
         return Err(ProviderError::configuration(
             "provider",
             "endpoint_access must be configured as a top-level provider field",
-        ));
-    }
-    if endpoint_access == ProviderEndpointAccess::PrivateNetwork {
-        return Err(ProviderError::configuration(
-            "provider",
-            "private_network is staged until all provider routes are policy-wired",
         ));
     }
     if let Some(def) = catalog_definition_for_supported_selector(provider_selector) {
@@ -147,6 +173,14 @@ pub async fn create_provider(
         return Err(ProviderError::not_implemented(
             provider_diagnostic_name(&provider_type_enum),
             format!("Factory for {:?} not yet implemented", provider_type_enum),
+        ));
+    }
+    if endpoint_access == ProviderEndpointAccess::PrivateNetwork
+        && !provider_type_supports_endpoint_access(&provider_type_enum)
+    {
+        return Err(ProviderError::configuration(
+            provider_diagnostic_name(&provider_type_enum),
+            "private_network endpoint access is unavailable because this provider runtime is not policy-wired",
         ));
     }
 
@@ -233,33 +267,6 @@ mod tests {
             "{selector} should remain a pure catalog-only selector for this guard"
         );
         assert!(catalog_definition_for_supported_selector(selector).is_some());
-    }
-
-    #[tokio::test]
-    async fn test_catalog_entries_are_creatable_via_factory() {
-        for (name, def) in provider_registry::PROVIDER_CATALOG.iter() {
-            let config = crate::config::models::provider::ProviderConfig {
-                name: (*name).to_string(),
-                provider_type: (*name).to_string(),
-                api_key: if def.skip_api_key {
-                    String::new()
-                } else {
-                    "test-key".to_string()
-                },
-                ..Default::default()
-            };
-
-            let provider = create_provider(config).await.unwrap_or_else(|e| {
-                panic!("Catalog provider '{}' should be creatable: {}", name, e)
-            });
-
-            assert!(
-                matches!(&provider, Provider::OpenAILike(_)),
-                "Catalog provider '{}' must create OpenAILike variant",
-                name
-            );
-            assert_eq!(provider.capabilities(), def.capabilities);
-        }
     }
 
     #[tokio::test]

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -69,8 +69,7 @@ pub(crate) fn provider_type_supports_endpoint_access(provider_type: &ProviderTyp
         ProviderType::Cloudflare
         | ProviderType::FalAI
         | ProviderType::Replicate
-        | ProviderType::GitHubCopilot
-        | ProviderType::Custom(_) => false,
+        | ProviderType::GitHubCopilot => false,
         _ => provider_registry::catalog_definition_for_provider_type(provider_type).is_some(),
     }
 }
@@ -84,8 +83,16 @@ pub(crate) fn is_provider_endpoint_access_supported(selector: &str) -> bool {
         .is_ok_and(|provider_type| provider_type_supports_endpoint_access(&provider_type))
 }
 
-pub(crate) fn selector_uses_catalog_endpoint(selector: &str) -> bool {
-    catalog_definition_for_supported_selector(selector).is_some()
+pub(crate) fn selector_allows_implicit_private_endpoint(selector: &str) -> bool {
+    if selector
+        .parse::<ProviderType>()
+        .is_ok_and(|provider_type| matches!(provider_type, ProviderType::Bedrock))
+    {
+        return true;
+    }
+    catalog_definition_for_supported_selector(selector)
+        .and_then(|definition| url::Url::parse(definition.base_url).ok())
+        .is_some_and(|url| url.host_str() == Some("localhost"))
 }
 
 /// Create a provider from configuration

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -88,9 +88,10 @@ pub async fn create_provider(
     } else {
         provider_type.as_str()
     };
-    if ["base_url", "api_base"]
-        .into_iter()
-        .any(|key| invalid_endpoint(settings.get(key)))
+    if base_url.as_ref().is_some_and(|url| url.trim().is_empty())
+        || ["base_url", "api_base"]
+            .into_iter()
+            .any(|key| invalid_endpoint(settings.get(key)))
     {
         return Err(ProviderError::configuration(
             "provider",

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -84,6 +84,10 @@ pub(crate) fn is_provider_endpoint_access_supported(selector: &str) -> bool {
         .is_ok_and(|provider_type| provider_type_supports_endpoint_access(&provider_type))
 }
 
+pub(crate) fn selector_uses_catalog_endpoint(selector: &str) -> bool {
+    catalog_definition_for_supported_selector(selector).is_some()
+}
+
 /// Create a provider from configuration
 ///
 /// This is the main factory function for creating providers
@@ -113,6 +117,7 @@ pub async fn create_provider(
     } else {
         provider_type.as_str()
     };
+    let settings_endpoint = settings.contains_key("base_url") || settings.contains_key("api_base");
     if settings.contains_key("endpoint_access") {
         return Err(ProviderError::configuration(
             "provider",
@@ -176,7 +181,9 @@ pub async fn create_provider(
         ));
     }
     if !provider_type_supports_endpoint_access(&provider_type_enum)
-        && (endpoint_access == ProviderEndpointAccess::PrivateNetwork || base_url.is_some())
+        && (endpoint_access == ProviderEndpointAccess::PrivateNetwork
+            || base_url.is_some()
+            || settings_endpoint)
     {
         return Err(ProviderError::configuration(
             provider_diagnostic_name(&provider_type_enum),

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -14,6 +14,7 @@ mod builder_tests;
 mod cohere_builder;
 #[cfg(test)]
 mod endpoint_access_tests;
+mod endpoint_policy;
 #[cfg(feature = "providers-extended")]
 mod fal_ai_builder;
 #[cfg(feature = "providers-extended")]
@@ -23,12 +24,16 @@ mod registry;
 mod replicate_builder;
 mod resolver;
 
+pub(crate) use endpoint_policy::{
+    invalid_endpoint, selector_allows_implicit_private, selector_supports_endpoint_access,
+};
 pub use resolver::is_provider_selector_supported;
 
 use super::provider_type::ProviderType;
 use super::unified_provider::ProviderError;
 use super::{Provider, openai_like, registry as provider_registry};
 use crate::core::net::ProviderEndpointAccess;
+use endpoint_policy::provider_type_supports;
 use tracing::warn;
 
 fn provider_diagnostic_name(provider_type: &ProviderType) -> &'static str {
@@ -52,59 +57,6 @@ fn catalog_definition_for_supported_selector(
         Some(_) => None,
         None => Some(def),
     }
-}
-
-pub(crate) fn provider_type_supports_endpoint_access(provider_type: &ProviderType) -> bool {
-    match provider_type {
-        ProviderType::OpenAI
-        | ProviderType::OpenAICompatible
-        | ProviderType::Anthropic
-        | ProviderType::Mistral
-        | ProviderType::Cohere
-        | ProviderType::Azure
-        | ProviderType::AzureAI
-        | ProviderType::Bedrock
-        | ProviderType::VertexAI
-        | ProviderType::Gemini => true,
-        ProviderType::Cloudflare
-        | ProviderType::FalAI
-        | ProviderType::Replicate
-        | ProviderType::GitHubCopilot => false,
-        _ => provider_registry::catalog_definition_for_provider_type(provider_type).is_some(),
-    }
-}
-
-pub(crate) fn is_provider_endpoint_access_supported(selector: &str) -> bool {
-    if catalog_definition_for_supported_selector(selector).is_some() {
-        return true;
-    }
-    selector
-        .parse::<ProviderType>()
-        .is_ok_and(|provider_type| provider_type_supports_endpoint_access(&provider_type))
-}
-
-pub(crate) fn selector_allows_implicit_private_endpoint(selector: &str) -> bool {
-    if selector
-        .parse::<ProviderType>()
-        .is_ok_and(|provider_type| matches!(provider_type, ProviderType::Bedrock))
-    {
-        return true;
-    }
-    catalog_definition_for_supported_selector(selector)
-        .and_then(|definition| url::Url::parse(definition.base_url).ok())
-        .is_some_and(|url| url.host_str() == Some("localhost"))
-}
-
-pub(crate) fn config_has_explicit_endpoint(config: &serde_json::Value) -> bool {
-    let has_url = |key| {
-        config
-            .get(key)
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
-    };
-    config.get("endpoint_access").is_some_and(|v| !v.is_null())
-        || has_url("base_url")
-        || has_url("api_base")
 }
 
 /// Create a provider from configuration
@@ -136,16 +88,36 @@ pub async fn create_provider(
     } else {
         provider_type.as_str()
     };
+    if ["base_url", "api_base"]
+        .into_iter()
+        .any(|key| invalid_endpoint(settings.get(key)))
+    {
+        return Err(ProviderError::configuration(
+            "provider",
+            "endpoint must be a string",
+        ));
+    }
+    let base_endpoint = base_url.as_deref().filter(|url| !url.trim().is_empty());
     let settings_endpoint = ["base_url", "api_base"].into_iter().any(|key| {
         settings
             .get(key)
             .and_then(Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
     });
+    let has_endpoint = base_endpoint.is_some() || settings_endpoint;
     if settings.contains_key("endpoint_access") {
         return Err(ProviderError::configuration(
             "provider",
             "endpoint_access must be configured as a top-level provider field",
+        ));
+    }
+    if endpoint_access == ProviderEndpointAccess::PrivateNetwork
+        && !has_endpoint
+        && !selector_allows_implicit_private(provider_selector)
+    {
+        return Err(ProviderError::configuration(
+            "provider",
+            "private_network endpoint access requires a base URL",
         ));
     }
     if let Some(def) = catalog_definition_for_supported_selector(provider_selector) {
@@ -165,7 +137,7 @@ pub async fn create_provider(
             });
         let mut oai_config = def.to_openai_like_config(
             effective_key.as_deref(),
-            base_url.as_deref().or(settings_base_url.as_deref()),
+            base_endpoint.or(settings_base_url.as_deref()),
         );
         oai_config.base.endpoint_access = endpoint_access;
         oai_config.base.timeout = timeout;
@@ -209,10 +181,8 @@ pub async fn create_provider(
         .parse::<ProviderType>()
         .map_err(|e| ProviderError::invalid_request("provider_type", e.to_string()))?;
 
-    if !provider_type_supports_endpoint_access(&provider_type_enum)
-        && (endpoint_access == ProviderEndpointAccess::PrivateNetwork
-            || base_url.is_some()
-            || settings_endpoint)
+    if !provider_type_supports(&provider_type_enum)
+        && (endpoint_access == ProviderEndpointAccess::PrivateNetwork || has_endpoint)
     {
         return Err(ProviderError::configuration(
             provider_diagnostic_name(&provider_type_enum),
@@ -284,6 +254,7 @@ pub async fn create_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::net::ProviderEndpointAccess::{PrivateNetwork, PublicOnly};
     use crate::core::providers::registry as provider_registry;
 
     #[test]
@@ -309,6 +280,32 @@ mod tests {
             "{selector} should remain a pure catalog-only selector for this guard"
         );
         assert!(catalog_definition_for_supported_selector(selector).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_catalog_entries_are_creatable_via_factory() {
+        for (name, def) in provider_registry::PROVIDER_CATALOG.iter() {
+            let is_local = def.base_url.contains("localhost");
+            let config = crate::config::models::provider::ProviderConfig {
+                name: (*name).to_string(),
+                provider_type: (*name).to_string(),
+                api_key: "test-key".into(),
+                endpoint_access: if is_local { PrivateNetwork } else { PublicOnly },
+                ..Default::default()
+            };
+            let mut opposite = config.clone();
+            opposite.endpoint_access = if is_local { PublicOnly } else { PrivateNetwork };
+            if is_local {
+                assert!(create_provider(opposite).await.is_err());
+            } else {
+                assert!(crate::config::Validate::validate(&opposite).is_err());
+            }
+            let provider = create_provider(config)
+                .await
+                .unwrap_or_else(|error| panic!("Catalog provider '{name}': {error}"));
+            assert!(matches!(&provider, Provider::OpenAILike(_)));
+            assert_eq!(provider.capabilities(), def.capabilities);
+        }
     }
 
     #[tokio::test]

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -174,12 +174,6 @@ pub async fn create_provider(
         .parse::<ProviderType>()
         .map_err(|e| ProviderError::invalid_request("provider_type", e.to_string()))?;
 
-    if !Provider::factory_supported_provider_types().contains(&provider_type_enum) {
-        return Err(ProviderError::not_implemented(
-            provider_diagnostic_name(&provider_type_enum),
-            format!("Factory for {:?} not yet implemented", provider_type_enum),
-        ));
-    }
     if !provider_type_supports_endpoint_access(&provider_type_enum)
         && (endpoint_access == ProviderEndpointAccess::PrivateNetwork
             || base_url.is_some()
@@ -188,6 +182,12 @@ pub async fn create_provider(
         return Err(ProviderError::configuration(
             provider_diagnostic_name(&provider_type_enum),
             "configurable endpoint access is unavailable because this provider runtime is not policy-wired",
+        ));
+    }
+    if !Provider::factory_supported_provider_types().contains(&provider_type_enum) {
+        return Err(ProviderError::not_implemented(
+            provider_diagnostic_name(&provider_type_enum),
+            format!("Factory for {:?} not yet implemented", provider_type_enum),
         ));
     }
 

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -175,12 +175,12 @@ pub async fn create_provider(
             format!("Factory for {:?} not yet implemented", provider_type_enum),
         ));
     }
-    if endpoint_access == ProviderEndpointAccess::PrivateNetwork
-        && !provider_type_supports_endpoint_access(&provider_type_enum)
+    if !provider_type_supports_endpoint_access(&provider_type_enum)
+        && (endpoint_access == ProviderEndpointAccess::PrivateNetwork || base_url.is_some())
     {
         return Err(ProviderError::configuration(
             provider_diagnostic_name(&provider_type_enum),
-            "private_network endpoint access is unavailable because this provider runtime is not policy-wired",
+            "configurable endpoint access is unavailable because this provider runtime is not policy-wired",
         ));
     }
 
@@ -371,7 +371,6 @@ mod tests {
             name: "fal_ai".to_string(),
             provider_type: "fal_ai".to_string(),
             api_key: "test-fal-ai-key".to_string(),
-            base_url: Some("https://fal.run".to_string()),
             timeout: 30,
             max_retries: 2,
             ..Default::default()
@@ -415,7 +414,6 @@ mod tests {
             name: "replicate".to_string(),
             provider_type: "replicate".to_string(),
             api_key: "test-replicate-token".to_string(),
-            base_url: Some("https://api.replicate.com/v1".to_string()),
             timeout: 30,
             max_retries: 2,
             ..Default::default()

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -50,11 +50,7 @@ impl Provider {
         config: serde_json::Value,
     ) -> Result<Self, ProviderError> {
         if !super::provider_type_supports_endpoint_access(&provider_type)
-            && config
-                .get("endpoint_access")
-                .or_else(|| config.get("base_url"))
-                .or_else(|| config.get("api_base"))
-                .is_some()
+            && super::config_has_explicit_endpoint(&config)
         {
             return Err(ProviderError::configuration(
                 super::provider_diagnostic_name(&provider_type),
@@ -552,7 +548,7 @@ mod tests {
     async fn test_from_config_async_cloudflare_accepts_alias_fields() {
         let config = serde_json::json!({
             "organization": "acct-alias",
-            "api_key": "token-alias"
+            "api_key": "token-alias", "api_base": null
         });
 
         let provider = Provider::from_config_async(ProviderType::Cloudflare, config)

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -273,6 +273,8 @@ impl Provider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "providers-extended")]
+    use crate::core::providers::{fal_ai::FalAIConfig, replicate::ReplicateConfig};
     use provider_registry::{ProviderDispatchKind, provider_type_registry};
 
     fn supported_factory_provider_types() -> Vec<ProviderType> {
@@ -558,7 +560,7 @@ mod tests {
     async fn test_from_config_async_fal_ai_creates_native_image_provider() {
         let provider = Provider::from_config_async(
             ProviderType::FalAI,
-            minimal_dispatch_config_for(&ProviderType::FalAI),
+            serde_json::to_value(FalAIConfig::with_api_key("test-fal-ai-key")).unwrap(),
         )
         .await
         .unwrap_or_else(|err| panic!("fal_ai should create native provider: {err}"));
@@ -578,7 +580,7 @@ mod tests {
     async fn test_from_config_async_replicate_creates_native_prediction_provider() {
         let provider = Provider::from_config_async(
             ProviderType::Replicate,
-            minimal_dispatch_config_for(&ProviderType::Replicate),
+            serde_json::to_value(ReplicateConfig::new("test-replicate-token")).unwrap(),
         )
         .await
         .unwrap_or_else(|err| panic!("replicate should create native provider: {err}"));

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -131,7 +131,8 @@ impl Provider {
                 }
                 #[cfg(not(feature = "providers-extra"))]
                 {
-                    let oai_config = build_azure_ai_openai_like_config_from_factory(&config)?;
+                    let mut oai_config = build_azure_ai_openai_like_config_from_factory(&config)?;
+                    oai_config.base.endpoint_access = config_endpoint_access(&config, "azure_ai")?;
                     let provider = openai_like::OpenAILikeProvider::new(oai_config)
                         .await
                         .map_err(|e| ProviderError::initialization("azure_ai", e.to_string()))?;
@@ -164,7 +165,8 @@ impl Provider {
                 }
                 #[cfg(not(feature = "providers-extra"))]
                 {
-                    let oai_config = build_azure_openai_like_config_from_factory(&config)?;
+                    let mut oai_config = build_azure_openai_like_config_from_factory(&config)?;
+                    oai_config.base.endpoint_access = config_endpoint_access(&config, "azure")?;
                     let provider = openai_like::OpenAILikeProvider::new(oai_config)
                         .await
                         .map_err(|e| ProviderError::initialization("azure", e.to_string()))?;
@@ -279,7 +281,6 @@ impl Provider {
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -49,12 +49,16 @@ impl Provider {
         provider_type: ProviderType,
         config: serde_json::Value,
     ) -> Result<Self, ProviderError> {
-        if config.get("endpoint_access").is_some()
-            && !super::provider_type_supports_endpoint_access(&provider_type)
+        if !super::provider_type_supports_endpoint_access(&provider_type)
+            && config
+                .get("endpoint_access")
+                .or_else(|| config.get("base_url"))
+                .or_else(|| config.get("api_base"))
+                .is_some()
         {
             return Err(ProviderError::configuration(
                 super::provider_diagnostic_name(&provider_type),
-                "endpoint_access is unavailable because this provider runtime is not policy-wired",
+                "configurable endpoint access is unavailable because this provider runtime is not policy-wired",
             ));
         }
         Self::from_gateway_config_async(provider_type, config).await
@@ -326,15 +330,17 @@ mod tests {
                 "enable_caching": false,
                 "debug": true
             }),
+            ProviderType::Cloudflare => serde_json::json!({
+                "organization": "test-account",
+                "api_key": "sk-test-key"
+            }),
             ProviderType::GitHubCopilot => serde_json::json!({
                 "token_dir": "/tmp/litellm-rs-github-copilot-test",
                 "access_token_file": "access-token",
                 "api_key_file": "api-key.json",
-                "api_base": "https://example.test",
                 "timeout": 30,
                 "max_retries": 2,
-                "disable_system_to_assistant": true,
-                "debug": true
+                "disable_system_to_assistant": true
             }),
             ProviderType::Cohere => serde_json::json!({
                 "api_key": "test-cohere-key",
@@ -346,7 +352,6 @@ mod tests {
             }),
             ProviderType::FalAI => serde_json::json!({
                 "api_key": "test-fal-ai-key",
-                "api_base": "https://fal.run",
                 "timeout": 30,
                 "max_retries": 2,
                 "output_format": "png",
@@ -354,7 +359,6 @@ mod tests {
             }),
             ProviderType::Replicate => serde_json::json!({
                 "api_key": "test-replicate-token",
-                "api_base": "https://api.replicate.com/v1",
                 "timeout": 30,
                 "max_retries": 2,
                 "polling_delay_seconds": 1,

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -49,10 +49,12 @@ impl Provider {
         provider_type: ProviderType,
         config: serde_json::Value,
     ) -> Result<Self, ProviderError> {
-        if config.get("endpoint_access").is_some() {
+        if config.get("endpoint_access").is_some()
+            && !super::provider_type_supports_endpoint_access(&provider_type)
+        {
             return Err(ProviderError::configuration(
                 super::provider_diagnostic_name(&provider_type),
-                "endpoint_access is staged until provider routes are policy-wired",
+                "endpoint_access is unavailable because this provider runtime is not policy-wired",
             ));
         }
         Self::from_gateway_config_async(provider_type, config).await

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -49,14 +49,7 @@ impl Provider {
         provider_type: ProviderType,
         config: serde_json::Value,
     ) -> Result<Self, ProviderError> {
-        if !super::provider_type_supports_endpoint_access(&provider_type)
-            && super::config_has_explicit_endpoint(&config)
-        {
-            return Err(ProviderError::configuration(
-                super::provider_diagnostic_name(&provider_type),
-                "configurable endpoint access is unavailable because this provider runtime is not policy-wired",
-            ));
-        }
+        super::endpoint_policy::validate_direct_endpoint_policy(&provider_type, &config)?;
         Self::from_gateway_config_async(provider_type, config).await
     }
 
@@ -548,7 +541,8 @@ mod tests {
     async fn test_from_config_async_cloudflare_accepts_alias_fields() {
         let config = serde_json::json!({
             "organization": "acct-alias",
-            "api_key": "token-alias", "api_base": null
+            "api_key": "token-alias",
+            "api_base": null
         });
 
         let provider = Provider::from_config_async(ProviderType::Cloudflare, config)

--- a/src/core/providers/openai/api_methods.rs
+++ b/src/core/providers/openai/api_methods.rs
@@ -350,24 +350,10 @@ mod tests {
         config.base.api_key = Some("sk-test".to_string());
         config.base.api_base = Some(format!("http://{address}"));
         config.base.endpoint_access = ProviderEndpointAccess::PublicOnly;
-        let provider = OpenAIProvider::new(config)
+        let error = OpenAIProvider::new(config)
             .await
-            .expect("provider construction should stay lazy for multipart");
-
-        let result = provider
-            .audio_transcription(TranscriptionRequest {
-                file: b"audio".to_vec(),
-                filename: "audio.mp3".to_string(),
-                model: "whisper-1".to_string(),
-                language: None,
-                prompt: None,
-                response_format: Some("json".to_string()),
-                temperature: None,
-                timestamp_granularities: None,
-            })
-            .await;
-
-        assert!(result.is_err());
+            .expect_err("public-only loopback must fail during provider construction");
+        assert!(error.to_string().contains("private or reserved"));
         assert!(
             tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
                 .await

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -13,8 +13,7 @@ use crate::core::audio::types::{
     TranslationResponse,
 };
 use crate::core::providers::base::{
-    GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
-    read_streaming_error_body, send_streaming_request, streaming_unbounded_client,
+    GlobalPoolManager, HeaderPair, HttpMethod, header, header_owned, read_streaming_error_body,
 };
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
@@ -86,13 +85,10 @@ impl OpenAIProvider {
         // Note: Headers are now built per-request in get_request_headers()
         // This avoids redundant HashMap allocation during initialization.
 
-        let pool_manager =
-            Arc::new(
-                GlobalPoolManager::new().map_err(|e| ProviderError::Network {
-                    provider: "openai",
-                    message: e.to_string(),
-                })?,
-            );
+        let pool_manager = Arc::new(GlobalPoolManager::new_for_provider(
+            "openai",
+            config.base.clone(),
+        )?);
         let model_registry = get_openai_registry();
 
         Ok(Self {
@@ -167,14 +163,10 @@ impl OpenAIProvider {
         // Execute streaming request without a total response-lifetime timeout.
         let url = format!("{}/chat/completions", self.config.get_api_base());
         let headers = self.get_request_headers();
-        let req = apply_headers(
-            streaming_unbounded_client()
-                .post(&url)
-                .json(&openai_request),
-            headers,
-        );
-
-        let response = send_streaming_request(req, "openai").await?;
+        let response = self
+            .pool_manager
+            .execute_streaming_request(&url, headers, openai_request, "openai")
+            .await?;
         let status = response.status();
         if !status.is_success() {
             let body = read_streaming_error_body(response)
@@ -474,14 +466,11 @@ impl LLMProvider for OpenAIProvider {
 
     async fn health_check(&self) -> HealthStatus {
         let url = format!("{}/models?limit=1", self.config.get_api_base());
-        let client = crate::core::http::outbound::default_outbound_client().clone();
-        let mut req = client.get(&url);
-
-        if let Some(api_key) = &self.config.base.api_key {
-            req = req.header("Authorization", format!("Bearer {}", api_key));
-        }
-
-        match req.send().await {
+        match self
+            .pool_manager
+            .execute_request(&url, HttpMethod::GET, self.get_request_headers(), None)
+            .await
+        {
             Ok(response) if response.status().is_success() => HealthStatus::Healthy,
             _ => HealthStatus::Unhealthy,
         }

--- a/src/core/providers/openai/config.rs
+++ b/src/core/providers/openai/config.rs
@@ -240,6 +240,7 @@ pub(crate) fn test_openai_config(
     let mut config = OpenAIConfig::default();
     config.base.api_base = Some(api_base.into());
     config.base.api_key = Some(api_key.into());
+    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
     config
 }
 

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -113,24 +113,16 @@ async fn test_openai_streaming_maps_non_success_status_before_sse()
 }
 
 #[tokio::test]
-async fn openai_private_health_uses_policy_bound_runtime_client()
--> Result<(), Box<dyn std::error::Error>> {
-    let api_base = response_url("200 OK", "{}").await?;
-    let config = test_openai_config(api_base, "sk-test-health");
-    let provider = OpenAIProvider::new(config).await?;
-
-    let health = LLMProvider::health_check(&provider).await;
-    assert_eq!(health, HealthStatus::Healthy);
-    Ok(())
-}
-
-#[tokio::test]
 async fn openai_policy_pool_rejects_cross_authority_without_connect()
 -> Result<(), Box<dyn std::error::Error>> {
-    let source = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let api_base = response_url("200 OK", "{}").await?;
+    let health_provider = OpenAIProvider::new(test_openai_config(api_base, "sk-health")).await?;
+    assert_eq!(
+        LLMProvider::health_check(&health_provider).await,
+        HealthStatus::Healthy
+    );
     let target = TcpListener::bind(("127.0.0.1", 0)).await?;
-    let source_url = format!("http://{}", source.local_addr()?);
-    let config = test_openai_config(source_url, "sk-test-authority");
+    let config = test_openai_config("http://127.0.0.1:1", "sk-test-authority");
     let provider = OpenAIProvider::new(config).await?;
     let target_url = format!("http://{}/models", target.local_addr()?);
 
@@ -150,14 +142,10 @@ async fn openai_policy_pool_rejects_cross_authority_without_connect()
     let accepted =
         tokio::time::timeout(std::time::Duration::from_millis(100), target.accept()).await;
     assert!(accepted.is_err());
-    Ok(())
-}
-
-#[tokio::test]
-async fn openai_private_metadata_endpoint_is_permanently_rejected() {
     let config = test_openai_config("http://169.254.169.254/v1", "sk-test-metadata");
     let error = OpenAIProvider::new(config)
         .await
         .expect_err("metadata endpoints must remain forbidden");
     assert!(error.to_string().contains("private or reserved"));
+    Ok(())
 }

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -1,6 +1,5 @@
 use super::OpenAIProvider;
 use super::config::test_openai_config;
-use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::base::HttpMethod;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
@@ -120,10 +119,8 @@ async fn openai_private_health_uses_policy_bound_runtime_client()
     let config = test_openai_config(api_base, "sk-test-health");
     let provider = OpenAIProvider::new(config).await?;
 
-    assert_eq!(
-        LLMProvider::health_check(&provider).await,
-        HealthStatus::Healthy
-    );
+    let health = LLMProvider::health_check(&provider).await;
+    assert_eq!(health, HealthStatus::Healthy);
     Ok(())
 }
 
@@ -132,10 +129,8 @@ async fn openai_policy_pool_rejects_cross_authority_without_connect()
 -> Result<(), Box<dyn std::error::Error>> {
     let source = TcpListener::bind(("127.0.0.1", 0)).await?;
     let target = TcpListener::bind(("127.0.0.1", 0)).await?;
-    let config = test_openai_config(
-        format!("http://{}", source.local_addr()?),
-        "sk-test-authority",
-    );
+    let source_url = format!("http://{}", source.local_addr()?);
+    let config = test_openai_config(source_url, "sk-test-authority");
     let provider = OpenAIProvider::new(config).await?;
     let target_url = format!("http://{}/models", target.local_addr()?);
 
@@ -145,31 +140,22 @@ async fn openai_policy_pool_rejects_cross_authority_without_connect()
         .await
         .expect_err("cross-authority request must fail closed");
     assert!(error.to_string().contains("authority"));
+    let body = serde_json::json!({"stream": true});
     let streaming_error = provider
         .pool_manager
-        .execute_streaming_request(
-            &target_url,
-            Vec::new(),
-            serde_json::json!({"stream": true}),
-            "openai",
-        )
+        .execute_streaming_request(&target_url, Vec::new(), body, "openai")
         .await
         .expect_err("streaming cross-authority request must fail closed");
     assert!(streaming_error.to_string().contains("authority"));
-    assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(100), target.accept())
-            .await
-            .is_err(),
-        "cross-authority request must not reach the listener"
-    );
+    let accepted =
+        tokio::time::timeout(std::time::Duration::from_millis(100), target.accept()).await;
+    assert!(accepted.is_err());
     Ok(())
 }
 
 #[tokio::test]
 async fn openai_private_metadata_endpoint_is_permanently_rejected() {
-    let mut config = test_openai_config("http://169.254.169.254/v1", "sk-test-metadata");
-    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-
+    let config = test_openai_config("http://169.254.169.254/v1", "sk-test-metadata");
     let error = OpenAIProvider::new(config)
         .await
         .expect_err("metadata endpoints must remain forbidden");

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -1,9 +1,12 @@
 use super::OpenAIProvider;
 use super::config::test_openai_config;
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::base::HttpMethod;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::chat::{ChatMessage, ChatRequest};
 use crate::core::types::context::RequestContext;
+use crate::core::types::health::HealthStatus;
 use crate::core::types::message::{MessageContent, MessageRole};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -108,4 +111,67 @@ async fn test_openai_streaming_maps_non_success_status_before_sse()
     }
 
     Ok(())
+}
+
+#[tokio::test]
+async fn openai_private_health_uses_policy_bound_runtime_client()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api_base = response_url("200 OK", "{}").await?;
+    let config = test_openai_config(api_base, "sk-test-health");
+    let provider = OpenAIProvider::new(config).await?;
+
+    assert_eq!(
+        LLMProvider::health_check(&provider).await,
+        HealthStatus::Healthy
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_policy_pool_rejects_cross_authority_without_connect()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let target = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let config = test_openai_config(
+        format!("http://{}", source.local_addr()?),
+        "sk-test-authority",
+    );
+    let provider = OpenAIProvider::new(config).await?;
+    let target_url = format!("http://{}/models", target.local_addr()?);
+
+    let error = provider
+        .pool_manager
+        .execute_request(&target_url, HttpMethod::GET, Vec::new(), None)
+        .await
+        .expect_err("cross-authority request must fail closed");
+    assert!(error.to_string().contains("authority"));
+    let streaming_error = provider
+        .pool_manager
+        .execute_streaming_request(
+            &target_url,
+            Vec::new(),
+            serde_json::json!({"stream": true}),
+            "openai",
+        )
+        .await
+        .expect_err("streaming cross-authority request must fail closed");
+    assert!(streaming_error.to_string().contains("authority"));
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), target.accept())
+            .await
+            .is_err(),
+        "cross-authority request must not reach the listener"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_private_metadata_endpoint_is_permanently_rejected() {
+    let mut config = test_openai_config("http://169.254.169.254/v1", "sk-test-metadata");
+    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+
+    let error = OpenAIProvider::new(config)
+        .await
+        .expect_err("metadata endpoints must remain forbidden");
+    assert!(error.to_string().contains("private or reserved"));
 }

--- a/src/core/providers/openai_like/config.rs
+++ b/src/core/providers/openai_like/config.rs
@@ -242,7 +242,9 @@ impl ProviderConfig for OpenAILikeConfig {
 
 #[cfg(test)]
 pub(crate) fn test_openai_like_config(api_base: impl Into<String>) -> OpenAILikeConfig {
-    OpenAILikeConfig::new(api_base).with_skip_api_key(true)
+    let mut config = OpenAILikeConfig::new(api_base).with_skip_api_key(true);
+    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+    config
 }
 
 #[cfg(test)]

--- a/src/core/providers/openai_like/config.rs
+++ b/src/core/providers/openai_like/config.rs
@@ -242,9 +242,7 @@ impl ProviderConfig for OpenAILikeConfig {
 
 #[cfg(test)]
 pub(crate) fn test_openai_like_config(api_base: impl Into<String>) -> OpenAILikeConfig {
-    let mut config = OpenAILikeConfig::new(api_base).with_skip_api_key(true);
-    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-    config
+    OpenAILikeConfig::new(api_base).with_skip_api_key(true)
 }
 
 #[cfg(test)]

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -607,6 +607,7 @@ impl LLMProvider for OpenAILikeProvider {
     }
 
     async fn health_check(&self) -> HealthStatus {
+        // Try to connect to the API base via pool_manager's client
         let url = format!("{}/models", self.config.get_api_base());
         match self
             .pool_manager

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -215,10 +215,12 @@ impl OpenAILikeProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let body = response
-                .text()
-                .await
-                .map_err(|error| OpenAILikeError::network(PROVIDER_NAME, error.to_string()))?;
+            let body = response.text().await.map_err(|error| {
+                self.map_error_response(
+                    status.as_u16(),
+                    &format!("failed to read upstream error body: {error}"),
+                )
+            })?;
             return Err(self.map_error_response(status.as_u16(), &body));
         }
 

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -9,8 +9,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::core::providers::base::{
-    GlobalPoolManager, HeaderPair, HttpMethod, apply_headers, header, header_owned,
-    read_streaming_error_body, send_streaming_request, streaming_unbounded_client,
+    GlobalPoolManager, HeaderPair, HttpMethod, header, header_owned, read_streaming_error_body,
 };
 use crate::core::providers::openai::{OpenAIResponseTransformer, models::OpenAIChatResponse};
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
@@ -104,8 +103,8 @@ impl OpenAILikeProvider {
         Self::validate_capability_profile(capabilities, allowed_capabilities)?;
 
         let pool_manager = Arc::new(
-            GlobalPoolManager::new()
-                .map_err(|e| OpenAILikeError::network(PROVIDER_NAME, e.to_string()))?,
+            GlobalPoolManager::new_for_provider(PROVIDER_NAME, config.base.clone())
+                .map_err(|e| OpenAILikeError::configuration(PROVIDER_NAME, e.to_string()))?,
         );
         let model_registry = get_openai_like_registry();
         let provider_name = config.provider_name.clone();
@@ -216,7 +215,10 @@ impl OpenAILikeProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = response
+                .text()
+                .await
+                .map_err(|error| OpenAILikeError::network(PROVIDER_NAME, error.to_string()))?;
             return Err(self.map_error_response(status.as_u16(), &body));
         }
 
@@ -244,14 +246,10 @@ impl OpenAILikeProvider {
 
         let url = format!("{}/chat/completions", self.config.get_api_base());
         let headers = self.get_request_headers();
-        let req = apply_headers(
-            streaming_unbounded_client()
-                .post(&url)
-                .json(&openai_request),
-            headers,
-        );
-
-        let response = send_streaming_request(req, PROVIDER_NAME).await?;
+        let response = self
+            .pool_manager
+            .execute_streaming_request(&url, headers, openai_request, PROVIDER_NAME)
+            .await?;
 
         let status = response.status();
         if !status.is_success() {
@@ -607,13 +605,12 @@ impl LLMProvider for OpenAILikeProvider {
     }
 
     async fn health_check(&self) -> HealthStatus {
-        // Try to connect to the API base via pool_manager's client
         let url = format!("{}/models", self.config.get_api_base());
-        let client = self.pool_manager.client();
-        let headers = self.get_request_headers();
-        let req = apply_headers(client.get(&url), headers);
-
-        match req.send().await {
+        match self
+            .pool_manager
+            .execute_request(&url, HttpMethod::GET, self.get_request_headers(), None)
+            .await
+        {
             Ok(response) if response.status().is_success() => HealthStatus::Healthy,
             Ok(_) => HealthStatus::Degraded,
             Err(_) => HealthStatus::Unhealthy,

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::core::types::chat::ChatMessage;
 use crate::core::types::context::RequestContext;
+use crate::core::types::health::HealthStatus;
 use crate::core::types::message::{MessageContent, MessageRole};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -176,6 +177,60 @@ async fn test_openai_like_streaming_maps_non_success_status_before_sse()
     }
 
     Ok(())
+}
+
+#[tokio::test]
+async fn openai_like_private_health_uses_policy_bound_runtime_client()
+-> Result<(), Box<dyn std::error::Error>> {
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    let api_base = openai_like_stream_response_url("200 OK", "{}").await?;
+    let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
+    let provider = OpenAILikeProvider::new(config).await?;
+
+    assert_eq!(
+        LLMProvider::health_check(&provider).await,
+        HealthStatus::Healthy
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_like_policy_pool_rejects_cross_authority_without_connect()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let target = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let config = crate::core::providers::openai_like::config::test_openai_like_config(format!(
+        "http://{}",
+        source.local_addr()?
+    ));
+    let provider = OpenAILikeProvider::new(config).await?;
+    let target_url = format!("http://{}/models", target.local_addr()?);
+
+    let error = provider
+        .pool_manager
+        .execute_request(&target_url, HttpMethod::GET, Vec::new(), None)
+        .await
+        .expect_err("cross-authority request must fail closed");
+    assert!(error.to_string().contains("authority"));
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), target.accept())
+            .await
+            .is_err(),
+        "cross-authority request must not reach the listener"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_like_private_metadata_endpoint_is_permanently_rejected() {
+    let mut config = OpenAILikeConfig::new("http://169.254.169.254/v1").with_skip_api_key(true);
+    config.base.endpoint_access = crate::core::net::ProviderEndpointAccess::PrivateNetwork;
+
+    let error = OpenAILikeProvider::new(config)
+        .await
+        .expect_err("metadata endpoints must remain forbidden");
+    assert!(error.to_string().contains("private or reserved"));
 }
 
 #[tokio::test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -190,25 +190,18 @@ async fn test_openai_like_streaming_maps_non_success_status_before_sse()
 }
 
 #[tokio::test]
-async fn openai_like_private_health_uses_policy_bound_runtime_client()
+async fn openai_like_policy_pool_rejects_cross_authority_without_connect()
 -> Result<(), Box<dyn std::error::Error>> {
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
     let api_base = openai_like_stream_response_url("200 OK", "{}", true).await?;
-    let config = private_openai_like_config(api_base);
-    let provider = OpenAILikeProvider::new(config).await?;
-
-    let health = LLMProvider::health_check(&provider).await;
-    assert_eq!(health, HealthStatus::Healthy);
-    Ok(())
-}
-
-#[tokio::test]
-async fn openai_like_policy_pool_rejects_cross_authority_without_connect()
--> Result<(), Box<dyn std::error::Error>> {
-    let source = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let health_provider = OpenAILikeProvider::new(private_openai_like_config(api_base)).await?;
+    assert_eq!(
+        LLMProvider::health_check(&health_provider).await,
+        HealthStatus::Healthy
+    );
     let target = TcpListener::bind(("127.0.0.1", 0)).await?;
-    let config = private_openai_like_config(format!("http://{}", source.local_addr()?));
+    let config = private_openai_like_config("http://127.0.0.1:1");
     let provider = OpenAILikeProvider::new(config).await?;
     let target_url = format!("http://{}/models", target.local_addr()?);
 
@@ -221,16 +214,12 @@ async fn openai_like_policy_pool_rejects_cross_authority_without_connect()
     let accepted =
         tokio::time::timeout(std::time::Duration::from_millis(100), target.accept()).await;
     assert!(accepted.is_err());
-    Ok(())
-}
-
-#[tokio::test]
-async fn openai_like_private_metadata_endpoint_is_permanently_rejected() {
     let config = private_openai_like_config("http://169.254.169.254/v1");
     let error = OpenAILikeProvider::new(config)
         .await
         .expect_err("metadata endpoints must remain forbidden");
     assert!(error.to_string().contains("private or reserved"));
+    Ok(())
 }
 
 #[tokio::test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -8,6 +8,12 @@ use tokio::net::{TcpListener, TcpStream};
 
 const TEST_PUBLIC_API_BASE: &str = "https://api.example.com/v1";
 
+fn private_openai_like_config(api_base: impl Into<String>) -> OpenAILikeConfig {
+    let mut config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
+    config.base.endpoint_access = crate::core::net::ProviderEndpointAccess::PrivateNetwork;
+    config
+}
+
 async fn read_full_http_request(socket: &mut TcpStream) -> std::io::Result<()> {
     let mut request_bytes = Vec::new();
     let mut buffer = [0_u8; 1024];
@@ -154,7 +160,7 @@ async fn test_openai_like_streaming_maps_non_success_status_before_sse()
 
     let body = r#"{"error":{"type":"rate_limit_error","message":"slow down","retry_after":5}}"#;
     let api_base = openai_like_stream_response_url("429 Too Many Requests", body, true).await?;
-    let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
+    let config = private_openai_like_config(api_base);
     let provider = OpenAILikeProvider::new(config).await?;
 
     let err = match LLMProvider::chat_completion_stream(
@@ -189,13 +195,11 @@ async fn openai_like_private_health_uses_policy_bound_runtime_client()
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
     let api_base = openai_like_stream_response_url("200 OK", "{}", true).await?;
-    let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
+    let config = private_openai_like_config(api_base);
     let provider = OpenAILikeProvider::new(config).await?;
 
-    assert_eq!(
-        LLMProvider::health_check(&provider).await,
-        HealthStatus::Healthy
-    );
+    let health = LLMProvider::health_check(&provider).await;
+    assert_eq!(health, HealthStatus::Healthy);
     Ok(())
 }
 
@@ -204,10 +208,7 @@ async fn openai_like_policy_pool_rejects_cross_authority_without_connect()
 -> Result<(), Box<dyn std::error::Error>> {
     let source = TcpListener::bind(("127.0.0.1", 0)).await?;
     let target = TcpListener::bind(("127.0.0.1", 0)).await?;
-    let config = crate::core::providers::openai_like::config::test_openai_like_config(format!(
-        "http://{}",
-        source.local_addr()?
-    ));
+    let config = private_openai_like_config(format!("http://{}", source.local_addr()?));
     let provider = OpenAILikeProvider::new(config).await?;
     let target_url = format!("http://{}/models", target.local_addr()?);
 
@@ -217,20 +218,15 @@ async fn openai_like_policy_pool_rejects_cross_authority_without_connect()
         .await
         .expect_err("cross-authority request must fail closed");
     assert!(error.to_string().contains("authority"));
-    assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(100), target.accept())
-            .await
-            .is_err(),
-        "cross-authority request must not reach the listener"
-    );
+    let accepted =
+        tokio::time::timeout(std::time::Duration::from_millis(100), target.accept()).await;
+    assert!(accepted.is_err());
     Ok(())
 }
 
 #[tokio::test]
 async fn openai_like_private_metadata_endpoint_is_permanently_rejected() {
-    let mut config = OpenAILikeConfig::new("http://169.254.169.254/v1").with_skip_api_key(true);
-    config.base.endpoint_access = crate::core::net::ProviderEndpointAccess::PrivateNetwork;
-
+    let config = private_openai_like_config("http://169.254.169.254/v1");
     let error = OpenAILikeProvider::new(config)
         .await
         .expect_err("metadata endpoints must remain forbidden");
@@ -241,7 +237,7 @@ async fn openai_like_private_metadata_endpoint_is_permanently_rejected() {
 async fn ordinary_error_body_failure_preserves_http_status()
 -> Result<(), Box<dyn std::error::Error>> {
     let api_base = openai_like_stream_response_url("401 Unauthorized", "{}", false).await?;
-    let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
+    let config = private_openai_like_config(api_base);
     let provider = OpenAILikeProvider::new(config).await?;
 
     let error = provider

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -38,12 +38,16 @@ async fn read_full_http_request(socket: &mut TcpStream) -> std::io::Result<()> {
     }
 }
 
-async fn openai_like_stream_response_url(status: &str, body: &str) -> std::io::Result<String> {
+async fn openai_like_stream_response_url(
+    status: &str,
+    body: &str,
+    complete: bool,
+) -> std::io::Result<String> {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
     let addr = listener.local_addr()?;
     let response = format!(
         "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
+        body.len() + usize::from(!complete)
     );
 
     tokio::spawn(async move {
@@ -149,7 +153,7 @@ async fn test_openai_like_streaming_maps_non_success_status_before_sse()
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
     let body = r#"{"error":{"type":"rate_limit_error","message":"slow down","retry_after":5}}"#;
-    let api_base = openai_like_stream_response_url("429 Too Many Requests", body).await?;
+    let api_base = openai_like_stream_response_url("429 Too Many Requests", body, true).await?;
     let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
     let provider = OpenAILikeProvider::new(config).await?;
 
@@ -184,7 +188,7 @@ async fn openai_like_private_health_uses_policy_bound_runtime_client()
 -> Result<(), Box<dyn std::error::Error>> {
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
-    let api_base = openai_like_stream_response_url("200 OK", "{}").await?;
+    let api_base = openai_like_stream_response_url("200 OK", "{}", true).await?;
     let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
     let provider = OpenAILikeProvider::new(config).await?;
 
@@ -231,6 +235,21 @@ async fn openai_like_private_metadata_endpoint_is_permanently_rejected() {
         .await
         .expect_err("metadata endpoints must remain forbidden");
     assert!(error.to_string().contains("private or reserved"));
+}
+
+#[tokio::test]
+async fn ordinary_error_body_failure_preserves_http_status()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api_base = openai_like_stream_response_url("401 Unauthorized", "{}", false).await?;
+    let config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
+    let provider = OpenAILikeProvider::new(config).await?;
+
+    let error = provider
+        .execute_chat_completion(openai_like_chat_stream_request())
+        .await
+        .expect_err("truncated 401 body must remain an authentication error");
+    assert!(matches!(error, OpenAILikeError::Authentication { .. }));
+    Ok(())
 }
 
 #[tokio::test]

--- a/tests/common/providers.rs
+++ b/tests/common/providers.rs
@@ -232,13 +232,8 @@ mod tests {
         assert!(config.organization.is_none());
         assert!(config.project.is_none());
         assert!(config.settings.is_empty());
-    }
-
-    #[test]
-    fn loopback_runtime_helpers_opt_in_to_private_policy() {
         let openai = mock_openai_runtime_config("http://127.0.0.1:1234/v1", "sk-test");
         let openai_like = mock_openai_like_runtime_config("http://127.0.0.1:1235/v1");
-        let private = ProviderEndpointAccess::PrivateNetwork;
         assert_eq!(openai.base.endpoint_access, private);
         assert_eq!(openai_like.base.endpoint_access, private);
     }

--- a/tests/common/providers.rs
+++ b/tests/common/providers.rs
@@ -227,10 +227,8 @@ mod tests {
         assert_eq!(config.api_key, "sk-test");
         assert_eq!(config.base_url.as_deref(), Some("http://127.0.0.1:1234/v1"));
         assert_eq!(config.models, vec!["gpt-test"]);
-        assert_eq!(
-            config.endpoint_access,
-            ProviderEndpointAccess::PrivateNetwork
-        );
+        let private = ProviderEndpointAccess::PrivateNetwork;
+        assert_eq!(config.endpoint_access, private);
         assert!(config.organization.is_none());
         assert!(config.project.is_none());
         assert!(config.settings.is_empty());
@@ -240,14 +238,9 @@ mod tests {
     fn loopback_runtime_helpers_opt_in_to_private_policy() {
         let openai = mock_openai_runtime_config("http://127.0.0.1:1234/v1", "sk-test");
         let openai_like = mock_openai_like_runtime_config("http://127.0.0.1:1235/v1");
-        assert_eq!(
-            openai.base.endpoint_access,
-            ProviderEndpointAccess::PrivateNetwork
-        );
-        assert_eq!(
-            openai_like.base.endpoint_access,
-            ProviderEndpointAccess::PrivateNetwork
-        );
+        let private = ProviderEndpointAccess::PrivateNetwork;
+        assert_eq!(openai.base.endpoint_access, private);
+        assert_eq!(openai_like.base.endpoint_access, private);
     }
 
     #[test]

--- a/tests/common/providers.rs
+++ b/tests/common/providers.rs
@@ -23,19 +23,21 @@ pub fn mock_provider_config(
         provider_type: provider_type.to_string(),
         api_key: api_key.to_string(),
         base_url: Some(base_url.to_string()),
+        endpoint_access: ProviderEndpointAccess::PrivateNetwork,
         models,
         ..ProviderConfig::default()
     }
 }
 
-/// Build startup-safe copies for direct-route tests that activate private runtime policy later.
+/// Preserve private test endpoints while staging PublicOnly request-time negative cases.
 pub fn route_policy_bootstrap_providers(providers: &[ProviderConfig]) -> Vec<ProviderConfig> {
     providers
         .iter()
         .cloned()
         .map(|mut provider| {
-            provider.base_url = Some("https://example.com/v1".to_string());
-            provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
+            if provider.endpoint_access == ProviderEndpointAccess::PublicOnly {
+                provider.base_url = Some("https://example.com/v1".to_string());
+            }
             provider
         })
         .collect()
@@ -48,11 +50,14 @@ pub fn mock_openai_runtime_config(
     let mut config = OpenAIConfig::default();
     config.base.api_base = Some(api_base.into());
     config.base.api_key = Some(api_key.into());
+    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
     config
 }
 
 pub fn mock_openai_like_runtime_config(api_base: impl Into<String>) -> OpenAILikeConfig {
-    OpenAILikeConfig::new(api_base).with_skip_api_key(true)
+    let mut config = OpenAILikeConfig::new(api_base).with_skip_api_key(true);
+    config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+    config
 }
 
 /// Configuration for provider tests
@@ -222,9 +227,27 @@ mod tests {
         assert_eq!(config.api_key, "sk-test");
         assert_eq!(config.base_url.as_deref(), Some("http://127.0.0.1:1234/v1"));
         assert_eq!(config.models, vec!["gpt-test"]);
+        assert_eq!(
+            config.endpoint_access,
+            ProviderEndpointAccess::PrivateNetwork
+        );
         assert!(config.organization.is_none());
         assert!(config.project.is_none());
         assert!(config.settings.is_empty());
+    }
+
+    #[test]
+    fn loopback_runtime_helpers_opt_in_to_private_policy() {
+        let openai = mock_openai_runtime_config("http://127.0.0.1:1234/v1", "sk-test");
+        let openai_like = mock_openai_like_runtime_config("http://127.0.0.1:1235/v1");
+        assert_eq!(
+            openai.base.endpoint_access,
+            ProviderEndpointAccess::PrivateNetwork
+        );
+        assert_eq!(
+            openai_like.base.endpoint_access,
+            ProviderEndpointAccess::PrivateNetwork
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- activate provider-bound ordinary, streaming, and health clients for OpenAI and OpenAI-compatible runtimes
- lift endpoint-access staging only for fully policy-wired native and catalog providers while rejecting settings aliases and unwired runtimes
- require explicit private-network access for localhost/self-hosted providers, preserve official public endpoint construction, and fail closed without fallback
- add authority-isolation, metadata, health, factory, config, shared fixture, and source-boundary coverage

## Verification

- cargo test --lib --all-features --locked -- --test-threads=1: 10369 passed, 1 ignored
- cargo check --all-targets --all-features --locked
- CI-equivalent strict Clippy
- six CI feature-matrix cargo checks
- cargo test --all-features --locked -- --test-threads=1
- OpenAI/OpenAI-like ordinary, streaming, health, authority, metadata, config, and factory matrices
- affected route integration matrix
- scope guard: 15 files / 699 changed lines
- overlap guard: no open PR overlap

Partial implementation of SP968-T9R; issue remains open for T11F, T12, and T13.

Refs #968