### PR TITLE
docs(specrail): preserve GH966 endpoint policy errors

### DIFF
--- a/specs/GH966/tasks.md
+++ b/specs/GH966/tasks.md
@@ -11,34 +11,101 @@ GH-966 / #966
 
 ## 实现任务
 
-- [x] `SP966-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010, B-011. Owner: coordinator. Dependencies: none. Done when: GH966 product/tech/tasks 三件套存在，behavior invariant、implementation mapping 与 task coverage 集合完整，SpecRail workflow 与 write-spec route gate 通过；规格 PR 使用 `Refs #966` 并经独立 current-head review、CI、threads 与 PR gate 合并。 Verify: `python3 checks/check_workflow.py --repo <specrail> --spec-dir "$PWD/specs/GH966"`; 比较 product/tech/tasks 的 `B-[0-9]{3}` 集合；GitHub evidence adapter + offline PR gate。
-- [ ] `SP966-T2` Covers: B-003, B-004, B-011. Owner: Phase A runtime dispatch owner. Dependencies: SP966-T1 and this staged-plan amendment merged. Done when: amendment 合并后，在原 PR 原分支 `codex/gh966-runtime-dispatch` merge 最新 `origin/main`（禁止 force push、禁止新建替代 PR）；typed Gemini native capability/request 与 closed `Provider` dispatch 接入 route，实际 HTTP sender 只能是 selected runtime provider；native Gemini 和名称规范化后精确属于 `gemini|googleai|googleaistudio` 的 OpenAI-like runtime 使用自身 immutable endpoint/key/headers/policy/client/timeout，任意标点或空格名称拒绝；non-success body 在 provider 边界脱敏 raw/URL-encoded key；route 仅可暂时用 config 构造候选/identity，旧 adapter/client 不得参与 send。PR 限 tech Phase A 的 10 文件、最多 500 changed lines，使用 `Refs #966`。 Verify: CI 六组 feature matrix `lite`、`sqlite,redis`、`postgres,redis`、`sqlite,redis,metrics,tracing`、`postgres,redis,s3,metrics,tracing`、`postgres,sqlite,redis,s3,metrics,tracing,websockets,analytics`；capability/name、native URL/error redaction、named stream header timeout 与 unary config-mutation sender snapshot tests；all-feature check；strict Clippy；全量 test；scope/overlap；exact-head implementation + security review PASS；CI/reviewThreads/required gate。合并后删除远端阶段分支并确认 #966 仍 open。
-- [ ] `SP966-T3` Covers: B-002, B-006, B-009. Owner: Phase B route ownership owner. Dependencies: SP966-T2 merged. Done when: selected deployment 后的 `state.config().providers()` 反查、route-owned client construction、API key/base URL/headers/timeout 复制和旧 Gemini send/error helpers 全部删除；adapter 只保留 selected provider/pricing identity 与 original requested Gemini model，native URL/budget/spend 不使用 empty-model named deployment 的 selection key。pre-selection candidate scan 可暂留，但不得影响已选 snapshot。PR 仅修改 tech Phase B 的四文件集合、最多 500 changed lines，使用 `Refs #966`。 Verify: selected snapshot endpoint/key/header/timeout mutation tests；empty-model URL/pricing/model-budget/spend identity tests；focused Gemini SDK/fallback/spend tests；六组 feature matrix；strict Clippy；全量 test；scope/overlap；exact-head implementation + security review PASS；CI/reviewThreads/required gate。合并后删除远端阶段分支并确认 #966 仍 open。
-- [ ] `SP966-T4` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010, B-011. Owner: Phase C runtime-only discovery owner. Dependencies: SP966-T3 merged. Done when: Gemini candidate model/alias 只从 immutable router deployments 派生，route 不再读取 `state.config().providers()`；unary/stream snapshot、native + 三命名兼容正例、任意名称拒绝、fallback/budget/health/lease/spend、client cancel neutral、read failure 与 raw/encoded key 脱敏全部覆盖；source guard 拒绝 config scan、`RouteHttpClient`、敏感 adapter 字段与第二 sender。PR 仅修改 tech Phase C 的四文件集合、最多 500 changed lines，并使用 `Fixes #966`。 Verify: focused Gemini SDK/fallback/spend/execution tests；source guard；`cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; strict Clippy；全量 test；scope/overlap。
-- [ ] `SP966-T5` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010, B-011. Owner: integration verification owner + independent reviewer. Dependencies: SP966-T4 exact head ready. Done when: Phase C exact-head CI 全绿、0 unresolved review threads、独立 spec-vs-implementation/security review PASS、required PR gate PASS；合并后 #966 closed、远端实现分支删除，main 与 closure audit 一致。 Verify: GitHub evidence adapter；offline `pr_gate.py --mode required`；merged SHA checks；issue/PR queue closure audit。旧 full checkpoint 仅作参考，不得作为 alias/cancel/read-failure 或 gate 证据。
+- [x] `SP966-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
+  B-009, B-010, B-011. Owner: coordinator. Dependencies: none. Done when: GH966
+  product/tech/tasks 三件套存在，behavior invariant、implementation mapping 与 task coverage
+  集合完整，SpecRail workflow 与 write-spec route gate 通过；规格 PR 使用 `Refs #966`
+  并经独立 current-head review、CI、threads 与 PR gate 合并。 Verify:
+  `python3 checks/check_workflow.py --repo <specrail>`；比较 product/tech/tasks 的
+  `B-[0-9]{3}` 集合；GitHub evidence adapter + offline PR gate。
+- [x] `SP966-T2` Covers: B-003, B-004, B-011. Owner: Phase A runtime dispatch owner.
+  Dependencies: SP966-T1 and staged-plan amendment merged. Done when: typed Gemini native
+  capability/request 与 closed `Provider` dispatch 接入 route，实际 HTTP sender 只能是
+  selected runtime provider；native Gemini 和名称规范化后精确属于
+  `gemini|googleai|googleaistudio` 的 OpenAI-like runtime 使用自身 immutable
+  endpoint/key/headers/policy/client/timeout，任意标点或空格名称拒绝；non-success body
+  在 provider 边界脱敏 raw/URL-encoded key；route 仅可暂时用 config 构造候选/identity，
+  旧 adapter/client 不得参与 send。PR 限 tech Phase A 的 10 文件、最多 500 changed
+  lines，使用 `Refs #966`。 Verify: PR #1019 exact-head 六组 feature matrix、focused tests、
+  all-feature check、strict Clippy、全量 test、scope/overlap、implementation/security review、
+  CI/reviewThreads/required gate 全部通过；合并后 #966 仍 open。
+- [ ] `SP966-T2R` Covers: B-005, B-007, B-010. Owner: Phase A endpoint-policy regression
+  owner. Dependencies: SP966-T2 and this regression amendment merged. Done when: 在原 PR
+  #1021、原分支 `codex/gh966-transport-classification` merge 最新 `origin/main`（禁止
+  force push、禁止新建替代 PR）；connection pool 新增仅由 OpenAI-like Gemini native
+  sender 使用的 opt-in ordinary/streaming 执行路径，在字符串化前保留直接 outbound URL
+  拒绝与 `reqwest::Error` source chain 中的 redirect-target/DNS-rebinding policy 信号；
+  policy 错误映射为固定、无敏感数据的 `Configuration`，redirect loop/普通 transport
+  仍为 `Network`，timeout 仍为 `Timeout`，其他 provider 与旧 connection-pool 执行方法
+  语义不变。PR 限 tech follow-up 的 5 文件、最多 500 changed lines，使用
+  `Refs #966`。 Verify: 真实本地 redirect policy 与 redirect-loop 对照、DNS-rebinding
+  source、unsupported scheme、timeout、ordinary/streaming、raw/URL-encoded key 与 endpoint
+  不泄露；all-feature check；strict Clippy；全量 test；scope/overlap；exact-head
+  implementation + security review PASS；CI/0 unresolved threads/required gate。合并后删除
+  远程分支并确认 #966 仍 open。
+- [ ] `SP966-T3` Covers: B-002, B-006, B-009. Owner: Phase B route ownership owner.
+  Dependencies: SP966-T2R merged. Done when: selected deployment 后的
+  `state.config().providers()` 反查、route-owned client construction、API key/base
+  URL/headers/timeout 复制和旧 Gemini send/error helpers 全部删除；adapter 只保留
+  selected provider/pricing identity 与 original requested Gemini model，native URL/budget/spend
+  不使用 empty-model named deployment 的 selection key。pre-selection candidate scan 可暂留，
+  但不得影响已选 snapshot。PR 仅修改 tech Phase B 的四文件集合、最多 500 changed
+  lines，使用 `Refs #966`。 Verify: selected snapshot endpoint/key/header/timeout
+  mutation tests；empty-model URL/pricing/model-budget/spend identity tests；focused Gemini
+  SDK/fallback/spend tests；六组 feature matrix；strict Clippy；全量 test；scope/overlap；
+  exact-head implementation + security review PASS；CI/reviewThreads/required gate。合并后
+  删除远程阶段分支并确认 #966 仍 open。
+- [ ] `SP966-T4` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
+  B-009, B-010, B-011. Owner: Phase C runtime-only discovery owner. Dependencies: SP966-T3
+  merged. Done when: Gemini candidate model/alias 只从 immutable router deployments 派生，route
+  不再读取 `state.config().providers()`；unary/stream snapshot、native + 三命名兼容正例、
+  任意名称拒绝、fallback/budget/health/lease/spend、client cancel neutral、read failure 与
+  raw/encoded key 脱敏全部覆盖；source guard 拒绝 config scan、`RouteHttpClient`、敏感
+  adapter 字段与第二 sender。PR 仅修改 tech Phase C 的四文件集合、最多 500 changed
+  lines，并使用 `Fixes #966`。 Verify: focused Gemini SDK/fallback/spend/execution tests；
+  source guard；`cargo fmt --all -- --check`; `cargo check --all-targets --all-features
+  --locked`; strict Clippy；全量 test；scope/overlap。
+- [ ] `SP966-T5` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
+  B-009, B-010, B-011. Owner: integration verification owner + independent reviewer.
+  Dependencies: SP966-T4 exact head ready. Done when: Phase C exact-head CI 全绿、0 unresolved
+  review threads、独立 spec-vs-implementation/security review PASS、required PR gate PASS；合并后
+  #966 closed、远程实现分支删除，main 与 closure audit 一致。 Verify: GitHub evidence
+  adapter；offline `pr_gate.py --mode required`；merged SHA checks；issue/PR queue closure audit。
+  旧 full checkpoint 仅作参考，不得作为 alias/cancel/read-failure 或 gate 证据。
 
 ## 并行拆分
 
