### PR TITLE
docs(spec): define built-in admin dashboard (#1067)

### DIFF
--- a/specs/GH1067/product.md
+++ b/specs/GH1067/product.md
@@ -50,7 +50,10 @@ and can easily miss loading, empty, or permission failures.
    deliberately, and is not retained after its one-time notice is dismissed.
 4. The key view lists the existing key records with status, scope, creation or
    expiration information when available, and explicit pagination. An admin can
-   create a minimally scoped key and revoke an active key after confirmation.
+   create a key owned by their user or a selected team only after providing at
+   least one allowed model pattern and one allowed endpoint pattern; the
+   dashboard never creates an unowned, admin, or unrestricted-wildcard key. An
+   active key can be revoked after confirmation.
 5. The team view lists existing teams with status and available metadata. An
    admin can create a team and delete an existing team after confirmation.
 6. The spend view derives its values only from successful existing key and team
@@ -82,8 +85,10 @@ and can easily miss loading, empty, or permission failures.
       failed data.
 - [ ] Tokens and one-time raw keys are absent from browser storage and are
       cleared from page state at their documented lifecycle boundaries.
-- [ ] Route, content, authentication-state, API-contract, empty/error, and
-      accessibility behavior has deterministic test coverage.
+- [ ] Route registration, response headers, static content/API contracts, and
+      unsafe browser primitives have deterministic automated coverage;
+      authentication-state, empty/error, concurrency, and accessibility
+      behavior follow a repeatable manual verification checklist.
 
 ## Edge Cases
 

--- a/specs/GH1067/product.md
+++ b/specs/GH1067/product.md
@@ -1,0 +1,107 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1067 / #1067
+
+## User Problem
+
+The gateway exposes APIs for API-key and team administration plus usage
+statistics, but operators have no browser interface for routine management.
+They must assemble requests manually, cannot see key/team spend in one place,
+and can easily miss loading, empty, or permission failures.
+
+## Goals
+
+- Provide a built-in browser dashboard for administrators without requiring a
+  separate frontend deployment.
+- Reuse the gateway's existing login, key, team, and usage contracts.
+- Support the minimum daily workflow: inspect and create keys, revoke keys,
+  inspect and create teams, delete teams, and view key/team usage and spend.
+- Make authentication, permission, loading, empty, validation, and API failure
+  states explicit.
+
+## Non-Goals
+
+- Adding new key, team, budget, spend, user, or authentication APIs.
+- Adding a general analytics warehouse, time-series charts, exports, or billing
+  reconciliation.
+- Adding team membership or role editing, key rotation, key editing, budget
+  editing, registration, password reset, OAuth, or SSO controls.
+- Persisting browser credentials, access tokens, refresh tokens, or newly
+  created raw API keys.
+- Creating or deploying a separate frontend repository or frontend build
+  service.
+
+## Behavior Invariants
+
+1. `GET /admin/dashboard` returns the dashboard shell without requiring
+   credentials. The shell contains no gateway data, credentials, or
+   environment-derived configuration; every management or usage request still
+   passes through the existing authenticated API.
+2. An operator signs in through the existing username/password login contract.
+   The dashboard accepts only an authenticated admin response before loading
+   management data. Invalid credentials, non-admin users, expired tokens, and
+   unavailable authentication are displayed as explicit errors and reveal no
+   protected data.
+3. Access and refresh tokens exist only in page memory, are not written to
+   cookies or browser storage, and are discarded on sign-out, reload, or tab
+   close. The raw value of a newly created API key is shown once, can be copied
+   deliberately, and is not retained after its one-time notice is dismissed.
+4. The key view lists the existing key records with status, scope, creation or
+   expiration information when available, and explicit pagination. An admin can
+   create a minimally scoped key and revoke an active key after confirmation.
+5. The team view lists existing teams with status and available metadata. An
+   admin can create a team and delete an existing team after confirmation.
+6. The spend view derives its values only from successful existing key and team
+   usage responses. Explicit numeric zero is displayed as zero; unavailable or
+   failed data remains blank and is accompanied by an error indicator rather
+   than being guessed or silently treated as zero.
+7. Initial loads, refreshes, and mutations have visible progress. Empty key,
+   team, and usage collections have distinct empty states. A failed request
+   preserves already displayed valid data where safe and shows the failed
+   operation and server message.
+8. Concurrent refresh or navigation responses cannot overwrite newer page
+   state. Controls that would duplicate an in-flight mutation are disabled
+   until that mutation completes.
+9. The dashboard is usable by keyboard, exposes programmatic labels for inputs
+   and controls, maintains visible focus, announces status/error changes, and
+   does not rely on color alone for meaning.
+10. Existing API routes, authentication behavior, JSON shapes, CLI clients, and
+    deployments that never open the dashboard remain unchanged.
+
+## Acceptance Criteria
+
+- [ ] `/admin/dashboard` serves a self-contained dashboard shell with no
+      external frontend runtime or asset host.
+- [ ] Admin login loads key, team, and spend views by calling only existing
+      gateway APIs; invalid or non-admin login never loads protected data.
+- [ ] Key list/create/revoke and team list/create/delete workflows complete
+      against the existing APIs and refresh the affected view.
+- [ ] Key and team usage/spend render explicit zero separately from missing or
+      failed data.
+- [ ] Tokens and one-time raw keys are absent from browser storage and are
+      cleared from page state at their documented lifecycle boundaries.
+- [ ] Route, content, authentication-state, API-contract, empty/error, and
+      accessibility behavior has deterministic test coverage.
+
+## Edge Cases
+
+- Authentication may be disabled, partially configured, or temporarily
+  unavailable; the shell remains renderable and the login error remains
+  explicit.
+- A key or team can disappear between list and mutation requests; the dashboard
+  reports the server result and refreshes instead of fabricating success.
+- Usage requests can partially fail across a collection. Successful values
+  remain visible, while failed entries stay blank and are identified.
+- Long names and identifiers wrap or truncate accessibly without changing the
+  submitted value.
+- Network responses arriving after sign-out are ignored and cannot repopulate
+  protected state.
+
+## Rollout Notes
+
+The dashboard is an additive built-in surface. It reuses existing authorization
+and management APIs and requires no data migration. A code rollback removes the
+dashboard route and embedded assets; existing API behavior and stored data are
+unchanged.

--- a/specs/GH1067/tasks.md
+++ b/specs/GH1067/tasks.md
@@ -1,0 +1,85 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1067 / #1067
+
+## Spec Packet
+
+- Product: `specs/GH1067/product.md`
+- Tech: `specs/GH1067/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1067-T1` Covers: P1, P10, security. Owner: coordinator. Dependencies: none. Done when: a dashboard route module serves the compile-time HTML, CSS, and JavaScript assets at the three declared exact paths with correct content types, `Cache-Control: no-store`, and the restrictive CSP; route assembly exposes no prefix fallback or filesystem serving. Verify: focused dashboard handler/route tests and `rg -n "ServeDir|ServeFile|NamedFile" src/server`.
+
+- [ ] `SP1067-T2` Covers: P7, P9. Owner: coordinator. Dependencies: T1. Done when: the semantic HTML/CSS provides labeled login, key, team, and spend panels; keyboard navigation, visible focus, responsive tables, empty states, confirmation dialogs, and a live status/error region are present without external assets. Verify: dashboard asset contract tests and manual keyboard/narrow-viewport inspection.
+
+- [ ] `SP1067-T3` Covers: P2-P5. Owner: coordinator. Dependencies: T1-T2. Done when: memory-only admin login and sign-out call the existing auth contract; key list/create/revoke and team list/create/delete call only the declared existing APIs; mutation controls are confirmation-gated and disabled while pending; the one-time raw key lifecycle is explicit. Verify: asset contract/safety tests, focused existing auth/key/team route tests, and manual end-to-end interaction.
+
+- [ ] `SP1067-T4` Covers: P6-P8. Owner: coordinator. Dependencies: T3. Done when: key and visible-team spend are rendered separately with finite numeric zero distinct from missing data; partial failures remain visible; abort/generation guards prevent stale refresh or post-sign-out writes. Verify: asset contract tests for formatter, row errors, `AbortController`, generation checks, and no key/team aggregate sum; manual slow/failure response inspection.
+
+- [ ] `SP1067-T5` Covers: all. Owner: coordinator. Dependencies: T1-T4. Done when: focused Rust tests cover dashboard responses, exact route behavior, security headers, asset API contracts, accessibility hooks, forbidden browser storage/unsafe sinks/external URLs, and near-match path protection without weakening existing assertions. Verify: `cargo test admin_dashboard --lib`, the focused middleware helper test, focused key/team/auth tests, and `cargo fmt --check`.
+
+- [ ] `SP1067-T6` Covers: all. Owner: verification owner. Dependencies: T1-T5. Done when: one serialized full verification pass from this worktree succeeds and evidence is saved under `artifacts/logs/gh1067/`. Verify: commands in the Verification section.
+
+- [ ] `SP1067-T7` Covers: all acceptance criteria. Owner: coordinator and independent reviewer. Dependencies: T6. Done when: the heavy-tier spec PR is independently reviewed, gated, and merged without closing #1067; the final implementation PR closes #1067 and has current green blocking CI, an independent exact-head review with no blocking findings, zero unresolved review threads, a clean merge state, an allowed PR gate, and remotely confirmed merge/closure. Verify: PR, review, CI, gate, merge, branch-deletion, and closure evidence in the runtime checkpoint.
+
+## Parallelization
+
+The route, assets, and tests form one dependent implementation chain and share
+one worktree, so the coordinator owns all writes and all cargo commands.
+Native subagents are read-only: a bounded planner may inspect scope before
+implementation, and a separate reviewer or merge-reviewer inspects each exact
+PR head after push. No two cargo commands run concurrently in this worktree.
+
+The public authentication boundary makes this a `heavy` PR tier. Follow the
+two-PR flow: first a spec-only PR with `Refs #1067`, then the final
+implementation PR with `Fixes #1067`.
+
+## Verification
+
+During implementation:
+
+```bash
+cargo test admin_dashboard --lib
+cargo test server::middleware --lib
+cargo test server::routes::keys --lib
+cargo test server::routes::teams --lib
+```
+
+Once before PR readiness:
+
+```bash
+cargo fmt --check
+cargo check
+cargo clippy --all-targets -- -D warnings
+cargo test
+python3 checks/check_workflow.py --repo .
+python3 checks/check_workflow.py --repo . --spec-dir specs/GH1067
+bash scripts/guards/check_pr_scope.sh
+bash scripts/guards/check_pr_overlap.sh
+```
+
+After each push:
+
+```bash
+gh pr checks <pr> --repo majiayu000/litellm-rs --watch --fail-fast
+```
+
+Collect current PR/head/check/review-thread evidence, run the repository PR
+gate serially, and merge only when its decision is `allowed`.
+
+## Handoff Notes
+
+- Only #1067 is in scope. Do not inspect, edit, comment on, or merge another
+  issue or PR.
+- Do not add a frontend package manager, generated bundle, static filesystem
+  service, storage model, migration, or backend management API.
+- Anonymous responses contain inert compiled assets only. Existing key/team
+  APIs remain the authorization authority.
+- Access/refresh tokens and raw API keys must never reach browser storage,
+  cookies, logs, URLs, HTML templates, or unsafe DOM sinks.
+- Spend remains page-scoped and per-scope; do not sum key and team totals.
+- All cargo commands run only in this worktree and are serialized by the
+  coordinator.

--- a/specs/GH1067/tasks.md
+++ b/specs/GH1067/tasks.md
@@ -11,15 +11,15 @@ GH-1067 / #1067
 
 ## Implementation Tasks
 
-- [ ] `SP1067-T1` Covers: P1, P10, security. Owner: coordinator. Dependencies: none. Done when: a dashboard route module serves the compile-time HTML, CSS, and JavaScript assets at the three declared exact paths with correct content types, `Cache-Control: no-store`, and the restrictive CSP; route assembly exposes no prefix fallback or filesystem serving. Verify: focused dashboard handler/route tests and `rg -n "ServeDir|ServeFile|NamedFile" src/server`.
+- [ ] `SP1067-T1` Covers: P1, P10, security. Owner: coordinator. Dependencies: none. Done when: a dashboard route module serves the compile-time HTML, CSS, and JavaScript assets at the three declared exact paths with correct content types, `Cache-Control: no-store`, and the restrictive CSP; route assembly exposes no prefix fallback or filesystem serving. Verify: focused dashboard handler/route tests and `rg -n "actix_files|Files::new|NamedFile|ServeDir|ServeFile" src/server`.
 
 - [ ] `SP1067-T2` Covers: P7, P9. Owner: coordinator. Dependencies: T1. Done when: the semantic HTML/CSS provides labeled login, key, team, and spend panels; keyboard navigation, visible focus, responsive tables, empty states, confirmation dialogs, and a live status/error region are present without external assets. Verify: dashboard asset contract tests and manual keyboard/narrow-viewport inspection.
 
-- [ ] `SP1067-T3` Covers: P2-P5. Owner: coordinator. Dependencies: T1-T2. Done when: memory-only admin login and sign-out call the existing auth contract; key list/create/revoke and team list/create/delete call only the declared existing APIs; mutation controls are confirmation-gated and disabled while pending; the one-time raw key lifecycle is explicit. Verify: asset contract/safety tests, focused existing auth/key/team route tests, and manual end-to-end interaction.
+- [ ] `SP1067-T3` Covers: P2-P5. Owner: coordinator. Dependencies: T1-T2. Done when: memory-only admin login and sign-out call the existing auth contract; every authenticated response is generation-checked before state/DOM commit and sign-out aborts all active requests; key list/create/revoke and team list/create/delete call only the declared existing APIs; key creation requires exactly one user/team owner plus non-wildcard model/endpoint permissions with `is_admin=false`; mutation controls are confirmation-gated and disabled while pending; the one-time raw key lifecycle is explicit. Verify: asset contract/safety tests, focused existing auth/key/team route tests, and the repeatable manual checklist.
 
-- [ ] `SP1067-T4` Covers: P6-P8. Owner: coordinator. Dependencies: T3. Done when: key and visible-team spend are rendered separately with finite numeric zero distinct from missing data; partial failures remain visible; abort/generation guards prevent stale refresh or post-sign-out writes. Verify: asset contract tests for formatter, row errors, `AbortController`, generation checks, and no key/team aggregate sum; manual slow/failure response inspection.
+- [ ] `SP1067-T4` Covers: P6-P8. Owner: coordinator. Dependencies: T3. Done when: key and visible-team spend are rendered separately with finite numeric zero distinct from missing data; partial failures remain visible; all-request abort/generation guards prevent stale refresh, mutation, one-time raw-key, or post-sign-out writes. Verify: deterministic asset contract tests for formatter, row errors, active-controller cleanup, session generation checks before commits, and no key/team aggregate sum; repeatable delayed/failing-response manual checklist.
 
-- [ ] `SP1067-T5` Covers: all. Owner: coordinator. Dependencies: T1-T4. Done when: focused Rust tests cover dashboard responses, exact route behavior, security headers, asset API contracts, accessibility hooks, forbidden browser storage/unsafe sinks/external URLs, and near-match path protection without weakening existing assertions. Verify: `cargo test admin_dashboard --lib`, the focused middleware helper test, focused key/team/auth tests, and `cargo fmt --check`.
+- [ ] `SP1067-T5` Covers: all. Owner: coordinator. Dependencies: T1-T4. Done when: focused Rust tests cover dashboard responses, exact route behavior, security headers, asset API contracts, safe key ownership/permissions, all-request session guards, accessibility hooks, forbidden browser storage/unsafe sinks/external URLs, and near-match path protection without weakening existing assertions. Verify: `cargo test admin_dashboard --lib`, the focused middleware helper test, focused key/team/auth tests, and `cargo fmt --check`.
 
 - [ ] `SP1067-T6` Covers: all. Owner: verification owner. Dependencies: T1-T5. Done when: one serialized full verification pass from this worktree succeeds and evidence is saved under `artifacts/logs/gh1067/`. Verify: commands in the Verification section.
 
@@ -75,7 +75,8 @@ gate serially, and merge only when its decision is `allowed`.
 - Only #1067 is in scope. Do not inspect, edit, comment on, or merge another
   issue or PR.
 - Do not add a frontend package manager, generated bundle, static filesystem
-  service, storage model, migration, or backend management API.
+  service (`actix_files`, `Files::new`, `NamedFile`, `ServeDir`, or
+  `ServeFile`), storage model, migration, or backend management API.
 - Anonymous responses contain inert compiled assets only. Existing key/team
   APIs remain the authorization authority.
 - Access/refresh tokens and raw API keys must never reach browser storage,

--- a/specs/GH1067/tech.md
+++ b/specs/GH1067/tech.md
@@ -29,7 +29,7 @@ constants and handlers:
 
 - `GET /admin/dashboard` → `text/html`
 - `GET /admin/dashboard/app.css` → `text/css`
-- `GET /admin/dashboard/app.js` → `application/javascript`
+- `GET /admin/dashboard/app.js` → `text/javascript`
 
 The source assets live under `src/server/routes/admin_dashboard/` and are
 included with `include_str!`. Responses set `Cache-Control: no-store` and a CSP
@@ -65,11 +65,15 @@ Use semantic HTML with login, key, team, and spend panels. JavaScript uses only
 DOM construction plus `textContent`; it does not use `innerHTML`, `eval`, or
 dynamic script/style injection.
 
-The state object holds the access token, current view, key/team page numbers,
-the latest successful key/team payloads, an `AbortController`, a monotonically
-increasing request generation, and per-mutation busy flags. Each refresh aborts
-the older refresh and validates the generation before committing results.
-Sign-out increments the generation so late responses are ignored.
+The state object holds the access token, authenticated admin ID, current view,
+key/team page numbers, the latest successful key/team payloads, a set of active
+`AbortController` values, a monotonically increasing session generation, and
+per-mutation busy flags. Every authenticated request, including each mutation,
+captures the token plus generation and registers its controller. Before any
+state or DOM commit, the response must still match both values. Sign-out aborts
+every active controller, increments the generation, clears protected state, and
+therefore prevents late list, usage, mutation, or one-time raw-key responses
+from repopulating the page.
 
 Existing contracts are used as follows:
 
@@ -87,7 +91,12 @@ formatted only after a finite-number check; missing, non-finite, rejected, or
 unavailable values render blank with a row-level error.
 
 Create-key submits only declared `CreateKeyRequest` fields used by the form:
-`name`, optional `description`, and optional `team_id`. The raw key response is
+`name`, optional `description`, exactly one ownership field, and explicit
+`permissions`. Selecting a team sends `team_id`; otherwise the authenticated
+admin's ID is sent as `user_id`, so the dashboard never creates an unowned key.
+The form requires non-empty comma-separated `allowed_models` and
+`allowed_endpoints`, rejects the unrestricted `*` value, and sends
+`is_admin=false` plus no custom management permissions. The raw key response is
 rendered into a one-time notice with an explicit copy button and is removed from
 page state when dismissed or on the next authentication-state transition.
 Create-team submits only `name`, optional `display_name`, and optional
@@ -99,12 +108,12 @@ disable the originating control until the request settles.
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
 | P1, P10 | dashboard route registration and exact public paths | Actix handler tests plus `is_public_route` positive and near-match negative tests |
-| P2, P3 | login/state code | asset contract tests for existing login shape, admin-role check, memory-only state, and forbidden storage/sink APIs |
-| P4 | key panel and request builder | asset contract tests for declared key endpoints/fields; focused existing key route tests |
+| P2, P3 | login/state code | asset contract tests for existing login shape, admin-role check, all-request generation/abort guards, memory-only state, and forbidden storage/sink APIs |
+| P4 | key panel and request builder | asset contract tests for declared key endpoints, exactly-one ownership, non-wildcard model/endpoint permissions, and `is_admin=false`; focused existing key route tests |
 | P5 | team panel and request builder | asset contract tests for declared team endpoints/fields; focused existing team route tests |
-| P6 | finite-value formatter and spend renderers | source-level unit contract assertions plus manual browser verification with zero/missing/failed fixtures |
-| P7, P8 | request generation, abort, status region, busy flags | source-level contract assertions and manual slow/failing-request verification |
-| P9 | semantic HTML and CSS | asset assertions for labels, landmarks, live region, focus styling, and no color-only status |
+| P6 | finite-value formatter and spend renderers | deterministic asset contract assertions plus repeatable manual browser verification with explicit zero/missing/failed fixtures |
+| P7, P8 | request generation, abort, status region, busy flags | deterministic all-request guard/abort contract assertions plus a repeatable slow/failing-request manual checklist |
+| P9 | semantic HTML and CSS | deterministic asset assertions for labels, landmarks, live region, focus styling, and no color-only status plus a keyboard checklist |
 | Security | CSP, no-store, safe DOM sinks | response-header tests and negative asset assertions for storage, `innerHTML`, `eval`, and external URLs |
 
 ## Data Flow
@@ -153,9 +162,11 @@ cross-origin call is added.
       route matching, asset safety/contract/accessibility assertions.
 - [ ] Focused tests: dashboard module, middleware public/admin route helpers,
       existing key handler tests, and existing team route tests.
-- [ ] Manual verification: admin login; key list/create/revoke; team
-      list/create/delete; zero/missing/failed spend; keyboard navigation; reload
-      clears auth and one-time key.
+- [ ] Manual verification checklist: admin and non-admin login; key
+      list/create/revoke; required safe key ownership/model/endpoint scope; team
+      list/create/delete; explicit zero/missing/failed spend; delayed
+      list/create responses followed by sign-out; keyboard-only navigation;
+      narrow viewport; reload clears auth and one-time key.
 - [ ] Deterministic verification: `cargo fmt --check`, `cargo check`,
       `cargo clippy --all-targets -- -D warnings`, full `cargo test`, SpecRail
       workflow/spec checks, scope guard, and overlap guard.

--- a/specs/GH1067/tech.md
+++ b/specs/GH1067/tech.md
@@ -1,0 +1,167 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1067 / #1067
+
+## Product Spec
+
+See `specs/GH1067/product.md` (invariants P1-P10).
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| HTTP assembly | `src/server/http.rs`, `src/server/routes/mod.rs` | Actix configures health, auth, key, team, budget, admin-cache, AI, and pricing routes; no UI route exists | Register one additive dashboard route module |
+| Public-route boundary | `src/server/middleware/helpers.rs`, `src/server/middleware/auth.rs` | Only exact paths in `PUBLIC_ROUTES` bypass authentication; all other requests pass through configured auth | The inert shell/assets must load before login without broadening protected API access |
+| Security headers | `src/server/middleware/security.rs` | Global middleware sets nosniff, frame denial, HSTS, and referrer policy; it does not set a content security policy | Dashboard responses need a route-specific restrictive CSP |
+| Login | `src/server/routes/auth/login.rs`, `src/server/routes/auth/models.rs` | `POST /auth/login` returns `ApiResponse<LoginResponse>` with JWTs and user role | Reuse the existing contract and accept only an admin response |
+| Key management | `src/server/routes/keys/{mod.rs,handlers.rs,types.rs}` | `/v1/keys` supports admin list/create and per-key revoke; `KeyInfo` already includes masked identity and usage totals | Drive the minimum key workflow without a new backend API |
+| Team management | `src/server/routes/teams.rs` | `/v1/teams` supports admin list/create/delete and per-team usage | Drive the minimum team and spend workflow without a new backend API |
+| Frontend assets | none | No HTML, CSS, JavaScript, build pipeline, or static file service exists | Add small compile-time embedded assets instead of a second toolchain |
+
+## Proposed Design
+
+### Embedded route module
+
+Add `src/server/routes/admin_dashboard.rs` with three compile-time embedded
+constants and handlers:
+
+- `GET /admin/dashboard` → `text/html`
+- `GET /admin/dashboard/app.css` → `text/css`
+- `GET /admin/dashboard/app.js` → `application/javascript`
+
+The source assets live under `src/server/routes/admin_dashboard/` and are
+included with `include_str!`. Responses set `Cache-Control: no-store` and a CSP
+equivalent to:
+
+```text
+default-src 'none'; script-src 'self'; style-src 'self';
+connect-src 'self'; img-src 'self' data:; font-src 'self';
+base-uri 'none'; form-action 'self'; frame-ancestors 'none'
+```
+
+The route module is registered from the existing route assembly. No filesystem
+path, directory traversal surface, frontend package manager, runtime asset
+directory, or new dependency is introduced.
+
+### Authentication boundary
+
+Add only those three exact asset paths to `is_public_route`. Prefixes, suffixes,
+and child paths remain protected. The anonymous responses are immutable source
+assets and contain no server data.
+
+The JavaScript calls `POST /auth/login`, unwraps the existing `ApiResponse`,
+checks `data.user.role` case-insensitively for `admin`, and only then retains
+`data.access_token` in a module-scoped state object. The refresh token is not
+retained because this minimum dashboard does not implement token refresh.
+Authenticated requests use `Authorization: Bearer <token>`. Sign-out clears all
+state and rendered protected data. No browser storage or cookies are read or
+written.
+
+### Dashboard state and rendering
+
+Use semantic HTML with login, key, team, and spend panels. JavaScript uses only
+DOM construction plus `textContent`; it does not use `innerHTML`, `eval`, or
+dynamic script/style injection.
+
+The state object holds the access token, current view, key/team page numbers,
+the latest successful key/team payloads, an `AbortController`, a monotonically
+increasing request generation, and per-mutation busy flags. Each refresh aborts
+the older refresh and validates the generation before committing results.
+Sign-out increments the generation so late responses are ignored.
+
+Existing contracts are used as follows:
+
+- keys: `GET /v1/keys?page=<n>&limit=20`, `POST /v1/keys`,
+  `DELETE /v1/keys/{id}`;
+- teams: `GET /v1/teams?page=<n>&limit=20`, `POST /v1/teams`,
+  `DELETE /v1/teams/{id}`;
+- spend: key `usage_stats` from the successful key-list payload and
+  `GET /v1/teams/{id}/usage` for teams visible on the current page.
+
+The spend view is explicitly page-scoped. It renders per-key and per-team
+`cost_today`, `total_cost`, requests, and tokens. It does not sum key and team
+totals together, which could double-count the same traffic. Numeric fields are
+formatted only after a finite-number check; missing, non-finite, rejected, or
+unavailable values render blank with a row-level error.
+
+Create-key submits only declared `CreateKeyRequest` fields used by the form:
+`name`, optional `description`, and optional `team_id`. The raw key response is
+rendered into a one-time notice with an explicit copy button and is removed from
+page state when dismissed or on the next authentication-state transition.
+Create-team submits only `name`, optional `display_name`, and optional
+`description`. Destructive operations use an explicit confirmation dialog and
+disable the originating control until the request settles.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1, P10 | dashboard route registration and exact public paths | Actix handler tests plus `is_public_route` positive and near-match negative tests |
+| P2, P3 | login/state code | asset contract tests for existing login shape, admin-role check, memory-only state, and forbidden storage/sink APIs |
+| P4 | key panel and request builder | asset contract tests for declared key endpoints/fields; focused existing key route tests |
+| P5 | team panel and request builder | asset contract tests for declared team endpoints/fields; focused existing team route tests |
+| P6 | finite-value formatter and spend renderers | source-level unit contract assertions plus manual browser verification with zero/missing/failed fixtures |
+| P7, P8 | request generation, abort, status region, busy flags | source-level contract assertions and manual slow/failing-request verification |
+| P9 | semantic HTML and CSS | asset assertions for labels, landmarks, live region, focus styling, and no color-only status |
+| Security | CSP, no-store, safe DOM sinks | response-header tests and negative asset assertions for storage, `innerHTML`, `eval`, and external URLs |
+
+## Data Flow
+
+Anonymous browser request → embedded shell/assets only → login form posts to
+existing `/auth/login` → successful admin response yields an in-memory access
+token → same-origin authenticated key/team requests → existing server-side
+authorization and persistence → JSON response → safe DOM rendering.
+
+No dashboard request bypasses the existing key/team authorization checks. No
+new persistence, schema, migration, generated file, external service, or
+cross-origin call is added.
+
+## Alternatives Considered
+
+- Separate SPA repository and deployment: rejected because the issue requests a
+  minimum built-in surface and provides no cross-repository ownership or
+  deployment contract.
+- Add React/Vite or another build tool: rejected because it adds dependency,
+  release, and generated-asset workflows disproportionate to the bounded
+  feature.
+- Put a token in a URL, browser storage, or embedded HTML: rejected because it
+  leaks credentials through history, storage, logs, or source.
+- Make management APIs public or proxy them through dashboard-only endpoints:
+  rejected because existing API authorization is the correct authority and a
+  proxy would duplicate contracts.
+- Sum key and team spend into one total: rejected because the scopes can overlap
+  and silently double-count.
+
+## Risks
+
+- Security: three exact anonymous asset paths sit under `/admin`; restrictive
+  headers, exact-match route tests, inert compile-time content, safe DOM sinks,
+  and unchanged API authorization constrain the exposure.
+- Compatibility: all API shapes and protected-route behavior remain unchanged;
+  only additive `GET` assets are registered.
+- Performance: spend loads usage only for teams on the visible page and aborts
+  stale refreshes; it does not fan out across the entire database.
+- Maintenance: frontend contracts can drift from Rust response types; named API
+  paths/fields and route tests make drift visible, while the scope avoids a
+  second dependency ecosystem.
+
+## Test Plan
+
+- [ ] Unit tests: dashboard content types, CSP/no-store headers, exact public
+      route matching, asset safety/contract/accessibility assertions.
+- [ ] Focused tests: dashboard module, middleware public/admin route helpers,
+      existing key handler tests, and existing team route tests.
+- [ ] Manual verification: admin login; key list/create/revoke; team
+      list/create/delete; zero/missing/failed spend; keyboard navigation; reload
+      clears auth and one-time key.
+- [ ] Deterministic verification: `cargo fmt --check`, `cargo check`,
+      `cargo clippy --all-targets -- -D warnings`, full `cargo test`, SpecRail
+      workflow/spec checks, scope guard, and overlap guard.
+
+## Rollback Plan
+
+Remove the dashboard route registration, route module, exact public asset
+entries, and embedded asset sources together. No stored data, configuration,
+API contract, or migration requires rollback.


### PR DESCRIPTION
## What

Adds the complete SpecRail product, technical, and task packet for the built-in
admin dashboard requested by #1067. The packet fixes the minimum scope, reuses
existing auth/key/team APIs, and defines the security and verification
boundaries before implementation.

## Why

#1067 explicitly deferred implementation until frontend scope, authentication,
and the minimum feature set were decided. This spec resolves those decisions
without adding code or closing the issue.

Refs #1067

## SpecRail

- Spec packet: `specs/GH1067/`
- Spec status: `complete`
- PR kind: `spec`
- PR tier: `heavy` because implementation will add an exact public asset shell
  adjacent to the authentication boundary
- Completion mode: partial; the implementation PR will use `Fixes #1067`

## Test Plan

- [x] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" python3 checks/check_workflow.py --repo .`
- [x] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" python3 checks/check_workflow.py --repo . --spec-dir specs/GH1067`
- [x] `git diff --check`

## Agent Disclosure

- [x] Agent authored the spec packet under the user's `implx auto` authorization.
- [ ] No implementation code is included in this PR.
