### PR TITLE
docs(spec): fail closed on corrupt legacy teams

### DIFF
--- a/specs/GH1053/product.md
+++ b/specs/GH1053/product.md
@@ -1,0 +1,68 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1053 / #1053
+
+complexity: low
+
+## 用户问题
+
+canonical team repository 为兼容旧数据，会在查询前枚举并同步 `um_teams`。当前枚举逻辑遇到无法反序列化的
+`um_teams.data` 时只记录 warning 并跳过该行，随后继续返回成功结果。因此持久化损坏会被伪装成“团队不存在”，
+并使 list、count、name lookup 与 user-team 查询返回不完整数据。
+
+同一存储层的单条 legacy team 读取和 legacy `list_teams` 已经会传播反序列化错误；canonical compatibility path
+的 silent skip 形成了不一致的读契约。
+
+## 目标
+
+- legacy team 枚举采用 all-or-error 语义，任何不可解码 row 都中止查询。
+- 所有依赖该枚举的 canonical team 查询传播同一错误，不返回 partial/default 结果。
+- 错误指出 persisted `um_teams.data` contract 损坏，但不回显原始 payload。
+- 合法 legacy/canonical team 的同步、分页、计数和成员行为保持不变。
+
+## 非目标
+
+- 不增加 schema migration、row quarantine、自动修复或删除损坏数据。
+- 不改变 inactive/invalid legacy member 的转换规则。
+- 不重设计 legacy/canonical 双写或同步架构。
+- 不修改其他 JSON-backed entity 的错误策略。
+- 不改变对合法 team name conflict 的既有处理。
+
+## Behavior Invariants
+
+1. B-001 `list_legacy_um_teams` 对全部 selected rows 成功反序列化后才返回 teams；任一 `data` row 不合法时返回 `Err`，不得 warning + skip。
+2. B-002 canonical `list`、`count`、`get_by_name`、legacy synchronization 和 `get_user_teams` 必须传播枚举错误，不得返回已处理 prefix、空列表或错误 total。
+3. B-003 混合 valid 与 corrupt legacy rows 时仍整体失败；valid peer 不得掩盖 corruption 或形成 partial truth。
+4. B-004 corruption error 使用 typed `GatewayError` 并包含 `um_teams.data` field context，但不得包含 raw persisted payload。
+5. B-005 valid legacy rows 继续同步为 canonical teams/members，合法 canonical pagination、count、name lookup 与 user-team 查询结果不变。
+6. B-006 单条 `get_legacy_um_team` 的既有 fail-closed 行为保持；本次不扩展或收紧 member conversion、name-conflict、repair 与 migration 语义。
+
+## 验收标准
+
+- [ ] 一个 corrupt legacy row 使 canonical list 返回错误，而不是成功空列表。
+- [ ] valid + corrupt 混合 rows 仍返回错误且不暴露 partial list/total。
+- [ ] count、name lookup 与 user-team synchronization 传播相同 corruption failure。
+- [ ] 错误包含 `um_teams.data` context 且不包含测试用 raw corrupt payload。
+- [ ] valid legacy/canonical team repository tests 保持通过。
+- [ ] 格式、全 target/feature 编译、strict Clippy 与全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001, B-004；空 `data` 是不可解码 persisted row，必须报错。 |
+| 错误与失败路径 | covered: B-001 至 B-004；corruption 显式传播且禁止 partial truth。 |
+| 授权/权限 | N/A；本 issue 只收紧 repository decode contract，不改变 RBAC。 |
+| 并发/竞态 | covered: B-005；不改变同步顺序、事务或并发冲突处理。 |
+| 重试/幂等 | covered: B-001, B-003；损坏未修复前重复查询稳定失败。 |
+| 非法状态转换 | N/A；没有 lifecycle state transition。 |
+| 兼容/迁移 | covered: B-005, B-006；合法旧 row 继续兼容，不执行 migration/repair。 |
+| 降级/回退 | covered: B-001 至 B-003；明确禁止 skip、空列表和 partial fallback。 |
+| 证据与审计完整性 | covered: B-003, B-004；调用者能区分真实空数据与持久化损坏。 |
+| 取消/中断 | N/A；同步查询没有独立取消状态。 |
+
+## 发布说明
+
+团队兼容查询遇到损坏的 legacy JSON 时现在会显式失败，不再成功返回缺失团队或错误计数。

