### PR TITLE
docs(spec): define MCP initialization lifecycle fix

### DIFF
--- a/specs/GH1041/product.md
+++ b/specs/GH1041/product.md
@@ -1,0 +1,65 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1041 / #1041
+
+complexity: medium
+
+## 用户问题
+
+MCP 客户端声明使用 `2024-11-05` 协议，但初始化报文使用错误的 snake_case 字段，且会把缺失或损坏的初始化结果静默当作空 capabilities。客户端也未在成功协商后发送规范要求的 `notifications/initialized`，却直接把服务标记为已连接。
+
+结果是协议不兼容或初始化不完整时仍可能呈现“连接成功”，而遵循规范的服务端可能一直等待初始化完成通知。
+
+## 目标
+
+- 初始化 API 边界使用 MCP 规范的 camelCase 字段。
+- 严格验证服务端返回的协议版本、capabilities 和 server info。
+- 仅在有效响应及 `notifications/initialized` 发送成功后进入 `Connected`。
+- 初始化任一步骤失败时显式返回错误，不保留未完成协商的 capabilities。
+
+## 非目标
+
+- 不增加 `2024-11-05` 以外的 MCP 协议版本支持。
+- 不实现 Stdio 或 WebSocket transport。
+- 不修改 tools/resources/prompts 的业务语义。
+- 不在本 issue 扩展通用 JSON-RPC response ID 校验。
+
+## Behavior Invariants
+
+1. B-001 initialize request 必须发送 `protocolVersion`、`clientInfo`，不得发送对应 snake_case 字段；capability 子字段必须使用 `listChanged`。
+2. B-002 initialize response 必须包含可解析的 `protocolVersion`、`capabilities`、`serverInfo`；缺失、类型错误或空响应必须返回 `McpError::ProtocolError`，不得生成默认 capabilities。
+3. B-003 服务端返回的 `protocolVersion` 必须等于客户端唯一支持的 `2024-11-05`；其他版本必须显式失败。
+4. B-004 有效 initialize response 后，客户端必须发送无 JSON-RPC ID 的 `notifications/initialized`，且该通知成功前不得进入 `Connected`。
+5. B-005 HTTP 与 SSE-over-HTTP notification 的成功响应允许为空 body；认证、授权、限流、网络和非成功 HTTP 状态必须保持显式错误。
+6. B-006 initialize 解析、版本校验或 initialized notification 任一步骤失败时，server state 必须为 `Failed`，capabilities 必须保持 `None`。
+7. B-007 完整成功路径只按顺序发送 initialize request 和 initialized notification，随后保存服务端 capabilities 并进入 `Connected`。
+
+## 验收标准
+
+- [ ] 序列化测试证明 canonical camelCase 字段存在且对应 snake_case 字段不存在。
+- [ ] 缺失/损坏 required fields、空响应及版本不匹配均 fail closed。
+- [ ] HTTP 生命周期测试证明 initialize 在前、initialized notification 在后，且 notification 没有 `id`。
+- [ ] notification 失败测试证明 state 为 `Failed` 且 capabilities 为 `None`。
+- [ ] 成功测试证明 notification 成功后才保存 capabilities 并进入 `Connected`。
+- [ ] MCP focused tests、格式、全特性编译、strict Clippy 和全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-002；required result fields 和空 JSON-RPC response 均显式失败。 |
+| 错误与失败路径 | covered: B-002, B-003, B-005, B-006；协议与 transport 错误不降级。 |
+| 授权/权限 | covered: B-005；HTTP 401/403 保持现有 typed error。 |
+| 并发/竞态 | N/A；本 issue 不改变 connect 调用的并发协调策略。 |
+| 重试/幂等 | covered: B-006；失败不缓存部分协商结果，后续显式 connect 可重试。 |
+| 非法状态转换 | covered: B-004, B-006, B-007；只有完整握手可进入 Connected。 |
+| 兼容/迁移 | covered: B-001, B-003；修正为仓库声明支持的 2024-11-05 规范，不新增版本。 |
+| 降级/回退 | covered: B-002, B-003, B-005；所有无效响应和非成功 transport 状态 fail closed。 |
+| 证据与审计完整性 | covered: B-001 至 B-007；focused mock 与全量验证共同覆盖。 |
+| 取消/中断 | covered: B-006；中断导致 transport error 时不发布部分状态。 |
+
+## 发布说明
+
+MCP `2024-11-05` 初始化现在使用规范字段并完成 initialized notification；无效或不兼容的握手将显式失败，不再伪装为已连接。

