### PR TITLE
feat(observability): wire external lifecycle callbacks

### DIFF
--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -135,6 +135,12 @@ monitoring:
     path: "/health"
     detailed: true
   logging: null
+  # External request lifecycle exporters are opt-in. Backend secrets should be
+  # supplied through environment substitution, never committed literally.
+  callbacks:
+    queue_capacity: 1024
+    timeout_ms: 5000
+    backends: []
 
 cache:
   # NOT YET IMPLEMENTED: the response cache is not wired into the request

--- a/specs/GH1066/product.md
+++ b/specs/GH1066/product.md
@@ -1,0 +1,94 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1066 / #1066
+
+## User Problem
+
+The gateway exposes Prometheus metrics, but its existing OpenTelemetry,
+Datadog, and Langfuse integrations are not connected to startup or to real LLM
+request execution. Operators can configure and import these components without
+receiving request lifecycle data, while integration failures have no explicit
+runtime isolation contract.
+
+## Goals
+
+- Let operators enable OpenTelemetry, Datadog, and Langfuse callback backends
+  through gateway configuration.
+- Emit start and exactly one terminal success/error event for each provider-backed
+  chat, completion, response, and embedding request, including streaming requests.
+- Export request ID, selected provider/model, latency, token usage, cost when
+  pricing is available, and errors without delaying or failing the client request.
+- Provide one reusable callback plugin boundary for built-in and custom backends.
+
+## Non-Goals
+
+- Capturing prompt or generated content; lifecycle events are metadata-only by
+  default.
+- Replacing the existing Prometheus HTTP metrics middleware.
+- Adding new external observability SDK dependencies or changing provider
+  routing, retry, cache, budget, or pricing policy.
+- Instrumenting non-LLM file, batch-management, fine-tuning, image, audio,
+  moderation, or rerank operations in this issue.
+
+## Behavior Invariants
+
+1. `monitoring.callbacks.backends` is empty by default; default gateway behavior
+   and external network activity remain unchanged.
+2. Each configured backend is initialized once at gateway startup. A backend
+   initialization failure is logged with the backend name and does not prevent
+   other backends or the HTTP server from starting.
+3. Built-in and custom callbacks use the same lifecycle contract: one start
+   event followed by exactly one success or error event for each observed
+   provider-backed request.
+4. Callback delivery is ordered per gateway dispatcher and never waits in the
+   client request path. Queue closure or capacity exhaustion is reported as an
+   error log rather than silently dropping data or failing the request.
+5. Success events include the request ID, selected provider/model, elapsed
+   latency, input/output tokens when supplied by the provider, and calculated
+   cost when the existing pricing authority can calculate it. Unavailable data
+   remains absent.
+6. Error events include the request ID, selected provider/model when known,
+   error text, and elapsed latency metadata. Callback failures never replace or
+   alter the original gateway response.
+7. Streaming requests emit one terminal event on normal completion, upstream
+   error, idle timeout, conversion/serialization failure, or client disconnect.
+   They do not emit an early success merely because response headers were sent.
+8. Callback metadata must not include API keys, authorization headers, prompt
+   content, generated content, or configured backend secrets.
+9. Configuration rejects duplicate backend kinds and invalid queue/timeout
+   values before server startup.
+
+## Acceptance Criteria
+
+- [ ] Gateway configuration can enable each of `opentelemetry`, `datadog`, and
+      `langfuse`, while an omitted callback section remains disabled.
+- [ ] Startup tests prove configured backends are registered and one failed
+      backend does not block healthy backends or server construction.
+- [ ] A test integration attached to a real provider-backed request observes
+      ordered start plus success/error events with request ID, provider/model,
+      latency, tokens, and cost when available.
+- [ ] Streaming tests prove normal completion and each terminal failure path
+      emit exactly one terminal event.
+- [ ] Callback backpressure and backend errors are observable but do not change
+      client response status or body.
+- [ ] Prompt/output payloads and secrets are absent from lifecycle fixtures.
+
+## Edge Cases
+
+- A request rejected before provider execution does not emit an LLM start event.
+- A cache hit does not claim a provider execution or fabricate token/cost data.
+- Provider retries still describe one logical request; the terminal event names
+  the final selected target when known.
+- Missing provider usage or pricing produces absent token/cost fields rather
+  than zero or guessed values.
+- Shutdown drains queued callback events and flushes registered backends after
+  the HTTP server stops accepting requests.
+
+## Rollout Notes
+
+The callback section is opt-in. Operators should enable one backend at a time,
+confirm exporter connectivity in logs, and size the queue for peak request
+volume. Reverting the implementation or removing all configured backends
+restores the previous no-export behavior.

--- a/specs/GH1066/tasks.md
+++ b/specs/GH1066/tasks.md
@@ -19,7 +19,7 @@ GH-1066 / #1066
 
 - [x] `SP1066-T4` Covers: P3-P8. Owner: coordinator. Dependencies: T2-T3. Done when: provider-backed chat, completion, response, and embedding unary/streaming paths emit metadata-only start plus exactly one terminal event with selected target, latency, usage/cost when available, and explicit error/disconnect outcomes; cache hits do not fabricate provider events. Verify: focused lifecycle unit tests and real mock-provider route tests for success, provider error, stream completion, stream error, timeout, and disconnect.
 
-- [ ] `SP1066-T5` Covers: all. Owner: verification owner. Dependencies: T1-T4. Done when: focused tests, formatting, build, strict clippy, full test suite, SpecRail workflow/spec checks, scope guard, and overlap guard pass from this worktree with evidence saved under `artifacts/logs/gh1066/`. Verify: commands listed below.
+- [x] `SP1066-T5` Covers: all. Owner: verification owner. Dependencies: T1-T4. Done when: focused tests, formatting, build, strict clippy, full test suite, SpecRail workflow/spec checks, scope guard, and overlap guard pass from this worktree with evidence saved under `artifacts/logs/gh1066/`. Verify: commands listed below.
 
 - [ ] `SP1066-T6` Covers: all acceptance criteria. Owner: coordinator and independent reviewer. Dependencies: T5. Done when: one final-slice `mixed_impl` PR closes #1066; independent exact-head review has no blocking findings; blocking CI wait, GraphQL review-thread query, merge-state check, and `pr_gate.py` are current and green; merge and issue closure are remotely confirmed. Verify: PR/check/gate/merge evidence recorded in the runtime checkpoint.
 

--- a/specs/GH1066/tasks.md
+++ b/specs/GH1066/tasks.md
@@ -1,0 +1,68 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1066 / #1066
+
+## Spec Packet
+
+- Product: `specs/GH1066/product.md`
+- Tech: `specs/GH1066/tech.md`
+
+## Implementation Tasks
+
+- [x] `SP1066-T1` Covers: P1, P9. Owner: coordinator. Dependencies: none. Done when: default-empty typed callback configuration embeds existing OTel/Datadog/Langfuse config types, validates capacity/timeout/backend uniqueness and backend requirements, and the example config documents opt-in use without literal secrets. Verify: focused config model and validator tests; `rg` confirms no duplicate backend config structs.
+
+- [x] `SP1066-T2` Covers: P2-P4 and shutdown. Owner: coordinator. Dependencies: T1. Done when: the bounded callback runtime accepts a public `IntegrationManager`, preserves queue order, reports full/closed queue errors, isolates backend failures, and drains/flushes/shuts down; Langfuse is adapted to the canonical `Integration` trait. Verify: callback runtime, manager, and Langfuse adapter tests.
+
+- [x] `SP1066-T3` Covers: P2. Owner: coordinator. Dependencies: T1-T2. Done when: `HttpServer::new` independently initializes configured backends, logs and skips a failed backend, injects the dispatcher into `AppState`, and `HttpServer::start` drains it after Actix shutdown. Verify: startup registration and partial-failure tests.
+
+- [x] `SP1066-T4` Covers: P3-P8. Owner: coordinator. Dependencies: T2-T3. Done when: provider-backed chat, completion, response, and embedding unary/streaming paths emit metadata-only start plus exactly one terminal event with selected target, latency, usage/cost when available, and explicit error/disconnect outcomes; cache hits do not fabricate provider events. Verify: focused lifecycle unit tests and real mock-provider route tests for success, provider error, stream completion, stream error, timeout, and disconnect.
+
+- [ ] `SP1066-T5` Covers: all. Owner: verification owner. Dependencies: T1-T4. Done when: focused tests, formatting, build, strict clippy, full test suite, SpecRail workflow/spec checks, scope guard, and overlap guard pass from this worktree with evidence saved under `artifacts/logs/gh1066/`. Verify: commands listed below.
+
+- [ ] `SP1066-T6` Covers: all acceptance criteria. Owner: coordinator and independent reviewer. Dependencies: T5. Done when: one final-slice `mixed_impl` PR closes #1066; independent exact-head review has no blocking findings; blocking CI wait, GraphQL review-thread query, merge-state check, and `pr_gate.py` are current and green; merge and issue closure are remotely confirmed. Verify: PR/check/gate/merge evidence recorded in the runtime checkpoint.
+
+## Parallelization
+
+Implementation is serial in the current worktree because config, runtime,
+AppState, and route lifecycle changes are dependent and cargo must not run
+concurrently. The only native parallel lanes are read-only architecture review
+before implementation and an independent exact-head reviewer after the PR is
+pushed.
+
+## Verification
+
+Run focused tests during implementation, then once before PR readiness:
+
+```bash
+cargo fmt --check
+cargo check
+cargo clippy --all-targets -- -D warnings
+cargo test
+python3 checks/check_workflow.py --repo .
+python3 checks/check_workflow.py --repo . --spec-dir specs/GH1066
+bash scripts/guards/check_pr_scope.sh
+bash scripts/guards/check_pr_overlap.sh
+```
+
+After push:
+
+```bash
+gh pr checks <pr> --repo majiayu000/litellm-rs --watch --fail-fast
+```
+
+Then collect current PR evidence, run the repository PR gate serially, merge
+only on an allowed decision, and confirm the merged PR plus closed issue
+remotely.
+
+## Handoff Notes
+
+- `Integration` is the canonical callback boundary; do not add a third trait or
+  an `Any`-typed public hook.
+- Request/exporter failures are independent: callback failure is observable but
+  never replaces the gateway response.
+- No callback event may contain authorization headers, provider/backend
+  credentials, prompt content, or generated content.
+- All cargo commands belong to the current GH1066 worktree and one verification
+  owner.

--- a/specs/GH1066/tech.md
+++ b/specs/GH1066/tech.md
@@ -85,14 +85,14 @@ Add an AI-route lifecycle helper that owns request ID, requested model, start
 instant, dispatcher, and a synchronized final selected target. It emits
 metadata-only canonical events and centralizes terminal-once behavior.
 
-- Unary chat/completion/response and embeddings: enqueue start immediately
-  before provider selection; record the selected provider/pricing identity
-  inside the retryable operation; enqueue success after settlement and error
-  on the returned gateway error.
-- Streaming chat/completion/response: enqueue start before stream creation;
-  move the lifecycle into the existing stream worker; enqueue one success after
-  final usage settlement, or one error on upstream error, idle timeout,
-  conversion/serialization failure, or disconnect.
+- Unary chat/completion/response and embeddings: create a lazy lifecycle before
+  selection, then atomically record the selected provider/pricing identity and
+  enqueue start only inside the provider-call closure after budget admission;
+  enqueue success after settlement and error on a returned provider error.
+- Streaming chat/completion/response: enqueue start in the admitted provider
+  stream-call closure, then move the lifecycle into the existing stream worker;
+  enqueue one success after final usage settlement, or one error on upstream
+  error, idle timeout, conversion/serialization failure, or disconnect.
 - Cache hits return before lifecycle creation and do not fabricate a provider
   callback.
 

