### PR TITLE
docs(spec): define canonical user state validation

### DIFF
--- a/specs/GH1047/product.md
+++ b/specs/GH1047/product.md
@@ -1,0 +1,72 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1047 / #1047
+
+complexity: medium
+
+## 用户问题
+
+authoritative `users` 表中的 `role` 和 `status` 是认证与授权输入。当前实体转换会把未知 role 静默改为
+`UserRole::User`，把未知 status 静默改为 `UserStatus::Pending`。更严重的是，写入端支持并保存合法的
+`deleted`，读取端却不识别它，同样返回 `Pending`，破坏用户生命周期状态的往返一致性。
+
+ID、username、email 三个 canonical 查询入口都会接收这些合成的默认用户。JWT 认证还把数据库错误和转换错误
+统一伪装成 “User not found”，导致损坏数据与基础设施故障不可观察、不可区分。
+
+## 目标
+
+- authoritative canonical user 的 role/status 必须严格解析，非法值显式失败。
+- 所有已声明的 `UserStatus`（包括 `Deleted`）必须无损往返。
+- ID、username、email 查询都传播同一转换错误，真实缺失仍保持 `Ok(None)`。
+- JWT 认证必须区分真实用户缺失与存储/转换故障，后者通过现有 `Result` 错误通道传播。
+- 错误提供稳定字段上下文，但不泄露 raw persisted value、password hash 或 credential。
+- 有效用户创建、查询、RBAC、active 判定和 legacy bridge 行为保持不变。
+
+## 非目标
+
+- 不增加 schema constraint、migration 或自动修复已有损坏 row。
+- 不改变合法 role 集合、权限含义或角色继承。
+- 不改变合法 status 的 active/inactive 判定。
+- 不修改 legacy `um_users` JSON 格式或其转换规则。
+- 不把本 issue 扩展为所有认证错误文案或所有数据库实体转换重构。
+
+## Behavior Invariants
+
+1. B-001 非空 canonical `role` 必须解析为声明的 `UserRole`；未知值返回 typed `GatewayError`，不得合成为 `User`。
+2. B-002 非空 canonical `status` 必须精确解析 `active`、`inactive`、`pending`、`suspended`、`deleted`；未知值返回错误，不得合成为 `Pending`。
+3. B-003 每个合法 role/status 都保持 entity → domain 转换语义，尤其 `deleted` 必须转换为 `UserStatus::Deleted`。
+4. B-004 canonical ID、username、email 查询遇到损坏 row 都返回错误；真实无匹配 row 仍返回 `Ok(None)`，不得回退到 legacy 或返回部分/default 用户。
+5. B-005 JWT access-token 认证只对真实 `Ok(None)` 返回 “User not found”；数据库或转换错误必须通过 `Result` 传播，不得伪装为认证拒绝。
+6. B-006 转换错误只包含稳定的 entity/field/category 上下文，不包含 raw role/status、username、email、password hash、token 或其他 credential。
+7. B-007 valid canonical user 的创建、读取、更新、RBAC、active 判定和 canonical/legacy bridge 保持现有行为。
+
+## 验收标准
+
+- [ ] malformed role 对 ID、username、email 三条 canonical lookup 都显式失败。
+- [ ] malformed status 对三条 canonical lookup 都显式失败。
+- [ ] `Deleted` 写入后读取仍为 `Deleted`，其余合法 role/status 覆盖回归测试。
+- [ ] missing user 仍是 `Ok(None)`，不得与 conversion/storage error 合并。
+- [ ] JWT authentication 对 lookup error 返回 `Err`，对真实 missing user 保持现有失败结果。
+- [ ] 错误断言证明包含字段名，但不包含 fixture 原文、用户名、邮箱、password hash 或 token。
+- [ ] focused SQLite/auth tests、格式、全特性编译、strict Clippy 和全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001, B-002, B-004；空字符串是非法 persisted value，no row 保持 `None`。 |
+| 错误与失败路径 | covered: B-001, B-002, B-004, B-005；转换和 DB 错误完整传播。 |
+| 授权/权限 | covered: B-001, B-003, B-005, B-007；role 不再被合成，valid RBAC 不变。 |
+| 并发/竞态 | N/A；只改变 row 转换与错误传播，不新增共享状态或写事务。 |
+| 重试/幂等 | covered: B-004；重复读取损坏 row 持续失败且不修改数据。 |
+| 非法状态转换 | covered: B-002, B-003；未知值不进入 domain，`Deleted` 不再变成 `Pending`。 |
+| 兼容/迁移 | covered: B-003, B-007；合法 row 无需迁移，损坏 row 从静默默认变成显式错误。 |
+| 降级/回退 | covered: B-001, B-002, B-004, B-005；禁止 default、legacy fallback 和错误伪装。 |
+| 证据与审计完整性 | covered: B-006；保留字段上下文且不泄露 persisted secret/data。 |
+| 取消/中断 | covered: B-004；读取失败没有写入或部分持久化，可安全重试。 |
+
+## 发布说明
+
+canonical 用户的 role/status 损坏时现在会显式失败；合法 `Deleted` 状态可正确往返，认证不再把存储故障误报为用户不存在。

