### PR TITLE
docs(spec): define anyhow unsoundness remediation

### DIFF
--- a/specs/GH1032/product.md
+++ b/specs/GH1032/product.md
@@ -1,0 +1,66 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1032 / #1032
+
+complexity: small
+
+## 用户问题
+
+仓库 lockfile 固定 `anyhow 1.0.102`，RustSec `RUSTSEC-2026-0190` 将该版本标记为 unsound；
+`cargo audit --deny unsound` 因此失败。上游已在 `1.0.103` 修复，当前依赖约束允许精确升级而无需修改
+manifest 或其他 package。
+
+## 目标
+
+- 将解析后的 `anyhow` 版本精确更新到 `1.0.103`。
+- 消除 `RUSTSEC-2026-0190`，恢复 `cargo audit --deny unsound` 安全门。
+- 保持依赖更新最小化、可复现，并证明所有 feature/target 继续构建和测试。
+
+## 非目标
+
+- 不升级其他落后依赖。
+- 不处理 `proc-macro-error2` unmaintained 或 `spin` yanked warning。
+- 不修改 `Cargo.toml`、`.cargo/audit.toml`、生产代码或公开 API。
+- 不新增 advisory ignore。
+
+## Behavior Invariants
+
+1. B-001 `Cargo.lock` 中解析到的 `anyhow` 版本必须为 `1.0.103`，不得继续包含 `1.0.102`。
+2. B-002 lockfile 更新只能改变 `anyhow` package 的 version 与对应 checksum；其他 package 的版本、source、
+   checksum 和依赖关系不得变化。
+3. B-003 `cargo audit --deny unsound` 必须成功，且输出不得包含 `RUSTSEC-2026-0190`；禁止通过 ignore、
+   降低 deny 级别或修改 audit 配置制造成功。
+4. B-004 普通 `cargo audit` 必须继续完整报告剩余 unmaintained/yanked warning；本变更不得把既有 warning
+   静默隐藏或误称为零告警。
+5. B-005 all-target/all-feature check、strict Clippy 和全 feature tests 必须在更新后的 lockfile 上通过。
+6. B-006 使用 `--locked` 的构建和测试必须成功，证明提交的 lockfile 可以在不重新解析依赖的情况下复现。
+
+## 验收标准
+
+- [ ] `Cargo.lock` 只包含 `anyhow 1.0.103`，diff 中没有其他 package 更新。
+- [ ] `cargo tree -i anyhow --locked --all-features` 显示 `anyhow v1.0.103`。
+- [ ] `cargo audit --deny unsound` 成功且不再报告 `RUSTSEC-2026-0190`。
+- [ ] `cargo audit` 保留其他基线 warning 的可见性。
+- [ ] 格式、check、strict Clippy 与全 feature tests 全部产生当前 head 的成功证据。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | N/A：无运行时输入；Cargo.lock package 必须存在并由 B-001 固定。 |
+| 错误与失败路径 | covered: B-003, B-005, B-006；audit、解析、构建或测试失败均阻断交付。 |
+| 授权/权限 | N/A：不改变认证、授权或运行时权限。 |
+| 并发/竞态 | N/A：lockfile 更新与离线检查无共享运行时状态。 |
+| 重试/幂等 | covered: B-001, B-002；相同 precise update 重跑不应产生额外 diff。 |
+| 非法状态转换 | covered: B-002；不得借修复 advisory 转为全量依赖刷新。 |
+| 兼容/迁移 | covered: B-005, B-006；所有 feature/target 与锁定构建证明兼容。 |
+| 降级/回退 | covered: B-003, B-004；禁止 ignore 或隐藏 warning 作为 fallback。 |
+| 证据与审计完整性 | covered: B-002, B-003, B-004；diff 与两种 audit 输出共同证明结果。 |
+| 取消/中断 | N/A：更新只有一个 lockfile commit；中断后可从干净基线重跑。 |
+
+## 发布说明
+
+依赖安全维护：将传递依赖 `anyhow` 更新到 `1.0.103`，修复 `RUSTSEC-2026-0190`；无运行时 API
+或配置变更。

