### PR TITLE
docs(spec): define executable DOM verification for GH1067

### DIFF
--- a/specs/GH1067/product.md
+++ b/specs/GH1067/product.md
@@ -30,8 +30,9 @@ and can easily miss loading, empty, or permission failures.
   editing, registration, password reset, OAuth, or SSO controls.
 - Persisting browser credentials, access tokens, refresh tokens, or newly
   created raw API keys.
-- Creating or deploying a separate frontend repository or frontend build
-  service.
+- 不增加运行时前端 bundle、运行时包管理器或随部署交付的前端工具链。允许使用
+  隔离、版本锁定、仅测试用途的 `node:test` + jsdom harness，前提是它既不随
+  gateway 运行时发布，也不在 gateway 运行时中执行。
 
 ## Behavior Invariants
 
@@ -73,6 +74,22 @@ and can easily miss loading, empty, or permission failures.
 10. Existing API routes, authentication behavior, JSON shapes, CLI clients, and
     deployments that never open the dashboard remain unchanged.
 
+以下追加的 `B` 不变量定义可执行 DOM 自动化证据，同时不改变 P1-P10：
+
+- `B1` — refresh、navigation 或 mutation 响应乱序完成时，只有最新认证 session
+  generation 且符合操作顺序的响应可以更新受保护页面状态或 DOM。
+- `B2` — 每个请求 controller 在 success、failure 或 cancellation 后都必须从
+  active-request tracking 移除；sign-out 会 abort 所有仍活跃的 controller，且不
+  留下 stale controller。
+- `B3` — 新建 raw API key 只出现在一次性 notice 中，只能经明确操作复制，并在
+  dismissal 或下一次 authentication-state transition 时不可恢复地清除。
+- `B4` — usage 请求部分失败时，成功 row 保持可见，真实数值 zero 仍显示为 zero；
+  只有 unavailable/failed value 留空并带明确 row-level error。
+- `B5` — revoke-key 与 delete-team 仅在 affirmative confirmation 后发出请求；
+  取消确认不会发出破坏性请求，也不会产生 optimistic destructive DOM change。
+- `B6` — sign-out 后，前一 generation 的延迟 login、list、usage、mutation 与
+  raw-key 响应都不能恢复 credential、protected data、status 或一次性 secret。
+
 ## Acceptance Criteria
 
 - [ ] `/admin/dashboard` serves a self-contained dashboard shell with no
@@ -85,10 +102,12 @@ and can easily miss loading, empty, or permission failures.
       failed data.
 - [ ] Tokens and one-time raw keys are absent from browser storage and are
       cleared from page state at their documented lifecycle boundaries.
+- [ ] 可执行 DOM harness 仅使用隔离且锁定的测试专用 Node/jsdom 环境，对真实
+      embedded JavaScript source 确定性执行 `B1`-`B6`。
 - [ ] Route registration, response headers, static content/API contracts, and
       unsafe browser primitives have deterministic automated coverage;
-      authentication-state, empty/error, concurrency, and accessibility
-      behavior follow a repeatable manual verification checklist.
+      keyboard flow、narrow-layout behavior 与 real-browser rendering 仍保留在
+      可重复的 manual verification checklist 中。
 
 ## Edge Cases
 
@@ -103,6 +122,8 @@ and can easily miss loading, empty, or permission failures.
   submitted value.
 - Network responses arriving after sign-out are ignored and cannot repopulate
   protected state.
+- 可执行 DOM automation 不作为 keyboard ergonomics、narrow-layout readability
+  或 real-browser visual rendering 的证据；这些检查继续保持 manual。
 
 ## Rollout Notes
 

