### PR TITLE
fix(auth): reject corrupt API key JSON

### DIFF
--- a/src/storage/database/entities/api_key.rs
+++ b/src/storage/database/entities/api_key.rs
@@ -1,7 +1,22 @@
 use sea_orm::Set;
 use sea_orm::entity::prelude::*;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use crate::utils::error::gateway_error::{GatewayError, Result as GatewayResult};
+
+fn parse_json_field<T: DeserializeOwned>(raw: &str, field: &str) -> GatewayResult<T> {
+    serde_json::from_str(raw).map_err(|_| {
+        GatewayError::Serialization(format!("Invalid persisted API key JSON field '{field}'"))
+    })
+}
+
+fn serialize_json_field<T: Serialize>(value: &T, field: &str) -> GatewayResult<String> {
+    serde_json::to_string(value).map_err(|_| {
+        GatewayError::Serialization(format!("Failed to serialize API key field '{field}'"))
+    })
+}
 
 /// API key database model
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
@@ -82,21 +97,20 @@ impl ActiveModelBehavior for ActiveModel {}
 
 impl Model {
     /// Convert SeaORM model to domain API key model
-    pub fn to_domain_api_key(&self) -> crate::core::models::ApiKey {
+    pub fn to_domain_api_key(&self) -> GatewayResult<crate::core::models::ApiKey> {
         use crate::core::models::{Metadata, RateLimits, UsageStats};
 
-        let permissions =
-            serde_json::from_str::<Vec<String>>(&self.permissions).unwrap_or_else(|_| vec![]);
+        let permissions = parse_json_field::<Vec<String>>(&self.permissions, "permissions")?;
         let rate_limits = self
             .rate_limits
-            .as_ref()
-            .and_then(|raw| serde_json::from_str::<RateLimits>(raw).ok());
-        let usage_stats = serde_json::from_str::<UsageStats>(&self.usage_stats).unwrap_or_default();
-        let extra = self
-            .extra
-            .as_ref()
-            .and_then(|raw| serde_json::from_str::<HashMap<String, serde_json::Value>>(raw).ok())
-            .unwrap_or_default();
+            .as_deref()
+            .map(|raw| parse_json_field::<RateLimits>(raw, "rate_limits"))
+            .transpose()?;
+        let usage_stats = parse_json_field::<UsageStats>(&self.usage_stats, "usage_stats")?;
+        let extra = match self.extra.as_deref() {
+            Some(raw) => parse_json_field::<HashMap<String, serde_json::Value>>(raw, "extra")?,
+            None => HashMap::new(),
+        };
 
         let metadata = Metadata {
             id: self.id,
@@ -106,7 +120,7 @@ impl Model {
             extra,
         };
 
-        crate::core::models::ApiKey {
+        Ok(crate::core::models::ApiKey {
             metadata,
             name: self.name.clone(),
             key_hash: self.key_hash.clone(),
@@ -119,26 +133,27 @@ impl Model {
             is_active: self.is_active,
             last_used_at: self.last_used_at.map(|dt| dt.naive_utc().and_utc()),
             usage_stats,
-        }
+        })
     }
 
     /// Convert domain API key model to SeaORM active model
-    pub fn from_domain_api_key(api_key: &crate::core::models::ApiKey) -> ActiveModel {
-        let permissions =
-            serde_json::to_string(&api_key.permissions).unwrap_or_else(|_| "[]".into());
+    pub fn from_domain_api_key(
+        api_key: &crate::core::models::ApiKey,
+    ) -> GatewayResult<ActiveModel> {
+        let permissions = serialize_json_field(&api_key.permissions, "permissions")?;
         let rate_limits = api_key
             .rate_limits
             .as_ref()
-            .and_then(|limits| serde_json::to_string(limits).ok());
-        let usage_stats =
-            serde_json::to_string(&api_key.usage_stats).unwrap_or_else(|_| "{}".into());
+            .map(|limits| serialize_json_field(limits, "rate_limits"))
+            .transpose()?;
+        let usage_stats = serialize_json_field(&api_key.usage_stats, "usage_stats")?;
         let extra = if api_key.metadata.extra.is_empty() {
             None
         } else {
-            serde_json::to_string(&api_key.metadata.extra).ok()
+            Some(serialize_json_field(&api_key.metadata.extra, "extra")?)
         };
 
-        ActiveModel {
+        Ok(ActiveModel {
             id: Set(api_key.metadata.id),
             name: Set(api_key.name.clone()),
             key_hash: Set(api_key.key_hash.clone()),
@@ -155,6 +170,6 @@ impl Model {
             created_at: Set(api_key.metadata.created_at.into()),
             updated_at: Set(api_key.metadata.updated_at.into()),
             version: Set(api_key.metadata.version as i32),
-        }
+        })
     }
 }

--- a/src/storage/database/seaorm_db/api_key_corruption_tests.rs
+++ b/src/storage/database/seaorm_db/api_key_corruption_tests.rs
@@ -1,0 +1,196 @@
+use super::super::entities::{self, api_key};
+use super::types::SeaOrmDatabase;
+use crate::config::models::storage::DatabaseConfig;
+use crate::core::models::user::types::User;
+use crate::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
+use sea_orm::prelude::Expr;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+const CORRUPT_JSON: &str = "SENSITIVE_CORRUPT_JSON";
+const KEY_HASH: &str = "SENSITIVE_KEY_HASH";
+const KEY_PREFIX: &str = "SENSITIVE_KEY_PREFIX";
+
+async fn create_database() -> SeaOrmDatabase {
+    let db = SeaOrmDatabase::new(&DatabaseConfig {
+        enabled: false,
+        ..DatabaseConfig::default()
+    })
+    .await
+    .expect("failed to create in-memory database");
+    db.migrate().await.expect("failed to run migrations");
+    db
+}
+
+async fn create_owner(db: &SeaOrmDatabase) -> Uuid {
+    let user = User::new(
+        "api-key-json-owner".to_string(),
+        "api-key-json-owner@example.com".to_string(),
+        "password-hash".to_string(),
+    );
+    let user_id = user.id();
+    db.create_user(&user).await.expect("owner should be stored");
+    user_id
+}
+
+fn valid_api_key(user_id: Uuid, team_id: Uuid) -> ApiKey {
+    let mut metadata = Metadata::new();
+    metadata.extra = HashMap::from([("source".to_string(), serde_json::json!("test"))]);
+
+    ApiKey {
+        metadata,
+        name: "corruption-test".to_string(),
+        key_hash: KEY_HASH.to_string(),
+        key_prefix: KEY_PREFIX.to_string(),
+        user_id: Some(user_id),
+        team_id: Some(team_id),
+        permissions: vec!["api.chat".to_string()],
+        rate_limits: Some(RateLimits {
+            rpm: Some(2),
+            tpm: None,
+            rpd: None,
+            tpd: None,
+            concurrent: None,
+        }),
+        expires_at: None,
+        is_active: true,
+        last_used_at: None,
+        usage_stats: UsageStats::default(),
+    }
+}
+
+async fn set_json_column(db: &SeaOrmDatabase, key_id: Uuid, column: api_key::Column, value: &str) {
+    entities::ApiKey::update_many()
+        .col_expr(column, Expr::value(value.to_string()))
+        .filter(api_key::Column::Id.eq(key_id))
+        .exec(&db.db)
+        .await
+        .expect("test should update JSON column");
+}
+
+fn assert_redacted_field_error(error: impl std::fmt::Display, field: &str) {
+    let message = error.to_string();
+    assert!(message.contains(field), "missing field context: {message}");
+    for sensitive in [CORRUPT_JSON, KEY_HASH, KEY_PREFIX] {
+        assert!(
+            !message.contains(sensitive),
+            "error leaked sensitive fixture {sensitive}: {message}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn every_malformed_json_field_fails_without_defaulting_or_leaking() {
+    let db = create_database().await;
+    let owner_id = create_owner(&db).await;
+    let key = valid_api_key(owner_id, Uuid::new_v4());
+    let key_id = key.metadata.id;
+    db.create_api_key(&key).await.expect("key should be stored");
+
+    let stored = entities::ApiKey::find_by_id(key_id)
+        .one(&db.db)
+        .await
+        .expect("raw key lookup should succeed")
+        .expect("raw key should exist");
+    let cases = [
+        (
+            api_key::Column::Permissions,
+            "permissions",
+            stored.permissions,
+        ),
+        (
+            api_key::Column::RateLimits,
+            "rate_limits",
+            stored.rate_limits.expect("rate limits should be stored"),
+        ),
+        (
+            api_key::Column::UsageStats,
+            "usage_stats",
+            stored.usage_stats,
+        ),
+        (
+            api_key::Column::Extra,
+            "extra",
+            stored.extra.expect("extra metadata should be stored"),
+        ),
+    ];
+
+    for (column, field, valid_value) in cases {
+        set_json_column(&db, key_id, column, CORRUPT_JSON).await;
+        let error = db
+            .find_api_key_by_id(key_id)
+            .await
+            .expect_err("corrupt JSON should fail conversion");
+        assert_redacted_field_error(error, field);
+        set_json_column(&db, key_id, column, &valid_value).await;
+    }
+}
+
+#[tokio::test]
+async fn malformed_rate_limits_fail_authoritative_lookups_and_lists() {
+    let db = create_database().await;
+    let owner_id = create_owner(&db).await;
+    let team_id = Uuid::new_v4();
+    let key = valid_api_key(owner_id, team_id);
+    let key_id = key.metadata.id;
+    db.create_api_key(&key).await.expect("key should be stored");
+    set_json_column(&db, key_id, api_key::Column::RateLimits, CORRUPT_JSON).await;
+
+    let lookup_results = [
+        db.find_api_key_by_hash(KEY_HASH).await.map(|_| ()),
+        db.find_api_key_by_id(key_id).await.map(|_| ()),
+        db.list_api_keys_by_user(owner_id).await.map(|_| ()),
+        db.list_api_keys_by_team(team_id).await.map(|_| ()),
+        db.list_api_keys(None, None, None).await.map(|_| ()),
+    ];
+    for result in lookup_results {
+        let error = result.expect_err("corrupt rate limits should fail every read path");
+        assert_redacted_field_error(error, "rate_limits");
+    }
+}
+
+#[tokio::test]
+async fn failed_usage_update_preserves_corrupt_row() {
+    let db = create_database().await;
+    let owner_id = create_owner(&db).await;
+    let key = valid_api_key(owner_id, Uuid::new_v4());
+    let key_id = key.metadata.id;
+    db.create_api_key(&key).await.expect("key should be stored");
+    set_json_column(&db, key_id, api_key::Column::UsageStats, CORRUPT_JSON).await;
+
+    let error = db
+        .update_api_key_usage(key_id, 1, 10, 0.25, false, None)
+        .await
+        .expect_err("usage update should fail on corrupt persisted counters");
+    assert_redacted_field_error(error, "usage_stats");
+
+    let stored = entities::ApiKey::find_by_id(key_id)
+        .one(&db.db)
+        .await
+        .expect("raw key lookup should succeed")
+        .expect("raw key should exist");
+    assert_eq!(stored.usage_stats, CORRUPT_JSON);
+    assert_eq!(stored.version, key.metadata.version as i32);
+}
+
+#[tokio::test]
+async fn null_optional_json_fields_and_valid_round_trip_remain_supported() {
+    let db = create_database().await;
+    let owner_id = create_owner(&db).await;
+    let mut key = valid_api_key(owner_id, Uuid::new_v4());
+    key.rate_limits = None;
+    key.metadata.extra.clear();
+    let key_id = key.metadata.id;
+    db.create_api_key(&key).await.expect("key should be stored");
+
+    let loaded = db
+        .find_api_key_by_id(key_id)
+        .await
+        .expect("valid key should load")
+        .expect("valid key should exist");
+    assert!(loaded.rate_limits.is_none());
+    assert!(loaded.metadata.extra.is_empty());
+    assert_eq!(loaded.permissions, key.permissions);
+    assert_eq!(loaded.usage_stats.total_requests, 0);
+}

--- a/src/storage/database/seaorm_db/api_key_ops.rs
+++ b/src/storage/database/seaorm_db/api_key_ops.rs
@@ -34,7 +34,7 @@ impl SeaOrmDatabase {
     ) -> Result<crate::core::models::ApiKey> {
         debug!("Creating API key: {}", api_key.metadata.id);
 
-        let active_model = api_key::Model::from_domain_api_key(api_key);
+        let active_model = api_key::Model::from_domain_api_key(api_key)?;
         entities::ApiKey::insert(active_model)
             .exec(&self.db)
             .await
@@ -56,7 +56,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(model.map(|m| m.to_domain_api_key()))
+        model.map(|m| m.to_domain_api_key()).transpose()
     }
 
     /// Find API key by ID
@@ -71,7 +71,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(model.map(|m| m.to_domain_api_key()))
+        model.map(|m| m.to_domain_api_key()).transpose()
     }
 
     /// Deactivate API key with transaction wrapping and optimistic locking
@@ -159,7 +159,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(models.into_iter().map(|m| m.to_domain_api_key()).collect())
+        models.into_iter().map(|m| m.to_domain_api_key()).collect()
     }
 
     /// List API keys by team
@@ -175,7 +175,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(models.into_iter().map(|m| m.to_domain_api_key()).collect())
+        models.into_iter().map(|m| m.to_domain_api_key()).collect()
     }
 
     /// List API keys with optional status filter and pagination
@@ -196,7 +196,7 @@ impl SeaOrmDatabase {
         }
 
         let models = query.all(&self.db).await.map_err(GatewayError::from)?;
-        Ok(models.into_iter().map(|m| m.to_domain_api_key()).collect())
+        models.into_iter().map(|m| m.to_domain_api_key()).collect()
     }
 
     /// Count API keys with optional status filter
@@ -449,7 +449,7 @@ impl SeaOrmDatabase {
             .map_err(GatewayError::from)?
             .ok_or_else(|| GatewayError::NotFound("API key not found".to_string()))?;
 
-        let mut domain_key = model.to_domain_api_key();
+        let mut domain_key = model.to_domain_api_key()?;
         domain_key.usage_stats.total_requests = domain_key
             .usage_stats
             .total_requests

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -1,5 +1,7 @@
 // Module declarations
 mod analytics_ops;
+#[cfg(test)]
+mod api_key_corruption_tests;
 mod api_key_ops;
 #[cfg(all(test, any(feature = "postgres", feature = "sqlite")))]
 mod api_key_owner_migration_tests;


### PR DESCRIPTION
## Summary

- make SeaORM API-key entity/domain JSON conversion strict and fallible
- preserve the distinction between nullable optional policy fields and malformed non-null JSON
- propagate conversion errors through create, lookup, list, and usage-update paths
- prevent corrupt usage counters from being reset and overwritten
- redact raw JSON and key identity from field-context errors

## Why

Malformed persisted `rate_limits` previously became `None`, allowing authoritative authentication reads to lose key-specific RPM policy and fall back to a wider gateway default or no limit. Other malformed policy/usage fields were likewise silently emptied or reset.

## Verification

- focused corruption tests: 4 passed
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
  - library: 10424 passed, 0 failed, 1 ignored
  - integration library: 189 passed, 0 failed, 12 ignored
  - all route/integration binaries passed
  - doctests: 33 passed, 0 failed, 32 ignored

Fixes #1044