--- a/specs/GH1032/tasks.md
+++ b/specs/GH1032/tasks.md
@@ -1,0 +1,69 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1032 / #1032
+
+## Execution Constraints
+
+- 实现分支从包含本 Spec 的基线创建，其 `origin/main` 基底为
+  `0baa92798d15630edc0b6abd65646b25e49ca23c`。
+- Spec PR 与 Impl PR 分离；不自动合并。
+- 实现 diff 只能包含 `Cargo.lock`，不得修改 manifest、audit 配置或源码。
+
+## Implementation Tasks
+
+### SP1032-T1 — 精确更新 anyhow lock entry
+
+- Owner: implementation agent
+- Dependencies: approved `product.md` and `tech.md`
+- Covers: B-001, B-002
+- Work:
+  - 执行 `cargo update -p anyhow --precise 1.0.103`。
+  - 检查 lockfile package diff，拒绝任何无关 package 更新。
+- Done when:
+  - `Cargo.lock` 的 `anyhow` 为 `1.0.103`，且 `1.0.102` 不再存在。
+  - 唯一变化是 anyhow version/checksum。
+- Verify:
+  - `cargo tree -i anyhow --locked --all-features`
+  - `cargo update -p anyhow --precise 1.0.103 --dry-run`
+  - `git diff -- Cargo.lock`
+
+## Verification Tasks
+
+### SP1032-T2 — 恢复安全门并验证兼容性
+
+- Owner: implementation agent
+- Dependencies: SP1032-T1
+- Covers: B-003, B-004, B-005, B-006
+- Done when:
+  - `cargo audit --deny unsound` 成功且不含 `RUSTSEC-2026-0190`。
+  - 普通 audit 继续显示剩余基线 warning。
+  - 格式、all-target/all-feature check、strict Clippy 与全 feature tests 在 `--locked` 下通过。
+- Verify:
+  - `cargo fmt --all -- --check`
+  - `cargo audit --deny unsound`
+  - `cargo audit`
+  - `cargo check --all-targets --all-features --locked`
+  - `cargo clippy --all-targets --all-features --locked -- -D warnings`
+  - `cargo test --all-features --locked`
+
+## Handoff
+
+### SP1032-T3 — 独立 Impl PR 交付
+
+- Owner: implementation agent
+- Dependencies: SP1032-T2
+- Covers: none — 该任务只封装验证证据，不新增产品行为。
+- Done when:
+  - Impl PR 使用 `Fixes #1032`，链接 Spec PR，并记录 precise update、audit 与测试证据。
+  - PR diff 只有 `Cargo.lock`，保持未合并等待最终人工决定。
+- Verify:
+  - `git diff --check origin/main...HEAD`
+  - `git diff --name-only origin/main...HEAD`
+
+## Invariant Coverage Audit
+
+- Product IDs: `B-001, B-002, B-003, B-004, B-005, B-006`
+- Task coverage union: `B-001, B-002, B-003, B-004, B-005, B-006`
+- Missing: none

