### PR TITLE
docs(spec): stage GH966 Phase B prerequisite

### DIFF
--- a/specs/GH966/tasks.md
+++ b/specs/GH966/tasks.md
@@ -29,7 +29,7 @@ GH-966 / #966
   lines，使用 `Refs #966`。 Verify: PR #1019 exact-head 六组 feature matrix、focused tests、
   all-feature check、strict Clippy、全量 test、scope/overlap、implementation/security review、
   CI/reviewThreads/required gate 全部通过；合并后 #966 仍 open。
-- [ ] `SP966-T2R` Covers: B-002, B-007, B-010, B-011. Owner: Phase A endpoint-policy regression
+- [x] `SP966-T2R` Covers: B-002, B-007, B-010, B-011. Owner: Phase A endpoint-policy regression
   owner. Dependencies: SP966-T2 and this regression amendment merged. Done when: 在原 PR
   #1021、原分支 `codex/gh966-transport-classification` merge 最新 `origin/main`（禁止
   force push、禁止新建替代 PR）；connection pool 新增仅由 OpenAI-like Gemini native
@@ -44,8 +44,22 @@ GH-966 / #966
   不泄露；all-feature check；strict Clippy；全量 test；scope/overlap；exact-head
   implementation + security review PASS；CI/0 unresolved threads/required gate。合并后删除
   远程分支并确认 #966 仍 open。
+- [ ] `SP966-T2S` Covers: B-002, B-010. Owner: Phase B prerequisite regression owner.
+  Dependencies: SP966-T2R and this prerequisite amendment merged. Done when: 独立 follow-up PR
+  仅修改 `tests/gemini_sdk_routes.rs`，只删除/替换不可达的
+  `public_only_gemini_route_rejects_loopback_before_connect` 历史 route-time assertion；新断言
+  在 runtime provider bootstrap/configuration 阶段证明 `PublicOnly` + loopback 以明确的
+  `Configuration`/SSRF 错误 fail closed 且 listener 零连接。不得恢复 route config scan，
+  不得接受 405 作为安全成功，不得删除、skip 或弱化 config validation、factory、Gemini
+  runtime client、Base HTTP 的底层 SSRF 覆盖。PR 最多 1 个非文档文件、500 changed lines，
+  使用 `Refs #966`。 Verify: focused parent integration test；
+  `test_ssrf_validation_loopback`；`GeminiConfig::test_policy_client_settings_fail_closed`；
+  `base_http_client_rejects_public_loopback_base`；factory endpoint-access tests；全特性构建；
+  strict Clippy；全量 test；scope/overlap；exact-head implementation/security review PASS；
+  CI/0 unresolved threads/required gate。合并后删除远程分支并确认 #966 仍 open。
 - [ ] `SP966-T3` Covers: B-002, B-006, B-009. Owner: Phase B route ownership owner.
-  Dependencies: SP966-T2R merged. Done when: selected deployment 后的
+  Dependencies: SP966-T2S merged. Done when: 原 PR #1023、原 Phase B 分支 merge prerequisite
+  follow-up 后的最新 `origin/main`（禁止 force push、禁止新建替代 PR），再删除 selected deployment 后的
   `state.config().providers()` 反查、route-owned client construction、API key/base
   URL/headers/timeout 复制和旧 Gemini send/error helpers 全部删除；adapter 只保留
   selected provider/pricing identity 与 original requested Gemini model，native URL/budget/spend
@@ -55,7 +69,8 @@ GH-966 / #966
   mutation tests；empty-model URL/pricing/model-budget/spend identity tests；focused Gemini
   SDK/fallback/spend tests；六组 feature matrix；strict Clippy；全量 test；scope/overlap；
   exact-head implementation + security review PASS；CI/reviewThreads/required gate。合并后
-  删除远程阶段分支并确认 #966 仍 open。
+  删除远程阶段分支并确认 #966 仍 open。不得把 parent test 修改挤入已有 497-line Phase B diff；
+  Phase B 四文件 writable scope 与 500 changed-line 上限保持不变。
 - [ ] `SP966-T4` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
   B-009, B-010, B-011. Owner: Phase C runtime-only discovery owner. Dependencies: SP966-T3
   merged. Done when: Gemini candidate model/alias 只从 immutable router deployments 派生，route
@@ -76,11 +91,13 @@ GH-966 / #966
 
 ## 并行拆分
 
-- T2、T2R、T3、T4 是严格串行的 implementation PR；T2R 是 Phase A 合并后暴露的
-  回归修复，必须在 T3 前合并；每阶段必须合并后，下一阶段才从最新 `main` 继续。
+- T2、T2R、T2S、T3、T4 是严格串行的 implementation/regression PR；T2R 是 Phase A 合并后暴露的
+  endpoint-policy 回归修复，T2S 是 Phase B exact-head 暴露的历史 route assertion 修正；两者都必须在
+  T3 前合并，每阶段必须合并后，下一阶段才从最新 `main` 继续。
 - 每个阶段最多 10 个非文档文件、500 changed lines；三阶段 writable union 为 tech spec
