### PR TITLE
docs(spec): define spin 0.10.0 yanked remediation

### DIFF
--- a/specs/GH1038/product.md
+++ b/specs/GH1038/product.md
@@ -1,0 +1,66 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1038 / #1038
+
+complexity: small
+
+## 用户问题
+
+`Cargo.lock` 锁定了 crates.io 已撤回的 `spin 0.10.0`。该版本通过
+`crc-fast -> aws-smithy-checksums -> aws-sdk-s3` 进入完整 feature 依赖图，导致供应链审计持续报告
+yanked warning，并降低锁文件的长期构建可靠性。
+
+## 目标
+
+- 将完整 feature 依赖图中的 `spin 0.10.0` 精确更新到同一兼容版本线的 `0.10.1`。
+- 消除 `cargo audit` 对 `spin 0.10.0` 的 yanked warning。
+- 保持 AWS S3、checksum、应用行为、公开 API 和项目源码不变。
+- 以一个 package 的最小 lockfile diff 完成更新。
+
+## 非目标
+
+- 不升级 `crc-fast`、AWS SDK 或其他落后依赖。
+- 不重复处理独立的 `spin 0.9.8` package。
+- 不修改 `Cargo.toml`、生产代码、测试、CI 或公开 API。
+- 不用 audit ignore 隐藏 yanked warning。
+
+## Behavior Invariants
+
+1. B-001 `Cargo.lock` 不再解析到 `spin 0.10.0`，而解析到 `spin 0.10.1`。
+2. B-002 lockfile diff 只包含 `spin` package version/checksum，以及 `crc-fast` 既有依赖项对该 package 的
+   版本消歧引用；不能更新其他 package 版本或依赖集合。
+3. B-003 active feature graph 中反向依赖仍为
+   `spin -> crc-fast -> aws-smithy-checksums -> aws-sdk-s3 -> litellm-rs`，AWS S3 feature 与行为不变。
+4. B-004 `cargo audit` 不再报告 `spin 0.10.0` yanked warning；其他独立 warning 必须继续可见。
+5. B-005 格式、all-target/all-feature 编译、strict Clippy 与全 feature 测试保持通过。
+6. B-006 Spec PR 与 Impl PR 必须分离，Impl PR 关联 #1038 且不自动合并。
+
+## 验收标准
+
+- [ ] `Cargo.lock` 只更新 `spin` package version/checksum 和 `crc-fast` 的既有版本消歧引用。
+- [ ] `cargo tree -i spin@0.10.1 --locked --all-features` 显示既有 AWS S3 路径。
+- [ ] `cargo tree -i spin@0.10.0 --locked --all-features` 不再找到 package。
+- [ ] `cargo audit` 不再报告 `spin 0.10.0`，且没有新增 ignore。
+- [ ] Rust 格式、编译、Clippy 和全量测试通过。
+- [ ] 独立 Spec PR 与 Impl PR 已创建，未自动合并。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | N/A；纯 lockfile 依赖解析变更。 |
+| 错误与失败路径 | covered: B-004, B-005；审计或验证失败必须阻断完成声明。 |
+| 授权/权限 | N/A；不改变认证或权限代码。 |
+| 并发/竞态 | covered: B-003, B-005；同步原语 patch 更新由完整测试验证。 |
+| 重试/幂等 | covered: B-001, B-002；对新 package ID 的 precise dry-run 不得产生额外变化。 |
+| 非法状态转换 | N/A；不修改应用状态机。 |
+| 兼容/迁移 | covered: B-001, B-003；停留在 0.10 兼容版本线，无数据迁移。 |
+| 降级/回退 | covered: B-004；不得用 audit ignore 静默放行。 |
+| 证据与审计完整性 | covered: B-002, B-004, B-005；diff、依赖树、audit 与完整 Rust 验证缺一不可。 |
+| 取消/中断 | covered: B-002；lockfile 更新可从干净分支安全重做。 |
+
+## 发布说明
+
+AWS S3 checksum 依赖链不再锁定已撤回的 `spin 0.10.0`，改为兼容的 `0.10.1`；没有用户可见行为或 API 变化。

