### PR TITLE
docs(spec): formalize GH1064 roadmap closure

### DIFF
--- a/docs/plan/2026-07-18-best-gateway-gap-analysis.md
+++ b/docs/plan/2026-07-18-best-gateway-gap-analysis.md
@@ -5,6 +5,17 @@
 > 再对标业界最佳实践。外部对标来自模型训练知识（截至 2026-01），已在文末按"事实/推断/建议"分离标注。
 > 本文是**前瞻 roadmap**，不是 bug 清单；已有 issue（#519/#837/#838/#965）的项只做交叉引用，不重复开工。
 
+## Roadmap lifecycle
+
+- PR #1068 delivered this repository-backed analysis for parent roadmap #1064.
+- Implementation remains owned by focused issues: existing work stays under
+  #519/#837/#838/#965, while newly identified gaps use #1065/#1066/#1067.
+- Closing #1064 means the roadmap, gap ownership, and planning handoff are
+  complete. It does **not** mean the linked implementation issues are complete,
+  and it does not change their state or acceptance criteria.
+- Future implementation-sized discoveries must receive focused issue/spec
+  coverage instead of accumulating under the closed parent roadmap.
+
 ---
 
 ## 0. 一句话结论

--- a/specs/GH1064/product.md
+++ b/specs/GH1064/product.md
@@ -26,8 +26,8 @@ issues.
 
 - Implementing any runtime, API, UI, security, provider, or architecture change.
 - Changing, closing, relabeling, or reprioritizing any child or pre-existing issue.
-- Claiming that the gaps tracked by #519, #837, #838, #965, or #1065–#1067
-  have shipped.
+- Claiming that the gaps tracked by #519, #837, #838, #965, #1065, #1066, or
+  #1067 have shipped.
 - Re-running the external competitor survey as part of this closure tranche.
 
 ## Behavior Invariants

--- a/specs/GH1064/product.md
+++ b/specs/GH1064/product.md
@@ -1,0 +1,69 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1064 / #1064
+
+## User Problem
+
+The repository has a durable competitive gap analysis for the “best LLM
+gateway” roadmap, but the parent issue has no SpecRail packet or explicit
+closure contract. That makes it easy to mistake closing the planning issue for
+shipping every child capability, or to duplicate work already owned by focused
+issues.
+
+## Goals
+
+- Preserve one repository-backed roadmap that separates current facts,
+  inferences, and recommendations.
+- Make ownership of every roadmap gap explicit through existing or focused
+  child issues.
+- Define closure of #1064 as completion of the roadmap and decomposition work,
+  without claiming that independently tracked implementation is complete.
+- Prevent production implementation from accumulating under the umbrella issue.
+
+## Non-Goals
+
+- Implementing any runtime, API, UI, security, provider, or architecture change.
+- Changing, closing, relabeling, or reprioritizing any child or pre-existing issue.
+- Claiming that the gaps tracked by #519, #837, #838, #965, or #1065–#1067
+  have shipped.
+- Re-running the external competitor survey as part of this closure tranche.
+
+## Behavior Invariants
+
+1. The gap-analysis document remains the durable source for the roadmap and
+   continues to distinguish verified repository facts from inference and advice.
+2. Every implementation-sized gap stays assigned to a focused issue; #1064
+   does not become a shared implementation container.
+3. Closing #1064 means its planning artifact, gap ownership, and handoff are
+   complete. It does not change the state or completion meaning of linked work.
+4. Future discoveries are added to an appropriate focused issue and may update
+   the roadmap without requiring #1064 to remain open indefinitely.
+5. The closure change affects documentation and workflow metadata only; gateway
+   runtime behavior and public contracts remain unchanged.
+
+## Acceptance Criteria
+
+- [ ] `specs/GH1064/` contains a complete product, technical, and task packet.
+- [ ] The roadmap records its parent-issue closure semantics and the focused
+      ownership of implementation work.
+- [ ] The closing PR references the already merged roadmap delivery in #1068
+      and uses `Fixes #1064` without closing or modifying another issue.
+- [ ] SpecRail deterministic checks pass for the repository and GH1064 packet.
+- [ ] An independent reviewer confirms that the PR neither claims child work is
+      complete nor expands into production implementation.
+
+## Edge Cases
+
+- A linked issue may still be open, deferred, or only partially implemented
+  when #1064 closes; its own acceptance criteria remain authoritative.
+- A roadmap statement may become stale as `main` evolves. A focused follow-up
+  may refresh the document without reopening the umbrella issue.
+- A newly discovered gap without an owner requires a focused issue before
+  implementation begins.
+
+## Rollout Notes
+
+This is a documentation-only closure. Merging the closing PR archives the
+planning umbrella while leaving all linked implementation work independent.

