### PR TITLE
fix(auth): reject corrupt persisted user state

### DIFF
--- a/src/auth/system.rs
+++ b/src/auth/system.rs
@@ -102,8 +102,9 @@ impl AuthSystem {
                     });
                 }
 
-                // Get user from database
-                if let Ok(Some(user)) = self.storage.db().find_user_by_id(claims.sub).await {
+                // Get user from database. Storage and conversion failures must remain errors;
+                // only a successful lookup with no row is an authentication rejection.
+                if let Some(user) = self.storage.db().find_user_by_id(claims.sub).await? {
                     if user.is_active() {
                         context.user_id = Some(user.id().to_string());
                         if let Some(team_id) = user.team_ids.first().copied() {

--- a/src/auth/tests.rs
+++ b/src/auth/tests.rs
@@ -239,3 +239,76 @@ async fn api_key_storage_error_propagates_from_auth_system() {
         crate::utils::error::gateway_error::GatewayError::Storage(_)
     ));
 }
+
+#[tokio::test]
+async fn jwt_canonical_user_conversion_error_propagates_from_auth_system() {
+    use crate::core::models::user::types::{User, UserStatus};
+    use crate::storage::database::entities::user;
+    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+
+    let mut config = crate::config::Config::default();
+    config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+
+    let storage = std::sync::Arc::new(
+        crate::storage::StorageLayer::new(&config.gateway.storage)
+            .await
+            .expect("storage should initialize"),
+    );
+    let mut persisted = User::new(
+        "jwt-corrupt-user".to_string(),
+        "jwt-corrupt@example.com".to_string(),
+        "secret-hash".to_string(),
+    );
+    persisted.status = UserStatus::Active;
+    storage.db().create_user(&persisted).await.unwrap();
+
+    let auth_system = super::system::AuthSystem::new(&config.gateway.auth, storage.clone())
+        .await
+        .expect("AuthSystem should initialize");
+    let token = auth_system
+        .jwt()
+        .create_access_token(persisted.id(), "user".to_string(), vec![], None, None)
+        .await
+        .unwrap();
+
+    user::ActiveModel {
+        id: Set(persisted.id()),
+        role: Set("sentinel-invalid-jwt-role".to_string()),
+        ..Default::default()
+    }
+    .update(storage.db().connection())
+    .await
+    .expect("test should corrupt persisted role");
+
+    let error = auth_system
+        .authenticate(AuthMethod::Jwt(token.clone()), RequestContext::new())
+        .await
+        .expect_err("canonical conversion error must propagate from JWT authentication");
+
+    let rendered = error.to_string();
+    assert!(rendered.contains("role"));
+    assert!(!rendered.contains("sentinel-invalid-jwt-role"));
+    assert!(!rendered.contains("jwt-corrupt-user"));
+    assert!(!rendered.contains("jwt-corrupt@example.com"));
+    assert!(!rendered.contains("secret-hash"));
+    assert!(!rendered.contains(&token));
+
+    storage
+        .db()
+        .delete_user(&persisted.id().to_string())
+        .await
+        .expect("test should delete the legacy mirror");
+    user::Entity::delete_by_id(persisted.id())
+        .exec(storage.db().connection())
+        .await
+        .expect("test should delete the canonical user");
+
+    let missing = auth_system
+        .authenticate(AuthMethod::Jwt(token), RequestContext::new())
+        .await
+        .expect("a genuinely missing user remains an authentication result");
+    assert!(!missing.success);
+    assert_eq!(missing.error.as_deref(), Some("User not found"));
+}

--- a/src/storage/database/entities/user.rs
+++ b/src/storage/database/entities/user.rs
@@ -78,10 +78,13 @@ impl ActiveModelBehavior for ActiveModel {}
 // Conversion methods between SeaORM model and our domain model
 impl Model {
     /// Convert SeaORM model to domain user model
-    pub fn to_domain_user(&self) -> crate::core::models::user::types::User {
+    pub fn to_domain_user(
+        &self,
+    ) -> crate::utils::error::gateway_error::Result<crate::core::models::user::types::User> {
         use crate::core::models::user::preferences::UserPreferences;
         use crate::core::models::user::types::{UserProfile, UserRole, UserStatus};
         use crate::core::models::{Metadata, UsageStats};
+        use crate::utils::error::gateway_error::GatewayError;
         use std::str::FromStr;
 
         let metadata = Metadata {
@@ -92,16 +95,22 @@ impl Model {
             extra: std::collections::HashMap::new(),
         };
 
-        let role = UserRole::from_str(&self.role).unwrap_or(UserRole::User);
+        let role = UserRole::from_str(&self.role)
+            .map_err(|_| GatewayError::Storage("Invalid persisted users.role enum".to_string()))?;
         let status = match self.status.as_str() {
             "active" => UserStatus::Active,
             "inactive" => UserStatus::Inactive,
             "pending" => UserStatus::Pending,
             "suspended" => UserStatus::Suspended,
-            _ => UserStatus::Pending,
+            "deleted" => UserStatus::Deleted,
+            _ => {
+                return Err(GatewayError::Storage(
+                    "Invalid persisted users.status enum".to_string(),
+                ));
+            }
         };
 
-        crate::core::models::user::types::User {
+        Ok(crate::core::models::user::types::User {
             metadata,
             username: self.username.clone(),
             email: self.email.clone(),
@@ -117,7 +126,7 @@ impl Model {
             email_verified: self.email_verified,
             two_factor_enabled: self.two_factor_enabled,
             profile: UserProfile::default(),
-        }
+        })
     }
 
     /// Convert domain user model to SeaORM active model

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -15,6 +15,8 @@ mod user_management_ops;
 mod user_ops;
 #[cfg(test)]
 mod user_repository_tests;
+#[cfg(test)]
+mod user_state_corruption_tests;
 mod virtual_key_ops;
 
 // Re-export public types

--- a/src/storage/database/seaorm_db/user_ops.rs
+++ b/src/storage/database/seaorm_db/user_ops.rs
@@ -179,7 +179,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(user_model.map(|model| model.to_domain_user()))
+        user_model.map(|model| model.to_domain_user()).transpose()
     }
 
     pub(crate) async fn find_canonical_user_by_username(
@@ -192,7 +192,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(user_model.map(|model| model.to_domain_user()))
+        user_model.map(|model| model.to_domain_user()).transpose()
     }
 
     pub(crate) async fn find_canonical_user_by_email(&self, email: &str) -> Result<Option<User>> {
@@ -202,7 +202,7 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        Ok(user_model.map(|model| model.to_domain_user()))
+        user_model.map(|model| model.to_domain_user()).transpose()
     }
 
     pub(crate) async fn persist_legacy_user(&self, legacy: &LegacyUser) -> Result<Option<User>> {

--- a/src/storage/database/seaorm_db/user_repository_tests.rs
+++ b/src/storage/database/seaorm_db/user_repository_tests.rs
@@ -11,7 +11,7 @@ use sea_orm::EntityTrait;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-async fn create_database() -> SeaOrmDatabase {
+pub(super) async fn create_database() -> SeaOrmDatabase {
     let db = SeaOrmDatabase::new(&DatabaseConfig {
         enabled: false,
         ..DatabaseConfig::default()
@@ -22,7 +22,7 @@ async fn create_database() -> SeaOrmDatabase {
     db
 }
 
-fn canonical_user(username: &str, email: &str) -> User {
+pub(super) fn canonical_user(username: &str, email: &str) -> User {
     let mut user = User::new(username.to_string(), email.to_string(), "hash".to_string());
     user.status = UserStatus::Active;
     user.display_name = Some("Canonical User".to_string());

--- a/src/storage/database/seaorm_db/user_state_corruption_tests.rs
+++ b/src/storage/database/seaorm_db/user_state_corruption_tests.rs
@@ -1,0 +1,133 @@
+use super::super::entities;
+use super::types::SeaOrmDatabase;
+use super::user_repository_tests::{canonical_user, create_database};
+use crate::core::models::user::types::{User, UserRole, UserStatus};
+use sea_orm::{ActiveModelTrait, Set};
+use uuid::Uuid;
+
+const INVALID_ROLE: &str = "sentinel-invalid-role-do-not-expose";
+const INVALID_STATUS: &str = "sentinel-invalid-status-do-not-expose";
+
+async fn replace_role(db: &SeaOrmDatabase, user_id: Uuid, role: &str) {
+    entities::user::ActiveModel {
+        id: Set(user_id),
+        role: Set(role.to_string()),
+        ..Default::default()
+    }
+    .update(&db.db)
+    .await
+    .expect("test should replace persisted role");
+}
+
+async fn replace_status(db: &SeaOrmDatabase, user_id: Uuid, status: &str) {
+    entities::user::ActiveModel {
+        id: Set(user_id),
+        status: Set(status.to_string()),
+        ..Default::default()
+    }
+    .update(&db.db)
+    .await
+    .expect("test should replace persisted status");
+}
+
+async fn assert_all_lookup_paths_fail(db: &SeaOrmDatabase, user: &User, field: &str) {
+    for result in [
+        db.find_user_by_id(user.id()).await,
+        db.find_user_by_username(&user.username).await,
+        db.find_user_by_email(&user.email).await,
+    ] {
+        let error = result.expect_err("corrupt canonical user must fail lookup");
+        let rendered = error.to_string();
+        assert!(rendered.contains(field));
+        assert!(!rendered.contains(INVALID_ROLE));
+        assert!(!rendered.contains(INVALID_STATUS));
+        assert!(!rendered.contains(&user.username));
+        assert!(!rendered.contains(&user.email));
+        assert!(!rendered.contains(&user.password_hash));
+    }
+}
+
+#[tokio::test]
+async fn malformed_role_fails_every_canonical_lookup_without_exposing_row_data() {
+    let db = create_database().await;
+    let user = canonical_user("corrupt-role-user", "corrupt-role@example.com");
+    db.create_user(&user).await.unwrap();
+    replace_role(&db, user.id(), INVALID_ROLE).await;
+
+    assert_all_lookup_paths_fail(&db, &user, "role").await;
+}
+
+#[tokio::test]
+async fn malformed_status_fails_every_canonical_lookup_without_exposing_row_data() {
+    let db = create_database().await;
+    let user = canonical_user("corrupt-status-user", "corrupt-status@example.com");
+    db.create_user(&user).await.unwrap();
+    replace_status(&db, user.id(), INVALID_STATUS).await;
+
+    assert_all_lookup_paths_fail(&db, &user, "status").await;
+}
+
+#[tokio::test]
+async fn valid_roles_and_statuses_round_trip_exactly() {
+    let db = create_database().await;
+    let roles = [
+        UserRole::SuperAdmin,
+        UserRole::Admin,
+        UserRole::Manager,
+        UserRole::User,
+        UserRole::Viewer,
+        UserRole::ApiUser,
+    ];
+
+    for (index, role) in roles.into_iter().enumerate() {
+        let mut user = canonical_user(
+            &format!("role-{index}"),
+            &format!("role-{index}@example.com"),
+        );
+        user.role = role.clone();
+        db.create_user(&user).await.unwrap();
+        let loaded = db.find_user_by_id(user.id()).await.unwrap().unwrap();
+        assert_eq!(loaded.role, role);
+    }
+
+    let statuses = [
+        UserStatus::Active,
+        UserStatus::Inactive,
+        UserStatus::Pending,
+        UserStatus::Suspended,
+        UserStatus::Deleted,
+    ];
+
+    for (index, status) in statuses.into_iter().enumerate() {
+        let mut user = canonical_user(
+            &format!("status-{index}"),
+            &format!("status-{index}@example.com"),
+        );
+        user.status = status.clone();
+        db.create_user(&user).await.unwrap();
+        let loaded = db.find_user_by_id(user.id()).await.unwrap().unwrap();
+        assert!(
+            std::mem::discriminant(&loaded.status) == std::mem::discriminant(&status),
+            "status variant changed during round trip"
+        );
+    }
+}
+
+#[tokio::test]
+async fn missing_canonical_users_remain_none() {
+    let db = create_database().await;
+
+    assert!(db.find_user_by_id(Uuid::new_v4()).await.unwrap().is_none());
+    assert!(
+        db.find_user_by_username("missing-user")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.find_user_by_email("missing@example.com")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}


### PR DESCRIPTION
## Why

The authoritative `users` row currently turns unknown persisted roles into `User`, unknown statuses into `Pending`, and even maps the valid stored `deleted` status to `Pending`. JWT authentication then hides database/conversion failures behind `User not found`. This silently converts corrupt authorization state into a valid domain user and destroys lifecycle fidelity.

## Implementation

- make canonical user entity-to-domain conversion fallible;
- strictly validate persisted role and status values;
- map `deleted` back to `UserStatus::Deleted`;
- propagate conversion failures through canonical ID, username, and email lookups with `Option::transpose`;
- propagate JWT lookup/storage failures while preserving the existing genuine-missing-user result;
- keep errors limited to stable field context and omit raw persisted values, identity fields, password hashes, and tokens;
- add focused SQLite and real-JWT regression coverage.

## Red/green evidence

Before the production fix:

- user-state suite: 1 passed, 3 failed;
- malformed role was returned as `User`;
- malformed status was returned as `Pending`;
- `Deleted` round-trip changed variant;
- JWT authentication accepted a user whose persisted role was corrupt.

After the fix:

- focused user-state tests: 4 passed;
- focused JWT propagation/missing-user test: 1 passed.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1 --quiet`
  - lib: 10,425 passed, 0 failed, 1 ignored
  - integration: 189 passed, 0 failed, 12 ignored
  - route binaries: all passed
  - doctests: 33 passed, 0 failed, 32 ignored
- `git diff --check`

Fixes #1047

Depends on and is based on spec PR #1048. No schema migration or automatic data repair is included.