### PR TITLE
security(deps): replace yanked spin 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3141,7 +3141,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -5047,9 +5047,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary

Implements #1035 by precisely updating the locked `spin` package from yanked `0.9.8` to compatible `0.9.9`.

The implementation diff is only `Cargo.lock`: the `spin` package version/checksum plus the existing `flume` and `lazy_static` dependency disambiguation references. No other package version, dependency set, manifest, source, test, or CI file changes.

## Why

`cargo audit` reported the locked `spin 0.9.8` as yanked. Cargo can resolve `0.9.9` within the existing constraints and the same 0.9 compatibility line, avoiding broader `flume`, SQLx, or SeaORM upgrades.

## Implementation

- `cargo update -p spin@0.9.8 --precise 0.9.9`
- active reverse dependency path remains `spin -> flume -> sqlx-sqlite -> sqlx -> SeaORM`
- old package ID no longer resolves
- post-update `cargo update -p spin@0.9.9 --precise 0.9.9 --dry-run` is clean

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo check --all-targets --all-features --locked` — pass
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --all-features --locked -- --test-threads=1` — pass
  - lib: 10420 passed, 0 failed, 1 ignored
  - integration test library: 189 passed, 0 failed, 12 ignored
  - remaining route/integration suites: all pass
  - doctests: 33 passed, 0 failed, 32 ignored
- `cargo audit` — exit 0; `spin 0.9.8` warning absent; unrelated warnings remain visible
- `git diff --check` — pass
- implementation diff: 1 file, 4 insertions, 4 deletions

## Scope

The independent yanked `spin 0.10.0` path remains out of scope and will be evaluated separately. This PR does not add audit ignores and must not be auto-merged.

Fixes #1035