--- a/specs/GH1064/tasks.md
+++ b/specs/GH1064/tasks.md
@@ -1,0 +1,43 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1064 / #1064
+
+## Spec Packet
+
+- Product: `specs/GH1064/product.md`
+- Tech: `specs/GH1064/tech.md`
+
+## Implementation Tasks
+
+- [x] `SP1064-T1` — Owner: coordinator. Dependencies: merged roadmap PR #1068. Done when: the product and technical specs define #1064 as a planning umbrella, keep child implementation out of scope, and give parent closure an explicit meaning. Verify: SpecRail packet checks and manual spec review.
+- [x] `SP1064-T2` — Owner: coordinator. Dependencies: `SP1064-T1`. Done when: the roadmap records delivery, focused ownership, and closure semantics without changing a child spec, issue, or production file. Verify: `git diff --check` and changed-path inspection.
+- [ ] `SP1064-T3` — Owner: coordinator and independent reviewer. Dependencies: `SP1064-T1`, `SP1064-T2`. Done when: deterministic checks pass, the closing PR uses `Fixes #1064`, an independent exact-head review is clean, current-head CI and PR gates are green, the PR is merged, and remote closure confirms only #1064 closed. Verify: local command evidence, reviewer artifact, GitHub PR evidence, offline PR gate, merge confirmation, and closure audit.
+
+## Parallelization
+
+The documentation edits are one coordinator-owned serial lane. The independent
+reviewer is read-only and starts after the PR head is stable. Cargo and full
+repository verification, if required by CI or repository gates, run only in
+this worktree under the coordinator.
+
+## Verification
+
+Run these commands during `SP1064-T3`:
+
+```bash
+python3 checks/check_workflow.py --repo .
+python3 checks/check_workflow.py --repo . --spec-dir specs/GH1064
+python3 checks/route_gate.py --repo . --route implement --issue 1064 --state ready_to_implement --artifact product_spec=specs/GH1064/product.md --artifact tech_spec=specs/GH1064/tech.md --artifact task_plan=specs/GH1064/tasks.md --duplicate-evidence .specrail/runtime/evidence/duplicate-1064.json --json
+git diff --check
+```
+
+Then collect exact-head CI, independent review, resolved review threads, clean
+merge state, and an allowed PR gate.
+
+## Handoff Notes
+
+PR #1068 already delivered the gap analysis. This tranche only makes the
+planning umbrella auditable and closable; all linked implementation remains
+owned by its focused issue.

--- a/specs/GH1064/tech.md
+++ b/specs/GH1064/tech.md
@@ -37,7 +37,7 @@ spec packet changes.
 | P2: focused implementation ownership | GH1064 packet and roadmap closure section | Confirm linked ownership is descriptive and no child files/issues are changed. |
 | P3: parent closure does not imply child completion | Explicit closure semantics | Independent review of the diff and PR body. |
 | P4: future gaps use focused issues | Product invariant and roadmap guidance | Independent review. |
-| P5: documentation-only behavior | Git diff scope | `git diff --name-only origin/main...HEAD` contains only GH1064 docs/spec files. |
+| P5: documentation-only behavior | Git diff scope | `git diff --name-only origin/main...HEAD` contains only `docs/plan/2026-07-18-best-gateway-gap-analysis.md` and the three files under `specs/GH1064/`. |
 
 ## Data Flow
 