--- a/specs/GH1041/tasks.md
+++ b/specs/GH1041/tasks.md
@@ -1,0 +1,34 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1041 / #1041
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1041-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: coordinator. Dependencies: none. Done when: GH1041 product/tech/tasks packet 存在，behavior invariants 连续且 product-to-test/task coverage 完整，spec 文档检查通过. Verify: `test -f specs/GH1041/product.md && test -f specs/GH1041/tech.md && test -f specs/GH1041/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1041/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1041/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1041-T2` Covers: B-001, B-002, B-003. Owner: implementation owner. Dependencies: SP1041-T1. Done when: protocol boundary DTOs emit/accept canonical camelCase, typed initialize result requires protocol version/capabilities/server info, and only `2024-11-05` is accepted. Verify: focused `core::mcp::protocol` and initialize parser tests, including missing/wrong-type/version-negative cases.
+- [ ] `SP1041-T3` Covers: B-004, B-005. Owner: implementation owner. Dependencies: SP1041-T2. Done when: HTTP/SSE request and notification paths share status/error behavior while notification has no ID, accepts empty 2xx body, and rejects non-2xx/network/auth/rate-limit failures explicitly. Verify: loopback HTTP tests inspect serialized messages and response handling.
+- [ ] `SP1041-T4` Covers: B-004, B-006, B-007. Owner: implementation owner. Dependencies: SP1041-T2, SP1041-T3. Done when: connect commits capabilities and Connected only after valid initialize result plus successful initialized notification; every failure leaves Failed/None. Verify: focused lifecycle success and notification-rejection tests assert message order, state, and capabilities.
+- [ ] `SP1041-T5` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP1041-T4. Done when: diff is limited to GH1041 spec and MCP protocol/server implementation/tests, formatting/build/lint/full tests pass with fresh output, and no production SSRF rule is weakened. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → protocol DTO/parser → notification transport → lifecycle state commit → focused tests → repository-wide verification。步骤共享 `protocol.rs` 与 `server.rs`，由单一 implementation owner 串行完成，避免并行写入冲突。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 均为 B-001 至 B-007，无 orphan。
+- Impl PR 使用 `Fixes #1041`，并以 Spec branch 为 base，使实现与 Spec 审查历史分离。
+- 远端 PR 只报告 current-head CI 事实；不自动合并。
+
+## Handoff Notes
+
+- 仓库当前只声明 `2024-11-05`，不得顺手升级到最新 MCP 版本。
+- loopback client 只能存在于 test code；production `McpServer::new` 继续委托 SSRF-safe client。
+- JSON-RPC response ID validation 与 concurrent connect serialization 留给独立证据和独立 issue。