-  明列的 11 个文件，regression follow-up 另限定为 tech spec 明列的 6 个文件，不修改
-  799 行的 `execution.rs` 或 budget API。
+  明列的 11 个文件，T2R 另限定为 tech spec 明列的 6 个文件，T2S 另限定为 parent integration
+  test 1 个文件；T2S 不扩大 Phase B 四文件 scope 或 500-line budget。不修改 799 行的
+  `execution.rs` 或 budget API。
 - T5 的只读 reviewer/security lane 可与 coordinator 的 final verification 并行；reviewer 不写
   production/test 文件，只在 exact head 给 verdict，并由 reviewer 身份解析 review threads。
 - writable worker 使用独立 worktree 且单一 owner；同一阶段不并行修改 `gemini.rs`、
@@ -93,9 +110,9 @@ GH-966 / #966
   undeclared invariant。
 - 本 amendment PR 只包含 `specs/GH966/tech.md` 与 `specs/GH966/tasks.md`；不改变 product
   behavior invariants。
-- Phase A/regression follow-up/B/C 每个 PR 的 fresh exact-head focused、feature matrix、check、
+- Phase A/T2R/T2S/B/C 每个 PR 的 fresh exact-head focused、feature matrix、check、
   strict Clippy、全量 test、scope/overlap、CI、reviewThreads 与 offline gate 全部通过；Phase A、
-  regression follow-up 与 Phase B 合并后 issue 保持 open，Phase C 合并后 #966 closed。
+  T2R、T2S 与 Phase B 合并后 issue 保持 open，Phase C 合并后 #966 closed。
 
 ## Handoff Notes
 
@@ -110,3 +127,6 @@ GH-966 / #966
   URL-encoded key；route 不得取回 key。
 - spec amendment、regression follow-up 与 Phase B 使用 `Refs #966`；仅 Phase C 使用
   `Fixes #966`。
+- Phase B prerequisite 只把失效的 route-time loopback assertion 替换为 bootstrap/configuration
+  fail-closed evidence；#1023 必须在该 follow-up 合并后 merge 最新 `main`，不得用扩大 Phase B diff、
+  压缩测试或恢复 config reconstruction 绕过 500-line gate。

--- a/specs/GH966/tech.md
+++ b/specs/GH966/tech.md
@@ -125,6 +125,29 @@ unsupported-scheme、timeout、ordinary 和 streaming。本 follow-up 最多 6 �
 使用 `Refs #966`；exact-head implementation/security review、CI、0 unresolved threads 与 required gate 通过后才可
 合并，合并后 #966 仍保持 open。
 
+#### Phase B prerequisite regression follow-up — align PublicOnly evidence with immutable runtime
+
+Phase B 的 exact-head 回归暴露出 `tests/gemini_sdk_routes.rs` 中
+`public_only_gemini_route_rejects_loopback_before_connect` 已不再能证明它声明的 route-time 行为：测试在
+`AppState`/router bootstrap 之后发请求，但 immutable selected runtime provider 已在 bootstrap 时固定；旧 fixture
+的 route 请求实际落到 bootstrap runtime 的 `example.com`，返回 405，而不是重新读取 Gateway config 中后来提供的
+loopback endpoint 并返回 500。继续保留该断言会要求 route 恢复 post-selection config reconstruction，直接违反
+B-001/B-002/B-009。
+
+因此在 Phase B 前增加一个严格串行、独立的 regression follow-up，只允许修改
+`tests/gemini_sdk_routes.rs`。它只能删除/替换上述这一条不可达的历史 route assertion：新断言必须在 runtime
+provider bootstrap/configuration 阶段以 `PublicOnly` + loopback 构造 Gemini provider，证明构造以明确的
+`Configuration`/SSRF 错误 fail closed，并证明 loopback listener 未收到连接。不得删除、跳过或放宽底层
+`test_ssrf_validation_loopback`、`GeminiConfig::test_policy_client_settings_fail_closed`、
+`base_http_client_rejects_public_loopback_base` 以及 factory endpoint-access 覆盖；不得把 405 当作安全成功，也不得
+通过恢复 route config scan 让旧断言重新可达。
+
+本 follow-up 最多 1 个非文档文件、500 changed lines，使用 `Refs #966`；exact-head focused test、全特性构建、
+strict Clippy、全量测试、scope/overlap、independent implementation/security review、CI、0 unresolved threads 与
+required gate 全部通过后才可合并，合并后 #966 保持 open。随后原 Phase B PR #1023 必须在原分支 merge 最新
+`origin/main`（禁止 force push、禁止新建替代 PR），并在新的 exact head 重跑全部验证。该 follow-up 不进入 Phase B
+diff，因此 Phase B 仍保持下述四文件 writable scope 和最多 500 changed lines。
+
 #### Phase B — remove post-selection reconstruction
 
 允许修改 `src/server/routes/ai/gemini.rs`、`src/server/routes/ai/gemini/provider.rs`、
