### PR TITLE
fix(teams): reject deletes for missing rows

### DIFF
--- a/src/storage/database/seaorm_db/team_repository/repository_impl.rs
+++ b/src/storage/database/seaorm_db/team_repository/repository_impl.rs
@@ -113,7 +113,7 @@ impl TeamRepository for SeaOrmTeamRepository {
             &sql,
             [Value::String(Some(Box::new(id_str)))],
         );
-        txn.execute(stmt).await.map_err(GatewayError::from)?;
+        let canonical_delete = txn.execute(stmt).await.map_err(GatewayError::from)?;
 
         let sql = format!("DELETE FROM um_teams WHERE team_id = {}", self.ph(1));
         let stmt = Statement::from_sql_and_values(
@@ -121,7 +121,12 @@ impl TeamRepository for SeaOrmTeamRepository {
             &sql,
             [Value::String(Some(Box::new(id.to_string())))],
         );
-        txn.execute(stmt).await.map_err(GatewayError::from)?;
+        let legacy_delete = txn.execute(stmt).await.map_err(GatewayError::from)?;
+
+        if canonical_delete.rows_affected() == 0 && legacy_delete.rows_affected() == 0 {
+            txn.rollback().await.map_err(GatewayError::from)?;
+            return Err(GatewayError::NotFound(format!("Team {} not found", id)));
+        }
 
         txn.commit().await.map_err(GatewayError::from)?;
 

--- a/src/storage/database/seaorm_db/team_repository_tests.rs
+++ b/src/storage/database/seaorm_db/team_repository_tests.rs
@@ -344,6 +344,52 @@ async fn test_delete_does_not_resurrect_backfilled_legacy_team() {
 }
 
 #[tokio::test]
+async fn test_delete_missing_team_returns_not_found_and_rolls_back_cleanup() {
+    let (repo, db) = create_repository_with_db().await;
+    let missing_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let mut user = legacy_user(user_id, "orphan-member@example.com");
+    user.teams.push(missing_id.to_string());
+    db.um_create_user(&user).await.unwrap();
+
+    let orphan_member = TeamMember::new(missing_id, user_id, TeamRole::Member, None);
+    db.db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO team_members (team_id, user_id, data) VALUES (?, ?, ?)",
+            [
+                Value::String(Some(Box::new(missing_id.to_string()))),
+                Value::String(Some(Box::new(user_id.to_string()))),
+                Value::String(Some(Box::new(
+                    serde_json::to_string(&orphan_member).unwrap(),
+                ))),
+            ],
+        ))
+        .await
+        .unwrap();
+
+    let error = repo
+        .delete(missing_id)
+        .await
+        .expect_err("deleting a missing team must not report success");
+    assert!(matches!(error, GatewayError::NotFound(_)));
+    assert!(
+        repo.get_member(missing_id, user_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        db.get_user(&user_id.to_string())
+            .await
+            .unwrap()
+            .unwrap()
+            .teams,
+        vec![missing_id.to_string()]
+    );
+}
+
+#[tokio::test]
 async fn test_legacy_name_conflict_does_not_return_wrong_team_for_id_lookup() {
     let (repo, db) = create_repository_with_db().await;
     let canonical = Team::new("shared-name".to_string(), None);


### PR DESCRIPTION
## Why

SeaORM team deletion ignored affected-row counts for both canonical and legacy representations. A completely unknown ID committed a no-op transaction and returned success, diverging from the in-memory repository and allowing false success after a concurrent delete.

## Plan implemented

- capture canonical `teams` and legacy `um_teams` delete results
- explicitly roll back and return `GatewayError::NotFound` when both affect zero rows
- preserve legacy-only, canonical and bridged deletion when either representation exists
- prove member cleanup is rolled back for a missing team
- prove post-commit legacy user-membership cleanup is skipped on failure

## Reproduction evidence

Before the production fix:

```text
deleting a missing team must not report success: ()
test result: FAILED. 0 passed; 1 failed
```

## Verification

- `cargo fmt --all`
- focused missing-delete/rollback regression: 1 passed, 0 failed
- complete team repository module: 15 passed, 0 failed
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1 --quiet`
  - library: 10,421 passed, 0 failed, 1 ignored
  - integration library: 189 passed, 0 failed, 12 ignored
  - doctests: 33 passed, 0 failed, 32 ignored
  - all route and binary suites passed

The compile/test commands reused a shared `CARGO_TARGET_DIR`; they executed the current implementation worktree sources.

Depends on #1060.

Fixes #1059.