### PR TITLE
fix(router): preserve model group insertion order

### DIFF
--- a/src/core/router/tests/router_tests.rs
+++ b/src/core/router/tests/router_tests.rs
@@ -148,6 +148,104 @@ async fn test_add_multiple_models() {
 }
 
 #[tokio::test]
+async fn test_ordered_model_groups_preserve_first_insertion_and_group_order() {
+    let router = Router::default();
+
+    router.add_deployment(create_test_deployment("primary-1", "zz-primary").await);
+    router.add_deployment(create_test_deployment("primary-2", "zz-primary").await);
+    router.add_deployment(create_test_deployment("backup-1", "aa-backup").await);
+    router
+        .add_model_alias("primary-alias", "zz-primary")
+        .unwrap();
+
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["zz-primary", "aa-backup"]
+    );
+    assert_eq!(
+        router.get_deployments_for_model("zz-primary"),
+        vec!["primary-1", "primary-2"]
+    );
+
+    router.add_deployment(create_test_deployment("primary-1", "zz-primary").await);
+
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["zz-primary", "aa-backup"]
+    );
+    assert_eq!(
+        router.get_deployments_for_model("primary-alias"),
+        vec!["primary-1", "primary-2"]
+    );
+}
+
+#[tokio::test]
+async fn test_ordered_model_groups_remove_only_last_and_reappend_removed_group() {
+    let router = Router::default();
+
+    router.add_deployment(create_test_deployment("primary-1", "primary").await);
+    router.add_deployment(create_test_deployment("primary-2", "primary").await);
+    router.add_deployment(create_test_deployment("backup-1", "backup").await);
+
+    router.remove_deployment("primary-1").unwrap();
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["primary", "backup"]
+    );
+    assert_eq!(
+        router.get_deployments_for_model("primary"),
+        vec!["primary-2"]
+    );
+
+    router.remove_deployment("primary-2").unwrap();
+    assert_eq!(router.list_models_in_insertion_order(), vec!["backup"]);
+    assert!(router.get_deployments_for_model("primary").is_empty());
+
+    router.add_deployment(create_test_deployment("primary-3", "primary").await);
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["backup", "primary"]
+    );
+}
+
+#[tokio::test]
+async fn test_ordered_model_groups_reindex_to_existing_or_new_group() {
+    let router = Router::default();
+
+    router.add_deployment(create_test_deployment("shared", "first").await);
+    router.add_deployment(create_test_deployment("first-stable", "first").await);
+    router.add_deployment(create_test_deployment("second-stable", "second").await);
+    router.add_deployment(create_test_deployment("third-stable", "third").await);
+
+    router.add_deployment(create_test_deployment("shared", "second").await);
+
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["first", "second", "third"]
+    );
+    assert_eq!(
+        router.get_deployments_for_model("first"),
+        vec!["first-stable"]
+    );
+    assert_eq!(
+        router.get_deployments_for_model("second"),
+        vec!["second-stable", "shared"]
+    );
+
+    router.add_deployment(create_test_deployment("first-stable", "fourth").await);
+
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["second", "third", "fourth"]
+    );
+    assert!(router.get_deployments_for_model("first").is_empty());
+    assert_eq!(
+        router.get_deployments_for_model("fourth"),
+        vec!["first-stable"]
+    );
+}
+
+#[tokio::test]
 async fn test_get_deployment() {
     let router = Router::default();
     let deployment = create_test_deployment("test-1", "gpt-4").await;
@@ -238,6 +336,57 @@ async fn test_set_model_list_installs_complete_snapshot_generation() {
     );
     assert!(!new_snapshot.deployments.contains_key("old-1"));
     assert!(!new_snapshot.model_index.contains_key("gpt-4"));
+}
+
+#[tokio::test]
+async fn test_set_model_list_publishes_input_first_occurrence_order_atomically() {
+    let router = Router::default();
+
+    router.add_deployment(create_test_deployment("old-1", "old-first").await);
+    router.add_deployment(create_test_deployment("old-2", "old-second").await);
+    let old_snapshot = router.routing_snapshot.load_full();
+
+    router.set_model_list(vec![
+        create_test_deployment("beta-1", "beta").await,
+        create_test_deployment("alpha-1", "alpha").await,
+        create_test_deployment("beta-2", "beta").await,
+        create_test_deployment("gamma-1", "gamma").await,
+    ]);
+    let new_snapshot = router.routing_snapshot.load_full();
+
+    assert_eq!(old_snapshot.model_order, vec!["old-first", "old-second"]);
+    assert!(old_snapshot.deployments.contains_key("old-1"));
+    assert!(!old_snapshot.deployments.contains_key("beta-1"));
+
+    assert_eq!(new_snapshot.model_order, vec!["beta", "alpha", "gamma"]);
+    assert_eq!(
+        new_snapshot.model_index.get("beta"),
+        Some(&vec!["beta-1".to_string(), "beta-2".to_string()])
+    );
+    assert!(!new_snapshot.deployments.contains_key("old-1"));
+    assert!(new_snapshot.deployments.contains_key("gamma-1"));
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["beta", "alpha", "gamma"]
+    );
+}
+
+#[tokio::test]
+async fn test_set_model_list_keeps_first_group_order_when_duplicate_id_moves_groups() {
+    let router = Router::default();
+
+    router.set_model_list(vec![
+        create_test_deployment("shared-id", "alpha").await,
+        create_test_deployment("shared-id", "beta").await,
+        create_test_deployment("alpha-id", "alpha").await,
+    ]);
+
+    assert_eq!(
+        router.list_models_in_insertion_order(),
+        vec!["alpha", "beta"]
+    );
+    assert_eq!(router.get_deployments_for_model("alpha"), vec!["alpha-id"]);
+    assert_eq!(router.get_deployments_for_model("beta"), vec!["shared-id"]);
 }
 
 #[tokio::test]

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -43,12 +43,13 @@ pub struct CapabilityDeployment {
 /// Immutable deployment routing generation.
 ///
 /// Each snapshot owns a complete, internally consistent view of deployments,
-/// model indexes, and aliases. Router readers load one snapshot and never walk
-/// split mutable maps from different generations.
+/// model indexes, model-group insertion order, and aliases. Router readers load
+/// one snapshot and never walk split mutable maps from different generations.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RoutingSnapshot {
     pub(crate) deployments: HashMap<DeploymentId, Arc<Deployment>>,
     pub(crate) model_index: HashMap<String, Vec<DeploymentId>>,
+    pub(crate) model_order: Vec<String>,
     pub(crate) model_aliases: HashMap<String, String>,
 }
 
