### PR TITLE
fix(teams): reject updates for missing rows

### DIFF
--- a/src/storage/database/seaorm_db/team_repository/repository_impl.rs
+++ b/src/storage/database/seaorm_db/team_repository/repository_impl.rs
@@ -63,7 +63,13 @@ impl TeamRepository for SeaOrmTeamRepository {
                 Value::String(Some(Box::new(id))),
             ],
         );
-        self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        let result = self.db.db.execute(stmt).await.map_err(GatewayError::from)?;
+        if result.rows_affected() == 0 {
+            return Err(GatewayError::NotFound(format!(
+                "Team {} not found",
+                team.id()
+            )));
+        }
         self.sync_legacy_team_from_canonical(team.id()).await?;
         Ok(team)
     }

--- a/src/storage/database/seaorm_db/team_repository_tests.rs
+++ b/src/storage/database/seaorm_db/team_repository_tests.rs
@@ -8,6 +8,7 @@ use crate::core::user_management::{
     TeamSettings as LegacyTeamSettings, User as LegacyUser,
     UserPreferences as LegacyUserPreferences, UserRole as LegacyUserRole,
 };
+use crate::utils::error::gateway_error::GatewayError;
 use chrono::Utc;
 use sea_orm::{ConnectionTrait, DatabaseBackend, Statement, Value};
 use std::collections::HashMap;
@@ -123,6 +124,26 @@ async fn test_list_and_count_exclude_deleted_teams() {
 
     let count = repo.count().await.unwrap();
     assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn test_update_missing_team_returns_not_found_without_side_effects() {
+    let (repo, db) = create_repository_with_db().await;
+    let missing = Team::new("missing-team".to_string(), None);
+    let missing_id = missing.id();
+
+    let error = repo
+        .update(missing)
+        .await
+        .expect_err("updating a missing team must not report success");
+    assert!(matches!(error, GatewayError::NotFound(_)));
+    assert!(repo.get(missing_id).await.unwrap().is_none());
+    assert!(
+        db.get_team(&missing_id.to_string())
+            .await
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

The SeaORM team repository ignored SQL affected-row counts. Updating a never-created team returned `Ok(Team)` despite writing nothing, diverging from the in-memory repository and allowing false success after a concurrent delete.

## Plan implemented

- capture the canonical team update `ExecResult`
- return `GatewayError::NotFound` when zero rows are affected
- stop before legacy synchronization on a missing row
- verify the missing ID remains absent from canonical and legacy lookups
- preserve the existing one-row update and compatibility synchronization path

## Reproduction evidence

Before the production fix:

```text
updating a missing team must not report success: Team { ... }
test result: FAILED. 0 passed; 1 failed
```

## Verification

- `cargo fmt --all`
- focused missing-update/no-side-effect regression: 1 passed, 0 failed
- complete team repository module: 15 passed, 0 failed
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1 --quiet`
  - library: 10,421 passed, 0 failed, 1 ignored
  - integration library: 189 passed, 0 failed, 12 ignored
  - doctests: 33 passed, 0 failed, 32 ignored
  - all route and binary suites passed

Depends on #1057.

Fixes #1056.