--- a/specs/GH1067/tasks.md
+++ b/specs/GH1067/tasks.md
@@ -19,19 +19,23 @@ GH-1067 / #1067
 
 - [x] `SP1067-T4` Covers: P6-P8. Owner: coordinator. Dependencies: T3. Done when: key and visible-team spend are rendered separately with finite numeric zero distinct from missing data; partial failures remain visible; all-request abort/generation guards prevent stale refresh, mutation, one-time raw-key, or post-sign-out writes. Verify: deterministic asset contract tests for formatter, row errors, active-controller cleanup, session generation checks before commits, and no key/team aggregate sum; repeatable delayed/failing-response manual checklist.
 
-- [x] `SP1067-T5` Covers: all. Owner: coordinator. Dependencies: T1-T4. Done when: focused Rust tests cover dashboard responses, exact route behavior, security headers, asset API contracts, safe key ownership/permissions, all-request session guards, accessibility hooks, forbidden browser storage/unsafe sinks/external URLs, and near-match path protection without weakening existing assertions. Verify: `cargo test admin_dashboard --lib`, the focused middleware helper test, focused key/team/auth tests, and `cargo fmt --check`.
+- [x] `SP1067-T5` Covers: P1-P10（仅 source/Rust）. Owner: coordinator. Dependencies: T1-T4. Done when: focused Rust tests and static source assertions cover dashboard responses, exact route behavior, security headers, asset API contracts, safe key ownership/permissions, all-request session guard source structure, accessibility hooks, forbidden browser storage/unsafe sinks/external URLs, and near-match path protection without weakening existing assertions; this task does not claim executable DOM behavior. Verify: `cargo test admin_dashboard --lib`, the focused middleware helper test, focused key/team/auth tests, and `cargo fmt --check`.
 
-- [x] `SP1067-T6` Covers: all. Owner: verification owner. Dependencies: T1-T5. Done when: one serialized full verification pass from this worktree succeeds and evidence is saved under `artifacts/logs/gh1067/`. Verify: commands in the Verification section.
+- [ ] `SP1067-T6` Covers: all. Owner: verification owner. Dependencies: T1-T5, T8. Done when: one serialized full verification pass from the exact implementation head succeeds, including the executable DOM suite, and SHA-scoped evidence is saved under the ignored `artifacts/logs/gh1067/<HEAD_SHA>/` contract. Verify: commands in the Verification section and the remote Actions run/artifact evidence.
 
-- [ ] `SP1067-T7` Covers: all acceptance criteria. Owner: coordinator and independent reviewer. Dependencies: T6. Done when: the heavy-tier spec PR is independently reviewed, gated, and merged without closing #1067; the final implementation PR closes #1067 and has current green blocking CI, an independent exact-head review with no blocking findings, zero unresolved review threads, a clean merge state, an allowed PR gate, and remotely confirmed merge/closure. Verify: PR, review, CI, gate, merge, branch-deletion, and closure evidence in the runtime checkpoint.
+- [ ] `SP1067-T7` Covers: all acceptance criteria. Owner: coordinator and independent reviewer. Dependencies: T6. Done when: the heavy-tier spec PR is independently reviewed, gated, and merged without closing #1067; the final implementation PR closes #1067 and has a current-head check rollup, an independent exact-head review with no blocking findings, zero unresolved review threads, a clean merge state, and an `allowed` SpecRail PR gate before human-authorized merge and remotely confirmed closure. The workflow check is not described as required or blocking because branch protection is external, mutable state. Verify: exact PR head, check rollup, review, review-thread, merge-state, PR-gate, merge, branch-deletion, and closure evidence in the runtime checkpoint.
+
+- [ ] `SP1067-T8` Covers: B1, B2, B3, B4, B5, B6. Owner: executable DOM verification owner. Dependencies: T5. Done when: the complete six-path implementation manifest is implemented exactly; Node `24.14.0`, jsdom `29.1.1`, a committed lockfile, and `npm ci --ignore-scripts` provide an isolated test-only environment; the `node:test` harness executes the real embedded `app.js` and deterministically covers every B invariant; the verification script writes ignored SHA-scoped manifest/log/checksum/`_SUCCESS` evidence; and exact-head Actions uploads that evidence with `actions/upload-artifact@v4`. `app.js` is not changed unless a failing executable test first triggers another spec-only amendment. Verify: dependency install, DOM test, evidence script, manifest/scope checks, and the exact-head Actions run/artifact URL.
 
 ## Parallelization
 