-- T2、T3、T4 是严格串行的三个 implementation PR；每阶段必须合并后，下一阶段才从最新 `main` 创建。
-- 每个阶段最多 10 个非文档文件、500 changed lines；三阶段 writable union 为 tech spec 明列的 11 个文件，
-  不修改 799 行的 `execution.rs` 或 budget API。
-- T5 的只读 reviewer/security lane 可与 coordinator 的 final verification 并行；reviewer 不写 production/test
-  文件，只在 exact head 给 verdict，并由 reviewer 身份解析 review threads。
-- writable worker 使用独立 worktree且单一 owner；同一阶段不并行修改 `gemini.rs`、provider adapter 或 integration
-  fixture。若 scope 超限，先更新并合并规范，不得临时扩大文件集合或弱化测试。
+- T2、T2R、T3、T4 是严格串行的 implementation PR；T2R 是 Phase A 合并后暴露的
+  回归修复，必须在 T3 前合并；每阶段必须合并后，下一阶段才从最新 `main` 继续。
+- 每个阶段最多 10 个非文档文件、500 changed lines；三阶段 writable union 为 tech spec
+  明列的 11 个文件，regression follow-up 另限定为 tech spec 明列的 5 个文件，不修改
+  799 行的 `execution.rs` 或 budget API。
+- T5 的只读 reviewer/security lane 可与 coordinator 的 final verification 并行；reviewer 不写
+  production/test 文件，只在 exact head 给 verdict，并由 reviewer 身份解析 review threads。
+- writable worker 使用独立 worktree 且单一 owner；同一阶段不并行修改 `gemini.rs`、
+  provider adapter 或 integration fixture。若 scope 超限，先更新并合并规范，不得临时
+  扩大文件集合或弱化测试。
 
 ## 验证
 
