### PR TITLE
fix(security): close provider endpoint policy gaps

### DIFF
--- a/src/config/models/provider.rs
+++ b/src/config/models/provider.rs
@@ -121,6 +121,22 @@ impl Default for ProviderConfig {
 }
 
 impl ProviderConfig {
+    pub(crate) fn configured_endpoint(&self) -> Option<&str> {
+        self.base_url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+            .or_else(|| {
+                crate::core::providers::factory::endpoint_keys_for_selector(&self.provider_type)
+                    .iter()
+                    .find_map(|key| {
+                        self.settings
+                            .get(*key)
+                            .and_then(serde_json::Value::as_str)
+                            .filter(|url| !url.trim().is_empty())
+                    })
+            })
+    }
+
     /// Resolve a configured custom health endpoint to an absolute URL.
     pub(crate) fn resolved_health_check_endpoint(&self) -> Result<Option<Url>, String> {
         let Some(endpoint) = self.health_check.endpoint.as_deref() else {
@@ -137,9 +153,9 @@ impl ProviderConfig {
         match Url::parse(endpoint) {
             Ok(url) => Ok(Some(url)),
             Err(url::ParseError::RelativeUrlWithoutBase) => {
-                let base_url = self.base_url.as_deref().ok_or_else(|| {
+                let base_url = self.configured_endpoint().ok_or_else(|| {
                     format!(
-                        "Provider {} relative health check endpoint requires base_url",
+                        "Provider {} relative health check endpoint requires a configured endpoint",
                         self.name
                     )
                 })?;

--- a/src/config/models/provider.rs
+++ b/src/config/models/provider.rs
@@ -122,11 +122,16 @@ impl Default for ProviderConfig {
 
 impl ProviderConfig {
     pub(crate) fn configured_endpoint(&self) -> Option<&str> {
+        let provider_selector = if self.provider_type.trim().is_empty() {
+            self.name.as_str()
+        } else {
+            self.provider_type.as_str()
+        };
         self.base_url
             .as_deref()
             .filter(|url| !url.trim().is_empty())
             .or_else(|| {
-                crate::core::providers::factory::endpoint_keys_for_selector(&self.provider_type)
+                crate::core::providers::factory::endpoint_keys_for_selector(provider_selector)
                     .iter()
                     .find_map(|key| {
                         self.settings
@@ -434,6 +439,31 @@ mod tests {
         assert_eq!(config.name, "openai-main");
         assert_eq!(config.provider_type, "openai");
         assert_eq!(config.models.len(), 1);
+    }
+
+    #[test]
+    fn name_only_provider_uses_effective_selector_for_endpoint_aliases() {
+        let mut config = ProviderConfig {
+            name: "azure".to_string(),
+            health_check: ProviderHealthCheckConfig {
+                endpoint: Some("health".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        config.settings.insert(
+            "azure_endpoint".to_string(),
+            "http://127.0.0.1:18080/openai/deployments/test".into(),
+        );
+
+        assert_eq!(
+            config
+                .resolved_health_check_endpoint()
+                .expect("name fallback must resolve relative health endpoint")
+                .expect("health endpoint must be configured")
+                .as_str(),
+            "http://127.0.0.1:18080/openai/deployments/test/health"
+        );
     }
 
     #[test]

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -203,20 +203,11 @@ impl Validate for ProviderConfig {
                 self.name
             ));
         }
-        if self.endpoint_access == ProviderEndpointAccess::PrivateNetwork
-            && provider_selector
-                .parse::<crate::core::providers::ProviderType>()
-                .is_ok_and(|provider_type| {
-                    provider_type == crate::core::providers::ProviderType::OpenAI
-                })
-            && configured_endpoint
-                .is_some_and(crate::core::providers::openai::config::is_official_openai_endpoint)
-        {
-            return Err(format!(
-                "Provider {} cannot grant private_network access to the official OpenAI endpoint",
-                self.name
-            ));
-        }
+        crate::core::providers::factory::validate_private_official_openai_endpoint(
+            self.endpoint_access,
+            configured_endpoint,
+        )
+        .map_err(|message| format!("Provider {} {message}", self.name))?;
 
         let requires_api_key =
             crate::core::providers::registry::get_definition(&provider_selector.to_lowercase())
@@ -556,6 +547,20 @@ mod endpoint_access_tests {
         assert!(error.contains("must be a string"), "azure: {error}");
     }
 
+    #[test]
+    fn provider_selector_normalization_preserves_endpoint_alias_policy() {
+        let mut config = public_provider();
+        config.provider_type = " Azure ".to_string();
+        config.base_url = None;
+        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        config.settings.insert(
+            "azure_endpoint".to_string(),
+            "http://127.0.0.1:18080/openai/deployments/test".into(),
+        );
+
+        assert!(Validate::validate(&config).is_ok());
+    }
+
     #[cfg(feature = "providers-extra")]
     #[test]
     fn vertex_endpoint_alias_is_a_provider_specific_endpoint_source() {
@@ -608,11 +613,26 @@ mod endpoint_access_tests {
 
     #[test]
     fn official_openai_endpoint_cannot_receive_private_access() {
-        let mut config = public_provider();
-        config.provider_type = "openai".to_string();
-        config.base_url = Some("https://api.openai.com/v1".to_string());
-        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
-        let error = Validate::validate(&config).expect_err("official OpenAI must stay public");
-        assert!(error.contains("official OpenAI"), "{error}");
+        for provider_type in ["openai", "openai_compatible"] {
+            for endpoint_key in ["base_url", "api_base"] {
+                let mut config = public_provider();
+                config.provider_type = provider_type.to_string();
+                config.base_url = None;
+                config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+                if endpoint_key == "base_url" {
+                    config.base_url = Some("https://api.openai.com/v1".to_string());
+                } else {
+                    config
+                        .settings
+                        .insert(endpoint_key.to_string(), "https://api.openai.com/v1".into());
+                }
+                let error =
+                    Validate::validate(&config).expect_err("official OpenAI must stay public");
+                assert!(
+                    error.contains("official OpenAI"),
+                    "{provider_type}.{endpoint_key}: {error}"
+                );
+            }
+        }
     }
 }

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -8,9 +8,10 @@ use crate::config::models::gateway::{GatewayConfig, GatewayPricingConfig};
 use crate::config::models::provider::{ProviderConfig, ProviderHealthCheckConfig, RetryConfig};
 use crate::config::models::server::ServerConfig;
 use crate::core::net::{
-    validate_provider_endpoint_url, validate_provider_endpoint_url_without_resolution,
+    ProviderEndpointAccess, ProviderEndpointPolicy, validate_provider_endpoint_url,
+    validate_provider_endpoint_url_without_resolution,
 };
-use crate::core::providers::factory::invalid_endpoint;
+use crate::core::providers::factory::{endpoint_keys_for_selector, invalid_endpoint};
 use std::collections::HashSet;
 use tracing::debug;
 
@@ -171,25 +172,16 @@ impl Validate for ProviderConfig {
             .base_url
             .as_ref()
             .is_some_and(|url| url.trim().is_empty());
+        let endpoint_keys = endpoint_keys_for_selector(provider_selector);
         if blank_base
-            || ["base_url", "api_base"]
-                .into_iter()
+            || endpoint_keys
+                .iter()
+                .copied()
                 .any(|key| invalid_endpoint(self.settings.get(key)))
         {
             return Err(format!("Provider {} endpoint must be a string", self.name));
         }
-        let setting_url = |key| {
-            self.settings
-                .get(key)
-                .and_then(serde_json::Value::as_str)
-                .filter(|url| !url.trim().is_empty())
-        };
-        let configured_endpoint = self
-            .base_url
-            .as_deref()
-            .filter(|url| !url.trim().is_empty())
-            .or_else(|| setting_url("base_url"))
-            .or_else(|| setting_url("api_base"));
+        let configured_endpoint = self.configured_endpoint();
         let has_configured_endpoint = configured_endpoint.is_some();
         if (self.endpoint_access == crate::core::net::ProviderEndpointAccess::PrivateNetwork
             || has_configured_endpoint)
@@ -208,6 +200,20 @@ impl Validate for ProviderConfig {
         {
             return Err(format!(
                 "Provider {} private_network endpoint access requires a base URL",
+                self.name
+            ));
+        }
+        if self.endpoint_access == ProviderEndpointAccess::PrivateNetwork
+            && provider_selector
+                .parse::<crate::core::providers::ProviderType>()
+                .is_ok_and(|provider_type| {
+                    provider_type == crate::core::providers::ProviderType::OpenAI
+                })
+            && configured_endpoint
+                .is_some_and(crate::core::providers::openai::config::is_official_openai_endpoint)
+        {
+            return Err(format!(
+                "Provider {} cannot grant private_network access to the official OpenAI endpoint",
                 self.name
             ));
         }
@@ -305,6 +311,26 @@ impl ProviderConfig {
                     self.name,
                     endpoint.scheme()
                 ));
+            }
+            if self.endpoint_access == ProviderEndpointAccess::PrivateNetwork {
+                let base_url = self.configured_endpoint().ok_or_else(|| {
+                    format!(
+                        "Provider {} private health check requires a configured endpoint",
+                        self.name
+                    )
+                })?;
+                let policy = ProviderEndpointPolicy::for_base_url(self.endpoint_access, base_url)
+                    .map_err(|error| {
+                    format!("Provider {} endpoint policy is invalid: {error}", self.name)
+                })?;
+                policy
+                    .validate_url_without_resolution(&endpoint)
+                    .map_err(|error| {
+                        format!(
+                            "Provider {} health check endpoint is invalid: {error}",
+                            self.name
+                        )
+                    })?;
             }
             validate_provider_endpoint_url(&endpoint, self.endpoint_access).map_err(|error| {
                 format!(
@@ -481,5 +507,112 @@ mod endpoint_access_tests {
             .validate_health_check_runtime()
             .expect_err("health checks must remain limited to HTTP transports");
         assert!(error.contains("http:// or https://"));
+    }
+
+    #[test]
+    fn azure_endpoint_aliases_are_provider_specific_endpoint_sources() {
+        for (provider_type, key, endpoint) in [
+            (
+                "azure",
+                "endpoint",
+                "http://127.0.0.1:18080/openai/deployments/test",
+            ),
+            (
+                "azure",
+                "azure_endpoint",
+                "http://127.0.0.1:18080/openai/deployments/test",
+            ),
+            ("azure_ai", "endpoint", "http://127.0.0.1:18080/models"),
+            (
+                "azure_ai",
+                "azure_ai_endpoint",
+                "http://127.0.0.1:18080/models",
+            ),
+        ] {
+            let mut config = public_provider();
+            config.provider_type = provider_type.to_string();
+            config.base_url = None;
+            config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+            config.settings.insert(key.to_string(), endpoint.into());
+            assert!(Validate::validate(&config).is_ok(), "{provider_type}.{key}");
+        }
+
+        let mut unrelated = public_provider();
+        unrelated.base_url = None;
+        unrelated.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        unrelated
+            .settings
+            .insert("endpoint".to_string(), "http://127.0.0.1:18080/v1".into());
+        let error = Validate::validate(&unrelated).expect_err("OpenAI aliases must stay closed");
+        assert!(error.contains("requires a base URL"), "{error}");
+
+        let mut invalid = public_provider();
+        invalid.provider_type = "azure".to_string();
+        invalid.base_url = None;
+        invalid
+            .settings
+            .insert("azure_endpoint".to_string(), serde_json::json!(42));
+        let error = Validate::validate(&invalid).expect_err("invalid alias must fail");
+        assert!(error.contains("must be a string"), "azure: {error}");
+    }
+
+    #[cfg(feature = "providers-extra")]
+    #[test]
+    fn vertex_endpoint_alias_is_a_provider_specific_endpoint_source() {
+        let mut config = public_provider();
+        config.provider_type = "vertex_ai".to_string();
+        config.base_url = None;
+        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        config
+            .settings
+            .insert("endpoint".to_string(), "http://127.0.0.1:18080/v1".into());
+        assert!(Validate::validate(&config).is_ok());
+
+        for value in [serde_json::json!(42), serde_json::json!(" ")] {
+            config.settings.insert("endpoint".to_string(), value);
+            let error = Validate::validate(&config).expect_err("invalid alias must fail");
+            assert!(error.contains("must be a string"), "{error}");
+        }
+    }
+
+    #[test]
+    fn private_health_check_is_bound_to_the_provider_authority() {
+        let mut config = public_provider();
+        config.base_url = Some("http://127.0.0.1:18080/v1".to_string());
+        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        for endpoint in ["health", "http://127.0.0.1:18080/health"] {
+            config.health_check.endpoint = Some(endpoint.to_string());
+            assert!(config.validate_health_check_runtime().is_ok(), "{endpoint}");
+        }
+        for endpoint in [
+            "http://127.0.0.2:18080/health",
+            "http://127.0.0.1:18081/health",
+            "https://127.0.0.1:18080/health",
+        ] {
+            config.health_check.endpoint = Some(endpoint.to_string());
+            let error = config
+                .validate_health_check_runtime()
+                .expect_err("private health authority must not expand");
+            assert!(error.contains("authority"), "{endpoint}: {error}");
+        }
+
+        config.base_url = None;
+        config.provider_type = "azure".to_string();
+        config.settings.insert(
+            "azure_endpoint".to_string(),
+            "http://127.0.0.1:18080/openai/deployments/test".into(),
+        );
+        config.health_check.endpoint = Some("health".to_string());
+        assert!(config.validate_health_check_runtime().is_ok());
+    }
+
+    #[test]
+    fn official_openai_endpoint_cannot_receive_private_access() {
+        let mut config = public_provider();
+        config.provider_type = "openai".to_string();
+        config.base_url = Some("https://api.openai.com/v1".to_string());
+        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        let error = Validate::validate(&config).expect_err("official OpenAI must stay public");
+        assert!(error.contains("official OpenAI"), "{error}");
     }
 }

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -207,7 +207,12 @@ fn test_provider_health_check_rejects_unsupported_combinations() {
     };
 
     config.health_check.endpoint = Some("/health".to_string());
-    assert!(config.validate().unwrap_err().contains("requires base_url"));
+    assert!(
+        config
+            .validate()
+            .unwrap_err()
+            .contains("requires a configured endpoint")
+    );
 
     config.health_check.endpoint = None;
     config.health_check.expected_codes = vec![204];

--- a/src/core/providers/azure/chat.rs
+++ b/src/core/providers/azure/chat.rs
@@ -6,7 +6,6 @@ use futures::{Stream, StreamExt};
 use reqwest::Method;
 use serde_json::{Value, json};
 use std::pin::Pin;
-use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time::timeout;
 
@@ -26,8 +25,8 @@ use super::config::AzureConfig;
 use super::error::{azure_api_error, azure_config_error};
 use super::utils::{AzureEndpointType, AzureUtils};
 use crate::core::providers::base::{
-    HeaderPair, apply_provider_headers, header, header_owned, header_static,
-    read_streaming_error_body,
+    HeaderPair, STREAMING_HEADER_TIMEOUT_SECS, apply_provider_headers, header, header_owned,
+    header_static, read_streaming_error_body,
 };
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::streaming::utils::is_done_marker;
@@ -172,7 +171,7 @@ impl AzureChatHandler {
 
         // Execute streaming request
         let response = timeout(
-            Duration::from_secs(self.client.get_config().timeout),
+            std::time::Duration::from_secs(STREAMING_HEADER_TIMEOUT_SECS),
             apply_provider_headers(
                 self.client
                     .streaming_request(Method::POST, &url)?
@@ -182,7 +181,7 @@ impl AzureChatHandler {
             .send(),
         )
         .await
-        .map_err(|_| ProviderError::network("azure", "Request timeout"))?
+        .map_err(|_| ProviderError::network("azure", "Streaming response header timeout"))?
         .map_err(|error| ProviderError::network("azure", error.to_string()))?;
 
         // Check status

--- a/src/core/providers/azure/policy_tests.rs
+++ b/src/core/providers/azure/policy_tests.rs
@@ -142,6 +142,45 @@ async fn azure_core_operation_matrix_uses_policy_client() {
     }
 }
 
+#[tokio::test]
+async fn azure_streaming_uses_the_shared_header_timeout() {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("test listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("listener should have an address");
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("request should connect");
+        let mut request = String::new();
+        BufReader::new(&mut socket)
+            .read_line(&mut request)
+            .await
+            .expect("request line should be readable");
+        tokio::time::sleep(Duration::from_millis(1_250)).await;
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .expect("response headers should be writable");
+    });
+    let mut config = private_config(format!("http://{address}"));
+    config.timeout = 1;
+    let chat = AzureChatHandler::new(config).expect("chat should build");
+
+    drop(
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            chat.create_chat_completion_stream(policy_chat_request(), RequestContext::default()),
+        )
+        .await
+        .expect("shared streaming header timeout must exceed the ordinary provider timeout")
+        .expect("delayed response headers must remain valid"),
+    );
+    server.await.expect("server should finish");
+}
+
 fn assert_private_endpoint_rejected<T>(result: Result<T, ProviderError>) {
     let Err(error) = result else {
         panic!("public-only Azure handler accepted a private endpoint");

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -255,29 +255,66 @@ async fn vertex_endpoint_alias_reaches_gateway_and_direct_factories() {
 #[tokio::test]
 async fn official_openai_authority_rejects_private_factory_access() {
     for endpoint in ["https://api.openai.com/v1", "https://api.openai.com./v1"] {
-        let direct = Provider::from_config_async(
-            ProviderType::OpenAI,
-            serde_json::json!({
-                "api_key": "sk-test",
-                "base_url": endpoint,
-                "endpoint_access": "private_network"
-            }),
-        )
-        .await
-        .expect_err("direct official OpenAI endpoint must stay public");
-        assert!(direct.to_string().contains("official OpenAI"), "{direct}");
+        for provider_type in [ProviderType::OpenAI, ProviderType::OpenAICompatible] {
+            for endpoint_key in ["base_url", "api_base"] {
+                let mut direct_config = serde_json::json!({
+                    "api_key": "sk-test",
+                    "endpoint_access": "private_network"
+                });
+                direct_config[endpoint_key] = endpoint.into();
+                let direct = Provider::from_config_async(provider_type.clone(), direct_config)
+                    .await
+                    .expect_err("direct official OpenAI endpoint must stay public");
+                assert!(
+                    direct.to_string().contains("official OpenAI"),
+                    "{provider_type}.{endpoint_key}: {direct}"
+                );
+            }
+        }
 
-        let gateway = ProviderConfig {
-            name: "openai-test".to_string(),
-            provider_type: "openai".to_string(),
-            api_key: "sk-test".to_string(),
-            base_url: Some(endpoint.to_string()),
-            endpoint_access: PrivateNetwork,
-            ..Default::default()
-        };
-        let error = create_provider(gateway)
-            .await
-            .expect_err("gateway official OpenAI endpoint must stay public");
-        assert!(error.to_string().contains("official OpenAI"), "{error}");
+        for provider_type in ["openai", "openai_compatible"] {
+            for endpoint_key in ["base_url", "api_base"] {
+                let mut gateway = ProviderConfig {
+                    name: "openai-test".to_string(),
+                    provider_type: provider_type.to_string(),
+                    api_key: "sk-test".to_string(),
+                    endpoint_access: PrivateNetwork,
+                    ..Default::default()
+                };
+                if endpoint_key == "base_url" {
+                    gateway.base_url = Some(endpoint.to_string());
+                } else {
+                    gateway
+                        .settings
+                        .insert(endpoint_key.to_string(), endpoint.into());
+                }
+                let error = create_provider(gateway)
+                    .await
+                    .expect_err("gateway official OpenAI endpoint must stay public");
+                assert!(
+                    error.to_string().contains("official OpenAI"),
+                    "{provider_type}.{endpoint_key}: {error}"
+                );
+            }
+        }
     }
+}
+
+#[tokio::test]
+async fn gateway_selector_normalization_preserves_endpoint_alias_policy() {
+    let mut config = ProviderConfig {
+        name: "azure-test".to_string(),
+        provider_type: " Azure ".to_string(),
+        api_key: "sk-test".to_string(),
+        endpoint_access: PrivateNetwork,
+        ..Default::default()
+    };
+    config.settings.insert(
+        "azure_endpoint".to_string(),
+        "http://127.0.0.1:18080/openai/deployments/test".into(),
+    );
+
+    create_provider(config)
+        .await
+        .expect("normalized Azure selector must retain its endpoint alias");
 }

--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -108,3 +108,176 @@ async fn invalid_or_implicit_private_endpoints_fail_closed() {
         assert!(error.to_string().contains("endpoint"), "{error}");
     }
 }
+
+#[tokio::test]
+async fn azure_endpoint_aliases_reach_gateway_and_direct_factories() {
+    for (provider_type, selector, key, endpoint) in [
+        (
+            ProviderType::Azure,
+            "azure",
+            "endpoint",
+            "http://127.0.0.1:18080/openai/deployments/test",
+        ),
+        (
+            ProviderType::Azure,
+            "azure",
+            "azure_endpoint",
+            "http://127.0.0.1:18080/openai/deployments/test",
+        ),
+        (
+            ProviderType::AzureAI,
+            "azure_ai",
+            "endpoint",
+            "http://127.0.0.1:18080/models",
+        ),
+        (
+            ProviderType::AzureAI,
+            "azure_ai",
+            "azure_ai_endpoint",
+            "http://127.0.0.1:18080/models",
+        ),
+    ] {
+        let direct = serde_json::json!({
+            "api_key": "test-key",
+            key: endpoint,
+            "endpoint_access": "private_network"
+        });
+        Provider::from_config_async(provider_type, direct)
+            .await
+            .unwrap_or_else(|error| panic!("direct {selector}.{key} failed: {error}"));
+
+        let mut gateway = ProviderConfig {
+            name: format!("{selector}-test"),
+            provider_type: selector.to_string(),
+            api_key: "test-key".to_string(),
+            endpoint_access: PrivateNetwork,
+            ..Default::default()
+        };
+        gateway.settings.insert(key.to_string(), endpoint.into());
+        create_provider(gateway)
+            .await
+            .unwrap_or_else(|error| panic!("gateway {selector}.{key} failed: {error}"));
+    }
+}
+
+#[cfg(feature = "providers-extra")]
+#[tokio::test]
+async fn vertex_endpoint_alias_reaches_gateway_and_direct_factories() {
+    let endpoint = "http://127.0.0.1:18080/v1/projects/test";
+    let direct = serde_json::json!({
+        "project_id": "test-project",
+        "access_token": "test-token",
+        "endpoint": endpoint,
+        "endpoint_access": "private_network"
+    });
+    Provider::from_config_async(ProviderType::VertexAI, direct)
+        .await
+        .unwrap_or_else(|error| panic!("direct vertex_ai.endpoint failed: {error}"));
+
+    let mut gateway = ProviderConfig {
+        name: "vertex-test".to_string(),
+        provider_type: "vertex_ai".to_string(),
+        project: Some("test-project".to_string()),
+        endpoint_access: PrivateNetwork,
+        ..Default::default()
+    };
+    gateway
+        .settings
+        .insert("endpoint".to_string(), endpoint.into());
+    gateway
+        .settings
+        .insert("access_token".to_string(), "test-token".into());
+    create_provider(gateway)
+        .await
+        .unwrap_or_else(|error| panic!("gateway vertex_ai.endpoint failed: {error}"));
+
+    for invalid in [serde_json::json!(42), serde_json::json!(" ")] {
+        let direct = serde_json::json!({
+            "project_id": "test-project",
+            "access_token": "test-token",
+            "endpoint": invalid.clone(),
+            "endpoint_access": "private_network"
+        });
+        let error = Provider::from_config_async(ProviderType::VertexAI, direct)
+            .await
+            .expect_err("invalid direct Vertex endpoint alias must fail");
+        assert!(
+            error.to_string().contains("endpoint must be a string"),
+            "{error}"
+        );
+
+        let mut gateway = ProviderConfig {
+            name: "vertex-invalid".to_string(),
+            provider_type: "vertex_ai".to_string(),
+            project: Some("test-project".to_string()),
+            endpoint_access: PrivateNetwork,
+            ..Default::default()
+        };
+        gateway.settings.insert("endpoint".to_string(), invalid);
+        gateway
+            .settings
+            .insert("access_token".to_string(), "test-token".into());
+        let error = create_provider(gateway)
+            .await
+            .expect_err("invalid gateway Vertex endpoint alias must fail");
+        assert!(
+            error.to_string().contains("endpoint must be a string"),
+            "{error}"
+        );
+    }
+
+    let unrelated = serde_json::json!({
+        "api_key": "sk-test",
+        "endpoint": endpoint,
+        "endpoint_access": "private_network"
+    });
+    let error = Provider::from_config_async(ProviderType::OpenAI, unrelated)
+        .await
+        .expect_err("Vertex endpoint alias must stay provider-specific");
+    assert!(error.to_string().contains("requires a base URL"), "{error}");
+
+    let mut unrelated = ProviderConfig {
+        name: "openai-test".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        endpoint_access: PrivateNetwork,
+        ..Default::default()
+    };
+    unrelated
+        .settings
+        .insert("endpoint".to_string(), endpoint.into());
+    let error = create_provider(unrelated)
+        .await
+        .expect_err("Vertex gateway endpoint alias must stay provider-specific");
+    assert!(error.to_string().contains("requires a base URL"), "{error}");
+}
+
+#[tokio::test]
+async fn official_openai_authority_rejects_private_factory_access() {
+    for endpoint in ["https://api.openai.com/v1", "https://api.openai.com./v1"] {
+        let direct = Provider::from_config_async(
+            ProviderType::OpenAI,
+            serde_json::json!({
+                "api_key": "sk-test",
+                "base_url": endpoint,
+                "endpoint_access": "private_network"
+            }),
+        )
+        .await
+        .expect_err("direct official OpenAI endpoint must stay public");
+        assert!(direct.to_string().contains("official OpenAI"), "{direct}");
+
+        let gateway = ProviderConfig {
+            name: "openai-test".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            base_url: Some(endpoint.to_string()),
+            endpoint_access: PrivateNetwork,
+            ..Default::default()
+        };
+        let error = create_provider(gateway)
+            .await
+            .expect_err("gateway official OpenAI endpoint must stay public");
+        assert!(error.to_string().contains("official OpenAI"), "{error}");
+    }
+}

--- a/src/core/providers/factory/endpoint_policy.rs
+++ b/src/core/providers/factory/endpoint_policy.rs
@@ -28,6 +28,20 @@ pub(crate) fn selector_allows_implicit_private(selector: &str) -> bool {
             .is_some_and(|url| url.host_str() == Some("localhost"))
 }
 
+const STANDARD_ENDPOINT_KEYS: &[&str] = &["base_url", "api_base"];
+const AZURE_ENDPOINT_KEYS: &[&str] = &["base_url", "api_base", "endpoint", "azure_endpoint"];
+const AZURE_AI_ENDPOINT_KEYS: &[&str] = &["base_url", "api_base", "endpoint", "azure_ai_endpoint"];
+const VERTEX_ENDPOINT_KEYS: &[&str] = &["base_url", "api_base", "endpoint"];
+
+pub(crate) fn endpoint_keys_for_selector(selector: &str) -> &'static [&'static str] {
+    match selector.parse::<ProviderType>() {
+        Ok(ProviderType::Azure) => AZURE_ENDPOINT_KEYS,
+        Ok(ProviderType::AzureAI) => AZURE_AI_ENDPOINT_KEYS,
+        Ok(ProviderType::VertexAI) => VERTEX_ENDPOINT_KEYS,
+        _ => STANDARD_ENDPOINT_KEYS,
+    }
+}
+
 pub(crate) fn invalid_endpoint(value: Option<&serde_json::Value>) -> bool {
     value.is_some_and(|value| {
         !value.is_null() && value.as_str().is_none_or(|url| url.trim().is_empty())
@@ -58,13 +72,15 @@ pub(super) fn validate_direct_endpoint_policy(
 ) -> Result<(), ProviderError> {
     let provider = provider_diagnostic_name(provider_type);
     let fail = |message| ProviderError::configuration(provider, message);
-    if ["base_url", "api_base"]
-        .into_iter()
+    let endpoint_keys = endpoint_keys_for_selector(&provider_type.to_string());
+    if endpoint_keys
+        .iter()
+        .copied()
         .any(|key| invalid_endpoint(config.get(key)))
     {
         return Err(fail("endpoint must be a string"));
     }
-    let has_endpoint = ["base_url", "api_base"].into_iter().any(|key| {
+    let has_endpoint = endpoint_keys.iter().copied().any(|key| {
         config
             .get(key)
             .and_then(serde_json::Value::as_str)

--- a/src/core/providers/factory/endpoint_policy.rs
+++ b/src/core/providers/factory/endpoint_policy.rs
@@ -48,6 +48,33 @@ pub(crate) fn invalid_endpoint(value: Option<&serde_json::Value>) -> bool {
     })
 }
 
+pub(crate) fn configured_endpoint_for_keys<'a>(
+    base_endpoint: Option<&'a str>,
+    config: &'a std::collections::HashMap<String, serde_json::Value>,
+    endpoint_keys: &[&str],
+) -> Option<&'a str> {
+    base_endpoint.or_else(|| {
+        endpoint_keys.iter().copied().find_map(|key| {
+            config
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+    })
+}
+
+pub(crate) fn validate_private_official_openai_endpoint(
+    access: ProviderEndpointAccess,
+    endpoint: Option<&str>,
+) -> Result<(), &'static str> {
+    if access == ProviderEndpointAccess::PrivateNetwork
+        && endpoint.is_some_and(crate::core::providers::openai::config::is_official_openai_endpoint)
+    {
+        return Err("private_network access cannot target the official OpenAI endpoint");
+    }
+    Ok(())
+}
+
 fn is_native_default_endpoint(
     provider_type: &ProviderType,
     config: &serde_json::Value,
@@ -80,13 +107,15 @@ pub(super) fn validate_direct_endpoint_policy(
     {
         return Err(fail("endpoint must be a string"));
     }
-    let has_endpoint = endpoint_keys.iter().copied().any(|key| {
+    let configured_endpoint = endpoint_keys.iter().copied().find_map(|key| {
         config
             .get(key)
             .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
+            .filter(|value| !value.trim().is_empty())
     });
+    let has_endpoint = configured_endpoint.is_some();
     let access = builder::config_endpoint_access(config, provider)?;
+    validate_private_official_openai_endpoint(access, configured_endpoint).map_err(fail)?;
     let selector = provider_type.to_string();
     if access == ProviderEndpointAccess::PrivateNetwork
         && !has_endpoint

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -25,7 +25,8 @@ mod replicate_builder;
 mod resolver;
 
 pub(crate) use endpoint_policy::{
-    invalid_endpoint, selector_allows_implicit_private, selector_supports_endpoint_access,
+    endpoint_keys_for_selector, invalid_endpoint, selector_allows_implicit_private,
+    selector_supports_endpoint_access,
 };
 pub use resolver::is_provider_selector_supported;
 
@@ -88,9 +89,11 @@ pub async fn create_provider(
     } else {
         provider_type.as_str()
     };
+    let endpoint_keys = endpoint_keys_for_selector(provider_selector);
     if base_url.as_ref().is_some_and(|url| url.trim().is_empty())
-        || ["base_url", "api_base"]
-            .into_iter()
+        || endpoint_keys
+            .iter()
+            .copied()
             .any(|key| invalid_endpoint(settings.get(key)))
     {
         return Err(ProviderError::configuration(
@@ -99,7 +102,7 @@ pub async fn create_provider(
         ));
     }
     let base_endpoint = base_url.as_deref().filter(|url| !url.trim().is_empty());
-    let settings_endpoint = ["base_url", "api_base"].into_iter().any(|key| {
+    let settings_endpoint = endpoint_keys.iter().copied().any(|key| {
         settings
             .get(key)
             .and_then(Value::as_str)

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -25,8 +25,9 @@ mod replicate_builder;
 mod resolver;
 
 pub(crate) use endpoint_policy::{
-    endpoint_keys_for_selector, invalid_endpoint, selector_allows_implicit_private,
-    selector_supports_endpoint_access,
+    configured_endpoint_for_keys, endpoint_keys_for_selector, invalid_endpoint,
+    selector_allows_implicit_private, selector_supports_endpoint_access,
+    validate_private_official_openai_endpoint,
 };
 pub use resolver::is_provider_selector_supported;
 
@@ -102,13 +103,8 @@ pub async fn create_provider(
         ));
     }
     let base_endpoint = base_url.as_deref().filter(|url| !url.trim().is_empty());
-    let settings_endpoint = endpoint_keys.iter().copied().any(|key| {
-        settings
-            .get(key)
-            .and_then(Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
-    });
-    let has_endpoint = base_endpoint.is_some() || settings_endpoint;
+    let configured_endpoint = configured_endpoint_for_keys(base_endpoint, &settings, endpoint_keys);
+    let has_endpoint = configured_endpoint.is_some();
     if settings.contains_key("endpoint_access") {
         return Err(ProviderError::configuration(
             "provider",
@@ -124,6 +120,8 @@ pub async fn create_provider(
             "private_network endpoint access requires a base URL",
         ));
     }
+    validate_private_official_openai_endpoint(endpoint_access, configured_endpoint)
+        .map_err(|message| ProviderError::configuration("provider", message))?;
     if let Some(def) = catalog_definition_for_supported_selector(provider_selector) {
         let effective_key = if api_key.is_empty() {
             def.resolve_api_key(None)

--- a/src/core/providers/openai/config.rs
+++ b/src/core/providers/openai/config.rs
@@ -67,6 +67,15 @@ fn default_provider_name() -> String {
     "openai".to_string()
 }
 
+pub(crate) fn is_official_openai_endpoint(raw_url: &str) -> bool {
+    url::Url::parse(raw_url).is_ok_and(|url| {
+        url.host_str().is_some_and(|host| {
+            host.trim_end_matches('.')
+                .eq_ignore_ascii_case("api.openai.com")
+        })
+    })
+}
+
 impl Default for OpenAIFeatures {
     fn default() -> Self {
         Self {
@@ -137,6 +146,17 @@ impl OpenAIConfig {
     pub fn validate(&self) -> Result<(), String> {
         // Validate base config
         self.base.validate("openai")?;
+        if self.base.endpoint_access == ProviderEndpointAccess::PrivateNetwork
+            && self
+                .base
+                .api_base
+                .as_deref()
+                .is_some_and(is_official_openai_endpoint)
+        {
+            return Err(
+                "private_network access cannot target the official OpenAI endpoint".to_string(),
+            );
+        }
 
         // OpenAI specific validations
         if let Some(ref api_key) = self.base.api_key
@@ -273,6 +293,24 @@ mod tests {
             serde_json::to_value(config).unwrap()["endpoint_access"],
             "private_network"
         );
+    }
+
+    #[test]
+    fn private_access_rejects_the_official_openai_authority() {
+        let mut config = OpenAIConfig::default();
+        config.base.api_key = Some("sk-test".to_string());
+        config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        let error = config
+            .validate()
+            .expect_err("official OpenAI must stay public");
+        assert!(error.contains("official OpenAI"), "{error}");
+
+        config.base.api_base = Some("http://127.0.0.1:18080/v1".to_string());
+        assert!(config.validate().is_ok());
+
+        config.base.api_base = Some("https://api.openai.com/v1".to_string());
+        config.base.endpoint_access = ProviderEndpointAccess::PublicOnly;
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -334,6 +334,6 @@ mod tests {
             .await
             .expect_err("direct factory must validate disabled providers too");
         assert!(matches!(error, RouterError::InvalidConfiguration(_)));
-        assert!(error.to_string().contains("requires base_url"));
+        assert!(error.to_string().contains("requires a configured endpoint"));
     }
 }


### PR DESCRIPTION
## Summary

- recognize Azure, Azure AI, and Vertex provider-specific endpoint aliases at gateway/direct policy boundaries
- bind private health checks to the configured provider authority and keep the official OpenAI authority public-only
- restore Azure streaming response-header timeout semantics to the shared 600-second policy

## Review-gap mapping

- PR #1001 thread PRRT_kwDOPMtB5s6QfsU-: Azure streaming header timeout now uses the shared policy without timing the response body
- PR #1007 thread PRRT_kwDOPMtB5s6Qnar2: Azure/Azure AI/Vertex endpoint aliases are provider-specific and validated consistently
- PR #1007 thread PRRT_kwDOPMtB5s6Qnar8: private health endpoints require exact normalized authority equality
- PR #1007 thread PRRT_kwDOPMtB5s6Qnar-: official OpenAI endpoints, including trailing-dot variants, cannot receive private access

## Verification

- cargo check --all-targets --all-features --locked
- CI Fast clippy command with the repository feature bundle
- cargo test --lib --locked -- --test-threads=1 (8975 passed, 0 failed)
- cargo test --all-features --locked -- --test-threads=1
- bash scripts/guards/check_outbound_http_clients.sh
- bash scripts/guards/check_pr_scope.sh origin/main
- independent exact-head review: PASS

Refs #968