--- a/specs/GH1064/tech.md
+++ b/specs/GH1064/tech.md
@@ -1,0 +1,79 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1064 / #1064
+
+## Product Spec
+
+See `specs/GH1064/product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Roadmap | `docs/plan/2026-07-18-best-gateway-gap-analysis.md` | PR #1068 delivered the verified gap analysis and split recommendations, but the document does not define when the umbrella issue can close. | This is the only direct deliverable of #1064. |
+| SpecRail packet | `specs/GH1064/` | No GH1064 packet exists. Focused child packets exist separately. | A complete packet prevents the umbrella from absorbing child implementation scope. |
+| Focused work | `specs/GH1065/`, `specs/GH1066/`, `specs/GH1067/` and existing issue-owned specs | Implementation requirements are already owned outside #1064. | The closure must preserve those ownership boundaries and states. |
+
+## Proposed Design
+
+Add a small GH1064 SpecRail packet that treats the issue as a planning
+umbrella. Add a closure-status section to the existing roadmap that records:
+
+- the roadmap delivery PR (#1068),
+- the focused issue ownership model,
+- the meaning of closing #1064, and
+- the prohibition on interpreting parent closure as child completion.
+
+No production source, configuration, schema, API, workflow policy, or child
+spec packet changes.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1: durable fact/inference/advice separation | Existing roadmap plus closure section | Review the rendered Markdown and run SpecRail checks. |
+| P2: focused implementation ownership | GH1064 packet and roadmap closure section | Confirm linked ownership is descriptive and no child files/issues are changed. |
+| P3: parent closure does not imply child completion | Explicit closure semantics | Independent review of the diff and PR body. |
+| P4: future gaps use focused issues | Product invariant and roadmap guidance | Independent review. |
+| P5: documentation-only behavior | Git diff scope | `git diff --name-only origin/main...HEAD` contains only GH1064 docs/spec files. |
+
+## Data Flow
+
+There is no runtime data flow. The GitHub issue points to the repository
+roadmap; the GH1064 packet defines its acceptance and closure contract; the
+closing PR links both and closes only #1064.
+
+## Alternatives Considered
+
+- Keep #1064 open until every linked issue completes: rejected because it
+  conflates roadmap planning with independently scoped implementation and
+  creates no stable terminal for the planning deliverable.
+- Implement one roadmap gap under #1064: rejected because each gap requires a
+  focused issue/spec and several already have explicit owners.
+- Close #1064 without repository changes: rejected because the missing closure
+  semantics would remain implicit and the SpecRail coverage gap would persist.
+
+## Risks
+
+- Security: None; no runtime or security behavior changes.
+- Compatibility: Readers could misread parent closure as product completion;
+  explicit wording and independent review mitigate this.
+- Performance: None.
+- Maintenance: Ownership links can age; focused issues remain authoritative.
+
+## Test Plan
+
+- [ ] `python3 checks/check_workflow.py --repo .`
+- [ ] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1064`
+- [ ] `python3 checks/route_gate.py --repo . --route implement --issue 1064 --state ready_to_implement --artifact product_spec=specs/GH1064/product.md --artifact tech_spec=specs/GH1064/tech.md --artifact task_plan=specs/GH1064/tasks.md --duplicate-evidence .specrail/runtime/evidence/duplicate-1064.json --json`
+- [ ] `git diff --check`
+- [ ] Independent exact-head documentation/spec review.
+- [ ] Fresh PR CI, review-thread, merge-state, and PR-gate evidence.
+
+## Rollback Plan
+
+Revert the closing PR and reopen #1064 if the parent must again serve as the
+active planning umbrella. Reverting does not affect any child issue or runtime
+behavior.


### PR DESCRIPTION
## Summary

Formalize #1064 as the planning umbrella for the best-gateway roadmap and make
its closure semantics explicit. This adds the missing SpecRail packet and
records that closing the parent means the roadmap/decomposition handoff is
complete, not that linked implementation work has shipped.

PR #1068 already delivered the underlying competitive gap analysis. This PR
does not change production code or the state/scope of any child issue.

## Linked Work

- Fixes #1064
- Prior roadmap delivery: #1068
- Spec packet: `specs/GH1064/`

## Readiness Gate

- [x] #1064 has `ready_to_implement` (applied by the authorized `implx auto` run after packet validation).
- [x] Product, technical, and task specs are included.
- [x] No security-sensitive or production behavior is changed.

## Review Gate

- [ ] Independent exact-head reviewer lane completed.
- [x] Final review and merge are governed by current-head CI, review threads, and the offline PR gate.

## Merge Gate

- [x] Local head: `88a20e8dfaa9435d573241bd7e86814faf4c3cd9`.
- [ ] CI/check rollup is complete and passing.
- [ ] Review threads are resolved.
- [ ] Merge state is clean.
- [x] Merge authorization source: current `implx auto` invocation for issue #1064 only.
- [ ] Offline PR gate is allowed on fresh evidence.

## Verification

- [x] `python3 checks/check_workflow.py --repo .`
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1064`
- [x] Implementation route gate with issue and duplicate-work evidence: `allowed`
- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (the default soft descriptor limit of 256 first produced OS error 24; the named test passed alone, and the full suite passed with a per-process soft limit of 4096)

## Release Notes

- [x] Not user-visible; no release note needed.

## Agent Disclosure

- [x] Agent-assisted change; merge remains gated by independent review and fresh automated evidence.
