### PR TITLE
fix(gemini): preserve endpoint policy errors

### DIFF
--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -667,6 +667,44 @@ mod tests {
         Ok(())
     }
 
+    #[rustfmt::skip]
+    #[tokio::test]
+    async fn preserved_policy_requests_keep_timeout_variants()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let url = delayed_response_url(Duration::from_millis(1_100), Duration::ZERO).await?;
+        let config = BaseConfig {
+            api_base: Some(url.clone()),
+            endpoint_access: crate::core::net::ProviderEndpointAccess::PrivateNetwork,
+            timeout: 1,
+            ..Default::default()
+        };
+        let mut manager = GlobalPoolManager::new_for_provider("test", config)?;
+        let error = manager
+            .execute_request_preserving_endpoint_policy(&url, HttpMethod::GET, Vec::new(), None)
+            .await
+            .expect_err("ordinary request must time out");
+        assert!(matches!(error, ProviderError::Timeout { .. }));
+
+        let url = delayed_response_url(Duration::from_millis(100), Duration::ZERO).await?;
+        manager = GlobalPoolManager::new_for_provider("test", BaseConfig { api_base: Some(url.clone()), endpoint_access: crate::core::net::ProviderEndpointAccess::PrivateNetwork, ..Default::default() })?;
+        manager
+            .policy
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("test manager must have endpoint policy"))?
+            .streaming_header_timeout = Duration::from_millis(20);
+        let error = manager
+            .execute_streaming_request_preserving_endpoint_policy(
+                &url,
+                Vec::new(),
+                serde_json::json!({}),
+                "test",
+            )
+            .await
+            .expect_err("streaming header request must time out");
+        assert!(matches!(error, ProviderError::Timeout { .. }));
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_streaming_error_body_read_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
         let url = delayed_error_body_url(Duration::from_millis(150)).await?;

--- a/src/core/providers/base/connection_pool.rs
+++ b/src/core/providers/base/connection_pool.rs
@@ -14,33 +14,25 @@ use crate::utils::net::http::{
     HttpClientPoolConfig, create_custom_client_with_config, create_streaming_client,
 };
 
-/// Type alias for HTTP headers using Cow to avoid allocations for static strings.
-///
-/// Use `Cow::Borrowed("Header-Name")` for static strings and `Cow::Owned(value)` for dynamic values.
+/// HTTP headers that borrow static values when possible.
 pub type HeaderPair = (Cow<'static, str>, Cow<'static, str>);
 
-/// Helper to create a header from static key and dynamic value.
 #[inline]
 pub fn header(key: &'static str, value: String) -> HeaderPair {
     (Cow::Borrowed(key), Cow::Owned(value))
 }
 
-/// Helper to create a header from both static key and static value (zero allocation).
 #[inline]
 pub fn header_static(key: &'static str, value: &'static str) -> HeaderPair {
     (Cow::Borrowed(key), Cow::Borrowed(value))
 }
 
-/// Helper to create a header from both dynamic key and value.
 #[inline]
 pub fn header_owned(key: String, value: String) -> HeaderPair {
     (Cow::Owned(key), Cow::Owned(value))
 }
 
