### PR TITLE
fix(streaming): harden callback terminal delivery

### DIFF
--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -174,10 +174,29 @@ pub(super) async fn handle_streaming_chat_completion(
 
                 loop {
                     let chunk_result = if idle_timeout_secs == 0 {
-                        stream.next().await
+                        tokio::select! {
+                            biased;
+                            _ = tx.closed() => {
+                                info!("Client disconnected while waiting for stream output");
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_after_upstream_output!();
+                                return;
+                            }
+                            result = stream.next() => result,
+                        }
                     } else {
                         let timeout_dur = Duration::from_secs(idle_timeout_secs);
-                        match tokio::time::timeout(timeout_dur, stream.next()).await {
+                        let timed_result = tokio::select! {
+                            biased;
+                            _ = tx.closed() => {
+                                info!("Client disconnected while waiting for stream output");
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_after_upstream_output!();
+                                return;
+                            }
+                            result = tokio::time::timeout(timeout_dur, stream.next()) => result,
+                        };
+                        match timed_result {
                             Ok(result) => result,
                             Err(_) => {
                                 warn!(
@@ -307,7 +326,7 @@ pub(super) async fn handle_streaming_chat_completion(
                     if tx.send(bytes).await.is_err() {
                         info!("Client disconnected during streaming, cancelling upstream");
                         callback.fail("client disconnected", "client_disconnect");
-                        settlement.record_disconnect(final_usage.as_ref()).await;
+                        settle_after_upstream_output!();
                         return;
                     }
                 }
@@ -315,6 +334,9 @@ pub(super) async fn handle_streaming_chat_completion(
                 let done_event = Event::default().data("[DONE]");
                 if tx.send(done_event.to_bytes()).await.is_err() {
                     info!("Client disconnected before [DONE] event could be sent");
+                    callback.fail("client disconnected", "client_disconnect");
+                    settle_after_upstream_output!();
+                    return;
                 }
                 settlement
                     .record_completion(final_usage.as_ref(), saw_upstream_output)

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -172,14 +172,29 @@ pub(super) async fn handle_streaming_completion(
 
                 loop {
                     let chunk_result = if idle_timeout_secs == 0 {
-                        stream.next().await
+                        tokio::select! {
+                            biased;
+                            _ = tx.closed() => {
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_if_chargeable!();
+                                return;
+                            }
+                            result = stream.next() => result,
+                        }
                     } else {
-                        match tokio::time::timeout(
-                            Duration::from_secs(idle_timeout_secs),
-                            stream.next(),
-                        )
-                        .await
-                        {
+                        let timed_result = tokio::select! {
+                            biased;
+                            _ = tx.closed() => {
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_if_chargeable!();
+                                return;
+                            }
+                            result = tokio::time::timeout(
+                                Duration::from_secs(idle_timeout_secs),
+                                stream.next(),
+                            ) => result,
+                        };
+                        match timed_result {
                             Ok(result) => result,
                             Err(_) => {
                                 warn!(
@@ -282,7 +297,15 @@ pub(super) async fn handle_streaming_completion(
                     }
                 }
 
-                let _ = tx.send(Event::default().data("[DONE]").to_bytes()).await;
+                if tx
+                    .send(Event::default().data("[DONE]").to_bytes())
+                    .await
+                    .is_err()
+                {
+                    callback.fail("client disconnected", "client_disconnect");
+                    settle_if_chargeable!();
+                    return;
+                }
                 settlement
                     .record_completion(final_usage.as_ref(), saw_upstream_output)
                     .await;

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -37,8 +37,8 @@ use responses_stream_budget::StreamBudgetSettlement;
 #[path = "responses_stream_support.rs"]
 mod responses_stream_support;
 use responses_stream_support::{
-    classify, completed_reasoning_item, emit, in_progress_reasoning_item, make_shell,
-    output_items_in_stream_order, response_usage_from_chat_usage, sse_error,
+    ResponseStreamEmitError, classify, completed_reasoning_item, emit, in_progress_reasoning_item,
+    make_shell, output_items_in_stream_order, response_usage_from_chat_usage, sse_error,
 };
 
 /// Accumulated state for one in-progress tool call during streaming.
@@ -213,16 +213,28 @@ pub(crate) async fn handle_streaming_response(
                 let mut settlement = settlement;
 
                 let shell = make_shell(&resp_id, created_at, &model_name, "in_progress", &original);
-                if emit(
+                if let Err(error) = emit(
                     &tx,
                     &ResponseStreamEvent::ResponseCreated {
                         response: Box::new(shell),
                     },
                 )
                 .await
-                .is_err()
                 {
-                    callback.fail("client disconnected", "client_disconnect");
+                    match error {
+                        ResponseStreamEmitError::ClientDisconnected => {
+                            callback.fail("client disconnected", "client_disconnect");
+                        }
+                        ResponseStreamEmitError::Serialization(error) => {
+                            let message = format!("stream serialization failed: {error}");
+                            if let Some(lease) = lease.take() {
+                                let provider_error =
+                                    ProviderError::serialization("router", message.clone());
+                                lease.finish_failure(&provider_error);
+                            }
+                            callback.fail(message, "serialization_error");
+                        }
+                    }
                     return;
                 }
 
@@ -242,23 +254,62 @@ pub(crate) async fn handle_streaming_response(
                 let mut reasoning_item_id = String::new();
                 let mut reasoning_output_index: u32 = 0;
                 let mut reasoning_started = false;
-                macro_rules! return_after_disconnect {
+                macro_rules! settle_if_chargeable {
                     () => {
-                        callback.fail("client disconnected", "client_disconnect");
                         if final_usage.is_some() || saw_upstream_output {
                             settlement.record_disconnect(final_usage.as_ref()).await;
                         }
+                    };
+                }
+                macro_rules! return_after_disconnect {
+                    () => {
+                        callback.fail("client disconnected", "client_disconnect");
+                        settle_if_chargeable!();
+                        return;
+                    };
+                }
+                macro_rules! return_after_emit_error {
+                    ($error:expr) => {
+                        match $error {
+                            ResponseStreamEmitError::ClientDisconnected => {
+                                callback.fail("client disconnected", "client_disconnect");
+                            }
+                            ResponseStreamEmitError::Serialization(error) => {
+                                let message = format!("stream serialization failed: {error}");
+                                if let Some(lease) = lease.take() {
+                                    let provider_error =
+                                        ProviderError::serialization("router", message.clone());
+                                    lease.finish_failure(&provider_error);
+                                }
+                                callback.fail(message, "serialization_error");
+                            }
+                        }
+                        settle_if_chargeable!();
                         return;
                     };
                 }
 
                 loop {
                     let next = if idle_timeout == 0 {
-                        stream.next().await
+                        tokio::select! {
+                            biased;
+                            _ = tx.closed() => {
+                                return_after_disconnect!();
+                            }
+                            result = stream.next() => result,
+                        }
                     } else {
-                        match tokio::time::timeout(Duration::from_secs(idle_timeout), stream.next())
-                            .await
-                        {
+                        let timed_result = tokio::select! {
+                            biased;
+                            _ = tx.closed() => {
+                                return_after_disconnect!();
+                            }
+                            result = tokio::time::timeout(
+                                Duration::from_secs(idle_timeout),
+                                stream.next(),
+                            ) => result,
+                        };
+                        match timed_result {
                             Ok(r) => r,
                             Err(_) => {
                                 warn!("Responses API stream idle timeout after {idle_timeout}s");
@@ -280,7 +331,8 @@ pub(crate) async fn handle_streaming_response(
                                     format!("stream idle timeout after {idle_timeout}s"),
                                     "timeout",
                                 );
-                                return_after_disconnect!();
+                                settle_if_chargeable!();
+                                return;
                             }
                         }
                     };
@@ -319,7 +371,7 @@ pub(crate) async fn handle_streaming_response(
                                         next_output_index += 1;
                                         reasoning_item_id = format!("rs_{}", uuid_v4_hex());
 
-                                        if emit(
+                                        if let Err(error) = emit(
                                             &tx,
                                             &ResponseStreamEvent::ResponseOutputItemAdded {
                                                 output_index: reasoning_output_index,
@@ -329,13 +381,12 @@ pub(crate) async fn handle_streaming_response(
                                             },
                                         )
                                         .await
-                                        .is_err()
                                         {
-                                            return_after_disconnect!();
+                                            return_after_emit_error!(error);
                                         }
                                     }
                                     full_reasoning.push_str(reasoning_text);
-                                    if emit(
+                                    if let Err(error) = emit(
                                         &tx,
                                         &ResponseStreamEvent::ResponseReasoningSummaryTextDelta {
                                             output_index: reasoning_output_index,
@@ -344,9 +395,8 @@ pub(crate) async fn handle_streaming_response(
                                         },
                                     )
                                     .await
-                                    .is_err()
                                     {
-                                        return_after_disconnect!();
+                                        return_after_emit_error!(error);
                                     }
                                 }
 
@@ -366,7 +416,7 @@ pub(crate) async fn handle_streaming_response(
                                                 status: "in_progress".to_string(),
                                                 content: vec![],
                                             });
-                                        if emit(
+                                        if let Err(error) = emit(
                                             &tx,
                                             &ResponseStreamEvent::ResponseOutputItemAdded {
                                                 output_index: text_output_index,
@@ -374,12 +424,11 @@ pub(crate) async fn handle_streaming_response(
                                             },
                                         )
                                         .await
-                                        .is_err()
                                         {
-                                            return_after_disconnect!();
+                                            return_after_emit_error!(error);
                                         }
 
-                                        if emit(
+                                        if let Err(error) = emit(
                                             &tx,
                                             &ResponseStreamEvent::ResponseContentPartAdded {
                                                 output_index: text_output_index,
@@ -392,14 +441,13 @@ pub(crate) async fn handle_streaming_response(
                                             },
                                         )
                                         .await
-                                        .is_err()
                                         {
-                                            return_after_disconnect!();
+                                            return_after_emit_error!(error);
                                         }
                                     }
 
                                     full_text.push_str(text);
-                                    if emit(
+                                    if let Err(error) = emit(
                                         &tx,
                                         &ResponseStreamEvent::ResponseOutputTextDelta {
                                             output_index: text_output_index,
@@ -408,9 +456,8 @@ pub(crate) async fn handle_streaming_response(
                                         },
                                     )
                                     .await
-                                    .is_err()
                                     {
-                                        return_after_disconnect!();
+                                        return_after_emit_error!(error);
                                     }
                                 }
 
@@ -446,7 +493,7 @@ pub(crate) async fn handle_streaming_response(
                                                     call_id: Some(call_id.clone()),
                                                 },
                                             );
-                                            if emit(
+                                            if let Err(error) = emit(
                                                 &tx,
                                                 &ResponseStreamEvent::ResponseOutputItemAdded {
                                                     output_index: out_idx,
@@ -454,9 +501,8 @@ pub(crate) async fn handle_streaming_response(
                                                 },
                                             )
                                             .await
-                                            .is_err()
                                             {
-                                                return_after_disconnect!();
+                                                return_after_emit_error!(error);
                                             }
 
                                             entry.insert(ToolCallAccum {
@@ -485,7 +531,7 @@ pub(crate) async fn handle_streaming_response(
                                                 state.arguments.push_str(args);
                                                 let (cid, oi) =
                                                     (state.call_id.clone(), state.output_index);
-                                                if emit(
+                                                if let Err(error) = emit(
                                                     &tx,
                                                     &ResponseStreamEvent::ResponseFunctionCallArgumentsDelta {
                                                         output_index: oi,
@@ -494,9 +540,8 @@ pub(crate) async fn handle_streaming_response(
                                                     },
                                                 )
                                                 .await
-                                                .is_err()
                                                 {
-                                                    return_after_disconnect!();
+                                                    return_after_emit_error!(error);
                                                 }
                                             }
                                         }
@@ -512,7 +557,8 @@ pub(crate) async fn handle_streaming_response(
                                 lease.finish_failure(&e);
                             }
                             callback.fail(e.to_string(), "provider_error");
-                            return_after_disconnect!();
+                            settle_if_chargeable!();
+                            return;
                         }
                     }
                 }
@@ -521,7 +567,7 @@ pub(crate) async fn handle_streaming_response(
                 let mut all_output: Vec<(u32, ResponseOutputItem)> = Vec::new();
 
                 if reasoning_started {
-                    if emit(
+                    if let Err(error) = emit(
                         &tx,
                         &ResponseStreamEvent::ResponseReasoningSummaryTextDone {
                             output_index: reasoning_output_index,
@@ -530,14 +576,13 @@ pub(crate) async fn handle_streaming_response(
                         },
                     )
                     .await
-                    .is_err()
                     {
-                        return_after_disconnect!();
+                        return_after_emit_error!(error);
                     }
 
                     let reasoning_done =
                         completed_reasoning_item(reasoning_item_id, item_status, full_reasoning);
-                    if emit(
+                    if let Err(error) = emit(
                         &tx,
                         &ResponseStreamEvent::ResponseOutputItemDone {
                             output_index: reasoning_output_index,
@@ -545,15 +590,14 @@ pub(crate) async fn handle_streaming_response(
                         },
                     )
                     .await
-                    .is_err()
                     {
-                        return_after_disconnect!();
+                        return_after_emit_error!(error);
                     }
                     all_output.push((reasoning_output_index, reasoning_done));
                 }
 
                 if text_started {
-                    if emit(
+                    if let Err(error) = emit(
                         &tx,
                         &ResponseStreamEvent::ResponseOutputTextDone {
                             output_index: text_output_index,
@@ -562,12 +606,11 @@ pub(crate) async fn handle_streaming_response(
                         },
                     )
                     .await
-                    .is_err()
                     {
-                        return_after_disconnect!();
+                        return_after_emit_error!(error);
                     }
 
-                    if emit(
+                    if let Err(error) = emit(
                         &tx,
                         &ResponseStreamEvent::ResponseContentPartDone {
                             output_index: text_output_index,
@@ -580,9 +623,8 @@ pub(crate) async fn handle_streaming_response(
                         },
                     )
                     .await
-                    .is_err()
                     {
-                        return_after_disconnect!();
+                        return_after_emit_error!(error);
                     }
 
                     let text_done = ResponseOutputItem::Message(ResponseOutputMessage {
@@ -595,7 +637,7 @@ pub(crate) async fn handle_streaming_response(
                             logprobs: None,
                         }],
                     });
-                    if emit(
+                    if let Err(error) = emit(
                         &tx,
                         &ResponseStreamEvent::ResponseOutputItemDone {
                             output_index: text_output_index,
@@ -603,16 +645,15 @@ pub(crate) async fn handle_streaming_response(
                         },
                     )
                     .await
-                    .is_err()
                     {
-                        return_after_disconnect!();
+                        return_after_emit_error!(error);
                     }
                     all_output.push((text_output_index, text_done));
                 }
 
                 for idx in &tool_order {
                     if let Some(state) = tool_states.get(idx) {
-                        if emit(
+                        if let Err(error) = emit(
                             &tx,
                             &ResponseStreamEvent::ResponseFunctionCallArgumentsDone {
                                 output_index: state.output_index,
@@ -621,9 +662,8 @@ pub(crate) async fn handle_streaming_response(
                             },
                         )
                         .await
-                        .is_err()
                         {
-                            return_after_disconnect!();
+                            return_after_emit_error!(error);
                         }
 
                         let fc_done = ResponseOutputItem::FunctionCall(ResponseFunctionCall {
@@ -633,7 +673,7 @@ pub(crate) async fn handle_streaming_response(
                             status: "completed".to_string(),
                             call_id: Some(state.call_id.clone()),
                         });
-                        if emit(
+                        if let Err(error) = emit(
                             &tx,
                             &ResponseStreamEvent::ResponseOutputItemDone {
                                 output_index: state.output_index,
@@ -641,9 +681,8 @@ pub(crate) async fn handle_streaming_response(
                             },
                         )
                         .await
-                        .is_err()
                         {
-                            return_after_disconnect!();
+                            return_after_emit_error!(error);
                         }
                         all_output.push((state.output_index, fc_done));
                     }
@@ -652,7 +691,7 @@ pub(crate) async fn handle_streaming_response(
                 let output_items = output_items_in_stream_order(all_output);
 
                 let total = in_tokens + out_tokens;
-                let budget_usage = final_usage.or_else(|| {
+                let budget_usage = final_usage.clone().or_else(|| {
                     (total > 0).then_some(ChatUsage {
                         prompt_tokens: in_tokens,
                         completion_tokens: out_tokens,
@@ -662,17 +701,6 @@ pub(crate) async fn handle_streaming_response(
                         thinking_usage: None,
                     })
                 });
-                settlement
-                    .record_completion(budget_usage.as_ref(), saw_upstream_output)
-                    .await;
-                callback.complete_usage(budget_usage.as_ref(), "success");
-                if let Some(lease) = lease.take() {
-                    let tokens_used = budget_usage
-                        .as_ref()
-                        .map(|u| u.total_tokens)
-                        .unwrap_or(total);
-                    lease.finish_success(u64::from(tokens_used));
-                }
                 let usage = budget_usage.as_ref().map(response_usage_from_chat_usage);
                 let completed = ResponsesApiResponse {
                     id: resp_id,
@@ -686,16 +714,37 @@ pub(crate) async fn handle_streaming_response(
                     previous_response_id: original.previous_response_id.clone(),
                     metadata: original.metadata.clone(),
                 };
-                store_response_if_requested(&original, &completed, owner);
-                let _ = emit(
+                if let Err(error) = emit(
                     &tx,
                     &ResponseStreamEvent::ResponseCompleted {
-                        response: Box::new(completed),
+                        response: Box::new(completed.clone()),
                     },
                 )
-                .await;
+                .await
+                {
+                    return_after_emit_error!(error);
+                }
 
-                let _ = tx.send(Event::default().data("[DONE]").to_bytes()).await;
+                if tx
+                    .send(Event::default().data("[DONE]").to_bytes())
+                    .await
+                    .is_err()
+                {
+                    return_after_disconnect!();
+                }
+
+                store_response_if_requested(&original, &completed, owner);
+                settlement
+                    .record_completion(budget_usage.as_ref(), saw_upstream_output)
+                    .await;
+                callback.complete_usage(budget_usage.as_ref(), "success");
+                if let Some(lease) = lease.take() {
+                    let tokens_used = budget_usage
+                        .as_ref()
+                        .map(|u| u.total_tokens)
+                        .unwrap_or(total);
+                    lease.finish_success(u64::from(tokens_used));
+                }
             });
 
             let body = tokio_stream::wrappers::ReceiverStream::new(rx)

--- a/src/server/routes/ai/responses_stream_support.rs
+++ b/src/server/routes/ai/responses_stream_support.rs
@@ -1,7 +1,8 @@
 use bytes::Bytes;
+use serde::Serialize;
 use serde_json::json;
+use std::fmt;
 use tokio::sync::mpsc;
-use tracing::error;
 
 use crate::core::models::openai::responses_api::{
     ResponseInputTokensDetails, ResponseOutputItem, ResponseOutputTokensDetails,
@@ -81,17 +82,36 @@ pub(super) fn make_shell(
     }
 }
 
-pub(super) async fn emit(tx: &mpsc::Sender<Bytes>, event: &ResponseStreamEvent) -> Result<(), ()> {
-    match serde_json::to_string(event) {
-        Ok(json) => tx
-            .send(Event::default().data(&json).to_bytes())
-            .await
-            .map_err(|_| ()),
-        Err(error) => {
-            error!("Failed to serialise stream event: {error}");
-            Err(())
+#[derive(Debug)]
+pub(super) enum ResponseStreamEmitError {
+    Serialization(serde_json::Error),
+    ClientDisconnected,
+}
+
+impl fmt::Display for ResponseStreamEmitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Serialization(error) => write!(formatter, "stream serialization failed: {error}"),
+            Self::ClientDisconnected => formatter.write_str("client disconnected"),
         }
     }
+}
+
+pub(super) async fn emit(
+    tx: &mpsc::Sender<Bytes>,
+    event: &ResponseStreamEvent,
+) -> Result<(), ResponseStreamEmitError> {
+    emit_serialized(tx, event).await
+}
+
+async fn emit_serialized<T: Serialize + ?Sized>(
+    tx: &mpsc::Sender<Bytes>,
+    event: &T,
+) -> Result<(), ResponseStreamEmitError> {
+    let json = serde_json::to_string(event).map_err(ResponseStreamEmitError::Serialization)?;
+    tx.send(Event::default().data(&json).to_bytes())
+        .await
+        .map_err(|_| ResponseStreamEmitError::ClientDisconnected)
 }
 
 pub(super) fn sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
@@ -109,5 +129,43 @@ pub(super) fn classify(error: &ProviderError) -> (&'static str, &'static str) {
         ProviderError::RateLimit { .. } => ("rate_limit_error", "rate_limit_exceeded"),
         ProviderError::Timeout { .. } => ("server_error", "timeout"),
         _ => ("server_error", "internal_error"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serializer;
+
+    struct FailingSerialization;
+
+    impl Serialize for FailingSerialization {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Err(serde::ser::Error::custom(
+                "intentional serialization failure",
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_serialized_preserves_serialization_failure() {
+        let (tx, _rx) = mpsc::channel(1);
+        let error = emit_serialized(&tx, &FailingSerialization)
+            .await
+            .expect_err("serialization should fail");
+        assert!(matches!(error, ResponseStreamEmitError::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn emit_serialized_preserves_client_disconnect() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let error = emit_serialized(&tx, &json!({"type": "test"}))
+            .await
+            .expect_err("closed receiver should reject delivery");
+        assert!(matches!(error, ResponseStreamEmitError::ClientDisconnected));
     }
 }

--- a/tests/integration/completions_route_tests.rs
+++ b/tests/integration/completions_route_tests.rs
@@ -33,6 +33,7 @@ mod tests {
 
     struct RecordingCallback {
         events: Arc<Mutex<Vec<RecordedCallback>>>,
+        error_notify: Option<Arc<tokio::sync::Notify>>,
     }
 
     #[async_trait::async_trait]
@@ -66,6 +67,9 @@ mod tests {
                 .lock()
                 .expect("callback events should not be poisoned")
                 .push(RecordedCallback::Error(event.clone()));
+            if let Some(notify) = &self.error_notify {
+                notify.notify_one();
+            }
             Ok(())
         }
 
@@ -141,6 +145,11 @@ mod tests {
 
         async fn shutdown(self) {
             self.handle.stop(true).await;
+            let _ = self.task.await;
+        }
+
+        async fn abort(self) {
+            self.handle.stop(false).await;
             let _ = self.task.await;
         }
     }
@@ -262,7 +271,24 @@ mod tests {
     async fn build_callback_runtime(events: Arc<Mutex<Vec<RecordedCallback>>>) -> CallbackRuntime {
         let manager = Arc::new(IntegrationManager::with_defaults());
         manager
-            .register(Arc::new(RecordingCallback { events }))
+            .register(Arc::new(RecordingCallback {
+                events,
+                error_notify: None,
+            }))
+            .await;
+        CallbackRuntime::new(manager, 8).expect("callback runtime should initialize")
+    }
+
+    async fn build_notifying_callback_runtime(
+        events: Arc<Mutex<Vec<RecordedCallback>>>,
+        error_notify: Arc<tokio::sync::Notify>,
+    ) -> CallbackRuntime {
+        let manager = Arc::new(IntegrationManager::with_defaults());
+        manager
+            .register(Arc::new(RecordingCallback {
+                events,
+                error_notify: Some(error_notify),
+            }))
             .await;
         CallbackRuntime::new(manager, 8).expect("callback runtime should initialize")
     }

--- a/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
+++ b/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
@@ -161,6 +161,78 @@ async fn test_completions_stream_timeout_before_output_does_not_record_spend() {
     mock_server.shutdown().await;
 }
 
+async fn assert_zero_idle_timeout_observes_client_disconnect(uri: &str, request: Value) {
+    let mock_server = MockOpenAIServer::start(MockScenario::StreamingIdle).await;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let error_notify = Arc::new(tokio::sync::Notify::new());
+    let runtime =
+        build_notifying_callback_runtime(Arc::clone(&events), Arc::clone(&error_notify)).await;
+    let state = build_test_app_state_with_idle_timeout(&mock_server.base_url, Some(0))
+        .await
+        .with_callbacks(runtime.dispatcher());
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(litellm_rs::server::routes::ai::configure_routes),
+    )
+    .await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(uri)
+            .set_json(request)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let disconnected = error_notify.notified();
+    drop(response);
+    tokio::time::timeout(Duration::from_secs(2), disconnected)
+        .await
+        .expect("stream worker should observe the dropped response body");
+    runtime
+        .shutdown()
+        .await
+        .expect("callback runtime should drain");
+
+    let events = events
+        .lock()
+        .expect("callback events should not be poisoned")
+        .clone();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], RecordedCallback::Start(_)));
+    let RecordedCallback::Error(error) = &events[1] else {
+        panic!("client disconnect should emit one terminal error callback");
+    };
+    assert_eq!(error.error_type.as_deref(), Some("client_disconnect"));
+
+    mock_server.abort().await;
+}
+
+#[tokio::test]
+async fn test_completions_zero_idle_timeout_observes_client_disconnect() {
+    assert_zero_idle_timeout_observes_client_disconnect(
+        "/v1/completions",
+        completion_request(Some(true)),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_chat_zero_idle_timeout_observes_client_disconnect() {
+    assert_zero_idle_timeout_observes_client_disconnect(
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true
+        }),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn test_completions_streaming_response_sends_sse_and_done() {
     let mock_server = MockOpenAIServer::start(MockScenario::StreamingSuccess).await;

--- a/tests/responses_routes.rs
+++ b/tests/responses_routes.rs
@@ -10,6 +10,10 @@ mod tests {
     use futures::stream;
     use litellm_rs::Config;
     use litellm_rs::config::models::provider::ProviderConfig;
+    use litellm_rs::core::integrations::{
+        CallbackRuntime, Integration, IntegrationManager, IntegrationResult, LlmEndEvent,
+        LlmErrorEvent, LlmStartEvent,
+    };
     use litellm_rs::core::types::context::RequestContext;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use litellm_rs::server::state::AppState;
@@ -22,6 +26,57 @@ mod tests {
     enum MockScenario {
         NonStreaming,
         Streaming,
+        StreamingIdle,
+    }
+
+    #[derive(Clone)]
+    enum RecordedCallback {
+        Start,
+        End,
+        Error(LlmErrorEvent),
+    }
+
+    struct RecordingCallback {
+        events: Arc<Mutex<Vec<RecordedCallback>>>,
+        error_notify: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl Integration for RecordingCallback {
+        fn name(&self) -> &'static str {
+            "responses-route-test-recorder"
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        async fn on_llm_start(&self, _event: &LlmStartEvent) -> IntegrationResult<()> {
+            self.events.lock().unwrap().push(RecordedCallback::Start);
+            Ok(())
+        }
+
+        async fn on_llm_end(&self, _event: &LlmEndEvent) -> IntegrationResult<()> {
+            self.events.lock().unwrap().push(RecordedCallback::End);
+            Ok(())
+        }
+
+        async fn on_llm_error(&self, event: &LlmErrorEvent) -> IntegrationResult<()> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(RecordedCallback::Error(event.clone()));
+            self.error_notify.notify_one();
+            Ok(())
+        }
+
+        async fn flush(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> IntegrationResult<()> {
+            Ok(())
+        }
     }
 
     #[derive(Clone)]
@@ -80,6 +135,11 @@ mod tests {
                 panic!("mock server should stop cleanly: {error}");
             }
         }
+
+        async fn abort(self) {
+            self.handle.stop(false).await;
+            let _ = self.task.await;
+        }
     }
 
     async fn mock_chat_completions(
@@ -124,6 +184,12 @@ mod tests {
                     .insert_header(("Content-Type", "text/event-stream"))
                     .streaming(stream)
             }
+            MockScenario::StreamingIdle => {
+                let stream = stream::pending::<Result<Bytes, actix_web::Error>>();
+                HttpResponse::Ok()
+                    .insert_header(("Content-Type", "text/event-stream"))
+                    .streaming(stream)
+            }
         }
     }
 
@@ -140,9 +206,19 @@ mod tests {
     }
 
     async fn app_state(base_url: &str) -> AppState {
+        app_state_with_idle_timeout(base_url, None).await
+    }
+
+    async fn app_state_with_idle_timeout(
+        base_url: &str,
+        stream_idle_timeout: Option<u64>,
+    ) -> AppState {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
+        if let Some(stream_idle_timeout) = stream_idle_timeout {
+            config.gateway.server.stream_idle_timeout = stream_idle_timeout;
+        }
         config.gateway.providers = vec![provider_config(base_url)];
 
         GatewayHttpServer::new(&config)
@@ -150,6 +226,20 @@ mod tests {
             .expect("gateway server should initialize")
             .state()
             .clone()
+    }
+
+    async fn callback_runtime(
+        events: Arc<Mutex<Vec<RecordedCallback>>>,
+        error_notify: Arc<tokio::sync::Notify>,
+    ) -> CallbackRuntime {
+        let manager = Arc::new(IntegrationManager::with_defaults());
+        manager
+            .register(Arc::new(RecordingCallback {
+                events,
+                error_notify,
+            }))
+            .await;
+        CallbackRuntime::new(manager, 8).expect("callback runtime should initialize")
     }
 
     macro_rules! with_user {
@@ -311,6 +401,53 @@ mod tests {
         assert_eq!(fetched["output"][0]["content"][0]["text"], "Hello");
 
         mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn streamed_response_zero_timeout_observes_client_disconnect() {
+        let mock = MockOpenAiServer::start(MockScenario::StreamingIdle).await;
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let error_notify = Arc::new(tokio::sync::Notify::new());
+        let runtime = callback_runtime(Arc::clone(&events), Arc::clone(&error_notify)).await;
+        let state = app_state_with_idle_timeout(&mock.base_url, Some(0))
+            .await
+            .with_callbacks(runtime.dispatcher());
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let request = with_user!(
+            test::TestRequest::post()
+                .uri("/v1/responses")
+                .set_json(response_request(Some(true)))
+                .to_request(),
+            "disconnect-owner"
+        );
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let disconnected = error_notify.notified();
+        drop(response);
+        tokio::time::timeout(Duration::from_secs(2), disconnected)
+            .await
+            .expect("responses worker should observe the dropped response body");
+        runtime
+            .shutdown()
+            .await
+            .expect("callback runtime should drain");
+
+        let events = events.lock().unwrap().clone();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], RecordedCallback::Start));
+        let RecordedCallback::Error(error) = &events[1] else {
+            panic!("client disconnect should emit one terminal error callback");
+        };
+        assert_eq!(error.error_type.as_deref(), Some("client_disconnect"));
+
+        mock.abort().await;
     }
 
     fn response_id_from_sse(body: &str) -> String {


### PR DESCRIPTION
Refs #1066

This partial hardening slice fixes the post-merge streaming blockers without closing the issue:

- treat client disconnect and final enqueue failure as terminal errors
- preserve typed Responses event serialization failures
- report success only after the final streaming event is accepted
- cover chat, completions, and Responses zero-timeout disconnect paths

Verification:
- focused streaming and Responses tests passed
- cargo fmt/check/clippy all features and all targets passed
- serial full all-feature test suite passed
- SpecRail workflow/spec checks and scope/overlap guards passed

The remaining Datadog and callback runtime hardening will follow in separate scoped PRs.