-- Product、tech mapping 与 tasks `Covers:` union 精确为 B-001 至 B-011，无 orphan 或 undeclared invariant。
-- 本 amendment PR 只包含 `specs/GH966/tech.md` 与 `specs/GH966/tasks.md`；不改变 product behavior invariants。
-- Phase A/B/C 每个 PR 的 fresh exact-head focused、feature matrix、check、strict Clippy、全量 test、scope/overlap、
-  CI、reviewThreads 与 offline gate 全部通过；前两阶段 issue 保持 open，Phase C 合并后 #966 closed。
+- Product、tech mapping 与 tasks `Covers:` union 精确为 B-001 至 B-011，无 orphan 或
+  undeclared invariant。
+- 本 amendment PR 只包含 `specs/GH966/tech.md` 与 `specs/GH966/tasks.md`；不改变 product
+  behavior invariants。
+- Phase A/regression follow-up/B/C 每个 PR 的 fresh exact-head focused、feature matrix、check、
+  strict Clippy、全量 test、scope/overlap、CI、reviewThreads 与 offline gate 全部通过；Phase A、
+  regression follow-up 与 Phase B 合并后 issue 保持 open，Phase C 合并后 #966 closed。
 
 ## Handoff Notes
 
-- selected runtime provider 是唯一执行器；禁止再从 Gateway config 复原认证、endpoint 或 client。
-- `GeminiRouteProvider` 只可保留 selected provider name + original requested Gemini model 的 budget/spend identity，
-  不可保存 API key、base URL、headers、timeout、client，亦不可把 named deployment model 当作请求 model。
-- 兼容范围仅为显式命名 `gemini|googleai|googleaistudio` 的 OpenAI-compatible runtime；不得扩大为任意实例。
-- upstream error 脱敏必须在持有 runtime key 的 provider 内完成，覆盖 raw 与 URL-encoded key；route 不得取回 key。
-- spec amendment 与 Phase A/B 使用 `Refs #966`；仅 Phase C 使用 `Fixes #966`。
+- selected runtime provider 是唯一执行器；禁止再从 Gateway config 复原认证、endpoint 或
+  client。
+- `GeminiRouteProvider` 只可保留 selected provider name + original requested Gemini model 的
+  budget/spend identity，不可保存 API key、base URL、headers、timeout、client，亦不可把
+  named deployment model 当作请求 model。
+- 兼容范围仅为显式命名 `gemini|googleai|googleaistudio` 的 OpenAI-compatible runtime；
+  不得扩大为任意实例。
+- upstream error 脱敏必须在持有 runtime key 的 provider 内完成，覆盖 raw 与
+  URL-encoded key；route 不得取回 key。
+- spec amendment、regression follow-up 与 Phase B 使用 `Refs #966`；仅 Phase C 使用
+  `Fixes #966`。

