### PR TITLE
docs(spec): reject missing canonical team deletes

### DIFF
--- a/specs/GH1059/product.md
+++ b/specs/GH1059/product.md
@@ -1,0 +1,69 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1059 / #1059
+
+complexity: medium
+
+## 用户问题
+
+`SeaOrmTeamRepository::delete` 忽略 canonical `teams` 与 compatibility `um_teams` 两个 delete 的 affected-row
+结果。完全不存在的 ID 会提交 no-op transaction 并返回 `Ok(())`，而 in-memory repository 返回
+`GatewayError::NotFound`。
+
+SeaORM bridge 还支持删除仅存在于 `um_teams` 的 legacy-only team，因此不能只用 canonical row 判断存在性；同时
+member rows 先于 team rows 删除，missing-team 判定必须回滚该清理，避免错误请求产生副作用。
+
+## 目标
+
+- canonical 与 legacy representation 均不存在时，delete 返回 `NotFound`。
+- canonical 或 legacy 任一 representation 存在时，delete 继续成功。
+- missing delete 回滚 transaction 内 member cleanup，不修改 legacy user membership。
+- bridged、canonical-only、legacy-only 删除和既有 membership cleanup 行为保持。
+- SeaORM 与 in-memory missing-delete contract 一致。
+
+## 非目标
+
+- 不增加 schema/foreign-key migration。
+- 不改变 delete 为幂等成功，也不引入 soft delete。
+- 不修复或自动删除 pre-existing orphan member rows。
+- 不改变 create/update/member operations。
+- 不重设计 legacy/canonical bridge 或 user-membership 模型。
+
+## Behavior Invariants
+
+1. B-001 canonical `teams` 与 legacy `um_teams` delete 都影响 zero rows 时，repository 回滚 transaction 并返回 `GatewayError::NotFound`。
+2. B-002 missing-team transaction 中先执行的 `team_members` cleanup 必须回滚；pre-existing orphan member row 不得因本次请求被删除。
+3. B-003 missing delete 不得执行 transaction 后的 legacy user-membership cleanup，用户 `teams` 数据保持不变。
+4. B-004 canonical-only、legacy-only 或 bridged team 任一 representation 被删除时 operation 成功并提交相应 team/member 删除。
+5. B-005 successful delete 后既有 legacy user-membership cleanup 继续执行，合法成员不保留被删 team ID。
+6. B-006 SQL/transaction/rollback error 继续传播 typed database/storage error，不得伪装成 NotFound 或成功。
+7. B-007 missing behavior 与 `InMemoryTeamRepository` 一致，并关闭 manager 预读后并发删除产生的 false success。
+
+## 验收标准
+
+- [ ] 完全不存在的 UUID delete 返回 `GatewayError::NotFound`。
+- [ ] missing delete 后 orphan member 与 legacy user membership 未被修改。
+- [ ] canonical/bridged team delete 继续删除 team、members 与 legacy membership。
+- [ ] legacy-only team delete 继续成功。
+- [ ] 格式、全 target/feature 编译、strict Clippy 与全量测试通过。
+
+## 边界情况清单
+
+| 类别 | 判定（covered: B-xxx / N/A + 原因） |
+| --- | --- |
+| 空/缺失输入 | covered: B-001；missing UUID 是核心输入。 |
+| 错误与失败路径 | covered: B-001, B-006；NotFound 与 database failure 区分。 |
+| 授权/权限 | N/A；repository contract 不改变 API/RBAC。 |
+| 并发/竞态 | covered: B-007；write boundary 检测 read 后并发删除。 |
+| 重试/幂等 | covered: B-001, B-004；首次合法删除成功，再次删除 NotFound。 |
+| 非法状态转换 | N/A；不改变 lifecycle state。 |
+| 兼容/迁移 | covered: B-004, B-005；legacy-only 与 bridged delete 保持，无 migration。 |
+| 降级/回退 | covered: B-001；禁止 missing no-op 降级为成功。 |
+| 证据与审计完整性 | covered: B-002, B-003, B-007；失败响应对应零已提交副作用。 |
+| 取消/中断 | covered: B-001, B-006；rollback failure 显式传播。 |
+
+## 发布说明
+
+团队删除现在会在 canonical 与 legacy 两侧都不存在目标时返回 NotFound，并回滚预先执行的成员清理。