--- a/specs/GH1047/tasks.md
+++ b/specs/GH1047/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1047 / #1047
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1047-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: coordinator. Dependencies: none. Done when: GH1047 product/tech/tasks packet 齐全，B-001 至 B-007 连续且 product-to-test/task coverage 完整. Verify: `test -f specs/GH1047/product.md && test -f specs/GH1047/tech.md && test -f specs/GH1047/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1047/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1047/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1047-T2` Covers: B-001, B-002, B-003, B-006. Owner: implementation owner. Dependencies: SP1047-T1. Done when: canonical user entity conversion is fallible, strictly parses role/status, maps every declared valid enum including Deleted, and returns redacted field-context errors without default fallbacks. Verify: focused entity/SQLite tests; `rg -n 'unwrap_or\(UserRole::User\)|_ => UserStatus::Pending' src/storage/database/entities/user.rs` returns no fallback hit.
+- [ ] `SP1047-T3` Covers: B-004, B-006, B-007. Owner: implementation owner. Dependencies: SP1047-T2. Done when: canonical ID/username/email lookups propagate conversion failures, invalid present rows cannot trigger legacy fallback, and genuine missing rows remain `Ok(None)`. Verify: in-memory SQLite tests exercise corrupt role/status through all three lookup paths and missing lookup regression.
+- [ ] `SP1047-T4` Covers: B-005, B-007. Owner: implementation owner. Dependencies: SP1047-T3. Done when: JWT authentication propagates lookup/storage errors through `Result` while preserving the existing results for missing and inactive users. Verify: focused auth tests plus diff inspection of `authenticate_jwt` three-way match.
+- [ ] `SP1047-T5` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP1047-T3, SP1047-T4. Done when: diff is limited to GH1047 spec, user conversion/query/auth code and focused tests; format, all-target/all-feature check, strict Clippy and full serial tests pass with fresh output. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → failing corruption/Deleted reproduction tests → fallible entity conversion → query propagation → JWT error propagation → focused verification → repository-wide verification。转换、query 和 auth 存在直接依赖，由单一 implementation owner 串行修改。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 精确为 B-001 至 B-007。
+- Impl PR 使用 `Fixes #1047` 并以 Spec branch 为 base，代码审查与规范审查分离。
+- 远端 PR 保持未自动合并，只报告 current-head checks 事实。
+
+## Handoff Notes
+
+- `deleted` 是合法 persisted status，不是 corruption；必须精确恢复为 `UserStatus::Deleted`。
+- 错误不得包含 raw invalid value、username、email、password hash 或 token。
+- canonical present-but-invalid row 必须阻止 legacy fallback；只有真实 `None` 才允许既有 fallback。
+- 不顺手增加 migration、repair、role 语义变化或 legacy JSON 重构。

