### PR TITLE
docs(spec): define API key JSON fail-closed handling

### DIFF
--- a/specs/GH1044/product.md
+++ b/specs/GH1044/product.md
@@ -1,0 +1,67 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1044 / #1044
+
+complexity: medium
+
+## 用户问题
+
+authoritative `api_keys` 表把 permissions、rate limits、usage stats 和 metadata 保存为 JSON text。当前读取转换会把损坏的非空 JSON 静默变成空值或默认值，其中损坏的 key-specific rate limit 会变成 `None`，随后请求限流回退到更宽的 gateway default，或在没有 default 时不应用 RPM 限制。
+
+损坏的 usage stats 还会被当作零值参与 read-modify-write，并在下一次 usage update 时覆盖原始损坏数据，造成计量丢失且隐藏数据完整性问题。
+
+## 目标
+
+- authoritative API-key row 的非空 JSON 字段必须严格解析，损坏时显式失败。
+- `NULL` optional field 与“非空但损坏”保持不同语义。
+- lookup/list/authentication source 和 usage update 都传播转换错误。
+- 错误提供字段上下文但不泄露原 JSON、key hash 或 secret。
+- 有效 API-key 的创建、读取、更新、列举和 rate-limit precedence 保持不变。
+
+## 非目标
+
+- 不增加跨 SQLite/PostgreSQL 的 JSON CHECK constraint 或数据修复 migration。
+- 不自动修复、清空或删除已有损坏行。
+- 不改变有效 key-specific rate limit 与 gateway default 的优先级。
+- 不修改 Redis/local rate limiter 的 failure mode。
+
+## Behavior Invariants
+
+1. B-001 非空 `permissions`、`rate_limits`、`usage_stats`、`extra` 必须解析为声明类型；任何 malformed/type mismatch 都返回 typed `GatewayError`，不得使用空/默认 domain value。
+2. B-002 optional `rate_limits`/`extra` 只有数据库值为 `NULL` 时才转换为 `None`/empty metadata；非空损坏值不得与缺失值等价。
+3. B-003 authoritative hash/id lookup 遇到损坏 row 必须返回错误而不是 `Ok(Some(ApiKey))`，authentication 因此不能接收丢失 key-specific policy 的有效 key。
+4. B-004 user/team/global list 遇到任一损坏 row 必须传播错误，不得丢弃该 row、返回部分列表或默认字段。
+5. B-005 `update_api_key_usage` 遇到损坏 persisted usage/policy 必须回滚并保持原 row 不变，不得以零 counters 覆盖损坏数据。
+6. B-006 domain-to-entity JSON serialization 必须传播错误，不得写入 `[]`、`{}` 或 `NULL` fallback；正常 valid values 保持 round-trip。
+7. B-007 conversion error 只包含 field context 与 parser category，不包含 raw JSON、key hash、key prefix 或 secret；有效 create/read/update/list 行为不变。
+
+## 验收标准
+
+- [ ] malformed non-null rate limits 的 hash/id lookup 显式失败，不能形成 `rate_limits: None` 的 ApiKey。
+- [ ] malformed permissions、usage stats、extra 均显式失败。
+- [ ] list 查询遇到损坏 row 不返回 partial/default result。
+- [ ] usage update 遇到损坏 row 返回错误且数据库原值未改变。
+- [ ] 错误断言证明包含字段名但不包含 fixture 原文或 key identity/secret。
+- [ ] valid `NULL` optionals 与 valid JSON round-trip 保持原行为。
+- [ ] focused DB/auth tests、格式、全特性编译、strict Clippy 和全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001, B-002；required 空字符串损坏，optional NULL 保持缺失语义。 |
+| 错误与失败路径 | covered: B-001 至 B-006；所有 conversion consumer 传播同一错误。 |
+| 授权/权限 | covered: B-003；损坏 policy 不得形成可认证 domain key。 |
+| 并发/竞态 | covered: B-005；既有 transaction/optimistic lock 保留，转换失败先于写入。 |
+| 重试/幂等 | covered: B-005；重复读取持续失败且不修改损坏 row。 |
+| 非法状态转换 | covered: B-003, B-005；corrupt persisted state 不转成 valid/default domain state。 |
+| 兼容/迁移 | covered: B-002, B-007；valid/null rows 不需迁移，损坏 rows 从静默降级变显式错误。 |
+| 降级/回退 | covered: B-001 至 B-006；禁止 JSON fallback 与 partial list。 |
+| 证据与审计完整性 | covered: B-005, B-007；损坏原值保留，错误不泄密。 |
+| 取消/中断 | covered: B-005；transaction 在 conversion error 时不提交。 |
+
+## 发布说明
+
+API-key 持久化 policy 或 usage JSON 损坏时现在会显式失败；key-specific 限流、权限和计量数据不再被静默置空或重置。

