### PR TITLE
security(deps): replace yanked spin 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
  "crc",
  "digest 0.10.7",
  "rustversion",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -5056,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Summary

Implements #1038 by precisely updating the locked `spin` package from yanked `0.10.0` to compatible `0.10.1`.

The implementation diff is only `Cargo.lock`: `spin` version/checksum plus the existing `crc-fast` dependency disambiguation reference. No other package version, dependency set, manifest, source, test, or CI file changes.

## Why

`cargo audit` reported `spin 0.10.0` as yanked through `crc-fast -> aws-smithy-checksums -> aws-sdk-s3`. The current constraints permit a one-package patch-line update without upgrading AWS SDK or `crc-fast`.

## Implementation

- `cargo update -p spin@0.10.0 --precise 0.10.1`
- active reverse dependency path remains `spin -> crc-fast -> aws-smithy-checksums -> aws-sdk-s3`
- old package ID no longer resolves
- post-update `cargo update -p spin@0.10.1 --precise 0.10.1 --dry-run` exits 0 with no changes

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo check --all-targets --all-features --locked` — pass
- `cargo clippy --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --all-features --locked -- --test-threads=1` — pass
  - lib: 10420 passed, 0 failed, 1 ignored
  - integration test library: 189 passed, 0 failed, 12 ignored
  - all route/integration binaries: pass
  - doctests: 33 passed, 0 failed, 32 ignored
- `cargo audit` — exit 0; `spin 0.10.0` absent; unrelated warnings remain visible
- `git diff --check` — pass
- implementation diff: 1 file, 3 insertions, 3 deletions

## Scope

This PR does not contain the separate `spin 0.9.x` update, does not add audit ignores, and must not be auto-merged.

Fixes #1038