--- a/specs/GH1038/tasks.md
+++ b/specs/GH1038/tasks.md
@@ -1,0 +1,38 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1038 / #1038
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1038-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: coordinator. Dependencies: none. Done when: GH1038 product/tech/tasks 三件套完整，范围排除其他依赖更新，全部 invariant 有 task/test mapping. Verify: `test -f specs/GH1038/product.md -a -f specs/GH1038/tech.md -a -f specs/GH1038/tasks.md`; product/tasks 的 `B-[0-9]{3}` 集合一致.
+- [ ] `SP1038-T2` Covers: B-001, B-002, B-003. Owner: implementation owner. Dependencies: SP1038-T1. Done when: precise update 将唯一 `spin 0.10.0` package 更新到 `0.10.1`，只修改 `Cargo.lock`；diff 只含 package version/checksum 与 `crc-fast` 既有版本消歧引用. Verify: `cargo update -p spin@0.10.0 --precise 0.10.1`; `git diff --stat`; `git diff -- Cargo.lock`; `cargo update -p spin@0.10.1 --precise 0.10.1 --dry-run`.
+- [ ] `SP1038-T3` Covers: B-001, B-003, B-004. Owner: verification owner. Dependencies: SP1038-T2. Done when: 旧 package 从完整依赖图消失，新 package 沿既有 AWS S3 checksum 路径解析，audit 不再报告目标 warning且无新增 ignore. Verify: `cargo tree -i spin@0.10.0 --locked --all-features` 预期失败；`cargo tree -i spin@0.10.1 --locked --all-features`; `cargo audit`; `git diff origin/main...HEAD -- .cargo Cargo.toml deny.toml` 预期为空.
+- [ ] `SP1038-T4` Covers: B-002, B-003, B-005. Owner: verification owner. Dependencies: SP1038-T3. Done when: 最小 lockfile diff 通过格式、编译、strict Clippy 与全 feature serial tests. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`.
+- [ ] `SP1038-T5` Covers: B-006. Owner: coordinator. Dependencies: SP1038-T4. Done when: Impl PR 以 Spec 分支为 base、只显示 `Cargo.lock`、关联 #1038、记录 fresh verification 且保持未合并. Verify: `gh pr view <impl-pr> --json baseRefName,headRefName,state,mergeable,body,statusCheckRollup`; `gh issue view 1038 --json state`.
+
+## 执行顺序
+
+1. Spec PR 独立面向 `main`。
+2. Impl 分支从 Spec branch HEAD 派生，Impl PR 只展示实现 diff。
+3. 精确更新并审核 lockfile diff 后运行完整验证。
+4. 验证通过后创建 Impl PR，不自动合并。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 均为 B-001 至 B-006，无 orphan。
+- 实现只有 `spin 0.10.0 -> 0.10.1` package metadata 与 `crc-fast` 既有版本消歧引用变化。
+- `cargo audit` 保留其他独立 warning 的可见性。
+- Impl PR 使用 `Fixes #1038`，人工合并前 Issue 保持 open。
+
+## Handoff Notes
+
+- 不把 #1035 的 `spin 0.9.x` lockfile diff 混入本 PR。
+- 若 precise update 出现 probe 之外的 package 变化，停止并调查 resolver。
+- 不修改用户工作树中的 `WORKFLOW.md`。

