### PR TITLE
fix(security): reject private access to official OpenAI endpoint

### DIFF
--- a/src/core/providers/factory/endpoint_policy.rs
+++ b/src/core/providers/factory/endpoint_policy.rs
@@ -1,5 +1,6 @@
 use super::{builder, catalog_definition_for_supported_selector, provider_diagnostic_name};
 use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::openai::config::validate_private_official_openai_endpoint;
 use crate::core::providers::{ProviderError, ProviderType, registry as provider_registry};
 
 pub(super) fn provider_type_supports(provider_type: &ProviderType) -> bool {
@@ -61,18 +62,6 @@ pub(crate) fn configured_endpoint_for_keys<'a>(
                 .filter(|value| !value.trim().is_empty())
         })
     })
-}
-
-pub(crate) fn validate_private_official_openai_endpoint(
-    access: ProviderEndpointAccess,
-    endpoint: Option<&str>,
-) -> Result<(), &'static str> {
-    if access == ProviderEndpointAccess::PrivateNetwork
-        && endpoint.is_some_and(crate::core::providers::openai::config::is_official_openai_endpoint)
-    {
-        return Err("private_network access cannot target the official OpenAI endpoint");
-    }
-    Ok(())
 }
 
 fn is_native_default_endpoint(

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -24,10 +24,10 @@ mod registry;
 mod replicate_builder;
 mod resolver;
 
+pub(crate) use super::openai::config::validate_private_official_openai_endpoint;
 pub(crate) use endpoint_policy::{
     configured_endpoint_for_keys, endpoint_keys_for_selector, invalid_endpoint,
     selector_allows_implicit_private, selector_supports_endpoint_access,
-    validate_private_official_openai_endpoint,
 };
 pub use resolver::is_provider_selector_supported;
 

--- a/src/core/providers/openai/config.rs
+++ b/src/core/providers/openai/config.rs
@@ -76,6 +76,18 @@ pub(crate) fn is_official_openai_endpoint(raw_url: &str) -> bool {
     })
 }
 
+pub(crate) fn validate_private_official_openai_endpoint(
+    access: ProviderEndpointAccess,
+    endpoint: Option<&str>,
+) -> Result<(), &'static str> {
+    if access == ProviderEndpointAccess::PrivateNetwork
+        && endpoint.is_some_and(is_official_openai_endpoint)
+    {
+        return Err("private_network access cannot target the official OpenAI endpoint");
+    }
+    Ok(())
+}
+
 impl Default for OpenAIFeatures {
     fn default() -> Self {
         Self {
@@ -146,17 +158,11 @@ impl OpenAIConfig {
     pub fn validate(&self) -> Result<(), String> {
         // Validate base config
         self.base.validate("openai")?;
-        if self.base.endpoint_access == ProviderEndpointAccess::PrivateNetwork
-            && self
-                .base
-                .api_base
-                .as_deref()
-                .is_some_and(is_official_openai_endpoint)
-        {
-            return Err(
-                "private_network access cannot target the official OpenAI endpoint".to_string(),
-            );
-        }
+        validate_private_official_openai_endpoint(
+            self.base.endpoint_access,
+            self.base.api_base.as_deref(),
+        )
+        .map_err(str::to_owned)?;
 
         // OpenAI specific validations
         if let Some(ref api_key) = self.base.api_key

--- a/src/core/providers/openai_like/config.rs
+++ b/src/core/providers/openai_like/config.rs
@@ -174,6 +174,12 @@ impl OpenAILikeConfig {
             return Err("api_base is required for openai_like provider".to_string());
         }
 
+        crate::core::providers::openai::config::validate_private_official_openai_endpoint(
+            self.base.endpoint_access,
+            self.base.api_base.as_deref(),
+        )
+        .map_err(str::to_owned)?;
+
         // API key is required unless skip_api_key is set
         if !self.skip_api_key && self.base.api_key.is_none() {
             return Err(
@@ -318,6 +324,17 @@ mod tests {
     fn test_validation_with_api_key() {
         let config = OpenAILikeConfig::with_api_key("http://localhost:8000/v1", "sk-test123");
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_rejects_private_access_to_official_openai_endpoint() {
+        let mut config = OpenAILikeConfig::new("https://api.openai.com/v1").with_skip_api_key(true);
+        config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+
+        assert_eq!(
+            config.validate(),
+            Err("private_network access cannot target the official OpenAI endpoint".to_string())
+        );
     }
 
     #[test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -94,6 +94,24 @@ async fn test_provider_creation_with_api_base() {
 }
 
 #[tokio::test]
+async fn provider_rejects_private_access_to_official_openai_endpoint() {
+    OpenAILikeProvider::with_api_base("https://api.openai.com/v1")
+        .await
+        .expect("official OpenAI endpoints must remain valid with public-only access");
+
+    let config = private_openai_like_config("https://api.openai.com/v1");
+
+    let error = OpenAILikeProvider::new(config)
+        .await
+        .expect_err("official OpenAI endpoints must remain public-only");
+    assert!(
+        error
+            .to_string()
+            .contains("private_network access cannot target the official OpenAI endpoint")
+    );
+}
+
+#[tokio::test]
 async fn generic_openai_like_declares_only_catalog_executable_capabilities() {
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 


### PR DESCRIPTION
## What

- 将官方 OpenAI endpoint + private_network 的拒绝逻辑收敛到 OpenAI 配置模块的共享校验函数。
- 让 OpenAI、OpenAI-like 和 provider factory 三条公开构造路径复用同一约束。
- 增加 OpenAI-like 直接构造回归测试：public_only 可用，private_network 明确报错。

## Why

PR #1010 的独立审查留下了一个未解决 P1：OpenAILikeConfig::validate 没有执行官方 OpenAI authority 的 private_network 禁止规则。调用方可绕过 factory，直接用公开的 OpenAILikeProvider::new 构造不符合 GH968 B-005/B-011 的策略。

这是一张阻塞 GH968 T13 收尾的最小修复 PR，不在本 PR 内关闭 #968。

Refs #968

- pr_kind: impl
- completion_mode: partial

## Test Plan

- [x] 红/绿回归：修复前 direct OpenAI-like private official endpoint 返回 Ok；修复后返回特定 Err
- [x] cargo check --all-targets --all-features --locked
- [x] cargo clippy --all-targets --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if
- [x] cargo test --all-features --locked -- --test-threads=1（10,388 library tests；integration/doctest 全通过）
- [x] cargo fmt --all -- --check
- [x] bash scripts/guards/check_outbound_http_clients.sh
- [x] 独立 exact-head 安全复核：P0/P1/P2 均无

补充：全 all-features clippy 仍会命中未改动的 src/core/providers/mod.rs 中 Provider large_enum_variant 基线；仓库 CI 使用的 feature bundle strict clippy 已通过。

## Agent disclosure

本 PR 由 Codex 在 implx/SpecRail review 模式下实现并验证；合并前仍需人工授权。