### PR TITLE
docs(spec): define canonical batch status encoding

### DIFF
--- a/specs/GH1050/product.md
+++ b/specs/GH1050/product.md
@@ -1,0 +1,72 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1050 / #1050
+
+complexity: medium
+
+## 用户问题
+
+内部 BatchProcessor 使用 Rust `Debug` 文本持久化状态，因此 `InProgress`、`Completed`、`Cancelling` 等值被写入
+数据库；读取端只识别 `in_progress`、`completed`、`cancelling` 等 snake_case 值，所有不匹配值又被静默合成为
+`Failed`。结果是库自身完成的正常状态更新在重新 list 后变成失败状态。
+
+同一个 `BatchStatus` 的 JSON 序列化也输出 Rust variant casing，而不是 OpenAI-compatible snake_case 状态词汇。
+Debug 输出不是稳定的持久化或 API contract，未知值更不能伪造一个终态。
+
+## 目标
+
+- 所有 `BatchStatus` 使用唯一 canonical snake_case 编码作为新持久化与 JSON contract。
+- 数据库更新边界接收 typed `BatchStatus`，禁止任意字符串与 `Debug` 格式化。
+- 读取 canonical 值时精确恢复原 variant。
+- 兼容读取当前实现已产生的历史 Debug spellings，但不得继续写入这些值。
+- 真正未知的 persisted status 显式失败，不得变成 `Failed`。
+- status-specific timestamp 更新和既有状态转换策略保持不变。
+
+## 非目标
+
+- 不增加 schema migration 或批量重写历史 row。
+- 不实现当前缺失的 batch request/result 持久化。
+- 不改变 batch metadata、request counts 或 completion-window 行为。
+- 不新增或删除 `BatchStatus` variant。
+- 不重设计 batch 状态机或允许/禁止的 transition。
+
+## Behavior Invariants
+
+1. B-001 每个声明的 `BatchStatus` 都有唯一 canonical snake_case 文本：`validating`、`failed`、`in_progress`、`finalizing`、`completed`、`expired`、`cancelling`、`cancelled`。
+2. B-002 `BatchStatus` 的 JSON serialization/deserialization 使用 canonical snake_case，API response 不输出 Rust Debug variant casing。
+3. B-003 create/update persistence 只通过 typed status 的 canonical encoder 写入；`update_batch_status` 不接受任意 `&str`，生产代码不使用 `format!("{:?}", status)`。
+4. B-004 list/read 对 canonical 值和当前缺陷已生成的八个 historical Debug spellings 都恢复相同 domain variant；historical 兼容只读、不产生新 legacy 写入。
+5. B-005 任何 canonical/historical 闭集之外的 persisted status 返回 typed `GatewayError`，不得映射为 `Failed`、跳过 row 或返回 partial list。
+6. B-006 status update 仍只设置对应 variant 的 timestamp；合法状态写入、事务、not-found 与 ordering 行为保持不变。
+7. B-007 existing batch domain/API consumers 对合法状态继续工作，唯一可见变化是正确的 snake_case wire value 和不再伪造失败状态。
+
+## 验收标准
+
+- [ ] 八个合法状态分别通过 canonical persistence 和 JSON 精确 round-trip。
+- [ ] BatchProcessor 的 `InProgress`、`Completed`、`Cancelling` 更新写入 snake_case 并在 list 时保持原 variant。
+- [ ] 八个 historical Debug values 均可读取并映射正确。
+- [ ] unknown persisted status 使 list 返回错误且错误不把该 batch 标记为 Failed。
+- [ ] production source 不再以 Debug/任意字符串持久化 batch status。
+- [ ] status timestamp、missing batch、分页排序与其他合法行为保持。
+- [ ] focused SQLite/domain tests、格式、全特性编译、strict Clippy 和全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-005；空 status 是 unknown persisted value，必须失败。 |
+| 错误与失败路径 | covered: B-005, B-006；unknown 显式 error，真实 Failed 仍合法。 |
+| 授权/权限 | N/A；batch lifecycle 状态不参与 auth/RBAC。 |
+| 并发/竞态 | covered: B-006；既有 status transaction 保持，不改变锁或事务边界。 |
+| 重试/幂等 | covered: B-001, B-003；重复写同一 typed status 产生相同 canonical 值。 |
+| 非法状态转换 | covered: B-003, B-005；字符串绕过被类型边界移除，unknown row 不进入 domain。 |
+| 兼容/迁移 | covered: B-004；无需 migration 即可读取历史 Debug 值，新写入收敛到 canonical。 |
+| 降级/回退 | covered: B-005；禁止 unknown → Failed fallback 和 partial list。 |
+| 证据与审计完整性 | covered: B-004, B-005；真实 persisted lifecycle 不被伪造。 |
+| 取消/中断 | covered: B-004, B-006；Cancelling/Cancelled 精确编码，事务语义保持。 |
+
+## 发布说明
+
+内部 batch 状态现在以 OpenAI-compatible snake_case 稳定编码；正常的 processing/completed/cancelling 状态不再在读取时错误显示为 Failed。