--- a/specs/GH1059/tasks.md
+++ b/specs/GH1059/tasks.md
@@ -1,0 +1,33 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1059 / #1059
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 实现任务
+
+- [ ] `SP1059-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: coordinator. Dependencies: none. Done when: GH1059 product/tech/tasks packet 齐全，B-001 至 B-007 连续且 product-to-test/task coverage 完整. Verify: `test -f specs/GH1059/product.md && test -f specs/GH1059/tech.md && test -f specs/GH1059/tasks.md`; `rg -o "B-[0-9]{3}" specs/GH1059/product.md | sort -u`; `rg -o "B-[0-9]{3}" specs/GH1059/tasks.md | sort -u`; `git diff --check origin/main...HEAD`.
+- [ ] `SP1059-T2` Covers: B-001, B-002, B-003, B-006, B-007. Owner: implementation owner. Dependencies: SP1059-T1. Done when: SeaORM delete captures canonical/legacy ExecResults, explicitly rolls back and returns NotFound when both are zero, preserves rollback errors, and skips post-commit user cleanup. Verify: focused missing-team/orphan-member/legacy-user regression.
+- [ ] `SP1059-T3` Covers: B-004, B-005. Owner: implementation owner. Dependencies: SP1059-T2. Done when: either canonical or legacy affected row commits deletion, and bridged/canonical/legacy-only membership cleanup behavior remains. Verify: complete `team_repository_tests` module.
+- [ ] `SP1059-T4` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007. Owner: verification owner. Dependencies: SP1059-T3. Done when: diff is limited to GH1059 spec, canonical delete implementation and focused repository tests; format, all-target/all-feature check, strict Clippy and full serial tests pass on final head. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD`.
+
+## 执行顺序
+
+Spec packet → failing missing-delete reproduction → dual affected-row guard + rollback → orphan/user side-effect assertions → supported delete regressions → repository-wide verification。transaction 代码直接相关，由单一 implementation owner 串行修改。
+
+## 验证
+
+- Product invariant set 与 tasks `Covers:` union 精确为 B-001 至 B-007。
+- Impl PR 使用 `Fixes #1059` 并以 Spec branch 为 base，代码审查与规范审查分离。
+- 远端 PR 保持未自动合并，只报告 current-head checks 事实。
+
+## Handoff Notes
+
+- existence 是 canonical/legacy delete affected-row 的 OR；禁止只检查 canonical。
+- both zero 必须 rollback member delete，且不得进入 post-commit user cleanup。
+- 不夹带 foreign-key migration、orphan repair、soft delete 或其他 repository operation 修改。