--- a/specs/GH1041/tech.md
+++ b/specs/GH1041/tech.md
@@ -1,0 +1,69 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1041 / #1041
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Protocol DTOs | `src/core/mcp/protocol.rs` | initialization and nested capability structs inherit Rust snake_case field names | B-001 API-boundary mismatch |
+| Connection lifecycle | `src/core/mcp/server.rs` | extracts optional `capabilities`, defaults parse failures, and marks Connected immediately | B-002/B-003/B-004/B-006/B-007 root cause |
+| HTTP/SSE transport | `src/core/mcp/server.rs` | request helper always allocates an ID and always parses a JSON response | B-004/B-005 notification gap |
+| Existing tests | `src/core/mcp/protocol.rs`, `src/core/mcp/server.rs` | basic message and registry tests; no initialization lifecycle coverage | Regression gap |
+
+## 设计方案
+
+1. 在 `protocol.rs` 定义唯一支持版本常量，并为 MCP boundary DTO 使用 `#[serde(rename_all = "camelCase")]`。复用现有 `ClientInfo` 的 name/version shape，新增 typed `InitializeResult`，要求 `protocol_version`、`capabilities`、`server_info` 全部存在且类型正确。
+2. `initialize()` 将 success result 一次性反序列化为 `InitializeResult`。解析错误转换为包含上下文的 `ProtocolError`；协议版本必须精确匹配支持版本。
+3. 把 HTTP/SSE 发送逻辑拆为共享的 typed message transport：request 仍分配 ID 并解析 JSON-RPC response；notification 使用 `JsonRpcRequest::notification()`，不分配 ID、不解析 response body，2xx/empty body 为成功。
+4. 复用现有 HTTP error mapping，新增对其他非 2xx status 的显式 `TransportError`，避免错误页面被误报为 JSON parse error或 notification 成功。
+5. `connect()` 的顺序固定为：state=Connecting → initialize request/validate → initialized notification → store capabilities → state=Connected。任一步骤错误进入 Failed；开始新连接前清空 capabilities，防止重连失败保留旧协商结果。
+6. 使用 loopback HTTP mock 做真实报文与顺序断言；测试模块用 private-field access 注入允许 loopback 的 reqwest client，不放宽生产 SSRF client。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | protocol serde attributes | exact JSON serialization/deserialization unit tests |
+| B-002 | typed `InitializeResult` parser | missing/malformed/empty result focused tests |
+| B-003 | supported-version check | mismatched-version test returns ProtocolError |
+| B-004 | notification send path + connect ordering | loopback server captures two ordered JSON messages and no notification id |
+| B-005 | shared HTTP status mapping + notification body handling | empty 2xx notification succeeds; rejected notification returns typed error |
+| B-006 | connect failure branch and cache ordering | parse/version/notification failures assert Failed + capabilities None |
+| B-007 | complete loopback lifecycle | valid server data persisted only after both messages; state Connected |
+
+## 数据流
+
+`McpServer::connect` constructs typed initialize params → serde emits canonical MCP JSON → HTTP/SSE request receives JSON-RPC result → typed initialize parsing and version validation → notification transport emits `notifications/initialized` without ID → capabilities/state are committed together after success. Errors flow back as existing `McpError` variants without fallback values.
+
+## 备选方案
+
+- 继续使用 `Value::get` 并手工检查字段：容易遗漏 nested types，不能让 serde 集中执行 required-field validation，拒绝。
+- 对 response version 自动回退到客户端版本：掩盖协商失败并违反 fail-closed 目标，拒绝。
+- 让 notification 复用 request helper并忽略 response parse error：会错误携带 ID，且以静默吞错完成生命周期，拒绝。
+- 为测试放宽生产 SSRF 规则：扩大安全边界且无必要，测试可在同模块注入 loopback client，拒绝。
+
+## 风险
+
+- Compatibility: 依赖当前错误 snake_case 或缺少 initialized notification 的非标准服务会从伪成功变为显式失败；这是协议修正。
+- State correctness: capabilities 必须在 notification 成功后一次性发布，不能提前写入。
+- Transport: notification 常见成功状态为空 body，不能调用 `.json()`；其他非 2xx 状态不能被接受。
+- Security: production 构造仍必须使用 SSRF-safe client；loopback client 仅限 `#[cfg(test)]` 内部构造。
+
+## 测试计划
+
+- [ ] Protocol unit: initialize params 和 capability fields exact camelCase，snake_case absent。
+- [ ] Parser unit: valid result、missing fields、wrong types、empty result、mismatched version。
+- [ ] HTTP lifecycle: ordered initialize + initialized notification，ID presence/absence，empty success body。
+- [ ] State failure: notification rejection produces Failed/None；valid lifecycle produces Connected/expected capabilities。
+- [ ] Repository: `cargo fmt --all -- --check`、all-target/all-feature check、strict Clippy、full serial tests。
+
+## 回滚方案
+
+若 compatibility regression 被证实，保留 camelCase boundary 和 fail-closed validation，通过后续独立 issue 增加明确支持的协议版本或 transport compatibility；不得恢复默认 capabilities、跳过 initialized notification 或在失败后标记 Connected。


### PR DESCRIPTION
## Summary

- define the fail-closed MCP 2024-11-05 initialization behavior for #1041
- specify canonical camelCase API fields and typed required response fields
- require `notifications/initialized` before publishing Connected state
- map each invariant to deterministic protocol, transport, and state tests

## Verification

- `git diff --cached --check`
- confirmed product/task invariant coverage is exactly B-001 through B-007
- confirmed the PR contains only `specs/GH1041/{product,tech,tasks}.md`

Issue: #1041