--- a/specs/GH1044/tasks.md
+++ b/specs/GH1044/tasks.md
@@ -1,0 +1,34 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1044 / #1044
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1044-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: coordinator. Dependencies: none. Done when: GH1044 product/tech/tasks packet 齐全，B-001 至 B-007 连续且 product-to-test/task coverage 完整. Verify: `test -f specs/GH1044/product.md && test -f specs/GH1044/tech.md && test -f specs/GH1044/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1044/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1044/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1044-T2` Covers: B-001, B-002, B-006, B-007. Owner: implementation owner. Dependencies: SP1044-T1. Done when: SeaORM API-key entity/domain conversions are fallible, strict for every non-null JSON field, preserve genuine NULL optionals, and emit redacted field-context errors without fallback JSON. Verify: focused entity conversion tests plus `rg -n 'unwrap_or_default|unwrap_or_else|\.ok\(\)' src/storage/database/entities/api_key.rs` yields no JSON conversion fallback.
+- [ ] `SP1044-T3` Covers: B-003, B-004. Owner: implementation owner. Dependencies: SP1044-T2. Done when: create/hash/id lookup and user/team/global list propagate conversion errors; malformed rate limits cannot produce an authenticated domain key or partial list. Verify: in-memory DB tests inject corrupt rate-limit row and assert all lookup/list results are `Err`.
+- [ ] `SP1044-T4` Covers: B-005, B-007. Owner: implementation owner. Dependencies: SP1044-T2. Done when: usage update validates before mutation/UPDATE, corrupt row returns error, transaction does not overwrite the raw value, and error omits sentinel/key identity. Verify: DB test reads raw usage column before/after failed update and asserts exact equality.
+- [ ] `SP1044-T5` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP1044-T3, SP1044-T4. Done when: diff is limited to GH1044 spec, API-key conversion/operations and focused tests; format, all-feature check, strict Clippy and full serial tests pass with fresh output. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → fallible conversion → DB propagation → corruption/rollback tests → focused verification → repository-wide verification。转换与 consumer 存在直接依赖，由单一 implementation owner 串行修改。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 精确为 B-001 至 B-007。
+- Impl PR 使用 `Fixes #1044` 并以 Spec branch 为 base，代码审查与规范审查分离。
+- 远端 PR 保持未自动合并，只报告 current-head checks 事实。
+
+## Handoff Notes
+
+- `rate_limits=NULL` 是合法缺失；`rate_limits='broken'` 必须是错误，不能合并语义。
+- error 中不得包含 raw field value、key hash、prefix 或 secret。
+- 不顺手增加 migration、repair 或改变 valid policy precedence。