-The route, assets, and tests form one dependent implementation chain and share
-one worktree, so the coordinator owns all writes and all cargo commands.
-Native subagents are read-only: a bounded planner may inspect scope before
-implementation, and a separate reviewer or merge-reviewer inspects each exact
-PR head after push. No two cargo commands run concurrently in this worktree.
+The route, assets, and Rust/source tests through T5 form the completed
+implementation chain. T8 is a bounded executable-verification lane whose
+exclusive future writes are the six paths in the complete manifest. T6 consumes
+both lanes serially. Native subagents remain read-only unless given explicit,
+disjoint ownership; a separate reviewer or merge-reviewer inspects each exact
+PR head after push. No two verification commands write the evidence directory
+concurrently in one worktree.
 
 The public authentication boundary makes this a `heavy` PR tier. Follow the
 two-PR flow: first a spec-only PR with `Refs #1067`, then the final
@@ -46,6 +50,9 @@ cargo test admin_dashboard --lib
 cargo test server::middleware --lib
 cargo test server::routes::keys --lib
 cargo test server::routes::teams --lib
+(cd tests/admin_dashboard && npm ci --ignore-scripts)
+node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs
+bash scripts/verify-gh1067.sh
 ```
 
 Once before PR readiness:
@@ -55,6 +62,7 @@ cargo fmt --check
 cargo check
 cargo clippy --all-targets -- -D warnings
 cargo test
+bash scripts/verify-gh1067.sh
 python3 checks/check_workflow.py --repo .
 python3 checks/check_workflow.py --repo . --spec-dir specs/GH1067
 bash scripts/guards/check_pr_scope.sh
@@ -74,13 +82,29 @@ gate serially, and merge only when its decision is `allowed`.
 
 - Only #1067 is in scope. Do not inspect, edit, comment on, or merge another
   issue or PR.
-- Do not add a frontend package manager, generated bundle, static filesystem
-  service (`actix_files`, `Files::new`, `NamedFile`, `ServeDir`, or
-  `ServeFile`), storage model, migration, or backend management API.
+- Do not add a runtime frontend bundle, runtime package manager, deployed
+  frontend toolchain, static filesystem service (`actix_files`, `Files::new`,
+  `NamedFile`, `ServeDir`, or `ServeFile`), storage model, migration, or backend
+  management API. Only the exact, locked, isolated test-only Node/jsdom harness
+  is allowed.
+- The complete implementation manifest contains exactly
+  `tests/admin_dashboard/package.json`,
+  `tests/admin_dashboard/package-lock.json`,
+  `tests/admin_dashboard/admin_dashboard_dom.test.mjs`,
+  `scripts/verify-gh1067.sh`,
+  `.github/workflows/admin-dashboard-verification.yml`, and `.gitignore`.
+  `src/server/routes/admin_dashboard/app.js` remains out of scope unless a
+  later spec-only amendment adds it after an executable test exposes a defect.
 - Anonymous responses contain inert compiled assets only. Existing key/team
   APIs remain the authorization authority.
 - Access/refresh tokens and raw API keys must never reach browser storage,
   cookies, logs, URLs, HTML templates, or unsafe DOM sinks.
 - Spend remains page-scoped and per-scope; do not sum key and team totals.
+- Keyboard flow, narrow-layout behavior, and real-browser rendering remain
+  manual checks; executable DOM automation must not be presented as their
+  evidence.
+- Report the workflow as current-head check evidence/check rollup, not as a
+  required or blocking check; branch-protection configuration is external and
+  mutable.
 - All cargo commands run only in this worktree and are serialized by the
   coordinator.

--- a/specs/GH1067/tech.md
+++ b/specs/GH1067/tech.md
@@ -18,7 +18,7 @@ See `specs/GH1067/product.md` (invariants P1-P10).
 | Login | `src/server/routes/auth/login.rs`, `src/server/routes/auth/models.rs` | `POST /auth/login` returns `ApiResponse<LoginResponse>` with JWTs and user role | Reuse the existing contract and accept only an admin response |
 | Key management | `src/server/routes/keys/{mod.rs,handlers.rs,types.rs}` | `/v1/keys` supports admin list/create and per-key revoke; `KeyInfo` already includes masked identity and usage totals | Drive the minimum key workflow without a new backend API |
 | Team management | `src/server/routes/teams.rs` | `/v1/teams` supports admin list/create/delete and per-team usage | Drive the minimum team and spend workflow without a new backend API |
-| Frontend assets | none | No HTML, CSS, JavaScript, build pipeline, or static file service exists | Add small compile-time embedded assets instead of a second toolchain |
+| Frontend assets | `src/server/routes/admin_dashboard/{index.html,app.css,app.js}` | Compile-time embedded HTML/CSS/JavaScript now exists; Rust/source assertions do not execute the browser state machine | Add an isolated test-only executable DOM harness without a runtime frontend toolchain |
 
 ## Proposed Design
 
@@ -42,8 +42,10 @@ base-uri 'none'; form-action 'self'; frame-ancestors 'none'
 ```
 
 The route module is registered from the existing route assembly. No filesystem
