### PR TITLE
fix(teams): fail closed on corrupt legacy data

### DIFF
--- a/src/storage/database/seaorm_db/team_repository/legacy_sync.rs
+++ b/src/storage/database/seaorm_db/team_repository/legacy_sync.rs
@@ -44,10 +44,10 @@ impl SeaOrmTeamRepository {
         let mut teams = Vec::with_capacity(rows.len());
         for row in rows {
             let data: String = row.try_get("", "data").map_err(GatewayError::from)?;
-            match Self::from_json::<LegacyTeam>(&data) {
-                Ok(team) => teams.push(team),
-                Err(err) => warn!(error = %err, "Skipping invalid legacy um_teams row"),
-            }
+            let team = Self::from_json::<LegacyTeam>(&data).map_err(|_| {
+                GatewayError::Storage("Invalid persisted um_teams.data JSON".to_string())
+            })?;
+            teams.push(team);
         }
         Ok(teams)
     }

--- a/src/storage/database/seaorm_db/team_repository/repository_impl.rs
+++ b/src/storage/database/seaorm_db/team_repository/repository_impl.rs
@@ -29,11 +29,13 @@ impl TeamRepository for SeaOrmTeamRepository {
     }
 
     async fn get_by_name(&self, name: &str) -> Result<Option<Team>> {
+        let legacy_teams = self.list_legacy_um_teams().await?;
+
         if let Some(team) = self.get_canonical_by_name(name).await? {
             return Ok(Some(team));
         }
 
-        for legacy in self.list_legacy_um_teams().await? {
+        for legacy in legacy_teams {
             if legacy.team_name == name {
                 return self.persist_legacy_team(&legacy).await;
             }

--- a/src/storage/database/seaorm_db/team_repository_tests.rs
+++ b/src/storage/database/seaorm_db/team_repository_tests.rs
@@ -189,6 +189,9 @@ async fn test_corrupt_legacy_team_fails_enumeration_backed_queries() {
     let raw_data = "{raw-corrupt-team-json";
 
     db.create_team(&valid).await.unwrap();
+    let valid_id = Uuid::parse_str(&valid.team_id).unwrap();
+    assert!(repo.get(valid_id).await.unwrap().is_some());
+
     db.create_team(&corrupt).await.unwrap();
     corrupt_legacy_team_data(&db, &corrupt.team_id, raw_data).await;
 

--- a/src/storage/database/seaorm_db/team_repository_tests.rs
+++ b/src/storage/database/seaorm_db/team_repository_tests.rs
@@ -9,6 +9,7 @@ use crate::core::user_management::{
     UserPreferences as LegacyUserPreferences, UserRole as LegacyUserRole,
 };
 use chrono::Utc;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -76,6 +77,26 @@ fn legacy_user(user_id: Uuid, email: &str) -> LegacyUser {
         last_login_at: None,
         preferences: LegacyUserPreferences::default(),
     }
+}
+
+async fn corrupt_legacy_team_data(db: &SeaOrmDatabase, team_id: &str, raw_data: &str) {
+    db.db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "UPDATE um_teams SET data = ? WHERE team_id = ?",
+            [
+                Value::String(Some(Box::new(raw_data.to_string()))),
+                Value::String(Some(Box::new(team_id.to_string()))),
+            ],
+        ))
+        .await
+        .unwrap();
+}
+
+fn assert_legacy_team_corruption_error(error: impl std::fmt::Display, raw_data: &str) {
+    let message = error.to_string();
+    assert!(message.contains("um_teams.data"));
+    assert!(!message.contains(raw_data));
 }
 
 #[tokio::test]
@@ -158,6 +179,42 @@ async fn test_legacy_user_management_team_is_visible_through_canonical_repositor
     assert_eq!(total, 1);
     assert_eq!(teams.len(), 1);
     assert_eq!(teams[0].id(), legacy_id);
+}
+
+#[tokio::test]
+async fn test_corrupt_legacy_team_fails_enumeration_backed_queries() {
+    let (repo, db) = create_repository_with_db().await;
+    let valid = legacy_team("legacy-valid-peer", Uuid::new_v4());
+    let corrupt = legacy_team("legacy-corrupt", Uuid::new_v4());
+    let raw_data = "{raw-corrupt-team-json";
+
+    db.create_team(&valid).await.unwrap();
+    db.create_team(&corrupt).await.unwrap();
+    corrupt_legacy_team_data(&db, &corrupt.team_id, raw_data).await;
+
+    let list_error = repo
+        .list(0, 10)
+        .await
+        .expect_err("corrupt legacy data must fail list");
+    assert_legacy_team_corruption_error(list_error, raw_data);
+
+    let count_error = repo
+        .count()
+        .await
+        .expect_err("corrupt legacy data must fail count");
+    assert_legacy_team_corruption_error(count_error, raw_data);
+
+    let name_error = repo
+        .get_by_name(&valid.team_name)
+        .await
+        .expect_err("a valid peer must not mask corrupt legacy data");
+    assert_legacy_team_corruption_error(name_error, raw_data);
+
+    let user_teams_error = repo
+        .get_user_teams(Uuid::new_v4())
+        .await
+        .expect_err("corrupt legacy data must fail user-team synchronization");
+    assert_legacy_team_corruption_error(user_teams_error, raw_data);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

The canonical team compatibility path warned and skipped undecodable `um_teams.data` rows. With one valid peer and one corrupt row, `TeamRepository::list` returned a successful one-team result and total instead of reporting persisted corruption.

## Plan implemented

- replace warning/skip legacy-team enumeration with all-or-error deserialization
- map corrupt JSON to a typed storage error with `um_teams.data` context
- keep the raw persisted payload out of the error
- verify list, count, name lookup and user-team synchronization all propagate the failure
- preserve valid legacy/canonical bridge, member and name-conflict behavior

## Reproduction evidence

Before the production fix:

```text
corrupt legacy data must fail list: ([Team { name: "legacy-valid-peer", ... }], 1)
test result: FAILED. 0 passed; 1 failed
```

This proves the old path returned partial truth rather than only logging an incidental warning.

## Verification

- `cargo fmt --all`
- focused corrupt-row regression: 1 passed, 0 failed
- complete team repository module: 15 passed, 0 failed
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1 --quiet`
  - library: 10,421 passed, 0 failed, 1 ignored
  - integration library: 189 passed, 0 failed, 12 ignored
  - doctests: 33 passed, 0 failed, 32 ignored
  - all route and binary suites passed

Depends on #1054.

Fixes #1053.