### PR TITLE
fix(batch): canonicalize persisted status encoding

### DIFF
--- a/src/core/batch/processor/core.rs
+++ b/src/core/batch/processor/core.rs
@@ -157,7 +157,7 @@ impl BatchProcessor {
 
                 // Update in database
                 self.database
-                    .update_batch_status(batch_id, &format!("{:?}", batch.status))
+                    .update_batch_status(batch_id, batch.status.clone())
                     .await?;
 
                 Ok(batch)

--- a/src/core/batch/processor/utils.rs
+++ b/src/core/batch/processor/utils.rs
@@ -21,9 +21,7 @@ impl BatchProcessor {
         }
 
         // Update in database
-        self.database
-            .update_batch_status(batch_id, &format!("{:?}", status))
-            .await
+        self.database.update_batch_status(batch_id, status).await
     }
 
     /// Update batch progress

--- a/src/core/batch/types.rs
+++ b/src/core/batch/types.rs
@@ -137,6 +137,7 @@ pub struct BatchResponse {
 
 /// Batch processing status
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum BatchStatus {
     /// Batch is being validated
     Validating,
@@ -154,6 +155,40 @@ pub enum BatchStatus {
     Cancelling,
     /// Batch has been cancelled
     Cancelled,
+}
+
+impl BatchStatus {
+    /// Return the canonical status spelling used by APIs and persistence.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Validating => "validating",
+            Self::Failed => "failed",
+            Self::InProgress => "in_progress",
+            Self::Finalizing => "finalizing",
+            Self::Completed => "completed",
+            Self::Expired => "expired",
+            Self::Cancelling => "cancelling",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl std::str::FromStr for BatchStatus {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "validating" | "Validating" => Ok(Self::Validating),
+            "failed" | "Failed" => Ok(Self::Failed),
+            "in_progress" | "InProgress" => Ok(Self::InProgress),
+            "finalizing" | "Finalizing" => Ok(Self::Finalizing),
+            "completed" | "Completed" => Ok(Self::Completed),
+            "expired" | "Expired" => Ok(Self::Expired),
+            "cancelling" | "Cancelling" => Ok(Self::Cancelling),
+            "cancelled" | "Cancelled" => Ok(Self::Cancelled),
+            _ => Err("invalid batch status"),
+        }
+    }
 }
 
 /// Request counts for batch
@@ -343,21 +378,33 @@ mod tests {
 
     #[test]
     fn test_batch_status_variants() {
-        let statuses = vec![
-            BatchStatus::Validating,
-            BatchStatus::Failed,
-            BatchStatus::InProgress,
-            BatchStatus::Finalizing,
-            BatchStatus::Completed,
-            BatchStatus::Expired,
-            BatchStatus::Cancelling,
-            BatchStatus::Cancelled,
+        let statuses = [
+            (BatchStatus::Validating, "validating", "Validating"),
+            (BatchStatus::Failed, "failed", "Failed"),
+            (BatchStatus::InProgress, "in_progress", "InProgress"),
+            (BatchStatus::Finalizing, "finalizing", "Finalizing"),
+            (BatchStatus::Completed, "completed", "Completed"),
+            (BatchStatus::Expired, "expired", "Expired"),
+            (BatchStatus::Cancelling, "cancelling", "Cancelling"),
+            (BatchStatus::Cancelled, "cancelled", "Cancelled"),
         ];
 
-        for status in statuses {
-            let json = serde_json::to_string(&status).unwrap();
-            assert!(!json.is_empty());
+        for (status, canonical, historical) in statuses {
+            assert_eq!(status.as_str(), canonical);
+            assert_eq!(canonical.parse::<BatchStatus>().unwrap(), status);
+            assert_eq!(historical.parse::<BatchStatus>().unwrap(), status);
+            assert_eq!(
+                serde_json::to_string(&status).unwrap(),
+                format!("\"{canonical}\"")
+            );
+            assert_eq!(
+                serde_json::from_str::<BatchStatus>(&format!("\"{canonical}\"")).unwrap(),
+                status
+            );
         }
+
+        assert!("unknown".parse::<BatchStatus>().is_err());
+        assert!(serde_json::from_str::<BatchStatus>("\"InProgress\"").is_err());
     }
 
     #[test]
@@ -370,7 +417,7 @@ mod tests {
     fn test_batch_status_serialization() {
         let status = BatchStatus::InProgress;
         let json = serde_json::to_string(&status).unwrap();
-        assert!(json.contains("InProgress"));
+        assert_eq!(json, "\"in_progress\"");
     }
 
     // ==================== BatchRequestCounts Tests ====================

--- a/src/storage/database/seaorm_db/batch_ops.rs
+++ b/src/storage/database/seaorm_db/batch_ops.rs
@@ -1,3 +1,4 @@
+use crate::core::batch::BatchStatus;
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use sea_orm::*;
 use tracing::{debug, warn};
@@ -23,7 +24,7 @@ impl SeaOrmDatabase {
             }),
             input_file_id: Set(None),
             completion_window: Set(format!("{}h", batch.completion_window.unwrap_or(24))),
-            status: Set("validating".to_string()),
+            status: Set(BatchStatus::Validating.as_str().to_string()),
             output_file_id: Set(None),
             error_file_id: Set(None),
             created_at: Set(chrono::Utc::now().into()),
@@ -54,8 +55,8 @@ impl SeaOrmDatabase {
     ///
     /// The read-then-update sequence is wrapped in a transaction to ensure
     /// status transitions are atomic.
-    pub async fn update_batch_status(&self, batch_id: &str, status: &str) -> Result<()> {
-        debug!("Updating batch status: {} -> {}", batch_id, status);
+    pub async fn update_batch_status(&self, batch_id: &str, status: BatchStatus) -> Result<()> {
+        debug!("Updating batch status: {} -> {}", batch_id, status.as_str());
 
         let txn = self.db.begin().await.map_err(GatewayError::from)?;
 
@@ -66,19 +67,19 @@ impl SeaOrmDatabase {
             .ok_or_else(|| GatewayError::NotFound("Batch not found".to_string()))?;
 
         let mut active_model: entities::batch::ActiveModel = batch_model.into();
-        active_model.status = Set(status.to_string());
+        active_model.status = Set(status.as_str().to_string());
 
         // Update timestamp based on status
         let now = chrono::Utc::now().into();
         match status {
-            "in_progress" => active_model.in_progress_at = Set(Some(now)),
-            "finalizing" => active_model.finalizing_at = Set(Some(now)),
-            "completed" => active_model.completed_at = Set(Some(now)),
-            "failed" => active_model.failed_at = Set(Some(now)),
-            "expired" => active_model.expired_at = Set(Some(now)),
-            "cancelling" => active_model.cancelling_at = Set(Some(now)),
-            "cancelled" => active_model.cancelled_at = Set(Some(now)),
-            _ => {}
+            BatchStatus::Validating => {}
+            BatchStatus::InProgress => active_model.in_progress_at = Set(Some(now)),
+            BatchStatus::Finalizing => active_model.finalizing_at = Set(Some(now)),
+            BatchStatus::Completed => active_model.completed_at = Set(Some(now)),
+            BatchStatus::Failed => active_model.failed_at = Set(Some(now)),
+            BatchStatus::Expired => active_model.expired_at = Set(Some(now)),
+            BatchStatus::Cancelling => active_model.cancelling_at = Set(Some(now)),
+            BatchStatus::Cancelled => active_model.cancelled_at = Set(Some(now)),
         }
 
         active_model
@@ -117,23 +118,14 @@ impl SeaOrmDatabase {
             .await
             .map_err(GatewayError::from)?;
 
-        let batch_records = batch_models
+        batch_models
             .into_iter()
             .map(|model| {
-                // Parse status string to BatchStatus enum
-                let status = match model.status.as_str() {
-                    "validating" => crate::core::batch::BatchStatus::Validating,
-                    "failed" => crate::core::batch::BatchStatus::Failed,
-                    "in_progress" => crate::core::batch::BatchStatus::InProgress,
-                    "finalizing" => crate::core::batch::BatchStatus::Finalizing,
-                    "completed" => crate::core::batch::BatchStatus::Completed,
-                    "expired" => crate::core::batch::BatchStatus::Expired,
-                    "cancelling" => crate::core::batch::BatchStatus::Cancelling,
-                    "cancelled" => crate::core::batch::BatchStatus::Cancelled,
-                    _ => crate::core::batch::BatchStatus::Failed,
-                };
+                let status = model.status.parse::<BatchStatus>().map_err(|_| {
+                    GatewayError::Storage("Invalid persisted batches.status enum".to_string())
+                })?;
 
-                crate::core::batch::BatchRecord {
+                Ok(crate::core::batch::BatchRecord {
                     id: model.id,
                     object: model.object,
                     endpoint: model.endpoint,
@@ -157,11 +149,9 @@ impl SeaOrmDatabase {
                         failed: model.request_counts_failed.unwrap_or(0),
                     },
                     metadata: model.metadata.and_then(|m| serde_json::from_str(&m).ok()),
-                }
+                })
             })
-            .collect();
-
-        Ok(batch_records)
+            .collect()
     }
 
     /// Get batch results
@@ -247,7 +237,7 @@ impl SeaOrmDatabase {
             .ok_or_else(|| GatewayError::NotFound("Batch not found".to_string()))?;
 
         let mut active_model: entities::batch::ActiveModel = batch_model.into();
-        active_model.status = Set("completed".to_string());
+        active_model.status = Set(BatchStatus::Completed.as_str().to_string());
         active_model.completed_at = Set(Some(chrono::Utc::now().into()));
 
         active_model

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -8,6 +8,7 @@ mod tests {
     use litellm_rs::config::models::file_storage::FileStorageConfig;
     use litellm_rs::config::models::storage::DatabaseConfig;
     use litellm_rs::config::models::storage::{RedisConfig, StorageConfig};
+    use litellm_rs::core::batch::{BatchRequest, BatchStatus, BatchType};
     use litellm_rs::core::models::user::types::User;
     use litellm_rs::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
     use litellm_rs::storage::StorageLayer;
@@ -438,10 +439,91 @@ mod tests {
             .expect("Failed to create database");
         db.migrate().await.expect("Migration failed");
 
-        // List batches (should be empty)
+        // List batches (should be empty).
         let batches = db.list_batches(Some(10), None).await;
         assert!(batches.is_ok());
         assert!(batches.unwrap().is_empty());
+
+        let request = BatchRequest {
+            batch_id: "batch-status-contract".to_string(),
+            user_id: "user-1".to_string(),
+            batch_type: BatchType::ChatCompletion,
+            requests: vec![],
+            metadata: std::collections::HashMap::new(),
+            completion_window: Some(24),
+            webhook_url: None,
+        };
+        db.create_batch(&request).await.unwrap();
+
+        db.update_batch_status(&request.batch_id, BatchStatus::InProgress)
+            .await
+            .unwrap();
+        let row = db
+            .connection()
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "SELECT status, in_progress_at FROM batches WHERE id = ?",
+                [Value::String(Some(Box::new(request.batch_id.clone())))],
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.try_get::<String>("", "status").unwrap(), "in_progress");
+        assert!(
+            row.try_get::<Option<String>>("", "in_progress_at")
+                .unwrap()
+                .is_some()
+        );
+
+        let historical_statuses = [
+            ("Validating", BatchStatus::Validating),
+            ("Failed", BatchStatus::Failed),
+            ("InProgress", BatchStatus::InProgress),
+            ("Finalizing", BatchStatus::Finalizing),
+            ("Completed", BatchStatus::Completed),
+            ("Expired", BatchStatus::Expired),
+            ("Cancelling", BatchStatus::Cancelling),
+            ("Cancelled", BatchStatus::Cancelled),
+        ];
+        for (historical, expected) in historical_statuses {
+            db.connection()
+                .execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Sqlite,
+                    "UPDATE batches SET status = ? WHERE id = ?",
+                    [
+                        Value::String(Some(Box::new(historical.to_string()))),
+                        Value::String(Some(Box::new(request.batch_id.clone()))),
+                    ],
+                ))
+                .await
+                .unwrap();
+            let batches = db.list_batches(Some(10), None).await.unwrap();
+            assert_eq!(batches.len(), 1);
+            assert_eq!(batches[0].status, expected);
+        }
+
+        let mut valid_peer = request.clone();
+        valid_peer.batch_id = "batch-status-valid-peer".to_string();
+        db.create_batch(&valid_peer).await.unwrap();
+
+        db.connection()
+            .execute(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "UPDATE batches SET status = ? WHERE id = ?",
+                [
+                    Value::String(Some(Box::new("unknown-status".to_string()))),
+                    Value::String(Some(Box::new(request.batch_id))),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let error = db
+            .list_batches(Some(10), None)
+            .await
+            .expect_err("unknown persisted batch status must fail the list");
+        assert!(error.to_string().contains("status"));
+        assert!(!error.to_string().contains("unknown-status"));
     }
 
     /// Test database statistics


### PR DESCRIPTION
## Why

Batch status updates persisted Rust Debug spellings such as `InProgress`, while reads only understood snake_case and silently mapped unknown values to `Failed`. That made normally updated batches appear failed and exposed non-canonical API JSON.

## Plan implemented

- serialize and persist the eight batch statuses with canonical snake_case spellings
- make database status updates accept `BatchStatus` instead of arbitrary strings
- read exact historical Debug spellings for backward compatibility
- fail explicitly on unknown persisted status values without echoing raw data
- cover canonical writes, timestamps, historical reads, API serialization, and unknown-value failure

## Reproduction evidence

Before the production fix:

- `cargo test --all-features test_batch_status_serialization -- --test-threads=1` failed because `InProgress` was emitted instead of `in_progress`
- `cargo test --all-features test_batch_list -- --test-threads=1` failed because a historical `Completed` row was listed as `Failed`

## Verification

- `cargo fmt --all`
- `cargo test --all-features test_batch_status -- --test-threads=1`
- `cargo test --all-features test_batch_list -- --test-threads=1`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1 --quiet`
  - library: 10,420 passed, 0 failed, 1 ignored
  - integration library: 189 passed, 0 failed, 12 ignored
  - doctests: 33 passed, 0 failed, 32 ignored
  - all route and binary suites passed

Depends on #1051.

Fixes #1050.