--- a/specs/GH1038/tech.md
+++ b/specs/GH1038/tech.md
@@ -1,0 +1,75 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1038 / #1038
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Dependency lock | `Cargo.lock` | 锁定已撤回的 `spin 0.10.0` | B-001/B-002 根因与唯一写入范围 |
+| Reverse dependency | Cargo resolver | `spin -> crc-fast 1.9.0 -> aws-smithy-checksums 0.64.7 -> aws-sdk-s3 1.131.0` | B-003 兼容边界 |
+| Supply-chain audit | `cargo audit` | 报告 `spin 0.10.0` yanked warning | B-004 验收信号 |
+| Rust verification | Cargo workspace | S3/checksum 路径依赖既有同步原语行为 | B-005 回归边界 |
+
+## 根因
+
+项目 manifest 没有直接声明 `spin`；`crc-fast` 的 `spin` feature 经 AWS checksum 依赖链启用，Cargo resolver
+曾锁定后来被撤回的 `0.10.0`。现有约束允许同一 0.10 版本线的 `0.10.1`，无需升级上游 crate 或 manifest。
+
+## 设计方案
+
+1. 在从最新 `origin/main` 创建且包含 GH1038 Spec 的 Impl 分支执行
+   `cargo update -p spin@0.10.0 --precise 0.10.1`。
+2. 拒绝任何超出 `Cargo.lock` 的文件变化；lockfile 内只接受 `spin` package version/checksum 和
+   `crc-fast` 既有 dependency entry 的版本消歧引用变化，不得改变其他 package。
+3. 用正反向依赖查询确认旧版本消失、新版本仍沿既有 AWS S3 checksum 路径解析。
+4. 运行 `cargo audit`，确认目标 warning 消失且其他独立 warning 没有被 ignore 或吞掉。
+5. 运行完整 Rust 格式、编译、strict Clippy 和全 feature 测试。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `Cargo.lock` spin package entry | old package ID 查询预期失败；新 package ID 查询成功 |
+| B-002 | 单一 lockfile diff | `git diff --stat`; `git diff -- Cargo.lock`; 新 package precise dry-run 无变化 |
+| B-003 | Cargo resolved graph | `cargo tree -i spin@0.10.1 --locked --all-features` |
+| B-004 | RustSec/crates.io audit | `cargo audit`; 检查无 `spin 0.10.0` 且无新增 ignore |
+| B-005 | Workspace | format、all-target/all-feature check、strict Clippy、全 feature tests |
+| B-006 | GitHub workflow | 独立 Spec/Impl PR metadata、base/head 与 open state |
+
+## 备选方案
+
+- 升级 `crc-fast` 或 AWS SDK：范围更大且当前无必要，违反 B-002，拒绝。
+- 升级到 `spin` 0.11/0.12：跨版本线且超出上游约束，回归面更大，拒绝。
+- 在 audit 配置中忽略 yanked warning：隐藏证据而未消除锁定版本，违反 B-004，拒绝。
+- 与 `spin 0.9.x` 合并处理：两个 package ID、依赖路径和 PR 都独立，不利于归因，拒绝。
+- 全量 `cargo update`：会同时更新大量无关依赖，违反最小范围，拒绝。
+
+## 风险
+
+- Compatibility: `0.10.1` 位于同一 semver 兼容版本线，且 MSRV Rust 1.60 低于项目工具链；仍以全量测试验证。
+- Concurrency: `spin` 提供同步原语并被 checksum cache 路径间接使用；需保留完整测试证据。
+- Scope drift: 精确 update 仍会合法重写 `crc-fast` 的版本消歧引用；除此以外的 package 变化都应停止实现。
+- Audit interpretation: 其他 warning 仍可能存在；只验证目标 warning 消失，不篡改其余证据。
+
+## 测试计划
+
+- [ ] 实现前 `cargo update -p spin@0.10.0 --precise 0.10.1 --dry-run` 只计划单 package 更新。
+- [ ] 实现后 `cargo update -p spin@0.10.1 --precise 0.10.1 --dry-run` 成功且无变化。
+- [ ] 旧 package ID 查询失败，新版本反向树显示既有 AWS S3 路径。
+- [ ] `cargo audit` 不再报告 `spin 0.10.0`，其他 warning 保持可见。
+- [ ] `cargo fmt --all -- --check`。
+- [ ] `cargo check --all-targets --all-features --locked`。
+- [ ] `cargo clippy --all-targets --all-features --locked -- -D warnings`。
+- [ ] `cargo test --all-features --locked -- --test-threads=1`。
+
+## 回滚方案
+
+若 `0.10.1` 引发可复现回归，回滚 Impl PR 的单一 lockfile commit，并为 `crc-fast`/AWS 依赖替代建立新的
+独立 issue；不得通过 audit ignore 静默保留 `0.10.0`。


### PR DESCRIPTION
## Summary

Defines the product, technical, and task Spec for #1038.

The optimization is restricted to a precise `Cargo.lock` update from yanked `spin 0.10.0` to compatible `0.10.1`. A detached probe proved the exact implementation diff: `spin` version/checksum plus the existing `crc-fast` dependency disambiguation reference, with no other package changes.

## Why optimize

The yanked package remains active through `crc-fast -> aws-smithy-checksums -> aws-sdk-s3`. The existing resolver constraints allow a one-package patch-line update without upgrading AWS SDK, `crc-fast`, application code, or public APIs.

## Plan

1. Derive a separate implementation branch from this Spec branch.
2. Run `cargo update -p spin@0.10.0 --precise 0.10.1`.
3. Require the pre-verified six-line lockfile diff only.
4. Verify old/new package IDs, reverse dependency graph, and audit output.
5. Run format, all-target/all-feature check, strict Clippy, and full feature tests.
6. Open a separate Impl PR; do not auto-merge.

## Verification

- `git diff --cached --check`
- Product invariant set and task coverage both equal B-001 through B-006
- Spec packet contains `product.md`, `tech.md`, and `tasks.md`

Refs #1038