### PR TITLE
fix(vertex-ai): shrink provider runtime state

### DIFF
--- a/src/core/providers/vertex_ai/client.rs
+++ b/src/core/providers/vertex_ai/client.rs
@@ -42,7 +42,7 @@ pub use self::error_mapper::VertexAIErrorMapper;
 /// Vertex AI Provider implementation
 #[derive(Debug, Clone)]
 pub struct VertexAIProvider {
-    config: VertexAIProviderConfig,
+    config: Box<VertexAIProviderConfig>,
     auth: Arc<VertexAuth>,
     http_client: BaseHttpClient,
     // Cost calculation integrated internally
@@ -68,7 +68,7 @@ impl VertexAIProvider {
         )?;
 
         Ok(Self {
-            config,
+            config: Box::new(config),
             auth,
             http_client,
             gemini_transformer: GeminiTransformer::new(),


### PR DESCRIPTION
## Summary
- box the private Vertex AI provider configuration to reduce the runtime provider size without changing the public `Provider::VertexAI(VertexAIProvider)` API
- preserve constructor, dispatch, matching, and deep-clone behavior
- make the GH968 final all-target/all-feature strict Clippy contract pass without lint suppression

Refs #968

## Root cause
GH968 policy wiring increased `VertexAIProvider` to 624 bytes by storing both a 400-byte config and a 216-byte policy-aware HTTP client inline. That made the public `Provider` enum 624 bytes versus its next-largest 344-byte variant and triggered `clippy::large_enum_variant`.

## Verification
- `cargo fmt --all -- --check`: PASS
- `cargo check --all-targets --all-features --locked`: PASS
- `cargo clippy --all-targets --all-features --locked -- -D warnings`: PASS
- Vertex factory exact test: 1/1 PASS
- Vertex AI module: 221/221 PASS
- outbound HTTP architecture guard: 3/3 PASS
- runtime/unit/integration suites from `cargo test --all-features --locked -- --test-threads=1`: 10,410 library + 5 binary + all integration suites PASS; 0 test failures
- the first command reached rustdoc with a transient `vaultrs` artifact-resolution error; exact-head `cargo test --all-features --locked --doc -- --test-threads=1` retry: 33 PASS, 0 failed, 34 ignored
- GitHub exact-head CI: 10/10 PASS
- scope: 1 file, 4 changed lines; overlap: PASS

## Compatibility
The boxed field is private. Public enum payloads and constructors are unchanged; derived `Clone` continues to deep-clone the configuration.