--- a/specs/GH1050/tasks.md
+++ b/specs/GH1050/tasks.md
@@ -1,0 +1,34 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1050 / #1050
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1050-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: coordinator. Dependencies: none. Done when: GH1050 product/tech/tasks packet 齐全，B-001 至 B-007 连续且 product-to-test/task coverage 完整. Verify: `test -f specs/GH1050/product.md && test -f specs/GH1050/tech.md && test -f specs/GH1050/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1050/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1050/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1050-T2` Covers: B-001, B-002, B-004. Owner: implementation owner. Dependencies: SP1050-T1. Done when: BatchStatus exposes canonical snake_case encoding, serde uses it, and parser accepts exact canonical plus historical Debug closed sets. Verify: table-driven domain tests assert eight exact strings, JSON round-trip and eight historical aliases.
+- [ ] `SP1050-T3` Covers: B-003, B-006. Owner: implementation owner. Dependencies: SP1050-T2. Done when: create/update DB paths and both processor callsites pass typed status, persist only canonical text, preserve transaction/not-found and status timestamp mapping, and contain no Debug formatting. Verify: focused SQLite update/timestamp tests; `rg -n 'format!\("\{:\?\}".*status|update_batch_status\([^,]+, *&?format!' src/core/batch src/storage/database/seaorm_db/batch_ops.rs` has no production hit.
+- [ ] `SP1050-T4` Covers: B-004, B-005, B-007. Owner: implementation owner. Dependencies: SP1050-T2. Done when: list accepts canonical/historical rows, unknown row returns `Err`, and mixed valid+invalid query does not return partial/default records. Verify: in-memory SQLite tests insert/update raw statuses and assert exact variants/error.
+- [ ] `SP1050-T5` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP1050-T3, SP1050-T4. Done when: diff is limited to GH1050 spec, batch status/domain/processor/storage code and focused tests; format, all-target/all-feature check, strict Clippy and full serial tests pass on final head. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → failing processor/DB reproduction → canonical domain contract → typed write path → strict compatible read path → focused verification → repository-wide verification。相关生产文件存在直接依赖，由单一 implementation owner 串行修改。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 精确为 B-001 至 B-007。
+- Impl PR 使用 `Fixes #1050` 并以 Spec branch 为 base，代码审查与规范审查分离。
+- 远端 PR 保持未自动合并，只报告 current-head checks 事实。
+
+## Handoff Notes
+
+- historical Debug values 是 read-only compatibility aliases；任何新写入仍必须 canonical snake_case。
+- unknown status 不能映射为真实 `BatchStatus::Failed`，也不能只跳过该 row。
+- 不夹带 metadata、request/result persistence、schema migration 或 transition redesign。

