### PR TITLE
test(gemini): assert bootstrap SSRF policy

### DIFF
--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -19,6 +19,7 @@ mod tests {
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::ApiKey;
     use litellm_rs::core::net::ProviderEndpointAccess;
+    use litellm_rs::core::providers::{ProviderError, create_provider};
     use serde_json::{Value, json};
     use std::time::{Duration, Instant};
 
@@ -445,7 +446,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_only_gemini_route_rejects_loopback_before_connect() {
+    async fn public_only_gemini_provider_bootstrap_rejects_loopback_before_connect() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("listener should bind");
@@ -455,36 +456,20 @@ mod tests {
             &format!("http://{address}"),
             vec!["gemini-3.1-flash-lite".to_string()],
         );
+        provider.provider_type = "gemini".to_string();
         provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
-        let state = build_test_state(vec![provider]).await;
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(state))
-                .configure(litellm_rs::server::routes::ai::configure_routes),
-        )
-        .await;
+        let error = create_provider(provider)
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("public-only Gemini bootstrap must reject loopback"));
 
-        let response = test::call_service(
-            &app,
-            test::TestRequest::post()
-                .uri("/v1beta/models/gemini-3.1-flash-lite:generateContent")
-                .set_json(gemini_body())
-                .to_request(),
-        )
-        .await;
-
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        let body: Value = test::read_body_json(response).await;
-        assert!(
-            body["error"]["message"]
-                .as_str()
-                .is_some_and(|message| message.contains("SSRF protection"))
-        );
+        assert!(matches!(error, ProviderError::Configuration { .. }));
+        assert!(error.to_string().contains("SSRF protection"));
         assert!(
             tokio::time::timeout(Duration::from_millis(100), listener.accept())
                 .await
                 .is_err(),
-            "public-only Gemini route must not connect to loopback listener"
+            "rejected public-only Gemini bootstrap must not connect to loopback listener"
         );
     }
 }

--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -16,10 +16,12 @@ mod tests {
     };
     use actix_web::{App, HttpMessage, dev::Service};
     use actix_web::{http::StatusCode, test, web};
+    use litellm_rs::Config;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
     use litellm_rs::core::models::ApiKey;
     use litellm_rs::core::net::ProviderEndpointAccess;
-    use litellm_rs::core::providers::{ProviderError, create_provider};
+    use litellm_rs::server::HttpServer as GatewayHttpServer;
+    use litellm_rs::utils::error::gateway_error::GatewayError;
     use serde_json::{Value, json};
     use std::time::{Duration, Instant};
 
@@ -456,14 +458,17 @@ mod tests {
             &format!("http://{address}"),
             vec!["gemini-3.1-flash-lite".to_string()],
         );
-        provider.provider_type = "gemini".to_string();
         provider.endpoint_access = ProviderEndpointAccess::PublicOnly;
-        let error = create_provider(provider)
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.providers = vec![provider];
+        let error = GatewayHttpServer::new(&config)
             .await
             .err()
             .unwrap_or_else(|| panic!("public-only Gemini bootstrap must reject loopback"));
 
-        assert!(matches!(error, ProviderError::Configuration { .. }));
+        assert!(matches!(error, GatewayError::Config(_)));
         assert!(error.to_string().contains("SSRF protection"));
         assert!(
             tokio::time::timeout(Duration::from_millis(100), listener.accept())


### PR DESCRIPTION
## Summary

- replace the obsolete route-time loopback assertion with deterministic Gateway runtime bootstrap evidence
- require a structured configuration/SSRF failure for PublicOnly loopback endpoints
- preserve proof that rejected bootstrap never connects to the loopback listener

## Verification

- current-CI feature focused Gateway bootstrap regression: 1 passed
- current-CI feature default-parallel full suite: exit 0; library 9117 passed / 1 ignored; Gemini integration 22/22
- config loopback validation: 1 passed
- GeminiConfig policy fail-closed: 1 passed
- BaseHttp PublicOnly loopback: 1 passed
- provider factory endpoint-access suite: 6 passed
- cargo fmt --all -- --check
- cargo check --all-targets --all-features --locked
- current-CI feature strict Clippy
- scope: 1 file, 40 changed lines, target file 480 lines

Refs #966