--- a/specs/GH1053/tasks.md
+++ b/specs/GH1053/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1053 / #1053
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1053-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: coordinator. Dependencies: none. Done when: GH1053 product/tech/tasks packet 齐全，B-001 至 B-006 连续且 product-to-test/task coverage 完整. Verify: `test -f specs/GH1053/product.md && test -f specs/GH1053/tech.md && test -f specs/GH1053/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1053/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1053/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1053-T2` Covers: B-001, B-003, B-004. Owner: implementation owner. Dependencies: SP1053-T1. Done when: `list_legacy_um_teams` uses all-or-error row deserialization, removes warning/skip, returns a typed redacted error with `um_teams.data` context, and never returns a converted prefix. Verify: focused corrupt-row repository test; `rg -n "Skipping invalid legacy um_teams row" src/storage/database/seaorm_db/team_repository/legacy_sync.rs` has no hit.
+- [ ] `SP1053-T3` Covers: B-002, B-003, B-005, B-006. Owner: implementation owner. Dependencies: SP1053-T2. Done when: list/count/get_by_name/get_user_teams propagate corrupt-row failure through existing `?`, mixed valid+corrupt rows cannot return partial values, and valid bridge/member/name-conflict behavior is unchanged. Verify: focused propagation/valid-peer tests and the complete `team_repository_tests` module.
+- [ ] `SP1053-T4` Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: verification owner. Dependencies: SP1053-T3. Done when: diff is limited to GH1053 spec, legacy enumeration, and focused repository tests; format, all-target/all-feature check, strict Clippy and full serial tests pass on final head. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → failing corrupt-row reproduction → strict all-or-error enumeration → propagation assertions → valid regression tests → repository-wide verification。生产修改集中在单个 legacy sync helper，由单一 implementation owner 串行执行。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 精确为 B-001 至 B-006。
+- Impl PR 使用 `Fixes #1053` 并以 Spec branch 为 base，代码审查与规范审查分离。
+- 远端 PR 保持未自动合并，只报告 current-head checks 事实。
+
+## Handoff Notes
+
+- red reproduction 已证明 current `origin/main` 返回 `Ok(([], 0))`；不要把 warning 文案测试当作行为验证。
+- error 需要 `um_teams.data` context，但不得拼接 raw corrupt payload。
+- 不夹带 member conversion、name-conflict、migration、repair 或其他 JSON entity 修改。

