### PR TITLE
fix(deps): update anyhow to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
## 关联事项

Fixes #1032

Spec PR: #1033

## 优化原因

`anyhow 1.0.102` 命中 `RUSTSEC-2026-0190`，使 `cargo audit --deny unsound` 失败。上游 `1.0.103` 已修复，传递依赖约束允许精确 lockfile 更新。

## 实现

- `Cargo.lock`: `anyhow 1.0.102 -> 1.0.103`
- 仅同步对应 checksum
- 没有其他 package、manifest、audit config 或源码变化

## 当前 head 验证

- precise update dry-run: 0 additional changes; 158 outdated dependencies untouched
- cargo tree -i anyhow --locked --all-features: both paths resolve `1.0.103`
- cargo audit --deny unsound: pass; `RUSTSEC-2026-0190` absent
- cargo audit --json: 0 vulnerabilities; baseline remains 1 unmaintained + 2 yanked warnings
- cargo fmt --all -- --check: pass
- cargo check --all-targets --all-features --locked: pass
- cargo clippy --all-targets --all-features --locked -- -D warnings: pass
- cargo test --all-features --locked --quiet: pass; lib 10420 passed, 0 failed, 1 ignored; integration/doc targets pass

一次全量运行中 moderation 单测发生无输出挂起；中断后 exact test、完整 moderation test binary 和第二次全量均通过，未修改测试或生产代码。

## 范围

Impl commit `c6e2b33e` 只修改 `Cargo.lock`。不自动合并。