### PR TITLE
feat(gemini): execute SDK routes through runtime providers

### DIFF
--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -78,8 +78,10 @@ mod tests {
         }
         assert!(!openai_like_provider_supports_gemini("google ai"));
         assert!(openai_like_provider_supports_rerank("cohere.ai"));
+        let timeout = ProviderError::timeout("x", "x");
+        let error = OpenAILikeProvider::map_gemini_stream_response::<()>(Ok(Err(timeout)));
+        assert!(matches!(error, Err(ProviderError::Timeout { .. })));
     }
-
     #[tokio::test]
     async fn named_gemini_stream_uses_runtime_header_timeout() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -35,7 +35,7 @@ impl Provider {
     }
 }
 
-fn openai_like_provider_supports_gemini(provider_name: &str) -> bool {
+pub(crate) fn openai_like_provider_supports_gemini(provider_name: &str) -> bool {
     matches!(
         normalize_provider_name(provider_name).as_str(),
         "gemini" | "googleai" | "googleaistudio"
@@ -48,24 +48,68 @@ fn openai_like_provider_supports_rerank(provider_name: &str) -> bool {
 }
 
 fn normalize_provider_name(provider_name: &str) -> String {
+    if !provider_name
+        .chars()
+        .all(|ch| matches!(ch, '_' | '-') || ch.is_ascii_alphanumeric())
+    {
+        return String::new();
+    }
     provider_name
         .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .flat_map(|ch| ch.to_lowercase())
+        .filter(|ch| !matches!(ch, '_' | '-'))
+        .flat_map(char::to_lowercase)
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::openai_like_provider_supports_gemini;
+    use crate::core::net::ProviderEndpointAccess;
+    use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
+    use crate::core::providers::{GeminiNativeRequest, ProviderError};
+    use serde_json::json;
+    use std::time::Duration;
 
     #[test]
     fn gemini_compatibility_name_set_is_closed_and_normalized() {
         for name in ["gemini", "Google-AI", "google_ai_studio"] {
             assert!(openai_like_provider_supports_gemini(name));
         }
-        for name in ["openai", "my-gemini-proxy", "google"] {
+        for name in ["openai", "my-gemini-proxy", "google", "g.e.m.i.n.i"] {
             assert!(!openai_like_provider_supports_gemini(name));
         }
+        assert!(!openai_like_provider_supports_gemini("google ai"));
+    }
+
+    #[tokio::test]
+    async fn named_gemini_stream_uses_runtime_header_timeout() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("timeout server should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            let _connection = listener.accept().await.expect("server should accept");
+            tokio::time::sleep(Duration::from_millis(1_200)).await;
+        });
+        let mut config = OpenAILikeConfig::with_api_key(format!("http://{address}"), "test-key");
+        config.provider_name = "Google-AI".to_string();
+        config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        config.base.timeout = 1;
+        let provider = OpenAILikeProvider::new_openai_compatible(config)
+            .await
+            .expect("named provider should build");
+        let error = provider
+            .gemini_generate_content(GeminiNativeRequest {
+                api_version: "v1beta".to_string(),
+                model: "gemini-3.1-flash-lite".to_string(),
+                method: "streamGenerateContent",
+                stream: true,
+                body: json!({"contents": []}),
+            })
+            .await
+            .expect_err("delayed headers should time out");
+
+        assert!(matches!(error, ProviderError::Timeout { .. }));
+        server.await.expect("timeout server should stop");
     }
 }

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -36,6 +36,12 @@ impl Provider {
 }
 
 pub(crate) fn openai_like_provider_supports_gemini(provider_name: &str) -> bool {
+    if !provider_name
+        .chars()
+        .all(|ch| matches!(ch, '_' | '-') || ch.is_ascii_alphanumeric())
+    {
+        return false;
+    }
     matches!(
         normalize_provider_name(provider_name).as_str(),
         "gemini" | "googleai" | "googleaistudio"
@@ -48,27 +54,19 @@ fn openai_like_provider_supports_rerank(provider_name: &str) -> bool {
 }
 
 fn normalize_provider_name(provider_name: &str) -> String {
-    if !provider_name
-        .chars()
-        .all(|ch| matches!(ch, '_' | '-') || ch.is_ascii_alphanumeric())
-    {
-        return String::new();
-    }
     provider_name
         .chars()
-        .filter(|ch| !matches!(ch, '_' | '-'))
+        .filter(|ch| ch.is_ascii_alphanumeric())
         .flat_map(char::to_lowercase)
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::openai_like_provider_supports_gemini;
+    use super::{openai_like_provider_supports_gemini, openai_like_provider_supports_rerank};
     use crate::core::net::ProviderEndpointAccess;
     use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
     use crate::core::providers::{GeminiNativeRequest, ProviderError};
-    use serde_json::json;
-    use std::time::Duration;
 
     #[test]
     fn gemini_compatibility_name_set_is_closed_and_normalized() {
@@ -79,6 +77,7 @@ mod tests {
             assert!(!openai_like_provider_supports_gemini(name));
         }
         assert!(!openai_like_provider_supports_gemini("google ai"));
+        assert!(openai_like_provider_supports_rerank("cohere.ai"));
     }
 
     #[tokio::test]
@@ -87,10 +86,6 @@ mod tests {
             .await
             .expect("timeout server should bind");
         let address = listener.local_addr().expect("listener should have address");
-        let server = tokio::spawn(async move {
-            let _connection = listener.accept().await.expect("server should accept");
-            tokio::time::sleep(Duration::from_millis(1_200)).await;
-        });
         let mut config = OpenAILikeConfig::with_api_key(format!("http://{address}"), "test-key");
         config.provider_name = "Google-AI".to_string();
         config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
@@ -104,12 +99,11 @@ mod tests {
                 model: "gemini-3.1-flash-lite".to_string(),
                 method: "streamGenerateContent",
                 stream: true,
-                body: json!({"contents": []}),
+                body: serde_json::json!({"contents": []}),
             })
             .await
             .expect_err("delayed headers should time out");
-
         assert!(matches!(error, ProviderError::Timeout { .. }));
-        server.await.expect("timeout server should stop");
+        drop(listener);
     }
 }

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -78,9 +78,17 @@ mod tests {
         }
         assert!(!openai_like_provider_supports_gemini("google ai"));
         assert!(openai_like_provider_supports_rerank("cohere.ai"));
-        let timeout = ProviderError::timeout("x", "x");
-        let error = OpenAILikeProvider::map_gemini_stream_response::<()>(Ok(Err(timeout)));
-        assert!(matches!(error, Err(ProviderError::Timeout { .. })));
+        let leaked = "raw/key+value raw%2Fkey%2Bvalue";
+        for (inner, is_timeout) in [
+            (ProviderError::timeout("x", leaked), true),
+            (ProviderError::network("x", leaked), false),
+        ] {
+            let error = OpenAILikeProvider::map_gemini_stream_response::<()>(Ok(Err(inner)))
+                .expect_err("transport error must remain an error");
+            assert_eq!(matches!(error, ProviderError::Timeout { .. }), is_timeout);
+            let text = format!("{error:?} {error}");
+            assert!(!text.contains("raw/key+value") && !text.contains("raw%2Fkey%2Bvalue"));
+        }
     }
     #[tokio::test]
     async fn named_gemini_stream_uses_runtime_header_timeout() {

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -25,17 +25,47 @@ impl Provider {
             Provider::OpenAILike(provider) if capability == &ProviderCapability::Rerank => {
                 openai_like_provider_supports_rerank(provider.name())
             }
+            Provider::OpenAILike(provider)
+                if capability == &ProviderCapability::GeminiGenerateContent =>
+            {
+                openai_like_provider_supports_gemini(provider.name())
+            }
             _ => self.supports_capability(capability),
         }
     }
 }
 
+fn openai_like_provider_supports_gemini(provider_name: &str) -> bool {
+    matches!(
+        normalize_provider_name(provider_name).as_str(),
+        "gemini" | "googleai" | "googleaistudio"
+    )
+}
+
 fn openai_like_provider_supports_rerank(provider_name: &str) -> bool {
-    let normalized = provider_name
+    let normalized = normalize_provider_name(provider_name);
+    normalized.contains("cohere") || normalized.contains("jina")
+}
+
+fn normalize_provider_name(provider_name: &str) -> String {
+    provider_name
         .chars()
         .filter(|ch| ch.is_ascii_alphanumeric())
         .flat_map(|ch| ch.to_lowercase())
-        .collect::<String>();
+        .collect()
+}
 
-    normalized.contains("cohere") || normalized.contains("jina")
+#[cfg(test)]
+mod tests {
+    use super::openai_like_provider_supports_gemini;
+
+    #[test]
+    fn gemini_compatibility_name_set_is_closed_and_normalized() {
+        for name in ["gemini", "Google-AI", "google_ai_studio"] {
+            assert!(openai_like_provider_supports_gemini(name));
+        }
+        for name in ["openai", "my-gemini-proxy", "google"] {
+            assert!(!openai_like_provider_supports_gemini(name));
+        }
+    }
 }

--- a/src/core/providers/gemini/client.rs
+++ b/src/core/providers/gemini/client.rs
@@ -70,7 +70,8 @@ impl GeminiClient {
         request: &GeminiNativeRequest,
     ) -> Result<Response, ProviderError> {
         let api_key = self.api_key();
-        let url = super::provider::gemini_native_url(&self.config.base_url, api_key, request)?;
+        let url =
+            crate::core::providers::gemini_native_url(&self.config.base_url, api_key, request)?;
         let client = if request.stream {
             &self.streaming_client
         } else {

--- a/src/core/providers/gemini/client.rs
+++ b/src/core/providers/gemini/client.rs
@@ -9,6 +9,7 @@ use reqwest::Response;
 use serde_json::{Value, json};
 use tokio::time::timeout;
 
+use crate::core::providers::GeminiNativeRequest;
 use crate::core::providers::base::{
     BaseConfig, BaseHttpClient, HeaderPair, apply_provider_headers, header, header_owned,
     header_static, read_streaming_error_body,
@@ -39,6 +40,10 @@ pub struct GeminiClient {
 }
 
 impl GeminiClient {
+    pub(crate) fn api_key(&self) -> &str {
+        self.config.api_key.as_deref().unwrap_or_default()
+    }
+
     /// Create
     pub fn new(config: GeminiConfig) -> Result<Self, ProviderError> {
         config
@@ -58,6 +63,31 @@ impl GeminiClient {
             http_client,
             streaming_client,
         })
+    }
+
+    pub(crate) async fn send_native_request(
+        &self,
+        request: &GeminiNativeRequest,
+    ) -> Result<Response, ProviderError> {
+        let api_key = self.api_key();
+        let url = super::provider::gemini_native_url(&self.config.base_url, api_key, request)?;
+        let client = if request.stream {
+            &self.streaming_client
+        } else {
+            &self.http_client
+        };
+        let send = apply_provider_headers(
+            client.post(url)?.json(&request.body),
+            self.get_request_headers(),
+        )
+        .send();
+        let response = timeout(Duration::from_secs(self.config.request_timeout), send)
+            .await
+            .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
+            .map_err(|_| {
+                ProviderError::network("gemini_proxy", "Gemini upstream request failed")
+            })?;
+        Ok(response)
     }
 
     /// Request

--- a/src/core/providers/gemini/client.rs
+++ b/src/core/providers/gemini/client.rs
@@ -85,9 +85,7 @@ impl GeminiClient {
         let response = timeout(Duration::from_secs(self.config.request_timeout), send)
             .await
             .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
-            .map_err(|_| {
-                ProviderError::network("gemini_proxy", "Gemini upstream request failed")
-            })?;
+            .map_err(|error| crate::core::providers::gemini_transport_error(error.is_timeout()))?;
         Ok(response)
     }
 

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -403,7 +403,6 @@ mod native_tests {
     use super::*;
     use crate::core::net::ProviderEndpointAccess;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     async fn error_provider(status: u16, headers: &str, body: &str, key: &str) -> ProviderError {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -435,7 +434,6 @@ mod native_tests {
         task.await.unwrap();
         error
     }
-
     #[tokio::test]
     async fn native_error_redacts_raw_and_form_encoded_key() {
         let key = "secret/key+value-12345678901234567890";
@@ -447,37 +445,28 @@ mod native_tests {
             assert!(!text.contains(&encoded));
         }
     }
-
     #[tokio::test]
     async fn native_rate_limit_prefers_header_then_body_retry_after() {
         let key = "test-key-12345678901234567890";
         let header = error_provider(429, "retry-after: 7\r\n", r#"{"retry_after":3}"#, key).await;
         let body = error_provider(429, "", r#"{"retry_after":3}"#, key).await;
-        assert!(matches!(
-            header,
-            ProviderError::RateLimit {
-                retry_after: Some(7),
-                ..
-            }
-        ));
-        assert!(matches!(
-            body,
-            ProviderError::RateLimit {
-                retry_after: Some(3),
-                ..
-            }
-        ));
+        if let ProviderError::RateLimit { retry_after, .. } = header {
+            assert_eq!(retry_after, Some(7));
+        } else {
+            panic!("header response must be rate limited");
+        }
+        if let ProviderError::RateLimit { retry_after, .. } = body {
+            assert_eq!(retry_after, Some(3));
+        } else {
+            panic!("body response must be rate limited");
+        }
     }
-
     #[tokio::test]
     async fn native_non_rate_limit_empty_body_is_api_error() {
         let error = error_provider(503, "", "", "test-key-12345678901234567890").await;
         assert!(matches!(error, ProviderError::ApiError { status: 503, .. }));
-        assert!(
-            error
-                .to_string()
-                .contains("Gemini upstream returned HTTP 503")
-        );
+        let message = error.to_string();
+        assert!(message.contains("Gemini upstream returned HTTP 503"));
     }
 }
 

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -403,6 +403,11 @@ mod native_tests {
     use super::*;
     use crate::core::net::ProviderEndpointAccess;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    #[test]
+    fn native_transport_timeout_keeps_timeout_classification() {
+        let error = crate::core::providers::gemini_transport_error(true);
+        assert!(matches!(error, ProviderError::Timeout { .. }));
+    }
     async fn error_provider(status: u16, headers: &str, body: &str, key: &str) -> ProviderError {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -450,16 +455,11 @@ mod native_tests {
         let key = "test-key-12345678901234567890";
         let header = error_provider(429, "retry-after: 7\r\n", r#"{"retry_after":3}"#, key).await;
         let body = error_provider(429, "", r#"{"retry_after":3}"#, key).await;
-        if let ProviderError::RateLimit { retry_after, .. } = header {
-            assert_eq!(retry_after, Some(7));
-        } else {
-            panic!("header response must be rate limited");
-        }
-        if let ProviderError::RateLimit { retry_after, .. } = body {
-            assert_eq!(retry_after, Some(3));
-        } else {
-            panic!("body response must be rate limited");
-        }
+        let retries = [header, body].map(|error| match error {
+            ProviderError::RateLimit { retry_after, .. } => retry_after,
+            _ => None,
+        });
+        assert_eq!(retries, [Some(7), Some(3)]);
     }
     #[tokio::test]
     async fn native_non_rate_limit_empty_body_is_api_error() {

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -3,11 +3,14 @@
 //! Implementation
 
 use futures::Stream;
+use reqwest::{Url, header::RETRY_AFTER};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
 
-use crate::core::providers::unified_provider::ProviderError;
+use crate::core::providers::base::read_streaming_error_body;
+use crate::core::providers::shared::parse_retry_after_from_body;
+use crate::core::providers::{GeminiNativeRequest, ProviderError};
 use crate::core::traits::{
     provider::ProviderConfig, provider::llm_provider::trait_definition::LLMProvider,
 };
@@ -59,6 +62,15 @@ impl GeminiProvider {
             client,
             supported_models,
         })
+    }
+
+    pub(crate) async fn gemini_generate_content(
+        &self,
+        request: GeminiNativeRequest,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let api_key = self.client.api_key();
+        let response = self.client.send_native_request(&request).await?;
+        gemini_response_or_provider_error(response, api_key).await
     }
 
     /// Request
@@ -124,6 +136,7 @@ impl LLMProvider for GeminiProvider {
             ProviderCapability::ChatCompletion,
             ProviderCapability::ChatCompletionStream,
             ProviderCapability::ToolCalling,
+            ProviderCapability::GeminiGenerateContent,
             // NOTE: Vision capability not yet added to ProviderCapability enum
         ]
     }
@@ -385,6 +398,165 @@ impl LLMProvider for GeminiProvider {
             super::models::CostCalculator::calculate_cost(model, input_tokens, output_tokens)
                 .unwrap_or(0.0),
         )
+    }
+}
+
+pub(crate) fn gemini_native_url(
+    base_url: &str,
+    api_key: &str,
+    request: &GeminiNativeRequest,
+) -> Result<Url, ProviderError> {
+    if !matches!(request.api_version.as_str(), "v1" | "v1beta")
+        || !matches!(request.method, "generateContent" | "streamGenerateContent")
+        || request.model.is_empty()
+        || !request.model.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+    {
+        return Err(ProviderError::invalid_request(
+            "gemini_proxy",
+            "invalid Gemini native route segment",
+        ));
+    }
+    let mut url = Url::parse(&format!(
+        "{}/{}/models/{}:{}",
+        base_url.trim_end_matches('/'),
+        request.api_version,
+        request.model,
+        request.method
+    ))
+    .map_err(|_| ProviderError::configuration("gemini_proxy", "invalid Gemini API base URL"))?;
+    let mut query = url.query_pairs_mut();
+    if request.stream {
+        query.append_pair("alt", "sse");
+    }
+    query.append_pair("key", api_key);
+    drop(query);
+    Ok(url)
+}
+
+pub(crate) async fn gemini_response_or_provider_error(
+    response: reqwest::Response,
+    api_key: &str,
+) -> Result<reqwest::Response, ProviderError> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status().as_u16();
+    let header_retry = response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok());
+    let body = read_streaming_error_body(response)
+        .await
+        .map_err(|error| error.into_provider_error("gemini_proxy"))?;
+    let body = redact_gemini_key(&body, api_key);
+    let message = if body.trim().is_empty() {
+        format!("Gemini upstream returned HTTP {status}")
+    } else {
+        format!("Gemini upstream returned HTTP {status}: {body}")
+    };
+    Err(if status == 429 {
+        ProviderError::rate_limit_with_retry(
+            "gemini_proxy",
+            message,
+            header_retry.or_else(|| parse_retry_after_from_body(&body)),
+        )
+    } else {
+        ProviderError::api_error("gemini_proxy", status, message)
+    })
+}
+
+fn redact_gemini_key(body: &str, api_key: &str) -> String {
+    if api_key.is_empty() {
+        return body.to_string();
+    }
+    let encoded: String = url::form_urlencoded::byte_serialize(api_key.as_bytes()).collect();
+    body.replace(api_key, "[REDACTED]")
+        .replace(&encoded, "[REDACTED]")
+}
+
+#[cfg(test)]
+mod native_tests {
+    use super::*;
+    use crate::core::net::ProviderEndpointAccess;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn error_provider(status: u16, headers: &str, body: &str, key: &str) -> ProviderError {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let response = format!(
+            "HTTP/1.1 {status} Error\r\n{headers}content-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let bytes_read = socket.read(&mut request).await.unwrap();
+            assert!(bytes_read > 0);
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        let mut config = GeminiConfig::new_google_ai(key);
+        config.base_url = format!("http://{address}");
+        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        let provider = GeminiProvider::new(config).unwrap();
+        let error = provider
+            .gemini_generate_content(GeminiNativeRequest {
+                api_version: "v1beta".to_string(),
+                model: "gemini-test".to_string(),
+                method: "generateContent",
+                stream: false,
+                body: serde_json::json!({}),
+            })
+            .await
+            .unwrap_err();
+        task.await.unwrap();
+        error
+    }
+
+    #[tokio::test]
+    async fn native_error_redacts_raw_and_form_encoded_key() {
+        let key = "secret/key+value-12345678901234567890";
+        let encoded: String = url::form_urlencoded::byte_serialize(key.as_bytes()).collect();
+        let error = error_provider(500, "", &format!("{key} {encoded}"), key).await;
+        for text in [error.to_string(), format!("{error:?}")] {
+            assert!(text.contains("[REDACTED]"));
+            assert!(!text.contains(key));
+            assert!(!text.contains(&encoded));
+        }
+    }
+
+    #[tokio::test]
+    async fn native_rate_limit_prefers_header_then_body_retry_after() {
+        let key = "test-key-12345678901234567890";
+        let header = error_provider(429, "retry-after: 7\r\n", r#"{"retry_after":3}"#, key).await;
+        let body = error_provider(429, "", r#"{"retry_after":3}"#, key).await;
+        assert!(matches!(
+            header,
+            ProviderError::RateLimit {
+                retry_after: Some(7),
+                ..
+            }
+        ));
+        assert!(matches!(
+            body,
+            ProviderError::RateLimit {
+                retry_after: Some(3),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn native_non_rate_limit_empty_body_is_api_error() {
+        let error = error_provider(503, "", "", "test-key-12345678901234567890").await;
+        assert!(matches!(error, ProviderError::ApiError { status: 503, .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("Gemini upstream returned HTTP 503")
+        );
     }
 }
 

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -3,13 +3,10 @@
 //! Implementation
 
 use futures::Stream;
-use reqwest::{Url, header::RETRY_AFTER};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
 
-use crate::core::providers::base::read_streaming_error_body;
-use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::{GeminiNativeRequest, ProviderError};
 use crate::core::traits::{
     provider::ProviderConfig, provider::llm_provider::trait_definition::LLMProvider,
@@ -70,7 +67,7 @@ impl GeminiProvider {
     ) -> Result<reqwest::Response, ProviderError> {
         let api_key = self.client.api_key();
         let response = self.client.send_native_request(&request).await?;
-        gemini_response_or_provider_error(response, api_key).await
+        crate::core::providers::gemini_response_or_provider_error(response, api_key).await
     }
 
     /// Request
@@ -399,82 +396,6 @@ impl LLMProvider for GeminiProvider {
                 .unwrap_or(0.0),
         )
     }
-}
-
-pub(crate) fn gemini_native_url(
-    base_url: &str,
-    api_key: &str,
-    request: &GeminiNativeRequest,
-) -> Result<Url, ProviderError> {
-    if !matches!(request.api_version.as_str(), "v1" | "v1beta")
-        || !matches!(request.method, "generateContent" | "streamGenerateContent")
-        || request.model.is_empty()
-        || !request.model.chars().all(|character| {
-            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
-        })
-    {
-        return Err(ProviderError::invalid_request(
-            "gemini_proxy",
-            "invalid Gemini native route segment",
-        ));
-    }
-    let mut url = Url::parse(&format!(
-        "{}/{}/models/{}:{}",
-        base_url.trim_end_matches('/'),
-        request.api_version,
-        request.model,
-        request.method
-    ))
-    .map_err(|_| ProviderError::configuration("gemini_proxy", "invalid Gemini API base URL"))?;
-    let mut query = url.query_pairs_mut();
-    if request.stream {
-        query.append_pair("alt", "sse");
-    }
-    query.append_pair("key", api_key);
-    drop(query);
-    Ok(url)
-}
-
-pub(crate) async fn gemini_response_or_provider_error(
-    response: reqwest::Response,
-    api_key: &str,
-) -> Result<reqwest::Response, ProviderError> {
-    if response.status().is_success() {
-        return Ok(response);
-    }
-    let status = response.status().as_u16();
-    let header_retry = response
-        .headers()
-        .get(RETRY_AFTER)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.trim().parse::<u64>().ok());
-    let body = read_streaming_error_body(response)
-        .await
-        .map_err(|error| error.into_provider_error("gemini_proxy"))?;
-    let body = redact_gemini_key(&body, api_key);
-    let message = if body.trim().is_empty() {
-        format!("Gemini upstream returned HTTP {status}")
-    } else {
-        format!("Gemini upstream returned HTTP {status}: {body}")
-    };
-    Err(if status == 429 {
-        ProviderError::rate_limit_with_retry(
-            "gemini_proxy",
-            message,
-            header_retry.or_else(|| parse_retry_after_from_body(&body)),
-        )
-    } else {
-        ProviderError::api_error("gemini_proxy", status, message)
-    })
-}
-
-fn redact_gemini_key(body: &str, api_key: &str) -> String {
-    if api_key.is_empty() {
-        return body.to_string();
-    }
-    let encoded: String = url::form_urlencoded::byte_serialize(api_key.as_bytes()).collect();
-    body.replace(api_key, "[REDACTED]")
-        .replace(&encoded, "[REDACTED]")
 }
 
 #[cfg(test)]

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -146,6 +146,82 @@ pub(crate) struct GeminiNativeRequest {
     pub(crate) body: serde_json::Value,
 }
 
+pub(crate) fn gemini_native_url(
+    base_url: &str,
+    api_key: &str,
+    request: &GeminiNativeRequest,
+) -> Result<reqwest::Url, ProviderError> {
+    if !matches!(request.api_version.as_str(), "v1" | "v1beta")
+        || !matches!(request.method, "generateContent" | "streamGenerateContent")
+        || request.model.is_empty()
+        || !request.model.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+    {
+        return Err(ProviderError::invalid_request(
+            "gemini_proxy",
+            "invalid Gemini native route segment",
+        ));
+    }
+    let mut url = reqwest::Url::parse(&format!(
+        "{}/{}/models/{}:{}",
+        base_url.trim_end_matches('/'),
+        request.api_version,
+        request.model,
+        request.method
+    ))
+    .map_err(|_| ProviderError::configuration("gemini_proxy", "invalid Gemini API base URL"))?;
+    let mut query = url.query_pairs_mut();
+    if request.stream {
+        query.append_pair("alt", "sse");
+    }
+    query.append_pair("key", api_key);
+    drop(query);
+    Ok(url)
+}
+
+pub(crate) async fn gemini_response_or_provider_error(
+    response: reqwest::Response,
+    api_key: &str,
+) -> Result<reqwest::Response, ProviderError> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status().as_u16();
+    let header_retry = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    let body = base::read_streaming_error_body(response)
+        .await
+        .map_err(|error| error.into_provider_error("gemini_proxy"))?;
+    let body = redact_gemini_key(&body, api_key);
+    let message = if body.trim().is_empty() {
+        format!("Gemini upstream returned HTTP {status}")
+    } else {
+        format!("Gemini upstream returned HTTP {status}: {body}")
+    };
+    Err(if status == 429 {
+        ProviderError::rate_limit_with_retry(
+            "gemini_proxy",
+            message,
+            header_retry.or_else(|| shared::parse_retry_after_from_body(&body)),
+        )
+    } else {
+        ProviderError::api_error("gemini_proxy", status, message)
+    })
+}
+
+fn redact_gemini_key(body: &str, api_key: &str) -> String {
+    if api_key.is_empty() {
+        return body.to_string();
+    }
+    let encoded: String = url::form_urlencoded::byte_serialize(api_key.as_bytes()).collect();
+    body.replace(api_key, "[REDACTED]")
+        .replace(&encoded, "[REDACTED]")
+}
+
 // ==================== Provider Dispatch Macros ====================
 //
 // Consolidated into a single `dispatch_provider!` macro with 4 dispatch kinds,

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -137,6 +137,15 @@ pub use failure::{ProviderFailureFacts, ProviderFailureKind, ProviderRetryHint};
 pub use provider_registry::ProviderRegistry;
 pub use unified_provider::ProviderError;
 
+#[derive(Debug, Clone)]
+pub(crate) struct GeminiNativeRequest {
+    pub(crate) api_version: String,
+    pub(crate) model: String,
+    pub(crate) method: &'static str,
+    pub(crate) stream: bool,
+    pub(crate) body: serde_json::Value,
+}
+
 // ==================== Provider Dispatch Macros ====================
 //
 // Consolidated into a single `dispatch_provider!` macro with 4 dispatch kinds,
@@ -350,6 +359,21 @@ pub enum Provider {
 }
 
 impl Provider {
+    pub(crate) async fn gemini_generate_content(
+        &self,
+        request: GeminiNativeRequest,
+    ) -> Result<reqwest::Response, ProviderError> {
+        match self {
+            #[cfg(feature = "providers-extended")]
+            Provider::Gemini(provider) => provider.gemini_generate_content(request).await,
+            Provider::OpenAILike(provider) => provider.gemini_generate_content(request).await,
+            _ => Err(ProviderError::not_supported(
+                "provider",
+                "Gemini native generateContent",
+            )),
+        }
+    }
+
     /// Get provider name
     pub fn name(&self) -> &str {
         match self {

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -218,7 +218,13 @@ fn redact_gemini_key(body: &str, api_key: &str) -> String {
     body.replace(api_key, "[REDACTED]")
         .replace(&encoded, "[REDACTED]")
 }
-
+pub(crate) fn gemini_transport_error(is_timeout: bool) -> ProviderError {
+    let message = "Gemini upstream request failed";
+    if is_timeout {
+        return ProviderError::timeout("gemini_proxy", message);
+    }
+    ProviderError::network("gemini_proxy", message)
+}
 // ==================== Provider Dispatch Macros ====================
 //
 // Consolidated into a single `dispatch_provider!` macro with 4 dispatch kinds,

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -145,7 +145,6 @@ pub(crate) struct GeminiNativeRequest {
     pub(crate) stream: bool,
     pub(crate) body: serde_json::Value,
 }
-
 pub(crate) fn gemini_native_url(
     base_url: &str,
     api_key: &str,
@@ -179,7 +178,6 @@ pub(crate) fn gemini_native_url(
     drop(query);
     Ok(url)
 }
-
 pub(crate) async fn gemini_response_or_provider_error(
     response: reqwest::Response,
     api_key: &str,
@@ -212,7 +210,6 @@ pub(crate) async fn gemini_response_or_provider_error(
         ProviderError::api_error("gemini_proxy", status, message)
     })
 }
-
 fn redact_gemini_key(body: &str, api_key: &str) -> String {
     if api_key.is_empty() {
         return body.to_string();

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -28,7 +28,7 @@ use super::{
     error::{OpenAILikeError, PROVIDER_NAME},
     models::{OpenAILikeModelRegistry, get_openai_like_registry},
 };
-use crate::core::providers::{GeminiNativeRequest, ProviderError};
+use crate::core::providers::{GeminiNativeRequest, ProviderError, gemini_transport_error};
 
 pub(crate) static OPENAI_LIKE_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
     ProviderCapability::ChatCompletion,
@@ -120,12 +120,7 @@ impl OpenAILikeProvider {
     ) -> Result<T, ProviderError> {
         result
             .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
-            .map_err(|error| match error {
-                ProviderError::Timeout { .. } => {
-                    ProviderError::timeout("gemini_proxy", "Gemini upstream request timed out")
-                }
-                _ => ProviderError::network("gemini_proxy", "Gemini upstream request failed"),
-            })
+            .map_err(|error| gemini_transport_error(matches!(error, ProviderError::Timeout { .. })))
     }
 
     /// Create a new OpenAI-like provider

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::core::providers::base::{
     GlobalPoolManager, HeaderPair, HttpMethod, header, header_owned, read_streaming_error_body,
@@ -68,15 +69,8 @@ impl OpenAILikeProvider {
         &self,
         request: GeminiNativeRequest,
     ) -> Result<reqwest::Response, ProviderError> {
-        let normalized = self
-            .provider_name
-            .chars()
-            .filter(|ch| ch.is_ascii_alphanumeric())
-            .flat_map(|ch| ch.to_lowercase())
-            .collect::<String>();
-        if !matches!(
-            normalized.as_str(),
-            "gemini" | "googleai" | "googleaistudio"
+        if !crate::core::providers::capability_dispatch::openai_like_provider_supports_gemini(
+            &self.provider_name,
         ) {
             return Err(ProviderError::not_supported(
                 "openai_like",
@@ -84,7 +78,7 @@ impl OpenAILikeProvider {
             ));
         }
         let api_key = self.config.base.api_key.as_deref().unwrap_or_default();
-        let url = crate::core::providers::gemini::provider::gemini_native_url(
+        let url = crate::core::providers::gemini_native_url(
             &self.config.get_api_base(),
             api_key,
             &request,
@@ -105,19 +99,27 @@ impl OpenAILikeProvider {
                 .map(|(key, value)| header_owned(key.clone(), value.clone())),
         );
         let response = if request.stream {
-            self.pool_manager
-                .execute_streaming_request(url.as_str(), headers, request.body, "gemini_proxy")
-                .await
+            tokio::time::timeout(
+                Duration::from_secs(self.config.base.timeout),
+                self.pool_manager.execute_streaming_request(
+                    url.as_str(),
+                    headers,
+                    request.body,
+                    "gemini_proxy",
+                ),
+            )
+            .await
+            .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
+            .map_err(|_| ProviderError::network("gemini_proxy", "Gemini upstream request failed"))?
         } else {
             self.pool_manager
                 .execute_request(url.as_str(), HttpMethod::POST, headers, Some(request.body))
                 .await
-        }
-        .map_err(|_| ProviderError::network("gemini_proxy", "Gemini upstream request failed"))?;
-        crate::core::providers::gemini::provider::gemini_response_or_provider_error(
-            response, api_key,
-        )
-        .await
+                .map_err(|_| {
+                    ProviderError::network("gemini_proxy", "Gemini upstream request failed")
+                })?
+        };
+        crate::core::providers::gemini_response_or_provider_error(response, api_key).await
     }
 
     /// Create a new OpenAI-like provider

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -27,7 +27,7 @@ use super::{
     error::{OpenAILikeError, PROVIDER_NAME},
     models::{OpenAILikeModelRegistry, get_openai_like_registry},
 };
-use crate::core::providers::unified_provider::ProviderError;
+use crate::core::providers::{GeminiNativeRequest, ProviderError};
 
 pub(crate) static OPENAI_LIKE_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
     ProviderCapability::ChatCompletion,
@@ -64,6 +64,62 @@ pub struct OpenAILikeProvider {
 }
 
 impl OpenAILikeProvider {
+    pub(crate) async fn gemini_generate_content(
+        &self,
+        request: GeminiNativeRequest,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let normalized = self
+            .provider_name
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric())
+            .flat_map(|ch| ch.to_lowercase())
+            .collect::<String>();
+        if !matches!(
+            normalized.as_str(),
+            "gemini" | "googleai" | "googleaistudio"
+        ) {
+            return Err(ProviderError::not_supported(
+                "openai_like",
+                "Gemini native generateContent",
+            ));
+        }
+        let api_key = self.config.base.api_key.as_deref().unwrap_or_default();
+        let url = crate::core::providers::gemini::provider::gemini_native_url(
+            &self.config.get_api_base(),
+            api_key,
+            &request,
+        )?;
+        let mut headers =
+            Vec::with_capacity(self.config.base.headers.len() + self.config.custom_headers.len());
+        headers.extend(
+            self.config
+                .base
+                .headers
+                .iter()
+                .map(|(key, value)| header_owned(key.clone(), value.clone())),
+        );
+        headers.extend(
+            self.config
+                .custom_headers
+                .iter()
+                .map(|(key, value)| header_owned(key.clone(), value.clone())),
+        );
+        let response = if request.stream {
+            self.pool_manager
+                .execute_streaming_request(url.as_str(), headers, request.body, "gemini_proxy")
+                .await
+        } else {
+            self.pool_manager
+                .execute_request(url.as_str(), HttpMethod::POST, headers, Some(request.body))
+                .await
+        }
+        .map_err(|_| ProviderError::network("gemini_proxy", "Gemini upstream request failed"))?;
+        crate::core::providers::gemini::provider::gemini_response_or_provider_error(
+            response, api_key,
+        )
+        .await
+    }
+
     /// Create a new OpenAI-like provider
     pub async fn new(config: OpenAILikeConfig) -> Result<Self, OpenAILikeError> {
         Self::new_with_profile(

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -120,6 +120,12 @@ impl OpenAILikeProvider {
     ) -> Result<T, ProviderError> {
         result
             .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
+            .map_err(|error| match error {
+                ProviderError::Timeout { .. } => {
+                    ProviderError::timeout("gemini_proxy", "Gemini upstream request timed out")
+                }
+                _ => ProviderError::network("gemini_proxy", "Gemini upstream request failed"),
+            })
     }
 
     /// Create a new OpenAI-like provider

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -83,34 +83,27 @@ impl OpenAILikeProvider {
             api_key,
             &request,
         )?;
-        let mut headers =
-            Vec::with_capacity(self.config.base.headers.len() + self.config.custom_headers.len());
-        headers.extend(
-            self.config
-                .base
-                .headers
-                .iter()
-                .map(|(key, value)| header_owned(key.clone(), value.clone())),
-        );
-        headers.extend(
-            self.config
-                .custom_headers
-                .iter()
-                .map(|(key, value)| header_owned(key.clone(), value.clone())),
-        );
+        let headers = self
+            .config
+            .base
+            .headers
+            .iter()
+            .chain(&self.config.custom_headers)
+            .map(|(key, value)| header_owned(key.clone(), value.clone()))
+            .collect();
         let response = if request.stream {
-            tokio::time::timeout(
-                Duration::from_secs(self.config.base.timeout),
-                self.pool_manager.execute_streaming_request(
-                    url.as_str(),
-                    headers,
-                    request.body,
-                    "gemini_proxy",
-                ),
-            )
-            .await
-            .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
-            .map_err(|_| ProviderError::network("gemini_proxy", "Gemini upstream request failed"))?
+            Self::map_gemini_stream_response(
+                tokio::time::timeout(
+                    Duration::from_secs(self.config.base.timeout),
+                    self.pool_manager.execute_streaming_request(
+                        url.as_str(),
+                        headers,
+                        request.body,
+                        "gemini_proxy",
+                    ),
+                )
+                .await,
+            )?
         } else {
             self.pool_manager
                 .execute_request(url.as_str(), HttpMethod::POST, headers, Some(request.body))
@@ -120,6 +113,13 @@ impl OpenAILikeProvider {
                 })?
         };
         crate::core::providers::gemini_response_or_provider_error(response, api_key).await
+    }
+
+    pub(crate) fn map_gemini_stream_response<T>(
+        result: Result<Result<T, ProviderError>, tokio::time::error::Elapsed>,
+    ) -> Result<T, ProviderError> {
+        result
+            .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
     }
 
     /// Create a new OpenAI-like provider

--- a/src/core/types/model.rs
+++ b/src/core/types/model.rs
@@ -44,6 +44,8 @@ pub enum ProviderCapability {
     BatchProcessing,
     /// Real-time API
     RealtimeApi,
+    /// Gemini SDK native generateContent transport
+    GeminiGenerateContent,
 }
 
 /// Model information
@@ -204,6 +206,7 @@ mod tests {
             ProviderCapability::FineTuning,
             ProviderCapability::BatchProcessing,
             ProviderCapability::RealtimeApi,
+            ProviderCapability::GeminiGenerateContent,
         ];
 
         for cap in capabilities {

--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use tracing::error;
 
 use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
-use crate::core::providers::ProviderError;
+use crate::core::providers::{GeminiNativeRequest, ProviderError};
 use crate::core::types::model::ProviderCapability;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
@@ -152,7 +152,7 @@ async fn proxy_gemini_route_inner(
         let result = run_unary(
             &state.unified_router,
             &router_model,
-            gemini_route_capability(stream),
+            gemini_route_capability(),
             {
                 let context = context.clone();
                 let request = request.clone();
@@ -172,11 +172,15 @@ async fn proxy_gemini_route_inner(
                         let (budget_reservation, key_budget_reservation, response) =
                             send_gemini_request(
                                 state,
+                                &selected_provider,
                                 &provider,
-                                api_version,
-                                method,
-                                false,
-                                &request,
+                                GeminiNativeRequest {
+                                    api_version: api_version.to_string(),
+                                    model: requested_model,
+                                    method,
+                                    stream: false,
+                                    body: request,
+                                },
                                 context.api_key_budget_id(),
                             )
                             .await?;
@@ -235,7 +239,7 @@ async fn proxy_gemini_stream_route_inner(
         let result = run_stream(
             state.unified_router.clone(),
             &router_model,
-            gemini_route_capability(true),
+            gemini_route_capability(),
             {
                 let request = request.clone();
                 let requested_model = requested_model.clone();
@@ -253,11 +257,15 @@ async fn proxy_gemini_stream_route_inner(
                         let (budget_reservation, key_budget_reservation, response) =
                             send_gemini_request(
                                 state,
+                                &selected_provider,
                                 &provider,
-                                api_version,
-                                method,
-                                true,
-                                &request,
+                                GeminiNativeRequest {
+                                    api_version: api_version.to_string(),
+                                    model: requested_model,
+                                    method,
+                                    stream: true,
+                                    body: request,
+                                },
                                 api_key_budget_id,
                             )
                             .await?;
@@ -532,12 +540,8 @@ fn gemini_streaming_response(state: &AppState, parts: GeminiStreamResponseParts)
         .streaming(upstream)
 }
 
-fn gemini_route_capability(stream: bool) -> ProviderCapability {
-    if stream {
-        ProviderCapability::ChatCompletionStream
-    } else {
-        ProviderCapability::ChatCompletion
-    }
+fn gemini_route_capability() -> ProviderCapability {
+    ProviderCapability::GeminiGenerateContent
 }
 
 fn ensure_gemini_route_authorized(

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -232,7 +232,12 @@ fn gemini_provider_uses_registry_models(provider: &ProviderConfig) -> bool {
 fn is_gemini_provider(provider: &ProviderConfig) -> bool {
     let provider_type =
         super::super::provider_config::normalize_provider_selector(&provider.provider_type);
-    let provider_name = super::super::provider_config::normalize_provider_selector(&provider.name);
+    let provider_name = provider
+        .settings
+        .get("provider_name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(&provider.name);
+    let provider_name = super::super::provider_config::normalize_provider_selector(provider_name);
 
     matches!(
         provider_type.as_str(),

--- a/src/server/routes/ai/gemini/provider.rs
+++ b/src/server/routes/ai/gemini/provider.rs
@@ -1,16 +1,15 @@
 use bytes::Bytes;
 use reqwest::{
     Url,
-    header::{CONTENT_TYPE, HeaderName, HeaderValue, RETRY_AFTER},
+    header::{HeaderName, HeaderValue, RETRY_AFTER},
 };
-use serde_json::Value;
 use std::time::Duration;
 
 use crate::config::models::provider::ProviderConfig;
 use crate::core::budget::{BudgetReservation, UnifiedBudgetReservation};
 use crate::core::providers::base::{ProviderRequestBuilder, read_streaming_error_body};
 use crate::core::providers::shared::parse_retry_after_from_body;
-use crate::core::providers::{Provider, ProviderError};
+use crate::core::providers::{GeminiNativeRequest, Provider, ProviderError};
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 
@@ -29,7 +28,9 @@ pub(super) struct GeminiRouteProvider {
     api_key: String,
     base_url: String,
     headers: Vec<(HeaderName, HeaderValue)>,
+    #[allow(dead_code)]
     timeout: Duration,
+    #[allow(dead_code)]
     client: RouteHttpClient,
 }
 
@@ -283,6 +284,7 @@ fn push_gemini_header(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn gemini_url(
     provider: &GeminiRouteProvider,
     api_version: &str,
@@ -315,11 +317,9 @@ fn gemini_url(
 
 pub(super) async fn send_gemini_request(
     state: &AppState,
+    selected_provider: &Provider,
     provider: &GeminiRouteProvider,
-    api_version: &str,
-    method: &'static str,
-    stream: bool,
-    request: &Value,
+    native_request: GeminiNativeRequest,
     api_key_budget_id: Option<Uuid>,
 ) -> Result<
     (
@@ -333,6 +333,7 @@ pub(super) async fn send_gemini_request(
     let pricing = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
     let budget_limits = budgeted.budget_limits();
+    let budget_request = native_request.body.clone();
     let (response, reservations) = budgeted
         .for_selected_with_api_key_budget(
             provider.provider_name.clone(),
@@ -347,45 +348,18 @@ pub(super) async fn send_gemini_request(
                     &pricing_config,
                     budget_limits.as_ref(),
                     provider,
-                    request,
+                    &budget_request,
                 )
                 .map_err(gemini_gateway_error_to_provider_error)
             },
-            || async {
-                let url = gemini_url(provider, api_version, method, stream)
-                    .map_err(gemini_gateway_error_to_provider_error)?;
-                let builder = if stream {
-                    provider.client.streaming_post(url)
-                } else {
-                    provider.client.ordinary_post(url)
-                }
-                .map_err(gemini_gateway_error_to_provider_error)?;
-                let builder = apply_gemini_headers(builder, provider)
-                    .header(CONTENT_TYPE, "application/json")
-                    .json(request);
-                let response = if stream {
-                    tokio::time::timeout(provider.timeout, builder.send())
-                        .await
-                        .map_err(|_| {
-                            ProviderError::timeout(
-                                "gemini_proxy",
-                                "Gemini streaming response header timeout",
-                            )
-                        })?
-                } else {
-                    builder.send().await
-                }
-                .map_err(|error| {
-                    gemini_gateway_error_to_provider_error(gemini_http_error(error))
-                })?;
-                gemini_response_or_provider_error(response, provider).await
-            },
+            || selected_provider.gemini_generate_content(native_request),
         )
         .await?;
     let (budget_reservation, key_budget_reservation) = reservations.into_parts();
     Ok((budget_reservation, key_budget_reservation, response))
 }
 
+#[allow(dead_code)]
 async fn gemini_response_or_provider_error(
     response: reqwest::Response,
     provider: &GeminiRouteProvider,
@@ -473,6 +447,7 @@ pub(super) fn gemini_gateway_error_to_provider_error(error: GatewayError) -> Pro
     }
 }
 
+#[allow(dead_code)]
 fn apply_gemini_headers(
     mut request: ProviderRequestBuilder,
     provider: &GeminiRouteProvider,

--- a/src/server/routes/ai/route_http.rs
+++ b/src/server/routes/ai/route_http.rs
@@ -9,6 +9,7 @@ use crate::utils::error::gateway_error::GatewayError;
 #[derive(Debug, Clone)]
 pub(super) struct RouteHttpClient {
     ordinary: BaseHttpClient,
+    #[cfg_attr(not(test), allow(dead_code))]
     streaming: BaseHttpClient,
 }
 
@@ -47,6 +48,7 @@ impl RouteHttpClient {
         self.ordinary.post(url).map_err(GatewayError::from)
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn streaming_post<U: IntoUrl>(
         &self,
         url: U,

--- a/tests/gemini_sdk_routes/runtime_provider_tests.rs
+++ b/tests/gemini_sdk_routes/runtime_provider_tests.rs
@@ -23,7 +23,6 @@ async fn gemini_sdk_route_executes_selected_runtime_provider_snapshot() {
             .configure(litellm_rs::server::routes::ai::configure_routes),
     )
     .await;
-
     let response = test::call_service(
         &app,
         test::TestRequest::post()
@@ -32,7 +31,6 @@ async fn gemini_sdk_route_executes_selected_runtime_provider_snapshot() {
             .to_request(),
     )
     .await;
-
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(selected.requests().len(), 1);
     assert!(replacement.requests().is_empty());

--- a/tests/gemini_sdk_routes/runtime_provider_tests.rs
+++ b/tests/gemini_sdk_routes/runtime_provider_tests.rs
@@ -1,6 +1,46 @@
 use super::*;
 
 #[tokio::test]
+async fn gemini_sdk_route_executes_selected_runtime_provider_snapshot() {
+    let selected = MockGeminiServer::launch().await;
+    let replacement = MockGeminiServer::launch().await;
+    let state = build_test_state(vec![gemini_provider(
+        "gemini",
+        &selected.base_url,
+        vec!["gemini-3.1-flash-lite".to_string()],
+    )])
+    .await;
+    let mut replaced_config = state.config().as_ref().clone();
+    replaced_config.gateway.providers = vec![gemini_provider(
+        "gemini",
+        &replacement.base_url,
+        vec!["gemini-3.1-flash-lite".to_string()],
+    )];
+    state.config.store(replaced_config);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(litellm_rs::server::routes::ai::configure_routes),
+    )
+    .await;
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
+            .set_json(gemini_body())
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(selected.requests().len(), 1);
+    assert!(replacement.requests().is_empty());
+    selected.shutdown().await;
+    replacement.shutdown().await;
+}
+
+#[tokio::test]
 async fn gemini_sdk_route_network_error_does_not_leak_provider_key() {
     let state = build_test_state(vec![gemini_provider(
         "gemini",

--- a/tests/gemini_sdk_routes/runtime_provider_tests.rs
+++ b/tests/gemini_sdk_routes/runtime_provider_tests.rs
@@ -4,18 +4,17 @@ use super::*;
 async fn gemini_sdk_route_executes_selected_runtime_provider_snapshot() {
     let selected = MockGeminiServer::launch().await;
     let replacement = MockGeminiServer::launch().await;
-    let state = build_test_state(vec![gemini_provider(
-        "gemini",
-        &selected.base_url,
-        vec!["gemini-3.1-flash-lite".to_string()],
-    )])
-    .await;
+    let configured = |name: &str, base_url: &str| {
+        let mut provider =
+            gemini_provider(name, base_url, vec!["gemini-3.1-flash-lite".to_string()]);
+        provider
+            .settings
+            .insert("provider_name".to_string(), json!("gemini"));
+        provider
+    };
+    let state = build_test_state(vec![configured("runtime-alias", &selected.base_url)]).await;
     let mut replaced_config = state.config().as_ref().clone();
-    replaced_config.gateway.providers = vec![gemini_provider(
-        "gemini",
-        &replacement.base_url,
-        vec!["gemini-3.1-flash-lite".to_string()],
-    )];
+    replaced_config.gateway.providers = vec![configured("replacement", &replacement.base_url)];
     state.config.store(replaced_config);
     let app = test::init_service(
         App::new()


### PR DESCRIPTION
## Summary
- add a typed Gemini native capability and closed Provider dispatch
- execute Gemini SDK wire requests with the selected runtime provider
- keep endpoint policy, headers, timeouts, and API keys owned by immutable provider clients
- redact raw and form-encoded API keys before ProviderError leaves the runtime

## Verification
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
- `bash scripts/guards/check_pr_scope.sh origin/main` (10 files, 454 lines)
- `bash scripts/guards/check_pr_overlap.sh origin/main`

Partial implementation for #966. Issue #966 remains open for route adapter state removal and runtime-only candidate discovery.

Refs #966