-path, directory traversal surface, frontend package manager, runtime asset
-directory, or new dependency is introduced.
+path, directory traversal surface, runtime frontend bundle, runtime package
+manager, deployed frontend toolchain, or runtime dependency is introduced. An
+isolated, locked, test-only Node/jsdom harness is allowed and is never shipped
+with or executed by the gateway runtime.
 
 ### Authentication boundary
 
@@ -103,6 +105,69 @@ Create-team submits only `name`, optional `display_name`, and optional
 `description`. Destructive operations use an explicit confirmation dialog and
 disable the originating control until the request settles.
 
+## 可执行 DOM 验证增补（B1-B6）
+
+`tests/admin_dashboard/admin_dashboard_dom.test.mjs` 必须读取并执行真实的
+`src/server/routes/admin_dashboard/app.js`，而不是复制或重写一份 dashboard
+状态机。harness 使用精确版本 Node `24.14.0`、精确版本 jsdom `29.1.1`、
+Node 内建 `node:test` 与 `node:assert/strict`。依赖只允许安装在隔离的测试目录：
+
+```bash
+(cd tests/admin_dashboard && npm ci --ignore-scripts)
+node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs
+```
+
+`package.json` 与已提交的 `package-lock.json` 必须锁定 jsdom `29.1.1`；
+`npm ci --ignore-scripts` 禁止 dependency lifecycle scripts。harness 可控地 mock
+`fetch`、`confirm`、clipboard、delayed promises 与 `AbortController`，并为
+`B1`-`B6` 分别提供确定性断言：乱序 generation/operation guard、controller
+全路径 cleanup、raw-key 一次性生命周期、partial usage failure 与真实 zero、
+affirmative confirmation gate，以及 sign-out 后所有旧 generation 响应失效。
+
+本次后续实现的完整文件清单是：
+
+```yaml
+implementation_manifest:
+  complete: true
+  planned_paths:
+    - tests/admin_dashboard/package.json
+    - tests/admin_dashboard/package-lock.json
+    - tests/admin_dashboard/admin_dashboard_dom.test.mjs
+    - scripts/verify-gh1067.sh
+    - .github/workflows/admin-dashboard-verification.yml
+    - .gitignore
+```
+
+`src/server/routes/admin_dashboard/app.js` 明确不在本清单内。如果可执行测试首先
+暴露真实实现缺陷，实施者必须停止，先用新的 spec-only amendment 更新清单与
+相关不变量，再修改应用代码；不得借本清单静默扩展实现范围。
+
+### CI 与证据契约
+
+`.github/workflows/admin-dashboard-verification.yml` 在 pull request 的 exact
+head SHA 上使用 `actions/checkout@v4`，使用 `actions/setup-node@v4` 安装
+Node `24.14.0`，并运行 `bash scripts/verify-gh1067.sh`。workflow 必须以
+`github.event.pull_request.head.sha`（非可能变化的 merge ref）作为 PR checkout
+目标，并使用 `actions/upload-artifact@v4` 上传验证证据。
+
+本地脚本以 `git rev-parse HEAD` 得到 `HEAD_SHA`，只在
+`artifacts/logs/gh1067/<HEAD_SHA>/` 写入：
+
+- `manifest.json`
+- `admin_dashboard_dom.log`
+- `checksums.sha256`
+- `_SUCCESS`（仅全部命令成功后生成）
+
+`.gitignore` 必须忽略 `/artifacts/logs/gh1067/`，并以
+`!tests/admin_dashboard/package-lock.json` 覆盖仓库现有的全局 lockfile 忽略
+规则；`node_modules/` 继续保持忽略。本地 SHA-scoped manifest、log、checksum
+与 `_SUCCESS` 永不提交。远端证据是 GitHub Actions run URL 与该 run 上传的
+artifact 名称/URL。
+
+以上 workflow 只能描述为“current-head check evidence/check rollup”。它是否
+成为 required 或 blocking check 由可变的 branch-protection 设置决定，本规格
+不声称、也不要求它已经是 required/blocking check。
+
 ## Product-to-Test Mapping
 
 | Product invariant | Implementation area | Verification |