--- a/specs/GH1044/tech.md
+++ b/specs/GH1044/tech.md
@@ -1,0 +1,71 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1044 / #1044
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Entity conversion | `src/storage/database/entities/api_key.rs` | `.ok()`/default fallbacks erase JSON parse and serialization failures | B-001/B-002/B-006 root cause |
+| DB operations | `src/storage/database/seaorm_db/api_key_ops.rs` | lookup/list/update usage call an infallible converter | B-003/B-004/B-005 propagation gap |
+| Auth source | `src/auth/api_key/creation.rs` | verification intentionally reads authoritative DB | B-003 security boundary |
+| RPM selection | `src/server/middleware/rate_limit_key_policy.rs` | absent key RPM falls back to gateway default | malformed rate limit becomes policy bypass/weakening |
+| DB schema | `src/storage/database/migration/m20240101_000005_create_api_keys_table.rs` | JSON values are TEXT, optional fields may be NULL | Must distinguish NULL from corrupt non-null text |
+
+## 设计方案
+
+1. 将 `api_key::Model::to_domain_api_key` 改为 `Result<ApiKey>`。用单一 field-aware helper 严格解析每个 JSON field，并把 serde error 映射为 `GatewayError::Serialization` 或 `Validation`，消息只包含稳定字段名与 serde category/line-column，不拼接原值。
+2. optional fields 使用 `Option::map(parse).transpose()`：数据库 `NULL` 保持 `None`，non-null parse error 直接返回；valid empty object/array 保持合法值。
+3. 将 `from_domain_api_key` 改为 `Result<ActiveModel>`，permissions、rate limits、usage stats、extra 全部使用 `?`/`transpose()`，删除序列化 fallback。
+4. 在 `api_key_ops.rs` 的 create、hash/id lookup、user/team/global list、update usage 中传播 `?`：single optional 使用 `map(...).transpose()`，list 使用 iterator `collect::<Result<Vec<_>>>()`。
+5. usage update 保持现有 transaction 和 optimistic lock；conversion 在任何 counter mutation/UPDATE 之前失败，使 transaction drop/rollback 且 row 原值不变。
+6. 新建独立 `api_key_corruption_tests.rs`（避免继续扩张 558 行的 `api_key_ops.rs`），复用内存 SQLite migration，插入 valid key 后用 entity update 注入 malformed fields，验证 lookup/list/update fail closed 与 row preservation。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | strict entity parser | per-field malformed/type-mismatch conversion tests |
+| B-002 | optional `map(...).transpose()` | NULL optional valid test vs non-null corrupt error test |
+| B-003 | hash/id lookup propagation | in-memory DB corrupt rate-limit lookup returns error; no ApiKey produced |
+| B-004 | list iterator result collection | list with corrupt row returns error, not partial Vec |
+| B-005 | usage transaction conversion order | corrupt usage update errors; raw column remains byte-for-byte unchanged |
+| B-006 | fallible domain-to-entity conversion | valid round-trip plus source/diff assertion that fallback calls are absent |
+| B-007 | error construction and valid regression suite | field-name present; sentinel JSON/key data absent; existing CRUD/full tests pass |
+
+## 数据流
+
+Database row → strict field parser → `Result<ApiKey>` → lookup/list/auth consumer. Only a fully valid row crosses into the domain/auth boundary. Domain write flow serializes all fields before creating an `ActiveModel`; any failure aborts before SQL. Usage update reads and validates the full row before mutating counters and executing UPDATE.
+
+## 备选方案
+
+- malformed rate limit 继续当 `None`，只写 warning：仍允许请求使用更宽 fallback，违反 B-003，拒绝。
+- 只严格解析 rate limits：permissions/usage/extra 仍隐藏同一持久化损坏根因，违反 B-001，拒绝。
+- 在 migration 中自动清空损坏 JSON：造成不可逆数据丢失且跨数据库约束复杂，超出本 issue，拒绝。
+- list 跳过损坏 row：返回不完整管理视图并隐藏数据，违反 B-004，拒绝。
+
+## 风险
+
+- Compatibility: 已损坏的 rows 从可读默认值变为显式错误；这是预期 fail-closed 行为。
+- Availability: 单个损坏 row 会使包含它的 list 失败，避免 partial truth；管理员需在数据库层修复。
+- Security: error message 不能包含 raw JSON、hash/prefix/secret；测试使用 sentinel 验证。
+- Transaction: usage update 必须在 SQL UPDATE 前转换，避免错误后仍写入。
+
+## 测试计划
+
+- [ ] Entity/DB: malformed permissions/rate_limits/usage_stats/extra each fail with redacted field context。
+- [ ] Optional: NULL rate_limits/extra remain valid; malformed non-null values fail。
+- [ ] Auth source: hash/id lookup on corrupt rate limits returns error, not domain key。
+- [ ] List: corrupt row makes user/team/global list error without partial result。
+- [ ] Usage: corrupt usage update returns error and raw column remains unchanged。
+- [ ] Regression: valid create/read/update/list round-trip plus format/check/clippy/full tests。
+
+## 回滚方案
+
+不得恢复 malformed JSON 的 permissive fallback。若兼容问题暴露历史坏数据，应提供独立的只读诊断或显式 repair 工具；紧急 forward-fix 可缩小错误上下文，但必须继续阻止损坏 row 进入 auth/domain boundary。


### PR DESCRIPTION
## Summary

- define fail-closed handling for malformed persisted API-key JSON fields
- preserve the distinction between nullable policy and corrupt non-null policy
- require lookup/list/auth source and usage updates to propagate conversion failures
- require redacted field-context errors and raw-row preservation

## Verification

- `git diff --cached --check`
- confirmed product/task invariant coverage is exactly B-001 through B-007
- confirmed the PR contains only `specs/GH1044/{product,tech,tasks}.md`

Issue: #1044