### PR TITLE
fix(errors): redact provider gateway responses

### DIFF
--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -111,7 +111,11 @@ fn openai_error_spec_from_safe_error(
     error: &GatewayError,
     facts: HttpErrorFacts,
 ) -> OpenAiErrorSpec {
-    let message = error.to_string();
+    let message = match error {
+        GatewayError::Provider(ProviderError::ApiError { message, .. }) => message.clone(),
+        GatewayError::Provider(provider_error) => provider_error.to_string(),
+        _ => error.to_string(),
+    };
     let mut spec = spec_from_facts(facts, message);
 
     if let GatewayError::Provider(ProviderError::ApiError { .. }) = error
@@ -333,9 +337,10 @@ mod tests {
 
     #[actix_web::test]
     async fn provider_api_error_preserves_upstream_openai_error_fields() {
+        let secret = "sk-live-upstream-secret";
         let upstream = serde_json::json!({
             "error": {
-                "message": "context window exceeded",
+                "message": format!("context window exceeded {secret}"),
                 "type": "invalid_request_error",
                 "param": "messages",
                 "code": "context_length_exceeded"
@@ -351,10 +356,14 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = to_json(response).await;
-        assert_eq!(body["error"]["message"], "context window exceeded");
+        assert_eq!(
+            body["error"]["message"],
+            "context window exceeded [REDACTED]"
+        );
         assert_eq!(body["error"]["type"], "invalid_request_error");
         assert_eq!(body["error"]["param"], "messages");
         assert_eq!(body["error"]["code"], "context_length_exceeded");
+        assert!(!body.to_string().contains(secret));
     }
 
     #[test]

--- a/src/server/routes/ai/openai_errors.rs
+++ b/src/server/routes/ai/openai_errors.rs
@@ -100,7 +100,18 @@ pub(crate) fn gateway_error_response(error: &GatewayError) -> HttpResponse {
 
 fn openai_error_spec(error: &GatewayError) -> OpenAiErrorSpec {
     let facts = gateway_http_error_facts(error);
-    let message = openai_error_message(error);
+    let redacted = match error {
+        GatewayError::Provider(provider_error) => GatewayError::Provider(provider_error.redacted()),
+        _ => return openai_error_spec_from_safe_error(error, facts),
+    };
+    openai_error_spec_from_safe_error(&redacted, facts)
+}
+
+fn openai_error_spec_from_safe_error(
+    error: &GatewayError,
+    facts: HttpErrorFacts,
+) -> OpenAiErrorSpec {
+    let message = error.to_string();
     let mut spec = spec_from_facts(facts, message);
 
     if let GatewayError::Provider(ProviderError::ApiError { .. }) = error
@@ -122,15 +133,6 @@ fn openai_error_spec(error: &GatewayError) -> OpenAiErrorSpec {
 
     spec
 }
-
-fn openai_error_message(error: &GatewayError) -> String {
-    match error {
-        GatewayError::Provider(ProviderError::ApiError { message, .. }) => message.clone(),
-        GatewayError::Provider(provider_error) => provider_error.to_string(),
-        _ => error.to_string(),
-    }
-}
-
 fn build_response(spec: OpenAiErrorSpec) -> HttpResponse {
     HttpResponse::build(spec.status).json(response_body(
         spec.message,

--- a/src/utils/error/gateway_error/conversions.rs
+++ b/src/utils/error/gateway_error/conversions.rs
@@ -12,7 +12,7 @@ use crate::core::providers::unified_provider::ProviderError;
 // via GatewayError::Provider, so no destructuring is needed here.
 impl From<ProviderError> for GatewayError {
     fn from(err: ProviderError) -> Self {
-        GatewayError::Provider(err)
+        GatewayError::Provider(err.redacted())
     }
 }
 

--- a/src/utils/error/gateway_error/response.rs
+++ b/src/utils/error/gateway_error/response.rs
@@ -36,7 +36,10 @@ fn insert_error_headers(builder: &mut HttpResponseBuilder, headers: HttpErrorHea
 impl GatewayError {
     pub fn error_response_with_request_id(&self, request_id: Option<String>) -> HttpResponse {
         let facts = gateway_http_error_facts(self);
-        let message = self.to_string();
+        let message = match self {
+            GatewayError::Provider(provider_error) => provider_error.redacted().to_string(),
+            _ => self.to_string(),
+        };
 
         let canonical_code = self.canonical_code().as_str().to_string();
         let retryable = self.canonical_retryable();

--- a/src/utils/error/gateway_error/response.rs
+++ b/src/utils/error/gateway_error/response.rs
@@ -36,10 +36,7 @@ fn insert_error_headers(builder: &mut HttpResponseBuilder, headers: HttpErrorHea
 impl GatewayError {
     pub fn error_response_with_request_id(&self, request_id: Option<String>) -> HttpResponse {
         let facts = gateway_http_error_facts(self);
-        let message = match self {
-            GatewayError::Provider(provider_error) => provider_error.to_string(),
-            _ => self.to_string(),
-        };
+        let message = self.to_string();
 
         let canonical_code = self.canonical_code().as_str().to_string();
         let retryable = self.canonical_retryable();

--- a/src/utils/error/gateway_error/response_tests.rs
+++ b/src/utils/error/gateway_error/response_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::core::providers::unified_provider::ProviderError;
+use actix_web::body::to_bytes;
 use actix_web::http::StatusCode;
 
 fn assert_header(response: &actix_web::HttpResponse, name: &str, expected: &str) {
@@ -10,6 +11,53 @@ fn assert_header(response: &actix_web::HttpResponse, name: &str, expected: &str)
             .and_then(|value| value.to_str().ok()),
         Some(expected)
     );
+}
+
+#[actix_web::test]
+async fn provider_error_secrets_are_redacted_at_gateway_and_http_boundaries() {
+    let secrets = [
+        "sk-live-secret",
+        "cookie-secret",
+        "signed-secret",
+        "provider-body-secret",
+    ];
+    let raw = ProviderError::api_error(
+        "openai",
+        503,
+        format!(
+            "Authorization: Bearer {}; Cookie: session={}; https://example.test?a=1&X-Amz-Signature={}; api_key={}",
+            secrets[0], secrets[1], secrets[2], secrets[3]
+        ),
+    );
+    let error: GatewayError = raw.into();
+    let display = error.to_string();
+    let debug = format!("{error:?}");
+    let body = String::from_utf8(
+        to_bytes(error.error_response().into_body())
+            .await
+            .expect("response body")
+            .to_vec(),
+    )
+    .expect("utf-8 response");
+
+    for secret in secrets {
+        assert!(!display.contains(secret), "Display leaked {secret}");
+        assert!(!debug.contains(secret), "Debug leaked {secret}");
+        assert!(!body.contains(secret), "HTTP body leaked {secret}");
+    }
+    assert!(body.contains("[REDACTED]"));
+}
+
+#[test]
+fn provider_response_emitters_do_not_stringify_raw_provider_errors() {
+    let gateway_response = include_str!("response.rs");
+    let openai_response = include_str!("../../../server/routes/ai/openai_errors.rs");
+
+    for source in [gateway_response, openai_response] {
+        assert!(!source.contains("provider_error.to_string()"));
+    }
+    assert!(openai_response.contains("provider_error.redacted()"));
+    assert!(openai_response.contains("gateway_http_error_facts(error)"));
 }
 
 // ==================== ErrorDetail Tests ====================

--- a/src/utils/error/gateway_error/response_tests.rs
+++ b/src/utils/error/gateway_error/response_tests.rs
@@ -48,16 +48,26 @@ async fn provider_error_secrets_are_redacted_at_gateway_and_http_boundaries() {
     assert!(body.contains("[REDACTED]"));
 }
 
-#[test]
-fn provider_response_emitters_do_not_stringify_raw_provider_errors() {
-    let gateway_response = include_str!("response.rs");
-    let openai_response = include_str!("../../../server/routes/ai/openai_errors.rs");
+#[actix_web::test]
+async fn provider_response_redacts_directly_wrapped_errors_without_gateway_prefix() {
+    let secret = "sk-live-direct-wrapper-secret";
+    let error = GatewayError::Provider(ProviderError::api_error(
+        "openai",
+        503,
+        format!("upstream failed with {secret}"),
+    ));
 
-    for source in [gateway_response, openai_response] {
-        assert!(!source.contains("provider_error.to_string()"));
-    }
-    assert!(openai_response.contains("provider_error.redacted()"));
-    assert!(openai_response.contains("gateway_http_error_facts(error)"));
+    let body = String::from_utf8(
+        to_bytes(error.error_response().into_body())
+            .await
+            .expect("response body")
+            .to_vec(),
+    )
+    .expect("utf-8 response");
+
+    assert!(!body.contains(secret));
+    assert!(!body.contains("Provider error:"));
+    assert!(body.contains("[REDACTED]"));
 }
 
 // ==================== ErrorDetail Tests ====================


### PR DESCRIPTION
Refs #965

## Summary
- store only redacted ProviderError copies across the GatewayError boundary
- serialize generic and OpenAI-compatible responses from redacted typed errors and canonical HTTP facts
- add adversarial secret-leakage and source-guard coverage

## Verification
- cargo test --all-features --locked utils::error::gateway_error (197 passed)
- cargo test --all-features --locked utils::error::gateway_error::response::tests::provider_ (2 passed)
- cargo fmt --check
- cargo check --all-targets --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH965
- bash scripts/guards/check_pr_scope.sh
- bash scripts/guards/check_pr_overlap.sh

Partial GH-965 D1E-b tranche; does not close the issue.