--- a/specs/GH966/tasks.md
+++ b/specs/GH966/tasks.md
@@ -37,7 +37,8 @@ GH-966 / #966
   拒绝与 `reqwest::Error` source chain 中的 redirect-target/DNS-rebinding policy 信号；
   policy 错误映射为固定、无敏感数据的 `Configuration`，redirect loop/普通 transport
   仍为 `Network`，timeout 仍为 `Timeout`，其他 provider 与旧 connection-pool 执行方法
-  语义不变。PR 限 tech follow-up 的 5 文件、最多 500 changed lines，使用
+  语义不变；`BaseHttpClient` 只可新增 crate-private typed request opt-in，现有方法不变。
+  PR 限 tech follow-up 的 6 文件、最多 500 changed lines，使用
   `Refs #966`。 Verify: 真实本地 redirect policy 与 redirect-loop 对照、DNS-rebinding
   source、unsupported scheme、timeout、ordinary/streaming、raw/URL-encoded key 与 endpoint
   不泄露；all-feature check；strict Clippy；全量 test；scope/overlap；exact-head
@@ -78,7 +79,7 @@ GH-966 / #966
 - T2、T2R、T3、T4 是严格串行的 implementation PR；T2R 是 Phase A 合并后暴露的
   回归修复，必须在 T3 前合并；每阶段必须合并后，下一阶段才从最新 `main` 继续。
 - 每个阶段最多 10 个非文档文件、500 changed lines；三阶段 writable union 为 tech spec
