### PR TITLE
security(webhooks): enforce outbound SSRF policy

### DIFF
--- a/src/core/webhooks/delivery.rs
+++ b/src/core/webhooks/delivery.rs
@@ -159,9 +159,7 @@ impl WebhookManager {
             })?;
 
         let status_code = response.status().as_u16();
-        let response_body = response.text().await.map_err(|_| {
-            GatewayError::Network("Webhook response body could not be read".to_string())
-        })?;
+        let response_body = response.text().await.unwrap_or_default();
 
         delivery.response_status = Some(status_code);
         delivery.response_body = Some(response_body.clone());

--- a/src/core/webhooks/delivery.rs
+++ b/src/core/webhooks/delivery.rs
@@ -33,19 +33,29 @@ impl WebhookManager {
         };
 
         // Process each delivery (without holding the lock)
-        let mut results: Vec<(usize, WebhookDeliveryStatus, Option<String>)> = Vec::new();
+        let mut results: Vec<(
+            usize,
+            WebhookDeliveryStatus,
+            Option<String>,
+            WebhookDelivery,
+        )> = Vec::new();
 
         for (idx, mut delivery, config) in deliveries_to_process {
             let result = self.deliver_webhook_internal(&mut delivery, &config).await;
 
             match result {
                 Ok(_) => {
-                    results.push((idx, WebhookDeliveryStatus::Delivered, None));
+                    results.push((idx, WebhookDeliveryStatus::Delivered, None, delivery));
                 }
                 Err(e) => {
                     delivery.attempts += 1;
                     if delivery.attempts >= config.max_retries {
-                        results.push((idx, WebhookDeliveryStatus::Failed, Some(e.to_string())));
+                        results.push((
+                            idx,
+                            WebhookDeliveryStatus::Failed,
+                            Some(e.to_string()),
+                            delivery,
+                        ));
                     } else {
                         let next_retry = chrono::Utc::now()
                             + chrono::Duration::seconds(config.retry_delay_seconds as i64);
@@ -53,6 +63,7 @@ impl WebhookManager {
                             idx,
                             WebhookDeliveryStatus::Retrying,
                             Some(next_retry.to_rfc3339()),
+                            delivery,
                         ));
                     }
                 }
@@ -62,10 +73,13 @@ impl WebhookManager {
         // Apply results with a single lock acquisition
         {
             let mut data = self.data.write().await;
-            for (idx, status, info) in results {
+            for (idx, status, info, attempted) in results {
                 if let Some(delivery) = data.delivery_queue.get_mut(idx) {
                     delivery.status = status.clone();
                     delivery.last_attempt_at = Some(chrono::Utc::now());
+                    delivery.attempts = attempted.attempts;
+                    delivery.response_status = attempted.response_status;
+                    delivery.response_body = attempted.response_body;
 
                     match status {
                         WebhookDeliveryStatus::Delivered => {
@@ -84,7 +98,6 @@ impl WebhookManager {
                                         .ok()
                                         .map(|dt| dt.with_timezone(&chrono::Utc));
                             }
-                            delivery.attempts += 1;
                         }
                         _ => {}
                     }
@@ -111,6 +124,11 @@ impl WebhookManager {
         let mut request = self
             .client
             .post(&config.url)
+            .map_err(|_| {
+                GatewayError::Network(
+                    "Webhook request rejected by outbound endpoint policy".to_string(),
+                )
+            })?
             .timeout(Duration::from_secs(config.timeout_seconds))
             .header("Content-Type", "application/json")
             .header("User-Agent", "LiteLLM-Gateway/1.0");
@@ -131,10 +149,19 @@ impl WebhookManager {
             .json(&delivery.payload)
             .send()
             .await
-            .map_err(|e| GatewayError::Network(e.to_string()))?;
+            .map_err(|error| {
+                let message = if crate::utils::net::http::ProviderHttpClient::request_error_is_endpoint_policy(&error) {
+                    "Webhook request rejected by outbound endpoint policy"
+                } else {
+                    "Webhook transport request failed"
+                };
+                GatewayError::Network(message.to_string())
+            })?;
 
         let status_code = response.status().as_u16();
-        let response_body = response.text().await.unwrap_or_default();
+        let response_body = response.text().await.map_err(|_| {
+            GatewayError::Network("Webhook response body could not be read".to_string())
+        })?;
 
         delivery.response_status = Some(status_code);
         delivery.response_body = Some(response_body.clone());
@@ -150,15 +177,12 @@ impl WebhookManager {
         }
 
         if (200..300).contains(&status_code) {
-            debug!(
-                "Webhook delivered successfully: {} -> {}",
-                delivery.webhook_id, config.url
-            );
+            debug!("Webhook delivered successfully: {}", delivery.webhook_id);
             Ok(())
         } else {
             Err(GatewayError::Network(format!(
-                "Webhook returned status {}: {}",
-                status_code, response_body
+                "Webhook returned non-success status {}",
+                status_code
             )))
         }
     }

--- a/src/core/webhooks/delivery.rs
+++ b/src/core/webhooks/delivery.rs
@@ -119,6 +119,8 @@ impl WebhookManager {
         config: &WebhookConfig,
     ) -> Result<()> {
         let start_time = std::time::Instant::now();
+        delivery.response_status = None;
+        delivery.response_body = None;
 
         // Prepare request
         let mut request = self

--- a/src/core/webhooks/manager.rs
+++ b/src/core/webhooks/manager.rs
@@ -6,11 +6,10 @@ use super::types::{
     WebhookConfig, WebhookData, WebhookDelivery, WebhookDeliveryStatus, WebhookEventType,
     WebhookPayload, WebhookStats,
 };
-use crate::core::http::outbound::default_outbound_client;
+use crate::core::net::ProviderEndpointPolicy;
 use crate::core::types::context::RequestContext;
 use crate::utils::error::gateway_error::{GatewayError, Result};
-use crate::utils::net::http::create_custom_client;
-use reqwest::Client;
+use crate::utils::net::http::ProviderHttpClient;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,8 +19,8 @@ use uuid::Uuid;
 
 /// Webhook manager
 pub struct WebhookManager {
-    /// HTTP client for webhook requests
-    pub(super) client: Client,
+    /// Public-only HTTP client for webhook requests
+    pub(super) client: ProviderHttpClient,
     /// Consolidated webhook data - single lock for all related state
     pub(super) data: Arc<RwLock<WebhookData>>,
 }
@@ -29,8 +28,13 @@ pub struct WebhookManager {
 impl WebhookManager {
     /// Create a new webhook manager
     pub fn new() -> Result<Self> {
-        let client = create_custom_client(Duration::from_secs(30))
-            .map_err(|e| GatewayError::Network(format!("Failed to create HTTP client: {}", e)))?;
+        let client = ProviderHttpClient::no_redirect(
+            ProviderEndpointPolicy::public_only(),
+            Duration::from_secs(30),
+        )
+        .map_err(|_| {
+            GatewayError::Network("Failed to create policy-bound webhook client".to_string())
+        })?;
 
         Ok(Self {
             client,
@@ -38,38 +42,32 @@ impl WebhookManager {
         })
     }
 
-    /// Create a new webhook manager with default settings, panics on failure
-    /// Use `new()` for fallible construction
-    pub fn new_or_default() -> Self {
-        Self::new().unwrap_or_else(|e| {
-            tracing::error!(
-                "Failed to create WebhookManager: {}, using minimal client",
-                e
-            );
-            // Create a minimal client as fallback
-            Self {
-                client: default_outbound_client().clone(),
-                data: Arc::new(RwLock::new(WebhookData::default())),
-            }
-        })
+    #[cfg(test)]
+    pub(super) fn with_client_for_test(client: ProviderHttpClient) -> Self {
+        Self {
+            client,
+            data: Arc::new(RwLock::new(WebhookData::default())),
+        }
     }
 
     /// Register a webhook
-    pub async fn register_webhook(&self, id: String, config: WebhookConfig) -> Result<()> {
-        info!("Registering webhook: {} -> {}", id, config.url);
-
-        // Validate webhook URL
-        if config.url.is_empty() {
+    pub async fn register_webhook(&self, id: String, mut config: WebhookConfig) -> Result<()> {
+        let url = reqwest::Url::parse(&config.url).map_err(|_| {
+            GatewayError::Validation(
+                "Webhook URL is invalid or disallowed by outbound policy".to_string(),
+            )
+        })?;
+        if !matches!(url.scheme(), "http" | "https")
+            || ProviderEndpointPolicy::public_only()
+                .validate_url_without_resolution(&url)
+                .is_err()
+        {
             return Err(GatewayError::Validation(
-                "Webhook URL cannot be empty".to_string(),
+                "Webhook URL is invalid or disallowed by outbound policy".to_string(),
             ));
         }
-
-        if !config.url.starts_with("http://") && !config.url.starts_with("https://") {
-            return Err(GatewayError::Validation(
-                "Webhook URL must be HTTP or HTTPS".to_string(),
-            ));
-        }
+        config.url = url.to_string();
+        info!("Registering webhook: {}", id);
 
         let mut data = self.data.write().await;
         data.webhooks.insert(id, config);
@@ -191,11 +189,5 @@ impl Clone for WebhookManager {
             client: self.client.clone(),
             data: self.data.clone(),
         }
-    }
-}
-
-impl Default for WebhookManager {
-    fn default() -> Self {
-        Self::new_or_default()
     }
 }

--- a/src/core/webhooks/tests.rs
+++ b/src/core/webhooks/tests.rs
@@ -289,16 +289,11 @@ async fn redirect_is_not_followed_and_status_is_recorded() {
     let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
     assert_eq!(delivery.response_status, Some(302));
     assert_eq!(delivery.response_body.as_deref(), Some(""));
-    let stats = manager.get_stats().await;
-    assert_eq!(stats.failed_deliveries, 1);
+    assert_eq!(manager.get_stats().await.failed_deliveries, 1);
     let logs = String::from_utf8(bytes.lock().expect("log lock").clone()).unwrap();
-    assert!(
-        logs.contains("Webhook delivery failed permanently"),
-        "{logs}"
-    );
+    assert!(logs.contains("failed permanently"), "{logs}");
     for secret in ["source-user", "source-password", "source-secret", "token="] {
         assert!(!logs.contains(secret), "{logs}");
-        assert!(!delivery.response_body.as_deref().unwrap().contains(secret));
     }
 }
 
@@ -321,6 +316,14 @@ async fn retries_revalidate_rebinding_and_never_reach_tripwire() {
         )
         .await
         .unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = tripwire.accept().await?;
+            let _request = read_http_request(&mut stream).await?;
+            stream
+                .write_all(b"HTTP/1.1 503 X\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx")
+                .await?;
+            Ok::<_, io::Error>(tripwire)
+        });
         let manager = WebhookManager::with_client_for_test(client);
         let secret_url = format!(
             "http://rebind-user:rebind-password@rebind.test:{}/hook?token=rebind-secret",
@@ -354,25 +357,27 @@ async fn retries_revalidate_rebinding_and_never_reach_tripwire() {
             assert!(!error.to_string().contains(secret), "{error}");
         }
         manager.process_delivery_queue().await.unwrap();
+        let tripwire = server.await.unwrap().unwrap();
         let retrying = manager.get_delivery_history(Some(1)).await.remove(0);
         assert_eq!(
             retrying.status,
             super::types::WebhookDeliveryStatus::Retrying
         );
         assert_eq!(retrying.attempts, 1);
+        assert_eq!(retrying.response_status, Some(503));
+        assert_eq!(retrying.response_body.as_deref(), Some("x"));
         assert_eq!(manager.get_stats().await.failed_deliveries, 0);
         manager.process_delivery_queue().await.unwrap();
         assert_listener_did_not_accept(&tripwire, "rebinding retry target").await;
         let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
         assert_eq!(delivery.status, super::types::WebhookDeliveryStatus::Failed);
         assert_eq!(delivery.attempts, 2);
+        assert_eq!(delivery.response_status, None);
+        assert_eq!(delivery.response_body, None);
         assert_eq!(manager.get_stats().await.failed_deliveries, 1);
     }
     let logs = String::from_utf8(bytes.lock().expect("log lock").clone()).unwrap();
-    assert!(
-        logs.contains("Webhook delivery failed permanently"),
-        "{logs}"
-    );
+    assert!(logs.contains("failed permanently"), "{logs}");
     for secret in ["rebind-user", "rebind-password", "rebind-secret", "token="] {
         assert!(!logs.contains(secret), "{logs}");
     }

--- a/src/core/webhooks/tests.rs
+++ b/src/core/webhooks/tests.rs
@@ -5,70 +5,38 @@
 #[cfg(test)]
 use super::manager::WebhookManager;
 use super::types::{WebhookConfig, WebhookEventType, WebhookPayload};
-use crate::core::net::{
-    ProviderEndpointAccess, ProviderEndpointPolicy, is_provider_endpoint_ip_allowed,
-};
+use crate::core::net::ProviderEndpointPolicy;
 use crate::utils::net::http::ProviderHttpClient;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use std::collections::{HashMap, VecDeque};
 use std::io::{self, Write};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-#[derive(Debug)]
-enum DnsAnswer {
-    Allow(SocketAddr),
-    Reject(IpAddr),
-}
-
 #[derive(Clone)]
 struct SequenceDnsResolver {
-    answers: Arc<Mutex<VecDeque<DnsAnswer>>>,
-    queries: Arc<Mutex<Vec<String>>>,
+    answers: Arc<Mutex<VecDeque<SocketAddr>>>,
 }
 
 impl SequenceDnsResolver {
-    fn new(answers: impl IntoIterator<Item = DnsAnswer>) -> Self {
+    fn new(answers: impl IntoIterator<Item = SocketAddr>) -> Self {
         Self {
             answers: Arc::new(Mutex::new(answers.into_iter().collect())),
-            queries: Arc::new(Mutex::new(Vec::new())),
         }
-    }
-
-    fn queries(&self) -> Vec<String> {
-        self.queries.lock().expect("queries lock").clone()
     }
 }
 
 impl Resolve for SequenceDnsResolver {
-    fn resolve(&self, name: Name) -> Resolving {
-        self.queries
-            .lock()
-            .expect("queries lock")
-            .push(name.as_str().to_string());
+    fn resolve(&self, _name: Name) -> Resolving {
         let answer = self
             .answers
             .lock()
             .expect("answers lock")
             .pop_front()
             .expect("test resolver answer");
-        Box::pin(async move {
-            match answer {
-                DnsAnswer::Allow(address) => Ok(Box::new(std::iter::once(address)) as Addrs),
-                DnsAnswer::Reject(ip) => {
-                    assert!(!is_provider_endpoint_ip_allowed(
-                        ProviderEndpointAccess::PublicOnly,
-                        &ip
-                    ));
-                    Err(Box::new(io::Error::other(
-                        "Host resolves to a disallowed address (SSRF protection)",
-                    ))
-                        as Box<dyn std::error::Error + Send + Sync>)
-                }
-            }
-        })
+        Box::pin(async move { Ok(Box::new(std::iter::once(answer)) as Addrs) })
     }
 }
 
@@ -116,23 +84,6 @@ async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<Str
         }
     }
     String::from_utf8(request).map_err(io::Error::other)
-}
-
-async fn write_http_response(
-    stream: &mut tokio::net::TcpStream,
-    status: &str,
-    headers: &str,
-    body: &str,
-) -> io::Result<()> {
-    stream
-        .write_all(
-            format!(
-                "HTTP/1.1 {status}\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                body.len()
-            )
-            .as_bytes(),
-        )
-        .await
 }
 
 #[derive(Clone)]
@@ -228,38 +179,10 @@ async fn webhook_registration_rejects_private_and_reserved_targets() {
 }
 
 #[tokio::test]
-async fn registration_errors_and_logs_redact_url_secrets() {
-    let bytes = Arc::new(Mutex::new(Vec::new()));
-    let subscriber = tracing_subscriber::fmt()
-        .without_time()
-        .with_ansi(false)
-        .with_writer(CapturedLogs(bytes.clone()))
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
-    let manager = WebhookManager::new().unwrap();
-    let secret_url = "http://admin:password@127.0.0.1/hook?token=query-secret";
-    let error = manager
-        .register_webhook(
-            "redacted".to_string(),
-            WebhookConfig {
-                url: secret_url.to_string(),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect_err("private URL with secrets must be rejected");
-    let logs = String::from_utf8(bytes.lock().expect("log lock").clone()).unwrap();
-    for secret in ["admin", "password", "query-secret", "token="] {
-        assert!(!error.to_string().contains(secret), "{error}");
-        assert!(!logs.contains(secret), "{logs}");
-    }
-}
-
-#[tokio::test]
 async fn legal_delivery_preserves_payload_headers_signature_and_stats() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
-    let resolver = Arc::new(SequenceDnsResolver::new([DnsAnswer::Allow(address)]));
+    let resolver = Arc::new(SequenceDnsResolver::new([address]));
     let manager = manager_with_resolver(resolver.clone());
     let (request_tx, request_rx) = tokio::sync::oneshot::channel();
     let server = tokio::spawn(async move {
@@ -268,7 +191,11 @@ async fn legal_delivery_preserves_payload_headers_signature_and_stats() {
         request_tx
             .send(request)
             .map_err(|_| io::Error::other("request receiver dropped"))?;
-        write_http_response(&mut stream, "202 Accepted", "", "accepted").await
+        stream
+            .write_all(
+                b"HTTP/1.1 202 Accepted\r\nContent-Length: 100\r\nConnection: close\r\n\r\nx",
+            )
+            .await
     });
     let mut headers = HashMap::new();
     headers.insert("X-Custom".to_string(), "expected".to_string());
@@ -304,7 +231,6 @@ async fn legal_delivery_preserves_payload_headers_signature_and_stats() {
     assert!(request.contains("x-custom: expected"));
     assert!(request.contains(&format!("x-webhook-signature: {}", expected_signature)));
     assert!(request.contains("\"model\":\"gpt-test\""));
-    assert_eq!(resolver.queries(), ["webhook.test"]);
     let stats = manager.get_stats().await;
     assert_eq!(stats.successful_deliveries, 1);
     assert_eq!(stats.failed_deliveries, 0);
@@ -312,31 +238,40 @@ async fn legal_delivery_preserves_payload_headers_signature_and_stats() {
 
 #[tokio::test]
 async fn redirect_is_not_followed_and_status_is_recorded() {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_writer(CapturedLogs(bytes.clone()))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
     let source = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let source_address = source.local_addr().unwrap();
     let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let target_address = target.local_addr().unwrap();
-    let resolver = Arc::new(SequenceDnsResolver::new([DnsAnswer::Allow(source_address)]));
+    let resolver = Arc::new(SequenceDnsResolver::new([source_address]));
     let manager = manager_with_resolver(resolver.clone());
     let server = tokio::spawn(async move {
         let (mut stream, _) = source.accept().await?;
         let _request = read_http_request(&mut stream).await?;
-        write_http_response(
-            &mut stream,
-            "302 Found",
-            &format!(
-                "Location: http://redirect.test:{}/private?token=redirect-secret\r\n",
-                target_address.port()
-            ),
-            "",
-        )
-        .await
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://redirect.test:{}/private?token=redirect-secret\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    target_address.port()
+                )
+                .as_bytes(),
+            )
+            .await
     });
     manager
         .register_webhook(
             "redirect".to_string(),
             WebhookConfig {
-                url: format!("http://source.test:{}/hook", source_address.port()),
+                url: format!(
+                    "http://source-user:source-password@source.test:{}/hook?token=source-secret",
+                    source_address.port()
+                ),
                 events: vec![WebhookEventType::RequestFailed],
                 max_retries: 1,
                 ..Default::default()
@@ -351,37 +286,55 @@ async fn redirect_is_not_followed_and_status_is_recorded() {
     manager.process_delivery_queue().await.unwrap();
     server.await.unwrap().unwrap();
     assert_listener_did_not_accept(&target, "redirect target").await;
-    assert_eq!(resolver.queries(), ["source.test"]);
     let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
     assert_eq!(delivery.response_status, Some(302));
+    assert_eq!(delivery.response_body.as_deref(), Some(""));
     let stats = manager.get_stats().await;
     assert_eq!(stats.failed_deliveries, 1);
+    let logs = String::from_utf8(bytes.lock().expect("log lock").clone()).unwrap();
+    assert!(
+        logs.contains("Webhook delivery failed permanently"),
+        "{logs}"
+    );
+    for secret in ["source-user", "source-password", "source-secret", "token="] {
+        assert!(!logs.contains(secret), "{logs}");
+        assert!(!delivery.response_body.as_deref().unwrap().contains(secret));
+    }
 }
 
 #[tokio::test]
 async fn retries_revalidate_rebinding_and_never_reach_tripwire() {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_writer(CapturedLogs(bytes.clone()))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
     for blocked_ip in ["127.0.0.1", "10.0.0.1", "169.254.169.254", "fd00::1"] {
-        let source = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let source_address = source.local_addr().unwrap();
         let tripwire = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let resolver = Arc::new(SequenceDnsResolver::new([
-            DnsAnswer::Allow(source_address),
-            DnsAnswer::Reject(blocked_ip.parse().unwrap()),
-        ]));
-        let manager = manager_with_resolver(resolver.clone());
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = source.accept().await?;
-            let _request = read_http_request(&mut stream).await?;
-            write_http_response(&mut stream, "503 Unavailable", "", "retry").await
-        });
+        let tripwire_address = tripwire.local_addr().unwrap();
+        let blocked_address = SocketAddr::new(blocked_ip.parse().unwrap(), tripwire_address.port());
+        let client = ProviderHttpClient::build_public_then_private_tripwire_for_test(
+            blocked_address,
+            tripwire_address,
+        )
+        .await
+        .unwrap();
+        let manager = WebhookManager::with_client_for_test(client);
+        let secret_url = format!(
+            "http://rebind-user:rebind-password@rebind.test:{}/hook?token=rebind-secret",
+            tripwire_address.port()
+        );
         manager
             .register_webhook(
                 "retry".to_string(),
                 WebhookConfig {
-                    url: format!("http://rebind.test:{}/hook", source_address.port()),
+                    url: secret_url,
                     events: vec![WebhookEventType::RequestFailed],
                     max_retries: 2,
                     retry_delay_seconds: 0,
+                    timeout_seconds: 1,
                     ..Default::default()
                 },
             )
@@ -391,14 +344,37 @@ async fn retries_revalidate_rebinding_and_never_reach_tripwire() {
             .send_event(WebhookEventType::RequestFailed, serde_json::json!({}), None)
             .await
             .unwrap();
+        let mut probe = manager.get_delivery_history(Some(1)).await.remove(0);
+        let config = manager.list_webhooks().await["retry"].clone();
+        let error = manager
+            .deliver_webhook_internal(&mut probe, &config)
+            .await
+            .expect_err("private rebind must be rejected during delivery");
+        for secret in ["rebind-user", "rebind-password", "rebind-secret", "token="] {
+            assert!(!error.to_string().contains(secret), "{error}");
+        }
         manager.process_delivery_queue().await.unwrap();
-        server.await.unwrap().unwrap();
+        let retrying = manager.get_delivery_history(Some(1)).await.remove(0);
+        assert_eq!(
+            retrying.status,
+            super::types::WebhookDeliveryStatus::Retrying
+        );
+        assert_eq!(retrying.attempts, 1);
+        assert_eq!(manager.get_stats().await.failed_deliveries, 0);
         manager.process_delivery_queue().await.unwrap();
         assert_listener_did_not_accept(&tripwire, "rebinding retry target").await;
-        assert_eq!(resolver.queries(), ["rebind.test", "rebind.test"]);
         let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
         assert_eq!(delivery.status, super::types::WebhookDeliveryStatus::Failed);
+        assert_eq!(delivery.attempts, 2);
         assert_eq!(manager.get_stats().await.failed_deliveries, 1);
+    }
+    let logs = String::from_utf8(bytes.lock().expect("log lock").clone()).unwrap();
+    assert!(
+        logs.contains("Webhook delivery failed permanently"),
+        "{logs}"
+    );
+    for secret in ["rebind-user", "rebind-password", "rebind-secret", "token="] {
+        assert!(!logs.contains(secret), "{logs}");
     }
 }
 

--- a/src/core/webhooks/tests.rs
+++ b/src/core/webhooks/tests.rs
@@ -5,7 +5,157 @@
 #[cfg(test)]
 use super::manager::WebhookManager;
 use super::types::{WebhookConfig, WebhookEventType, WebhookPayload};
-use std::collections::HashMap;
+use crate::core::net::{
+    ProviderEndpointAccess, ProviderEndpointPolicy, is_provider_endpoint_ip_allowed,
+};
+use crate::utils::net::http::ProviderHttpClient;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use std::collections::{HashMap, VecDeque};
+use std::io::{self, Write};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[derive(Debug)]
+enum DnsAnswer {
+    Allow(SocketAddr),
+    Reject(IpAddr),
+}
+
+#[derive(Clone)]
+struct SequenceDnsResolver {
+    answers: Arc<Mutex<VecDeque<DnsAnswer>>>,
+    queries: Arc<Mutex<Vec<String>>>,
+}
+
+impl SequenceDnsResolver {
+    fn new(answers: impl IntoIterator<Item = DnsAnswer>) -> Self {
+        Self {
+            answers: Arc::new(Mutex::new(answers.into_iter().collect())),
+            queries: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn queries(&self) -> Vec<String> {
+        self.queries.lock().expect("queries lock").clone()
+    }
+}
+
+impl Resolve for SequenceDnsResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        self.queries
+            .lock()
+            .expect("queries lock")
+            .push(name.as_str().to_string());
+        let answer = self
+            .answers
+            .lock()
+            .expect("answers lock")
+            .pop_front()
+            .expect("test resolver answer");
+        Box::pin(async move {
+            match answer {
+                DnsAnswer::Allow(address) => Ok(Box::new(std::iter::once(address)) as Addrs),
+                DnsAnswer::Reject(ip) => {
+                    assert!(!is_provider_endpoint_ip_allowed(
+                        ProviderEndpointAccess::PublicOnly,
+                        &ip
+                    ));
+                    Err(Box::new(io::Error::other(
+                        "Host resolves to a disallowed address (SSRF protection)",
+                    ))
+                        as Box<dyn std::error::Error + Send + Sync>)
+                }
+            }
+        })
+    }
+}
+
+fn manager_with_resolver(resolver: Arc<SequenceDnsResolver>) -> WebhookManager {
+    let client = ProviderHttpClient::build_with_dns_resolver_for_test(
+        ProviderEndpointPolicy::public_only(),
+        Duration::from_secs(30),
+        true,
+        resolver,
+    )
+    .expect("policy client");
+    WebhookManager::with_client_for_test(client)
+}
+
+async fn assert_listener_did_not_accept(listener: &tokio::net::TcpListener, context: &str) {
+    match tokio::time::timeout(Duration::from_millis(100), listener.accept()).await {
+        Err(_) => {}
+        Ok(Ok((_stream, peer))) => panic!("{context}: unexpectedly accepted {peer}"),
+        Ok(Err(error)) => panic!("{context}: listener failed: {error}"),
+    }
+}
+
+async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<String> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    loop {
+        let read = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut buffer))
+            .await
+            .map_err(|_| io::Error::other("request read timed out"))??;
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..read]);
+        let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]).to_ascii_lowercase();
+        let content_length = headers
+            .lines()
+            .find_map(|line| line.strip_prefix("content-length:"))
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        if request.len() >= header_end + 4 + content_length {
+            break;
+        }
+    }
+    String::from_utf8(request).map_err(io::Error::other)
+}
+
+async fn write_http_response(
+    stream: &mut tokio::net::TcpStream,
+    status: &str,
+    headers: &str,
+    body: &str,
+) -> io::Result<()> {
+    stream
+        .write_all(
+            format!(
+                "HTTP/1.1 {status}\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .as_bytes(),
+        )
+        .await
+}
+
+#[derive(Clone)]
+struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+impl Write for CapturedLogs {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("log lock").extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 #[tokio::test]
 async fn test_webhook_manager_creation() {
@@ -32,6 +182,224 @@ async fn test_webhook_registration() {
     let webhooks = manager.list_webhooks().await;
     assert_eq!(webhooks.len(), 1);
     assert!(webhooks.contains_key("test"));
+}
+
+#[tokio::test]
+async fn webhook_registration_rejects_private_and_reserved_targets() {
+    let manager = WebhookManager::new().unwrap();
+
+    for url in [
+        "",
+        " ",
+        "not a url",
+        "file:///tmp/hook",
+        "ftp://example.com/hook",
+        "http://127.0.0.1/webhook",
+        "http://10.0.0.1/webhook",
+        "http://169.254.169.254/latest/meta-data",
+        "http://localhost/webhook",
+        "http://foo.localhost/webhook",
+        "http://internal/webhook",
+        "http://foo.internal/webhook",
+        "http://local/webhook",
+        "http://foo.local/webhook",
+        "http://metadata/webhook",
+        "http://metadata.google.internal/webhook",
+        "http://metadata.goog/webhook",
+        "http://[::1]/webhook",
+        "http://[fd00::1]/webhook",
+        "http://[fe80::1]/webhook",
+        "http://[::ffff:169.254.169.254]/webhook",
+        "http://[64:ff9b::a9fe:a9fe]/webhook",
+    ] {
+        let config = WebhookConfig {
+            url: url.to_string(),
+            events: vec![WebhookEventType::RequestCompleted],
+            ..Default::default()
+        };
+        assert!(
+            manager
+                .register_webhook("blocked".to_string(), config)
+                .await
+                .is_err(),
+            "unsafe webhook URL was accepted: {url}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn registration_errors_and_logs_redact_url_secrets() {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_writer(CapturedLogs(bytes.clone()))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let manager = WebhookManager::new().unwrap();
+    let secret_url = "http://admin:password@127.0.0.1/hook?token=query-secret";
+    let error = manager
+        .register_webhook(
+            "redacted".to_string(),
+            WebhookConfig {
+                url: secret_url.to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("private URL with secrets must be rejected");
+    let logs = String::from_utf8(bytes.lock().expect("log lock").clone()).unwrap();
+    for secret in ["admin", "password", "query-secret", "token="] {
+        assert!(!error.to_string().contains(secret), "{error}");
+        assert!(!logs.contains(secret), "{logs}");
+    }
+}
+
+#[tokio::test]
+async fn legal_delivery_preserves_payload_headers_signature_and_stats() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let resolver = Arc::new(SequenceDnsResolver::new([DnsAnswer::Allow(address)]));
+    let manager = manager_with_resolver(resolver.clone());
+    let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await?;
+        let request = read_http_request(&mut stream).await?;
+        request_tx
+            .send(request)
+            .map_err(|_| io::Error::other("request receiver dropped"))?;
+        write_http_response(&mut stream, "202 Accepted", "", "accepted").await
+    });
+    let mut headers = HashMap::new();
+    headers.insert("X-Custom".to_string(), "expected".to_string());
+    manager
+        .register_webhook(
+            "legal".to_string(),
+            WebhookConfig {
+                url: format!("http://webhook.test:{}/hook", address.port()),
+                events: vec![WebhookEventType::RequestCompleted],
+                headers,
+                secret: Some("signing-secret".to_string()),
+                max_retries: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    manager
+        .send_event(
+            WebhookEventType::RequestCompleted,
+            serde_json::json!({"model": "gpt-test"}),
+            None,
+        )
+        .await
+        .unwrap();
+    let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
+    let expected_signature = manager
+        .generate_signature(&delivery.payload, "signing-secret")
+        .unwrap();
+    manager.process_delivery_queue().await.unwrap();
+    server.await.unwrap().unwrap();
+    let request = request_rx.await.unwrap().to_ascii_lowercase();
+    assert!(request.contains("x-custom: expected"));
+    assert!(request.contains(&format!("x-webhook-signature: {}", expected_signature)));
+    assert!(request.contains("\"model\":\"gpt-test\""));
+    assert_eq!(resolver.queries(), ["webhook.test"]);
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.successful_deliveries, 1);
+    assert_eq!(stats.failed_deliveries, 0);
+}
+
+#[tokio::test]
+async fn redirect_is_not_followed_and_status_is_recorded() {
+    let source = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let source_address = source.local_addr().unwrap();
+    let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_address = target.local_addr().unwrap();
+    let resolver = Arc::new(SequenceDnsResolver::new([DnsAnswer::Allow(source_address)]));
+    let manager = manager_with_resolver(resolver.clone());
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = source.accept().await?;
+        let _request = read_http_request(&mut stream).await?;
+        write_http_response(
+            &mut stream,
+            "302 Found",
+            &format!(
+                "Location: http://redirect.test:{}/private?token=redirect-secret\r\n",
+                target_address.port()
+            ),
+            "",
+        )
+        .await
+    });
+    manager
+        .register_webhook(
+            "redirect".to_string(),
+            WebhookConfig {
+                url: format!("http://source.test:{}/hook", source_address.port()),
+                events: vec![WebhookEventType::RequestFailed],
+                max_retries: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    manager
+        .send_event(WebhookEventType::RequestFailed, serde_json::json!({}), None)
+        .await
+        .unwrap();
+    manager.process_delivery_queue().await.unwrap();
+    server.await.unwrap().unwrap();
+    assert_listener_did_not_accept(&target, "redirect target").await;
+    assert_eq!(resolver.queries(), ["source.test"]);
+    let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
+    assert_eq!(delivery.response_status, Some(302));
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.failed_deliveries, 1);
+}
+
+#[tokio::test]
+async fn retries_revalidate_rebinding_and_never_reach_tripwire() {
+    for blocked_ip in ["127.0.0.1", "10.0.0.1", "169.254.169.254", "fd00::1"] {
+        let source = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let source_address = source.local_addr().unwrap();
+        let tripwire = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let resolver = Arc::new(SequenceDnsResolver::new([
+            DnsAnswer::Allow(source_address),
+            DnsAnswer::Reject(blocked_ip.parse().unwrap()),
+        ]));
+        let manager = manager_with_resolver(resolver.clone());
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = source.accept().await?;
+            let _request = read_http_request(&mut stream).await?;
+            write_http_response(&mut stream, "503 Unavailable", "", "retry").await
+        });
+        manager
+            .register_webhook(
+                "retry".to_string(),
+                WebhookConfig {
+                    url: format!("http://rebind.test:{}/hook", source_address.port()),
+                    events: vec![WebhookEventType::RequestFailed],
+                    max_retries: 2,
+                    retry_delay_seconds: 0,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        manager
+            .send_event(WebhookEventType::RequestFailed, serde_json::json!({}), None)
+            .await
+            .unwrap();
+        manager.process_delivery_queue().await.unwrap();
+        server.await.unwrap().unwrap();
+        manager.process_delivery_queue().await.unwrap();
+        assert_listener_did_not_accept(&tripwire, "rebinding retry target").await;
+        assert_eq!(resolver.queries(), ["rebind.test", "rebind.test"]);
+        let delivery = manager.get_delivery_history(Some(1)).await.remove(0);
+        assert_eq!(delivery.status, super::types::WebhookDeliveryStatus::Failed);
+        assert_eq!(manager.get_stats().await.failed_deliveries, 1);
+    }
 }
 
 #[test]

--- a/src/utils/net/http/provider_tests.rs
+++ b/src/utils/net/http/provider_tests.rs
@@ -251,11 +251,10 @@ impl ProviderHttpClient {
         tripwire: SocketAddr,
     ) -> Result<Self, ProviderHttpClientError> {
         let policy = ProviderEndpointPolicy::public_only();
-        let mut answers = vec![vec![blocked_address]; 3];
-        answers.insert(
-            0,
-            vec![SocketAddr::from(([93, 184, 216, 34], tripwire.port()))],
-        );
+        let public_address = SocketAddr::from(([93, 184, 216, 34], tripwire.port()));
+        let mut answers = vec![vec![public_address]; 4];
+        answers[1] = vec![blocked_address];
+        answers[3] = vec![blocked_address];
         let resolver = Arc::new(SequenceResolver::new(answers));
         let priming_resolver = PolicyDnsResolver {
             access: policy.access(),

--- a/src/utils/net/http/provider_tests.rs
+++ b/src/utils/net/http/provider_tests.rs
@@ -246,6 +246,38 @@ impl ProviderHttpClient {
         Ok(Self { client, policy })
     }
 
+    pub(crate) async fn build_public_then_private_tripwire_for_test(
+        blocked_address: SocketAddr,
+        tripwire: SocketAddr,
+    ) -> Result<Self, ProviderHttpClientError> {
+        let policy = ProviderEndpointPolicy::public_only();
+        let mut answers = vec![vec![blocked_address]; 3];
+        answers.insert(
+            0,
+            vec![SocketAddr::from(([93, 184, 216, 34], tripwire.port()))],
+        );
+        let resolver = Arc::new(SequenceResolver::new(answers));
+        let priming_resolver = PolicyDnsResolver {
+            access: policy.access(),
+            resolver: resolver.clone(),
+        };
+        drop(
+            reqwest::dns::Resolve::resolve(
+                &priming_resolver,
+                "rebind.test".parse().expect("valid test hostname"),
+            )
+            .await
+            .expect("public priming answer must pass endpoint policy"),
+        );
+        Self::build_with_rebinding_tripwire_for_test(
+            policy,
+            Duration::from_secs(1),
+            ProviderClientMode::NoRedirect,
+            resolver,
+            tripwire,
+        )
+    }
+
     fn build_with_connector_tripwire_for_test(
         policy: ProviderEndpointPolicy,
         address: SocketAddr,


### PR DESCRIPTION
Refs #1065

## Summary
- bind the core webhook manager to the shared public-only, no-redirect ProviderHttpClient
- fail closed at webhook URL admission and remove generic outbound client fallback paths
- preserve delivery payload, custom headers, HMAC signature, retry/failure state, response status, and statistics
- add deterministic URL, secret-redaction, redirect, legal-delivery, and retry/rebinding regression coverage

## Scope
- SpecRail task: SP1065-T001 only (core/webhooks slice)
- 4 non-document files, 500 changed lines
- no runtime wiring or other webhook sender changes

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked core::webhooks -- --test-threads=1 (40 passed)
- cargo test --all-features --locked -- --test-threads=1
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1065
- scripts/guards/check_pr_scope.sh origin/main (4 files / 500 lines)
- scripts/guards/check_pr_overlap.sh (no overlap)

## Security review
SEC-11 applies. Human security review, exact-head independent review, CI, review-thread resolution, PR gate, and human merge authorization remain required.