--- a/specs/GH1053/tech.md
+++ b/specs/GH1053/tech.md
@@ -1,0 +1,75 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1053 / #1053
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Legacy enumeration | `src/storage/database/seaorm_db/team_repository/legacy_sync.rs` | loops rows, warns and skips `from_json` errors | B-001 root cause |
+| Canonical queries | `src/storage/database/seaorm_db/team_repository/repository_impl.rs` | list/count/name/user-team paths call enumeration/sync and trust success | B-002 propagation surface |
+| Direct legacy API | `src/storage/database/seaorm_db/user_management_ops.rs` | `list_teams` already collects fallible deserialization | reference fail-closed contract |
+| Repository tests | `src/storage/database/seaorm_db/team_repository_tests.rs` | covers valid bridge behavior but no corrupt row | regression gap |
+
+## 设计方案
+
+1. 将 `list_legacy_um_teams` 的 row conversion 改为 fallible collection：每行先读取 `data`，再严格调用 `from_json`；
+   任一转换失败立即返回 `Err`，不保留已转换 prefix。
+2. 将反序列化错误映射为稳定的 `GatewayError::Storage`（或同等 typed variant），message 指明
+   `um_teams.data` 无效，但不拼接 raw JSON。SQL/column extraction errors 继续使用既有 database mapping。
+3. 移除该枚举路径的 `warn + skip`。调用方已使用 `?`，保持现有签名即可让 list/count/get_by_name/sync/get_user_teams
+   自动传播错误，不在上层增加 fallback。
+4. 在现有 team repository test module 增加参数化 SQLite regression：创建 valid legacy row 与 corrupt row，通过
+   parameterized statement 修改 `data`，断言 canonical operations 返回错误、message 有 field context 且无 raw payload。
+5. 不修改 `persist_legacy_team` 的 conversion/name-conflict 策略，也不修改 legacy member skip 行为；这些需要独立 issue。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | fallible `list_legacy_um_teams` iterator | single corrupt row makes enumeration-backed list fail |
+| B-002 | existing `?` propagation in repository methods | focused list/count/get_by_name/get_user_teams assertions |
+| B-003 | all-or-error collection | mixed valid+corrupt rows return only `Err`, never partial values |
+| B-004 | redacted typed error mapping | assert field context present and raw marker absent |
+| B-005 | unchanged valid conversion/sync paths | existing repository tests plus valid peer coverage |
+| B-006 | minimal diff and source inspection | direct-get/member/name-conflict tests remain unchanged and pass |
+
+## 数据流
+
+SQL rows → per-row `data` extraction → strict `LegacyTeam` deserialization → all-or-error `Vec<LegacyTeam>` → existing canonical
+sync/query logic。任何 corrupt row 在进入同步前终止整个 operation，调用者收到 storage error，不会观察到 partial canonical state/result。
+
+## 备选方案
+
+- 保留 skip 并返回 skipped count：调用仍可把不完整列表当真，违反 B-001/B-003，拒绝。
+- 用默认 `LegacyTeam` 替换坏 row：会伪造 identity/membership/budget 数据，拒绝。
+- 只让 public `list` 失败：count/name/user-team 仍 silent degrade，契约不一致，拒绝。
+- 自动删除或修复 corrupt row：不可逆且需要产品级恢复策略，超出本 issue。
+- 同时收紧 invalid member 行为：扩大兼容风险，留给独立审计项。
+
+## 风险
+
+- Availability: 过去返回 partial success 的查询会在存在坏 row 时失败；这是避免静默数据丢失的预期变化。
+- Error exposure: 错误必须有可诊断 field context，但不能包含 raw persisted content。
+- Test isolation: corruption 必须通过 parameterized SQL 写入 in-memory SQLite，不能改 migration 或测试基础设施。
+- Scope drift: `persist_legacy_team` 仍可能对其他 conversion/name conflict 返回 `None`；本 issue 只修 row JSON decode。
+
+## 测试计划
+
+- [ ] Red: current `TeamRepository::list` 对唯一 corrupt legacy row 返回 `Ok(([], 0))`，证明 silent partial success。
+- [ ] Corruption: single corrupt row causes list error。
+- [ ] Atomicity: valid peer + corrupt row causes error, no partial list/total。
+- [ ] Propagation: count、get_by_name、get_user_teams 同样返回 error。
+- [ ] Redaction: error 包含 `um_teams.data`，不包含 raw marker。
+- [ ] Regression: existing team repository tests、format、all-target/all-feature check、strict Clippy、full serial tests。
+
+## 回滚方案
+
+不得恢复 warning + skip 或 default row。若部署发现历史损坏，应在独立受审计的 repair/migration 流程中修复数据；查询路径继续
+fail closed。若需更细诊断，可增加不含 payload 的 row identifier，但必须另行评估信息暴露与兼容性。


### PR DESCRIPTION
## Why

Canonical team compatibility queries currently warn and skip undecodable `um_teams.data` rows. A reproduced corrupt row made `TeamRepository::list` return successful empty results, hiding persisted corruption and producing incorrect counts.

## Spec packet

- `product.md`: user impact, goals/non-goals, B-001 through B-006, acceptance criteria and edge cases
- `tech.md`: root cause, all-or-error design, propagation surface, redacted error contract, risks and test mapping
- `tasks.md`: ordered implementation and verification plan with exact coverage

## Plan

1. Add the failing corrupt-row and mixed-row regression coverage.
2. Replace warning/skip enumeration with fallible collection and a redacted `um_teams.data` storage error.
3. Verify list/count/name/user-team propagation and preserve valid bridge behavior.
4. Run formatting, all-target/all-feature check, strict clippy and the full serial suite in a separate implementation PR.

## Validation

- B-001 through B-006 are contiguous and fully covered by the task plan.
- Diff contains only `specs/GH1053/product.md`, `tech.md`, and `tasks.md`.
- `git diff --check` passes.

Relates to #1053. Implementation will be submitted separately.