-  明列的 11 个文件，regression follow-up 另限定为 tech spec 明列的 5 个文件，不修改
+  明列的 11 个文件，regression follow-up 另限定为 tech spec 明列的 6 个文件，不修改
   799 行的 `execution.rs` 或 budget API。
 - T5 的只读 reviewer/security lane 可与 coordinator 的 final verification 并行；reviewer 不写
   production/test 文件，只在 exact head 给 verdict，并由 reviewer 身份解析 review threads。

--- a/specs/GH966/tasks.md
+++ b/specs/GH966/tasks.md
@@ -29,7 +29,7 @@ GH-966 / #966
   lines，使用 `Refs #966`。 Verify: PR #1019 exact-head 六组 feature matrix、focused tests、
   all-feature check、strict Clippy、全量 test、scope/overlap、implementation/security review、
   CI/reviewThreads/required gate 全部通过；合并后 #966 仍 open。
-- [ ] `SP966-T2R` Covers: B-005, B-007, B-010. Owner: Phase A endpoint-policy regression
+- [ ] `SP966-T2R` Covers: B-002, B-007, B-010, B-011. Owner: Phase A endpoint-policy regression
   owner. Dependencies: SP966-T2 and this regression amendment merged. Done when: 在原 PR
   #1021、原分支 `codex/gh966-transport-classification` merge 最新 `origin/main`（禁止
   force push、禁止新建替代 PR）；connection pool 新增仅由 OpenAI-like Gemini native

--- a/specs/GH966/tech.md
+++ b/specs/GH966/tech.md
@@ -105,21 +105,23 @@ Phase A 合并后的公开回归证明，仅在 OpenAI-like provider 层分析�
 无法无损区分 endpoint policy 与普通 transport 错误：`reqwest::Error` 的 `Display` 不保留
 redirect-target 与 DNS-rebinding 的 source chain，而宽泛匹配 `error following redirect` 会把 redirect loop
 错判为不可重试配置错误。因此 Phase B 之前先在原 PR #1021、原分支
-`codex/gh966-transport-classification` 完成一个严格串行的 regression follow-up，允许修改以下 5 个文件：
+`codex/gh966-transport-classification` 完成一个严格串行的 regression follow-up，允许修改以下 6 个文件：
 
 1. `src/utils/net/http.rs`
 2. `src/utils/net/http/provider_tests.rs`
-3. `src/core/providers/base/connection_pool.rs`
-4. `src/core/providers/openai_like/provider.rs`
-5. `src/core/providers/openai_like/provider/tests.rs`
+3. `src/core/providers/base/http.rs`
+4. `src/core/providers/base/connection_pool.rs`
+5. `src/core/providers/openai_like/provider.rs`
+6. `src/core/providers/openai_like/provider/tests.rs`
 
