### PR TITLE
refactor(errors): converge provider retry facts

### DIFF
--- a/src/core/providers/failure.rs
+++ b/src/core/providers/failure.rs
@@ -5,35 +5,9 @@
 //! gateway adapters so those layers can reason from facts.
 
 use super::ProviderError;
+use super::unified_provider::{ProviderHttpErrorFacts, provider_http_error_facts};
+use crate::utils::error::{CanonicalError, ErrorCode};
 use std::time::Duration;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProviderFailureKind {
-    Authentication,
-    RateLimit,
-    QuotaExceeded,
-    ModelNotFound,
-    InvalidRequest,
-    Network,
-    ProviderUnavailable,
-    NotSupported,
-    NotImplemented,
-    Configuration,
-    Serialization,
-    Timeout,
-    ContextLengthExceeded,
-    ContentFiltered,
-    ApiError,
-    TokenLimitExceeded,
-    FeatureDisabled,
-    DeploymentError,
-    ResponseParsing,
-    RoutingError,
-    TransformationError,
-    Cancelled,
-    Streaming,
-    Other,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ProviderRetryHint {
@@ -43,9 +17,18 @@ pub struct ProviderRetryHint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderFailureFacts {
     pub provider: &'static str,
-    pub kind: ProviderFailureKind,
+    pub canonical_code: ErrorCode,
+    pub http: ProviderHttpErrorFacts,
     pub upstream_status: Option<u16>,
     pub retry_hint: ProviderRetryHint,
+    pub content_filter_retryable: bool,
+    pub(crate) retry_candidate: bool,
+    pub pre_output_only: bool,
+    pub streaming_failure: bool,
+    pub cancelled: bool,
+    pub modeled_bedrock_retry: bool,
+    pub(super) legacy_retryable: bool,
+    pub(super) legacy_retry_delay: Option<Duration>,
 }
 
 impl ProviderFailureFacts {
@@ -56,51 +39,97 @@ impl ProviderFailureFacts {
 
 impl From<&ProviderError> for ProviderFailureFacts {
     fn from(error: &ProviderError) -> Self {
-        Self {
+        let mut facts = Self {
             provider: error.provider(),
-            kind: ProviderFailureKind::from(error),
-            upstream_status: match error {
-                ProviderError::ApiError { status, .. } => Some(*status),
-                _ => None,
-            },
-            retry_hint: match error {
-                ProviderError::RateLimit { retry_after, .. } => ProviderRetryHint {
-                    retry_after: retry_after.map(Duration::from_secs),
-                },
-                _ => ProviderRetryHint::default(),
-            },
-        }
-    }
-}
+            canonical_code: CanonicalError::canonical_code(error),
+            http: provider_http_error_facts(error),
+            upstream_status: None,
+            retry_hint: ProviderRetryHint::default(),
+            content_filter_retryable: false,
+            retry_candidate: false,
+            pre_output_only: false,
+            streaming_failure: false,
+            cancelled: false,
+            modeled_bedrock_retry: false,
+            legacy_retryable: false,
+            legacy_retry_delay: None,
+        };
 
-impl From<&ProviderError> for ProviderFailureKind {
-    fn from(error: &ProviderError) -> Self {
         match error {
-            ProviderError::Authentication { .. } => Self::Authentication,
-            ProviderError::RateLimit { .. } => Self::RateLimit,
-            ProviderError::QuotaExceeded { .. } => Self::QuotaExceeded,
-            ProviderError::ModelNotFound { .. } => Self::ModelNotFound,
-            ProviderError::InvalidRequest { .. } => Self::InvalidRequest,
-            ProviderError::Network { .. } => Self::Network,
-            ProviderError::ProviderUnavailable { .. } => Self::ProviderUnavailable,
-            ProviderError::NotSupported { .. } => Self::NotSupported,
-            ProviderError::NotImplemented { .. } => Self::NotImplemented,
-            ProviderError::Configuration { .. } => Self::Configuration,
-            ProviderError::Serialization { .. } => Self::Serialization,
-            ProviderError::Timeout { .. } => Self::Timeout,
-            ProviderError::ContextLengthExceeded { .. } => Self::ContextLengthExceeded,
-            ProviderError::ContentFiltered { .. } => Self::ContentFiltered,
-            ProviderError::ApiError { .. } => Self::ApiError,
-            ProviderError::TokenLimitExceeded { .. } => Self::TokenLimitExceeded,
-            ProviderError::FeatureDisabled { .. } => Self::FeatureDisabled,
-            ProviderError::DeploymentError { .. } => Self::DeploymentError,
-            ProviderError::ResponseParsing { .. } => Self::ResponseParsing,
-            ProviderError::RoutingError { .. } => Self::RoutingError,
-            ProviderError::TransformationError { .. } => Self::TransformationError,
-            ProviderError::Cancelled { .. } => Self::Cancelled,
-            ProviderError::Streaming { .. } => Self::Streaming,
-            ProviderError::Other { .. } => Self::Other,
+            ProviderError::RateLimit { retry_after, .. } => {
+                facts.retry_candidate = true;
+                facts.legacy_retryable = true;
+                facts.retry_hint.retry_after = retry_after.map(Duration::from_secs);
+                facts.legacy_retry_delay = facts.retry_hint.retry_after;
+            }
+            ProviderError::Network { .. } | ProviderError::Timeout { .. } => {
+                facts.retry_candidate = true;
+                facts.legacy_retryable = true;
+                facts.legacy_retry_delay = Some(Duration::from_secs(1));
+            }
+            ProviderError::ProviderUnavailable { .. } => {
+                facts.retry_candidate = true;
+                facts.legacy_retryable = true;
+                facts.legacy_retry_delay = Some(Duration::from_secs(5));
+            }
+            ProviderError::ContentFiltered {
+                potentially_retryable,
+                ..
+            } => {
+                facts.content_filter_retryable = potentially_retryable.unwrap_or(false);
+                facts.retry_candidate = facts.content_filter_retryable;
+                facts.pre_output_only = true;
+                facts.legacy_retryable = facts.content_filter_retryable;
+                facts.legacy_retry_delay = facts
+                    .content_filter_retryable
+                    .then_some(Duration::from_secs(10));
+            }
+            ProviderError::ApiError { status, .. } => {
+                facts.upstream_status = Some(*status);
+                facts.modeled_bedrock_retry = error.is_bedrock_modeled_retry_error();
+                facts.retry_candidate =
+                    facts.modeled_bedrock_retry || matches!(*status, 408 | 429 | 500..=599);
+                facts.legacy_retryable =
+                    facts.modeled_bedrock_retry || *status == 429 || (500..=599).contains(status);
+                facts.legacy_retry_delay = match *status {
+                    424 if facts.modeled_bedrock_retry => Some(Duration::from_secs(3)),
+                    429 => Some(Duration::from_secs(60)),
+                    500..=599 => Some(Duration::from_secs(3)),
+                    _ => None,
+                };
+            }
+            ProviderError::DeploymentError { .. } => {
+                facts.retry_candidate = true;
+                facts.pre_output_only = true;
+                facts.legacy_retryable = true;
+                facts.legacy_retry_delay = Some(Duration::from_secs(5));
+            }
+            ProviderError::Cancelled { .. } => facts.cancelled = true,
+            ProviderError::Streaming { .. } => {
+                facts.retry_candidate = true;
+                facts.pre_output_only = true;
+                facts.streaming_failure = true;
+                facts.legacy_retryable = true;
+                facts.legacy_retry_delay = Some(Duration::from_secs(2));
+            }
+            ProviderError::Authentication { .. }
+            | ProviderError::QuotaExceeded { .. }
+            | ProviderError::ModelNotFound { .. }
+            | ProviderError::InvalidRequest { .. }
+            | ProviderError::NotSupported { .. }
+            | ProviderError::NotImplemented { .. }
+            | ProviderError::Configuration { .. }
+            | ProviderError::Serialization { .. }
+            | ProviderError::ContextLengthExceeded { .. }
+            | ProviderError::TokenLimitExceeded { .. }
+            | ProviderError::FeatureDisabled { .. }
+            | ProviderError::ResponseParsing { .. }
+            | ProviderError::RoutingError { .. }
+            | ProviderError::TransformationError { .. }
+            | ProviderError::Other { .. } => {}
         }
+
+        facts
     }
 }
 
@@ -108,13 +137,14 @@ impl From<&ProviderError> for ProviderFailureKind {
 mod tests {
     use super::*;
     use crate::core::providers::bedrock::BedrockErrorMapper;
+    use crate::core::router::RouterConfig;
+    use crate::core::router::retry_policy::{RetryContext, RetryPolicy};
 
     #[test]
     fn facts_capture_rate_limit_retry_after_without_policy() {
         let facts = ProviderFailureFacts::from_error(&ProviderError::rate_limit("openai", Some(7)));
 
         assert_eq!(facts.provider, "openai");
-        assert_eq!(facts.kind, ProviderFailureKind::RateLimit);
         assert_eq!(facts.upstream_status, None);
         assert_eq!(facts.retry_hint.retry_after, Some(Duration::from_secs(7)));
     }
@@ -128,7 +158,6 @@ mod tests {
         ));
 
         assert_eq!(facts.provider, "anthropic");
-        assert_eq!(facts.kind, ProviderFailureKind::ApiError);
         assert_eq!(facts.upstream_status, Some(503));
         assert_eq!(facts.retry_hint.retry_after, None);
     }
@@ -145,9 +174,141 @@ mod tests {
             "ModelNotReadyException: misleading ordinary HTTP message",
         ));
 
-        assert_eq!(modeled.kind, ProviderFailureKind::ApiError);
         assert_eq!(modeled.upstream_status, Some(424));
-        assert_eq!(ordinary.kind, ProviderFailureKind::ApiError);
+        assert!(modeled.modeled_bedrock_retry);
         assert_eq!(ordinary.upstream_status, Some(424));
+        assert!(!ordinary.modeled_bedrock_retry);
+    }
+
+    #[test]
+    fn variant_table_locks_canonical_http_and_stream_retry_facts() {
+        macro_rules! case {
+            ($error:expr, $code:ident, $status:expr, $retry:expr) => {{
+                let error = $error;
+                let facts = ProviderFailureFacts::from_error(&error);
+                let before = RetryPolicy.decide(
+                    &RouterConfig::default(),
+                    &error,
+                    RetryContext::stream_pre_output(1, 2),
+                );
+                let after = RetryPolicy.decide(
+                    &RouterConfig::default(),
+                    &error,
+                    RetryContext::stream_after_chunks(1, 2),
+                );
+                assert_eq!(
+                    (facts.canonical_code, facts.http.status, before.should_retry),
+                    (ErrorCode::$code, $status, $retry)
+                );
+                assert!(!after.should_retry);
+            }};
+        }
+        let (p, m) = ("p", "m");
+        case!(
+            ProviderError::authentication(p, m),
+            Authentication,
+            401,
+            false
+        );
+        case!(ProviderError::rate_limit(p, None), RateLimited, 429, true);
+        case!(
+            ProviderError::quota_exceeded(p, m),
+            QuotaExceeded,
+            402,
+            false
+        );
+        case!(ProviderError::model_not_found(p, m), NotFound, 404, false);
+        case!(
+            ProviderError::invalid_request(p, m),
+            InvalidRequest,
+            400,
+            false
+        );
+        case!(ProviderError::network(p, m), Network, 502, true);
+        case!(
+            ProviderError::provider_unavailable(p, m),
+            Unavailable,
+            503,
+            true
+        );
+        case!(
+            ProviderError::not_supported(p, m),
+            NotImplemented,
+            501,
+            false
+        );
+        case!(
+            ProviderError::not_implemented(p, m),
+            NotImplemented,
+            501,
+            false
+        );
+        case!(
+            ProviderError::configuration(p, m),
+            Configuration,
+            500,
+            false
+        );
+        case!(ProviderError::serialization(p, m), Parsing, 500, false);
+        case!(ProviderError::timeout(p, m), Timeout, 504, true);
+        case!(
+            ProviderError::context_length_exceeded(p, 1, 2),
+            InvalidRequest,
+            400,
+            false
+        );
+        case!(
+            ProviderError::content_filtered(p, m, None, Some(true)),
+            InvalidRequest,
+            400,
+            true
+        );
+        let api_408 = ProviderError::api_error(p, 408, m);
+        assert!(!api_408.is_retryable());
+        assert_eq!(api_408.retry_delay(), None);
+        case!(api_408, Timeout, 408, true);
+        case!(ProviderError::api_error(p, 429, m), RateLimited, 429, true);
+        case!(ProviderError::api_error(p, 200, m), Internal, 502, false);
+        case!(ProviderError::api_error(p, 302, m), Internal, 502, false);
+        case!(ProviderError::api_error(p, 700, m), Internal, 502, false);
+        case!(
+            ProviderError::token_limit_exceeded(p, m),
+            InvalidRequest,
+            400,
+            false
+        );
+        case!(
+            ProviderError::feature_disabled(p, m),
+            NotImplemented,
+            501,
+            false
+        );
+        case!(ProviderError::deployment_error(m, m), NotFound, 404, true);
+        case!(ProviderError::response_parsing(p, m), Parsing, 502, false);
+        case!(
+            ProviderError::routing_error(p, Vec::new(), m),
+            Unavailable,
+            503,
+            false
+        );
+        case!(
+            ProviderError::transformation_error(p, m, m, m),
+            Parsing,
+            500,
+            false
+        );
+        case!(
+            ProviderError::cancelled(p, m, None),
+            InvalidRequest,
+            499,
+            false
+        );
+        case!(
+            ProviderError::streaming_error(p, m, None, None, m),
+            Internal,
+            502,
+            true
+        );
+        case!(ProviderError::other(p, m), Internal, 502, false);
     }
 }

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -131,7 +131,7 @@ use crate::core::types::{
 };
 use crate::core::types::{context::RequestContext, model::ProviderCapability};
 pub use contextual_error::ContextualError;
-pub use failure::{ProviderFailureFacts, ProviderFailureKind, ProviderRetryHint};
+pub use failure::{ProviderFailureFacts, ProviderRetryHint};
 pub use provider_registry::ProviderRegistry;
 pub use unified_provider::ProviderError;
 

--- a/src/core/providers/unified_provider_http_mapping.rs
+++ b/src/core/providers/unified_provider_http_mapping.rs
@@ -299,10 +299,9 @@ const fn facts(
 }
 
 const fn valid_status_or_bad_gateway(status: u16) -> u16 {
-    if status >= 100 && status < 1000 {
-        status
-    } else {
-        502
+    match status {
+        400..=599 => status,
+        _ => 502,
     }
 }
 

--- a/src/core/providers/unified_provider_methods.rs
+++ b/src/core/providers/unified_provider_methods.rs
@@ -1,4 +1,6 @@
-use super::{ContextualError, ProviderError};
+use super::{ContextualError, ProviderError, ProviderHttpErrorFacts, provider_http_error_facts};
+use crate::core::providers::failure::ProviderFailureFacts;
+use crate::utils::error::{CanonicalError, ErrorCode};
 
 impl ProviderError {
     fn bedrock_modeled_retry_provider() -> &'static str {
@@ -372,99 +374,24 @@ impl ProviderError {
 
     /// Check if this error is retryable
     pub fn is_retryable(&self) -> bool {
-        match self {
-            Self::Network { .. }
-            | Self::Timeout { .. }
-            | Self::RateLimit { .. }
-            | Self::ProviderUnavailable { .. } => true,
-
-            // API errors depend on status code
-            Self::ApiError { status, .. } => {
-                self.is_bedrock_modeled_retry_error() || matches!(*status, 429 | 500..=599)
-            }
-
-            // Deployment errors might be retryable depending on the issue
-            Self::DeploymentError { .. } => true,
-
-            // Streaming errors are typically retryable
-            Self::Streaming { .. } => true,
-
-            // Content filtered might be retryable with prompt changes
-            Self::ContentFiltered { potentially_retryable, .. } => {
-                potentially_retryable.unwrap_or(false)
-            },
-
-            // All other errors are not retryable
-            Self::Authentication { .. }
-            | Self::QuotaExceeded { .. }
-            | Self::ModelNotFound { .. }
-            | Self::InvalidRequest { .. }
-            | Self::NotSupported { .. }
-            | Self::NotImplemented { .. }
-            | Self::Configuration { .. }
-            | Self::Serialization { .. }
-            | Self::ContextLengthExceeded { .. }
-            | Self::TokenLimitExceeded { .. }
-            | Self::FeatureDisabled { .. }
-            | Self::ResponseParsing { .. }
-            | Self::RoutingError { .. }
-            | Self::TransformationError { .. }
-            | Self::Cancelled { .. } // User cancelled, don't retry
-            | Self::Other { .. } => false,
-        }
+        ProviderFailureFacts::from_error(self).legacy_retryable
     }
 
     /// Get retry delay in seconds
     pub fn retry_delay(&self) -> Option<u64> {
-        match self {
-            Self::RateLimit { retry_after, .. } => *retry_after,
-            Self::Network { .. } | Self::Timeout { .. } => Some(1),
-            Self::ProviderUnavailable { .. } => Some(5),
+        ProviderFailureFacts::from_error(self)
+            .legacy_retry_delay
+            .map(|delay| delay.as_secs())
+    }
 
-            // API errors with 429 (rate limit) or 5xx get retry delays
-            Self::ApiError { status, .. } => match *status {
-                424 if self.is_bedrock_modeled_retry_error() => Some(3),
-                429 => Some(60),      // Rate limit, wait longer
-                500..=599 => Some(3), // Server errors, shorter delay
-                _ => None,
-            },
+    /// Canonical closed-set classification for protocol adapters.
+    pub fn canonical_code(&self) -> ErrorCode {
+        CanonicalError::canonical_code(self)
+    }
 
-            // Deployment errors get a retry delay
-            Self::DeploymentError { .. } => Some(5),
-
-            // Streaming errors get a shorter retry delay
-            Self::Streaming { .. } => Some(2),
-
-            // Content filtered - conditional retry
-            Self::ContentFiltered {
-                potentially_retryable,
-                ..
-            } => {
-                if potentially_retryable.unwrap_or(false) {
-                    Some(10) // Allow time for prompt modification
-                } else {
-                    None
-                }
-            }
-
-            // All other errors have no retry delay
-            Self::Authentication { .. }
-            | Self::QuotaExceeded { .. }
-            | Self::ModelNotFound { .. }
-            | Self::InvalidRequest { .. }
-            | Self::NotSupported { .. }
-            | Self::NotImplemented { .. }
-            | Self::Configuration { .. }
-            | Self::Serialization { .. }
-            | Self::ContextLengthExceeded { .. }
-            | Self::TokenLimitExceeded { .. }
-            | Self::FeatureDisabled { .. }
-            | Self::ResponseParsing { .. }
-            | Self::RoutingError { .. }
-            | Self::TransformationError { .. }
-            | Self::Cancelled { .. }
-            | Self::Other { .. } => None,
-        }
+    /// Canonical HTTP facts for protocol adapters.
+    pub fn http_facts(&self) -> ProviderHttpErrorFacts {
+        provider_http_error_facts(self)
     }
 
     /// Create an error with request context for better debugging.

--- a/src/core/router/retry_policy.rs
+++ b/src/core/router/retry_policy.rs
@@ -4,7 +4,7 @@ use super::config::RouterConfig;
 use super::deployment::DeploymentConfig;
 use super::execution::{calculate_retry_delay, calculate_retry_delay_for_schedule};
 use crate::core::providers::ProviderError;
-use crate::core::providers::failure::{ProviderFailureFacts, ProviderFailureKind};
+use crate::core::providers::failure::ProviderFailureFacts;
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -169,7 +169,6 @@ impl RetryPolicy {
         F: FnOnce() -> Duration,
     {
         let facts = ProviderFailureFacts::from_error(error);
-        let explicitly_retryable = error.is_bedrock_modeled_retry_error();
 
         if context.attempt >= context.max_attempts {
             return RetryDecision::stop(RetryDecisionReason::AttemptsExhausted);
@@ -187,7 +186,7 @@ impl RetryPolicy {
             return RetryDecision::stop(RetryDecisionReason::NonIdempotentRequest);
         }
 
-        if !failure_is_retryable(facts, context, explicitly_retryable) {
+        if !failure_is_retryable(facts, context) {
             return RetryDecision::stop(RetryDecisionReason::NonRetryableFailure);
         }
 
@@ -203,26 +202,15 @@ impl RetryPolicy {
     }
 }
 
-fn failure_is_retryable(
-    facts: ProviderFailureFacts,
-    context: RetryContext,
-    explicitly_retryable: bool,
-) -> bool {
-    match facts.kind {
-        ProviderFailureKind::RateLimit
-        | ProviderFailureKind::Timeout
-        | ProviderFailureKind::ProviderUnavailable
-        | ProviderFailureKind::Network
-        | ProviderFailureKind::DeploymentError => true,
-        ProviderFailureKind::ApiError => facts.upstream_status.is_some_and(|status| {
-            explicitly_retryable || status == 429 || (500..=599).contains(&status)
-        }),
-        ProviderFailureKind::Streaming => {
-            context.operation == RetryOperation::Streaming
-                && context.stream_stage == StreamRetryStage::BeforeFirstChunk
-        }
-        _ => false,
+fn failure_is_retryable(facts: ProviderFailureFacts, context: RetryContext) -> bool {
+    if facts.cancelled {
+        return false;
     }
+    if facts.streaming_failure {
+        return context.operation == RetryOperation::Streaming
+            && context.stream_stage == StreamRetryStage::BeforeFirstChunk;
+    }
+    facts.retry_candidate
 }
 
 #[cfg(test)]

--- a/src/utils/error/canonical.rs
+++ b/src/utils/error/canonical.rs
@@ -79,15 +79,14 @@ impl CanonicalError for ProviderError {
             | ProviderError::ContextLengthExceeded { .. }
             | ProviderError::ContentFiltered { .. }
             | ProviderError::TokenLimitExceeded { .. }
-            | ProviderError::FeatureDisabled { .. }
             | ProviderError::Cancelled { .. } => ErrorCode::InvalidRequest,
             ProviderError::Network { .. } => ErrorCode::Network,
             ProviderError::ProviderUnavailable { .. } | ProviderError::RoutingError { .. } => {
                 ErrorCode::Unavailable
             }
-            ProviderError::NotSupported { .. } | ProviderError::NotImplemented { .. } => {
-                ErrorCode::NotImplemented
-            }
+            ProviderError::NotSupported { .. }
+            | ProviderError::NotImplemented { .. }
+            | ProviderError::FeatureDisabled { .. } => ErrorCode::NotImplemented,
             ProviderError::Configuration { .. } => ErrorCode::Configuration,
             ProviderError::Serialization { .. }
             | ProviderError::ResponseParsing { .. }


### PR DESCRIPTION
## Summary

- remove the mirrored `ProviderFailureKind` taxonomy and retain canonical, HTTP, and retry-only facts in one exhaustive `ProviderError` match
- make `RetryPolicy::decide` consume typed facts plus `RetryContext`, including 408, modeled Bedrock 424, cancellation, and pre/post-output stream behavior
- restrict passthrough API status codes to 400..=599 and align `FeatureDisabled` with the approved canonical mapping
- preserve the existing context-free compatibility helper behavior by delegating it to the typed facts; SDK conversion and redaction remain unchanged for T023

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --locked utils::error` (325 passed)
- `cargo test --all-features --locked core::router::retry_policy` (10 passed)
- `cargo test --all-features --locked variant_table_locks_canonical_http_and_stream_retry_facts` (1 passed)
- `cargo test --all-features --locked` (full suite and doctests passed)
- `ProviderFailureKind` source guard: zero matches under `src`
- scope: 6 files / 460 changed lines; overlap guard: no open PRs

Refs #965