--- a/specs/GH1050/tech.md
+++ b/specs/GH1050/tech.md
@@ -1,0 +1,77 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1050 / #1050
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Domain status | `src/core/batch/types.rs` | serde uses Rust variant names; no stable text encoder/parser | B-001/B-002 contract gap |
+| Processor persistence | `src/core/batch/processor/utils.rs`, `core.rs` | `format!("{:?}", status)` writes PascalCase/compound Debug names | B-003 root cause |
+| Database update | `src/storage/database/seaorm_db/batch_ops.rs` | public method accepts arbitrary `&str` and matches timestamps by string | type-safety gap |
+| Database list | `src/storage/database/seaorm_db/batch_ops.rs` | recognizes snake_case only; unknown including library-written Debug becomes Failed | B-004/B-005 silent corruption |
+| Domain tests | `src/core/batch/types.rs` tests | explicitly expects `InProgress` JSON | current wire mismatch proof |
+
+## 设计方案
+
+1. 在 `BatchStatus` 上设置 `#[serde(rename_all = "snake_case")]`，实现 `as_str() -> &'static str` 作为唯一新写入编码；
+   实现 strict persisted parser（`FromStr` 或等价 helper），闭集包含八个 canonical 值及八个 exact historical Debug 值。
+2. historical aliases 只存在于 parser。`as_str`、serde serialization 和所有新 DB write 永远只输出 canonical snake_case。
+3. 将 `SeaOrmDatabase::update_batch_status` 参数改为 `BatchStatus` 或 `&BatchStatus`。SQL value 使用 `as_str()`，timestamp
+   match 使用 enum variant，移除任意 string branch。
+4. BatchProcessor 的普通 update 与 cancel 路径直接传 typed enum；必要时 clone，禁止 `Debug`/case conversion。
+5. create path 使用 `BatchStatus::Validating.as_str()`；list path 将每个 model 转换为 `Result<BatchRecord>` 并
+   `collect::<Result<Vec<_>>>()`，unknown status 传播 `GatewayError::Storage/Validation` 而非返回 Failed/partial list。
+6. 错误提供 batch status field/category context；不需要回显 raw unknown value。metadata/request count fallback 留给独立 issue。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `BatchStatus::as_str` + parser | table-driven eight-variant canonical round-trip |
+| B-002 | serde rename contract | exact JSON strings and deserialize round-trip |
+| B-003 | typed DB update + processor callsites | compile-time signature; source search has no Debug persistence |
+| B-004 | parser legacy aliases | table-driven eight historical spellings and SQLite rows |
+| B-005 | fallible list collection | corrupt status row makes list `Err`, valid peer not returned as partial truth |
+| B-006 | enum timestamp match | focused update tests assert corresponding timestamp and not-found behavior |
+| B-007 | existing processor/domain/full suites | repository-wide tests and minimal scope diff |
+
+## 数据流
+
+`BatchStatus` domain variant → `as_str()` → DB canonical text；DB canonical/historical text → strict parser → domain variant；
+domain variant → serde snake_case → API payload。任意不在闭集的 DB 值在进入 response 前失败，不能伪造成 Failed。
+
+## 备选方案
+
+- 对 Debug 文本调用 `to_lowercase()`：`InProgress` 会变为 `inprogress` 而非 `in_progress`，仍错误，拒绝。
+- 扩展 list match 只接受 PascalCase：继续同时存在两个新写入 contract，且 API casing 不修，拒绝。
+- unknown 继续返回 Failed 并记录 warning：仍伪造终态和 partial truth，违反 B-005。
+- migration 立即重写历史 rows：增加部署风险且 typed read compatibility 已足够，超出本 issue。
+- 用 serde JSON string 作为 DB status：会引入引号/JSON 层且不如 `as_str` 明确，拒绝。
+
+## 风险
+
+- Compatibility: JSON status 从 Rust casing 改为 OpenAI-compatible snake_case；这是目标行为，但依赖错误 casing 的客户端需调整。
+- Historical data: parser 必须完整覆盖八个旧 Debug spelling，尤其 compound variants，避免现有 row 变不可读。
+- Error propagation: list 必须原子失败，不能在 iterator 中丢 row 或返回已转换 prefix。
+- Timestamp: typed match 不能改变哪个 variant 设置哪个 timestamp。
+
+## 测试计划
+
+- [ ] Red: current processor/DB test 写 `InProgress`、`Completed`、`Cancelling` 后 list，证明它们当前变为 Failed。
+- [ ] Domain: exact eight canonical strings、serde serialization/deserialization round-trip。
+- [ ] Compatibility: exact eight historical Debug strings parse to matching variants。
+- [ ] DB: typed update stores canonical raw text，list restores variant and timestamp。
+- [ ] Corruption: unknown/empty status returns redacted error and no partial list。
+- [ ] Repository: format、all-target/all-feature check、strict Clippy、full serial tests。
+
+## 回滚方案
+
+不得恢复 Debug persistence 或 unknown → Failed fallback。若客户端兼容需要过渡，只可在 deserialization/read parser 增加
+明确的 temporary alias；serialization 和新 DB writes 必须继续 canonical snake_case，并单独跟踪 alias removal。


### PR DESCRIPTION
## Summary

Defines the SpecRail product, technical, and task specifications for #1050.

The packet establishes one canonical snake_case contract for batch status JSON and persistence, requires typed writes, preserves read compatibility for historical Rust Debug spellings, and makes truly unknown persisted states fail instead of fabricating `Failed`.

## Files

- `specs/GH1050/product.md`
- `specs/GH1050/tech.md`
- `specs/GH1050/tasks.md`

## Verification

- `git diff --cached --check`
- product invariant set equals task coverage set (`B-001` through `B-007`)
- exactly three SpecRail files changed

Refs #1050

This is the spec-only PR. Implementation will be submitted in a separate PR based on this branch.