### PR TITLE
fix(mcp): enforce initialization lifecycle

### DIFF
--- a/src/core/mcp/protocol.rs
+++ b/src/core/mcp/protocol.rs
@@ -9,6 +9,9 @@ use serde_json::Value;
 /// JSON-RPC 2.0 version constant
 pub const JSONRPC_VERSION: &str = "2.0";
 
+/// MCP protocol version supported by this client
+pub const SUPPORTED_PROTOCOL_VERSION: &str = "2024-11-05";
+
 /// JSON-RPC 2.0 Request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcRequest {
@@ -238,6 +241,9 @@ pub mod methods {
     /// Initialize the connection
     pub const INITIALIZE: &str = "initialize";
 
+    /// Notify the server that initialization completed
+    pub const INITIALIZED: &str = "notifications/initialized";
+
     /// List available tools
     pub const LIST_TOOLS: &str = "tools/list";
 
@@ -288,6 +294,7 @@ pub struct McpCapabilities {
 
 /// Tools capability
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ToolsCapability {
     /// Whether list_changed notifications are supported
     #[serde(default)]
@@ -296,6 +303,7 @@ pub struct ToolsCapability {
 
 /// Resources capability
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesCapability {
     /// Whether subscribe is supported
     #[serde(default)]
@@ -308,6 +316,7 @@ pub struct ResourcesCapability {
 
 /// Prompts capability
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptsCapability {
     /// Whether list_changed notifications are supported
     #[serde(default)]
@@ -320,6 +329,7 @@ pub struct LoggingCapability {}
 
 /// Initialize request params
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
     /// Protocol version
     pub protocol_version: String,
@@ -329,6 +339,20 @@ pub struct InitializeParams {
 
     /// Client info
     pub client_info: ClientInfo,
+}
+
+/// Initialize response result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResult {
+    /// Protocol version selected by the server
+    pub protocol_version: String,
+
+    /// Server capabilities
+    pub capabilities: McpCapabilities,
+
+    /// Server implementation information
+    pub server_info: ClientInfo,
 }
 
 /// Client info for initialization
@@ -459,8 +483,68 @@ mod tests {
     }
 
     #[test]
+    fn test_initialize_params_use_mcp_camel_case_fields() {
+        let params = InitializeParams {
+            protocol_version: SUPPORTED_PROTOCOL_VERSION.to_string(),
+            capabilities: McpCapabilities {
+                tools: Some(ToolsCapability { list_changed: true }),
+                resources: Some(ResourcesCapability {
+                    subscribe: true,
+                    list_changed: true,
+                }),
+                prompts: Some(PromptsCapability { list_changed: true }),
+                logging: None,
+            },
+            client_info: ClientInfo::default(),
+        };
+
+        let value = serde_json::to_value(params).expect("initialize params should serialize");
+        assert_eq!(value["protocolVersion"], SUPPORTED_PROTOCOL_VERSION);
+        assert!(value.get("clientInfo").is_some());
+        assert!(value.get("protocol_version").is_none());
+        assert!(value.get("client_info").is_none());
+        assert_eq!(value["capabilities"]["tools"]["listChanged"], true);
+        assert_eq!(value["capabilities"]["resources"]["listChanged"], true);
+        assert_eq!(value["capabilities"]["prompts"]["listChanged"], true);
+        assert!(value["capabilities"]["tools"].get("list_changed").is_none());
+    }
+
+    #[test]
+    fn test_initialize_result_requires_all_mcp_fields() {
+        let valid = serde_json::json!({
+            "protocolVersion": SUPPORTED_PROTOCOL_VERSION,
+            "capabilities": {"tools": {"listChanged": true}},
+            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+        });
+
+        let result: InitializeResult =
+            serde_json::from_value(valid.clone()).expect("valid result should parse");
+        assert_eq!(result.protocol_version, SUPPORTED_PROTOCOL_VERSION);
+        assert!(
+            result
+                .capabilities
+                .tools
+                .expect("tools capability")
+                .list_changed
+        );
+
+        for required_field in ["protocolVersion", "capabilities", "serverInfo"] {
+            let mut invalid = valid.clone();
+            invalid
+                .as_object_mut()
+                .expect("fixture should be an object")
+                .remove(required_field);
+            assert!(
+                serde_json::from_value::<InitializeResult>(invalid).is_err(),
+                "missing {required_field} should fail"
+            );
+        }
+    }
+
+    #[test]
     fn test_method_constants() {
         assert_eq!(methods::INITIALIZE, "initialize");
+        assert_eq!(methods::INITIALIZED, "notifications/initialized");
         assert_eq!(methods::LIST_TOOLS, "tools/list");
         assert_eq!(methods::CALL_TOOL, "tools/call");
     }

--- a/src/core/mcp/server.rs
+++ b/src/core/mcp/server.rs
@@ -319,8 +319,31 @@ impl McpServer {
         params: Option<serde_json::Value>,
     ) -> McpResult<()> {
         let notification = JsonRpcRequest::notification(method, params);
-        self.send_http_message(&notification).await?;
+        self.send_http_message(&notification)
+            .await?
+            .bytes()
+            .await
+            .map_err(|error| self.map_http_error(error))?;
         Ok(())
+    }
+
+    fn map_http_error(&self, error: reqwest::Error) -> McpError {
+        if error.is_timeout() {
+            McpError::Timeout {
+                server_name: self.config.name.clone(),
+                timeout_ms: self.config.timeout_ms,
+            }
+        } else if error.is_connect() {
+            McpError::ConnectionError {
+                server_name: self.config.name.clone(),
+                message: error.to_string(),
+            }
+        } else {
+            McpError::TransportError {
+                transport: "http".to_string(),
+                message: error.to_string(),
+            }
+        }
     }
 
     async fn send_http_message(&self, request: &JsonRpcRequest) -> McpResult<reqwest::Response> {
@@ -331,24 +354,7 @@ impl McpServer {
             .json(&request)
             .send()
             .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    McpError::Timeout {
-                        server_name: self.config.name.clone(),
-                        timeout_ms: self.config.timeout_ms,
-                    }
-                } else if e.is_connect() {
-                    McpError::ConnectionError {
-                        server_name: self.config.name.clone(),
-                        message: e.to_string(),
-                    }
-                } else {
-                    McpError::TransportError {
-                        transport: "http".to_string(),
-                        message: e.to_string(),
-                    }
-                }
-            })?;
+            .map_err(|error| self.map_http_error(error))?;
 
         let status = response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED {

--- a/src/core/mcp/server.rs
+++ b/src/core/mcp/server.rs
@@ -10,7 +10,8 @@ use tokio::sync::RwLock;
 use super::config::McpServerConfig;
 use super::error::{McpError, McpResult};
 use super::protocol::{
-    ClientInfo, InitializeParams, JsonRpcRequest, JsonRpcResponse, McpCapabilities, methods,
+    ClientInfo, InitializeParams, InitializeResult, JsonRpcRequest, JsonRpcResponse,
+    McpCapabilities, SUPPORTED_PROTOCOL_VERSION, methods,
 };
 use super::tools::{Tool, ToolCall, ToolList, ToolResult};
 use super::transport::Transport;
@@ -154,6 +155,7 @@ impl McpServer {
             }
             *state = ServerState::Connecting;
         }
+        *self.capabilities.write().await = None;
 
         match self.initialize().await {
             Ok(caps) => {
@@ -171,7 +173,7 @@ impl McpServer {
     /// Initialize the MCP connection
     async fn initialize(&self) -> McpResult<McpCapabilities> {
         let params = InitializeParams {
-            protocol_version: "2024-11-05".to_string(),
+            protocol_version: SUPPORTED_PROTOCOL_VERSION.to_string(),
             capabilities: McpCapabilities::default(),
             client_info: ClientInfo::default(),
         };
@@ -179,19 +181,10 @@ impl McpServer {
         let response = self
             .send_request(methods::INITIALIZE, Some(serde_json::to_value(params)?))
             .await?;
+        let result = parse_initialize_response(response)?;
 
-        if let Some(result) = response.result {
-            let caps: McpCapabilities =
-                serde_json::from_value(result.get("capabilities").cloned().unwrap_or_default())
-                    .unwrap_or_default();
-            Ok(caps)
-        } else if let Some(error) = response.error {
-            Err(McpError::ProtocolError {
-                message: format!("Initialize failed: {}", error.message),
-            })
-        } else {
-            Ok(McpCapabilities::default())
-        }
+        self.send_notification(methods::INITIALIZED, None).await?;
+        Ok(result.capabilities)
     }
 
     /// Disconnect from the server
@@ -280,6 +273,25 @@ impl McpServer {
         }
     }
 
+    /// Send a JSON-RPC notification without expecting a response body
+    async fn send_notification(
+        &self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> McpResult<()> {
+        match self.config.transport {
+            Transport::Http | Transport::Sse => self.send_http_notification(method, params).await,
+            Transport::Stdio => Err(McpError::TransportError {
+                transport: "stdio".to_string(),
+                message: "Stdio transport not yet implemented".to_string(),
+            }),
+            Transport::WebSocket => Err(McpError::TransportError {
+                transport: "websocket".to_string(),
+                message: "WebSocket transport not yet implemented".to_string(),
+            }),
+        }
+    }
+
     /// Send HTTP request
     async fn send_http_request(
         &self,
@@ -293,6 +305,25 @@ impl McpServer {
         let request =
             JsonRpcRequest::new(method, params).with_id(serde_json::Value::Number(id.into()));
 
+        let response = self.send_http_message(&request).await?;
+
+        response.json().await.map_err(|e| McpError::ProtocolError {
+            message: format!("Failed to parse response: {e}"),
+        })
+    }
+
+    /// Send an HTTP notification and accept a successful empty response body
+    async fn send_http_notification(
+        &self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> McpResult<()> {
+        let notification = JsonRpcRequest::notification(method, params);
+        self.send_http_message(&notification).await?;
+        Ok(())
+    }
+
+    async fn send_http_message(&self, request: &JsonRpcRequest) -> McpResult<reqwest::Response> {
         let response = self
             .http_client
             .post(&self.config.url)
@@ -346,13 +377,14 @@ impl McpServer {
                 retry_after_ms: retry_after,
             });
         }
+        if !status.is_success() {
+            return Err(McpError::TransportError {
+                transport: "http".to_string(),
+                message: format!("MCP server returned HTTP status {status}"),
+            });
+        }
 
-        let rpc_response: JsonRpcResponse =
-            response.json().await.map_err(|e| McpError::ProtocolError {
-                message: format!("Failed to parse response: {}", e),
-            })?;
-
-        Ok(rpc_response)
+        Ok(response)
     }
 
     /// Send SSE request (for now, falls back to HTTP POST)
@@ -395,6 +427,42 @@ impl McpServer {
     pub async fn capabilities(&self) -> Option<McpCapabilities> {
         self.capabilities.read().await.clone()
     }
+}
+
+fn parse_initialize_response(response: JsonRpcResponse) -> McpResult<InitializeResult> {
+    let result = match (response.result, response.error) {
+        (Some(result), None) => result,
+        (None, Some(error)) => {
+            return Err(McpError::ProtocolError {
+                message: format!("Initialize failed: {}", error.message),
+            });
+        }
+        (Some(_), Some(_)) => {
+            return Err(McpError::ProtocolError {
+                message: "Initialize response contained both result and error".to_string(),
+            });
+        }
+        (None, None) => {
+            return Err(McpError::ProtocolError {
+                message: "Initialize response contained neither result nor error".to_string(),
+            });
+        }
+    };
+
+    let result: InitializeResult =
+        serde_json::from_value(result).map_err(|error| McpError::ProtocolError {
+            message: format!("Invalid initialize result: {error}"),
+        })?;
+    if result.protocol_version != SUPPORTED_PROTOCOL_VERSION {
+        return Err(McpError::ProtocolError {
+            message: format!(
+                "Unsupported MCP protocol version '{}'; expected '{}'",
+                result.protocol_version, SUPPORTED_PROTOCOL_VERSION
+            ),
+        });
+    }
+
+    Ok(result)
 }
 
 /// Thread-safe MCP Server handle
@@ -665,3 +733,7 @@ mod tests {
         assert!(result.is_err());
     }
 }
+
+#[cfg(test)]
+#[path = "server_lifecycle_tests.rs"]
+mod lifecycle_tests;

--- a/src/core/mcp/server_lifecycle_tests.rs
+++ b/src/core/mcp/server_lifecycle_tests.rs
@@ -1,0 +1,246 @@
+use super::*;
+use crate::core::mcp::protocol::{JsonRpcError, ToolsCapability};
+use serde_json::json;
+use std::io;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+struct MockResponse {
+    status: &'static str,
+    body: String,
+}
+
+struct MockLifecycleServer {
+    url: String,
+    requests: oneshot::Receiver<Vec<Value>>,
+    task: JoinHandle<io::Result<()>>,
+}
+
+impl MockLifecycleServer {
+    async fn start(responses: Vec<MockResponse>) -> io::Result<Self> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let address = listener.local_addr()?;
+        let (request_sender, requests) = oneshot::channel();
+
+        let task = tokio::spawn(async move {
+            let mut captured = Vec::with_capacity(responses.len());
+            for response in responses {
+                let (mut socket, _) = listener.accept().await?;
+                captured.push(read_json_body(&mut socket).await?);
+                let wire_response = format!(
+                    "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response.status,
+                    response.body.len(),
+                    response.body
+                );
+                socket.write_all(wire_response.as_bytes()).await?;
+            }
+
+            request_sender.send(captured).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "lifecycle request receiver was dropped",
+                )
+            })
+        });
+
+        Ok(Self {
+            url: format!("http://{address}/mcp"),
+            requests,
+            task,
+        })
+    }
+
+    async fn captured_requests(self) -> TestResult<Vec<Value>> {
+        let requests = self.requests.await?;
+        self.task.await??;
+        Ok(requests)
+    }
+}
+
+async fn read_json_body(socket: &mut TcpStream) -> io::Result<Value> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 2048];
+
+    loop {
+        let bytes_read = socket.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "mock MCP server received an incomplete HTTP request",
+            ));
+        }
+        request.extend_from_slice(&buffer[..bytes_read]);
+
+        let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "mock MCP request is missing content-length",
+                )
+            })?;
+        let body_start = header_end + 4;
+        if request.len() < body_start + content_length {
+            continue;
+        }
+
+        return serde_json::from_slice(&request[body_start..body_start + content_length])
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+    }
+}
+
+fn valid_initialize_result() -> Value {
+    json!({
+        "protocolVersion": SUPPORTED_PROTOCOL_VERSION,
+        "capabilities": {"tools": {"listChanged": true}},
+        "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+    })
+}
+
+fn initialize_response(result: Value) -> JsonRpcResponse {
+    JsonRpcResponse::success(result, json!(1))
+}
+
+fn test_server(url: String) -> McpServer {
+    McpServer {
+        config: McpServerConfig::new("test", url).with_timeout(2_000),
+        state: RwLock::new(ServerState::Disconnected),
+        http_client: get_client_with_timeout(Duration::from_secs(2)),
+        custom_headers: reqwest::header::HeaderMap::new(),
+        tools_cache: RwLock::new(None),
+        tools_baseline_hash: RwLock::new(None),
+        capabilities: RwLock::new(None),
+        request_id: std::sync::atomic::AtomicU64::new(1),
+    }
+}
+
+#[test]
+fn initialize_response_fails_closed_on_invalid_shapes() {
+    let mut missing_capabilities = valid_initialize_result();
+    missing_capabilities
+        .as_object_mut()
+        .expect("fixture should be an object")
+        .remove("capabilities");
+
+    let invalid_responses = [
+        initialize_response(missing_capabilities),
+        initialize_response(json!({
+            "protocolVersion": SUPPORTED_PROTOCOL_VERSION,
+            "capabilities": [],
+            "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+        })),
+        JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            result: None,
+            error: None,
+            id: Some(json!(1)),
+        },
+        JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            result: Some(valid_initialize_result()),
+            error: Some(JsonRpcError::internal_error()),
+            id: Some(json!(1)),
+        },
+    ];
+
+    for response in invalid_responses {
+        assert!(matches!(
+            parse_initialize_response(response),
+            Err(McpError::ProtocolError { .. })
+        ));
+    }
+}
+
+#[test]
+fn initialize_response_rejects_unsupported_protocol_version() {
+    let mut result = valid_initialize_result();
+    result["protocolVersion"] = json!("2025-03-26");
+
+    let error = parse_initialize_response(initialize_response(result))
+        .expect_err("unsupported version should fail");
+    assert!(matches!(error, McpError::ProtocolError { .. }));
+    assert!(error.to_string().contains("2025-03-26"));
+}
+
+#[tokio::test]
+async fn connect_sends_initialized_notification_before_committing_state() -> TestResult {
+    let initialize_body = serde_json::to_string(&initialize_response(valid_initialize_result()))?;
+    let mock = MockLifecycleServer::start(vec![
+        MockResponse {
+            status: "200 OK",
+            body: initialize_body,
+        },
+        MockResponse {
+            status: "202 Accepted",
+            body: String::new(),
+        },
+    ])
+    .await?;
+    let server = test_server(mock.url.clone());
+
+    server.connect().await?;
+    assert_eq!(server.state().await, ServerState::Connected);
+    assert_eq!(
+        server
+            .capabilities()
+            .await
+            .and_then(|caps| caps.tools)
+            .map(|tools: ToolsCapability| tools.list_changed),
+        Some(true)
+    );
+
+    let requests = mock.captured_requests().await?;
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0]["method"], methods::INITIALIZE);
+    assert_eq!(
+        requests[0]["params"]["protocolVersion"],
+        SUPPORTED_PROTOCOL_VERSION
+    );
+    assert!(requests[0].get("id").is_some());
+    assert_eq!(requests[1]["method"], methods::INITIALIZED);
+    assert!(requests[1].get("id").is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn connect_does_not_publish_capabilities_when_notification_fails() -> TestResult {
+    let initialize_body = serde_json::to_string(&initialize_response(valid_initialize_result()))?;
+    let mock = MockLifecycleServer::start(vec![
+        MockResponse {
+            status: "200 OK",
+            body: initialize_body,
+        },
+        MockResponse {
+            status: "500 Internal Server Error",
+            body: String::new(),
+        },
+    ])
+    .await?;
+    let server = test_server(mock.url.clone());
+
+    let result = server.connect().await;
+    assert!(matches!(result, Err(McpError::TransportError { .. })));
+    assert_eq!(server.state().await, ServerState::Failed);
+    assert!(server.capabilities().await.is_none());
+
+    let requests = mock.captured_requests().await?;
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[1]["method"], methods::INITIALIZED);
+    assert!(requests[1].get("id").is_none());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- serialize MCP initialization DTOs with canonical camelCase fields
- parse required initialize result fields and reject unsupported protocol versions
- send `notifications/initialized` without an id before publishing capabilities or Connected state
- accept empty successful notification responses while failing explicitly on HTTP errors
- cover protocol shape, fail-closed parsing, ordered lifecycle success, and notification failure with deterministic loopback tests

## Why

The client advertised MCP `2024-11-05` but sent snake_case fields, silently defaulted malformed initialize results, and marked the server connected without the required initialized notification. This could expose incomplete or incompatible handshakes as healthy connections.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- focused MCP protocol tests: 15 passed
- focused MCP lifecycle tests: 4 passed
- `cargo test --all-features --locked -- --test-threads=1`
  - library: 10426 passed, 0 failed, 1 ignored
  - integration library: 189 passed, 0 failed, 12 ignored
  - all route/integration binaries passed
  - doctests: 33 passed, 0 failed, 32 ignored

Fixes #1041