@@ -115,6 +180,12 @@ disable the originating control until the request settles.
 | P7, P8 | request generation, abort, status region, busy flags | deterministic all-request guard/abort contract assertions plus a repeatable slow/failing-request manual checklist |
 | P9 | semantic HTML and CSS | deterministic asset assertions for labels, landmarks, live region, focus styling, and no color-only status plus a keyboard checklist |
 | Security | CSP, no-store, safe DOM sinks | response-header tests and negative asset assertions for storage, `innerHTML`, `eval`, and external URLs |
+| B1 | executable DOM generation and operation-order guards | delayed and out-of-order `fetch` resolutions prove that only the current session/operation commits |
+| B2 | active `AbortController` registry and request finalization | success, failure, cancellation, and sign-out paths leave no stale controller; sign-out aborts all active requests |
+| B3 | raw-key notice, copy, dismissal, and auth transition | the real DOM exposes the raw key once, copies only on explicit action, and cannot recover it after dismissal/auth transition |
+| B4 | per-row usage rendering and partial-failure handling | mixed successful/failed usage responses retain successful rows, preserve numeric zero, and leave only failed/unavailable values blank with row errors |
+| B5 | destructive-operation confirmation gates | `confirm=true` issues the declared request; `confirm=false` issues no request and makes no optimistic destructive DOM change |
+| B6 | logout generation invalidation | resolve delayed login/list/usage/mutation/raw-key operations after sign-out and assert no credential, protected DOM/state, status, or secret is restored |
 
 ## Data Flow
 
@@ -124,17 +195,20 @@ token → same-origin authenticated key/team requests → existing server-side
 authorization and persistence → JSON response → safe DOM rendering.
 
 No dashboard request bypasses the existing key/team authorization checks. No
-new persistence, schema, migration, generated file, external service, or
-cross-origin call is added.
+new persistence, schema, migration, runtime frontend bundle/toolchain,
+external service, or cross-origin call is added. Test-only Node dependencies
+stay under `tests/admin_dashboard/` and never enter the deployment data flow.
 
 ## Alternatives Considered
 
 - Separate SPA repository and deployment: rejected because the issue requests a
   minimum built-in surface and provides no cross-repository ownership or
   deployment contract.