@@ -134,7 +157,8 @@ deployment 到 `state.config().providers()` 的反查、route-owned client 构�
 identity 与客户端原始 requested Gemini model；URL/budget/spend 不得使用 named empty-model deployment 的
 provider-name selection key。Phase B 结束时，pre-selection candidate-key 生成仍可读取 Gateway config，但选择
 完成后不得再读取配置或重建执行器；issue 继续 open，PR 使用 `Refs #966`。合并后删除远端阶段分支并确认
-#966 仍为 open，再从最新 main 创建 Phase C。
+#966 仍为 open，再从最新 main 创建 Phase C。Phase B 必须依赖上述 prerequisite regression follow-up 已合并，并从
+该 merge 后的最新 `main` 重放；不得把 parent test 修改挤入已有 497-line Phase B diff。
 
 #### Phase C — runtime-only discovery and final closure
 
@@ -150,6 +174,7 @@ client cancel neutral、upstream read failure 与 source guard。parent integrat
 
 三个阶段的 writable union 为上述 11 个文件，不触碰 `src/server/routes/ai/execution.rs` 或 budget API。若任一阶段
 fresh diff 超过自身 scope，不得削弱断言、压缩可读性或扩大 writable union；先重新切分该阶段并更新已合并规范。
+Phase B prerequisite regression follow-up 是独立测试修正，不扩大 Phase B writable scope 或 changed-line budget。
 
 ### 5. Verification architecture
 
@@ -165,6 +190,8 @@ fresh diff 超过自身 scope，不得削弱断言、压缩可读性或扩大 wr
   和 config-selection helper；不使用可增长的数量 baseline。
 - provider 单测让 upstream error body/URI 分别回显 raw key 与 URL-encoded key，断言返回的 typed error/body、
   `ProviderError` display/debug 候选文本均只含 `[REDACTED]`，且不含两种原值。
+- PublicOnly 回归在 runtime provider bootstrap/configuration 边界断言 loopback fail closed 且 listener 零连接；
+  route integration 不以恢复 config rescan 来制造 500，底层 config/factory/Gemini client/Base HTTP SSRF 覆盖保持。
 
 ## Product-to-Test Mapping
 
@@ -179,7 +206,7 @@ fresh diff 超过自身 scope，不得削弱断言、压缩可读性或扩大 wr
 | B-007 | existing unary retry helper | upstream 429/5xx、provider/model budget fallback tests；policy redirect 不重试且 redirect loop/普通 transport 仍 fallback |
 | B-008 | existing stream execution lease + spend settlement | success=healthy、read failure=failed、cancel=neutral 的 lease/health/spend tests |
 | B-009 | reduced `GeminiRouteProvider` | compile-time struct fields + source guard 禁止 key/url/headers/timeout/client |
-| B-010 | focused source guard + full gates | guard red/green fixture、typed redirect/DNS source + ordinary/streaming regressions、strict Clippy、全量 test、PR gate |
+| B-010 | focused source guard + full gates | guard red/green fixture、typed redirect/DNS source + ordinary/streaming regressions、bootstrap PublicOnly loopback fail-closed、strict Clippy、全量 test、PR gate |
 | B-011 | provider-owned non-success response handling + fixed policy diagnostics | raw key、URL-encoded key、URI/endpoint echo 脱敏 tests；policy errors 不含敏感数据；route adapter 无 key source guard |
 
 ## 数据流
@@ -212,6 +239,8 @@ usage；spend 使用相同 provider/requested-model，健康、fallback 与 leas
 - [ ] Integration tests: unary/stream snapshot mutation、native与 named compatibility、fallback/budget/health/lease/spend。
 - [ ] Cancellation tests: client cancel health neutral/lease release/spend settlement，并以上游 read failure 为失败对照。
 - [ ] Security tests: upstream error/URI 中 raw 与 URL-encoded API key 均在 provider 边界内脱敏。
+- [ ] Endpoint policy tests: PublicOnly loopback 在 config/factory/runtime client/Base HTTP 构造边界 fail closed；
+  listener 零连接，且不依赖 route-time config reconstruction。
 - [ ] Architecture tests: Gemini route config rescan/route client/敏感字段 guard 红绿与 production 零命中。
 - [ ] Repository: `cargo fmt --all -- --check`、`cargo check --all-targets --all-features --locked`、
   `cargo clippy --all-targets --all-features --locked -- -D warnings`、


### PR DESCRIPTION
## Summary

- add a serial Phase B prerequisite regression follow-up for the obsolete Gemini route-time loopback assertion
- require bootstrap/configuration-time PublicOnly fail-closed evidence while preserving config, factory, Gemini client, and Base HTTP SSRF coverage
- keep PR #1023 on its original branch and unchanged four-file/500-line Phase B scope after merging latest main

## Verification

- git diff --check origin/main...HEAD
- docs-only exact scope: specs/GH966/tech.md and specs/GH966/tasks.md
- B-001 through B-011 invariant sets match across product/tech/tasks
- scripts/guards/check_pr_scope.sh origin/main
- scripts/guards/check_pr_overlap.sh origin/main

Refs #966