### PR TITLE
refactor(errors): add canonical provider redaction (T023a)

### DIFF
--- a/src/core/providers/unified_provider_methods.rs
+++ b/src/core/providers/unified_provider_methods.rs
@@ -1,6 +1,114 @@
 use super::{ContextualError, ProviderError, ProviderHttpErrorFacts, provider_http_error_facts};
 use crate::core::providers::failure::ProviderFailureFacts;
 use crate::utils::error::{CanonicalError, ErrorCode};
+use regex::Regex;
+use std::sync::OnceLock;
+use url::Url;
+
+const REDACTED: &str = "[REDACTED]";
+
+fn compiled_regex<'a>(cell: &'a OnceLock<Option<Regex>>, pattern: &str) -> Option<&'a Regex> {
+    cell.get_or_init(|| Regex::new(pattern).ok()).as_ref()
+}
+
+fn redact_sensitive_text(value: &str) -> String {
+    static URL_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
+    static HEADER_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
+    static AUTH_SCHEME_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
+    static SECRET_PAIR_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
+    static KNOWN_CREDENTIAL_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
+    static JWT_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
+
+    let Some(url_pattern) = compiled_regex(&URL_PATTERN, r#"https?://[^\s<>"']+"#) else {
+        return REDACTED.to_string();
+    };
+    let Some(header_pattern) = compiled_regex(
+        &HEADER_PATTERN,
+        r"(?im)\b(authorization|proxy-authorization|cookie|set-cookie)\s*[:=]\s*[^\r\n]+",
+    ) else {
+        return REDACTED.to_string();
+    };
+    let Some(auth_scheme_pattern) = compiled_regex(
+        &AUTH_SCHEME_PATTERN,
+        r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+",
+    ) else {
+        return REDACTED.to_string();
+    };
+    let Some(secret_pair_pattern) = compiled_regex(
+        &SECRET_PAIR_PATTERN,
+        r#"(?i)(["']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret[_-]?access[_-]?key|private[_-]?key|credential|password|passwd|token|secret|signature|sig)["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;&]+)"#,
+    ) else {
+        return REDACTED.to_string();
+    };
+    let Some(known_credential_pattern) = compiled_regex(
+        &KNOWN_CREDENTIAL_PATTERN,
+        r"\b(?:sk-[A-Za-z0-9_-]{8,}|AIza[A-Za-z0-9_-]{16,}|AKIA[A-Z0-9]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|xox[baprs]-[A-Za-z0-9-]{8,})\b",
+    ) else {
+        return REDACTED.to_string();
+    };
+    let Some(jwt_pattern) = compiled_regex(
+        &JWT_PATTERN,
+        r"\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b",
+    ) else {
+        return REDACTED.to_string();
+    };
+
+    let value = url_pattern
+        .replace_all(value, |captures: &regex::Captures<'_>| {
+            redact_url(&captures[0])
+        })
+        .into_owned();
+    let value = header_pattern
+        .replace_all(&value, |captures: &regex::Captures<'_>| {
+            format!("{}: {REDACTED}", &captures[1])
+        })
+        .into_owned();
+    let value = auth_scheme_pattern
+        .replace_all(&value, |captures: &regex::Captures<'_>| {
+            format!("{} {REDACTED}", &captures[1])
+        })
+        .into_owned();
+    let value = secret_pair_pattern
+        .replace_all(&value, |captures: &regex::Captures<'_>| {
+            format!("{}{REDACTED}", &captures[1])
+        })
+        .into_owned();
+    let value = known_credential_pattern
+        .replace_all(&value, REDACTED)
+        .into_owned();
+    jwt_pattern.replace_all(&value, REDACTED).into_owned()
+}
+
+fn redact_url(candidate: &str) -> String {
+    let core = candidate.trim_end_matches(['.', ',', ';', ')', ']', '}']);
+    let suffix = &candidate[core.len()..];
+    let Ok(mut url) = Url::parse(core) else {
+        return REDACTED.to_string();
+    };
+
+    if !url.username().is_empty() && url.set_username(REDACTED).is_err() {
+        return REDACTED.to_string();
+    }
+    if url.password().is_some() && url.set_password(Some(REDACTED)).is_err() {
+        return REDACTED.to_string();
+    }
+    if url.query().is_some() {
+        let keys = url
+            .query_pairs()
+            .map(|(key, _)| key.into_owned())
+            .collect::<Vec<_>>();
+        url.set_query(None);
+        let mut query = url.query_pairs_mut();
+        for key in keys {
+            query.append_pair(&key, REDACTED);
+        }
+    }
+    if url.fragment().is_some() {
+        url.set_fragment(Some(REDACTED));
+    }
+
+    format!("{url}{suffix}")
+}
 
 impl ProviderError {
     fn bedrock_modeled_retry_provider() -> &'static str {
@@ -389,6 +497,73 @@ impl ProviderError {
         CanonicalError::canonical_code(self)
     }
 
+    /// Return a typed copy safe for logs, protocol adapters, and public errors.
+    ///
+    /// The original variant and non-secret identity/limit fields are preserved.
+    pub fn redacted(&self) -> Self {
+        let mut redacted = self.clone();
+        match &mut redacted {
+            Self::Authentication { message, .. }
+            | Self::QuotaExceeded { message, .. }
+            | Self::InvalidRequest { message, .. }
+            | Self::Network { message, .. }
+            | Self::ProviderUnavailable { message, .. }
+            | Self::Configuration { message, .. }
+            | Self::Serialization { message, .. }
+            | Self::Timeout { message, .. }
+            | Self::ApiError { message, .. }
+            | Self::TokenLimitExceeded { message, .. }
+            | Self::ResponseParsing { message, .. }
+            | Self::Other { message, .. } => {
+                *message = redact_sensitive_text(message);
+            }
+            Self::RateLimit { message, .. } => {
+                *message = redact_sensitive_text(message);
+            }
+            Self::ContentFiltered {
+                reason,
+                policy_violations,
+                ..
+            } => {
+                *reason = redact_sensitive_text(reason);
+                if let Some(violations) = policy_violations {
+                    for violation in violations {
+                        *violation = redact_sensitive_text(violation);
+                    }
+                }
+            }
+            Self::DeploymentError { message, .. }
+            | Self::RoutingError { message, .. }
+            | Self::TransformationError { message, .. } => {
+                *message = redact_sensitive_text(message);
+            }
+            Self::Cancelled {
+                cancellation_reason,
+                ..
+            } => {
+                if let Some(reason) = cancellation_reason {
+                    *reason = redact_sensitive_text(reason);
+                }
+            }
+            Self::Streaming {
+                last_chunk,
+                message,
+                ..
+            } => {
+                if let Some(chunk) = last_chunk {
+                    *chunk = redact_sensitive_text(chunk);
+                }
+                *message = redact_sensitive_text(message);
+            }
+            Self::ModelNotFound { .. }
+            | Self::NotSupported { .. }
+            | Self::NotImplemented { .. }
+            | Self::ContextLengthExceeded { .. }
+            | Self::FeatureDisabled { .. } => {}
+        }
+        redacted
+    }
+
     /// Canonical HTTP facts for protocol adapters.
     pub fn http_facts(&self) -> ProviderHttpErrorFacts {
         provider_http_error_facts(self)
@@ -415,5 +590,144 @@ impl ProviderError {
     /// Get HTTP status code for this error
     pub fn http_status(&self) -> u16 {
         super::provider_http_error_facts(self).status
+    }
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    const RAW_KEY: &str = "sk-raw-secret-123456789";
+    const RAW_SIGNATURE: &str = "signed-value-123";
+
+    fn assert_secret_absent(error: &ProviderError) {
+        let display = error.to_string();
+        let debug = format!("{error:?}");
+        for raw in [RAW_KEY, RAW_SIGNATURE, "cookie-value", "password-value"] {
+            assert!(!display.contains(raw), "Display leaked {raw}: {display}");
+            assert!(!debug.contains(raw), "Debug leaked {raw}: {debug}");
+        }
+        assert!(display.contains(REDACTED) || debug.contains(REDACTED));
+    }
+
+    #[test]
+    fn redacted_preserves_variant_provider_and_limits() {
+        let error = ProviderError::RateLimit {
+            provider: "openai",
+            message: format!("Authorization: Bearer {RAW_KEY}"),
+            retry_after: Some(7),
+            rpm_limit: Some(60),
+            tpm_limit: Some(1_000),
+            current_usage: Some(0.75),
+        };
+
+        let redacted = error.redacted();
+
+        assert!(matches!(
+            redacted,
+            ProviderError::RateLimit {
+                provider: "openai",
+                retry_after: Some(7),
+                rpm_limit: Some(60),
+                tpm_limit: Some(1_000),
+                current_usage: Some(0.75),
+                ..
+            }
+        ));
+        assert_eq!(redacted.canonical_code(), error.canonical_code());
+        assert_secret_absent(&redacted);
+    }
+
+    #[test]
+    fn redacted_covers_url_userinfo_signed_query_and_known_patterns() {
+        let error = ProviderError::authentication(
+            "openai",
+            format!(
+                "request https://user:password-value@example.com/v1?X-Amz-Signature={RAW_SIGNATURE}&api_key={RAW_KEY} Cookie: session=cookie-value"
+            ),
+        );
+        let malformed = ProviderError::authentication(
+            "openai",
+            format!("request https://user:password-value@[::1?X-Amz-Signature={RAW_SIGNATURE}"),
+        );
+
+        for redacted in [error.redacted(), malformed.redacted()] {
+            assert!(matches!(
+                redacted,
+                ProviderError::Authentication {
+                    provider: "openai",
+                    ..
+                }
+            ));
+            assert_secret_absent(&redacted);
+        }
+    }
+
+    #[test]
+    fn redacted_covers_reason_and_optional_body_fields() {
+        let content = ProviderError::content_filtered(
+            "vertex_ai",
+            format!("client_secret={RAW_KEY}"),
+            Some(vec![format!("password=password-value; token={RAW_KEY}")]),
+            Some(true),
+        )
+        .redacted();
+        let streaming = ProviderError::streaming_error(
+            "openai",
+            "chat",
+            Some(9),
+            Some(format!(r#"{{"access_token":"{RAW_KEY}"}}"#)),
+            format!("Bearer {RAW_KEY}"),
+        )
+        .redacted();
+        let cancelled =
+            ProviderError::cancelled("openai", "chat", Some(format!("signature={RAW_SIGNATURE}")))
+                .redacted();
+
+        for error in [&content, &streaming, &cancelled] {
+            assert_secret_absent(error);
+        }
+        assert!(matches!(
+            content,
+            ProviderError::ContentFiltered {
+                provider: "vertex_ai",
+                potentially_retryable: Some(true),
+                ..
+            }
+        ));
+        assert!(matches!(
+            streaming,
+            ProviderError::Streaming {
+                provider: "openai",
+                stream_type,
+                position: Some(9),
+                ..
+            } if stream_type == "chat"
+        ));
+    }
+
+    #[test]
+    fn redacted_preserves_model_and_deployment_identity() {
+        let model = ProviderError::model_not_found("openai", "gpt-safe").redacted();
+        let deployment =
+            ProviderError::deployment_error("deployment-safe", format!("api_key={RAW_KEY}"))
+                .redacted();
+
+        assert!(matches!(
+            model,
+            ProviderError::ModelNotFound {
+                provider: "openai",
+                model,
+            } if model == "gpt-safe"
+        ));
+        assert!(matches!(
+            deployment,
+            ProviderError::DeploymentError {
+                provider: "azure",
+                ref deployment,
+                ..
+            } if deployment == "deployment-safe"
+        ));
+        assert_secret_absent(&deployment);
     }
 }

--- a/src/core/providers/unified_provider_methods.rs
+++ b/src/core/providers/unified_provider_methods.rs
@@ -555,11 +555,13 @@ impl ProviderError {
                 }
                 *message = redact_sensitive_text(message);
             }
-            Self::ModelNotFound { .. }
-            | Self::NotSupported { .. }
-            | Self::NotImplemented { .. }
-            | Self::ContextLengthExceeded { .. }
-            | Self::FeatureDisabled { .. } => {}
+            Self::ModelNotFound { model, .. } => *model = redact_sensitive_text(model),
+            Self::NotSupported { feature, .. }
+            | Self::NotImplemented { feature, .. }
+            | Self::FeatureDisabled { feature, .. } => {
+                *feature = redact_sensitive_text(feature);
+            }
+            Self::ContextLengthExceeded { .. } => {}
         }
         redacted
     }
@@ -708,18 +710,24 @@ mod redaction_tests {
 
     #[test]
     fn redacted_preserves_model_and_deployment_identity() {
-        let model = ProviderError::model_not_found("openai", "gpt-safe").redacted();
+        let identities = [
+            ProviderError::model_not_found(
+                "openai",
+                format!("gpt-safe https://example.com?signature={RAW_SIGNATURE}"),
+            ),
+            ProviderError::not_supported("openai", format!("audio-safe Authorization: {RAW_KEY}")),
+            ProviderError::not_implemented("openai", "batch-safe Cookie: session=cookie-value"),
+            ProviderError::feature_disabled("vertex_ai", "vision-safe password=password-value"),
+        ];
+        let redacted = identities.map(|error| error.redacted());
+        let combined = ProviderError::other("identity", format!("{redacted:?}"));
         let deployment =
             ProviderError::deployment_error("deployment-safe", format!("api_key={RAW_KEY}"))
                 .redacted();
 
-        assert!(matches!(
-            model,
-            ProviderError::ModelNotFound {
-                provider: "openai",
-                model,
-            } if model == "gpt-safe"
-        ));
+        for safe in ["gpt-safe", "audio-safe", "batch-safe", "vision-safe"] {
+            assert!(combined.to_string().contains(safe));
+        }
         assert!(matches!(
             deployment,
             ProviderError::DeploymentError {
@@ -728,6 +736,7 @@ mod redaction_tests {
                 ..
             } if deployment == "deployment-safe"
         ));
+        assert_secret_absent(&combined);
         assert_secret_absent(&deployment);
     }
 }

--- a/src/core/providers/unified_provider_methods.rs
+++ b/src/core/providers/unified_provider_methods.rs
@@ -19,12 +19,12 @@ fn redact_sensitive_text(value: &str) -> String {
     static KNOWN_CREDENTIAL_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
     static JWT_PATTERN: OnceLock<Option<Regex>> = OnceLock::new();
 
-    let Some(url_pattern) = compiled_regex(&URL_PATTERN, r#"https?://[^\s<>"']+"#) else {
+    let Some(url_pattern) = compiled_regex(&URL_PATTERN, r#"(?i)https?://[^\s<>"']+"#) else {
         return REDACTED.to_string();
     };
     let Some(header_pattern) = compiled_regex(
         &HEADER_PATTERN,
-        r"(?im)\b(authorization|proxy-authorization|cookie|set-cookie)\s*[:=]\s*[^\r\n]+",
+        r#"(?im)\b(authorization|proxy-authorization|cookie|set-cookie)["']?\s*[:=]\s*[^\r\n]+"#,
     ) else {
         return REDACTED.to_string();
     };
@@ -643,7 +643,7 @@ mod redaction_tests {
         let error = ProviderError::authentication(
             "openai",
             format!(
-                "request https://user:password-value@example.com/v1?X-Amz-Signature={RAW_SIGNATURE}&api_key={RAW_KEY} Cookie: session=cookie-value"
+                r#"request HTTPS://user:password-value@example.com/v1?X-Amz-Signature={RAW_SIGNATURE} debug={{"Cookie":"session=cookie-value","Authorization":"ApiKey password-value"}}"#
             ),
         );
         let malformed = ProviderError::authentication(

--- a/src/sdk/errors.rs
+++ b/src/sdk/errors.rs
@@ -2,6 +2,8 @@
 
 use thiserror::Error;
 
+use crate::utils::error::ErrorCode;
+
 /// Error
 #[derive(Error, Debug)]
 pub enum SDKError {
@@ -104,56 +106,21 @@ impl From<crate::utils::error::gateway_error::GatewayError> for SDKError {
 
 impl From<crate::core::providers::ProviderError> for SDKError {
     fn from(error: crate::core::providers::ProviderError) -> Self {
-        match error {
-            crate::core::providers::ProviderError::Authentication { message, .. } => {
-                SDKError::AuthError(message)
-            }
-            crate::core::providers::ProviderError::RateLimit { message, .. } => {
-                SDKError::RateLimitError(message)
-            }
-            crate::core::providers::ProviderError::ModelNotFound { model, .. } => {
-                SDKError::ModelNotFound(model)
-            }
-            crate::core::providers::ProviderError::InvalidRequest { message, .. } => {
-                SDKError::InvalidRequest(message)
-            }
-            crate::core::providers::ProviderError::Network { message, .. }
-            | crate::core::providers::ProviderError::Timeout { message, .. } => {
-                SDKError::NetworkError(message)
-            }
-            crate::core::providers::ProviderError::Configuration { message, .. } => {
-                SDKError::ConfigError(message)
-            }
-            crate::core::providers::ProviderError::ApiError {
-                message, status, ..
-            } => SDKError::ApiError(format!("HTTP {}: {}", status, message)),
-            crate::core::providers::ProviderError::NotSupported { feature, .. }
-            | crate::core::providers::ProviderError::NotImplemented { feature, .. }
-            | crate::core::providers::ProviderError::FeatureDisabled { feature, .. } => {
-                SDKError::NotSupported(feature)
-            }
-            crate::core::providers::ProviderError::ContentFiltered { reason, .. } => {
-                SDKError::InvalidRequest(reason)
-            }
-            crate::core::providers::ProviderError::ContextLengthExceeded {
-                max, actual, ..
-            } => SDKError::InvalidRequest(format!(
-                "Context length exceeded: max {} tokens, got {} tokens",
-                max, actual
-            )),
-            crate::core::providers::ProviderError::QuotaExceeded { .. }
-            | crate::core::providers::ProviderError::ProviderUnavailable { .. }
-            | crate::core::providers::ProviderError::Serialization { .. }
-            | crate::core::providers::ProviderError::TokenLimitExceeded { .. }
-            | crate::core::providers::ProviderError::DeploymentError { .. }
-            | crate::core::providers::ProviderError::ResponseParsing { .. }
-            | crate::core::providers::ProviderError::RoutingError { .. }
-            | crate::core::providers::ProviderError::TransformationError { .. }
-            | crate::core::providers::ProviderError::Cancelled { .. }
-            | crate::core::providers::ProviderError::Streaming { .. }
-            | crate::core::providers::ProviderError::Other { .. } => {
-                SDKError::ProviderError(error.to_string())
-            }
+        let redacted = error.redacted();
+        let code = redacted.canonical_code();
+        let message = redacted.to_string();
+
+        match code {
+            ErrorCode::Authentication | ErrorCode::Authorization => SDKError::AuthError(message),
+            ErrorCode::RateLimited | ErrorCode::QuotaExceeded => SDKError::RateLimitError(message),
+            ErrorCode::InvalidRequest | ErrorCode::Conflict => SDKError::InvalidRequest(message),
+            ErrorCode::NotFound => SDKError::ModelNotFound(message),
+            ErrorCode::Timeout | ErrorCode::Network => SDKError::NetworkError(message),
+            ErrorCode::Unavailable => SDKError::ProviderError(message),
+            ErrorCode::Configuration => SDKError::ConfigError(message),
+            ErrorCode::Parsing => SDKError::ParseError(message),
+            ErrorCode::NotImplemented => SDKError::NotSupported(message),
+            ErrorCode::Internal => SDKError::Internal(message),
         }
     }
 }
@@ -189,6 +156,27 @@ mod tests {
     use super::*;
     use crate::core::providers::ProviderError;
     use crate::utils::error::gateway_error::GatewayError;
+
+    fn sdk_variant(error: &SDKError) -> &'static str {
+        match error {
+            SDKError::ProviderNotFound(_) => "provider_not_found",
+            SDKError::NoDefaultProvider => "no_default_provider",
+            SDKError::ProviderError(_) => "provider_error",
+            SDKError::ConfigError(_) => "config_error",
+            SDKError::NetworkError(_) => "network_error",
+            SDKError::AuthError(_) => "auth_error",
+            SDKError::RateLimitError(_) => "rate_limit_error",
+            SDKError::ModelNotFound(_) => "model_not_found",
+            SDKError::NotSupported(_) => "not_supported",
+            SDKError::UnsupportedProvider(_) => "unsupported_provider",
+            SDKError::SerializationError(_) => "serialization_error",
+            SDKError::HttpError(_) => "http_error",
+            SDKError::InvalidRequest(_) => "invalid_request",
+            SDKError::Internal(_) => "internal",
+            SDKError::ApiError(_) => "api_error",
+            SDKError::ParseError(_) => "parse_error",
+        }
+    }
 
     // ==================== SDKError Display Tests ====================
 
@@ -279,7 +267,7 @@ mod tests {
     #[test]
     fn test_provider_error_auth_maps_to_sdk_auth_error() {
         let error = SDKError::from(ProviderError::authentication("openai", "bad key"));
-        assert!(matches!(error, SDKError::AuthError(ref msg) if msg == "bad key"));
+        assert!(matches!(error, SDKError::AuthError(ref msg) if msg.contains("bad key")));
     }
 
     #[test]
@@ -291,7 +279,92 @@ mod tests {
     #[test]
     fn test_provider_error_model_not_found_maps_to_sdk_model_not_found() {
         let error = SDKError::from(ProviderError::model_not_found("openai", "gpt-missing"));
-        assert!(matches!(error, SDKError::ModelNotFound(ref model) if model == "gpt-missing"));
+        assert!(
+            matches!(error, SDKError::ModelNotFound(ref message) if message.contains("gpt-missing"))
+        );
+    }
+
+    #[test]
+    fn provider_error_conversion_uses_existing_canonical_categories() {
+        let cases = [
+            (
+                ProviderError::authentication("openai", "bad key"),
+                "auth_error",
+            ),
+            (
+                ProviderError::api_error("openai", 403, "forbidden"),
+                "auth_error",
+            ),
+            (
+                ProviderError::rate_limit("openai", Some(2)),
+                "rate_limit_error",
+            ),
+            (
+                ProviderError::quota_exceeded("openai", "quota"),
+                "rate_limit_error",
+            ),
+            (
+                ProviderError::invalid_request("openai", "invalid"),
+                "invalid_request",
+            ),
+            (
+                ProviderError::api_error("openai", 409, "conflict"),
+                "invalid_request",
+            ),
+            (
+                ProviderError::model_not_found("openai", "missing"),
+                "model_not_found",
+            ),
+            (ProviderError::timeout("openai", "timeout"), "network_error"),
+            (ProviderError::network("openai", "network"), "network_error"),
+            (
+                ProviderError::provider_unavailable("openai", "down"),
+                "provider_error",
+            ),
+            (
+                ProviderError::configuration("openai", "bad config"),
+                "config_error",
+            ),
+            (
+                ProviderError::response_parsing("openai", "bad json"),
+                "parse_error",
+            ),
+            (
+                ProviderError::not_supported("openai", "audio"),
+                "not_supported",
+            ),
+            (ProviderError::other("openai", "other"), "internal"),
+        ];
+
+        for (provider_error, expected) in cases {
+            assert_eq!(
+                sdk_variant(&SDKError::from(provider_error)),
+                expected,
+                "canonical SDK category mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_error_conversion_redacts_display_and_debug() {
+        let raw_key = "sk-sdk-secret-123456789";
+        let raw_signature = "sdk-signed-value";
+        let sdk_error = SDKError::from(ProviderError::api_error(
+            "openai",
+            503,
+            format!(
+                "Authorization: Bearer {raw_key}\nrequest=https://user:password@example.com/v1?X-Amz-Signature={raw_signature}"
+            ),
+        ));
+
+        assert_eq!(sdk_variant(&sdk_error), "provider_error");
+        let display = sdk_error.to_string();
+        let debug = format!("{sdk_error:?}");
+        for raw in [raw_key, raw_signature, "password"] {
+            assert!(!display.contains(raw), "Display leaked {raw}: {display}");
+            assert!(!debug.contains(raw), "Debug leaked {raw}: {debug}");
+        }
+        assert!(display.contains("[REDACTED]") || debug.contains("[REDACTED]"));
     }
 
     // ==================== SDKError is_retryable Tests ====================


### PR DESCRIPTION
## Summary

- add a typed `ProviderError::redacted()` copy that preserves variants and non-secret identity/limit fields
- redact credentials, authorization/cookie headers, signed URL values, known credential patterns, and fail closed for malformed URL-like inputs
- map redacted provider errors into existing `SDKError` categories using canonical `ErrorCode` values

Refs #965

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features --locked`
- `cargo test --all-features --locked redaction_tests -- --test-threads=1`
- `cargo test --all-features --locked provider_error_conversion_ -- --test-threads=1`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir=specs/GH965`
- tech §5 classifier: `ProviderError classifier guard passed: phase=T023a`
- PR scope guard: 2 files / 491 changed lines
- PR overlap guard: no open PR overlap