### PR TITLE
docs(spec): reject missing canonical team updates

### DIFF
--- a/specs/GH1056/product.md
+++ b/specs/GH1056/product.md
@@ -1,0 +1,66 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1056 / #1056
+
+complexity: low
+
+## 用户问题
+
+`SeaOrmTeamRepository::update` 丢弃 SQL `UPDATE` 的执行结果。目标 ID 不存在时数据库返回 zero affected rows，repository
+却继续执行 legacy sync 并返回 `Ok(Team)`，使调用方认为更新已持久化。内存 repository 对相同输入已经返回
+`GatewayError::NotFound`，两种实现 contract 不一致。
+
+TeamManager 虽然通常先读取 team，但 read 与 update 之间存在并发删除窗口；因此 write boundary 必须验证自己的执行结果。
+
+## 目标
+
+- canonical team update 在 zero affected rows 时返回 `NotFound`。
+- zero-row update 不执行 legacy synchronization，也不返回未持久化 team。
+- exactly-one-row update 保持既有 metadata touch、持久化和 legacy sync 行为。
+- SeaORM 与 in-memory `TeamRepository::update` 的 missing-team contract 一致。
+
+## 非目标
+
+- 不增加 transaction、version compare 或完整 optimistic locking。
+- 不改变 create/delete/member operations。
+- 不修改 legacy `user_management::update_team`。
+- 不改变 name conflict、soft-delete 或 API route policy。
+- 不重设计 manager 的 read-modify-write 流程。
+
+## Behavior Invariants
+
+1. B-001 canonical `UPDATE teams ... WHERE id = ?` 影响 zero rows 时，SeaORM repository 返回 `GatewayError::NotFound`，不得返回输入 team。
+2. B-002 zero-row update 后 canonical `teams` 与 legacy `um_teams` 均不得出现该 ID；legacy synchronization 不得产生副作用。
+3. B-003 exactly one matched row 时，更新后的 name/data 被持久化，metadata touch 与返回值保持既有行为。
+4. B-004 exactly one matched row 后继续执行既有 canonical-to-legacy synchronization，organization/settings preservation contract 不变。
+5. B-005 SQL execution error 继续映射为既有 typed database/storage error；不得转换成 `NotFound` 或成功。
+6. B-006 missing-team behavior 与 `InMemoryTeamRepository` 一致，并关闭 manager 预读后 row 被删除所产生的 false success 窗口。
+
+## 验收标准
+
+- [ ] 从未 create 的 team 调用 SeaORM `update` 返回 `GatewayError::NotFound`。
+- [ ] missing ID 在 canonical 与 legacy table 中仍不存在。
+- [ ] existing team update 继续持久化字段并返回更新对象。
+- [ ] existing legacy synchronization/preservation tests 保持通过。
+- [ ] 格式、全 target/feature 编译、strict Clippy 与全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001, B-002；missing ID 是本 issue 的核心输入。 |
+| 错误与失败路径 | covered: B-001, B-005；zero row 与 SQL error 明确区分。 |
+| 授权/权限 | N/A；repository persistence contract 不改变 route/RBAC。 |
+| 并发/竞态 | covered: B-006；write result 关闭 read 后并发删除的 false success。 |
+| 重试/幂等 | covered: B-001, B-003；missing update 稳定 NotFound，existing update 维持既有语义。 |
+| 非法状态转换 | N/A；不改变 team lifecycle transition policy。 |
+| 兼容/迁移 | covered: B-003, B-004；无 schema/data migration，合法 update 保持。 |
+| 降级/回退 | covered: B-001；禁止 zero-row no-op 降级为成功。 |
+| 证据与审计完整性 | covered: B-002, B-006；成功响应必须对应真实 persisted row。 |
+| 取消/中断 | N/A；没有独立取消状态。 |
+
+## 发布说明
+
+团队更新现在会在目标已不存在时返回 NotFound，不再确认一个未写入数据库的成功结果。

--- a/specs/GH1056/tasks.md
+++ b/specs/GH1056/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1056 / #1056
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1056-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: coordinator. Dependencies: none. Done when: GH1056 product/tech/tasks packet 齐全，B-001 至 B-006 连续且 product-to-test/task coverage 完整. Verify: `test -f specs/GH1056/product.md && test -f specs/GH1056/tech.md && test -f specs/GH1056/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1056/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1056/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1056-T2` Covers: B-001, B-002, B-005, B-006. Owner: implementation owner. Dependencies: SP1056-T1. Done when: SeaORM canonical team update captures `ExecResult`, returns `NotFound` on zero rows before legacy sync, preserves database errors, and does not upsert. Verify: focused missing-team test plus canonical/legacy absence assertions.
+- [ ] `SP1056-T3` Covers: B-003, B-004. Owner: implementation owner. Dependencies: SP1056-T2. Done when: exactly-one-row update still touches/persists team and runs existing legacy synchronization/preservation logic unchanged. Verify: complete `team_repository_tests` module.
+- [ ] `SP1056-T4` Covers: B-001, B-002, B-003, B-004, B-005, B-006. Owner: verification owner. Dependencies: SP1056-T3. Done when: diff is limited to GH1056 spec, canonical update implementation and focused repository tests; format, all-target/all-feature check, strict Clippy and full serial tests pass on final head. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → failing missing-update reproduction → affected-row guard → no-side-effect assertions → successful update regressions → repository-wide verification。实现文件直接相关，由单一 implementation owner 串行修改。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 精确为 B-001 至 B-006。
+- Impl PR 使用 `Fixes #1056` 并以 Spec branch 为 base，代码审查与规范审查分离。
+- 远端 PR 保持未自动合并，只报告 current-head checks 事实。
+
+## Handoff Notes
+
+- red reproduction 已证明 current `origin/main` 对 never-created UUID 返回 `Ok(Team)`。
+- `rows_affected == 0` check 必须发生在 legacy sync 之前；禁止 SELECT-before-update 或 upsert。
+- 不夹带 legacy update、optimistic locking、name conflict、delete/member 修改。