-connection pool 必须保留现有 ordinary/streaming 执行方法与全局语义，仅新增显式 opt-in 路径；
+`BaseHttpClient` 与 connection pool 必须保留现有 ordinary/streaming 执行方法与全局语义；
+`BaseHttpClient` 仅可新增 crate-private typed request opt-in，connection pool 仅可新增显式 opt-in 路径；
 OpenAI-like Gemini native sender 是唯一调用者。opt-in 路径在字符串化前检查直接 outbound URL policy
 拒绝与 `reqwest::Error::source()` 链中的精确 redirect-target/DNS-rebinding policy 来源，并为 ordinary 与
 streaming 返回结构化 `Configuration`。不得用宽泛 redirect 文本、URL、host 或 key 作为分类标记；
 对外错误文本必须固定且不泄露 raw/URL-encoded key 或 endpoint。回归必须使用真实本地 redirect
 链证明 policy redirect 为 `Configuration`、redirect loop 仍为 `Network`，并覆盖 DNS-rebinding source、直接
-unsupported-scheme、timeout、ordinary 和 streaming。本 follow-up 最多 5 个非文档文件、500 changed lines，
+unsupported-scheme、timeout、ordinary 和 streaming。本 follow-up 最多 6 个非文档文件、500 changed lines，
 使用 `Refs #966`；exact-head implementation/security review、CI、0 unresolved threads 与 required gate 通过后才可
 合并，合并后 #966 仍保持 open。
 

--- a/specs/GH966/tech.md
+++ b/specs/GH966/tech.md
@@ -41,6 +41,11 @@ Link to `product.md`.
   `OpenAILikeConfig` base endpoint/API key/custom headers/timeout 与 pool-owned policy client，不读取 Gateway config。
 - URL 只接受现有 `v1|v1beta` 与 `generateContent|streamGenerateContent` 组合；stream 添加 `alt=sse`，AI Studio
   key 继续使用 query。所有 client/build/send/timeout/HTTP 错误映射为现有 `ProviderError`，无 silent fallback。
+- OpenAI-like Gemini native sender 的 endpoint-policy 错误必须在 `reqwest::Error` 被 `Display`/字符串化之前保留结构化
+  信号：直接 outbound URL policy 拒绝以及 source chain 中的 redirect-target/DNS-rebinding policy 拒绝映射为
+  不可重试的 `Configuration`；redirect loop、普通 redirect failure 与其他 transport 错误仍是可 fallback 的
+  `Network`，timeout 仍是 `Timeout`。只允许 Gemini native sender 显式选择该保真路径，不改变其他 provider
+  或现有 connection-pool 公共执行方法的错误语义。
 - provider-owned execute contract 在读取任何非成功 upstream body 后、返回/记录错误前，同时替换 runtime
   config 中 API key 的 raw 与 `application/x-www-form-urlencoded` 形式；route adapter 不重新获取或保存 key。
 
@@ -93,6 +98,30 @@ route 的共享 adapter 行为。Phase A 必须包含 config mutation 的 unary 
 Phase A 的原 PR 已在本 amendment 之前创建；amendment 合并后必须在原分支
 `codex/gh966-runtime-dispatch` merge 最新 `origin/main`，禁止 force push或新建替代 PR，再对新的 exact head 重跑
 CI、reviewThreads、implementation/security review 与 required gate。
+
+#### Phase A regression follow-up — preserve typed endpoint-policy failures
+
+Phase A 合并后的公开回归证明，仅在 OpenAI-like provider 层分析已字符串化的 `ProviderError::Network`
+无法无损区分 endpoint policy 与普通 transport 错误：`reqwest::Error` 的 `Display` 不保留
+redirect-target 与 DNS-rebinding 的 source chain，而宽泛匹配 `error following redirect` 会把 redirect loop
+错判为不可重试配置错误。因此 Phase B 之前先在原 PR #1021、原分支
+`codex/gh966-transport-classification` 完成一个严格串行的 regression follow-up，允许修改以下 5 个文件：
+
+1. `src/utils/net/http.rs`
+2. `src/utils/net/http/provider_tests.rs`
+3. `src/core/providers/base/connection_pool.rs`
+4. `src/core/providers/openai_like/provider.rs`
+5. `src/core/providers/openai_like/provider/tests.rs`
+
+connection pool 必须保留现有 ordinary/streaming 执行方法与全局语义，仅新增显式 opt-in 路径；
+OpenAI-like Gemini native sender 是唯一调用者。opt-in 路径在字符串化前检查直接 outbound URL policy
+拒绝与 `reqwest::Error::source()` 链中的精确 redirect-target/DNS-rebinding policy 来源，并为 ordinary 与
+streaming 返回结构化 `Configuration`。不得用宽泛 redirect 文本、URL、host 或 key 作为分类标记；
+对外错误文本必须固定且不泄露 raw/URL-encoded key 或 endpoint。回归必须使用真实本地 redirect
+链证明 policy redirect 为 `Configuration`、redirect loop 仍为 `Network`，并覆盖 DNS-rebinding source、直接
+unsupported-scheme、timeout、ordinary 和 streaming。本 follow-up 最多 5 个非文档文件、500 changed lines，
+使用 `Refs #966`；exact-head implementation/security review、CI、0 unresolved threads 与 required gate 通过后才可
+合并，合并后 #966 仍保持 open。
 
 #### Phase B — remove post-selection reconstruction
 

