### PR TITLE
security(observability): enforce log webhook outbound policy

### DIFF
--- a/src/core/observability/destinations.rs
+++ b/src/core/observability/destinations.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 /// Log destinations
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum LogDestination {
     /// Elasticsearch
     Elasticsearch {
@@ -36,6 +36,12 @@ pub enum LogDestination {
         url: String,
         headers: HashMap<String, String>,
     },
+}
+
+impl std::fmt::Debug for LogDestination {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("LogDestination { redacted }")
+    }
 }
 
 /// Alert channels

--- a/src/core/observability/logging.rs
+++ b/src/core/observability/logging.rs
@@ -2,12 +2,16 @@
 
 use super::destinations::LogDestination;
 use super::types::LogEntry;
-use crate::core::http::outbound::default_outbound_client;
+use crate::core::net::ProviderEndpointPolicy;
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use crate::utils::net::http::ProviderHttpClient;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{debug, error};
+
+pub(super) const LOG_WEBHOOK_TIMEOUT: Duration = Duration::from_secs(120);
+const INVALID_LOG_WEBHOOK_URL: &str = "Log webhook URL is invalid or disallowed by outbound policy";
 
 /// Log aggregator for centralized logging
 pub struct LogAggregator {
@@ -15,6 +19,7 @@ pub struct LogAggregator {
     destinations: Vec<LogDestination>,
     /// Log buffer
     pub(crate) buffer: Arc<RwLock<Vec<LogEntry>>>,
+    webhook_client: Option<ProviderHttpClient>,
     /// Buffer flush interval
     flush_interval: Duration,
 }
@@ -31,14 +36,58 @@ impl LogAggregator {
         Self {
             destinations: vec![],
             buffer: Arc::new(RwLock::new(Vec::new())),
+            webhook_client: None,
             flush_interval: Duration::from_secs(10),
         }
     }
 
     /// Add log destination
-    pub fn add_destination(mut self, destination: LogDestination) -> Self {
+    pub fn add_destination(self, destination: LogDestination) -> Result<Self> {
+        self.add_destination_with_client(destination, None)
+    }
+
+    fn add_destination_with_client(
+        mut self,
+        destination: LogDestination,
+        client: Option<ProviderHttpClient>,
+    ) -> Result<Self> {
+        let destination = if let LogDestination::Webhook { url, headers } = destination {
+            let url = reqwest::Url::parse(&url)
+                .map_err(|_| GatewayError::Validation(INVALID_LOG_WEBHOOK_URL.to_string()))?;
+            ProviderEndpointPolicy::public_only()
+                .validate_url_without_resolution(&url)
+                .map_err(|_| GatewayError::Validation(INVALID_LOG_WEBHOOK_URL.to_string()))?;
+            self.webhook_client = Some(match client {
+                Some(client) => client,
+                None => ProviderHttpClient::no_redirect(
+                    ProviderEndpointPolicy::public_only(),
+                    LOG_WEBHOOK_TIMEOUT,
+                )
+                .map_err(|_| {
+                    GatewayError::Network(
+                        "Failed to create policy-bound log webhook client".to_string(),
+                    )
+                })?,
+            });
+            LogDestination::Webhook {
+                url: url.to_string(),
+                headers,
+            }
+        } else {
+            destination
+        };
         self.destinations.push(destination);
-        self
+        Ok(self)
+    }
+
+    #[cfg(test)]
+    pub(super) fn add_webhook_with_client_for_test(
+        self,
+        url: String,
+        headers: std::collections::HashMap<String, String>,
+        client: ProviderHttpClient,
+    ) -> Result<Self> {
+        self.add_destination_with_client(LogDestination::Webhook { url, headers }, Some(client))
     }
 
     /// Log an entry
@@ -72,7 +121,7 @@ impl LogAggregator {
     }
 
     /// Send logs to a specific destination
-    async fn send_to_destination(
+    pub(super) async fn send_to_destination(
         &self,
         destination: &LogDestination,
         entries: &[LogEntry],
@@ -102,18 +151,36 @@ impl LogAggregator {
                 debug!("Sending {} logs to Datadog", entries.len());
             }
             LogDestination::Webhook { url, headers } => {
-                // Send to webhook
-                let client = default_outbound_client().clone();
-                let mut request = client.post(url).json(entries);
+                let client = self.webhook_client.as_ref().ok_or_else(|| {
+                    GatewayError::Internal("Log webhook client is not configured".to_string())
+                })?;
+                let mut request = client
+                    .post(url)
+                    .map_err(|_| {
+                        GatewayError::Network(
+                            "Log webhook rejected by outbound endpoint policy".to_string(),
+                        )
+                    })?
+                    .json(entries);
 
                 for (key, value) in headers {
                     request = request.header(key, value);
                 }
 
-                request
-                    .send()
-                    .await
-                    .map_err(|e| GatewayError::Network(e.to_string()))?;
+                let response = request.send().await.map_err(|error| {
+                    let message = if ProviderHttpClient::request_error_is_endpoint_policy(&error) {
+                        "Log webhook rejected by outbound endpoint policy"
+                    } else {
+                        "Failed to send logs to webhook"
+                    };
+                    GatewayError::Network(message.to_string())
+                })?;
+                if !response.status().is_success() {
+                    return Err(GatewayError::Network(format!(
+                        "Log webhook returned status: {}",
+                        response.status()
+                    )));
+                }
             }
             _ => {
                 // Other destinations would be implemented similarly
@@ -141,6 +208,7 @@ impl Clone for LogAggregator {
         Self {
             destinations: self.destinations.clone(),
             buffer: self.buffer.clone(),
+            webhook_client: self.webhook_client.clone(),
             flush_interval: self.flush_interval,
         }
     }

--- a/src/core/observability/logging.rs
+++ b/src/core/observability/logging.rs
@@ -42,33 +42,27 @@ impl LogAggregator {
     }
 
     /// Add log destination
-    pub fn add_destination(self, destination: LogDestination) -> Result<Self> {
-        self.add_destination_with_client(destination, None)
-    }
-
-    fn add_destination_with_client(
-        mut self,
-        destination: LogDestination,
-        client: Option<ProviderHttpClient>,
-    ) -> Result<Self> {
+    pub fn add_destination(mut self, destination: LogDestination) -> Result<Self> {
         let destination = if let LogDestination::Webhook { url, headers } = destination {
             let url = reqwest::Url::parse(&url)
                 .map_err(|_| GatewayError::Validation(INVALID_LOG_WEBHOOK_URL.to_string()))?;
-            ProviderEndpointPolicy::public_only()
-                .validate_url_without_resolution(&url)
-                .map_err(|_| GatewayError::Validation(INVALID_LOG_WEBHOOK_URL.to_string()))?;
-            self.webhook_client = Some(match client {
-                Some(client) => client,
-                None => ProviderHttpClient::no_redirect(
-                    ProviderEndpointPolicy::public_only(),
-                    LOG_WEBHOOK_TIMEOUT,
-                )
-                .map_err(|_| {
-                    GatewayError::Network(
-                        "Failed to create policy-bound log webhook client".to_string(),
-                    )
-                })?,
-            });
+            let policy = ProviderEndpointPolicy::public_only();
+            if !matches!(url.scheme(), "http" | "https")
+                || policy.validate_url_without_resolution(&url).is_err()
+            {
+                return Err(GatewayError::Validation(
+                    INVALID_LOG_WEBHOOK_URL.to_string(),
+                ));
+            }
+            if self.webhook_client.is_none() {
+                self.webhook_client = Some(
+                    ProviderHttpClient::no_redirect(policy, LOG_WEBHOOK_TIMEOUT).map_err(|_| {
+                        GatewayError::Network(
+                            "Failed to create policy-bound log webhook client".to_string(),
+                        )
+                    })?,
+                );
+            }
             LogDestination::Webhook {
                 url: url.to_string(),
                 headers,
@@ -81,13 +75,9 @@ impl LogAggregator {
     }
 
     #[cfg(test)]
-    pub(super) fn add_webhook_with_client_for_test(
-        self,
-        url: String,
-        headers: std::collections::HashMap<String, String>,
-        client: ProviderHttpClient,
-    ) -> Result<Self> {
-        self.add_destination_with_client(LogDestination::Webhook { url, headers }, Some(client))
+    pub(super) fn with_webhook_client_for_test(mut self, client: ProviderHttpClient) -> Self {
+        self.webhook_client = Some(client);
+        self
     }
 
     /// Log an entry

--- a/src/core/observability/tests.rs
+++ b/src/core/observability/tests.rs
@@ -1,13 +1,103 @@
 //! Tests for observability module
 
+use super::destinations::LogDestination;
 #[cfg(test)]
 use super::histogram::{BoundedHistogram, HISTOGRAM_MAX_SAMPLES};
-use super::logging::LogAggregator;
+use super::logging::{LOG_WEBHOOK_TIMEOUT, LogAggregator};
 use super::metrics::MetricsCollector;
 use super::types::{LogEntry, TokenUsage};
+use crate::core::net::ProviderEndpointPolicy;
+use crate::utils::net::http::{ProviderHttpClient, ProviderHttpClientError};
 use chrono::Utc;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use std::collections::HashMap;
+use std::io::{self, Write};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[derive(Clone)]
+struct FixedDnsResolver(SocketAddr);
+
+impl Resolve for FixedDnsResolver {
+    fn resolve(&self, _name: Name) -> Resolving {
+        let address = self.0;
+        Box::pin(async move { Ok(Box::new(std::iter::once(address)) as Addrs) })
+    }
+}
+
+fn policy_client(address: SocketAddr) -> Result<ProviderHttpClient, ProviderHttpClientError> {
+    ProviderHttpClient::build_with_dns_resolver_for_test(
+        ProviderEndpointPolicy::public_only(),
+        LOG_WEBHOOK_TIMEOUT,
+        true,
+        Arc::new(FixedDnsResolver(address)),
+    )
+}
+
+fn test_log_entry() -> LogEntry {
+    LogEntry {
+        timestamp: Utc::now(),
+        level: "INFO".to_string(),
+        message: "T004-entry".to_string(),
+        module: Some("observability".to_string()),
+        request_id: Some("req-t004".to_string()),
+        metadata: HashMap::from([("scope".to_string(), serde_json::json!("webhook"))]),
+    }
+}
+
+async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<String> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    loop {
+        let read = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut buffer))
+            .await
+            .map_err(|_| io::Error::other("request read timed out"))??;
+        if read == 0 {
+            return Err(io::Error::other("request closed before log payload"));
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request
+            .windows(b"T004-entry".len())
+            .any(|window| window == b"T004-entry")
+        {
+            return String::from_utf8(request).map_err(io::Error::other);
+        }
+    }
+}
+
+async fn assert_listener_did_not_accept(listener: &tokio::net::TcpListener, context: &str) {
+    match tokio::time::timeout(Duration::from_millis(100), listener.accept()).await {
+        Err(_) => {}
+        Ok(Ok((_stream, peer))) => panic!("{context}: unexpectedly accepted {peer}"),
+        Ok(Err(error)) => panic!("{context}: listener failed: {error}"),
+    }
+}
+
+#[derive(Clone)]
+struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+impl Write for CapturedLogs {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("log lock").extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 #[test]
 fn test_bounded_histogram_basic() {
@@ -150,4 +240,171 @@ async fn test_log_aggregation() {
     let buffer = aggregator.buffer.read().await;
     assert_eq!(buffer.len(), 1);
     assert_eq!(buffer[0].message, "Test log entry");
+}
+
+#[test]
+fn log_webhook_admission_rejects_complete_unsafe_url_table() {
+    for url in "\n \nnot a url\nfile:///tmp/hook\nftp://example.com/hook\nhttp://secret-user:secret-pass@127.0.0.1/hook?token=secret-query\nhttp://10.0.0.1/hook\nhttp://169.254.169.254/latest/meta-data\nhttp://localhost/hook\nhttp://foo.localhost/hook\nhttp://internal/hook\nhttp://foo.internal/hook\nhttp://local/hook\nhttp://foo.local/hook\nhttp://metadata/hook\nhttp://metadata.google.internal/hook\nhttp://metadata.goog/hook\nhttp://[::1]/hook\nhttp://[fd00::1]/hook\nhttp://[fe80::1]/hook\nhttp://[::ffff:169.254.169.254]/hook\nhttp://[64:ff9b::a9fe:a9fe]/hook".split('\n') {
+        let result = LogAggregator::new().add_destination(LogDestination::Webhook {
+            url: url.to_string(),
+            headers: HashMap::new(),
+        });
+        let Err(error) = result else {
+            panic!("unsafe log webhook URL was accepted: {url}");
+        };
+        for secret in ["secret-user", "secret-pass", "secret-query", "token="] {
+            assert!(!error.to_string().contains(secret), "{error}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn legal_log_webhook_preserves_entries_headers_and_120_second_timeout() -> TestResult {
+    assert_eq!(LOG_WEBHOOK_TIMEOUT, Duration::from_secs(120));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await?;
+        let request = read_http_request(&mut stream).await?;
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await?;
+        Ok::<_, io::Error>(request)
+    });
+    let url = format!("http://logs.test:{}/hook", address.port());
+    let headers = HashMap::from([("x-log-hook".to_string(), "preserved".to_string())]);
+    let destination = LogDestination::Webhook {
+        url: url.clone(),
+        headers: headers.clone(),
+    };
+    let aggregator = LogAggregator::new().add_webhook_with_client_for_test(
+        url,
+        headers,
+        policy_client(address)?,
+    )?;
+
+    aggregator
+        .send_to_destination(&destination, &[test_log_entry()])
+        .await?;
+    let request = server.await??.to_ascii_lowercase();
+    for expected in ["x-log-hook: preserved", "t004-entry", "req-t004", "webhook"] {
+        assert!(request.contains(expected), "{request}");
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn log_webhook_redirect_is_error_not_followed_and_logs_are_secret_safe() -> TestResult {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_writer(CapturedLogs(bytes.clone()))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let source = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let source_address = source.local_addr()?;
+    let target = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let target_address = target.local_addr()?;
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = source.accept().await?;
+        let _request = read_http_request(&mut stream).await?;
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://redirect.test:{}/private?token=redirect-secret\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    target_address.port()
+                )
+                .as_bytes(),
+            )
+            .await
+    });
+    let url = format!(
+        "http://source-user:source-pass@source.test:{}/hook?token=source-secret",
+        source_address.port()
+    );
+    let aggregator = LogAggregator::new().add_webhook_with_client_for_test(
+        url,
+        HashMap::new(),
+        policy_client(source_address)?,
+    )?;
+    aggregator.log(test_log_entry()).await;
+    aggregator.flush_buffer().await;
+    server.await??;
+    assert_listener_did_not_accept(&target, "log webhook redirect target").await;
+    let logs = String::from_utf8(bytes.lock().expect("log lock").clone())?;
+    assert!(logs.contains("302 Found"), "{logs}");
+    for secret in [
+        "source-user",
+        "source-pass",
+        "source-secret",
+        "redirect-secret",
+        "token=",
+    ] {
+        assert!(!logs.contains(secret), "{logs}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_webhook_public_then_private_rebind_never_reaches_listener() -> TestResult {
+    for blocked_ip in [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.169.254",
+        "::1",
+        "fd00::1",
+        "::ffff:169.254.169.254",
+        "64:ff9b::a9fe:a9fe",
+    ] {
+        let tripwire = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = tripwire.local_addr()?;
+        let client = ProviderHttpClient::build_public_then_private_tripwire_for_test(
+            SocketAddr::new(blocked_ip.parse()?, address.port()),
+            address,
+        )
+        .await?;
+        let url = format!(
+            "http://rebind-user:rebind-pass@rebind.test:{}/hook?token=rebind-secret",
+            address.port()
+        );
+        let destination = LogDestination::Webhook {
+            url: url.clone(),
+            headers: HashMap::new(),
+        };
+        let aggregator =
+            LogAggregator::new().add_webhook_with_client_for_test(url, HashMap::new(), client)?;
+        let error = aggregator
+            .send_to_destination(&destination, &[test_log_entry()])
+            .await
+            .expect_err("private rebinding answer must be rejected")
+            .to_string();
+        assert!(error.contains("outbound endpoint policy"), "{error}");
+        for secret in ["rebind-user", "rebind-pass", "rebind-secret", "token="] {
+            assert!(!error.contains(secret), "{error}");
+        }
+        assert_listener_did_not_accept(&tripwire, "log webhook rebinding target").await;
+    }
+    Ok(())
+}
+
+#[test]
+fn all_four_webhook_senders_avoid_generic_clients_and_private_ip_classification() {
+    let sources = [
+        include_str!("../webhooks/manager.rs"),
+        include_str!("../webhooks/delivery.rs"),
+        include_str!("../budget/alerts.rs"),
+        include_str!("../../monitoring/alerts/channels.rs"),
+        include_str!("logging.rs"),
+    ];
+    for source in sources {
+        for forbidden in [
+            "default_outbound_client",
+            "create_custom_client",
+            "reqwest::Client",
+            "is_private_or_reserved_ip",
+        ] {
+            assert!(!source.contains(forbidden), "found {forbidden}");
+        }
+    }
 }

--- a/src/core/observability/tests.rs
+++ b/src/core/observability/tests.rs
@@ -244,7 +244,7 @@ async fn test_log_aggregation() {
 
 #[test]
 fn log_webhook_admission_rejects_complete_unsafe_url_table() {
-    for url in "\n \nnot a url\nfile:///tmp/hook\nftp://example.com/hook\nhttp://secret-user:secret-pass@127.0.0.1/hook?token=secret-query\nhttp://10.0.0.1/hook\nhttp://169.254.169.254/latest/meta-data\nhttp://localhost/hook\nhttp://foo.localhost/hook\nhttp://internal/hook\nhttp://foo.internal/hook\nhttp://local/hook\nhttp://foo.local/hook\nhttp://metadata/hook\nhttp://metadata.google.internal/hook\nhttp://metadata.goog/hook\nhttp://[::1]/hook\nhttp://[fd00::1]/hook\nhttp://[fe80::1]/hook\nhttp://[::ffff:169.254.169.254]/hook\nhttp://[64:ff9b::a9fe:a9fe]/hook".split('\n') {
+    for url in "\n \nnot a url\nfile:///tmp/hook\nftp://example.com/hook\nws://secret-user:secret-pass@example.com/hook?token=secret-query\nwss://secret-user:secret-pass@example.com/hook?token=secret-query\nhttp://secret-user:secret-pass@127.0.0.1/hook?token=secret-query\nhttp://10.0.0.1/hook\nhttp://169.254.169.254/latest/meta-data\nhttp://localhost/hook\nhttp://foo.localhost/hook\nhttp://internal/hook\nhttp://foo.internal/hook\nhttp://local/hook\nhttp://foo.local/hook\nhttp://metadata/hook\nhttp://metadata.google.internal/hook\nhttp://metadata.goog/hook\nhttp://[::1]/hook\nhttp://[fd00::1]/hook\nhttp://[fe80::1]/hook\nhttp://[::ffff:169.254.169.254]/hook\nhttp://[64:ff9b::a9fe:a9fe]/hook".split('\n') {
         let result = LogAggregator::new().add_destination(LogDestination::Webhook {
             url: url.to_string(),
             headers: HashMap::new(),
@@ -255,6 +255,19 @@ fn log_webhook_admission_rejects_complete_unsafe_url_table() {
         for secret in ["secret-user", "secret-pass", "secret-query", "token="] {
             assert!(!error.to_string().contains(secret), "{error}");
         }
+    }
+}
+
+#[test]
+fn log_destination_debug_redacts_webhook_url_and_headers() {
+    let destination = LogDestination::Webhook {
+        url: "https://du:dp@example.com/hook?token=dq".to_string(),
+        headers: HashMap::from([("auth".to_string(), "dh".to_string())]),
+    };
+    let debug = format!("{destination:?}");
+    assert_eq!(debug, "LogDestination { redacted }");
+    for secret in "du dp dq auth dh token=".split_whitespace() {
+        assert!(!debug.contains(secret), "{debug}");
     }
 }
 
@@ -277,11 +290,9 @@ async fn legal_log_webhook_preserves_entries_headers_and_120_second_timeout() ->
         url: url.clone(),
         headers: headers.clone(),
     };
-    let aggregator = LogAggregator::new().add_webhook_with_client_for_test(
-        url,
-        headers,
-        policy_client(address)?,
-    )?;
+    let aggregator = LogAggregator::new()
+        .with_webhook_client_for_test(policy_client(address)?)
+        .add_destination(destination.clone())?;
 
     aggregator
         .send_to_destination(&destination, &[test_log_entry()])
@@ -323,24 +334,20 @@ async fn log_webhook_redirect_is_error_not_followed_and_logs_are_secret_safe() -
         "http://source-user:source-pass@source.test:{}/hook?token=source-secret",
         source_address.port()
     );
-    let aggregator = LogAggregator::new().add_webhook_with_client_for_test(
-        url,
-        HashMap::new(),
-        policy_client(source_address)?,
-    )?;
+    let aggregator = LogAggregator::new()
+        .with_webhook_client_for_test(policy_client(source_address)?)
+        .add_destination(LogDestination::Webhook {
+            url,
+            headers: HashMap::new(),
+        })?;
     aggregator.log(test_log_entry()).await;
     aggregator.flush_buffer().await;
     server.await??;
     assert_listener_did_not_accept(&target, "log webhook redirect target").await;
     let logs = String::from_utf8(bytes.lock().expect("log lock").clone())?;
     assert!(logs.contains("302 Found"), "{logs}");
-    for secret in [
-        "source-user",
-        "source-pass",
-        "source-secret",
-        "redirect-secret",
-        "token=",
-    ] {
+    for secret in "source-user source-pass source-secret redirect-secret token=".split_whitespace()
+    {
         assert!(!logs.contains(secret), "{logs}");
     }
     Ok(())
@@ -348,15 +355,10 @@ async fn log_webhook_redirect_is_error_not_followed_and_logs_are_secret_safe() -
 
 #[tokio::test]
 async fn log_webhook_public_then_private_rebind_never_reaches_listener() -> TestResult {
-    for blocked_ip in [
-        "127.0.0.1",
-        "10.0.0.1",
-        "169.254.169.254",
-        "::1",
-        "fd00::1",
-        "::ffff:169.254.169.254",
-        "64:ff9b::a9fe:a9fe",
-    ] {
+    for blocked_ip in
+        "127.0.0.1 10.0.0.1 169.254.169.254 ::1 fd00::1 ::ffff:169.254.169.254 64:ff9b::a9fe:a9fe"
+            .split_whitespace()
+    {
         let tripwire = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
         let address = tripwire.local_addr()?;
         let client = ProviderHttpClient::build_public_then_private_tripwire_for_test(
@@ -372,8 +374,9 @@ async fn log_webhook_public_then_private_rebind_never_reaches_listener() -> Test
             url: url.clone(),
             headers: HashMap::new(),
         };
-        let aggregator =
-            LogAggregator::new().add_webhook_with_client_for_test(url, HashMap::new(), client)?;
+        let aggregator = LogAggregator::new()
+            .with_webhook_client_for_test(client)
+            .add_destination(destination.clone())?;
         let error = aggregator
             .send_to_destination(&destination, &[test_log_entry()])
             .await
@@ -398,12 +401,10 @@ fn all_four_webhook_senders_avoid_generic_clients_and_private_ip_classification(
         include_str!("logging.rs"),
     ];
     for source in sources {
-        for forbidden in [
-            "default_outbound_client",
-            "create_custom_client",
-            "reqwest::Client",
-            "is_private_or_reserved_ip",
-        ] {
+        for forbidden in
+            "default_outbound_client create_custom_client reqwest::Client is_private_or_reserved_ip"
+                .split_whitespace()
+        {
             assert!(!source.contains(forbidden), "found {forbidden}");
         }
     }


### PR DESCRIPTION
## Summary
- completes SpecRail task SP1065-T004 with fallible canonical admission for LogDestination::Webhook
- accepts only explicit http/https webhook schemes, then sends through the shared public-only, no-redirect, no-proxy ProviderHttpClient with the preserved 120 second timeout
- treats every non-2xx response, including 3xx, as the existing explicit log-destination error path without exposing URL secrets
- gives LogDestination a fully redacted manual Debug implementation so webhook URLs, userinfo, query values, and headers are never formatted
- preserves log entries and custom headers; adds deterministic admission, ws/wss rejection, redirect, DNS rebind, Debug redaction, and four-sender guards

## Scope
- 3 non-document files
- 346 changed lines (334 insertions, 12 deletions)
- no runtime wiring or dependency changes
- merged current main at 0e388109894fdd8bb3bde8b4b13b0e6906854a52 with a normal merge commit; no history rewrite

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked core::observability -- --test-threads=1 (130 passed)
- cargo test --all-features --locked -- --test-threads=1 (all unit, integration, and doctests passed)
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir=specs/GH1065
- bash scripts/guards/check_pr_scope.sh origin/main
- bash scripts/guards/check_pr_overlap.sh
- git diff --check origin/main...HEAD
- four-sender rg guard for generic clients and duplicate private-IP classification

## SEC-11 follow-up
- webhook admission now rejects ws/wss before any outbound send and tests keep embedded URL secrets out of errors
- LogDestination Debug is runtime-tested to expose neither webhook URL components nor header values
- existing SSRF, redirect, DNS rebind, timeout, header, and four-sender assertions remain intact

## Closure audit
- SP1065-T001: PR #1075 merged as c4afe20b3142a464f84d8d8546de61edefb5f16e
- SP1065-T002: PR #1076 merged as 420c8d55a5964b82dd273d31905f474087fe5935
- SP1065-T003: PR #1077 merged as 6fb6c3ae9eddfe773abc0cff89b687315c03727d
- current base contains all three merge commits and issue #1065 remains open before this final tranche

Closes #1065