--- a/specs/GH1059/tech.md
+++ b/specs/GH1059/tech.md
@@ -1,0 +1,75 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1059 / #1059
+
+## Product Spec
+
+Link to `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| SeaORM delete | `src/storage/database/seaorm_db/team_repository/repository_impl.rs` | deletes members/teams/um_teams, discards all ExecResults, always commits | root cause |
+| In-memory delete | `src/core/teams/repository.rs` | missing map entry returns NotFound before member cleanup | parity reference |
+| Compatibility tests | `src/storage/database/seaorm_db/team_repository_tests.rs` | covers bridged and legacy-only deletes, not missing/rollback | regression surface |
+
+## 设计方案
+
+1. 保持现有 pre-read：收集 canonical/legacy member user IDs，供成功 commit 后清理 legacy user membership。
+2. 在现有 transaction 中继续先删除 `team_members`，保存 canonical `teams` 与 legacy `um_teams` delete 的两个
+   `ExecResult`。
+3. 若两个 `rows_affected()` 都为 `0`，显式 `rollback().await`；rollback 成功后返回
+   `GatewayError::NotFound(format!("Team {} not found", id))`。不得执行 transaction 后 user cleanup。
+4. 若任一 count 大于 `0`，按现有顺序 commit，再对收集的 user IDs 执行 `remove_legacy_user_team`。
+5. SQL execute、commit 与 rollback failure 继续用 `GatewayError::from`，真实 infrastructure error 优先于 NotFound。
+6. 增加 missing regression；为证明 rollback，参数化插入 orphan `team_members` row 和引用 missing ID 的 legacy user，
+   delete 后断言 member 与 user membership 均保留。现有 legacy-only/bridged tests 覆盖成功分支。
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | dual affected-row check + rollback | missing delete returns NotFound |
+| B-002 | transaction rollback | orphan canonical member remains readable |
+| B-003 | early return before post-commit loop | legacy user still references missing team ID |
+| B-004 | either-row existence predicate | existing canonical/bridged/legacy-only delete tests |
+| B-005 | unchanged post-commit cleanup | existing canonical membership deletion test |
+| B-006 | execute/rollback/commit mappings | source inspection, check/clippy/full tests |
+| B-007 | write-boundary result contract | missing regression and in-memory comparison |
+
+## 数据流
+
+Pre-read member IDs → transaction delete members → delete canonical team + delete legacy team → inspect both counts；both zero →
+rollback → NotFound；either nonzero → commit → legacy user-membership cleanup → success。
+
+## 备选方案
+
+- 只检查 canonical count：会破坏受支持的 legacy-only deletion，拒绝。
+- delete 前 SELECT：增加 round trip、仍有 TOCTOU，且需同时查两表，拒绝。
+- both zero 时 commit member cleanup 再 NotFound：失败请求产生副作用，违反 B-002，拒绝。
+- missing delete 继续幂等成功：与现有 repository contract/API 预期不一致，拒绝。
+- 本次增加 foreign keys/cascade：需要 migration 与跨 backend rollout，超出 issue。
+
+## 风险
+
+- Transaction control: missing branch 必须显式 rollback，不能依赖 drop timing。
+- Compatibility: legacy-only delete 必须以 `um_teams` affected row 判定为存在。
+- Side effects: post-commit user cleanup 只能在存在 team 且 commit 成功后运行。
+- Orphan data: regression 仅证明 missing request 不清理 orphan；不定义 orphan repair policy。
+
+## 测试计划
+
+- [ ] Red: current SeaORM repository delete unknown UUID 返回 `Ok(())`。
+- [ ] Missing: fixed path returns `GatewayError::NotFound`。
+- [ ] Rollback: orphan member row remains after missing delete。
+- [ ] No external side effect: legacy user membership remains after missing delete。
+- [ ] Success compatibility: bridged/canonical/legacy-only delete tests pass。
+- [ ] Repository: complete team repository module、format、all-target/all-feature check、strict Clippy、full serial tests。
+
+## 回滚方案
+
+不得恢复 unconditional commit/success。若 backend affected-row behavior 异常，应增加 backend-specific regression；若 rollback 失败，继续返回真实
+storage error，不得吞掉错误后返回 NotFound。


### PR DESCRIPTION
## Why

SeaORM team deletion discards affected-row counts for both `teams` and `um_teams`. A fully unknown ID commits a no-op transaction and returns success, unlike the in-memory repository. The bridge also supports legacy-only rows, so existence must be based on either representation.

## Spec packet

- `product.md`: NotFound contract, rollback/no-side-effect behavior, compatibility invariants and acceptance criteria
- `tech.md`: dual affected-row design, explicit rollback, alternatives, risks and test mapping
- `tasks.md`: ordered implementation and verification plan covering B-001 through B-007

## Plan

1. Preserve the missing-delete red regression.
2. Capture canonical and legacy delete results inside the transaction.
3. Roll back member cleanup and return NotFound only when both are zero.
4. Prove orphan member and legacy user membership are unchanged on failure.
5. Verify bridged, canonical and legacy-only successful deletes in a separate implementation PR.

## Validation

- B-001 through B-007 are contiguous and fully covered by tasks.
- Diff contains only `specs/GH1059/product.md`, `tech.md`, and `tasks.md`.
- `git diff --check` passes.

Relates to #1059. Implementation will be submitted separately.