-/// Apply a list of `HeaderPair`s to a `reqwest::RequestBuilder`.
-///
-/// This bridges the `Vec<HeaderPair>` pattern with providers that still use
-/// `reqwest::Client` directly instead of `GlobalPoolManager`.
+/// Apply `HeaderPair`s to a raw request builder.
 #[inline]
 pub fn apply_headers(
     mut builder: reqwest::RequestBuilder,
@@ -60,7 +52,6 @@ pub enum HttpMethod {
     DELETE,
 }
 
-/// Unified connection pool configuration
 pub struct PoolConfig;
 impl PoolConfig {
     pub const TIMEOUT_SECS: u64 = 600;
@@ -115,10 +106,7 @@ fn pool_http_config() -> HttpClientPoolConfig {
     }
 }
 
-/// Global HTTP client singleton
-///
-/// This is the actual global singleton that holds the reqwest::Client.
-/// All providers share this single client instance for connection pooling efficiency.
+/// Global shared HTTP client.
 static GLOBAL_CLIENT: LazyLock<Arc<Client>> = LazyLock::new(|| {
     let client = create_custom_client_with_config(
         Duration::from_secs(PoolConfig::TIMEOUT_SECS),
@@ -139,76 +127,25 @@ static STREAMING_CLIENT: LazyLock<Arc<Client>> = LazyLock::new(|| {
     Arc::new(client)
 });
 
-/// Get the global HTTP client
-///
-/// Returns a reference to the shared global HTTP client instance.
-/// This is the preferred way to access the HTTP client for connection pooling.
+/// Get the global HTTP client.
 #[inline]
 pub fn global_client() -> Arc<Client> {
     Arc::clone(&GLOBAL_CLIENT)
 }
 
-/// Get a streaming-ready HTTP client
-///
-/// Returns the legacy bounded HTTP client for streaming requests.
-/// This should be used instead of ad hoc client construction for streaming
-/// to benefit from the streaming connection pool.
-///
-/// Existing callers still use this client directly with `.send().await`, so it
-/// must keep the global total timeout until callers migrate to
-/// `streaming_unbounded_client()` plus `send_streaming_request()`.
-///
-/// # Example
-///
-/// ```ignore
-/// use crate::core::providers::base::connection_pool::streaming_client;
-///
-/// // Use the shared legacy streaming client.
-/// let response = streaming_client()
-///     .post(&url)
-///     .headers(headers)
-///     .json(&body)
-///     .send()
-///     .await?;
-/// let stream = response.bytes_stream();
-/// ```
+/// Get the legacy bounded client used by direct streaming callers.
 #[inline]
 pub fn streaming_client() -> Arc<Client> {
     global_client()
 }
 
 /// Get an HTTP client for streaming bodies without a total request timeout.
-///
-/// Pair this with `send_streaming_request()` so only the pre-header request
-/// phase is bounded and the response body can stream indefinitely.
-///
-/// # Example
-///
-/// ```ignore
-/// use crate::core::providers::base::connection_pool::{
-///     send_streaming_request, streaming_unbounded_client,
-/// };
-///
-/// let response = send_streaming_request(
-///     streaming_unbounded_client()
-///         .post(&url)
-///         .headers(headers)
-///         .json(&body),
-///     "provider_name",
-/// )
-/// .await?;
-/// let stream = response.bytes_stream();
-/// ```
 #[inline]
 pub fn streaming_unbounded_client() -> Arc<Client> {
     Arc::clone(&STREAMING_CLIENT)
 }
 
 /// Send a streaming request with a bounded pre-header phase.
-///
-/// The timeout wraps only `RequestBuilder::send()`, which completes when
-/// response headers arrive. It does not impose a total timeout on the response
-/// body stream.
 pub async fn send_streaming_request(
     request_builder: RequestBuilder,
     provider: &'static str,
@@ -233,10 +170,6 @@ pub async fn send_streaming_request_with_timeout(
 }
 
 /// Read a non-success streaming response body with bounded time and memory.
-///
-/// Successful SSE bodies must stay unbounded, but error bodies are finite
-/// diagnostics. This prevents a provider that sends 4xx/5xx headers and then
-/// stalls the body from tying up the task forever.
 pub async fn read_streaming_error_body(
     response: Response,
 ) -> Result<String, StreamingRequestError> {
@@ -296,20 +229,14 @@ pub struct ConnectionPool {
 }
 
 impl ConnectionPool {
-    /// Create a new connection pool with optimized settings
-    ///
-    /// Note: This now uses the global client singleton instead of creating a new client.
-    /// For true isolation (rare use cases), use `new_isolated()`.
+    /// Create a connection pool backed by the global client.
     pub fn new() -> Result<Self, ProviderError> {
         Ok(Self {
             client: global_client(),
         })
     }
 
-    /// Create an isolated connection pool with its own client
-    ///
-    /// Use this only when you need a separate connection pool from the global one.
-    /// Most use cases should use `new()` which shares the global client.
+    /// Create an isolated connection pool with its own client.
     pub fn new_isolated() -> Result<Self, ProviderError> {
         let client = create_custom_client_with_config(
             Duration::from_secs(PoolConfig::TIMEOUT_SECS),
@@ -328,10 +255,7 @@ impl ConnectionPool {
     }
 }
 
-/// Global pool manager - single instance for all providers
-///
-/// This manager wraps the global connection pool singleton.
-/// Multiple `GlobalPoolManager` instances all share the same underlying HTTP client.
+/// Manager for the global or provider-policy-bound clients.
 #[derive(Debug, Clone)]
 pub struct GlobalPoolManager {
     pool: Arc<ConnectionPool>,
@@ -347,10 +271,7 @@ struct ProviderPool {
 }
 
 impl GlobalPoolManager {
-    /// Create a new global pool manager
-    ///
-    /// Note: This returns a manager that uses the global client singleton.
-    /// Creating multiple managers is cheap as they all share the same client.
+    /// Create a manager backed by the global client.
     pub fn new() -> Result<Self, ProviderError> {
         Ok(Self {
             pool: Arc::new(ConnectionPool::new()?),
@@ -446,6 +367,37 @@ impl GlobalPoolManager {
             .map_err(|e| ProviderError::network("common", e.to_string()))
     }
 
+    pub(crate) async fn execute_request_preserving_endpoint_policy(
+        &self,
+        url: &str,
+        method: HttpMethod,
+        headers: Vec<HeaderPair>,
+        body: Option<serde_json::Value>,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let Some(policy) = &self.policy else {
+            return self.execute_request(url, method, headers, body).await;
+        };
+        let method = match method {
+            HttpMethod::GET => reqwest::Method::GET,
+            HttpMethod::POST => reqwest::Method::POST,
+            HttpMethod::PUT => reqwest::Method::PUT,
+            HttpMethod::DELETE => reqwest::Method::DELETE,
+        };
+        let mut request = policy
+            .ordinary
+            .request_preserving_endpoint_policy(method, url)?;
+        request = apply_provider_headers(request, headers);
+        if let Some(body) = body {
+            request = request
+                .header("Content-Type", "application/json")
+                .json(&body);
+        }
+        request
+            .send()
+            .await
+            .map_err(|error| policy.ordinary.map_preserved_request_error(error))
+    }
+
     /// Execute a policy-bound request while bounding only the response-header phase.
     pub async fn execute_streaming_request(
         &self,
@@ -470,6 +422,33 @@ impl GlobalPoolManager {
 
         let request = apply_headers(streaming_unbounded_client().post(url).json(&body), headers);
         send_streaming_request(request, legacy_provider).await
+    }
+
+    pub(crate) async fn execute_streaming_request_preserving_endpoint_policy(
+        &self,
+        url: &str,
+        headers: Vec<HeaderPair>,
+        body: serde_json::Value,
+        legacy_provider: &'static str,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let Some(policy) = &self.policy else {
+            return self
+                .execute_streaming_request(url, headers, body, legacy_provider)
+                .await;
+        };
+        let request = policy
+            .streaming
+            .request_preserving_endpoint_policy(reqwest::Method::POST, url)?;
+        let request = apply_provider_headers(request, headers).json(&body);
+        let timeout = policy.streaming_header_timeout;
+        match tokio::time::timeout(timeout, request.send()).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(error)) => Err(policy.streaming.map_preserved_request_error(error)),
+            Err(_) => Err(ProviderError::timeout(
+                policy.provider,
+                "Provider response header timeout",
+            )),
+        }
     }
 
     /// Get the underlying client for direct use

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -12,6 +12,8 @@ use crate::core::providers::base::connection_pool::HeaderPair;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::net::http::{ProviderHttpClient, ProviderRequestBuilder};
 
+const ENDPOINT_POLICY_ERROR_MESSAGE: &str = "Provider endpoint rejected by SSRF protection";
+
 /// Base HTTP client wrapper used by provider implementations.
 #[derive(Debug, Clone)]
 pub struct BaseHttpClient {
@@ -109,6 +111,30 @@ impl BaseHttpClient {
         self.client
             .request(method, url)
             .map_err(|error| ProviderError::network(self.provider, error.to_string()))
+    }
+
+    pub(crate) fn request_preserving_endpoint_policy<U: IntoUrl>(
+        &self,
+        method: Method,
+        url: U,
+    ) -> Result<ProviderRequestBuilder, ProviderError> {
+        self.client.request(method, url).map_err(|error| {
+            if error.is_endpoint_policy() {
+                ProviderError::configuration(self.provider, ENDPOINT_POLICY_ERROR_MESSAGE)
+            } else {
+                ProviderError::network(self.provider, error.to_string())
+            }
+        })
+    }
+
+    pub(crate) fn map_preserved_request_error(&self, error: reqwest::Error) -> ProviderError {
+        if ProviderHttpClient::request_error_is_endpoint_policy(&error) {
+            ProviderError::configuration(self.provider, ENDPOINT_POLICY_ERROR_MESSAGE)
+        } else if error.is_timeout() {
+            ProviderError::timeout(self.provider, "Provider request timed out")
+        } else {
+            ProviderError::network(self.provider, error.to_string())
+        }
     }
 
     /// Create a policy-checked GET request builder.
@@ -451,6 +477,26 @@ mod tests {
             .unwrap_or_else(|| panic!("cross-authority request must fail"));
         assert!(matches!(error, ProviderError::Network { .. }));
         assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn typed_request_preserves_direct_endpoint_policy_error() {
+        let client = BaseHttpClient::new_for_provider(
+            "test",
+            BaseConfig {
+                api_base: Some("https://api.example.com/v1".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("public test client should build");
+        let error = match client
+            .request_preserving_endpoint_policy(Method::GET, "ftp://api.example.com/v1")
+        {
+            Err(error) => error,
+            Ok(_) => panic!("unsupported schemes must be rejected"),
+        };
+
+        assert!(matches!(error, ProviderError::Configuration { .. }));
     }
 
     #[test]

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -444,6 +444,24 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[rustfmt::skip]
+    #[test]
+    fn endpoint_policy_preserving_opt_ins_are_gemini_only() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers"); let (mut stack, mut callers) = (vec![root.clone()], Vec::new());
+        while let Some(directory) = stack.pop() { for entry in std::fs::read_dir(directory).expect("provider sources must be readable") {
+                let path = entry.expect("provider entry must be readable").path(); if path.is_dir() { stack.push(path); continue; }
+                let name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+                if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || name == "tests.rs"
+                    || name.ends_with("_tests.rs") || path == root.join("base/connection_pool.rs") || path == root.join("base/http.rs") { continue; }
+                let source = std::fs::read_to_string(&path).expect("source must be readable");
+                for method in ["execute_request_preserving_endpoint_policy", "execute_streaming_request_preserving_endpoint_policy"] {
+                    if source.contains(method) { callers.push((path.strip_prefix(&root).unwrap_or(&path).to_path_buf(), method)); }
+                }
+            }
+        }
+        let expected = std::path::PathBuf::from("openai_like/provider.rs"); assert_eq!(callers, vec![(expected.clone(), "execute_request_preserving_endpoint_policy"), (expected, "execute_streaming_request_preserving_endpoint_policy")]);
+    }
+
     #[test]
     fn base_http_client_rejects_public_loopback_base() {
         let error = BaseHttpClient::new_for_provider(

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -447,19 +447,19 @@ mod tests {
     #[rustfmt::skip]
     #[test]
     fn endpoint_policy_preserving_opt_ins_are_gemini_only() {
-        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/core/providers"); let (mut stack, mut callers) = (vec![root.clone()], Vec::new());
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"); let (mut stack, mut callers) = (vec![root.clone()], Vec::new());
         while let Some(directory) = stack.pop() { for entry in std::fs::read_dir(directory).expect("provider sources must be readable") {
                 let path = entry.expect("provider entry must be readable").path(); if path.is_dir() { stack.push(path); continue; }
                 let name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
                 if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || name == "tests.rs"
-                    || name.ends_with("_tests.rs") || path == root.join("base/connection_pool.rs") || path == root.join("base/http.rs") { continue; }
+                    || name.ends_with("_tests.rs") || path == root.join("core/providers/base/connection_pool.rs") || path == root.join("core/providers/base/http.rs") { continue; }
                 let source = std::fs::read_to_string(&path).expect("source must be readable");
                 for method in ["execute_request_preserving_endpoint_policy", "execute_streaming_request_preserving_endpoint_policy"] {
                     if source.contains(method) { callers.push((path.strip_prefix(&root).unwrap_or(&path).to_path_buf(), method)); }
                 }
             }
         }
-        let expected = std::path::PathBuf::from("openai_like/provider.rs"); assert_eq!(callers, vec![(expected.clone(), "execute_request_preserving_endpoint_policy"), (expected, "execute_streaming_request_preserving_endpoint_policy")]);
+        let expected = std::path::PathBuf::from("core/providers/openai_like/provider.rs"); assert_eq!(callers, vec![(expected.clone(), "execute_request_preserving_endpoint_policy"), (expected, "execute_streaming_request_preserving_endpoint_policy")]);
     }
 
     #[test]

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -10,9 +10,7 @@ use crate::core::net::{ProviderEndpointAccess, ProviderEndpointPolicy};
 use crate::core::providers::base::BaseConfig;
 use crate::core::providers::base::connection_pool::HeaderPair;
 use crate::core::providers::unified_provider::ProviderError;
-use crate::utils::net::http::{
-    ProviderHttpClient, ProviderHttpClientError, ProviderRequestBuilder,
-};
+use crate::utils::net::http::{ProviderHttpClient, ProviderRequestBuilder};
 
 /// Base HTTP client wrapper used by provider implementations.
 #[derive(Debug, Clone)]
@@ -110,14 +108,7 @@ impl BaseHttpClient {
     ) -> Result<ProviderRequestBuilder, ProviderError> {
         self.client
             .request(method, url)
-            .map_err(|error| match error {
-                ProviderHttpClientError::Endpoint(error) => {
-                    ProviderError::configuration(self.provider, error.to_string())
-                }
-                ProviderHttpClientError::Request(error) => {
-                    ProviderError::network(self.provider, error.to_string())
-                }
-            })
+            .map_err(|error| ProviderError::network(self.provider, error.to_string()))
     }
 
     /// Create a policy-checked GET request builder.
@@ -458,7 +449,7 @@ mod tests {
             .get("http://127.0.0.1:11435/v1/models")
             .err()
             .unwrap_or_else(|| panic!("cross-authority request must fail"));
-        assert!(matches!(error, ProviderError::Configuration { .. }));
+        assert!(matches!(error, ProviderError::Network { .. }));
         assert!(error.to_string().contains("does not match"));
     }
 

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -10,7 +10,9 @@ use crate::core::net::{ProviderEndpointAccess, ProviderEndpointPolicy};
 use crate::core::providers::base::BaseConfig;
 use crate::core::providers::base::connection_pool::HeaderPair;
 use crate::core::providers::unified_provider::ProviderError;
-use crate::utils::net::http::{ProviderHttpClient, ProviderRequestBuilder};
+use crate::utils::net::http::{
+    ProviderHttpClient, ProviderHttpClientError, ProviderRequestBuilder,
+};
 
 /// Base HTTP client wrapper used by provider implementations.
 #[derive(Debug, Clone)]
@@ -108,7 +110,14 @@ impl BaseHttpClient {
     ) -> Result<ProviderRequestBuilder, ProviderError> {
         self.client
             .request(method, url)
-            .map_err(|error| ProviderError::network(self.provider, error.to_string()))
+            .map_err(|error| match error {
+                ProviderHttpClientError::Endpoint(error) => {
+                    ProviderError::configuration(self.provider, error.to_string())
+                }
+                ProviderHttpClientError::Request(error) => {
+                    ProviderError::network(self.provider, error.to_string())
+                }
+            })
     }
 
     /// Create a policy-checked GET request builder.
@@ -449,7 +458,7 @@ mod tests {
             .get("http://127.0.0.1:11435/v1/models")
             .err()
             .unwrap_or_else(|| panic!("cross-authority request must fail"));
-        assert!(matches!(error, ProviderError::Network { .. }));
+        assert!(matches!(error, ProviderError::Configuration { .. }));
         assert!(error.to_string().contains("does not match"));
     }
 

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -575,6 +575,9 @@ fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
         ProviderError::Configuration { message, .. } => {
             ProviderError::configuration("gemini_proxy", message)
         }
+        ProviderError::Network { message, .. } if message.contains("SSRF protection") => {
+            ProviderError::configuration("gemini_proxy", message)
+        }
         ProviderError::Timeout { .. } => gemini_transport_error(true),
         _ => gemini_transport_error(false),
     }

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -95,18 +95,24 @@ impl OpenAILikeProvider {
             Self::map_gemini_stream_response(
                 tokio::time::timeout(
                     Duration::from_secs(self.config.base.timeout),
-                    self.pool_manager.execute_streaming_request(
-                        url.as_str(),
-                        headers,
-                        request.body,
-                        "gemini_proxy",
-                    ),
+                    self.pool_manager
+                        .execute_streaming_request_preserving_endpoint_policy(
+                            url.as_str(),
+                            headers,
+                            request.body,
+                            "gemini_proxy",
+                        ),
                 )
                 .await,
             )?
         } else {
             self.pool_manager
-                .execute_request(url.as_str(), HttpMethod::POST, headers, Some(request.body))
+                .execute_request_preserving_endpoint_policy(
+                    url.as_str(),
+                    HttpMethod::POST,
+                    headers,
+                    Some(request.body),
+                )
                 .await
                 .map_err(gemini_openai_like_transport_error)?
         };
@@ -575,21 +581,9 @@ fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
         ProviderError::Configuration { message, .. } => {
             ProviderError::configuration("gemini_proxy", message)
         }
-        ProviderError::Network { message, .. } if is_gemini_endpoint_policy_error(&message) => {
-            ProviderError::configuration(
-                "gemini_proxy",
-                "Gemini endpoint rejected by SSRF protection",
-            )
-        }
         ProviderError::Timeout { .. } => gemini_transport_error(true),
         _ => gemini_transport_error(false),
     }
-}
-
-fn is_gemini_endpoint_policy_error(message: &str) -> bool {
-    message.starts_with("Outbound URL ")
-        || message.starts_with("error following redirect for url")
-        || message.contains("SSRF protection")
 }
 
 fn sanitized_upstream_error(status: u16) -> String {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -108,9 +108,7 @@ impl OpenAILikeProvider {
             self.pool_manager
                 .execute_request(url.as_str(), HttpMethod::POST, headers, Some(request.body))
                 .await
-                .map_err(|_| {
-                    ProviderError::network("gemini_proxy", "Gemini upstream request failed")
-                })?
+                .map_err(gemini_openai_like_transport_error)?
         };
         crate::core::providers::gemini_response_or_provider_error(response, api_key).await
     }
@@ -120,7 +118,7 @@ impl OpenAILikeProvider {
     ) -> Result<T, ProviderError> {
         result
             .map_err(|_| ProviderError::timeout("gemini_proxy", "Gemini response header timeout"))?
-            .map_err(|error| gemini_transport_error(matches!(error, ProviderError::Timeout { .. })))
+            .map_err(gemini_openai_like_transport_error)
     }
 
     /// Create a new OpenAI-like provider
@@ -569,6 +567,16 @@ impl OpenAILikeProvider {
     /// Get the provider configuration
     pub fn config(&self) -> &OpenAILikeConfig {
         &self.config
+    }
+}
+
+fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
+    match error {
+        ProviderError::Configuration { message, .. } => {
+            ProviderError::configuration("gemini_proxy", message)
+        }
+        ProviderError::Timeout { .. } => gemini_transport_error(true),
+        _ => gemini_transport_error(false),
     }
 }
 

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -576,7 +576,10 @@ fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
             ProviderError::configuration("gemini_proxy", message)
         }
         ProviderError::Network { message, .. } if message.contains("SSRF protection") => {
-            ProviderError::configuration("gemini_proxy", message)
+            ProviderError::configuration(
+                "gemini_proxy",
+                "Gemini endpoint rejected by SSRF protection",
+            )
         }
         ProviderError::Timeout { .. } => gemini_transport_error(true),
         _ => gemini_transport_error(false),

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -575,7 +575,7 @@ fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
         ProviderError::Configuration { message, .. } => {
             ProviderError::configuration("gemini_proxy", message)
         }
-        ProviderError::Network { message, .. } if message.contains("SSRF protection") => {
+        ProviderError::Network { message, .. } if is_gemini_endpoint_policy_error(&message) => {
             ProviderError::configuration(
                 "gemini_proxy",
                 "Gemini endpoint rejected by SSRF protection",
@@ -584,6 +584,12 @@ fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
         ProviderError::Timeout { .. } => gemini_transport_error(true),
         _ => gemini_transport_error(false),
     }
+}
+
+fn is_gemini_endpoint_policy_error(message: &str) -> bool {
+    message.starts_with("Outbound URL ")
+        || message.contains("Redirect target failed SSRF validation:")
+        || message.contains("SSRF protection")
 }
 
 fn sanitized_upstream_error(status: u16) -> String {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -588,7 +588,7 @@ fn gemini_openai_like_transport_error(error: ProviderError) -> ProviderError {
 
 fn is_gemini_endpoint_policy_error(message: &str) -> bool {
     message.starts_with("Outbound URL ")
-        || message.contains("Redirect target failed SSRF validation:")
+        || message.starts_with("error following redirect for url")
         || message.contains("SSRF protection")
 }
 

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -10,13 +10,19 @@ const TEST_PUBLIC_API_BASE: &str = "https://api.example.com/v1";
 
 #[test]
 fn gemini_transport_preserves_policy_configuration_errors() {
+    let raw_key = "secret/key+value";
+    let encoded_key: String = url::form_urlencoded::byte_serialize(raw_key.as_bytes()).collect();
     let error = gemini_openai_like_transport_error(ProviderError::network(
         "openai_like",
-        "blocked by SSRF protection",
+        format!(
+            "blocked by SSRF protection at https://example.test?raw={raw_key}&encoded={encoded_key}"
+        ),
     ));
 
     assert!(matches!(error, ProviderError::Configuration { .. }));
     assert!(error.to_string().contains("SSRF protection"));
+    assert!(!error.to_string().contains(raw_key));
+    assert!(!error.to_string().contains(&encoded_key));
 }
 
 #[test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -8,6 +8,28 @@ use tokio::net::{TcpListener, TcpStream};
 
 const TEST_PUBLIC_API_BASE: &str = "https://api.example.com/v1";
 
+#[test]
+fn gemini_transport_preserves_policy_configuration_errors() {
+    let error = gemini_openai_like_transport_error(ProviderError::configuration(
+        "openai_like",
+        "blocked by SSRF protection",
+    ));
+
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+    assert!(error.to_string().contains("SSRF protection"));
+}
+
+#[test]
+fn gemini_transport_redacts_network_error_details() {
+    let error = gemini_openai_like_transport_error(ProviderError::network(
+        "openai_like",
+        "https://example.test?key=secret-key",
+    ));
+
+    assert!(matches!(error, ProviderError::Network { .. }));
+    assert!(!error.to_string().contains("secret-key"));
+}
+
 fn private_openai_like_config(api_base: impl Into<String>) -> OpenAILikeConfig {
     let mut config = crate::core::providers::openai_like::config::test_openai_like_config(api_base);
     config.base.endpoint_access = crate::core::net::ProviderEndpointAccess::PrivateNetwork;

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -9,67 +9,24 @@ use tokio::net::{TcpListener, TcpStream};
 const TEST_PUBLIC_API_BASE: &str = "https://api.example.com/v1";
 
 #[test]
-fn gemini_transport_preserves_policy_configuration_errors() {
-    let raw_key = "secret/key+value";
-    let encoded_key: String = url::form_urlencoded::byte_serialize(raw_key.as_bytes()).collect();
-    let error = gemini_openai_like_transport_error(ProviderError::network(
+fn gemini_transport_preserves_typed_policy_configuration_errors() {
+    let error = gemini_openai_like_transport_error(ProviderError::configuration(
         "openai_like",
-        format!(
-            "blocked by SSRF protection at https://example.test?raw={raw_key}&encoded={encoded_key}"
-        ),
+        "Provider endpoint rejected by SSRF protection",
     ));
 
     assert!(matches!(error, ProviderError::Configuration { .. }));
     assert!(error.to_string().contains("SSRF protection"));
-    assert!(!error.to_string().contains(raw_key));
-    assert!(!error.to_string().contains(&encoded_key));
 }
 
 #[test]
-fn gemini_transport_classifies_direct_endpoint_policy_rejection() {
+fn gemini_transport_keeps_redirect_loops_retryable() {
     let error = gemini_openai_like_transport_error(ProviderError::network(
         "openai_like",
-        "Outbound URL scheme 'ftp' is not allowed",
+        "error following redirect for url (https://example.test/loop)",
     ));
 
-    assert!(matches!(error, ProviderError::Configuration { .. }));
-}
-
-#[tokio::test]
-async fn gemini_transport_classifies_reqwest_redirect_policy_rejection() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let address = listener.local_addr().unwrap();
-    let task = tokio::spawn(async move {
-        let (mut socket, _) = listener.accept().await.unwrap();
-        read_full_http_request(&mut socket).await.unwrap();
-        socket
-            .write_all(
-                b"HTTP/1.1 302 Found\r\nlocation: https://example.test?key=secret-key\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
-            )
-            .await
-            .unwrap();
-    });
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            attempt.error("Redirect target failed SSRF validation: blocked")
-        }))
-        .build()
-        .unwrap();
-    let transport_error = client
-        .get(format!("http://{address}"))
-        .send()
-        .await
-        .unwrap_err();
-    task.await.unwrap();
-    let message = transport_error.to_string();
-    assert!(message.starts_with("error following redirect for url"));
-    assert!(!message.contains("Redirect target failed SSRF validation"));
-
-    let error = gemini_openai_like_transport_error(ProviderError::network("openai_like", message));
-
-    assert!(matches!(error, ProviderError::Configuration { .. }));
-    assert!(!error.to_string().contains("secret-key"));
-    assert!(!error.to_string().contains("example.test"));
+    assert!(matches!(error, ProviderError::Network { .. }));
 }
 
 #[test]
@@ -80,6 +37,49 @@ fn gemini_transport_redacts_network_error_details() {
     ));
 
     assert!(matches!(error, ProviderError::Network { .. }));
+    assert!(!error.to_string().contains("secret-key"));
+}
+
+fn endpoint_policy_pool() -> GlobalPoolManager {
+    GlobalPoolManager::new_for_provider(
+        "openai_like",
+        crate::core::providers::base::BaseConfig {
+            api_base: Some("https://api.example.com/v1".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("policy pool should build")
+}
+
+#[tokio::test]
+async fn gemini_unary_pool_preserves_direct_policy_rejection() {
+    let error = endpoint_policy_pool()
+        .execute_request_preserving_endpoint_policy(
+            "ftp://api.example.com/secret-key",
+            HttpMethod::POST,
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect_err("unsupported scheme must fail");
+
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+    assert!(!error.to_string().contains("secret-key"));
+}
+
+#[tokio::test]
+async fn gemini_stream_pool_preserves_direct_policy_rejection() {
+    let error = endpoint_policy_pool()
+        .execute_streaming_request_preserving_endpoint_policy(
+            "ftp://api.example.com/secret-key",
+            Vec::new(),
+            serde_json::json!({}),
+            "gemini_proxy",
+        )
+        .await
+        .expect_err("unsupported scheme must fail");
+
+    assert!(matches!(error, ProviderError::Configuration { .. }));
     assert!(!error.to_string().contains("secret-key"));
 }
 

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -26,6 +26,20 @@ fn gemini_transport_preserves_policy_configuration_errors() {
 }
 
 #[test]
+fn gemini_transport_classifies_all_endpoint_policy_rejections() {
+    for message in [
+        "Outbound URL scheme 'ftp' is not allowed",
+        "Redirect target failed SSRF validation: scheme 'ftp' is not allowed at https://example.test?key=secret-key",
+    ] {
+        let error =
+            gemini_openai_like_transport_error(ProviderError::network("openai_like", message));
+
+        assert!(matches!(error, ProviderError::Configuration { .. }));
+        assert!(!error.to_string().contains("secret-key"));
+    }
+}
+
+#[test]
 fn gemini_transport_redacts_network_error_details() {
     let error = gemini_openai_like_transport_error(ProviderError::network(
         "openai_like",

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -26,17 +26,50 @@ fn gemini_transport_preserves_policy_configuration_errors() {
 }
 
 #[test]
-fn gemini_transport_classifies_all_endpoint_policy_rejections() {
-    for message in [
+fn gemini_transport_classifies_direct_endpoint_policy_rejection() {
+    let error = gemini_openai_like_transport_error(ProviderError::network(
+        "openai_like",
         "Outbound URL scheme 'ftp' is not allowed",
-        "Redirect target failed SSRF validation: scheme 'ftp' is not allowed at https://example.test?key=secret-key",
-    ] {
-        let error =
-            gemini_openai_like_transport_error(ProviderError::network("openai_like", message));
+    ));
 
-        assert!(matches!(error, ProviderError::Configuration { .. }));
-        assert!(!error.to_string().contains("secret-key"));
-    }
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+}
+
+#[tokio::test]
+async fn gemini_transport_classifies_reqwest_redirect_policy_rejection() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        read_full_http_request(&mut socket).await.unwrap();
+        socket
+            .write_all(
+                b"HTTP/1.1 302 Found\r\nlocation: https://example.test?key=secret-key\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+    });
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            attempt.error("Redirect target failed SSRF validation: blocked")
+        }))
+        .build()
+        .unwrap();
+    let transport_error = client
+        .get(format!("http://{address}"))
+        .send()
+        .await
+        .unwrap_err();
+    task.await.unwrap();
+    let message = transport_error.to_string();
+    assert!(message.starts_with("error following redirect for url"));
+    assert!(!message.contains("Redirect target failed SSRF validation"));
+
+    let error = gemini_openai_like_transport_error(ProviderError::network("openai_like", message));
+
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+    assert!(!error.to_string().contains("secret-key"));
+    assert!(!error.to_string().contains("example.test"));
 }
 
 #[test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -10,7 +10,7 @@ const TEST_PUBLIC_API_BASE: &str = "https://api.example.com/v1";
 
 #[test]
 fn gemini_transport_preserves_policy_configuration_errors() {
-    let error = gemini_openai_like_transport_error(ProviderError::configuration(
+    let error = gemini_openai_like_transport_error(ProviderError::network(
         "openai_like",
         "blocked by SSRF protection",
     ));

--- a/src/utils/net/http.rs
+++ b/src/utils/net/http.rs
@@ -28,6 +28,7 @@ use reqwest::{
     Body, Client, ClientBuilder, IntoUrl, Method, RequestBuilder, Version, multipart, redirect,
 };
 use serde::Serialize;
+use std::error::Error as _;
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::{Arc, OnceLock};
@@ -63,6 +64,35 @@ struct PolicyDnsResolver {
     resolver: Arc<dyn HostResolver>,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum ProviderEndpointPolicyRequestError {
+    #[error("Host resolution returned no addresses (SSRF protection)")]
+    EmptyDnsAnswer,
+    #[error("Host resolves to a disallowed address (SSRF protection)")]
+    DisallowedDnsAddress,
+    #[error("Redirect target failed SSRF validation")]
+    RedirectTarget,
+}
+
+fn reqwest_error_is_endpoint_policy(error: &reqwest::Error) -> bool {
+    let mut source = error.source();
+    while let Some(current) = source {
+        if current
+            .downcast_ref::<ProviderEndpointPolicyRequestError>()
+            .is_some()
+            || current
+                .downcast_ref::<io::Error>()
+                .and_then(io::Error::get_ref)
+                .and_then(|inner| inner.downcast_ref::<ProviderEndpointPolicyRequestError>())
+                .is_some()
+        {
+            return true;
+        }
+        source = current.source();
+    }
+    false
+}
+
 impl reqwest::dns::Resolve for PolicyDnsResolver {
     fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
         let host = name.as_str().to_owned();
@@ -85,7 +115,7 @@ fn validate_provider_addresses(
 ) -> io::Result<Vec<SocketAddr>> {
     if addrs.is_empty() {
         return Err(io::Error::other(
-            "Host resolution returned no addresses (SSRF protection)",
+            ProviderEndpointPolicyRequestError::EmptyDnsAnswer,
         ));
     }
     if addrs
@@ -93,7 +123,7 @@ fn validate_provider_addresses(
         .any(|addr| !is_provider_endpoint_ip_allowed(access, &addr.ip()))
     {
         return Err(io::Error::other(
-            "Host resolves to a disallowed address (SSRF protection)",
+            ProviderEndpointPolicyRequestError::DisallowedDnsAddress,
         ));
     }
     Ok(addrs)
@@ -101,8 +131,9 @@ fn validate_provider_addresses(
 
 fn ssrf_safe_redirect_policy() -> redirect::Policy {
     redirect::Policy::custom(|attempt| {
-        if let Err(error) = validate_outbound_url_without_resolution(attempt.url()) {
-            return attempt.error(format!("Redirect target failed SSRF validation: {error}"));
+        if validate_outbound_url_without_resolution(attempt.url()).is_err() {
+            debug!("blocked redirect target by outbound endpoint policy");
+            return attempt.error(ProviderEndpointPolicyRequestError::RedirectTarget);
         }
 
         redirect::Policy::limited(10).redirect(attempt)
@@ -115,8 +146,12 @@ fn provider_redirect_policy(policy: ProviderEndpointPolicy) -> redirect::Policy 
     }
 
     redirect::Policy::custom(move |attempt| {
-        if let Err(error) = policy.validate_url_without_resolution(attempt.url()) {
-            return attempt.error(format!("Redirect target failed SSRF validation: {error}"));
+        if policy
+            .validate_url_without_resolution(attempt.url())
+            .is_err()
+        {
+            debug!("blocked provider redirect target by endpoint policy");
+            return attempt.error(ProviderEndpointPolicyRequestError::RedirectTarget);
         }
         redirect::Policy::limited(10).redirect(attempt)
     })
@@ -128,6 +163,12 @@ pub enum ProviderHttpClientError {
     Endpoint(#[from] SsrfError),
     #[error(transparent)]
     Request(#[from] reqwest::Error),
+}
+
+impl ProviderHttpClientError {
+    pub(crate) fn is_endpoint_policy(&self) -> bool {
+        matches!(self, Self::Endpoint(_))
+    }
 }
 
 /// Request builder that cannot expose or replace its policy-bound HTTP client.
@@ -234,6 +275,10 @@ impl std::fmt::Debug for ProviderHttpClient {
 }
 
 impl ProviderHttpClient {
+    pub(crate) fn request_error_is_endpoint_policy(error: &reqwest::Error) -> bool {
+        reqwest_error_is_endpoint_policy(error)
+    }
+
     pub fn new(
         policy: ProviderEndpointPolicy,
         timeout: Duration,
@@ -690,10 +735,7 @@ mod tests {
             Err(error) => error,
         };
         assert!(error.is_redirect(), "{error:?}");
-        assert!(
-            format!("{error:?}").contains("SSRF validation"),
-            "{error:?}"
-        );
+        assert!(reqwest_error_is_endpoint_policy(&error), "{error:?}");
         assert!(
             tokio::time::timeout(Duration::from_millis(100), target.accept())
                 .await

--- a/src/utils/net/http/provider_tests.rs
+++ b/src/utils/net/http/provider_tests.rs
@@ -588,7 +588,7 @@ async fn security_evidence_public_redirect_to_private_literal_does_not_reach_tar
     assert!(reqwest_error_is_endpoint_policy(&error), "{error:?}");
     let mapped = map_preserved_error(error);
     assert!(matches!(mapped, ProviderError::Configuration { .. }));
-    assert!(!mapped.to_string().contains(&source_address.to_string()));
+    assert!(!mapped.to_string().contains(&target_address.to_string()));
     assert_listener_did_not_accept(&target, "provider redirect must not open the target socket")
         .await;
     server.await??;

--- a/src/utils/net/http/provider_tests.rs
+++ b/src/utils/net/http/provider_tests.rs
@@ -203,6 +203,7 @@ async fn assert_public_rebind_is_blocked(
         ),
         "{mode:?} must fail in the DNS policy for {blocked_ip}, got {error:?}"
     );
+    assert!(reqwest_error_is_endpoint_policy(&error), "{error:?}");
     assert_eq!(
         resolver.remaining_answers()?,
         0,
@@ -568,13 +569,58 @@ async fn security_evidence_public_redirect_to_private_literal_does_not_reach_tar
         ))
         .build()?;
 
-    let result = client
+    let error = client
         .get(format!("http://{source_address}/v1"))
         .send()
-        .await;
-    assert!(result.is_err(), "private redirect target must fail");
+        .await
+        .expect_err("private redirect target must fail");
+    assert!(reqwest_error_is_endpoint_policy(&error), "{error:?}");
     assert_listener_did_not_accept(&target, "provider redirect must not open the target socket")
         .await;
+    server.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn ordinary_redirect_loop_is_not_an_endpoint_policy_error()
+-> Result<(), Box<dyn std::error::Error>> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let url = format!("http://{address}/loop");
+    let redirect_url = url.clone();
+    let server = tokio::spawn(async move {
+        for _ in 0..4 {
+            let accepted = tokio::time::timeout(Duration::from_secs(1), listener.accept()).await;
+            let Ok(Ok((mut stream, _))) = accepted else {
+                break;
+            };
+            let mut request = [0_u8; 1024];
+            if stream.read(&mut request).await? == 0 {
+                return Err(io::Error::other("request ended before headers"));
+            }
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 302 Found\r\nLocation: {redirect_url}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+        }
+        Ok::<(), io::Error>(())
+    });
+    let client = ClientBuilder::new()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::limited(2))
+        .build()?;
+    let error = client
+        .get(url)
+        .send()
+        .await
+        .expect_err("redirect must loop");
+
+    assert!(error.is_redirect(), "{error:?}");
+    assert!(!reqwest_error_is_endpoint_policy(&error), "{error:?}");
     server.await??;
     Ok(())
 }

--- a/src/utils/net/http/provider_tests.rs
+++ b/src/utils/net/http/provider_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::core::providers::base::{BaseConfig, BaseHttpClient};
+use crate::core::providers::unified_provider::ProviderError;
 use std::collections::VecDeque;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Mutex;
@@ -6,6 +8,12 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 type ConnectorBoxError = Box<dyn std::error::Error + Send + Sync>;
+
+fn map_preserved_error(error: reqwest::Error) -> ProviderError {
+    BaseHttpClient::new_for_provider("test", BaseConfig::default())
+        .expect("test mapper should build")
+        .map_preserved_request_error(error)
+}
 
 fn error_chain_contains(error: &(dyn std::error::Error + 'static), expected: &str) -> bool {
     let mut current = Some(error);
@@ -204,6 +212,9 @@ async fn assert_public_rebind_is_blocked(
         "{mode:?} must fail in the DNS policy for {blocked_ip}, got {error:?}"
     );
     assert!(reqwest_error_is_endpoint_policy(&error), "{error:?}");
+    let mapped = map_preserved_error(error);
+    assert!(matches!(mapped, ProviderError::Configuration { .. }));
+    assert!(!mapped.to_string().contains(&blocked_ip.to_string()));
     assert_eq!(
         resolver.remaining_answers()?,
         0,
@@ -575,6 +586,9 @@ async fn security_evidence_public_redirect_to_private_literal_does_not_reach_tar
         .await
         .expect_err("private redirect target must fail");
     assert!(reqwest_error_is_endpoint_policy(&error), "{error:?}");
+    let mapped = map_preserved_error(error);
+    assert!(matches!(mapped, ProviderError::Configuration { .. }));
+    assert!(!mapped.to_string().contains(&source_address.to_string()));
     assert_listener_did_not_accept(&target, "provider redirect must not open the target socket")
         .await;
     server.await??;
@@ -621,6 +635,10 @@ async fn ordinary_redirect_loop_is_not_an_endpoint_policy_error()
 
     assert!(error.is_redirect(), "{error:?}");
     assert!(!reqwest_error_is_endpoint_policy(&error), "{error:?}");
+    assert!(matches!(
+        map_preserved_error(error),
+        ProviderError::Network { .. }
+    ));
     server.await??;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- preserve endpoint-policy/SSRF failures as configuration errors
- keep Gemini transport network details redacted
- cover policy classification and network-detail redaction

## SpecRail
- Refs #966
- Product spec: `specs/GH966/product.md`
- Technical spec: `specs/GH966/tech.md`
- Task plan: `specs/GH966/tasks.md`
- Partial Phase A regression follow-up; #966 remains open

## Verification
- `cargo test --lib core::providers::openai_like::provider::tests::gemini_transport -- --nocapture`
- `cargo test --lib core::providers::base::http::tests::base_http_client_accepts_private_base_and_pins_authority -- --exact --nocapture`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`