--- a/specs/GH966/tech.md
+++ b/specs/GH966/tech.md
@@ -171,16 +171,16 @@ fresh diff 超过自身 scope，不得削弱断言、压缩可读性或扩大 wr
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
 | B-001 | route selected callback + closed provider dispatch | unary/stream snapshot executor tests；source guard 无 config rescan |
-| B-002 | GeminiClient/OpenAILike runtime-owned config/client | router 后 config mutation 双 listener/key/header/timeout tests |
+| B-002 | GeminiClient/OpenAILike runtime-owned config/client + typed policy opt-in | router 后 config mutation 双 listener/key/header/timeout tests；直接 URL 与 reqwest source 在 stringify 前保真 |
 | B-003 | native Gemini passthrough | v1/v1beta unary/stream URL、query、headers、JSON/SSE integration matrix |
 | B-004 | OpenAILike named compatibility dispatch | 三个名称正例、大小写规范化与任意名称拒绝 tests |
 | B-005 | selection/unsupported error mapping | 无 deployment、模型不匹配、非 Gemini provider tests；无 fallback client source guard |
 | B-006 | identity-only route adapter + execution helper | selected provider + requested Gemini model 的 URL/budget/spend；deployment-id fallback/health/lease；空 `models` named compatibility assertions |
-| B-007 | existing unary retry helper | upstream 429/5xx、provider/model budget fallback tests |
+| B-007 | existing unary retry helper | upstream 429/5xx、provider/model budget fallback tests；policy redirect 不重试且 redirect loop/普通 transport 仍 fallback |
 | B-008 | existing stream execution lease + spend settlement | success=healthy、read failure=failed、cancel=neutral 的 lease/health/spend tests |
 | B-009 | reduced `GeminiRouteProvider` | compile-time struct fields + source guard 禁止 key/url/headers/timeout/client |
-| B-010 | focused source guard + full gates | guard red/green fixture、strict Clippy、全量 test、PR gate |
-| B-011 | provider-owned non-success response handling | raw key、URL-encoded key 与 URI echo 脱敏 tests；route adapter 无 key source guard |
+| B-010 | focused source guard + full gates | guard red/green fixture、typed redirect/DNS source + ordinary/streaming regressions、strict Clippy、全量 test、PR gate |
+| B-011 | provider-owned non-success response handling + fixed policy diagnostics | raw key、URL-encoded key、URI/endpoint echo 脱敏 tests；policy errors 不含敏感数据；route adapter 无 key source guard |
 
 ## 数据流
 


### PR DESCRIPTION
## Linked Work

Refs #966

## Scope

- authorize the original PR #1021 to preserve endpoint-policy failures before reqwest errors are stringified
- require an opt-in Gemini-only ordinary/streaming connection-pool path without changing existing global semantics
- distinguish policy redirect/DNS rebinding from redirect loops and ordinary transport failures
- record the 5-file/500-line regression tranche and Phase B dependency

## Verification

- SpecRail workflow pack check passed
- product/tech/tasks invariant sets are each exactly B-001 through B-011
- git diff --check