### PR TITLE
fix(bedrock): preserve InvokeAgent compatibility

### DIFF
--- a/src/core/providers/bedrock/agents/mod.rs
+++ b/src/core/providers/bedrock/agents/mod.rs
@@ -68,14 +68,12 @@ pub struct AgentInvocationResult {
 
 impl AgentInvocationResult {
     fn into_legacy_response(self) -> Result<AgentInvocationResponse, ProviderError> {
-        if self.memory_id.is_some()
-            || !self.attributions.is_empty()
-            || self.return_control.is_some()
-            || !self.files.is_empty()
+        if self.completion.text.is_empty()
+            && (self.return_control.is_some() || !self.files.is_empty())
         {
             return Err(ProviderError::response_parsing(
                 "bedrock",
-                "agent response contains extended metadata; use AgentClient::invoke_detailed",
+                "agent response has no text completion; use AgentClient::invoke_detailed",
             ));
         }
         Ok(AgentInvocationResponse {
@@ -248,7 +246,10 @@ impl<'a> AgentClient<'a> {
         Self { client }
     }
 
-    /// Invoke an agent
+    /// Invoke an agent using the legacy response shape.
+    ///
+    /// Successful memory, attribution, return-control, and file metadata is omitted when text is
+    /// available. Use [`Self::invoke_detailed`] to preserve those fields.
     pub async fn invoke(
         &self,
         agent_id: &str,
@@ -353,6 +354,25 @@ mod tests {
         }
     }
 
+    fn exception_message(exception_type: &str, payload: Value) -> EventStreamMessage {
+        EventStreamMessage {
+            headers: vec![
+                super::super::streaming::EventStreamHeader {
+                    name: ":message-type".to_string(),
+                    value: super::super::streaming::HeaderValue::String("exception".to_string()),
+                },
+                super::super::streaming::EventStreamHeader {
+                    name: ":exception-type".to_string(),
+                    value: super::super::streaming::HeaderValue::String(exception_type.to_string()),
+                },
+            ],
+            payload: bytes::Bytes::from(
+                serde_json::to_vec(&payload)
+                    .unwrap_or_else(|error| panic!("exception should serialize: {error}")),
+            ),
+        }
+    }
+
     fn finish(value: AgentResponseAccumulator) -> Result<AgentInvocationResult, ProviderError> {
         value.finish("session-1".to_string(), None)
     }
@@ -384,6 +404,89 @@ mod tests {
         };
 
         assert_eq!(response.completion.text, "hello");
+    }
+
+    #[test]
+    fn legacy_conversion_keeps_successful_text_when_extended_metadata_is_present() {
+        let result = AgentInvocationResult {
+            completion: AgentCompletion {
+                text: "hello".to_string(),
+            },
+            session_id: "session-1".to_string(),
+            memory_id: Some("memory-1".to_string()),
+            session_state: None,
+            trace: None,
+            attributions: vec![serde_json::json!({"citations": []})],
+            return_control: None,
+            files: Vec::new(),
+        };
+
+        let response = result
+            .into_legacy_response()
+            .unwrap_or_else(|error| panic!("successful legacy response must not fail: {error}"));
+        assert_eq!(response.completion.text, "hello");
+        assert_eq!(response.session_id, "session-1");
+    }
+
+    #[test]
+    fn legacy_conversion_rejects_control_only_successes() {
+        for (return_control, files) in [
+            (
+                Some(serde_json::json!({"invocationId": "invoke-1"})),
+                Vec::new(),
+            ),
+            (None, vec![serde_json::json!({"name": "report.csv"})]),
+        ] {
+            let result = AgentInvocationResult {
+                completion: AgentCompletion {
+                    text: String::new(),
+                },
+                session_id: "session-1".to_string(),
+                memory_id: None,
+                session_state: None,
+                trace: None,
+                attributions: Vec::new(),
+                return_control,
+                files,
+            };
+
+            let error = result
+                .into_legacy_response()
+                .expect_err("control-only response cannot be represented by legacy API");
+            assert!(error.to_string().contains("invoke_detailed"), "{error}");
+        }
+    }
+
+    #[test]
+    fn agent_error_events_keep_provider_error_categories() {
+        let cases = [
+            (
+                "throttlingException",
+                ProviderError::rate_limit("bedrock", None),
+            ),
+            (
+                "validationException",
+                ProviderError::invalid_request("bedrock", "invalid input"),
+            ),
+            (
+                "accessDeniedException",
+                ProviderError::authentication("bedrock", "denied"),
+            ),
+        ];
+
+        for (event_type, expected) in cases {
+            let error = AgentResponseAccumulator::default()
+                .consume(exception_message(
+                    event_type,
+                    serde_json::json!({"message": "request failed"}),
+                ))
+                .expect_err("agent error event must fail");
+            assert_eq!(
+                std::mem::discriminant(&error),
+                std::mem::discriminant(&expected),
+                "unexpected category for {event_type}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/src/core/providers/bedrock/agents/mod.rs
+++ b/src/core/providers/bedrock/agents/mod.rs
@@ -470,7 +470,7 @@ mod tests {
             ),
             (
                 "accessDeniedException",
-                ProviderError::authentication("bedrock", "denied"),
+                ProviderError::api_error("bedrock", 403, "denied"),
             ),
         ];
 

--- a/src/core/providers/bedrock/error.rs
+++ b/src/core/providers/bedrock/error.rs
@@ -11,6 +11,32 @@ use serde_json::Value;
 #[derive(Debug, Clone)]
 pub struct BedrockErrorMapper;
 
+impl BedrockErrorMapper {
+    pub(crate) fn map_service_error(
+        error_code: &str,
+        error_message: &str,
+    ) -> Option<ProviderError> {
+        let details = format!("{error_code}: {error_message}");
+        match error_code.to_ascii_lowercase().as_str() {
+            "validationexception" => Some(ProviderError::invalid_request("bedrock", details)),
+            "unauthorizedexception" | "accessdeniedexception" => {
+                Some(ProviderError::authentication("bedrock", details))
+            }
+            "throttlingexception" | "servicequotaexceededexception" => {
+                Some(ProviderError::rate_limit("bedrock", None))
+            }
+            "modelnotreadyexception" | "resourcenotfoundexception" => {
+                Some(ProviderError::model_not_found("bedrock", details))
+            }
+            "badgatewayexception" => Some(ProviderError::network("bedrock", details)),
+            "conflictexception" => Some(ProviderError::api_error("bedrock", 409, details)),
+            "dependencyfailedexception" => Some(ProviderError::api_error("bedrock", 424, details)),
+            "internalserverexception" => Some(ProviderError::api_error("bedrock", 500, details)),
+            _ => None,
+        }
+    }
+}
+
 impl ErrorMapper<ProviderError> for BedrockErrorMapper {
     fn map_http_error(&self, status_code: u16, response_body: &str) -> ProviderError {
         match status_code {
@@ -52,32 +78,13 @@ impl ErrorMapper<ProviderError> for BedrockErrorMapper {
                 .and_then(|m| m.as_str())
                 .unwrap_or("Unknown error");
 
-            match error_code {
-                "ValidationException" => ProviderError::invalid_request(
-                    "bedrock",
-                    format!("Validation error: {}", error_message),
-                ),
-                "UnauthorizedException" => ProviderError::authentication(
-                    "bedrock",
-                    format!("Unauthorized: {}", error_message),
-                ),
-                "ThrottlingException" => ProviderError::rate_limit("bedrock", None),
-                "ModelNotReadyException" => ProviderError::model_not_found(
-                    "bedrock",
-                    format!("Model not ready: {}", error_message),
-                ),
-                "ServiceQuotaExceededException" => ProviderError::rate_limit("bedrock", None),
-                "InternalServerException" => ProviderError::api_error(
-                    "bedrock",
-                    500,
-                    format!("Internal server error: {}", error_message),
-                ),
-                _ => ProviderError::api_error(
+            Self::map_service_error(error_code, error_message).unwrap_or_else(|| {
+                ProviderError::api_error(
                     "bedrock",
                     400,
                     format!("{}: {}", error_code, error_message),
-                ),
-            }
+                )
+            })
         } else {
             ProviderError::response_parsing("bedrock", "Unknown error response format".to_string())
         }

--- a/src/core/providers/bedrock/error.rs
+++ b/src/core/providers/bedrock/error.rs
@@ -19,9 +19,8 @@ impl BedrockErrorMapper {
         let details = format!("{error_code}: {error_message}");
         match error_code.to_ascii_lowercase().as_str() {
             "validationexception" => Some(ProviderError::invalid_request("bedrock", details)),
-            "unauthorizedexception" | "accessdeniedexception" => {
-                Some(ProviderError::authentication("bedrock", details))
-            }
+            "unauthorizedexception" => Some(ProviderError::authentication("bedrock", details)),
+            "accessdeniedexception" => Some(ProviderError::api_error("bedrock", 403, details)),
             "throttlingexception" | "servicequotaexceededexception" => {
                 Some(ProviderError::rate_limit("bedrock", None))
             }
@@ -46,8 +45,9 @@ impl ErrorMapper<ProviderError> for BedrockErrorMapper {
                 "bedrock",
                 "Invalid AWS credentials or insufficient permissions".to_string(),
             ),
-            403 => ProviderError::authentication(
+            403 => ProviderError::api_error(
                 "bedrock",
+                403,
                 format!("Access forbidden: {}", response_body),
             ),
             404 => ProviderError::model_not_found(
@@ -119,6 +119,14 @@ mod tests {
 
         let error = mapper.map_http_error(401, "Unauthorized");
         assert!(matches!(error, ProviderError::Authentication { .. }));
+
+        let error = mapper.map_http_error(403, "Forbidden");
+        assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
+        assert_eq!(
+            crate::core::providers::unified_provider::provider_http_error_facts(&error).status,
+            403
+        );
+        assert!(!error.is_retryable());
 
         let error = mapper.map_http_error(429, "Rate limited");
         assert!(matches!(error, ProviderError::RateLimit { .. }));

--- a/src/core/providers/bedrock/error.rs
+++ b/src/core/providers/bedrock/error.rs
@@ -25,9 +25,8 @@ impl BedrockErrorMapper {
             "throttlingexception" | "servicequotaexceededexception" => {
                 Some(ProviderError::rate_limit("bedrock", None))
             }
-            "modelnotreadyexception" | "resourcenotfoundexception" => {
-                Some(ProviderError::model_not_found("bedrock", details))
-            }
+            "modelnotreadyexception" => Some(ProviderError::api_error("bedrock", 424, details)),
+            "resourcenotfoundexception" => Some(ProviderError::api_error("bedrock", 404, details)),
             "badgatewayexception" => Some(ProviderError::network("bedrock", details)),
             "conflictexception" => Some(ProviderError::api_error("bedrock", 409, details)),
             "dependencyfailedexception" => Some(ProviderError::api_error("bedrock", 424, details)),

--- a/src/core/providers/bedrock/streaming/event_stream.rs
+++ b/src/core/providers/bedrock/streaming/event_stream.rs
@@ -218,7 +218,7 @@ mod strict_frame_tests {
     fn maps_modeled_service_exceptions_to_structured_provider_errors() {
         let cases = [
             ("validationException", "invalid_request", None, false),
-            ("accessDeniedException", "authentication", None, false),
+            ("accessDeniedException", "api_error", Some(403), false),
             ("throttlingException", "rate_limit", None, true),
             ("serviceQuotaExceededException", "rate_limit", None, true),
             ("resourceNotFoundException", "api_error", Some(404), false),

--- a/src/core/providers/bedrock/streaming/event_stream.rs
+++ b/src/core/providers/bedrock/streaming/event_stream.rs
@@ -217,21 +217,22 @@ mod strict_frame_tests {
     #[test]
     fn maps_modeled_service_exceptions_to_structured_provider_errors() {
         let cases = [
-            ("validationException", "invalid_request", None),
-            ("accessDeniedException", "authentication", None),
-            ("throttlingException", "rate_limit", None),
-            ("serviceQuotaExceededException", "rate_limit", None),
-            ("resourceNotFoundException", "model_not_found", None),
-            ("modelNotReadyException", "model_not_found", None),
-            ("badGatewayException", "network", None),
-            ("conflictException", "api_error", Some(409)),
-            ("dependencyFailedException", "api_error", Some(424)),
-            ("internalServerException", "api_error", Some(500)),
+            ("validationException", "invalid_request", None, false),
+            ("accessDeniedException", "authentication", None, false),
+            ("throttlingException", "rate_limit", None, true),
+            ("serviceQuotaExceededException", "rate_limit", None, true),
+            ("resourceNotFoundException", "api_error", Some(404), false),
+            ("modelNotReadyException", "api_error", Some(424), true),
+            ("badGatewayException", "network", None, true),
+            ("conflictException", "api_error", Some(409), false),
+            ("dependencyFailedException", "api_error", Some(424), true),
+            ("internalServerException", "api_error", Some(500), true),
         ];
 
-        for (exception_type, expected_category, expected_status) in cases {
+        for (exception_type, expected_category, expected_status, expected_retryable) in cases {
             let error = BedrockStream::check_stream_error(&exception_message(exception_type))
                 .expect_err("modeled exception must fail");
+            assert_eq!(error.is_retryable(), expected_retryable, "{exception_type}");
             let (category, status) = match error {
                 ProviderError::InvalidRequest { .. } => ("invalid_request", None),
                 ProviderError::Authentication { .. } => ("authentication", None),

--- a/src/core/providers/bedrock/streaming/event_stream.rs
+++ b/src/core/providers/bedrock/streaming/event_stream.rs
@@ -1,6 +1,7 @@
 //! AWS Event Stream parsing for Bedrock streaming responses.
 
 use super::BedrockStream;
+use crate::core::providers::bedrock::error::BedrockErrorMapper;
 use crate::core::providers::unified_provider::ProviderError;
 use bytes::Bytes;
 use serde_json::Value;
@@ -126,17 +127,16 @@ impl BedrockStream {
     }
 
     fn stream_error(code: &str, message: &str) -> ProviderError {
+        if let Some(error) = BedrockErrorMapper::map_service_error(code, message) {
+            return error;
+        }
         let details = if message.is_empty() {
             format!("Bedrock stream error: {code}")
         } else {
             format!("Bedrock stream error {code}: {message}")
         };
 
-        if code.eq_ignore_ascii_case("validationException") {
-            ProviderError::invalid_request("bedrock", details)
-        } else {
-            ProviderError::api_error("bedrock", 500, details)
-        }
+        ProviderError::api_error("bedrock", 500, details)
     }
 
     pub(crate) fn check_stream_error(message: &EventStreamMessage) -> Result<(), ProviderError> {
@@ -168,6 +168,22 @@ impl BedrockStream {
 mod strict_frame_tests {
     use super::*;
 
+    fn exception_message(exception_type: &str) -> EventStreamMessage {
+        EventStreamMessage {
+            headers: vec![
+                EventStreamHeader {
+                    name: ":message-type".to_string(),
+                    value: HeaderValue::String("exception".to_string()),
+                },
+                EventStreamHeader {
+                    name: ":exception-type".to_string(),
+                    value: HeaderValue::String(exception_type.to_string()),
+                },
+            ],
+            payload: Bytes::from_static(br#"{"message":"request failed"}"#),
+        }
+    }
+
     fn frame(headers: &[u8], payload: &[u8]) -> Vec<u8> {
         let total_length = 16 + headers.len() + payload.len();
         let mut data = Vec::new();
@@ -196,5 +212,37 @@ mod strict_frame_tests {
     fn rejects_truncated_header() {
         let truncated_header = [4_u8, b'a'];
         assert!(BedrockStream::parse_event_message(&frame(&truncated_header, &[])).is_err());
+    }
+
+    #[test]
+    fn maps_modeled_service_exceptions_to_structured_provider_errors() {
+        let cases = [
+            ("validationException", "invalid_request", None),
+            ("accessDeniedException", "authentication", None),
+            ("throttlingException", "rate_limit", None),
+            ("serviceQuotaExceededException", "rate_limit", None),
+            ("resourceNotFoundException", "model_not_found", None),
+            ("modelNotReadyException", "model_not_found", None),
+            ("badGatewayException", "network", None),
+            ("conflictException", "api_error", Some(409)),
+            ("dependencyFailedException", "api_error", Some(424)),
+            ("internalServerException", "api_error", Some(500)),
+        ];
+
+        for (exception_type, expected_category, expected_status) in cases {
+            let error = BedrockStream::check_stream_error(&exception_message(exception_type))
+                .expect_err("modeled exception must fail");
+            let (category, status) = match error {
+                ProviderError::InvalidRequest { .. } => ("invalid_request", None),
+                ProviderError::Authentication { .. } => ("authentication", None),
+                ProviderError::RateLimit { .. } => ("rate_limit", None),
+                ProviderError::ModelNotFound { .. } => ("model_not_found", None),
+                ProviderError::Network { .. } => ("network", None),
+                ProviderError::ApiError { status, .. } => ("api_error", Some(status)),
+                other => panic!("unexpected category for {exception_type}: {other}"),
+            };
+            assert_eq!(category, expected_category, "{exception_type}");
+            assert_eq!(status, expected_status, "{exception_type}");
+        }
     }
 }

--- a/src/core/providers/unified_provider_methods.rs
+++ b/src/core/providers/unified_provider_methods.rs
@@ -340,7 +340,7 @@ impl ProviderError {
             | Self::ProviderUnavailable { .. } => true,
 
             // API errors depend on status code
-            Self::ApiError { status, .. } => matches!(*status, 429 | 500..=599),
+            Self::ApiError { status, .. } => matches!(*status, 424 | 429 | 500..=599),
 
             // Deployment errors might be retryable depending on the issue
             Self::DeploymentError { .. } => true,
@@ -382,6 +382,7 @@ impl ProviderError {
 
             // API errors with 429 (rate limit) or 5xx get retry delays
             Self::ApiError { status, .. } => match *status {
+                424 => Some(3),       // Failed dependency/not ready, retry after a short delay
                 429 => Some(60),      // Rate limit, wait longer
                 500..=599 => Some(3), // Server errors, shorter delay
                 _ => None,

--- a/src/core/providers/unified_provider_methods.rs
+++ b/src/core/providers/unified_provider_methods.rs
@@ -340,7 +340,12 @@ impl ProviderError {
             | Self::ProviderUnavailable { .. } => true,
 
             // API errors depend on status code
-            Self::ApiError { status, .. } => matches!(*status, 424 | 429 | 500..=599),
+            Self::ApiError {
+                provider, status, ..
+            } => {
+                (*provider == "bedrock" && *status == 424)
+                    || matches!(*status, 429 | 500..=599)
+            }
 
             // Deployment errors might be retryable depending on the issue
             Self::DeploymentError { .. } => true,
@@ -381,10 +386,12 @@ impl ProviderError {
             Self::ProviderUnavailable { .. } => Some(5),
 
             // API errors with 429 (rate limit) or 5xx get retry delays
-            Self::ApiError { status, .. } => match *status {
-                424 => Some(3),       // Failed dependency/not ready, retry after a short delay
-                429 => Some(60),      // Rate limit, wait longer
-                500..=599 => Some(3), // Server errors, shorter delay
+            Self::ApiError {
+                provider, status, ..
+            } => match *status {
+                424 if *provider == "bedrock" => Some(3), // Bedrock dependency/not-ready
+                429 => Some(60),                          // Rate limit, wait longer
+                500..=599 => Some(3),                     // Server errors, shorter delay
                 _ => None,
             },
 

--- a/src/core/providers/unified_provider_tests.rs
+++ b/src/core/providers/unified_provider_tests.rs
@@ -430,6 +430,9 @@ mod provider_error_tests {
         assert!(ProviderError::provider_unavailable("a", "b").is_retryable());
         assert!(ProviderError::deployment_error("a", "b").is_retryable());
         assert!(ProviderError::streaming_error("a", "b", None, None, "c").is_retryable());
+        let failed_dependency = ProviderError::api_error("a", 424, "not ready");
+        assert!(failed_dependency.is_retryable());
+        assert_eq!(failed_dependency.retry_delay(), Some(3));
     }
 
     #[test]

--- a/src/core/providers/unified_provider_tests.rs
+++ b/src/core/providers/unified_provider_tests.rs
@@ -430,9 +430,12 @@ mod provider_error_tests {
         assert!(ProviderError::provider_unavailable("a", "b").is_retryable());
         assert!(ProviderError::deployment_error("a", "b").is_retryable());
         assert!(ProviderError::streaming_error("a", "b", None, None, "c").is_retryable());
-        let failed_dependency = ProviderError::api_error("a", 424, "not ready");
+        let failed_dependency = ProviderError::api_error("bedrock", 424, "not ready");
         assert!(failed_dependency.is_retryable());
         assert_eq!(failed_dependency.retry_delay(), Some(3));
+        let unrelated_failed_dependency = ProviderError::api_error("custom_httpx", 424, "failed");
+        assert!(!unrelated_failed_dependency.is_retryable());
+        assert_eq!(unrelated_failed_dependency.retry_delay(), None);
     }
 
     #[test]

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -20,7 +20,11 @@ pub fn is_retryable_error(error: &ProviderError) -> bool {
         | ProviderError::Timeout { .. }
         | ProviderError::ProviderUnavailable { .. }
         | ProviderError::Network { .. } => true,
-        ProviderError::ApiError { status: 424, .. } => true,
+        ProviderError::ApiError {
+            provider: "bedrock",
+            status: 424,
+            ..
+        } => true,
         ProviderError::QuotaExceeded { .. } => retryable_budget_scope(error).is_some(),
         _ => false,
     }

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -137,6 +137,13 @@ pub fn infer_cooldown_reason(error: &ProviderError) -> CooldownReason {
         // Timeout errors
         ProviderError::Timeout { .. } => CooldownReason::Timeout,
 
+        // Bedrock permission failures retain HTTP 403 while cooling down the deployment.
+        ProviderError::ApiError {
+            provider: "bedrock",
+            status: 403,
+            ..
+        } => CooldownReason::AuthError,
+
         // API errors - map based on status code
         ProviderError::ApiError { status, .. } => match *status {
             401 => CooldownReason::AuthError,

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -20,6 +20,7 @@ pub fn is_retryable_error(error: &ProviderError) -> bool {
         | ProviderError::Timeout { .. }
         | ProviderError::ProviderUnavailable { .. }
         | ProviderError::Network { .. } => true,
+        ProviderError::ApiError { status: 424, .. } => true,
         ProviderError::QuotaExceeded { .. } => retryable_budget_scope(error).is_some(),
         _ => false,
     }

--- a/src/core/router/retry_policy.rs
+++ b/src/core/router/retry_policy.rs
@@ -209,9 +209,11 @@ fn failure_is_retryable(facts: ProviderFailureFacts, context: RetryContext) -> b
         | ProviderFailureKind::ProviderUnavailable
         | ProviderFailureKind::Network
         | ProviderFailureKind::DeploymentError => true,
-        ProviderFailureKind::ApiError => facts
-            .upstream_status
-            .is_some_and(|status| status == 424 || status == 429 || (500..=599).contains(&status)),
+        ProviderFailureKind::ApiError => facts.upstream_status.is_some_and(|status| {
+            (facts.provider == "bedrock" && status == 424)
+                || status == 429
+                || (500..=599).contains(&status)
+        }),
         ProviderFailureKind::Streaming => {
             context.operation == RetryOperation::Streaming
                 && context.stream_stage == StreamRetryStage::BeforeFirstChunk
@@ -360,6 +362,7 @@ mod tests {
     fn failed_dependency_api_error_is_retryable_but_not_not_found() {
         let not_ready = ProviderError::api_error("bedrock", 424, "model not ready");
         let missing = ProviderError::api_error("bedrock", 404, "resource not found");
+        let unrelated = ProviderError::api_error("custom_httpx", 424, "failed dependency");
 
         let retry = RetryPolicy.decide(
             &RouterConfig::default(),
@@ -371,10 +374,20 @@ mod tests {
             &missing,
             RetryContext::unary(1, 2),
         );
+        let unrelated_stop = RetryPolicy.decide(
+            &RouterConfig::default(),
+            &unrelated,
+            RetryContext::unary(1, 2),
+        );
 
         assert!(retry.should_retry);
         assert!(!stop.should_retry);
         assert_eq!(stop.reason, RetryDecisionReason::NonRetryableFailure);
+        assert!(!unrelated_stop.should_retry);
+        assert_eq!(
+            unrelated_stop.reason,
+            RetryDecisionReason::NonRetryableFailure
+        );
     }
 
     #[test]

--- a/src/core/router/retry_policy.rs
+++ b/src/core/router/retry_policy.rs
@@ -211,7 +211,7 @@ fn failure_is_retryable(facts: ProviderFailureFacts, context: RetryContext) -> b
         | ProviderFailureKind::DeploymentError => true,
         ProviderFailureKind::ApiError => facts
             .upstream_status
-            .is_some_and(|status| status == 429 || (500..=599).contains(&status)),
+            .is_some_and(|status| status == 424 || status == 429 || (500..=599).contains(&status)),
         ProviderFailureKind::Streaming => {
             context.operation == RetryOperation::Streaming
                 && context.stream_stage == StreamRetryStage::BeforeFirstChunk
@@ -354,6 +354,27 @@ mod tests {
             RetryPolicy.decide(&RouterConfig::default(), &error, RetryContext::unary(1, 2));
 
         assert!(decision.should_retry);
+    }
+
+    #[test]
+    fn failed_dependency_api_error_is_retryable_but_not_not_found() {
+        let not_ready = ProviderError::api_error("bedrock", 424, "model not ready");
+        let missing = ProviderError::api_error("bedrock", 404, "resource not found");
+
+        let retry = RetryPolicy.decide(
+            &RouterConfig::default(),
+            &not_ready,
+            RetryContext::unary(1, 2),
+        );
+        let stop = RetryPolicy.decide(
+            &RouterConfig::default(),
+            &missing,
+            RetryContext::unary(1, 2),
+        );
+
+        assert!(retry.should_retry);
+        assert!(!stop.should_retry);
+        assert_eq!(stop.reason, RetryDecisionReason::NonRetryableFailure);
     }
 
     #[test]

--- a/src/core/router/tests/cooldown_tests.rs
+++ b/src/core/router/tests/cooldown_tests.rs
@@ -303,6 +303,21 @@ async fn test_infer_cooldown_reason_api_error_401() {
 }
 
 #[tokio::test]
+async fn test_infer_cooldown_reason_bedrock_403() {
+    let bedrock = ProviderError::api_error("bedrock", 403, "Access denied");
+    let unrelated = ProviderError::api_error("custom_httpx", 403, "Forbidden");
+
+    assert_eq!(
+        Router::infer_cooldown_reason(&bedrock),
+        CooldownReason::AuthError
+    );
+    assert_eq!(
+        Router::infer_cooldown_reason(&unrelated),
+        CooldownReason::ConsecutiveFailures
+    );
+}
+
+#[tokio::test]
 async fn test_infer_cooldown_reason_generic_error() {
     let error = ProviderError::network("test_provider", "Connection failed");
     let reason = Router::infer_cooldown_reason(&error);

--- a/src/core/router/tests/execution_tests.rs
+++ b/src/core/router/tests/execution_tests.rs
@@ -41,6 +41,11 @@ fn test_is_retryable_error() {
         404,
         "resource not found"
     )));
+    assert!(!is_retryable_error(&ProviderError::api_error(
+        "custom_httpx",
+        424,
+        "failed dependency"
+    )));
 
     assert!(!is_retryable_error(&ProviderError::authentication(
         "test",

--- a/src/core/router/tests/execution_tests.rs
+++ b/src/core/router/tests/execution_tests.rs
@@ -31,6 +31,16 @@ fn test_is_retryable_error() {
         provider: "test",
         message: "Service unavailable".to_string(),
     }));
+    assert!(is_retryable_error(&ProviderError::api_error(
+        "bedrock",
+        424,
+        "model not ready"
+    )));
+    assert!(!is_retryable_error(&ProviderError::api_error(
+        "bedrock",
+        404,
+        "resource not found"
+    )));
 
     assert!(!is_retryable_error(&ProviderError::authentication(
         "test",


### PR DESCRIPTION
## Summary
- keep legacy `AgentClient::invoke()` successful when text completion includes memory or attribution metadata
- keep control-only/file-only outcomes fail closed and direct metadata consumers to `invoke_detailed()`
- centralize Bedrock modeled service error mapping so Agent event-stream throttling/auth/validation/quota/dependency errors retain structured categories and status

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib core::providers::bedrock -- --nocapture` (369 passed)
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1` (all executed groups passed; 0 failed)

## Baseline note
`cargo clippy --all-targets --all-features --locked -- -D warnings` fails identically on clean `origin/main` at the pre-existing `Provider` large-enum-variant lint; this PR does not touch that enum.

Refs #968