--- a/specs/GH1066/tech.md
+++ b/specs/GH1066/tech.md
@@ -1,0 +1,166 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1066 / #1066
+
+## Product Spec
+
+See `specs/GH1066/product.md` (invariants P1-P9).
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Callback contract | `src/core/traits/integration.rs` | `Integration` already defines LLM start/end/error, stream, embedding, flush, and shutdown hooks | Reuse as the single plugin boundary |
+| Dispatcher | `src/core/integrations/manager.rs` | Registers enabled integrations and isolates hook failures with timeout/fail-fast policy, but callers must await it | Needs a non-blocking ordered runtime queue |
+| Built-in exporters | `src/core/integrations/observability/{datadog.rs,opentelemetry/*}` | Both implement `Integration`; neither is constructed by gateway startup | Register from config |
+| Langfuse | `src/core/integrations/langfuse/{logger.rs,config.rs}` | Implements a separate synchronous `LlmCallback`, not `Integration` | Add a translation adapter, not another runtime contract |
+| Configuration | `src/config/models/monitoring.rs`, `src/config/validation/monitoring_validators.rs`, `config/gateway.yaml.example` | Metrics/tracing config exists; no callback backend list or dispatcher settings | Add opt-in typed callback config |
+| Startup/shutdown | `src/server/http.rs`, `src/server/state.rs` | Builds AppState and drains storage/budget workers; no integration runtime | Construct once, inject dispatcher, drain/flush on shutdown |
+| Request lifecycle | `src/server/routes/ai/{chat.rs,chat_streaming.rs,completions*.rs,embeddings.rs,responses*.rs}` | Provider execution, settlement, streaming terminal paths, and request context exist; no external lifecycle events | Emit metadata from the real execution boundaries |
+
+## Proposed Design
+
+### Canonical callback boundary
+
+Keep `crate::core::traits::integration::Integration` as the only runtime plugin
+trait. `IntegrationManager` remains responsible for backend registration,
+per-hook timeout, parallel/sequential backend dispatch, and fail-open error
+isolation. Add `LangfuseIntegration`, which translates canonical lifecycle
+events to the existing `LangfuseLogger` request/response/error DTOs.
+
+### Non-blocking runtime
+
+Add a callback runtime beside `IntegrationManager`:
+
+- `CallbackDispatcher` is cloneable and exposes synchronous `try_send` methods
+  for canonical events.
+- A single bounded Tokio channel preserves enqueue order and prevents request
+  handlers from awaiting exporter I/O.
+- Full/closed queue errors are returned to the caller and logged at the request
+  integration point; they never change the gateway response.
+- `CallbackRuntime` owns the worker, drains queued events on shutdown, then
+  calls manager `flush` and `shutdown`.
+- The runtime accepts an existing `Arc<IntegrationManager>` so embedders and
+  tests can register custom implementations of the public trait.
+
+`IntegrationManagerConfig` is fixed to `fail_fast=false`; configured timeout is
+applied per backend hook. Backend failures are logged by the manager and the
+worker continues.
+
+### Configuration and startup
+
+Extend `MonitoringConfig` with a default-empty `callbacks` object:
+
+```yaml
+monitoring:
+  callbacks:
+    queue_capacity: 1024
+    timeout_ms: 5000
+    backends:
+      - type: opentelemetry
+        config: { ...existing OpenTelemetryConfig fields... }
+      - type: datadog
+        config: { ...existing DataDogConfig fields... }
+      - type: langfuse
+        config: { ...existing LangfuseConfig fields... }
+```
+
+The tagged backend enum embeds the existing backend config types; it does not
+duplicate their fields. Validation enforces positive capacity/timeout, unique
+backend kinds, required credentials/endpoints, valid sampling values, and
+positive batch settings. Secrets continue to use the existing `${ENV_VAR}`
+configuration substitution.
+
+`HttpServer::new` constructs the manager, attempts each backend independently,
+logs initialization failures, starts the runtime if at least one backend was
+registered, and injects the dispatcher into `AppState`. `HttpServer::start`
+shuts the runtime down after the Actix server has stopped and before storage is
+closed.
+
+### Request lifecycle
+
+Add an AI-route lifecycle helper that owns request ID, requested model, start
+instant, dispatcher, and a synchronized final selected target. It emits
+metadata-only canonical events and centralizes terminal-once behavior.
+
+- Unary chat/completion/response and embeddings: enqueue start immediately
+  before provider selection; record the selected provider/pricing identity
+  inside the retryable operation; enqueue success after settlement and error
+  on the returned gateway error.
+- Streaming chat/completion/response: enqueue start before stream creation;
+  move the lifecycle into the existing stream worker; enqueue one success after
+  final usage settlement, or one error on upstream error, idle timeout,
+  conversion/serialization failure, or disconnect.
+- Cache hits return before lifecycle creation and do not fabricate a provider
+  callback.
+
+Token usage comes only from provider usage structures. Cost uses
+`PricingService::calculate_loaded_settlement_cost_for_provider` with the same
+selected pricing identity and usage used by spend settlement; failure to
+calculate is logged and leaves `cost_usd` absent. Event input/output values
+remain null and headers are never copied.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1, P9 | monitoring config + validators | deserialize/default/duplicate/invalid-value unit tests |
+| P2 | server backend builder | registration and partial-initialization-failure tests |
+| P3, P4 | callback runtime + manager | ordered start/terminal, queue-full, closed-queue, failing-backend tests |
+| P5, P6 | AI lifecycle helper + unary routes | real mock-provider success/error tests with metadata assertions |
+| P7 | existing streaming workers | normal/error/timeout/disconnect terminal-once tests |
+| P8 | canonical event fixtures + Langfuse adapter | negative assertions for prompt/output/header/secret values |
+| Shutdown | `HttpServer::start` + callback runtime | deterministic drain/flush/shutdown unit test |
+
+## Data Flow
+
+`GatewayConfig` → validate callback config → construct enabled backends →
+register in `IntegrationManager` → start `CallbackRuntime` →
+inject `CallbackDispatcher` into `AppState` → real provider execution enqueues
+start/terminal metadata → worker invokes integrations → exporter batches send
+externally → graceful shutdown drains, flushes, and stops.
+
+No callback event mutates routing, provider responses, budgets, cache entries,
+or persistent application state.
+
+## Alternatives Considered
+
+- Keep both `Integration` and Langfuse `LlmCallback` as gateway contracts:
+  rejected because it creates two lifecycle sources and inconsistent failure
+  behavior.
+- Await `IntegrationManager` directly in handlers: rejected because exporter
+  timeouts would add latency to the request path.
+- Spawn one task per hook: rejected because start and terminal events can race
+  and task growth is unbounded.
+- Add vendor SDKs: rejected because the repository already contains HTTP
+  exporters and the issue does not require dependency expansion.
+
+## Risks
+
+- Security: lifecycle metadata can still identify users; emit only existing
+  request/user IDs and never headers, API keys, prompt, or output content.
+- Compatibility: the config schema only gains a defaulted optional field;
+  existing configs keep their current behavior.
+- Performance: `try_send` adds a bounded allocation/enqueue on enabled paths;
+  disabled paths are a cheap no-op.
+- Maintenance: route terminal paths can drift; terminal-once helper and source
+  tests keep streaming exits explicit.
+
+## Test Plan
+
+- [ ] Unit tests: callback config, Langfuse adapter mapping, runtime ordering,
+      queue errors, backend error isolation, shutdown drain.
+- [ ] Integration tests: configured startup registration and real mock-provider
+      unary/streaming success/error lifecycle events.
+- [ ] Deterministic verification: focused callback/AI tests, `cargo fmt --check`,
+      `cargo check`, strict clippy, full `cargo test`, SpecRail checks, scope and
+      overlap guards.
+
+## Rollback Plan
+
+Remove all configured callback backends for an operational rollback without
+changing request behavior. A code rollback removes the defaulted config field,
+runtime injection, lifecycle calls, and Langfuse adapter together; provider,
+budget, cache, and pricing behavior remains unchanged.

--- a/src/config/models/monitoring.rs
+++ b/src/config/models/monitoring.rs
@@ -3,6 +3,7 @@
 //! Unified configuration for metrics, tracing, health checks, and logging.
 
 use super::*;
+use crate::core::integrations::{DataDogConfig, LangfuseConfig, OpenTelemetryConfig};
 use serde::{Deserialize, Serialize};
 
 /// Monitoring configuration
@@ -21,6 +22,9 @@ pub struct MonitoringConfig {
     /// Logging configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logging: Option<LoggingConfig>,
+    /// External callback exporter configuration
+    #[serde(default)]
+    pub callbacks: CallbackConfig,
 }
 
 impl MonitoringConfig {
@@ -32,7 +36,72 @@ impl MonitoringConfig {
         if other.logging.is_some() {
             self.logging = other.logging;
         }
+        self.callbacks = self.callbacks.merge(other.callbacks);
         self
+    }
+}
+
+/// Non-blocking external callback dispatcher configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CallbackConfig {
+    /// Maximum lifecycle events waiting for exporter delivery.
+    #[serde(default = "default_callback_queue_capacity")]
+    pub queue_capacity: usize,
+    /// Timeout for each integration callback in milliseconds.
+    #[serde(default = "default_callback_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Enabled callback backends.
+    #[serde(default)]
+    pub backends: Vec<CallbackBackendConfig>,
+}
+
+impl Default for CallbackConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: default_callback_queue_capacity(),
+            timeout_ms: default_callback_timeout_ms(),
+            backends: Vec::new(),
+        }
+    }
+}
+
+impl CallbackConfig {
+    /// Merge callback settings, preferring explicitly non-default overlay values.
+    pub fn merge(mut self, other: Self) -> Self {
+        if other.queue_capacity != default_callback_queue_capacity() {
+            self.queue_capacity = other.queue_capacity;
+        }
+        if other.timeout_ms != default_callback_timeout_ms() {
+            self.timeout_ms = other.timeout_ms;
+        }
+        if !other.backends.is_empty() {
+            self.backends = other.backends;
+        }
+        self
+    }
+}
+
+/// A configured built-in callback backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum CallbackBackendConfig {
+    /// OTLP exporter backed by the existing OpenTelemetry integration.
+    #[serde(rename = "opentelemetry")]
+    OpenTelemetry(OpenTelemetryConfig),
+    /// Datadog metrics, trace, and log exporter.
+    Datadog(DataDogConfig),
+    /// Langfuse LLM observability exporter.
+    Langfuse(LangfuseConfig),
+}
+
+impl CallbackBackendConfig {
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::OpenTelemetry(_) => "opentelemetry",
+            Self::Datadog(_) => "datadog",
+            Self::Langfuse(_) => "langfuse",
+        }
     }
 }
 
@@ -222,6 +291,14 @@ fn default_interval_seconds() -> u64 {
     15
 }
 
+fn default_callback_queue_capacity() -> usize {
+    1024
+}
+
+fn default_callback_timeout_ms() -> u64 {
+    5000
+}
+
 fn default_sampling_rate() -> f64 {
     0.1
 }
@@ -247,6 +324,46 @@ mod tests {
         assert_eq!(config.port, 9090);
         assert_eq!(config.path, "/metrics");
         assert_eq!(config.interval_seconds, 15);
+    }
+
+    #[test]
+    fn callback_config_defaults_to_disabled_backends() {
+        let config = CallbackConfig::default();
+        assert_eq!(config.queue_capacity, 1024);
+        assert_eq!(config.timeout_ms, 5000);
+        assert!(config.backends.is_empty());
+    }
+
+    #[test]
+    fn callback_config_deserializes_tagged_existing_backend_configs() {
+        let yaml = r#"
+queue_capacity: 64
+timeout_ms: 250
+backends:
+  - type: opentelemetry
+    config:
+      enabled: true
+      endpoint: http://collector:4318
+      service_name: gateway
+      service_version: null
+      environment: test
+      resource_attributes: {}
+      export_traces: true
+      export_metrics: false
+      batch_interval_ms: 100
+      max_batch_size: 8
+      timeout_ms: 200
+      sampling_ratio: 1.0
+      headers: {}
+"#;
+        let config: CallbackConfig = match serde_yml::from_str(yaml) {
+            Ok(config) => config,
+            Err(error) => panic!("callback config should deserialize: {error}"),
+        };
+        assert_eq!(config.queue_capacity, 64);
+        assert_eq!(config.timeout_ms, 250);
+        assert_eq!(config.backends.len(), 1);
+        assert_eq!(config.backends[0].kind(), "opentelemetry");
     }
 
     #[test]

--- a/src/config/validation/monitoring_validators.rs
+++ b/src/config/validation/monitoring_validators.rs
@@ -6,8 +6,10 @@
 
 use super::trait_def::Validate;
 use crate::config::models::monitoring::{
-    HealthConfig, MetricsConfig, MonitoringConfig, TracingConfig,
+    CallbackBackendConfig, CallbackConfig, HealthConfig, MetricsConfig, MonitoringConfig,
+    TracingConfig,
 };
