### PR TITLE
refactor(router): pin canonical runtime generations

### DIFF
--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -11,6 +11,7 @@ use super::execution::{
 use super::fallback::{ExecutionResult, FallbackType};
 use super::retry_policy::{RetryContext, RetryPolicy};
 use super::unified::Router;
+use super::{RoutingSnapshot, RuntimeHandle};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::model::ProviderCapability;
 use std::collections::HashSet;
@@ -29,7 +30,8 @@ impl Router {
         F: Fn(Arc<Deployment>) -> Fut + Clone,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
-        self.execute_with_retry_inner(model_name, operation)
+        let snapshot = self.load_routing_snapshot();
+        self.execute_with_retry_inner(snapshot.as_ref(), model_name, operation)
             .await
             .map(
                 |(value, deployment_id, _model_used, attempts, latency_us)| {
@@ -63,6 +65,7 @@ impl Router {
 
     async fn execute_with_retry_inner<T, F, Fut>(
         &self,
+        snapshot: &RoutingSnapshot,
         model_name: &str,
         operation: F,
     ) -> Result<(T, DeploymentId, String, u32, u64), (ProviderError, u32)>
@@ -79,10 +82,11 @@ impl Router {
             let start = std::time::Instant::now();
 
             // Try to select a deployment
-            let deployment_lease = match self
-                .select_deployment_lease_matching(model_name, |deployment| {
-                    !excluded_budget_deployments.contains(deployment.id.as_str())
-                }) {
+            let deployment_lease = match self.select_deployment_lease_matching_in_snapshot(
+                snapshot,
+                model_name,
+                |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
+            ) {
                 Ok(lease) => lease,
                 Err(router_err) => {
                     if !excluded_budget_deployments.is_empty()
@@ -192,6 +196,7 @@ impl Router {
         F: Fn(Arc<Deployment>) -> Fut + Clone,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
+        let snapshot = self.load_routing_snapshot();
         let max_attempts = self.config.num_retries + 1;
         let mut attempt = 1;
         let mut last_error = None;
@@ -200,11 +205,13 @@ impl Router {
         while attempt <= max_attempts {
             let start = std::time::Instant::now();
 
-            let deployment_lease = match self.select_deployment_lease_for_capability_matching(
-                model_name,
-                capability,
-                |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
-            ) {
+            let deployment_lease = match self
+                .select_deployment_lease_for_capability_matching_in_snapshot(
+                    snapshot.as_ref(),
+                    model_name,
+                    capability,
+                    |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
+                ) {
                 Ok(lease) => lease,
                 Err(router_err) => {
                     if !excluded_budget_deployments.is_empty()
@@ -338,10 +345,29 @@ impl Router {
         F: Fn(Arc<Deployment>) -> Fut + Clone,
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
+        let snapshot = self.load_routing_snapshot();
+        self.execute_with_selected_deployment_in_snapshot(snapshot.as_ref(), model_name, operation)
+            .await
+    }
+
+    pub(super) async fn execute_with_selected_deployment_in_snapshot<T, F, Fut>(
+        &self,
+        snapshot: &RoutingSnapshot,
+        model_name: &str,
+        operation: F,
+    ) -> Result<ExecutionResult<T>, RouterError>
+    where
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
         let start = std::time::Instant::now();
 
         // Get all models to try (original + fallbacks), deduplicated to prevent cycles
-        let models_to_try = self.get_models_with_fallbacks(model_name, FallbackType::General);
+        let models_to_try = self.get_models_with_fallbacks_for_snapshot(
+            snapshot,
+            model_name,
+            FallbackType::General,
+        );
         let max_models = 1 + self.config.max_fallbacks as usize;
         let mut seen = std::collections::HashSet::new();
         let models_to_try: Vec<_> = models_to_try
@@ -369,7 +395,7 @@ impl Router {
             }
 
             match self
-                .execute_with_retry_inner(model, operation.clone())
+                .execute_with_retry_inner(snapshot, model, operation.clone())
                 .await
             {
                 Ok((result, deployment_id, model_used, attempts, _latency_us)) => {
@@ -498,5 +524,26 @@ impl Router {
             operation(deployment.id.clone())
         })
         .await
+    }
+}
+
+impl RuntimeHandle {
+    pub async fn execute_with_selected_deployment<T, F, Fut>(
+        &self,
+        model_name: &str,
+        operation: F,
+    ) -> Result<ExecutionResult<T>, RouterError>
+    where
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.binding
+            .router
+            .execute_with_selected_deployment_in_snapshot(
+                self.snapshot.as_ref(),
+                model_name,
+                operation,
+            )
+            .await
     }
 }

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -20,6 +20,7 @@
 
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::sync::AtomicValue;
+use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
@@ -56,18 +57,15 @@ pub use config::{RouterConfig, RoutingStrategy as UnifiedRoutingStrategy};
 pub use error::{CooldownReason, RouterError};
 pub use fallback::{ExecutionResult, FallbackConfig, FallbackType};
 pub use unified::{Router as UnifiedRouter, RoutingMetrics, RoutingSnapshot};
-
 /// Refreshable owner token for a canonical router runtime.
 #[derive(Clone)]
 pub struct RuntimeBinding {
     router: Arc<UnifiedRouter>,
 }
-
 impl RuntimeBinding {
     pub fn new(router: Arc<UnifiedRouter>) -> Self {
         Self { router }
     }
-
     pub fn bind(&self) -> RuntimeHandle {
         RuntimeHandle {
             binding: self.clone(),
@@ -75,73 +73,72 @@ impl RuntimeBinding {
         }
     }
 }
-
 #[derive(Clone)]
 pub struct RuntimeHandle {
     binding: RuntimeBinding,
     snapshot: Arc<RoutingSnapshot>,
 }
-
 impl RuntimeHandle {
     pub fn generation(&self) -> u64 {
         self.snapshot.generation()
     }
-
     pub fn snapshot(&self) -> &RoutingSnapshot {
         self.snapshot.as_ref()
     }
 }
-
 pub struct DefaultRuntimeBinding {
     current: AtomicValue<RuntimeBinding>,
+    replace_lock: Mutex<()>,
 }
-
 impl DefaultRuntimeBinding {
     pub fn new(initial: RuntimeBinding) -> Self {
         initial.router.publish_current_snapshot();
         Self {
             current: AtomicValue::new(initial),
+            replace_lock: Mutex::new(()),
         }
     }
-
     pub fn load(&self) -> RuntimeHandle {
         self.current.load().bind()
     }
-
     pub fn replace(&self, next: RuntimeBinding) -> RuntimeBinding {
+        let _guard = self.replace_lock.lock();
         next.router.publish_current_snapshot();
         self.current.swap(next).as_ref().clone()
     }
 }
-
 static DEFAULT_RUNTIME: OnceLock<DefaultRuntimeBinding> = OnceLock::new();
-
+static DEFAULT_RUNTIME_INSTALL_LOCK: Mutex<()> = Mutex::new(());
+fn default_runtime_already_installed() -> ProviderError {
+    ProviderError::configuration(
+        "router",
+        "default runtime is already installed; use replace_default_runtime",
+    )
+}
 pub fn install_default_runtime(runtime: RuntimeBinding) -> Result<RuntimeHandle, ProviderError> {
+    let _guard = DEFAULT_RUNTIME_INSTALL_LOCK.lock();
+    if DEFAULT_RUNTIME.get().is_some() {
+        return Err(default_runtime_already_installed());
+    }
     let default_runtime = DefaultRuntimeBinding::new(runtime);
     let handle = default_runtime.load();
-    DEFAULT_RUNTIME.set(default_runtime).map_err(|_| {
-        ProviderError::configuration(
-            "router",
-            "default runtime is already installed; use replace_default_runtime",
-        )
-    })?;
+    DEFAULT_RUNTIME
+        .set(default_runtime)
+        .map_err(|_| default_runtime_already_installed())?;
     Ok(handle)
 }
-
 pub fn default_runtime() -> Result<RuntimeHandle, ProviderError> {
     DEFAULT_RUNTIME
         .get()
         .map(DefaultRuntimeBinding::load)
         .ok_or_else(|| ProviderError::configuration("router", "default runtime is not installed"))
 }
-
 pub fn replace_default_runtime(runtime: RuntimeBinding) -> Result<RuntimeBinding, ProviderError> {
     DEFAULT_RUNTIME
         .get()
         .map(|current| current.replace(runtime))
         .ok_or_else(|| ProviderError::configuration("router", "default runtime is not installed"))
 }
-
 #[derive(Default)]
 pub struct RuntimeRequestOptions {
     pub headers: Option<HashMap<String, String>>,
@@ -151,7 +148,6 @@ pub struct RuntimeRequestOptions {
     pub api_version: Option<String>,
     pub organization: Option<String>,
 }
-
 #[allow(dead_code)] // Populated in D1; consumed by the staged completion migration.
 pub struct LegacyRuntimeSelector {
     pub(crate) api_key: Option<String>,
@@ -159,7 +155,6 @@ pub struct LegacyRuntimeSelector {
     pub(crate) api_version: Option<String>,
     pub(crate) organization: Option<String>,
 }
-
 /// Validated request context; fields cannot bypass [`Self::validate`].
 /// ```compile_fail
 /// use litellm_rs::core::router::RuntimeRequestContext;
@@ -174,7 +169,6 @@ pub struct RuntimeRequestContext {
     timeout: Option<Duration>,
     legacy_selector: Option<LegacyRuntimeSelector>,
 }
-
 impl RuntimeRequestContext {
     pub fn validate(
         options: RuntimeRequestOptions,
@@ -194,27 +188,28 @@ impl RuntimeRequestContext {
             })?;
             headers.insert(name, value);
         }
-
         if let Some(timeout) = options.timeout {
-            let max_timeout = Duration::from_secs(policy.timeout_secs);
-            if timeout.is_zero() || timeout > max_timeout {
+            if timeout.is_zero() {
+                return Err(invalid_request("request timeout must be greater than zero"));
+            }
+            if policy.timeout_secs > 0 && timeout > Duration::from_secs(policy.timeout_secs) {
                 return Err(invalid_request(format!(
-                    "request timeout must be greater than zero and at most {} seconds",
+                    "request timeout must be at most {} seconds",
                     policy.timeout_secs
                 )));
             }
         }
-
         let api_key = options.api_key;
         let api_version = options.api_version;
         let organization = options.organization;
         let api_base = options
             .api_base
             .map(|raw| {
-                if raw.trim().is_empty() {
+                let raw = raw.trim();
+                if raw.is_empty() {
                     return Err(invalid_request("legacy selector api_base cannot be empty"));
                 }
-                let url = Url::parse(&raw)
+                let url = Url::parse(raw)
                     .map_err(|_| invalid_request("legacy selector api_base is invalid"))?;
                 if !matches!(url.scheme(), "http" | "https") {
                     return Err(invalid_request(
@@ -224,7 +219,6 @@ impl RuntimeRequestContext {
                 Ok(url)
             })
             .transpose()?;
-
         let legacy_selector = if api_key.is_some()
             || api_base.is_some()
             || api_version.is_some()
@@ -239,31 +233,25 @@ impl RuntimeRequestContext {
         } else {
             None
         };
-
         Ok(Self {
             headers,
             timeout: options.timeout,
             legacy_selector,
         })
     }
-
     pub fn headers(&self) -> &HeaderMap {
         &self.headers
     }
-
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
-
     pub fn has_legacy_selector(&self) -> bool {
         self.legacy_selector.is_some()
     }
 }
-
 fn invalid_request(message: impl Into<String>) -> ProviderError {
     ProviderError::invalid_request("router", message)
 }
-
 fn is_forbidden_runtime_header(name: &HeaderName) -> bool {
     matches!(
         name.as_str(),

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -18,6 +18,14 @@
 //! - `execute_impl` - Execute methods with retry and fallback support
 //! - `gateway_config` - Gateway configuration integration
 
+use crate::core::providers::unified_provider::ProviderError;
+use crate::utils::sync::AtomicValue;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use url::Url;
+
 // New modular router components
 pub mod budget_routing;
 pub mod config;
@@ -47,4 +55,230 @@ pub use budget_routing::{BudgetAwareRouter, BudgetAwareRouting, RequestBudgetChe
 pub use config::{RouterConfig, RoutingStrategy as UnifiedRoutingStrategy};
 pub use error::{CooldownReason, RouterError};
 pub use fallback::{ExecutionResult, FallbackConfig, FallbackType};
-pub use unified::{Router as UnifiedRouter, RoutingMetrics};
+pub use unified::{Router as UnifiedRouter, RoutingMetrics, RoutingSnapshot};
+
+/// Refreshable owner token for a canonical router runtime.
+#[derive(Clone)]
+pub struct RuntimeBinding {
+    router: Arc<UnifiedRouter>,
+}
+
+impl RuntimeBinding {
+    pub fn new(router: Arc<UnifiedRouter>) -> Self {
+        Self { router }
+    }
+
+    pub fn bind(&self) -> RuntimeHandle {
+        RuntimeHandle {
+            binding: self.clone(),
+            snapshot: self.router.load_routing_snapshot(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RuntimeHandle {
+    binding: RuntimeBinding,
+    snapshot: Arc<RoutingSnapshot>,
+}
+
+impl RuntimeHandle {
+    pub fn generation(&self) -> u64 {
+        self.snapshot.generation()
+    }
+
+    pub fn snapshot(&self) -> &RoutingSnapshot {
+        self.snapshot.as_ref()
+    }
+}
+
+pub struct DefaultRuntimeBinding {
+    current: AtomicValue<RuntimeBinding>,
+}
+
+impl DefaultRuntimeBinding {
+    pub fn new(initial: RuntimeBinding) -> Self {
+        initial.router.publish_current_snapshot();
+        Self {
+            current: AtomicValue::new(initial),
+        }
+    }
+
+    pub fn load(&self) -> RuntimeHandle {
+        self.current.load().bind()
+    }
+
+    pub fn replace(&self, next: RuntimeBinding) -> RuntimeBinding {
+        next.router.publish_current_snapshot();
+        self.current.swap(next).as_ref().clone()
+    }
+}
+
+static DEFAULT_RUNTIME: OnceLock<DefaultRuntimeBinding> = OnceLock::new();
+
+pub fn install_default_runtime(runtime: RuntimeBinding) -> Result<RuntimeHandle, ProviderError> {
+    let default_runtime = DefaultRuntimeBinding::new(runtime);
+    let handle = default_runtime.load();
+    DEFAULT_RUNTIME.set(default_runtime).map_err(|_| {
+        ProviderError::configuration(
+            "router",
+            "default runtime is already installed; use replace_default_runtime",
+        )
+    })?;
+    Ok(handle)
+}
+
+pub fn default_runtime() -> Result<RuntimeHandle, ProviderError> {
+    DEFAULT_RUNTIME
+        .get()
+        .map(DefaultRuntimeBinding::load)
+        .ok_or_else(|| ProviderError::configuration("router", "default runtime is not installed"))
+}
+
+pub fn replace_default_runtime(runtime: RuntimeBinding) -> Result<RuntimeBinding, ProviderError> {
+    DEFAULT_RUNTIME
+        .get()
+        .map(|current| current.replace(runtime))
+        .ok_or_else(|| ProviderError::configuration("router", "default runtime is not installed"))
+}
+
+#[derive(Default)]
+pub struct RuntimeRequestOptions {
+    pub headers: Option<HashMap<String, String>>,
+    pub timeout: Option<Duration>,
+    pub api_key: Option<String>,
+    pub api_base: Option<String>,
+    pub api_version: Option<String>,
+    pub organization: Option<String>,
+}
+
+#[allow(dead_code)] // Populated in D1; consumed by the staged completion migration.
+pub struct LegacyRuntimeSelector {
+    pub(crate) api_key: Option<String>,
+    pub(crate) api_base: Option<Url>,
+    pub(crate) api_version: Option<String>,
+    pub(crate) organization: Option<String>,
+}
+
+/// Validated request context; fields cannot bypass [`Self::validate`].
+/// ```compile_fail
+/// use litellm_rs::core::router::RuntimeRequestContext;
+/// let _ = RuntimeRequestContext {
+///     headers: Default::default(),
+///     timeout: None,
+///     legacy_selector: None,
+/// };
+/// ```
+pub struct RuntimeRequestContext {
+    headers: HeaderMap,
+    timeout: Option<Duration>,
+    legacy_selector: Option<LegacyRuntimeSelector>,
+}
+
+impl RuntimeRequestContext {
+    pub fn validate(
+        options: RuntimeRequestOptions,
+        policy: &RouterConfig,
+    ) -> Result<Self, ProviderError> {
+        let mut headers = HeaderMap::new();
+        for (raw_name, raw_value) in options.headers.unwrap_or_default() {
+            let name = HeaderName::from_bytes(raw_name.as_bytes())
+                .map_err(|_| invalid_request(format!("invalid header name: {raw_name}")))?;
+            if is_forbidden_runtime_header(&name) {
+                return Err(invalid_request(format!(
+                    "request header override is forbidden: {name}"
+                )));
+            }
+            let value = HeaderValue::from_bytes(raw_value.as_bytes()).map_err(|_| {
+                invalid_request(format!("invalid value for request header: {name}"))
+            })?;
+            headers.insert(name, value);
+        }
+
+        if let Some(timeout) = options.timeout {
+            let max_timeout = Duration::from_secs(policy.timeout_secs);
+            if timeout.is_zero() || timeout > max_timeout {
+                return Err(invalid_request(format!(
+                    "request timeout must be greater than zero and at most {} seconds",
+                    policy.timeout_secs
+                )));
+            }
+        }
+
+        let api_key = options.api_key;
+        let api_version = options.api_version;
+        let organization = options.organization;
+        let api_base = options
+            .api_base
+            .map(|raw| {
+                if raw.trim().is_empty() {
+                    return Err(invalid_request("legacy selector api_base cannot be empty"));
+                }
+                let url = Url::parse(&raw)
+                    .map_err(|_| invalid_request("legacy selector api_base is invalid"))?;
+                if !matches!(url.scheme(), "http" | "https") {
+                    return Err(invalid_request(
+                        "legacy selector api_base must use http or https",
+                    ));
+                }
+                Ok(url)
+            })
+            .transpose()?;
+
+        let legacy_selector = if api_key.is_some()
+            || api_base.is_some()
+            || api_version.is_some()
+            || organization.is_some()
+        {
+            Some(LegacyRuntimeSelector {
+                api_key,
+                api_base,
+                api_version,
+                organization,
+            })
+        } else {
+            None
+        };
+
+        Ok(Self {
+            headers,
+            timeout: options.timeout,
+            legacy_selector,
+        })
+    }
+
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+
+    pub fn has_legacy_selector(&self) -> bool {
+        self.legacy_selector.is_some()
+    }
+}
+
+fn invalid_request(message: impl Into<String>) -> ProviderError {
+    ProviderError::invalid_request("router", message)
+}
+
+fn is_forbidden_runtime_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "proxy-authenticate"
+            | "cookie"
+            | "set-cookie"
+            | "host"
+            | "content-length"
+            | "connection"
+            | "keep-alive"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -8,6 +8,7 @@ use super::deployment::{Deployment, DeploymentId};
 use super::error::RouterError;
 use super::strategy_impl::{self, RoutingContext};
 use super::unified::Router;
+use super::{RoutingSnapshot, RuntimeHandle};
 use crate::core::types::model::ProviderCapability;
 use dashmap::DashMap;
 use std::sync::Arc;
@@ -94,18 +95,20 @@ impl Router {
         &self,
         model_name: &str,
     ) -> Result<DeploymentLease, RouterError> {
-        self.select_deployment_matching(model_name, |_| true, None)
+        let snapshot = self.load_routing_snapshot();
+        self.select_deployment_matching(snapshot.as_ref(), model_name, |_| true, None)
     }
 
-    pub(crate) fn select_deployment_lease_matching<F>(
+    pub(crate) fn select_deployment_lease_matching_in_snapshot<F>(
         &self,
+        snapshot: &RoutingSnapshot,
         model_name: &str,
         is_candidate: F,
     ) -> Result<DeploymentLease, RouterError>
     where
         F: Fn(&Deployment) -> bool,
     {
-        self.select_deployment_matching(model_name, is_candidate, None)
+        self.select_deployment_matching(snapshot, model_name, is_candidate, None)
     }
 
     /// Select the best deployment for a model that supports `capability`.
@@ -147,12 +150,32 @@ impl Router {
     where
         F: Fn(&Deployment) -> bool,
     {
+        let snapshot = self.load_routing_snapshot();
+        self.select_deployment_lease_for_capability_matching_in_snapshot(
+            snapshot.as_ref(),
+            model_name,
+            capability,
+            is_candidate,
+        )
+    }
+
+    pub(crate) fn select_deployment_lease_for_capability_matching_in_snapshot<F>(
+        &self,
+        snapshot: &RoutingSnapshot,
+        model_name: &str,
+        capability: &ProviderCapability,
+        is_candidate: F,
+    ) -> Result<DeploymentLease, RouterError>
+    where
+        F: Fn(&Deployment) -> bool,
+    {
         let no_matching_candidate_error = RouterError::UnsupportedCapability {
             model: model_name.to_string(),
             capability: format!("{capability:?}"),
         };
 
         self.select_deployment_matching(
+            snapshot,
             model_name,
             |deployment| {
                 deployment
@@ -201,6 +224,7 @@ impl Router {
 
     fn select_deployment_matching<F>(
         &self,
+        snapshot: &RoutingSnapshot,
         model_name: &str,
         is_candidate: F,
         no_matching_candidate_error: Option<RouterError>,
@@ -210,7 +234,6 @@ impl Router {
     {
         // 1. Resolve model aliases and deployment indexes from one immutable
         // routing generation.
-        let snapshot = self.routing_snapshot.load();
         let resolved_name = snapshot.resolve_model_name(model_name);
 
         // 2. Get all deployment IDs for this model.
@@ -436,7 +459,7 @@ impl Router {
         note = "Use select_deployment_lease so release targets the selected snapshot deployment"
     )]
     pub fn release_deployment(&self, deployment_id: &str) {
-        let snapshot = self.routing_snapshot.load();
+        let snapshot = self.load_routing_snapshot();
         if let Some(deployment) = snapshot.deployments.get(deployment_id) {
             Self::release_selected_deployment(deployment);
         }
@@ -448,5 +471,19 @@ impl Router {
             .active_requests
             .fetch_update(Relaxed, Relaxed, |v| Some(v.saturating_sub(1)));
         debug_assert!(result.is_ok());
+    }
+}
+
+impl RuntimeHandle {
+    pub fn select_deployment_lease(
+        &self,
+        model_name: &str,
+    ) -> Result<DeploymentLease, RouterError> {
+        self.binding.router.select_deployment_matching(
+            self.snapshot.as_ref(),
+            model_name,
+            |_| true,
+            None,
+        )
     }
 }

--- a/src/core/router/tests/router_tests.rs
+++ b/src/core/router/tests/router_tests.rs
@@ -7,8 +7,12 @@ use crate::core::providers::openai::OpenAIProvider;
 use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::deployment::{Deployment, HealthStatus};
 use crate::core::router::unified::Router;
+use crate::core::router::{
+    DefaultRuntimeBinding, RuntimeBinding, RuntimeRequestContext, RuntimeRequestOptions,
+};
 use crate::core::types::model::ProviderCapability;
-use std::sync::atomic::Ordering;
+use std::sync::{Arc, atomic::Ordering};
+use std::time::Duration;
 
 async fn create_test_provider() -> Provider {
     let openai = OpenAIProvider::with_api_key("sk-test-key-for-unit-testing-only")
@@ -51,14 +55,20 @@ async fn test_router_with_custom_config() {
 
 #[tokio::test]
 async fn test_add_deployment() {
-    let router = Router::default();
+    let router = Arc::new(Router::default());
+    let binding = RuntimeBinding::new(router.clone());
+    let old = binding.bind();
     let deployment = create_test_deployment("test-1", "gpt-4").await;
 
     router.add_deployment(deployment);
+    let current = binding.bind();
 
     assert_eq!(router.list_deployments().len(), 1);
     assert_eq!(router.list_models().len(), 1);
     assert!(router.list_models().contains(&"gpt-4".to_string()));
+    assert!(current.generation() > old.generation());
+    assert!(old.select_deployment_lease("gpt-4").is_err());
+    current.select_deployment_lease("gpt-4").unwrap();
 }
 
 #[tokio::test]
@@ -615,10 +625,12 @@ fn test_router_config_default() {
 fn test_alias_direct_cycle() {
     let router = Router::default();
     router.add_model_alias("a", "b").unwrap();
+    let generation = router.routing_snapshot.load().generation();
     let result = router.add_model_alias("b", "a");
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.to_string().contains("Circular alias"));
+    assert_eq!(router.routing_snapshot.load().generation(), generation);
 }
 
 #[test]
@@ -643,8 +655,36 @@ fn test_alias_self_cycle() {
 
 #[test]
 fn test_alias_no_cycle() {
-    let router = Router::default();
+    let router = Arc::new(Router::default());
+    let binding = RuntimeBinding::new(router.clone());
+    let old = binding.bind();
     assert!(router.add_model_alias("gpt4", "gpt-4").is_ok());
     assert!(router.add_model_alias("gpt-latest", "gpt-4").is_ok());
     assert!(router.add_model_alias("best", "gpt-latest").is_ok());
+    let current = binding.bind();
+    assert_eq!(old.snapshot().resolve_model_name("best"), "best");
+    assert_eq!(current.snapshot().resolve_model_name("best"), "gpt-4");
+}
+
+#[test]
+fn test_runtime_binding_rollback_and_request_context_validation() {
+    let first = RuntimeBinding::new(Arc::new(Router::default()));
+    let default = DefaultRuntimeBinding::new(first.clone());
+    let first_generation = default.load().generation();
+    let old = default.replace(RuntimeBinding::new(Arc::new(Router::default())));
+    let second_generation = default.load().generation();
+    default.replace(old);
+    assert!(second_generation > first_generation);
+    assert!(default.load().generation() > second_generation);
+
+    let policy = RouterConfig::default();
+    let mut options = RuntimeRequestOptions {
+        headers: Some([("authorization".into(), "secret".into())].into()),
+        ..Default::default()
+    };
+    assert!(RuntimeRequestContext::validate(std::mem::take(&mut options), &policy).is_err());
+    options.timeout = Some(Duration::ZERO);
+    assert!(RuntimeRequestContext::validate(std::mem::take(&mut options), &policy).is_err());
+    options.api_base = Some("file:///tmp/socket".into());
+    assert!(RuntimeRequestContext::validate(options, &policy).is_err());
 }

--- a/src/core/router/tests/router_tests.rs
+++ b/src/core/router/tests/router_tests.rs
@@ -9,6 +9,7 @@ use crate::core::router::deployment::{Deployment, HealthStatus};
 use crate::core::router::unified::Router;
 use crate::core::router::{
     DefaultRuntimeBinding, RuntimeBinding, RuntimeRequestContext, RuntimeRequestOptions,
+    default_runtime, install_default_runtime,
 };
 use crate::core::types::model::ProviderCapability;
 use std::sync::{Arc, atomic::Ordering};
@@ -676,8 +677,11 @@ fn test_runtime_binding_rollback_and_request_context_validation() {
     default.replace(old);
     assert!(second_generation > first_generation);
     assert!(default.load().generation() > second_generation);
+    let installed = install_default_runtime(first.clone()).unwrap().generation();
+    assert!(install_default_runtime(first).is_err());
+    assert_eq!(default_runtime().unwrap().generation(), installed);
 
-    let policy = RouterConfig::default();
+    let mut policy = RouterConfig::default();
     let mut options = RuntimeRequestOptions {
         headers: Some([("authorization".into(), "secret".into())].into()),
         ..Default::default()
@@ -686,5 +690,9 @@ fn test_runtime_binding_rollback_and_request_context_validation() {
     options.timeout = Some(Duration::ZERO);
     assert!(RuntimeRequestContext::validate(std::mem::take(&mut options), &policy).is_err());
     options.api_base = Some("file:///tmp/socket".into());
-    assert!(RuntimeRequestContext::validate(options, &policy).is_err());
+    assert!(RuntimeRequestContext::validate(std::mem::take(&mut options), &policy).is_err());
+    policy.timeout_secs = 0;
+    options.timeout = Some(Duration::from_secs(1));
+    options.api_base = Some(" https://example.com/v1 ".into());
+    assert!(RuntimeRequestContext::validate(options, &policy).is_ok());
 }

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -16,10 +16,21 @@ use dashmap::DashMap;
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed};
+use std::sync::atomic::{
+    AtomicU64, AtomicUsize,
+    Ordering::{Relaxed, SeqCst},
+};
 use std::time::Duration;
 
 const MAX_ALIAS_HOPS: usize = 16;
+static NEXT_ROUTING_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+fn next_routing_generation() -> u64 {
+    NEXT_ROUTING_GENERATION
+        .fetch_update(SeqCst, SeqCst, |current| current.checked_add(1))
+        .expect("routing generation space exhausted")
+        + 1
+}
 
 /// Snapshot of routing metrics counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,8 +56,9 @@ pub struct CapabilityDeployment {
 /// Each snapshot owns a complete, internally consistent view of deployments,
 /// model indexes, model-group insertion order, and aliases. Router readers load
 /// one snapshot and never walk split mutable maps from different generations.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct RoutingSnapshot {
+#[derive(Debug, Clone)]
+pub struct RoutingSnapshot {
+    generation: u64,
     pub(crate) deployments: HashMap<DeploymentId, Arc<Deployment>>,
     pub(crate) model_index: HashMap<String, Vec<DeploymentId>>,
     pub(crate) model_order: Vec<String>,
@@ -54,6 +66,20 @@ pub(crate) struct RoutingSnapshot {
 }
 
 impl RoutingSnapshot {
+    fn empty() -> Self {
+        Self {
+            generation: next_routing_generation(),
+            deployments: HashMap::new(),
+            model_index: HashMap::new(),
+            model_order: Vec::new(),
+            model_aliases: HashMap::new(),
+        }
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
     fn from_deployments_preserving_state(
         deployments: Vec<Deployment>,
         previous: &RoutingSnapshot,
@@ -66,8 +92,11 @@ impl RoutingSnapshot {
             }
         }
         let mut snapshot = Self {
+            generation: previous.generation,
+            deployments: HashMap::new(),
+            model_index: HashMap::new(),
+            model_order: Vec::new(),
             model_aliases: previous.model_aliases.clone(),
-            ..Default::default()
         };
 
         for mut deployment in deployments {
@@ -237,7 +266,7 @@ impl Router {
     /// Create a new router with the given configuration
     pub fn new(config: RouterConfig) -> Self {
         Self {
-            routing_snapshot: ArcSwap::from_pointee(RoutingSnapshot::default()),
+            routing_snapshot: ArcSwap::from_pointee(RoutingSnapshot::empty()),
             routing_snapshot_write_lock: Mutex::new(()),
             config,
             fallback_config: FallbackConfig::default(),
@@ -276,11 +305,33 @@ impl Router {
 
     // ========== Deployment Management ==========
 
-    fn update_routing_snapshot(&self, update: impl FnOnce(&mut RoutingSnapshot)) {
+    fn update_routing_snapshot<T>(&self, update: impl FnOnce(&mut RoutingSnapshot) -> T) -> T {
         let _guard = self.routing_snapshot_write_lock.lock();
         let mut next = self.routing_snapshot.load_full().as_ref().clone();
-        update(&mut next);
+        let result = update(&mut next);
+        next.generation = next_routing_generation();
         self.routing_snapshot.store(Arc::new(next));
+        result
+    }
+
+    fn try_update_routing_snapshot<T, E>(
+        &self,
+        update: impl FnOnce(&mut RoutingSnapshot) -> Result<T, E>,
+    ) -> Result<T, E> {
+        let _guard = self.routing_snapshot_write_lock.lock();
+        let mut next = self.routing_snapshot.load_full().as_ref().clone();
+        let result = update(&mut next)?;
+        next.generation = next_routing_generation();
+        self.routing_snapshot.store(Arc::new(next));
+        Ok(result)
+    }
+
+    pub(super) fn load_routing_snapshot(&self) -> Arc<RoutingSnapshot> {
+        self.routing_snapshot.load_full()
+    }
+
+    pub(super) fn publish_current_snapshot(&self) {
+        self.update_routing_snapshot(|_| ());
     }
 
     /// Add a deployment to the router
@@ -290,11 +341,7 @@ impl Router {
 
     /// Remove a deployment from the router
     pub fn remove_deployment(&self, id: &str) -> Option<Deployment> {
-        let mut removed = None;
-        self.update_routing_snapshot(|snapshot| {
-            removed = snapshot.remove_deployment(id);
-        });
-        removed
+        self.update_routing_snapshot(|snapshot| snapshot.remove_deployment(id))
     }
 
     /// Get a deployment by ID
@@ -323,11 +370,7 @@ impl Router {
         alias: &str,
         model_name: &str,
     ) -> Result<(), super::error::RouterError> {
-        let _guard = self.routing_snapshot_write_lock.lock();
-        let mut next = self.routing_snapshot.load_full().as_ref().clone();
-        next.add_model_alias(alias, model_name)?;
-        self.routing_snapshot.store(Arc::new(next));
-        Ok(())
+        self.try_update_routing_snapshot(|snapshot| snapshot.add_model_alias(alias, model_name))
     }
 
     /// Resolve a model name (handles aliases)
@@ -604,8 +647,27 @@ impl Router {
         model_name: &str,
         fallback_type: FallbackType,
     ) -> Vec<String> {
-        let mut models = vec![self.resolve_model_name(model_name)];
-        models.extend(self.get_fallbacks(model_name, fallback_type));
+        let snapshot = self.load_routing_snapshot();
+        self.get_models_with_fallbacks_for_snapshot(snapshot.as_ref(), model_name, fallback_type)
+    }
+
+    pub(super) fn get_models_with_fallbacks_for_snapshot(
+        &self,
+        snapshot: &RoutingSnapshot,
+        model_name: &str,
+        fallback_type: FallbackType,
+    ) -> Vec<String> {
+        let resolved = snapshot.resolve_model_name(model_name);
+        let mut fallbacks = self
+            .fallback_config
+            .get_fallbacks_for_type(&resolved, fallback_type);
+        if fallbacks.is_empty() && fallback_type != FallbackType::General {
+            fallbacks = self
+                .fallback_config
+                .get_fallbacks_for_type(&resolved, FallbackType::General);
+        }
+        let mut models = vec![resolved];
+        models.extend(fallbacks);
         models
     }
 


### PR DESCRIPTION
## Summary

- introduce `RuntimeBinding` / `RuntimeHandle` so each request pins one immutable `RoutingSnapshot`
- assign a process-monotonic generation to every successful snapshot publication, including legacy router mutations and default-runtime replacement
- thread the pinned snapshot through selection, retry, and fallback paths without changing public mutation signatures
- add validated, private-field `RuntimeRequestContext` plus regression coverage for isolation, failed publication, rollback, and unsafe request options

## Spec

- SpecRail: SP965-T002 / D1
- Base: `d058e758282a2caa633da884941b207ed379e415`
- Refs #965

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
- `bash scripts/guards/check_pr_scope.sh origin/main` — 5 files, 500 changed lines
- `bash scripts/guards/check_pr_overlap.sh` — no open PR overlap
- `git diff --check`

The repository has no root `workflow.yaml` / `route_gate.py`, so the SpecRail implement route gate is unavailable in this checkout and is not claimed as passed.