--- a/specs/GH1056/tech.md
+++ b/specs/GH1056/tech.md
@@ -1,0 +1,71 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1056 / #1056
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| SeaORM update | `src/storage/database/seaorm_db/team_repository/repository_impl.rs` | discards `ExecResult`, always syncs and returns team | B-001/B-002 root cause |
+| In-memory contract | `src/core/teams/repository.rs` | checks ID and returns `NotFound` | expected parity reference |
+| Manager | `src/core/teams/manager.rs` | reads then calls repository update | concurrent delete leaves write race |
+| SeaORM tests | `src/storage/database/seaorm_db/team_repository_tests.rs` | covers successful updates, not missing update | regression gap |
+
+## 设计方案
+
+1. 保存 `self.db.db.execute(stmt)` 返回的 `ExecResult`，继续用既有 `GatewayError::from` 映射 SQL execution failure。
+2. 在任何 legacy sync 之前检查 `rows_affected()`。值为 `0` 时返回
+   `GatewayError::NotFound(format!("Team {} not found", team.id()))`，与 in-memory repository 的语义/文案类别一致。
+3. 值为 `1` 时执行现有 `sync_legacy_team_from_canonical` 并返回 touched team，不改变成功路径顺序。
+4. `teams.id` 是主键，因此单条 ID update 不会合法影响多行；实现不增加不可达 recovery 分支。若未来 schema 破坏该约束，数据库本身应先失败。
+5. 在 SeaORM repository tests 中直接 update 未创建 team，断言 `NotFound`；随后通过 `get` 与 legacy `get_team` 断言没有副作用。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | ExecResult zero-row check | missing update returns exact error variant |
+| B-002 | early return before legacy sync | canonical and legacy lookup remain `None` |
+| B-003 | unchanged one-row path | existing successful canonical update tests |
+| B-004 | unchanged sync call | organization/settings preservation tests |
+| B-005 | existing execute error mapping | source inspection plus repository/full tests |
+| B-006 | parity with in-memory behavior | missing-update regression and contract comparison |
+
+## 数据流
+
+Touched `Team` → parameterized SQL update → `ExecResult.rows_affected()`；`0` → `NotFound` early return；`1` → existing
+canonical-to-legacy sync → returned persisted team。SQL error 在 row-count branch 之前传播。
+
+## 备选方案
+
+- 依赖 TeamManager 预读：无法关闭 read/update 间并发删除窗口，且 repository 可被直接调用，拒绝。
+- update 前再 SELECT：增加一次 round trip 且仍存在 TOCTOU，拒绝。
+- zero rows 时 INSERT/upsert：会把 update 变成 create 并绕过 create validation，拒绝。
+- zero rows 继续 warning + success：仍确认未持久化写入，拒绝。
+- 本次引入 optimistic version：影响 schema/API 与所有 writers，超出 issue。
+
+## 风险
+
+- Contract tightening: 依赖错误 no-op success 的直接 repository caller 将收到 NotFound；这是目标修复。
+- Backend semantics: SQLite/PostgreSQL 对按主键匹配的 update 都提供 affected row count；focused SQLite 与全量编译覆盖实现。
+- Side effects: check 必须位于 legacy sync 之前，防止 missing update 触发任何兼容写入。
+- Scope drift: legacy user-management update 仍有独立 zero-row behavior，本 issue 不触碰。
+
+## 测试计划
+
+- [ ] Red: current SeaORM repository update 未创建 team 返回 `Ok(Team)`。
+- [ ] Missing: after fix 返回 `GatewayError::NotFound`。
+- [ ] No side effect: canonical `get` 与 legacy `get_team` 对 ID 都为 `None`。
+- [ ] Success: existing update/preservation tests pass。
+- [ ] Repository: complete team repository module、format、all-target/all-feature check、strict Clippy、full serial tests。
+
+## 回滚方案
+
+不得恢复 zero-row success。若 affected-row semantics 在某 backend 出现差异，应增加 backend-specific regression 并修正检测方式；不可通过忽略
+`ExecResult` 回退。


### PR DESCRIPTION
## Why

SeaORM canonical team updates discard `ExecResult`. Updating a never-created ID returns `Ok(Team)` even though zero rows were written, while the in-memory repository returns `NotFound`. The write boundary can also observe zero rows after a concurrent delete following the manager read.

## Spec packet

- `product.md`: zero-row behavior, no-side-effect contract, success invariants and acceptance criteria
- `tech.md`: affected-row design, concurrency rationale, alternatives, risks and test mapping
- `tasks.md`: ordered implementation and full verification plan covering B-001 through B-006

## Plan

1. Preserve the failing missing-update regression.
2. Capture SQL `ExecResult` and return `NotFound` on zero rows before legacy sync.
3. Assert the missing ID remains absent from canonical and legacy tables.
4. Verify existing successful update/synchronization behavior and the complete repository suite in a separate implementation PR.

## Validation

- B-001 through B-006 are contiguous and fully covered by tasks.
- Diff contains only `specs/GH1056/product.md`, `tech.md`, and `tasks.md`.
- `git diff --check` passes.

Relates to #1056. Implementation will be submitted separately.