--- a/specs/GH1032/tech.md
+++ b/specs/GH1032/tech.md
@@ -1,0 +1,93 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1032 / #1032
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Locked dependency | `Cargo.lock:419` | `anyhow` 固定为 `1.0.102`，带对应 registry checksum | 唯一需要修改的实现区域 |
+| Audit policy | `.cargo/audit.toml:3` | 仅 ignore 三个与本 advisory 无关的既有条目 | 必须保持不变，不能用 ignore 绕过 unsound warning |
+| Direct manifests | workspace `Cargo.toml` files | 没有直接声明 `anyhow` | 修复不需要新增或修改 manifest dependency |
+| Dependency paths | `rustify -> vaultrs`、`tiktoken-rs` | 两条传递路径共同解析到同一个 `anyhow 1.0.102` | lockfile precise update 可同时修复两条路径 |
+
+## 根因
+
+依赖解析发生在 RustSec 修复版本发布前，`Cargo.lock` 因而持续固定 `anyhow 1.0.102`。现有传递依赖
+使用兼容 semver 约束，dry-run 已证明 Cargo 可以只把 `anyhow` 更新到 `1.0.103`，无需提升直接依赖或
+重解其他 package。
+
+## 设计方案
+
+### 1. Precise lockfile update
+
+在基于最新 `origin/main` 且包含本 Spec 的实现分支执行：
+
+```sh
+cargo update -p anyhow --precise 1.0.103
+```
+
+预期 `Cargo.lock` 的 `[[package]] name = "anyhow"` 只改变 `version` 与 `checksum`。`source`、依赖路径、
+其他 package 和 manifest 均不变。
+
+### 2. Scope proof
+
+- `git diff --name-only` 只能输出 `Cargo.lock`。
+- lockfile diff 只能出现 `anyhow` package 的旧/新 version 与 checksum。
+- `cargo update -p anyhow --precise 1.0.103 --dry-run` 在更新后必须报告无需额外变更。
+- `cargo tree -i anyhow --locked --all-features` 必须显示 `anyhow v1.0.103` 的现有两条传递路径。
+
+### 3. Security and compatibility proof
+
+- `cargo audit --deny unsound` 必须退出 0，且不得新增 `RUSTSEC-2026-0190` ignore。
+- 普通 `cargo audit` 仍记录剩余 unmaintained/yanked warning，避免把“unsound 已修复”误报为“无 warning”。
+- 使用更新后的 lockfile 运行 all-target/all-feature check、strict Clippy 和全 feature tests；所有 Cargo
+  验证使用 `--locked`。
+
+## 影响文件
+
+| Path | Change |
+| --- | --- |
+| `Cargo.lock` | `anyhow 1.0.102 -> 1.0.103` 及匹配 checksum |
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `Cargo.lock` anyhow package | `cargo tree -i anyhow --locked --all-features` 显示 `anyhow v1.0.103`；`rg 'version = "1.0.102"' Cargo.lock` 零命中 |
+| B-002 | precise lockfile diff | `git diff -- Cargo.lock` 只含 anyhow version/checksum；`git diff --name-only` 只含 `Cargo.lock` |
+| B-003 | RustSec audit gate | `cargo audit --deny unsound` 退出 0；`rg 'RUSTSEC-2026-0190' .cargo/audit.toml` 零命中 |
+| B-004 | ordinary audit reporting | `cargo audit` 退出 0并继续显示基线 unmaintained/yanked warning |
+| B-005 | workspace build/test surface | format、all-target/all-feature check、strict Clippy、全 feature tests |
+| B-006 | committed resolution | 所有 check/clippy/test 命令带 `--locked` 并成功 |
+
+## 风险与缓解
+
+- 风险：Cargo 顺带更新其他 package。缓解：使用 `-p` + `--precise`，并以 package-level diff 阻断额外变化。
+- 风险：通过 audit ignore 伪造修复。缓解：`.cargo/audit.toml` 不在影响文件中，并显式检查 advisory 零命中。
+- 风险：补丁版本改变传递依赖行为。缓解：完整 feature/target 编译、Clippy 与测试矩阵。
+
+## 验证计划
+
+```sh
+cargo fmt --all -- --check
+cargo tree -i anyhow --locked --all-features
+cargo update -p anyhow --precise 1.0.103 --dry-run
+cargo audit --deny unsound
+cargo audit
+cargo check --all-targets --all-features --locked
+cargo clippy --all-targets --all-features --locked -- -D warnings
+cargo test --all-features --locked
+git diff --check origin/main...HEAD
+```
+
+## 回滚
+
+若 `1.0.103` 导致兼容问题，回滚实现 commit 并重新打开 #1032；不得通过新增 advisory ignore 或降低
+audit deny 级别维持表面绿灯。


### PR DESCRIPTION
## 关联事项

Refs #1032

## 优化原因

`Cargo.lock` 固定 `anyhow 1.0.102`，导致 `cargo audit --deny unsound` 因 `RUSTSEC-2026-0190` 失败。dry-run 证明可以只更新到已修复的 `1.0.103`，无需刷新其他依赖。

## 计划

- 精确更新 `anyhow 1.0.102 -> 1.0.103`
- 实现 diff 只允许 `Cargo.lock` 的 version/checksum 变化
- 不修改 manifest、audit ignore 或源码
- 运行 audit、all-target/all-feature check、strict Clippy 与全 feature tests
- 另建 Impl PR，保持未合并

## 本 PR 范围

仅新增 `specs/GH1032/product.md`、`tech.md`、`tasks.md`，不包含实现。