-- Add React/Vite or another build tool: rejected because it adds dependency,
-  release, and generated-asset workflows disproportionate to the bounded
-  feature.
+- Add React/Vite or another runtime/deployment build tool: rejected because it
+  adds runtime dependency, release, and generated-asset workflows
+  disproportionate to the bounded feature. The isolated, locked,
+  test-only `node:test` + jsdom harness is accepted because it executes the
+  real embedded source without producing or shipping a frontend bundle.
 - Put a token in a URL, browser storage, or embedded HTML: rejected because it
   leaks credentials through history, storage, logs, or source.
 - Make management APIs public or proxy them through dashboard-only endpoints:
@@ -153,8 +227,9 @@ cross-origin call is added.
 - Performance: spend loads usage only for teams on the visible page and aborts
   stale refreshes; it does not fan out across the entire database.
 - Maintenance: frontend contracts can drift from Rust response types; named API
-  paths/fields and route tests make drift visible, while the scope avoids a
-  second dependency ecosystem.
+  paths/fields, route tests, and a locked executable DOM harness make drift
+  visible. The Node/jsdom dependency set is exact and test-only, so it does not
+  create a second runtime dependency ecosystem.
 
 ## Test Plan
 
@@ -162,11 +237,19 @@ cross-origin call is added.
       route matching, asset safety/contract/accessibility assertions.
 - [ ] Focused tests: dashboard module, middleware public/admin route helpers,
       existing key handler tests, and existing team route tests.
+- [ ] Executable DOM tests: Node `24.14.0`, jsdom `29.1.1`,
+      `(cd tests/admin_dashboard && npm ci --ignore-scripts)`, then
+      `node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs` covers
+      each of `B1`-`B6` against the real embedded JavaScript source.
+- [ ] Evidence workflow: `bash scripts/verify-gh1067.sh` writes the ignored
+      SHA-scoped manifest/log/checksum/`_SUCCESS`; exact-head Actions checkout
+      uploads it with `actions/upload-artifact@v4`.
 - [ ] Manual verification checklist: admin and non-admin login; key
       list/create/revoke; required safe key ownership/model/endpoint scope; team
       list/create/delete; explicit zero/missing/failed spend; delayed
-      list/create responses followed by sign-out; keyboard-only navigation;
-      narrow viewport; reload clears auth and one-time key.
+      list/create responses followed by sign-out; reload clears auth and
+      one-time key. Keyboard-only navigation, narrow-layout behavior, and
+      real-browser visual rendering remain manual.
 - [ ] Deterministic verification: `cargo fmt --check`, `cargo check`,
       `cargo clippy --all-targets -- -D warnings`, full `cargo test`, SpecRail
       workflow/spec checks, scope guard, and overlap guard.


### PR DESCRIPTION
SPEC-ONLY

Refs #1067

本 PR 仅增补 GH1067 的 SpecRail 规格包，不包含实现代码，也不关闭 issue。

- 追加 B1-B6 可执行 DOM 不变量，覆盖乱序/generation guard、AbortController cleanup、raw-key 一次性生命周期、partial failure 与真实 zero、confirm gate、logout 后 stale response suppression
- 将运行时非目标收窄为禁止 runtime frontend bundle/toolchain，同时允许精确锁定的 test-only Node 24.14.0 + jsdom 29.1.1
- 定义 complete=true 的 6 路径实现清单、exact-head Actions checkout、upload-artifact v4 以及 SHA-scoped 本地证据契约
- 保留 T5 为 source/Rust，新增 T8，重新打开 T6，并将 T7 改为 current-head check rollup + SpecRail PR gate

验证：
- write_spec route gate: allowed
- implement route gate + duplicate-work evidence: allowed
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1067
- bash scripts/guards/check_pr_scope.sh origin/main
- bash scripts/guards/check_pr_overlap.sh
- git diff --check origin/main...HEAD

注意：keyboard flow、narrow-layout behavior、real-browser rendering 仍为 manual；本 PR 不把 workflow 声称为 required/blocking check。