+use std::collections::HashSet;
 use tracing::debug;
 
 impl Validate for MonitoringConfig {
@@ -17,9 +19,94 @@ impl Validate for MonitoringConfig {
         self.metrics.validate()?;
         self.tracing.validate()?;
         self.health.validate()?;
+        self.callbacks.validate()?;
 
         Ok(())
     }
+}
+
+impl Validate for CallbackConfig {
+    fn validate(&self) -> Result<(), String> {
+        if self.queue_capacity == 0 {
+            return Err("Callback queue capacity must be greater than 0".to_string());
+        }
+        if self.timeout_ms == 0 {
+            return Err("Callback timeout must be greater than 0".to_string());
+        }
+
+        let mut kinds = HashSet::new();
+        for backend in &self.backends {
+            if !kinds.insert(backend.kind()) {
+                return Err(format!("Duplicate callback backend: {}", backend.kind()));
+            }
+            validate_callback_backend(backend)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_callback_backend(backend: &CallbackBackendConfig) -> Result<(), String> {
+    match backend {
+        CallbackBackendConfig::OpenTelemetry(config) => {
+            if !config.enabled {
+                return Err("Configured OpenTelemetry callback backend must be enabled".to_string());
+            }
+            validate_http_endpoint("OpenTelemetry callback endpoint", &config.endpoint)?;
+            if config.timeout_ms == 0 {
+                return Err("OpenTelemetry callback timeout must be greater than 0".to_string());
+            }
+            if config.max_batch_size == 0 {
+                return Err(
+                    "OpenTelemetry callback max_batch_size must be greater than 0".to_string(),
+                );
+            }
+            if !config.sampling_ratio.is_finite() || !(0.0..=1.0).contains(&config.sampling_ratio) {
+                return Err(
+                    "OpenTelemetry callback sampling_ratio must be between 0.0 and 1.0".to_string(),
+                );
+            }
+        }
+        CallbackBackendConfig::Datadog(config) => {
+            if config.api_key.trim().is_empty() {
+                return Err("Datadog callback api_key cannot be empty".to_string());
+            }
+            if config.site.trim().is_empty() {
+                return Err("Datadog callback site cannot be empty".to_string());
+            }
+            if config.batch_size == 0 {
+                return Err("Datadog callback batch_size must be greater than 0".to_string());
+            }
+            if config.flush_interval_ms == 0 {
+                return Err("Datadog callback flush_interval_ms must be greater than 0".to_string());
+            }
+        }
+        CallbackBackendConfig::Langfuse(config) => {
+            if !config.is_valid() {
+                return Err(
+                    "Langfuse callback requires enabled=true plus public_key and secret_key"
+                        .to_string(),
+                );
+            }
+            validate_http_endpoint("Langfuse callback host", &config.host)?;
+            if config.batch_size == 0 {
+                return Err("Langfuse callback batch_size must be greater than 0".to_string());
+            }
+            if config.flush_interval_ms == 0 {
+                return Err(
+                    "Langfuse callback flush_interval_ms must be greater than 0".to_string()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_http_endpoint(label: &str, value: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(value).map_err(|error| format!("{label} is invalid: {error}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(format!("{label} must use http or https"));
+    }
+    Ok(())
 }
 
 impl Validate for MetricsConfig {
@@ -76,6 +163,37 @@ mod tests {
     // Helper to call the Validate trait method explicitly
     fn validate_config<T: Validate>(config: &T) -> Result<(), String> {
         Validate::validate(config)
+    }
+
+    #[test]
+    fn callback_config_rejects_duplicate_backends() {
+        let config = CallbackConfig {
+            backends: vec![
+                CallbackBackendConfig::OpenTelemetry(
+                    crate::core::integrations::OpenTelemetryConfig::default(),
+                ),
+                CallbackBackendConfig::OpenTelemetry(
+                    crate::core::integrations::OpenTelemetryConfig::default(),
+                ),
+            ],
+            ..CallbackConfig::default()
+        };
+        assert_eq!(
+            validate_config(&config).unwrap_err(),
+            "Duplicate callback backend: opentelemetry"
+        );
+    }
+
+    #[test]
+    fn callback_config_rejects_zero_capacity() {
+        let config = CallbackConfig {
+            queue_capacity: 0,
+            ..CallbackConfig::default()
+        };
+        assert_eq!(
+            validate_config(&config).unwrap_err(),
+            "Callback queue capacity must be greater than 0"
+        );
     }
 
     // ==================== MetricsConfig Validation Tests ====================

--- a/src/core/integrations/callback_runtime.rs
+++ b/src/core/integrations/callback_runtime.rs
@@ -1,0 +1,444 @@
+//! Non-blocking ordered runtime for integration lifecycle callbacks.
+
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{error, warn};
+
+use super::IntegrationManager;
+use crate::core::traits::integration::{
+    IntegrationError, IntegrationResult, LlmEndEvent, LlmErrorEvent, LlmStartEvent, LlmStreamEvent,
+};
+
+#[derive(Debug)]
+enum CallbackEvent {
+    Start(LlmStartEvent),
+    End(LlmEndEvent),
+    Error(LlmErrorEvent),
+    Stream(LlmStreamEvent),
+}
+
+/// Error returned when an event cannot enter the non-blocking callback queue.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CallbackDispatchError {
+    /// The bounded queue is at capacity.
+    #[error("callback queue is full")]
+    QueueFull,
+    /// The callback worker is no longer accepting events.
+    #[error("callback queue is closed")]
+    QueueClosed,
+}
+
+/// Cloneable request-path handle for non-blocking callback delivery.
+#[derive(Clone, Default)]
+pub struct CallbackDispatcher {
+    sender: Option<mpsc::Sender<CallbackEvent>>,
+    manager: Option<Arc<IntegrationManager>>,
+}
+
+impl CallbackDispatcher {
+    /// Create a dispatcher that performs no external callback work.
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    /// Whether this dispatcher has an active callback worker.
+    pub fn is_enabled(&self) -> bool {
+        self.sender.is_some()
+    }
+
+    /// List the callback integrations registered with this dispatcher.
+    pub async fn registered_integrations(&self) -> Vec<&'static str> {
+        match &self.manager {
+            Some(manager) => manager.list_integrations().await,
+            None => Vec::new(),
+        }
+    }
+
+    /// Enqueue an LLM start event without waiting for exporter I/O.
+    pub fn emit_start(&self, event: LlmStartEvent) -> Result<(), CallbackDispatchError> {
+        self.try_send(CallbackEvent::Start(event))
+    }
+
+    /// Enqueue an LLM success event without waiting for exporter I/O.
+    pub fn emit_end(&self, event: LlmEndEvent) -> Result<(), CallbackDispatchError> {
+        self.try_send(CallbackEvent::End(event))
+    }
+
+    /// Enqueue an LLM error event without waiting for exporter I/O.
+    pub fn emit_error(&self, event: LlmErrorEvent) -> Result<(), CallbackDispatchError> {
+        self.try_send(CallbackEvent::Error(event))
+    }
+
+    /// Enqueue an LLM stream event without waiting for exporter I/O.
+    pub fn emit_stream(&self, event: LlmStreamEvent) -> Result<(), CallbackDispatchError> {
+        self.try_send(CallbackEvent::Stream(event))
+    }
+
+    fn try_send(&self, event: CallbackEvent) -> Result<(), CallbackDispatchError> {
+        let Some(sender) = &self.sender else {
+            return Ok(());
+        };
+        sender.try_send(event).map_err(|error| match error {
+            mpsc::error::TrySendError::Full(_) => CallbackDispatchError::QueueFull,
+            mpsc::error::TrySendError::Closed(_) => CallbackDispatchError::QueueClosed,
+        })
+    }
+}
+
+/// Owns the callback queue worker and its graceful-shutdown signal.
+pub struct CallbackRuntime {
+    dispatcher: CallbackDispatcher,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    worker: Option<JoinHandle<IntegrationResult<()>>>,
+}
+
+impl CallbackRuntime {
+    /// Start a callback worker around an existing integration manager.
+    pub fn new(manager: Arc<IntegrationManager>, queue_capacity: usize) -> IntegrationResult<Self> {
+        if queue_capacity == 0 {
+            return Err(IntegrationError::config(
+                "callback queue capacity must be greater than 0",
+            ));
+        }
+
+        let (sender, receiver) = mpsc::channel(queue_capacity);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let worker_manager = Arc::clone(&manager);
+        let worker = tokio::spawn(async move {
+            run_callback_worker(worker_manager, receiver, shutdown_rx).await
+        });
+
+        Ok(Self {
+            dispatcher: CallbackDispatcher {
+                sender: Some(sender),
+                manager: Some(manager),
+            },
+            shutdown_tx: Some(shutdown_tx),
+            worker: Some(worker),
+        })
+    }
+
+    /// Construct a disabled runtime.
+    pub fn disabled() -> Self {
+        Self {
+            dispatcher: CallbackDispatcher::disabled(),
+            shutdown_tx: None,
+            worker: None,
+        }
+    }
+
+    /// Obtain the request-path dispatcher.
+    pub fn dispatcher(&self) -> CallbackDispatcher {
+        self.dispatcher.clone()
+    }
+
+    /// Drain pending events, flush integrations, and stop the worker.
+    pub async fn shutdown(mut self) -> IntegrationResult<()> {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        let Some(worker) = self.worker.take() else {
+            return Ok(());
+        };
+        worker
+            .await
+            .map_err(|error| IntegrationError::other(format!("callback worker failed: {error}")))?
+    }
+}
+
+impl Drop for CallbackRuntime {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+    }
+}
+
+async fn run_callback_worker(
+    manager: Arc<IntegrationManager>,
+    mut receiver: mpsc::Receiver<CallbackEvent>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) -> IntegrationResult<()> {
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut shutdown_rx => {
+                receiver.close();
+                while let Some(event) = receiver.recv().await {
+                    dispatch_event(manager.as_ref(), event).await;
+                }
+                break;
+            }
+            event = receiver.recv() => {
+                let Some(event) = event else {
+                    break;
+                };
+                dispatch_event(manager.as_ref(), event).await;
+            }
+        }
+    }
+
+    if let Err(error) = manager.flush().await {
+        warn!("Callback integration flush failed: {}", error);
+    }
+    manager.shutdown().await
+}
+
+async fn dispatch_event(manager: &IntegrationManager, event: CallbackEvent) {
+    let result = match event {
+        CallbackEvent::Start(event) => manager.on_llm_start(&event).await,
+        CallbackEvent::End(event) => manager.on_llm_end(&event).await,
+        CallbackEvent::Error(event) => manager.on_llm_error(&event).await,
+        CallbackEvent::Stream(event) => manager.on_llm_stream(&event).await,
+    };
+    if let Err(error) = result {
+        error!("Callback event dispatch failed: {}", error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use async_trait::async_trait;
+    use parking_lot::Mutex;
+    use tokio::sync::Notify;
+
+    use super::*;
+    use crate::core::integrations::IntegrationManagerConfig;
+    use crate::core::traits::integration::{Integration, LlmErrorEvent};
+
+    struct RecordingIntegration {
+        events: Arc<Mutex<Vec<&'static str>>>,
+        flushed: Arc<AtomicBool>,
+    }
+
+    struct BlockingIntegration {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    struct FailingIntegration;
+
+    #[async_trait]
+    impl Integration for FailingIntegration {
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        async fn on_llm_start(&self, _event: &LlmStartEvent) -> IntegrationResult<()> {
+            Err(IntegrationError::other("test callback failure"))
+        }
+
+        async fn on_llm_end(&self, _event: &LlmEndEvent) -> IntegrationResult<()> {
+            Err(IntegrationError::other("test callback failure"))
+        }
+
+        async fn on_llm_error(&self, _event: &LlmErrorEvent) -> IntegrationResult<()> {
+            Err(IntegrationError::other("test callback failure"))
+        }
+
+        async fn flush(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Integration for BlockingIntegration {
+        fn name(&self) -> &'static str {
+            "blocking"
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        async fn on_llm_start(&self, _event: &LlmStartEvent) -> IntegrationResult<()> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(())
+        }
+
+        async fn on_llm_end(&self, _event: &LlmEndEvent) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn on_llm_error(&self, _event: &LlmErrorEvent) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn flush(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Integration for RecordingIntegration {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        async fn on_llm_start(&self, _event: &LlmStartEvent) -> IntegrationResult<()> {
+            self.events.lock().push("start");
+            Ok(())
+        }
+
+        async fn on_llm_end(&self, _event: &LlmEndEvent) -> IntegrationResult<()> {
+            self.events.lock().push("end");
+            Ok(())
+        }
+
+        async fn on_llm_error(&self, _event: &LlmErrorEvent) -> IntegrationResult<()> {
+            self.events.lock().push("error");
+            Ok(())
+        }
+
+        async fn flush(&self) -> IntegrationResult<()> {
+            self.flushed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_preserves_order_and_flushes_on_shutdown() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let flushed = Arc::new(AtomicBool::new(false));
+        let manager = Arc::new(IntegrationManager::with_defaults());
+        manager
+            .register(Arc::new(RecordingIntegration {
+                events: Arc::clone(&events),
+                flushed: Arc::clone(&flushed),
+            }))
+            .await;
+        let runtime = match CallbackRuntime::new(manager, 8) {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("callback runtime should start: {error}"),
+        };
+        let dispatcher = runtime.dispatcher();
+
+        assert!(
+            dispatcher
+                .emit_start(LlmStartEvent::new("req-1", "model"))
+                .is_ok()
+        );
+        assert!(
+            dispatcher
+                .emit_end(LlmEndEvent::new("req-1", "model"))
+                .is_ok()
+        );
+        assert!(runtime.shutdown().await.is_ok());
+        assert_eq!(*events.lock(), vec!["start", "end"]);
+        assert!(flushed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn runtime_rejects_zero_capacity() {
+        let manager = Arc::new(IntegrationManager::with_defaults());
+        let error = match CallbackRuntime::new(manager, 0) {
+            Ok(_) => panic!("zero-capacity callback runtime must fail"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("capacity"));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_reports_full_and_closed_queue() {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let manager = Arc::new(IntegrationManager::new(
+            IntegrationManagerConfig::default().parallel(false),
+        ));
+        manager
+            .register(Arc::new(BlockingIntegration {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            }))
+            .await;
+        let runtime = match CallbackRuntime::new(manager, 1) {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("callback runtime should start: {error}"),
+        };
+        let dispatcher = runtime.dispatcher();
+        let entered_wait = entered.notified();
+
+        assert!(
+            dispatcher
+                .emit_start(LlmStartEvent::new("req-1", "model"))
+                .is_ok()
+        );
+        entered_wait.await;
+        assert!(
+            dispatcher
+                .emit_end(LlmEndEvent::new("req-1", "model"))
+                .is_ok()
+        );
+        assert_eq!(
+            dispatcher.emit_error(LlmErrorEvent::new("req-1", "model", "failed")),
+            Err(CallbackDispatchError::QueueFull)
+        );
+
+        release.notify_one();
+        assert!(runtime.shutdown().await.is_ok());
+        assert_eq!(
+            dispatcher.emit_start(LlmStartEvent::new("req-2", "model")),
+            Err(CallbackDispatchError::QueueClosed)
+        );
+    }
+
+    #[tokio::test]
+    async fn failing_backend_does_not_block_healthy_backend() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let manager = Arc::new(IntegrationManager::new(
+            IntegrationManagerConfig::default()
+                .parallel(false)
+                .fail_fast(false),
+        ));
+        manager.register(Arc::new(FailingIntegration)).await;
+        manager
+            .register(Arc::new(RecordingIntegration {
+                events: Arc::clone(&events),
+                flushed: Arc::new(AtomicBool::new(false)),
+            }))
+            .await;
+        let runtime = match CallbackRuntime::new(manager, 8) {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("callback runtime should start: {error}"),
+        };
+        let dispatcher = runtime.dispatcher();
+
+        assert!(
+            dispatcher
+                .emit_start(LlmStartEvent::new("req-1", "model"))
+                .is_ok()
+        );
+        assert!(
+            dispatcher
+                .emit_end(LlmEndEvent::new("req-1", "model"))
+                .is_ok()
+        );
+        assert!(runtime.shutdown().await.is_ok());
+        assert_eq!(*events.lock(), vec!["start", "end"]);
+    }
+}

--- a/src/core/integrations/langfuse/integration.rs
+++ b/src/core/integrations/langfuse/integration.rs
@@ -1,0 +1,120 @@
+//! Adapter from the canonical integration lifecycle to Langfuse logging.
+
+use async_trait::async_trait;
+
+use super::{LangfuseConfig, LangfuseError, LangfuseLogger, LlmError, LlmRequest, LlmResponse};
+use crate::core::traits::integration::{
+    Integration, IntegrationError, IntegrationResult, LlmEndEvent, LlmErrorEvent, LlmStartEvent,
+};
+
+/// Canonical callback adapter for the existing Langfuse logger.
+pub struct LangfuseIntegration {
+    logger: LangfuseLogger,
+}
+
+impl LangfuseIntegration {
+    /// Build a Langfuse callback integration.
+    pub fn new(config: LangfuseConfig) -> Result<Self, LangfuseError> {
+        LangfuseLogger::new(config).map(|logger| Self { logger })
+    }
+}
+
+#[async_trait]
+impl Integration for LangfuseIntegration {
+    fn name(&self) -> &'static str {
+        "langfuse"
+    }
+
+    fn is_enabled(&self) -> bool {
+        true
+    }
+
+    async fn on_llm_start(&self, event: &LlmStartEvent) -> IntegrationResult<()> {
+        let mut request = LlmRequest::new(&event.request_id, &event.model);
+        request.provider = event.provider.clone();
+        request.user_id = event.user_id.clone();
+        request.session_id = event.session_id.clone();
+        request.metadata = event.metadata.clone();
+        request.tags = event.tags.clone();
+        request.parameters = event.parameters.clone();
+        self.logger.on_llm_start(request);
+        Ok(())
+    }
+
+    async fn on_llm_end(&self, event: &LlmEndEvent) -> IntegrationResult<()> {
+        let mut response = LlmResponse::new(&event.request_id);
+        response.input_tokens = event.input_tokens;
+        response.output_tokens = event.output_tokens;
+        response.cost = event.cost_usd;
+        response.metadata = event.metadata.clone();
+        if let Some(provider) = &event.provider {
+            response
+                .metadata
+                .insert("provider".to_string(), serde_json::json!(provider));
+        }
+        response.metadata.insert(
+            "latency_ms".to_string(),
+            serde_json::json!(event.latency_ms),
+        );
+        self.logger.on_llm_end(response);
+        Ok(())
+    }
+
+    async fn on_llm_error(&self, event: &LlmErrorEvent) -> IntegrationResult<()> {
+        let mut error = LlmError::new(&event.request_id, &event.error_message);
+        error.error_type = event.error_type.clone();
+        error.metadata = event.metadata.clone();
+        if let Some(provider) = &event.provider {
+            error
+                .metadata
+                .insert("provider".to_string(), serde_json::json!(provider));
+        }
+        self.logger.on_llm_error(error);
+        Ok(())
+    }
+
+    async fn flush(&self) -> IntegrationResult<()> {
+        self.logger
+            .flush()
+            .await
+            .map_err(|error| IntegrationError::other(format!("Langfuse flush failed: {error}")))
+    }
+
+    async fn shutdown(&self) -> IntegrationResult<()> {
+        self.flush().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn debug_config() -> LangfuseConfig {
+        LangfuseConfig {
+            public_key: Some("pk-test".to_string()),
+            secret_key: Some("sk-test".to_string()),
+            debug: true,
+            flush_interval_ms: 60_000,
+            ..LangfuseConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_tracks_canonical_start_and_end_without_content() {
+        let integration = match LangfuseIntegration::new(debug_config()) {
+            Ok(integration) => integration,
+            Err(error) => panic!("Langfuse adapter should initialize: {error}"),
+        };
+        let start = LlmStartEvent::new("req-1", "model").provider("provider");
+        assert!(integration.on_llm_start(&start).await.is_ok());
+        assert_eq!(integration.logger.active_count(), 1);
+
+        let end = LlmEndEvent::new("req-1", "model")
+            .provider("provider")
+            .tokens(10, 5)
+            .cost(0.25)
+            .latency(20);
+        assert!(integration.on_llm_end(&end).await.is_ok());
+        assert_eq!(integration.logger.active_count(), 0);
+    }
+}

--- a/src/core/integrations/langfuse/mod.rs
+++ b/src/core/integrations/langfuse/mod.rs
@@ -56,6 +56,7 @@
 
 pub mod client;
 pub mod config;
+pub mod integration;
 pub mod logger;
 #[cfg(feature = "gateway")]
 pub mod middleware;
@@ -64,6 +65,7 @@ pub mod types;
 // Re-export main types
 pub use client::{BatchSender, LangfuseClient, LangfuseError};
 pub use config::LangfuseConfig;
+pub use integration::LangfuseIntegration;
 pub use logger::{LangfuseLogger, LlmCallback, LlmError, LlmRequest, LlmResponse};
 #[cfg(feature = "gateway")]
 pub use middleware::{

--- a/src/core/integrations/mod.rs
+++ b/src/core/integrations/mod.rs
@@ -47,6 +47,7 @@
 //! manager.on_llm_start(&event).await?;
 //! ```
 
+pub mod callback_runtime;
 pub mod langfuse;
 pub mod manager;
 pub mod observability;
@@ -55,7 +56,8 @@ pub mod observability;
 #[cfg(feature = "gateway")]
 pub use langfuse::LangfuseTracing;
 pub use langfuse::{
-    LangfuseConfig, LangfuseLogger, LlmCallback, LlmError, LlmRequest, LlmResponse,
+    LangfuseConfig, LangfuseIntegration, LangfuseLogger, LlmCallback, LlmError, LlmRequest,
+    LlmResponse,
 };
 pub use manager::{IntegrationManager, IntegrationManagerConfig};
 pub use observability::{
@@ -69,3 +71,4 @@ pub use crate::core::traits::integration::{
     BoxedIntegration, CacheHitEvent, EmbeddingEndEvent, EmbeddingStartEvent, Integration,
     IntegrationError, IntegrationResult, LlmEndEvent, LlmErrorEvent, LlmStartEvent, LlmStreamEvent,
 };
+pub use callback_runtime::{CallbackDispatchError, CallbackDispatcher, CallbackRuntime};

--- a/src/core/integrations/observability/opentelemetry/integration_impl.rs
+++ b/src/core/integrations/observability/opentelemetry/integration_impl.rs
@@ -62,16 +62,40 @@ pub struct OpenTelemetryIntegration {
 }
 
 impl OpenTelemetryIntegration {
-    /// Create a new OpenTelemetry integration
-    pub fn new(config: OpenTelemetryConfig) -> Self {
+    /// Create a new OpenTelemetry integration and surface client construction errors.
+    pub fn try_new(config: OpenTelemetryConfig) -> IntegrationResult<Self> {
         let http_client =
-            create_custom_client(Duration::from_millis(config.timeout_ms)).unwrap_or_default();
+            create_custom_client(Duration::from_millis(config.timeout_ms)).map_err(|error| {
+                IntegrationError::connection(format!(
+                    "Failed to create OpenTelemetry HTTP client: {error}"
+                ))
+            })?;
 
-        Self {
+        Ok(Self {
             config,
             active_spans: RwLock::new(HashMap::new()),
             pending_spans: RwLock::new(SpanBatch::new()),
             http_client,
+        })
+    }
+
+    /// Create a new OpenTelemetry integration
+    pub fn new(config: OpenTelemetryConfig) -> Self {
+        match Self::try_new(config.clone()) {
+            Ok(integration) => integration,
+            Err(error) => {
+                warn!(
+                    "OpenTelemetry custom HTTP client initialization failed; \
+                     using the legacy default client fallback: {}",
+                    error
+                );
+                Self {
+                    config,
+                    active_spans: RwLock::new(HashMap::new()),
+                    pending_spans: RwLock::new(SpanBatch::new()),
+                    http_client: reqwest::Client::new(),
+                }
+            }
         }
     }
 

--- a/src/server/callbacks.rs
+++ b/src/server/callbacks.rs
@@ -1,0 +1,113 @@
+//! Gateway startup wiring for configured callback integrations.
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use crate::config::models::monitoring::{CallbackBackendConfig, CallbackConfig};
+use crate::core::integrations::{
+    CallbackRuntime, DataDogIntegration, IntegrationManager, IntegrationManagerConfig,
+    LangfuseIntegration, OpenTelemetryIntegration,
+};
+use crate::core::traits::integration::BoxedIntegration;
+
+pub(crate) async fn build_callback_runtime(config: &CallbackConfig) -> CallbackRuntime {
+    if config.backends.is_empty() {
+        return CallbackRuntime::disabled();
+    }
+
+    let manager = Arc::new(IntegrationManager::new(
+        IntegrationManagerConfig::new()
+            .fail_fast(false)
+            .parallel(true)
+            .timeout_ms(config.timeout_ms)
+            .log_errors(true),
+    ));
+
+    for backend in &config.backends {
+        match build_backend(backend) {
+            Ok(integration) => {
+                let name = integration.name();
+                manager.register(integration).await;
+                info!("Callback backend initialized: {}", name);
+            }
+            Err(error) => {
+                warn!(
+                    backend = backend.kind(),
+                    "Callback backend initialization failed; continuing without it: {}", error
+                );
+            }
+        }
+    }
+
+    if manager.count().await == 0 {
+        warn!("No configured callback backend initialized successfully");
+        return CallbackRuntime::disabled();
+    }
+
+    match CallbackRuntime::new(manager, config.queue_capacity) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            warn!(
+                "Callback runtime initialization failed; continuing without callbacks: {}",
+                error
+            );
+            CallbackRuntime::disabled()
+        }
+    }
+}
+
+fn build_backend(
+    backend: &CallbackBackendConfig,
+) -> crate::core::traits::integration::IntegrationResult<BoxedIntegration> {
+    match backend {
+        CallbackBackendConfig::OpenTelemetry(config) => {
+            OpenTelemetryIntegration::try_new(config.clone())
+                .map(|integration| Arc::new(integration) as BoxedIntegration)
+        }
+        CallbackBackendConfig::Datadog(config) => DataDogIntegration::new(config.clone())
+            .map(|integration| Arc::new(integration) as BoxedIntegration),
+        CallbackBackendConfig::Langfuse(config) => LangfuseIntegration::new(config.clone())
+            .map(|integration| Arc::new(integration) as BoxedIntegration)
+            .map_err(|error| {
+                crate::core::traits::integration::IntegrationError::config(format!(
+                    "Langfuse initialization failed: {error}"
+                ))
+            }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::integrations::{LangfuseConfig, OpenTelemetryConfig};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn startup_registers_healthy_backend_and_skips_failed_backend() {
+        let config = CallbackConfig {
+            queue_capacity: 16,
+            backends: vec![
+                CallbackBackendConfig::Langfuse(LangfuseConfig {
+                    public_key: None,
+                    secret_key: None,
+                    ..LangfuseConfig::default()
+                }),
+                CallbackBackendConfig::OpenTelemetry(OpenTelemetryConfig {
+                    max_batch_size: 1,
+                    ..OpenTelemetryConfig::default()
+                }),
+            ],
+            ..CallbackConfig::default()
+        };
+
+        let runtime = build_callback_runtime(&config).await;
+        let dispatcher = runtime.dispatcher();
+        assert!(dispatcher.is_enabled());
+        assert_eq!(
+            dispatcher.registered_integrations().await,
+            vec!["opentelemetry"]
+        );
+        assert!(runtime.shutdown().await.is_ok());
+    }
+}

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -5,6 +5,7 @@
 use crate::config::models::server::{CorsConfig, ServerConfig};
 use crate::config::{Config, Validate};
 use crate::core::budget::UnifiedBudgetLimits;
+use crate::core::integrations::CallbackRuntime;
 use crate::core::pricing_service::PricingService;
 use crate::core::rate_limiter::{get_global_rate_limiter, init_global_rate_limiter_with_redis};
 use crate::server::middleware::{
@@ -35,6 +36,8 @@ pub struct HttpServer {
     state: AppState,
     /// Background worker that drains budget persistence events on shutdown.
     budget_persistence_task: Option<JoinHandle<()>>,
+    /// Background worker that delivers configured callback events.
+    callback_runtime: CallbackRuntime,
 }
 
 impl HttpServer {
@@ -48,6 +51,12 @@ impl HttpServer {
             .cache
             .validate()
             .map_err(|e| GatewayError::Config(format!("Invalid cache configuration: {}", e)))?;
+        config
+            .gateway
+            .monitoring
+            .callbacks
+            .validate()
+            .map_err(|e| GatewayError::Config(format!("Invalid callback configuration: {}", e)))?;
         start_auth_rate_limiter_cleanup_task();
 
         let storage = crate::storage::StorageLayer::new(&config.gateway.storage).await?;
@@ -140,6 +149,9 @@ impl HttpServer {
             ))
         })?;
 
+        let callback_runtime =
+            crate::server::callbacks::build_callback_runtime(&config.gateway.monitoring.callbacks)
+                .await;
         let state = AppState::new_with_unified_router(
             config.clone(),
             auth,
@@ -147,12 +159,14 @@ impl HttpServer {
             storage,
             pricing,
             budget_limits,
-        );
+        )
+        .with_callbacks(callback_runtime.dispatcher());
 
         Ok(Self {
             config: config.gateway.server.clone(),
             state,
             budget_persistence_task,
+            callback_runtime,
         })
     }
 
@@ -300,6 +314,8 @@ impl HttpServer {
         let bind_addr = format!("{}:{}", self.config.host, self.config.port);
         let port = self.config.port;
         let budget_persistence_task = self.budget_persistence_task.take();
+        let callback_runtime =
+            std::mem::replace(&mut self.callback_runtime, CallbackRuntime::disabled());
 
         info!("Starting HTTP server on {}", bind_addr);
 
@@ -360,6 +376,11 @@ impl HttpServer {
             if let Err(e) = task.await {
                 warn!("Budget persistence worker join failed: {}", e);
             }
+        }
+
+        info!("Draining external callback worker");
+        if let Err(e) = callback_runtime.shutdown().await {
+            warn!("Callback worker shutdown reported an error: {}", e);
         }
 
         info!("Closing storage layer");
@@ -511,6 +532,30 @@ mod tests {
         };
 
         assert!(server.state().response_cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn new_wires_configured_callback_backend() {
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+        config.gateway.monitoring.callbacks.backends = vec![
+            crate::config::models::monitoring::CallbackBackendConfig::OpenTelemetry(
+                crate::core::integrations::OpenTelemetryConfig::default(),
+            ),
+        ];
+
+        let server = match HttpServer::new(&config).await {
+            Ok(server) => server,
+            Err(error) => panic!("configured callbacks should wire at startup: {error}"),
+        };
+
+        assert!(server.state().callbacks.is_enabled());
+        assert_eq!(
+            server.state().callbacks.registered_integrations().await,
+            vec!["opentelemetry"]
+        );
     }
 
     /// In-memory budget snapshots load succeeds (returns empty) on sqlite, so

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod routes;
 
 // New modular server components
 pub mod builder;
+mod callbacks;
 pub mod http;
 pub mod state;
 pub mod types;

--- a/src/server/routes/ai/callbacks.rs
+++ b/src/server/routes/ai/callbacks.rs
@@ -21,8 +21,9 @@ struct CallbackLifecycleInner {
     dispatcher: CallbackDispatcher,
     pricing: Arc<PricingService>,
     request_id: String,
+    user_id: Option<String>,
     requested_model: String,
-    started_at: Instant,
+    started_at: Mutex<Option<Instant>>,
     target: Mutex<Option<CallbackTarget>>,
     terminal_emitted: AtomicBool,
 }
@@ -36,49 +37,65 @@ struct CallbackTarget {
 }
 
 impl CallbackLifecycle {
-    pub(super) fn start(
+    pub(super) fn new(
         dispatcher: &CallbackDispatcher,
         pricing: Arc<PricingService>,
         requested_model: impl Into<String>,
         context: &RequestContext,
     ) -> Self {
         let requested_model = requested_model.into();
-        let mut event = LlmStartEvent::new(&context.request_id, &requested_model);
-        event.user_id.clone_from(&context.user_id);
-        if let Err(dispatch_error) = dispatcher.emit_start(event) {
-            error!(
-                request_id = %context.request_id,
-                "Failed to enqueue callback start event: {}",
-                dispatch_error
-            );
-        }
-
         Self {
             inner: Arc::new(CallbackLifecycleInner {
                 dispatcher: dispatcher.clone(),
                 pricing,
                 request_id: context.request_id.clone(),
+                user_id: context.user_id.clone(),
                 requested_model,
-                started_at: Instant::now(),
+                started_at: Mutex::new(None),
                 target: Mutex::new(None),
                 terminal_emitted: AtomicBool::new(false),
             }),
         }
     }
 
-    pub(super) fn select_target(
+    pub(super) fn begin_provider_execution(
         &self,
         provider: impl Into<String>,
         model: impl Into<String>,
         pricing_provider: impl Into<String>,
         pricing_model: impl Into<String>,
     ) {
-        *self.inner.target.lock() = Some(CallbackTarget {
+        let target = CallbackTarget {
             provider: provider.into(),
             model: model.into(),
             pricing_provider: pricing_provider.into(),
             pricing_model: pricing_model.into(),
-        });
+        };
+        *self.inner.target.lock() = Some(target.clone());
+
+        let should_emit_start = {
+            let mut started_at = self.inner.started_at.lock();
+            if started_at.is_some() {
+                false
+            } else {
+                *started_at = Some(Instant::now());
+                true
+            }
+        };
+        if !should_emit_start {
+            return;
+        }
+
+        let mut event =
+            LlmStartEvent::new(&self.inner.request_id, &target.model).provider(target.provider);
+        event.user_id.clone_from(&self.inner.user_id);
+        if let Err(dispatch_error) = self.inner.dispatcher.emit_start(event) {
+            error!(
+                request_id = %self.inner.request_id,
+                "Failed to enqueue callback start event: {}",
+                dispatch_error
+            );
+        }
     }
 
     pub(super) fn complete_usage(
@@ -95,6 +112,9 @@ impl CallbackLifecycle {
     }
 
     pub(super) fn fail(&self, _message: impl Into<String>, error_type: &'static str) {
+        if !self.has_started() {
+            return;
+        }
         if !self.claim_terminal() {
             return;
         }
@@ -110,10 +130,7 @@ impl CallbackLifecycle {
             safe_callback_error_message(error_type),
         )
         .error_type(error_type)
-        .metadata(
-            "latency_ms",
-            serde_json::json!(self.inner.started_at.elapsed().as_millis() as u64),
-        );
+        .metadata("latency_ms", serde_json::json!(self.elapsed_ms()));
         if let Some(target) = target {
             event = event.provider(target.provider);
         }
@@ -132,6 +149,9 @@ impl CallbackLifecycle {
         pricing_usage: Option<&PricingUsage>,
         outcome: &'static str,
     ) {
+        if !self.has_started() {
+            return;
+        }
         if !self.claim_terminal() {
             return;
         }
@@ -142,7 +162,7 @@ impl CallbackLifecycle {
             .map(|target| target.model.as_str())
             .unwrap_or(&self.inner.requested_model);
         let mut event = LlmEndEvent::new(&self.inner.request_id, model)
-            .latency(self.inner.started_at.elapsed().as_millis() as u64)
+            .latency(self.elapsed_ms())
             .metadata("outcome", serde_json::json!(outcome));
         if let Some((input_tokens, output_tokens)) = tokens {
             event = event.tokens(input_tokens, output_tokens);
@@ -184,6 +204,19 @@ impl CallbackLifecycle {
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
     }
+
+    fn has_started(&self) -> bool {
+        self.inner.started_at.lock().is_some()
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        self.inner
+            .started_at
+            .lock()
+            .as_ref()
+            .map(|started_at| started_at.elapsed().as_millis() as u64)
+            .unwrap_or_default()
+    }
 }
 
 fn safe_callback_error_message(error_type: &str) -> &'static str {
@@ -212,6 +245,7 @@ mod tests {
     type RecordedErrors = Arc<parking_lot::Mutex<Vec<(Option<String>, String)>>>;
 
     struct TerminalCounter {
+        start_count: Arc<AtomicUsize>,
         end_count: Arc<AtomicUsize>,
         error_count: Arc<AtomicUsize>,
         errors: RecordedErrors,
@@ -228,6 +262,7 @@ mod tests {
         }
 
         async fn on_llm_start(&self, _event: &LlmStartEvent) -> IntegrationResult<()> {
+            self.start_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
@@ -255,6 +290,7 @@ mod tests {
 
     #[tokio::test]
     async fn lifecycle_emits_exactly_one_terminal_event() {
+        let start_count = Arc::new(AtomicUsize::new(0));
         let end_count = Arc::new(AtomicUsize::new(0));
         let error_count = Arc::new(AtomicUsize::new(0));
         let errors = Arc::new(parking_lot::Mutex::new(Vec::new()));
@@ -263,6 +299,7 @@ mod tests {
         ));
         manager
             .register(Arc::new(TerminalCounter {
+                start_count: Arc::clone(&start_count),
                 end_count: Arc::clone(&end_count),
                 error_count: Arc::clone(&error_count),
                 errors,
@@ -274,16 +311,19 @@ mod tests {
         };
         let pricing = Arc::new(PricingService::new(None));
         let context = RequestContext::default();
-        let lifecycle = CallbackLifecycle::start(&runtime.dispatcher(), pricing, "model", &context);
+        let lifecycle = CallbackLifecycle::new(&runtime.dispatcher(), pricing, "model", &context);
+        lifecycle.begin_provider_execution("provider", "model", "provider", "model");
         lifecycle.complete_usage(None, "success");
         lifecycle.fail("late error", "provider_error");
         assert!(runtime.shutdown().await.is_ok());
+        assert_eq!(start_count.load(Ordering::SeqCst), 1);
         assert_eq!(end_count.load(Ordering::SeqCst), 1);
         assert_eq!(error_count.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
     async fn streaming_terminal_failure_kinds_are_safe_and_terminal_once() {
+        let start_count = Arc::new(AtomicUsize::new(0));
         let end_count = Arc::new(AtomicUsize::new(0));
         let error_count = Arc::new(AtomicUsize::new(0));
         let errors = Arc::new(parking_lot::Mutex::new(Vec::new()));
@@ -292,6 +332,7 @@ mod tests {
         ));
         manager
             .register(Arc::new(TerminalCounter {
+                start_count: Arc::clone(&start_count),
                 end_count: Arc::clone(&end_count),
                 error_count: Arc::clone(&error_count),
                 errors: Arc::clone(&errors),
@@ -311,17 +352,19 @@ mod tests {
             "serialization_error",
             "client_disconnect",
         ] {
-            let lifecycle = CallbackLifecycle::start(
+            let lifecycle = CallbackLifecycle::new(
                 &dispatcher,
                 Arc::clone(&pricing),
                 "model",
                 &RequestContext::default(),
             );
+            lifecycle.begin_provider_execution("provider", "model", "provider", "model");
             lifecycle.fail("upstream-secret-must-not-leak", error_type);
             lifecycle.complete_usage(None, "late_success");
         }
         assert!(runtime.shutdown().await.is_ok());
 
+        assert_eq!(start_count.load(Ordering::SeqCst), 5);
         assert_eq!(end_count.load(Ordering::SeqCst), 0);
         assert_eq!(error_count.load(Ordering::SeqCst), 5);
         let errors = errors.lock();
@@ -331,5 +374,39 @@ mod tests {
                 && !message.contains("prompt")
                 && !message.contains("output")
         }));
+    }
+
+    #[tokio::test]
+    async fn pre_provider_rejection_emits_no_lifecycle_events() {
+        let start_count = Arc::new(AtomicUsize::new(0));
+        let end_count = Arc::new(AtomicUsize::new(0));
+        let error_count = Arc::new(AtomicUsize::new(0));
+        let manager = Arc::new(IntegrationManager::new(
+            IntegrationManagerConfig::default().parallel(false),
+        ));
+        manager
+            .register(Arc::new(TerminalCounter {
+                start_count: Arc::clone(&start_count),
+                end_count: Arc::clone(&end_count),
+                error_count: Arc::clone(&error_count),
+                errors: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            }))
+            .await;
+        let runtime = match CallbackRuntime::new(manager, 4) {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("callback runtime should start: {error}"),
+        };
+
+        let lifecycle = CallbackLifecycle::new(
+            &runtime.dispatcher(),
+            Arc::new(PricingService::new(None)),
+            "model",
+            &RequestContext::default(),
+        );
+        lifecycle.fail("budget rejected before provider call", "provider_error");
+        assert!(runtime.shutdown().await.is_ok());
+        assert_eq!(start_count.load(Ordering::SeqCst), 0);
+        assert_eq!(end_count.load(Ordering::SeqCst), 0);
+        assert_eq!(error_count.load(Ordering::SeqCst), 0);
     }
 }

--- a/src/server/routes/ai/callbacks.rs
+++ b/src/server/routes/ai/callbacks.rs
@@ -1,0 +1,335 @@
+//! Metadata-only lifecycle callbacks for provider-backed AI requests.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use parking_lot::Mutex;
+use tracing::{error, warn};
+
+use crate::core::integrations::CallbackDispatcher;
+use crate::core::pricing_service::{PricingService, PricingUsage};
+use crate::core::traits::integration::{LlmEndEvent, LlmErrorEvent, LlmStartEvent};
+use crate::core::types::context::RequestContext;
+
+#[derive(Clone)]
+pub(super) struct CallbackLifecycle {
+    inner: Arc<CallbackLifecycleInner>,
+}
+
+struct CallbackLifecycleInner {
+    dispatcher: CallbackDispatcher,
+    pricing: Arc<PricingService>,
+    request_id: String,
+    requested_model: String,
+    started_at: Instant,
+    target: Mutex<Option<CallbackTarget>>,
+    terminal_emitted: AtomicBool,
+}
+
+#[derive(Clone)]
+struct CallbackTarget {
+    provider: String,
+    model: String,
+    pricing_provider: String,
+    pricing_model: String,
+}
+
+impl CallbackLifecycle {
+    pub(super) fn start(
+        dispatcher: &CallbackDispatcher,
+        pricing: Arc<PricingService>,
+        requested_model: impl Into<String>,
+        context: &RequestContext,
+    ) -> Self {
+        let requested_model = requested_model.into();
+        let mut event = LlmStartEvent::new(&context.request_id, &requested_model);
+        event.user_id.clone_from(&context.user_id);
+        if let Err(dispatch_error) = dispatcher.emit_start(event) {
+            error!(
+                request_id = %context.request_id,
+                "Failed to enqueue callback start event: {}",
+                dispatch_error
+            );
+        }
+
+        Self {
+            inner: Arc::new(CallbackLifecycleInner {
+                dispatcher: dispatcher.clone(),
+                pricing,
+                request_id: context.request_id.clone(),
+                requested_model,
+                started_at: Instant::now(),
+                target: Mutex::new(None),
+                terminal_emitted: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    pub(super) fn select_target(
+        &self,
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        pricing_provider: impl Into<String>,
+        pricing_model: impl Into<String>,
+    ) {
+        *self.inner.target.lock() = Some(CallbackTarget {
+            provider: provider.into(),
+            model: model.into(),
+            pricing_provider: pricing_provider.into(),
+            pricing_model: pricing_model.into(),
+        });
+    }
+
+    pub(super) fn complete_usage(
+        &self,
+        usage: Option<&crate::core::types::responses::Usage>,
+        outcome: &'static str,
+    ) {
+        let pricing_usage = usage.map(PricingUsage::from);
+        self.complete(
+            usage.map(|usage| (usage.prompt_tokens, usage.completion_tokens)),
+            pricing_usage.as_ref(),
+            outcome,
+        );
+    }
+
+    pub(super) fn fail(&self, _message: impl Into<String>, error_type: &'static str) {
+        if !self.claim_terminal() {
+            return;
+        }
+
+        let target = self.inner.target.lock().clone();
+        let model = target
+            .as_ref()
+            .map(|target| target.model.as_str())
+            .unwrap_or(&self.inner.requested_model);
+        let mut event = LlmErrorEvent::new(
+            &self.inner.request_id,
+            model,
+            safe_callback_error_message(error_type),
+        )
+        .error_type(error_type)
+        .metadata(
+            "latency_ms",
+            serde_json::json!(self.inner.started_at.elapsed().as_millis() as u64),
+        );
+        if let Some(target) = target {
+            event = event.provider(target.provider);
+        }
+        if let Err(dispatch_error) = self.inner.dispatcher.emit_error(event) {
+            error!(
+                request_id = %self.inner.request_id,
+                "Failed to enqueue callback error event: {}",
+                dispatch_error
+            );
+        }
+    }
+
+    fn complete(
+        &self,
+        tokens: Option<(u32, u32)>,
+        pricing_usage: Option<&PricingUsage>,
+        outcome: &'static str,
+    ) {
+        if !self.claim_terminal() {
+            return;
+        }
+
+        let target = self.inner.target.lock().clone();
+        let model = target
+            .as_ref()
+            .map(|target| target.model.as_str())
+            .unwrap_or(&self.inner.requested_model);
+        let mut event = LlmEndEvent::new(&self.inner.request_id, model)
+            .latency(self.inner.started_at.elapsed().as_millis() as u64)
+            .metadata("outcome", serde_json::json!(outcome));
+        if let Some((input_tokens, output_tokens)) = tokens {
+            event = event.tokens(input_tokens, output_tokens);
+        }
+        if let Some(target) = target {
+            event = event.provider(target.provider);
+            if let Some(usage) = pricing_usage {
+                match self
+                    .inner
+                    .pricing
+                    .calculate_loaded_settlement_cost_for_provider(
+                        &target.pricing_provider,
+                        &target.pricing_model,
+                        usage,
+                    ) {
+                    Ok(cost) => event = event.cost(cost.total_cost),
+                    Err(cost_error) => warn!(
+                        request_id = %self.inner.request_id,
+                        provider = %target.pricing_provider,
+                        model = %target.pricing_model,
+                        "Callback cost is unavailable: {}",
+                        cost_error
+                    ),
+                }
+            }
+        }
+        if let Err(dispatch_error) = self.inner.dispatcher.emit_end(event) {
+            error!(
+                request_id = %self.inner.request_id,
+                "Failed to enqueue callback success event: {}",
+                dispatch_error
+            );
+        }
+    }
+
+    fn claim_terminal(&self) -> bool {
+        self.inner
+            .terminal_emitted
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+}
+
+fn safe_callback_error_message(error_type: &str) -> &'static str {
+    match error_type {
+        "timeout" => "provider request timed out",
+        "client_disconnect" => "client disconnected",
+        "cache_error" => "response cache operation failed",
+        "serialization_error" => "response serialization failed",
+        "conversion_error" => "provider response conversion failed",
+        _ => "provider request failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::core::integrations::{
+        CallbackRuntime, IntegrationManager, IntegrationManagerConfig,
+    };
+    use crate::core::traits::integration::{Integration, IntegrationResult};
+
+    type RecordedErrors = Arc<parking_lot::Mutex<Vec<(Option<String>, String)>>>;
+
+    struct TerminalCounter {
+        end_count: Arc<AtomicUsize>,
+        error_count: Arc<AtomicUsize>,
+        errors: RecordedErrors,
+    }
+
+    #[async_trait]
+    impl Integration for TerminalCounter {
+        fn name(&self) -> &'static str {
+            "terminal-counter"
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        async fn on_llm_start(&self, _event: &LlmStartEvent) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn on_llm_end(&self, _event: &LlmEndEvent) -> IntegrationResult<()> {
+            self.end_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn on_llm_error(&self, event: &LlmErrorEvent) -> IntegrationResult<()> {
+            self.error_count.fetch_add(1, Ordering::SeqCst);
+            self.errors
+                .lock()
+                .push((event.error_type.clone(), event.error_message.clone()));
+            Ok(())
+        }
+
+        async fn flush(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_emits_exactly_one_terminal_event() {
+        let end_count = Arc::new(AtomicUsize::new(0));
+        let error_count = Arc::new(AtomicUsize::new(0));
+        let errors = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let manager = Arc::new(IntegrationManager::new(
+            IntegrationManagerConfig::default().parallel(false),
+        ));
+        manager
+            .register(Arc::new(TerminalCounter {
+                end_count: Arc::clone(&end_count),
+                error_count: Arc::clone(&error_count),
+                errors,
+            }))
+            .await;
+        let runtime = match CallbackRuntime::new(manager, 8) {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("callback runtime should start: {error}"),
+        };
+        let pricing = Arc::new(PricingService::new(None));
+        let context = RequestContext::default();
+        let lifecycle = CallbackLifecycle::start(&runtime.dispatcher(), pricing, "model", &context);
+        lifecycle.complete_usage(None, "success");
+        lifecycle.fail("late error", "provider_error");
+        assert!(runtime.shutdown().await.is_ok());
+        assert_eq!(end_count.load(Ordering::SeqCst), 1);
+        assert_eq!(error_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn streaming_terminal_failure_kinds_are_safe_and_terminal_once() {
+        let end_count = Arc::new(AtomicUsize::new(0));
+        let error_count = Arc::new(AtomicUsize::new(0));
+        let errors = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let manager = Arc::new(IntegrationManager::new(
+            IntegrationManagerConfig::default().parallel(false),
+        ));
+        manager
+            .register(Arc::new(TerminalCounter {
+                end_count: Arc::clone(&end_count),
+                error_count: Arc::clone(&error_count),
+                errors: Arc::clone(&errors),
+            }))
+            .await;
+        let runtime = match CallbackRuntime::new(manager, 16) {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("callback runtime should start: {error}"),
+        };
+        let dispatcher = runtime.dispatcher();
+        let pricing = Arc::new(PricingService::new(None));
+
+        for error_type in [
+            "provider_error",
+            "timeout",
+            "conversion_error",
+            "serialization_error",
+            "client_disconnect",
+        ] {
+            let lifecycle = CallbackLifecycle::start(
+                &dispatcher,
+                Arc::clone(&pricing),
+                "model",
+                &RequestContext::default(),
+            );
+            lifecycle.fail("upstream-secret-must-not-leak", error_type);
+            lifecycle.complete_usage(None, "late_success");
+        }
+        assert!(runtime.shutdown().await.is_ok());
+
+        assert_eq!(end_count.load(Ordering::SeqCst), 0);
+        assert_eq!(error_count.load(Ordering::SeqCst), 5);
+        let errors = errors.lock();
+        assert_eq!(errors.len(), 5);
+        assert!(errors.iter().all(|(_, message)| {
+            !message.contains("upstream-secret-must-not-leak")
+                && !message.contains("prompt")
+                && !message.contains("output")
+        }));
+    }
+}

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -114,7 +114,7 @@ async fn handle_chat_completion_internal(
         return Ok(cached);
     }
     let requested_model = core_request.model.clone();
-    let callback = CallbackLifecycle::start(
+    let callback = CallbackLifecycle::new(
         &state.callbacks,
         state.budgeted.pricing(),
         &requested_model,
@@ -153,12 +153,6 @@ async fn handle_chat_completion_internal(
                     &provider,
                     &selected_model,
                 );
-                callback.select_target(
-                    &provider_name,
-                    &selected_model,
-                    &pricing_provider,
-                    &pricing_model,
-                );
                 let request_for_provider = super::token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),
                     &provider_name,
@@ -181,6 +175,10 @@ async fn handle_chat_completion_internal(
                 let settle_pricing_provider = pricing_provider;
                 let settle_pricing_model = pricing_model;
                 let settle_key_manager = key_manager.clone();
+                let callback_provider = provider_name.clone();
+                let callback_model = selected_model.clone();
+                let callback_pricing_provider = reserve_pricing_provider.clone();
+                let callback_pricing_model = reserve_pricing_model.clone();
                 budgeted
                     .for_selected_with_api_key_budget(
                         provider_name.clone(),
@@ -201,7 +199,15 @@ async fn handle_chat_completion_internal(
                                 request_for_budget,
                             )
                         },
-                        || provider.chat_completion(request_for_provider, provider_context),
+                        || {
+                            callback.begin_provider_execution(
+                                callback_provider,
+                                callback_model,
+                                callback_pricing_provider,
+                                callback_pricing_model,
+                            );
+                            provider.chat_completion(request_for_provider, provider_context)
+                        },
                         |response, reservations, budget| {
                             let (budget_reservation, key_budget_reservation) =
                                 reservations.into_parts();

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
+use super::callbacks::CallbackLifecycle;
 use super::openai_errors;
 #[path = "chat_delta.rs"]
 mod chat_delta;
@@ -113,6 +114,12 @@ async fn handle_chat_completion_internal(
         return Ok(cached);
     }
     let requested_model = core_request.model.clone();
+    let callback = CallbackLifecycle::start(
+        &state.callbacks,
+        state.budgeted.pricing(),
+        &requested_model,
+        context.as_ref(),
+    );
     let context_for_execution = Arc::clone(&context);
     let request_for_execution = Arc::clone(&request);
 
@@ -124,8 +131,9 @@ async fn handle_chat_completion_internal(
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
     let budgeted = state.budgeted.clone();
+    let callback_for_execution = callback.clone();
 
-    let core_response = run_unary(
+    let core_response = match run_unary(
         unified_router,
         &requested_model,
         ProviderCapability::ChatCompletion,
@@ -137,12 +145,19 @@ async fn handle_chat_completion_internal(
             let key_manager = key_manager.clone();
             let budgeted = budgeted.clone();
             let pricing_config = pricing_config.clone();
+            let callback = callback_for_execution.clone();
             async move {
                 let provider_name = provider.name().to_string();
                 let (pricing_provider, pricing_model) = super::spend::pricing_identity_for_provider(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                );
+                callback.select_target(
+                    &provider_name,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
                 );
                 let request_for_provider = super::token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),
@@ -220,10 +235,24 @@ async fn handle_chat_completion_internal(
             }
         },
     )
-    .await?;
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            callback.fail(error.to_string(), "provider_error");
+            return Err(error);
+        }
+    };
 
     let response = convert_core_chat_response(core_response);
-    super::response_cache::store_chat(state, request.as_ref(), &response, context.as_ref()).await?;
+    if let Err(error) =
+        super::response_cache::store_chat(state, request.as_ref(), &response, context.as_ref())
+            .await
+    {
+        callback.fail(error.to_string(), "cache_error");
+        return Err(error);
+    }
+    callback.complete_usage(response.usage.as_ref(), "success");
     Ok(response)
 }
 

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -46,7 +46,7 @@ pub(super) async fn handle_streaming_chat_completion(
     };
 
     let requested_model = core_request.model.clone();
-    let callback = CallbackLifecycle::start(
+    let callback = CallbackLifecycle::new(
         &state.callbacks,
         state.budgeted.pricing(),
         &requested_model,
@@ -83,12 +83,6 @@ pub(super) async fn handle_streaming_chat_completion(
                     &provider,
                     &selected_model,
                 );
-                callback.select_target(
-                    &provider_name,
-                    &selected_model,
-                    &pricing_provider,
-                    &pricing_model,
-                );
                 let request_for_provider = token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),
                     &provider_name,
@@ -106,6 +100,10 @@ pub(super) async fn handle_streaming_chat_completion(
                 let reserve_pricing_config = pricing_config.clone();
                 let reserve_pricing_provider = pricing_provider.clone();
                 let reserve_pricing_model = pricing_model.clone();
+                let callback_provider = provider_name.clone();
+                let callback_model = selected_model.clone();
+                let callback_pricing_provider = reserve_pricing_provider.clone();
+                let callback_pricing_model = reserve_pricing_model.clone();
                 let (stream, reservations) = budgeted
                     .for_selected_with_api_key_budget(
                         provider_name.clone(),
@@ -126,7 +124,15 @@ pub(super) async fn handle_streaming_chat_completion(
                                 request_for_budget,
                             )
                         },
-                        || provider.chat_completion_stream(request_for_provider, provider_context),
+                        || {
+                            callback.begin_provider_execution(
+                                callback_provider,
+                                callback_model,
+                                callback_pricing_provider,
+                                callback_pricing_model,
+                            );
+                            provider.chat_completion_stream(request_for_provider, provider_context)
+                        },
                     )
                     .await?;
                 let (budget_reservation, key_budget_reservation) = reservations.into_parts();

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -15,6 +15,7 @@ use crate::core::types::{context::SharedRequestContext, model::ProviderCapabilit
 use crate::server::state::AppState;
 
 use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream, run_stream};
+use super::super::callbacks::CallbackLifecycle;
 use super::super::openai_errors;
 use super::super::{spend, token_policy};
 
@@ -45,6 +46,12 @@ pub(super) async fn handle_streaming_chat_completion(
     };
 
     let requested_model = core_request.model.clone();
+    let callback = CallbackLifecycle::start(
+        &state.callbacks,
+        state.budgeted.pricing(),
+        &requested_model,
+        context.as_ref(),
+    );
     let context_for_execution = Arc::clone(&context);
     let request_for_execution = Arc::clone(&request);
     let budgeted = state.budgeted.clone();
@@ -54,6 +61,7 @@ pub(super) async fn handle_streaming_chat_completion(
     let pricing_config = state.config().gateway.pricing.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
+    let callback_for_execution = callback.clone();
     match run_stream(
         state.unified_router.clone(),
         &requested_model,
@@ -67,12 +75,19 @@ pub(super) async fn handle_streaming_chat_completion(
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             let pricing_config = pricing_config.clone();
+            let callback = callback_for_execution.clone();
             async move {
                 let provider_name = provider.name().to_string();
                 let (pricing_provider, pricing_model) = spend::pricing_identity_for_provider(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                );
+                callback.select_target(
+                    &provider_name,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
                 );
                 let request_for_provider = token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),
@@ -181,6 +196,10 @@ pub(super) async fn handle_streaming_chat_completion(
                                     );
                                     lease.finish_failure(&error);
                                 }
+                                callback.fail(
+                                    format!("stream idle timeout after {}s", idle_timeout_secs),
+                                    "timeout",
+                                );
                                 settle_after_upstream_output!();
                                 return;
                             }
@@ -218,6 +237,7 @@ pub(super) async fn handle_streaming_chat_completion(
                                     if let Some(lease) = lease.take() {
                                         lease.finish_failure(&e);
                                     }
+                                    callback.fail(e.to_string(), "conversion_error");
                                     settle_after_upstream_output!();
                                     return;
                                 }
@@ -252,6 +272,10 @@ pub(super) async fn handle_streaming_chat_completion(
                                         );
                                         lease.finish_failure(&error);
                                     }
+                                    callback.fail(
+                                        format!("Serialization error: {}", e),
+                                        "serialization_error",
+                                    );
                                     settle_after_upstream_output!();
                                     return;
                                 }
@@ -268,6 +292,7 @@ pub(super) async fn handle_streaming_chat_completion(
                             if let Some(lease) = lease.take() {
                                 lease.finish_failure(&e);
                             }
+                            callback.fail(e.to_string(), "provider_error");
                             settle_after_upstream_output!();
                             return;
                         }
@@ -275,6 +300,7 @@ pub(super) async fn handle_streaming_chat_completion(
 
                     if tx.send(bytes).await.is_err() {
                         info!("Client disconnected during streaming, cancelling upstream");
+                        callback.fail("client disconnected", "client_disconnect");
                         settlement.record_disconnect(final_usage.as_ref()).await;
                         return;
                     }
@@ -287,6 +313,7 @@ pub(super) async fn handle_streaming_chat_completion(
                 settlement
                     .record_completion(final_usage.as_ref(), saw_upstream_output)
                     .await;
+                callback.complete_usage(final_usage.as_ref(), "success");
                 if let Some(lease) = lease.take() {
                     lease.finish_success(tokens_used);
                 }
@@ -304,6 +331,7 @@ pub(super) async fn handle_streaming_chat_completion(
         }
         Err(e) => {
             error!("Failed to create streaming response: {}", e);
+            callback.fail(e.to_string(), "provider_error");
             Ok(openai_errors::gateway_error_response(&e))
         }
     }

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -14,6 +14,7 @@ use crate::core::types::{context::SharedRequestContext, model::ProviderCapabilit
 use crate::server::state::AppState;
 
 use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream, run_stream};
+use super::super::callbacks::CallbackLifecycle;
 use super::super::{chat, openai_errors, spend, token_policy};
 use super::completions_sse::send_stream_error;
 use super::{CompletionAdapterRequest, chunk_has_text_delta, completion_chunk_from_core};
@@ -41,6 +42,12 @@ pub(super) async fn handle_streaming_completion(
         Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
     };
 
+    let callback = CallbackLifecycle::start(
+        &state.callbacks,
+        state.budgeted.pricing(),
+        &requested_model,
+        context.as_ref(),
+    );
     let context_for_execution = Arc::clone(&context);
     let request_for_execution = Arc::clone(&request);
     let budgeted = state.budgeted.clone();
@@ -50,6 +57,7 @@ pub(super) async fn handle_streaming_completion(
     let pricing_config = state.config().gateway.pricing.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
+    let callback_for_execution = callback.clone();
 
     match run_stream(
         state.unified_router.clone(),
@@ -64,12 +72,19 @@ pub(super) async fn handle_streaming_completion(
             let budget_limits = budget_limits.clone();
             let key_manager = key_manager.clone();
             let pricing_config = pricing_config.clone();
+            let callback = callback_for_execution.clone();
             async move {
                 let provider_name = provider.name().to_string();
                 let (pricing_provider, pricing_model) = spend::pricing_identity_for_provider(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                );
+                callback.select_target(
+                    &provider_name,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
                 );
                 let request_for_provider = token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),
@@ -179,6 +194,10 @@ pub(super) async fn handle_streaming_completion(
                                     );
                                     lease.finish_failure(&error);
                                 }
+                                callback.fail(
+                                    format!("stream idle timeout after {}s", idle_timeout_secs),
+                                    "timeout",
+                                );
                                 settle_if_chargeable!();
                                 return;
                             }
@@ -227,6 +246,10 @@ pub(super) async fn handle_streaming_completion(
                                         );
                                         lease.finish_failure(&error);
                                     }
+                                    callback.fail(
+                                        format!("Serialization error: {}", error),
+                                        "serialization_error",
+                                    );
                                     settle_if_chargeable!();
                                     return;
                                 }
@@ -240,12 +263,14 @@ pub(super) async fn handle_streaming_completion(
                             if let Some(lease) = lease.take() {
                                 lease.finish_failure(&error);
                             }
+                            callback.fail(error.to_string(), "provider_error");
                             settle_if_chargeable!();
                             return;
                         }
                     };
 
                     if tx.send(bytes).await.is_err() {
+                        callback.fail("client disconnected", "client_disconnect");
                         settle_if_chargeable!();
                         return;
                     }
@@ -255,6 +280,7 @@ pub(super) async fn handle_streaming_completion(
                 settlement
                     .record_completion(final_usage.as_ref(), saw_upstream_output)
                     .await;
+                callback.complete_usage(final_usage.as_ref(), "success");
                 if let Some(lease) = lease.take() {
                     lease.finish_success(tokens_used);
                 }
@@ -271,6 +297,7 @@ pub(super) async fn handle_streaming_completion(
         }
         Err(error) => {
             error!("Failed to create streaming completion response: {}", error);
+            callback.fail(error.to_string(), "provider_error");
             Ok(openai_errors::gateway_error_response(&error))
         }
     }

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -42,7 +42,7 @@ pub(super) async fn handle_streaming_completion(
         Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
     };
 
-    let callback = CallbackLifecycle::start(
+    let callback = CallbackLifecycle::new(
         &state.callbacks,
         state.budgeted.pricing(),
         &requested_model,
@@ -80,12 +80,6 @@ pub(super) async fn handle_streaming_completion(
                     &provider,
                     &selected_model,
                 );
-                callback.select_target(
-                    &provider_name,
-                    &selected_model,
-                    &pricing_provider,
-                    &pricing_model,
-                );
                 let request_for_provider = token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),
                     &provider_name,
@@ -102,6 +96,10 @@ pub(super) async fn handle_streaming_completion(
                 let reserve_pricing_config = pricing_config.clone();
                 let reserve_pricing_provider = pricing_provider.clone();
                 let reserve_pricing_model = pricing_model.clone();
+                let callback_provider = provider_name.clone();
+                let callback_model = selected_model.clone();
+                let callback_pricing_provider = reserve_pricing_provider.clone();
+                let callback_pricing_model = reserve_pricing_model.clone();
                 let (stream, reservations) = budgeted
                     .for_selected_with_api_key_budget(
                         provider_name.clone(),
@@ -122,7 +120,15 @@ pub(super) async fn handle_streaming_completion(
                                 request_for_budget,
                             )
                         },
-                        || provider.chat_completion_stream(request_for_provider, provider_context),
+                        || {
+                            callback.begin_provider_execution(
+                                callback_provider,
+                                callback_model,
+                                callback_pricing_provider,
+                                callback_pricing_model,
+                            );
+                            provider.chat_completion_stream(request_for_provider, provider_context)
+                        },
                     )
                     .await?;
                 let (budget_reservation, key_budget_reservation) = reservations.into_parts();

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -12,6 +12,7 @@ use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use tracing::info;
 
 use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
+use super::callbacks::CallbackLifecycle;
 use super::context::handle_ai_request;
 
 fn parse_embedding_input(input: &serde_json::Value) -> Result<EmbeddingInput, GatewayError> {
@@ -108,6 +109,12 @@ async fn handle_embedding_internal(
     };
 
     let requested_model = core_request.model.clone();
+    let callback = CallbackLifecycle::start(
+        &state.callbacks,
+        state.budgeted.pricing(),
+        &requested_model,
+        &context,
+    );
     let context_for_execution = context.clone();
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
@@ -115,7 +122,8 @@ async fn handle_embedding_internal(
     let key_manager = budgeted.key_manager();
     let pricing_service = budgeted.pricing();
     let pricing_config = state.config().gateway.pricing.clone();
-    let core_response = run_unary(
+    let callback_for_execution = callback.clone();
+    let core_response = match run_unary(
         &state.unified_router,
         &requested_model,
         ProviderCapability::Embeddings,
@@ -126,12 +134,19 @@ async fn handle_embedding_internal(
             let key_manager = key_manager.clone();
             let pricing_service = pricing_service.clone();
             let pricing_config = pricing_config.clone();
+            let callback = callback_for_execution.clone();
             async move {
                 let budget_provider = provider.name().to_string();
                 let (pricing_provider, pricing_model) = super::spend::pricing_identity_for_provider(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                );
+                callback.select_target(
+                    &budget_provider,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
                 );
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = selected_model.clone();
@@ -216,9 +231,17 @@ async fn handle_embedding_internal(
             }
         },
     )
-    .await?;
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            callback.fail(error.to_string(), "provider_error");
+            return Err(error);
+        }
+    };
 
     // Convert core response to OpenAI format
+    let callback_usage = core_response.usage.clone();
     let response = EmbeddingResponse {
         object: core_response.object,
         data: core_response
@@ -245,7 +268,13 @@ async fn handle_embedding_internal(
         },
     };
 
-    super::response_cache::store_embedding(state, &request_for_cache, &response, &context).await?;
+    if let Err(error) =
+        super::response_cache::store_embedding(state, &request_for_cache, &response, &context).await
+    {
+        callback.fail(error.to_string(), "cache_error");
+        return Err(error);
+    }
+    callback.complete_usage(callback_usage.as_ref(), "success");
     Ok(response)
 }
 

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -109,7 +109,7 @@ async fn handle_embedding_internal(
     };
 
     let requested_model = core_request.model.clone();
-    let callback = CallbackLifecycle::start(
+    let callback = CallbackLifecycle::new(
         &state.callbacks,
         state.budgeted.pricing(),
         &requested_model,
@@ -142,12 +142,6 @@ async fn handle_embedding_internal(
                     &provider,
                     &selected_model,
                 );
-                callback.select_target(
-                    &budget_provider,
-                    &selected_model,
-                    &pricing_provider,
-                    &pricing_model,
-                );
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = selected_model.clone();
                 let reserve_pricing_service = pricing_service.clone();
@@ -159,6 +153,10 @@ async fn handle_embedding_internal(
                 let settle_pricing_provider = pricing_provider;
                 let settle_pricing_model = pricing_model;
                 let settle_key_manager = key_manager.clone();
+                let callback_provider = budget_provider.clone();
+                let callback_model = selected_model.clone();
+                let callback_pricing_provider = reserve_pricing_provider.clone();
+                let callback_pricing_model = reserve_pricing_model.clone();
                 budgeted
                     .for_selected_with_api_key_budget(
                         budget_provider.clone(),
@@ -179,7 +177,15 @@ async fn handle_embedding_internal(
                                 &core_request.input,
                             )
                         },
-                        || provider.create_embeddings(request_for_provider, context),
+                        || {
+                            callback.begin_provider_execution(
+                                callback_provider,
+                                callback_model,
+                                callback_pricing_provider,
+                                callback_pricing_model,
+                            );
+                            provider.create_embeddings(request_for_provider, context)
+                        },
                         |response, reservations, budget| {
                             let (budget_reservation, key_budget_reservation) =
                                 reservations.into_parts();

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -6,6 +6,7 @@
 mod audio;
 mod batches;
 pub(crate) mod budgeted;
+mod callbacks;
 mod chat;
 mod completions;
 mod context;

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -5,9 +5,8 @@
 
 use crate::core::models::openai::requests::{ChatCompletionRequest, StreamOptions};
 use crate::core::models::openai::responses_api::{
-    ResponseFunctionCall, ResponseInputTokensDetails, ResponseOutputContent, ResponseOutputItem,
-    ResponseOutputMessage, ResponseOutputTokensDetails, ResponseReasoningItem, ResponseStreamEvent,
-    ResponseUsage, ResponsesApiRequest, ResponsesApiResponse,
+    ResponseFunctionCall, ResponseOutputContent, ResponseOutputItem, ResponseOutputMessage,
+    ResponseStreamEvent, ResponsesApiRequest, ResponsesApiResponse,
 };
 use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
@@ -23,7 +22,6 @@ use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use actix_web::{HttpResponse, Result as ActixResult};
 use bytes::Bytes;
 use futures::StreamExt;
-use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,10 +29,17 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use super::budgeted::{ApiKeyBudgetPolicy, run_stream};
+use super::callbacks::CallbackLifecycle;
 use super::{openai_errors, spend};
 #[path = "responses_stream_budget.rs"]
 mod responses_stream_budget;
 use responses_stream_budget::StreamBudgetSettlement;
+#[path = "responses_stream_support.rs"]
+mod responses_stream_support;
+use responses_stream_support::{
+    classify, completed_reasoning_item, emit, in_progress_reasoning_item, make_shell,
+    output_items_in_stream_order, response_usage_from_chat_usage, sse_error,
+};
 
 /// Accumulated state for one in-progress tool call during streaming.
 struct ToolCallAccum {
@@ -76,6 +81,12 @@ pub(crate) async fn handle_streaming_response(
         };
 
     let requested_model = core_request.model.clone();
+    let callback = CallbackLifecycle::start(
+        &state.callbacks,
+        state.budgeted.pricing(),
+        &requested_model,
+        context.as_ref(),
+    );
     let context_clone = Arc::clone(&context);
     let request_for_execution = Arc::clone(&chat_request);
     let budgeted = state.budgeted.clone();
@@ -84,6 +95,7 @@ pub(crate) async fn handle_streaming_response(
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
     let settlement_budgeted = state.budgeted.clone();
+    let callback_for_execution = callback.clone();
 
     match run_stream(
         state.unified_router.clone(),
@@ -96,12 +108,19 @@ pub(crate) async fn handle_streaming_response(
             let budgeted = budgeted.clone();
             let pricing_service = pricing_service.clone();
             let pricing_config = pricing_config.clone();
+            let callback = callback_for_execution.clone();
             async move {
                 let provider_name = provider.name().to_string();
                 let (pricing_provider, pricing_model) = spend::pricing_identity_for_provider(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                );
+                callback.select_target(
+                    &provider_name,
+                    &selected_model,
+                    &pricing_provider,
+                    &pricing_model,
                 );
                 let req = super::token_policy::prepare_chat_request_for_provider(
                     ctx.api_key_max_tokens_per_request(),
@@ -197,6 +216,7 @@ pub(crate) async fn handle_streaming_response(
                 .await
                 .is_err()
                 {
+                    callback.fail("client disconnected", "client_disconnect");
                     return;
                 }
 
@@ -218,6 +238,7 @@ pub(crate) async fn handle_streaming_response(
                 let mut reasoning_started = false;
                 macro_rules! return_after_disconnect {
                     () => {
+                        callback.fail("client disconnected", "client_disconnect");
                         if final_usage.is_some() || saw_upstream_output {
                             settlement.record_disconnect(final_usage.as_ref()).await;
                         }
@@ -249,6 +270,10 @@ pub(crate) async fn handle_streaming_response(
                                     );
                                     lease.finish_failure(&error);
                                 }
+                                callback.fail(
+                                    format!("stream idle timeout after {idle_timeout}s"),
+                                    "timeout",
+                                );
                                 return_after_disconnect!();
                             }
                         }
@@ -480,6 +505,7 @@ pub(crate) async fn handle_streaming_response(
                             if let Some(lease) = lease.take() {
                                 lease.finish_failure(&e);
                             }
+                            callback.fail(e.to_string(), "provider_error");
                             return_after_disconnect!();
                         }
                     }
@@ -633,6 +659,7 @@ pub(crate) async fn handle_streaming_response(
                 settlement
                     .record_completion(budget_usage.as_ref(), saw_upstream_output)
                     .await;
+                callback.complete_usage(budget_usage.as_ref(), "success");
                 if let Some(lease) = lease.take() {
                     let tokens_used = budget_usage
                         .as_ref()
@@ -677,108 +704,9 @@ pub(crate) async fn handle_streaming_response(
         }
         Err(e) => {
             error!("Failed to start Responses API stream: {e}");
+            callback.fail(e.to_string(), "provider_error");
             Ok(openai_errors::gateway_error_response(&e))
         }
-    }
-}
-
-fn completed_reasoning_item(
-    item_id: String,
-    status: &str,
-    summary_text: String,
-) -> ResponseOutputItem {
-    ResponseOutputItem::Reasoning(ResponseReasoningItem {
-        id: item_id,
-        status: status.to_string(),
-        summary: Some(vec![json!({
-            "type": "summary_text",
-            "text": summary_text,
-        })]),
-    })
-}
-
-fn in_progress_reasoning_item(item_id: String) -> ResponseOutputItem {
-    ResponseOutputItem::Reasoning(ResponseReasoningItem {
-        id: item_id,
-        status: "in_progress".to_string(),
-        summary: Some(vec![]),
-    })
-}
-
-fn output_items_in_stream_order(
-    mut all_output: Vec<(u32, ResponseOutputItem)>,
-) -> Vec<ResponseOutputItem> {
-    all_output.sort_by_key(|(i, _)| *i);
-    all_output.into_iter().map(|(_, item)| item).collect()
-}
-
-fn response_usage_from_chat_usage(usage: &ChatUsage) -> ResponseUsage {
-    ResponseUsage {
-        input_tokens: usage.prompt_tokens,
-        output_tokens: usage.completion_tokens,
-        total_tokens: usage.total_tokens,
-        input_tokens_details: usage.prompt_tokens_details.as_ref().map(|d| {
-            ResponseInputTokensDetails {
-                cached_tokens: d.cached_tokens.unwrap_or(0),
-            }
-        }),
-        output_tokens_details: usage.completion_tokens_details.as_ref().map(|d| {
-            ResponseOutputTokensDetails {
-                reasoning_tokens: d.reasoning_tokens.unwrap_or(0),
-            }
-        }),
-    }
-}
-
-fn make_shell(
-    id: &str,
-    created_at: i64,
-    model: &str,
-    status: &str,
-    original: &ResponsesApiRequest,
-) -> ResponsesApiResponse {
-    ResponsesApiResponse {
-        id: id.to_string(),
-        object: "response".to_string(),
-        created_at,
-        status: status.to_string(),
-        model: model.to_string(),
-        output: vec![],
-        usage: None,
-        error: None,
-        previous_response_id: original.previous_response_id.clone(),
-        metadata: None,
-    }
-}
-
-async fn emit(tx: &mpsc::Sender<Bytes>, event: &ResponseStreamEvent) -> Result<(), ()> {
-    match serde_json::to_string(event) {
-        Ok(json) => tx
-            .send(Event::default().data(&json).to_bytes())
-            .await
-            .map_err(|_| ()),
-        Err(e) => {
-            error!("Failed to serialise stream event: {e}");
-            Err(())
-        }
-    }
-}
-
-fn sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
-    let err = json!({"type":"error","error":{"type":error_type,"code":code,"message":message}});
-    let err_ev = Event::default().data(&err.to_string());
-    let done_ev = Event::default().data("[DONE]");
-    let mut v = err_ev.to_bytes().to_vec();
-    v.extend_from_slice(&done_ev.to_bytes());
-    Bytes::from(v)
-}
-
-fn classify(e: &ProviderError) -> (&'static str, &'static str) {
-    match e {
-        ProviderError::Authentication { .. } => ("invalid_request_error", "authentication_error"),
-        ProviderError::RateLimit { .. } => ("rate_limit_error", "rate_limit_exceeded"),
-        ProviderError::Timeout { .. } => ("server_error", "timeout"),
-        _ => ("server_error", "internal_error"),
     }
 }
 

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -81,7 +81,7 @@ pub(crate) async fn handle_streaming_response(
         };
 
     let requested_model = core_request.model.clone();
-    let callback = CallbackLifecycle::start(
+    let callback = CallbackLifecycle::new(
         &state.callbacks,
         state.budgeted.pricing(),
         &requested_model,
@@ -116,12 +116,6 @@ pub(crate) async fn handle_streaming_response(
                     &provider,
                     &selected_model,
                 );
-                callback.select_target(
-                    &provider_name,
-                    &selected_model,
-                    &pricing_provider,
-                    &pricing_model,
-                );
                 let req = super::token_policy::prepare_chat_request_for_provider(
                     ctx.api_key_max_tokens_per_request(),
                     &provider_name,
@@ -136,6 +130,10 @@ pub(crate) async fn handle_streaming_response(
                 let reserve_pricing_config = pricing_config.clone();
                 let reserve_pricing_provider = pricing_provider.clone();
                 let reserve_pricing_model = pricing_model.clone();
+                let callback_provider = provider_name.clone();
+                let callback_model = selected_model.clone();
+                let callback_pricing_provider = reserve_pricing_provider.clone();
+                let callback_pricing_model = reserve_pricing_model.clone();
                 let (stream, reservations) = budgeted
                     .for_selected_with_api_key_budget(
                         provider_name.clone(),
@@ -156,7 +154,15 @@ pub(crate) async fn handle_streaming_response(
                                 request_for_budget,
                             )
                         },
-                        || provider.chat_completion_stream(req, provider_context),
+                        || {
+                            callback.begin_provider_execution(
+                                callback_provider,
+                                callback_model,
+                                callback_pricing_provider,
+                                callback_pricing_model,
+                            );
+                            provider.chat_completion_stream(req, provider_context)
+                        },
                     )
                     .await?;
                 let (budget_reservation, key_budget_reservation) = reservations.into_parts();

--- a/src/server/routes/ai/responses_stream_support.rs
+++ b/src/server/routes/ai/responses_stream_support.rs
@@ -1,0 +1,113 @@
+use bytes::Bytes;
+use serde_json::json;
+use tokio::sync::mpsc;
+use tracing::error;
+
+use crate::core::models::openai::responses_api::{
+    ResponseInputTokensDetails, ResponseOutputItem, ResponseOutputTokensDetails,
+    ResponseReasoningItem, ResponseStreamEvent, ResponseUsage, ResponsesApiRequest,
+    ResponsesApiResponse,
+};
+use crate::core::providers::ProviderError;
+use crate::core::streaming::types::Event;
+use crate::core::types::responses::Usage as ChatUsage;
+
+pub(super) fn completed_reasoning_item(
+    item_id: String,
+    status: &str,
+    summary_text: String,
+) -> ResponseOutputItem {
+    ResponseOutputItem::Reasoning(ResponseReasoningItem {
+        id: item_id,
+        status: status.to_string(),
+        summary: Some(vec![json!({
+            "type": "summary_text",
+            "text": summary_text,
+        })]),
+    })
+}
+
+pub(super) fn in_progress_reasoning_item(item_id: String) -> ResponseOutputItem {
+    ResponseOutputItem::Reasoning(ResponseReasoningItem {
+        id: item_id,
+        status: "in_progress".to_string(),
+        summary: Some(vec![]),
+    })
+}
+
+pub(super) fn output_items_in_stream_order(
+    mut all_output: Vec<(u32, ResponseOutputItem)>,
+) -> Vec<ResponseOutputItem> {
+    all_output.sort_by_key(|(index, _)| *index);
+    all_output.into_iter().map(|(_, item)| item).collect()
+}
+
+pub(super) fn response_usage_from_chat_usage(usage: &ChatUsage) -> ResponseUsage {
+    ResponseUsage {
+        input_tokens: usage.prompt_tokens,
+        output_tokens: usage.completion_tokens,
+        total_tokens: usage.total_tokens,
+        input_tokens_details: usage.prompt_tokens_details.as_ref().map(|details| {
+            ResponseInputTokensDetails {
+                cached_tokens: details.cached_tokens.unwrap_or(0),
+            }
+        }),
+        output_tokens_details: usage.completion_tokens_details.as_ref().map(|details| {
+            ResponseOutputTokensDetails {
+                reasoning_tokens: details.reasoning_tokens.unwrap_or(0),
+            }
+        }),
+    }
+}
+
+pub(super) fn make_shell(
+    id: &str,
+    created_at: i64,
+    model: &str,
+    status: &str,
+    original: &ResponsesApiRequest,
+) -> ResponsesApiResponse {
+    ResponsesApiResponse {
+        id: id.to_string(),
+        object: "response".to_string(),
+        created_at,
+        status: status.to_string(),
+        model: model.to_string(),
+        output: vec![],
+        usage: None,
+        error: None,
+        previous_response_id: original.previous_response_id.clone(),
+        metadata: None,
+    }
+}
+
+pub(super) async fn emit(tx: &mpsc::Sender<Bytes>, event: &ResponseStreamEvent) -> Result<(), ()> {
+    match serde_json::to_string(event) {
+        Ok(json) => tx
+            .send(Event::default().data(&json).to_bytes())
+            .await
+            .map_err(|_| ()),
+        Err(error) => {
+            error!("Failed to serialise stream event: {error}");
+            Err(())
+        }
+    }
+}
+
+pub(super) fn sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
+    let error = json!({"type":"error","error":{"type":error_type,"code":code,"message":message}});
+    let error_event = Event::default().data(&error.to_string());
+    let done_event = Event::default().data("[DONE]");
+    let mut bytes = error_event.to_bytes().to_vec();
+    bytes.extend_from_slice(&done_event.to_bytes());
+    Bytes::from(bytes)
+}
+
+pub(super) fn classify(error: &ProviderError) -> (&'static str, &'static str) {
+    match error {
+        ProviderError::Authentication { .. } => ("invalid_request_error", "authentication_error"),
+        ProviderError::RateLimit { .. } => ("rate_limit_error", "rate_limit_exceeded"),
+        ProviderError::Timeout { .. } => ("server_error", "timeout"),
+        _ => ("server_error", "internal_error"),
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -5,6 +5,7 @@
 use crate::config::Config;
 use crate::core::budget::{BudgetManager, UnifiedBudgetLimits};
 use crate::core::cache::{DualCacheConfig, LLMCache, LLMCacheConfig};
+use crate::core::integrations::CallbackDispatcher;
 use crate::core::keys::{DatabaseKeyRepository, KeyManager};
 use crate::core::pricing_service::PricingService;
 use crate::core::teams::TeamManager;
@@ -49,6 +50,8 @@ pub struct AppState {
     pub(crate) budgeted: BudgetedExecutor,
     /// Optional deterministic response cache for non-streaming chat and embeddings
     pub response_cache: Option<Arc<LLMCache>>,
+    /// Non-blocking external request lifecycle callback dispatcher
+    pub callbacks: CallbackDispatcher,
 }
 
 impl AppState {
@@ -87,7 +90,14 @@ impl AppState {
             key_manager,
             budgeted,
             response_cache,
+            callbacks: CallbackDispatcher::disabled(),
         }
+    }
+
+    /// Attach a configured callback dispatcher.
+    pub fn with_callbacks(mut self, callbacks: CallbackDispatcher) -> Self {
+        self.callbacks = callbacks;
+        self
     }
 
     /// Load a snapshot of the current gateway configuration.

--- a/tests/integration/completions_route_tests.rs
+++ b/tests/integration/completions_route_tests.rs
@@ -11,6 +11,10 @@ mod tests {
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
+    use litellm_rs::core::integrations::{
+        CallbackRuntime, Integration, IntegrationManager, IntegrationResult, LlmEndEvent,
+        LlmErrorEvent, LlmStartEvent,
+    };
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
     use litellm_rs::core::types::context::RequestContext;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
@@ -19,6 +23,60 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
+
+    #[derive(Clone)]
+    enum RecordedCallback {
+        Start(LlmStartEvent),
+        End(LlmEndEvent),
+        Error(LlmErrorEvent),
+    }
+
+    struct RecordingCallback {
+        events: Arc<Mutex<Vec<RecordedCallback>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Integration for RecordingCallback {
+        fn name(&self) -> &'static str {
+            "route-test-recorder"
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        async fn on_llm_start(&self, event: &LlmStartEvent) -> IntegrationResult<()> {
+            self.events
+                .lock()
+                .expect("callback events should not be poisoned")
+                .push(RecordedCallback::Start(event.clone()));
+            Ok(())
+        }
+
+        async fn on_llm_end(&self, event: &LlmEndEvent) -> IntegrationResult<()> {
+            self.events
+                .lock()
+                .expect("callback events should not be poisoned")
+                .push(RecordedCallback::End(event.clone()));
+            Ok(())
+        }
+
+        async fn on_llm_error(&self, event: &LlmErrorEvent) -> IntegrationResult<()> {
+            self.events
+                .lock()
+                .expect("callback events should not be poisoned")
+                .push(RecordedCallback::Error(event.clone()));
+            Ok(())
+        }
+
+        async fn flush(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+    }
 
     #[derive(Clone, Copy)]
     enum MockScenario {
@@ -201,6 +259,14 @@ mod tests {
         server.state().clone()
     }
 
+    async fn build_callback_runtime(events: Arc<Mutex<Vec<RecordedCallback>>>) -> CallbackRuntime {
+        let manager = Arc::new(IntegrationManager::with_defaults());
+        manager
+            .register(Arc::new(RecordingCallback { events }))
+            .await;
+        CallbackRuntime::new(manager, 8).expect("callback runtime should initialize")
+    }
+
     fn completion_request(stream: Option<bool>) -> Value {
         json!({
             "model": "gpt-4o",
@@ -278,6 +344,56 @@ mod tests {
         assert_eq!(requests[0]["messages"][0]["content"], "Hello");
         assert!(requests[0].get("stream").is_none());
         assert!(requests[0].get("stream_options").is_none());
+
+        mock_server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_completions_route_emits_metadata_only_callback_lifecycle() {
+        let mock_server = MockOpenAIServer::start(MockScenario::NonStreamingSuccess).await;
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let runtime = build_callback_runtime(Arc::clone(&events)).await;
+        let state = build_test_app_state(&mock_server.base_url)
+            .await
+            .with_callbacks(runtime.dispatcher());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let request = test::TestRequest::post()
+            .uri("/v1/completions")
+            .set_json(completion_request(None))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let _: Value = test::read_body_json(response).await;
+        runtime
+            .shutdown()
+            .await
+            .expect("callback runtime should drain");
+
+        let events = events
+            .lock()
+            .expect("callback events should not be poisoned")
+            .clone();
+        assert_eq!(events.len(), 2);
+        let (RecordedCallback::Start(start), RecordedCallback::End(end)) = (&events[0], &events[1])
+        else {
+            panic!("route should emit one ordered start/end callback pair");
+        };
+        assert_eq!(start.request_id, end.request_id);
+        assert_eq!(start.model, "gpt-4o");
+        assert_eq!(start.input, Value::Null);
+        assert_eq!(end.output, Value::Null);
+        assert_eq!(end.provider.as_deref(), Some("openai"));
+        assert_eq!(end.input_tokens, Some(10));
+        assert_eq!(end.output_tokens, Some(6));
+        assert!(end.cost_usd.is_some());
+        assert!(end.metadata.contains_key("outcome"));
 
         mock_server.shutdown().await;
     }

--- a/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
+++ b/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
@@ -266,3 +266,53 @@ async fn test_completions_success_records_budget_spend() {
 
     mock_server.shutdown().await;
 }
+
+#[tokio::test]
+async fn test_completions_budget_rejection_emits_no_callback_lifecycle() {
+    let mock_server = MockOpenAIServer::start(MockScenario::NonStreamingSuccess).await;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime = build_callback_runtime(Arc::clone(&events)).await;
+    let state = build_test_app_state(&mock_server.base_url)
+        .await
+        .with_callbacks(runtime.dispatcher());
+    state.budget_limits.providers.set_provider_limit(
+        "openai",
+        ProviderLimitConfig::new(1.0, ResetPeriod::Monthly),
+    );
+    state
+        .budget_limits
+        .providers
+        .record_provider_spend("openai", 2.0);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(litellm_rs::server::routes::ai::configure_routes),
+    )
+    .await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/completions")
+            .set_json(completion_request(None))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    assert!(mock_server.requests().is_empty());
+    runtime
+        .shutdown()
+        .await
+        .expect("callback runtime should drain");
+    let events = events
+        .lock()
+        .expect("callback events should not be poisoned")
+        .clone();
+    assert!(
+        events.is_empty(),
+        "pre-provider budget rejection must not emit lifecycle callbacks"
+    );
+
+    mock_server.shutdown().await;
+}

--- a/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
+++ b/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
@@ -3,7 +3,11 @@ use super::*;
 #[tokio::test]
 async fn test_completions_provider_failure_maps_to_rate_limit() {
     let mock_server = MockOpenAIServer::start(MockScenario::RateLimitFailure).await;
-    let state = build_test_app_state(&mock_server.base_url).await;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime = build_callback_runtime(Arc::clone(&events)).await;
+    let state = build_test_app_state(&mock_server.base_url)
+        .await
+        .with_callbacks(runtime.dispatcher());
 
     let app = test::init_service(
         App::new()
@@ -35,6 +39,21 @@ async fn test_completions_provider_failure_maps_to_rate_limit() {
     let requests = mock_server.requests();
     assert!(!requests.is_empty());
     assert!(requests.iter().all(|request| request["model"] == "gpt-4o"));
+    runtime
+        .shutdown()
+        .await
+        .expect("callback runtime should drain");
+    let events = events
+        .lock()
+        .expect("callback events should not be poisoned")
+        .clone();
+    assert_eq!(events.len(), 2);
+    let RecordedCallback::Error(error) = &events[1] else {
+        panic!("provider failure should emit one terminal error callback");
+    };
+    assert_eq!(error.error_type.as_deref(), Some("provider_error"));
+    assert_eq!(error.error_message, "provider request failed");
+    assert!(!error.error_message.contains("sk-completion-secret"));
 
     mock_server.shutdown().await;
 }
@@ -76,7 +95,11 @@ async fn test_completions_streaming_echo_prefixes_prompt_once() {
 #[tokio::test]
 async fn test_completions_stream_timeout_before_output_does_not_record_spend() {
     let mock_server = MockOpenAIServer::start(MockScenario::StreamingIdle).await;
-    let state = build_test_app_state_with_idle_timeout(&mock_server.base_url, Some(1)).await;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime = build_callback_runtime(Arc::clone(&events)).await;
+    let state = build_test_app_state_with_idle_timeout(&mock_server.base_url, Some(1))
+        .await
+        .with_callbacks(runtime.dispatcher());
     state.budget_limits.providers.set_provider_limit(
         "openai",
         ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
@@ -119,6 +142,21 @@ async fn test_completions_stream_timeout_before_output_does_not_record_spend() {
         .unwrap_or(0.0);
     assert_eq!(provider_spend, 0.0);
     assert_eq!(model_spend, 0.0);
+    runtime
+        .shutdown()
+        .await
+        .expect("callback runtime should drain");
+    let events = events
+        .lock()
+        .expect("callback events should not be poisoned")
+        .clone();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], RecordedCallback::Start(_)));
+    let RecordedCallback::Error(error) = &events[1] else {
+        panic!("stream timeout should emit one terminal error callback");
+    };
+    assert_eq!(error.error_type.as_deref(), Some("timeout"));
+    assert_eq!(error.error_message, "provider request timed out");
 
     mock_server.shutdown().await;
 }
@@ -126,7 +164,11 @@ async fn test_completions_stream_timeout_before_output_does_not_record_spend() {
 #[tokio::test]
 async fn test_completions_streaming_response_sends_sse_and_done() {
     let mock_server = MockOpenAIServer::start(MockScenario::StreamingSuccess).await;
-    let state = build_test_app_state(&mock_server.base_url).await;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime = build_callback_runtime(Arc::clone(&events)).await;
+    let state = build_test_app_state(&mock_server.base_url)
+        .await
+        .with_callbacks(runtime.dispatcher());
 
     let app = test::init_service(
         App::new()
@@ -160,6 +202,17 @@ async fn test_completions_streaming_response_sends_sse_and_done() {
     let requests = mock_server.requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0]["stream"], true);
+    runtime
+        .shutdown()
+        .await
+        .expect("callback runtime should drain");
+    let events = events
+        .lock()
+        .expect("callback events should not be poisoned")
+        .clone();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], RecordedCallback::Start(_)));
+    assert!(matches!(events[1], RecordedCallback::End(_)));
 
     mock_server.shutdown().await;
 }


### PR DESCRIPTION
## What

- add opt-in OpenTelemetry, Datadog, and Langfuse callback backend configuration and startup wiring
- deliver ordered metadata-only request lifecycle events through a bounded non-blocking dispatcher
- instrument provider-backed chat, completions, responses, embeddings, and streaming terminal paths
- drain and flush integrations during gateway shutdown
- include the complete SpecRail packet for GH1066

## Why

The existing exporters and integration trait were not connected to gateway startup or real provider execution, so configured observability backends received no request lifecycle data.

## Test Plan

- [x] cargo fmt --check
- [x] cargo check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (full suite and doctests; ulimit -n 4096 for the test process)
- [x] focused callback runtime, lifecycle, startup, route, and streaming tests
- [x] SpecRail repository and GH1066 packet checks
- [x] overlap guard (no overlap); scope guard non-blocking warning disclosed for the issue-wide config/runtime/startup/route slice

Closes #1066