@@ -57,6 +58,13 @@ impl RoutingSnapshot {
         deployments: Vec<Deployment>,
         previous: &RoutingSnapshot,
     ) -> Self {
+        let mut seen_models = HashSet::new();
+        let mut input_model_order = Vec::new();
+        for deployment in &deployments {
+            if seen_models.insert(deployment.model_name.clone()) {
+                input_model_order.push(deployment.model_name.clone());
+            }
+        }
         let mut snapshot = Self {
             model_aliases: previous.model_aliases.clone(),
             ..Default::default()
@@ -68,6 +76,14 @@ impl RoutingSnapshot {
             }
             snapshot.insert_deployment(deployment);
         }
+
+        // Duplicate deployment IDs retain their existing last-wins behavior.
+        // Reapply input group order after indexing so a temporary empty group
+        // cannot move behind groups that first appeared later in the input.
+        snapshot.model_order = input_model_order
+            .into_iter()
+            .filter(|model_name| snapshot.model_index.contains_key(model_name))
+            .collect();
 
         snapshot
     }
@@ -85,6 +101,10 @@ impl RoutingSnapshot {
             && old.model_name != model_name
         {
             self.remove_from_model_index(&old.model_name, &deployment_id);
+        }
+
+        if !self.model_index.contains_key(&model_name) {
+            self.model_order.push(model_name.clone());
         }
 
         let entry = self.model_index.entry(model_name).or_default();
@@ -113,6 +133,13 @@ impl RoutingSnapshot {
 
         if should_remove {
             self.model_index.remove(model_name);
+            if let Some(position) = self
+                .model_order
+                .iter()
+                .position(|existing| existing == model_name)
+            {
+                self.model_order.remove(position);
+            }
         }
     }
 
@@ -417,6 +444,11 @@ impl Router {
             .keys()
             .cloned()
             .collect()
+    }
+
+    /// List model groups in first-insertion order for this immutable snapshot.
+    pub fn list_models_in_insertion_order(&self) -> Vec<String> {
+        self.routing_snapshot.load().model_order.clone()
     }
 
     /// List all deployment IDs


### PR DESCRIPTION
## Summary

- preserve model-group first-insertion order in the immutable routing snapshot
- expose an additive ordered model-group read API without changing existing lookup or selection behavior
- keep `set_model_list` input first-occurrence order even when duplicate deployment IDs move across groups under the existing last-wins rule

## SpecRail scope

- implements `SP966-T3O` from `specs/GH966/tasks.md`
- prerequisite for the existing Phase C PR #1026
- 2 files, 185 changed lines; no Gemini or configuration-scan changes
- partial tranche; does not close the issue

Refs #966

## Verification

- blocker regression: 1/1 passed
- router suite: 33/33 passed
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- full `cargo test --all-features --locked -- --test-threads=1`: library 10,428 passed / 1 ignored, gateway 5 passed, integration `tests/lib.rs` 189 passed / 12 ignored, all preceding route suites passed; bounded interruption only after the unrelated existing `moderations_routes` mock-cleanup hang made no progress for 3m52s
- independent exact-head review: PASS, 0 blockers

## Compatibility

- existing `list_models`, model lookup, deployment order within a group, aliases, selection, health, lease, and runtime state behavior remain unchanged
- the new ordered API is additive