--- a/specs/GH1047/tech.md
+++ b/specs/GH1047/tech.md
@@ -1,0 +1,82 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1047 / #1047
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| User entity conversion | `src/storage/database/entities/user.rs` | unknown role → `User`; unknown status and legal `deleted` → `Pending` | B-001/B-002/B-003 root cause |
+| Canonical queries | `src/storage/database/seaorm_db/user_ops.rs` | three query methods map an infallible converter and cannot propagate corruption | B-004 propagation gap |
+| JWT authentication | `src/auth/system.rs` | `if let Ok(Some(user))` collapses both `Err` and `None` into “User not found” | B-005 observability gap |
+| Domain enums | `src/core/models/user/types.rs` | `UserRole::from_str` already validates roles; `UserStatus` declares five variants | canonical validation source |
+| Existing DB tests | `src/storage/database/seaorm_db/user_repository_tests.rs` | exercises canonical/legacy bridge but not corrupt role/status or Deleted round-trip | focused regression home |
+
+## 设计方案
+
+1. 将 `user::Model::to_domain_user` 改为 `Result<User>`，复用 `UserRole::from_str`，并通过一个不回显原值的
+   field-context mapper 转成 `GatewayError`。status 使用完整显式 match，包含 `deleted`；unknown branch 返回同类错误。
+2. 错误消息只报告 `users.role` 或 `users.status` 及 invalid persisted enum category。不得 format `self.role`、
+   `self.status`、username、email、password hash、row debug 或 token。
+3. ID、username、email 三个 canonical query 使用 `Option::map(...).transpose()`，使 no row 保持 `Ok(None)`，
+   present invalid row 变为 `Err`。高层 fallback 只有在 canonical query 确实返回 `None` 时才可继续。
+4. `authenticate_jwt` 将 user lookup 改为三分支 match：`Ok(Some(user))` 保留 active 判定；`Ok(None)` 保留
+   “User not found”；`Err(error)` 直接返回 `Err(error)`。token verification error 和 inactive account 行为不变。
+5. 新建独立 `user_state_corruption_tests.rs`，用 in-memory SQLite migration 插入 valid user，再直接更新 role/status
+   制造损坏状态，覆盖三条 lookup、missing row、所有合法 enum、Deleted round-trip和错误脱敏。认证错误传播测试放在
+   现有 auth test module 或使用最小 storage fixture；不得通过放宽断言实现。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | fallible role conversion | malformed role DB test; source search confirms no role fallback |
+| B-002 | exhaustive status conversion | malformed status DB test; unknown value returns error |
+| B-003 | complete enum mapping | table-driven valid role/status tests and explicit Deleted round-trip |
+| B-004 | three query transposes | ID/username/email corruption tests plus missing-row regression |
+| B-005 | JWT lookup match | auth test distinguishes injected lookup error from `Ok(None)` result |
+| B-006 | redacted conversion error | sentinel values and identity/credential fixtures absent from rendered error |
+| B-007 | minimal conversion/query/auth diff | existing user repository, auth, RBAC and full test suites |
+
+## 数据流
+
+SeaORM row → strict fallible entity conversion → `Result<Option<User>>` → canonical lookup/auth consumer。只有完整合法的
+role/status row 能进入 domain 与 RBAC。无 row 保持 `None`；损坏 row 和数据库故障沿既有 `GatewayError` 通道上抛。
+本变更不写回、不清理损坏 row，因而保留故障证据。
+
+## 备选方案
+
+- 未知 role 继续降级为 `User`：虽为权限降级，仍会隐藏 authoritative corruption 并造成用户访问异常，违反 B-001。
+- 未知 status 继续降级为 `Pending`，只补 `deleted`：仍把未来/损坏值伪装为合法生命周期状态，违反 B-002。
+- 记录 warning 后使用默认值：运行仍携带错误 domain state，且日志可能泄露 raw value，违反 B-001/B-006。
+- 只修实体转换、不修 JWT：数据库错误仍被报告为用户不存在，违反 B-005。
+- migration 修复历史值：修复策略具有业务含义且可能不可逆，超出本 issue。
+
+## 风险
+
+- Compatibility: 已损坏 rows 从可读默认用户变为显式错误；这是预期 fail-closed 行为。
+- Availability: 损坏账户的 lookup/auth 会失败，避免基于合成身份继续运行；其他合法 row 不受影响。
+- Security: error construction 不能携带 raw enum、identity、hash 或 token；测试使用唯一 sentinel 证明脱敏。
+- Control flow: `Option::transpose` 必须只阻止 invalid present row，不能把真实 missing user 改成错误。
+- Bridge: canonical invalid row 不能被 legacy fallback 覆盖，否则仍会隐藏 authoritative corruption。
+
+## 测试计划
+
+- [ ] Red: 在生产改动前加入 corruption/Deleted tests；确认 malformed role/status 和 Deleted round-trip 断言失败。
+- [ ] Entity/DB: 三条 canonical lookup 对 malformed role/status 均返回 `Err`。
+- [ ] Enum: 所有合法 roles/statuses 精确映射，`Deleted` 显式覆盖。
+- [ ] Missing: 不存在的 ID/username/email 保持 `Ok(None)`。
+- [ ] Auth: lookup error 从 JWT authentication 返回 `Err`；missing/inactive 保持原结果。
+- [ ] Redaction: error 包含 `role`/`status` field context，但不包含 sentinel/raw identity/hash/token。
+- [ ] Repository: format、all-target/all-feature check、strict Clippy 和全量 serial tests。
+
+## 回滚方案
+
+不得恢复 permissive enum fallback 或 JWT error swallowing。若历史坏数据导致兼容问题，应提供独立只读诊断/显式修复流程；
+紧急 forward-fix 可改善错误分类或管理员提示，但必须继续阻止损坏 row 进入 domain/auth boundary。


### PR DESCRIPTION
## Summary

Defines the SpecRail product, technical, and task specifications for #1047.

The packet documents why persisted canonical user roles and statuses must fail closed, requires exact `Deleted` round trips, separates missing users from storage/conversion errors, and specifies redacted errors plus focused and repository-wide verification.

## Files

- `specs/GH1047/product.md`
- `specs/GH1047/tech.md`
- `specs/GH1047/tasks.md`

## Verification

- `git diff --cached --check`
- product invariant set equals task coverage set (`B-001` through `B-007`)
- exactly three SpecRail files changed

Refs #1047

This is the spec-only PR. Implementation will be submitted in a separate PR based on this branch.