### PR TITLE
docs(spec): reconcile GH1064 closure evidence

### DIFF
--- a/specs/GH1064/product.md
+++ b/specs/GH1064/product.md
@@ -80,8 +80,10 @@ remaining with focused issues.
   may refresh it without reopening the umbrella.
 - A newly discovered gap without an owner requires a focused issue before
   implementation begins.
-- A merged documentation PR without final-head independent review is historical
-  evidence, not reusable approval for a later reconciliation head.
+- PR #1084 has a GitHub-submitted review on an older head and a separate
+  independent post-merge exact-head review with verdict `FAIL`. Neither is a
+  clean, reusable `PASS` for a later reconciliation head, and resolved threads
+  or subsequent repairs must not erase the failed-review record.
 
 ## Rollout Notes
 

--- a/specs/GH1064/product.md
+++ b/specs/GH1064/product.md
@@ -7,63 +7,84 @@ GH-1064 / #1064
 ## User Problem
 
 The repository has a durable competitive gap analysis for the “best LLM
-gateway” roadmap, but the parent issue has no SpecRail packet or explicit
-closure contract. That makes it easy to mistake closing the planning issue for
-shipping every child capability, or to duplicate work already owned by focused
-issues.
+gateway” roadmap, but the planning umbrella needs an auditable closure contract.
+Without that contract, closing #1064 can be mistaken for shipping every linked
+capability, and implementation can be duplicated under the parent instead of
+remaining with focused issues.
 
 ## Goals
 
-- Preserve one repository-backed roadmap that separates current facts,
+- Preserve one repository-backed roadmap that separates verified facts,
   inferences, and recommendations.
-- Make ownership of every roadmap gap explicit through existing or focused
-  child issues.
-- Define closure of #1064 as completion of the roadmap and decomposition work,
-  without claiming that independently tracked implementation is complete.
+- Keep ownership of every implementation-sized gap explicit through an
+  existing or focused issue.
+- Define closure of #1064 as completion of the roadmap, decomposition, and
+  handoff, without claiming linked implementation is complete.
 - Prevent production implementation from accumulating under the umbrella issue.
 
 ## Non-Goals
 
 - Implementing any runtime, API, UI, security, provider, or architecture change.
 - Changing, closing, relabeling, or reprioritizing any child or pre-existing issue.
-- Claiming that the gaps tracked by #519, #837, #838, #965, #1065, #1066, or
-  #1067 have shipped.
+- Claiming that work tracked by #519, #837, #838, #965, or #1065-#1067 has shipped.
 - Re-running the external competitor survey as part of this closure tranche.
+- Modifying the roadmap or any child packet in the structural reconciliation PR.
 
 ## Behavior Invariants
 
-1. The gap-analysis document remains the durable source for the roadmap and
+1. `B-001`: The gap-analysis document remains the durable roadmap source and
    continues to distinguish verified repository facts from inference and advice.
-2. Every implementation-sized gap stays assigned to a focused issue; #1064
-   does not become a shared implementation container.
-3. Closing #1064 means its planning artifact, gap ownership, and handoff are
-   complete. It does not change the state or completion meaning of linked work.
-4. Future discoveries are added to an appropriate focused issue and may update
-   the roadmap without requiring #1064 to remain open indefinitely.
-5. The closure change affects documentation and workflow metadata only; gateway
-   runtime behavior and public contracts remain unchanged.
+2. `B-002`: Every implementation-sized gap remains assigned to a focused issue;
+   #1064 never becomes a shared implementation container.
+3. `B-003`: Closing #1064 means its planning artifact, gap ownership, and handoff
+   are complete; it does not change the state or completion meaning of linked work.
+4. `B-004`: Future discoveries are added to an appropriate focused issue and may
+   update the roadmap without requiring #1064 to remain open indefinitely.
+5. `B-005`: The closure change affects documentation and workflow metadata only;
+   gateway runtime behavior and public contracts remain unchanged.
 
 ## Acceptance Criteria
 
-- [ ] `specs/GH1064/` contains a complete product, technical, and task packet.
-- [ ] The roadmap records its parent-issue closure semantics and the focused
-      ownership of implementation work.
-- [ ] The closing PR references the already merged roadmap delivery in #1068
-      and uses `Fixes #1064` without closing or modifying another issue.
-- [ ] SpecRail deterministic checks pass for the repository and GH1064 packet.
-- [ ] An independent reviewer confirms that the PR neither claims child work is
-      complete nor expands into production implementation.
+- [x] PR #1068 delivered the repository-backed roadmap.
+- [x] PR #1084 merged the parent lifecycle, focused ownership, and closure
+      semantics without changing production or child-spec files.
+- [x] The reconciled GH1064 packet passes the repository-local deterministic
+      packet check and changed-path check.
+- [ ] The structural reconciliation PR body, owned by the coordinator, references
+      #1068 and #1084 and uses `Fixes #1064`.
+- [ ] A new independent reviewer returns a clean verdict for the reconciliation
+      PR exact head, and its required PR gate is allowed.
+- [ ] The reconciliation PR is merged and a post-merge audit confirms #1064 is
+      closed without attributing completion or a state transition to linked work.
+
+## Boundary Checklist
+
+| Boundary category | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by `B-001` and `B-002`: missing roadmap classification or missing focused ownership means the planning handoff is incomplete. |
+| Error and failure paths | Covered by `B-003`: a failed or incomplete handoff cannot be represented as parent closure. |
+| Authorization / permission | N/A: this packet defines documentation semantics and preserves the repository's existing human review and merge gates; it introduces no permission behavior. |
+| Concurrency / race / ordering | N/A: no runtime or concurrent state is introduced; repository commits serialize document revisions. |
+| Retry / repetition / idempotency | Covered by `B-004`: later discoveries use focused issues and may revise the roadmap without keeping or reopening the umbrella by default. |
+| Illegal state transitions | Covered by `B-003`: parent closure cannot transition, complete, or supersede linked work. |
+| Compatibility / migration | Covered by `B-003` and `B-005`: linked acceptance contracts and gateway public behavior remain unchanged. |
+| Degradation / fallback | Covered by `B-002`: an unowned implementation gap is incomplete planning, not a successful degraded outcome. |
+| Evidence and audit integrity | Covered by `B-001` through `B-003`: closure requires a durable artifact, complete ownership, and an explicit handoff; no one element substitutes for another. |
+| Cancellation / interruption / partial completion | Covered by `B-003`: partial decomposition does not complete the parent, while partial child implementation does not block an otherwise complete planning handoff. |
 
 ## Edge Cases
 
-- A linked issue may still be open, deferred, or only partially implemented
-  when #1064 closes; its own acceptance criteria remain authoritative.
+- A linked issue may be open, deferred, or partially implemented when #1064
+  closes; that issue's own acceptance criteria remain authoritative.
 - A roadmap statement may become stale as `main` evolves. A focused follow-up
-  may refresh the document without reopening the umbrella issue.
+  may refresh it without reopening the umbrella.
 - A newly discovered gap without an owner requires a focused issue before
   implementation begins.
+- A merged documentation PR without final-head independent review is historical
+  evidence, not reusable approval for a later reconciliation head.
 
 ## Rollout Notes
 
-This is a documentation-only closure. Merging the closing PR archives the
-planning umbrella while leaving all linked implementation work independent.
+This is documentation-only reconciliation. The new PR changes only the three
+GH1064 spec files; its body and post-merge runtime evidence are maintained by
+the coordinator outside the repository packet.

--- a/specs/GH1064/tasks.md
+++ b/specs/GH1064/tasks.md
@@ -11,33 +11,35 @@ GH-1064 / #1064
 
 ## Implementation Tasks
 
-- [x] `SP1064-T1` — Owner: coordinator. Dependencies: merged roadmap PR #1068. Done when: the product and technical specs define #1064 as a planning umbrella, keep child implementation out of scope, and give parent closure an explicit meaning. Verify: SpecRail packet checks and manual spec review.
-- [x] `SP1064-T2` — Owner: coordinator. Dependencies: `SP1064-T1`. Done when: the roadmap records delivery, focused ownership, and closure semantics without changing a child spec, issue, or production file. Verify: `git diff --check` and changed-path inspection.
-- [ ] `SP1064-T3` — Owner: coordinator and independent reviewer. Dependencies: `SP1064-T1`, `SP1064-T2`. Done when: deterministic checks pass, the closing PR uses `Fixes #1064`, an independent exact-head review is clean, current-head CI and PR gates are green, the PR is merged, and remote closure confirms only #1064 closed. Verify: local command evidence, reviewer artifact, GitHub PR evidence, offline PR gate, merge confirmation, and closure audit.
+- [x] `SP1064-T1` Covers: B-001, B-002, B-003, B-004, B-005. Owner: coordinator. Dependencies: merged roadmap PR #1068. Done when: the product and technical specs define #1064 as a planning umbrella, keep child implementation out of scope, and give parent closure an explicit meaning. Evidence: PR #1084 merged as `e1e2907e3e1e62da733901eaf751dca1faaa21fd`. Verify: `python3 checks/check_workflow.py --repo . --spec-dir "$PWD/specs/GH1064" && sed -n '8,17p' docs/plan/2026-07-18-best-gateway-gap-analysis.md`.
+- [x] `SP1064-T2` Covers: B-002, B-003, B-005. Owner: coordinator. Dependencies: `SP1064-T1`. Done when: the roadmap records delivery, focused ownership, and closure semantics without changing a child spec, issue, or production file. Evidence: PR #1084 changed exactly the roadmap and three GH1064 packet files. Verify: `test "$(git diff --name-only e1e2907e3e1e62da733901eaf751dca1faaa21fd^1 e1e2907e3e1e62da733901eaf751dca1faaa21fd | sort | paste -sd, -)" = "docs/plan/2026-07-18-best-gateway-gap-analysis.md,specs/GH1064/product.md,specs/GH1064/tasks.md,specs/GH1064/tech.md"`.
+- [ ] `SP1064-T3` Covers: B-001, B-002, B-003, B-004, B-005. Owner: coordinator and independent reviewer. Dependencies: `SP1064-T1`, `SP1064-T2`. Done when: the coordinator-authored structural reconciliation PR body references #1068/#1084 and uses `Fixes #1064`; deterministic checks pass; a new independent review, current-head CI, resolved threads, clean merge state, and required PR gate all bind the same exact head; the PR merges; then the runtime ledger records T3 complete and a separate issue-closure audit records `issue=1064`, the exact PR/head/merge SHA, `pr_state=MERGED`, `issue_state=CLOSED`, query time, and an empty `linked_issue_mutations` list without modifying the merged head. The repository checkbox intentionally remains unchecked to avoid self-reference. Verify: `test -n "$PR_EVIDENCE" && test -n "$CHECKPOINT" && test -n "$CLOSURE_AUDIT" && python3 checks/pr_gate.py --repo . --evidence "$PR_EVIDENCE" --mode required --json && python3 checks/runtime_ledger_gate.py --checkpoint "$CHECKPOINT" --json && jq -e '.issue == 1064 and .pr_state == "MERGED" and .issue_state == "CLOSED" and ((.pr | type) == "number") and (.head_sha | test("^[0-9a-f]{40}$")) and (.merge_sha | test("^[0-9a-f]{40}$")) and ((.queried_at | type) == "string") and ((.queried_at | length) > 0) and .linked_issue_mutations == []' "$CLOSURE_AUDIT" && test "$(gh issue view 1064 --repo majiayu000/litellm-rs --json state --jq .state)" = "CLOSED"`.
 
 ## Parallelization
 
-The documentation edits are one coordinator-owned serial lane. The independent
-reviewer is read-only and starts after the PR head is stable. Cargo and full
-repository verification, if required by CI or repository gates, run only in
-this worktree under the coordinator.
+The three packet edits are one coordinator-owned serial lane. The independent
+reviewer is read-only and starts only after the new PR head is stable. PR-body
+linkage, runtime checkpoint updates, and the post-merge issue audit are
+coordinator-owned external evidence; they do not edit the repository head.
 
 ## Verification
 
-Run these commands during `SP1064-T3`:
-
-```bash
-python3 checks/check_workflow.py --repo .
-python3 checks/check_workflow.py --repo . --spec-dir specs/GH1064
-python3 checks/route_gate.py --repo . --route implement --issue 1064 --state ready_to_implement --artifact product_spec=specs/GH1064/product.md --artifact tech_spec=specs/GH1064/tech.md --artifact task_plan=specs/GH1064/tasks.md --duplicate-evidence .specrail/runtime/evidence/duplicate-1064.json --json
-git diff --check
-```
-
-Then collect exact-head CI, independent review, resolved review threads, clean
-merge state, and an allowed PR gate.
+- Product invariant set: `B-001..B-005`.
+- Task `Covers:` union: `B-001..B-005`; no missing or unknown ID.
+- The tech spec contains exactly one complete issue-1064 manifest with four
+  paths and refs `B-001..B-005`.
+- Run `python3 checks/check_workflow.py --repo . --spec-dir "$PWD/specs/GH1064"`.
+- Run `git diff --check`.
+- Run the `B-005` changed-path command before opening the docs-only PR.
 
 ## Handoff Notes
 
-PR #1068 already delivered the gap analysis. This tranche only makes the
-planning umbrella auditable and closable; all linked implementation remains
-owned by its focused issue.
+- PR #1068 delivered the roadmap; PR #1084 delivered lifecycle wording and
+  resolved its two inline comments, but did not obtain independent final-head
+  review. Its review evidence must not be reused.
+- The new PR is docs-only structural reconciliation. Its coordinator-owned body
+  handles `Refs #1068`, `Refs #1084`, and `Fixes #1064`; this branch does not
+  modify the roadmap or child specs.
+- `SP1064-T3` remains `[ ]`. After merge, completion lives in the runtime ledger
+  and issue-closure audit so the exact reviewed head is never changed to tick
+  its own completion box.

--- a/specs/GH1064/tasks.md
+++ b/specs/GH1064/tasks.md
@@ -13,7 +13,7 @@ GH-1064 / #1064
 
 - [x] `SP1064-T1` Covers: B-001, B-002, B-003, B-004, B-005. Owner: coordinator. Dependencies: merged roadmap PR #1068. Done when: the product and technical specs define #1064 as a planning umbrella, keep child implementation out of scope, and give parent closure an explicit meaning. Evidence: PR #1084 merged as `e1e2907e3e1e62da733901eaf751dca1faaa21fd`. Verify: `python3 checks/check_workflow.py --repo . --spec-dir "$PWD/specs/GH1064" && sed -n '8,17p' docs/plan/2026-07-18-best-gateway-gap-analysis.md`.
 - [x] `SP1064-T2` Covers: B-002, B-003, B-005. Owner: coordinator. Dependencies: `SP1064-T1`. Done when: the roadmap records delivery, focused ownership, and closure semantics without changing a child spec, issue, or production file. Evidence: PR #1084 changed exactly the roadmap and three GH1064 packet files. Verify: `test "$(git diff --name-only e1e2907e3e1e62da733901eaf751dca1faaa21fd^1 e1e2907e3e1e62da733901eaf751dca1faaa21fd | sort | paste -sd, -)" = "docs/plan/2026-07-18-best-gateway-gap-analysis.md,specs/GH1064/product.md,specs/GH1064/tasks.md,specs/GH1064/tech.md"`.
-- [ ] `SP1064-T3` Covers: B-001, B-002, B-003, B-004, B-005. Owner: coordinator and independent reviewer. Dependencies: `SP1064-T1`, `SP1064-T2`. Done when: the coordinator-authored structural reconciliation PR body references #1068/#1084 and uses `Fixes #1064`; deterministic checks pass; a new independent review, current-head CI, resolved threads, clean merge state, and required PR gate all bind the same exact head; the PR merges; then the runtime ledger records T3 complete and a separate issue-closure audit records `issue=1064`, the exact PR/head/merge SHA, `pr_state=MERGED`, `issue_state=CLOSED`, query time, and an empty `linked_issue_mutations` list without modifying the merged head. The repository checkbox intentionally remains unchecked to avoid self-reference. Verify: `test -n "$PR_EVIDENCE" && test -n "$CHECKPOINT" && test -n "$CLOSURE_AUDIT" && python3 checks/pr_gate.py --repo . --evidence "$PR_EVIDENCE" --mode required --json && python3 checks/runtime_ledger_gate.py --checkpoint "$CHECKPOINT" --json && jq -e '.issue == 1064 and .pr_state == "MERGED" and .issue_state == "CLOSED" and ((.pr | type) == "number") and (.head_sha | test("^[0-9a-f]{40}$")) and (.merge_sha | test("^[0-9a-f]{40}$")) and ((.queried_at | type) == "string") and ((.queried_at | length) > 0) and .linked_issue_mutations == []' "$CLOSURE_AUDIT" && test "$(gh issue view 1064 --repo majiayu000/litellm-rs --json state --jq .state)" = "CLOSED"`.
+- [ ] `SP1064-T3` Covers: B-001, B-002, B-003, B-004, B-005. Owner: coordinator and independent reviewer. Dependencies: `SP1064-T1`, `SP1064-T2`. Done when: the coordinator-authored structural reconciliation PR body contains `Refs #1068`, `Refs #1084`, and `Fixes #1064`; deterministic checks pass; a new independent review, current-head CI, resolved threads, clean merge state, and required PR gate all bind one exact head; the PR merges; then the runtime ledger's sole issue-1064 item records the same PR/head/merge SHA with `state=merged`, while a separate issue-closure audit records those same identifiers, `issue_state=CLOSED`, `closing_issue_numbers=[1064]`, and query time. Live PR and issue evidence must match every identifier, body directive, merge state, and the exact closing-issue set. The repository checkbox intentionally remains unchecked so post-merge evidence never changes the reviewed head. Verify: run the complete executable `verify_t3_closure.sh` canonical command block in `tech.md` with `$PR_EVIDENCE`, `$CHECKPOINT`, and `$CLOSURE_AUDIT` set; any nonzero exit blocks completion.
 
 ## Parallelization
 
@@ -34,9 +34,12 @@ coordinator-owned external evidence; they do not edit the repository head.
 
 ## Handoff Notes
 
-- PR #1068 delivered the roadmap; PR #1084 delivered lifecycle wording and
-  resolved its two inline comments, but did not obtain independent final-head
-  review. Its review evidence must not be reused.
+- PR #1068 delivered the roadmap. For PR #1084, GitHub's only submitted review
+  targeted old head `88a20e8dfaa9435d573241bd7e86814faf4c3cd9`;
+  separately, the current `implx` run independently reviewed final head
+  `1d5502fdba342a53df8f766720d1affa4e344384` post-merge and returned `FAIL`
+  for the five packet-structure findings. There is no clean/reusable `PASS`,
+  and the failed exact-head review must remain recorded after repair.
 - The new PR is docs-only structural reconciliation. Its coordinator-owned body
   handles `Refs #1068`, `Refs #1084`, and `Fixes #1064`; this branch does not
   modify the roadmap or child specs.

--- a/specs/GH1064/tech.md
+++ b/specs/GH1064/tech.md
@@ -10,70 +10,132 @@ See `specs/GH1064/product.md`.
 
 ## Codebase Context
 
-| Area | Files | Current behavior | Why relevant |
+Anchors below were verified against `origin/main@bdc06ba364e8b9e095bb91f1c75572a624a954f5`.
+
+| Area | Verified anchor | Current behavior | Why relevant |
 | --- | --- | --- | --- |
-| Roadmap | `docs/plan/2026-07-18-best-gateway-gap-analysis.md` | PR #1068 delivered the verified gap analysis and split recommendations, but the document does not define when the umbrella issue can close. | This is the only direct deliverable of #1064. |
-| SpecRail packet | `specs/GH1064/` | No GH1064 packet exists. Focused child packets exist separately. | A complete packet prevents the umbrella from absorbing child implementation scope. |
-| Focused work | `specs/GH1065/`, `specs/GH1066/`, `specs/GH1067/` and existing issue-owned specs | Implementation requirements are already owned outside #1064. | The closure must preserve those ownership boundaries and states. |
+| Roadmap method | `docs/plan/2026-07-18-best-gateway-gap-analysis.md:3-6,140-159` | The roadmap names its evidence baseline and separates facts, inference, and recommendations. | Grounds `B-001` without re-running the survey. |
+| Roadmap lifecycle | `docs/plan/2026-07-18-best-gateway-gap-analysis.md:8-17` | PR #1068 delivery, focused ownership, parent closure semantics, and future focused-issue routing are recorded. | Grounds `B-002` through `B-004`. |
+| Gap ownership | `docs/plan/2026-07-18-best-gateway-gap-analysis.md:102-110` | New gaps map to #1065-#1067 and existing gaps remain with #519/#837/#838/#965. | Prevents umbrella implementation scope. |
+| Product packet | `specs/GH1064/product.md:33-55` at the baseline | Five invariants and acceptance criteria exist, but the invariants lack stable `B-xxx` IDs and the ten-category boundary checklist. | Structural reconciliation only. |
+| Tech packet | `specs/GH1064/tech.md:32-40` at the baseline | Mapping uses unstable legacy labels and no planned-changes manifest exists. | Requires stable refs and one fail-closed manifest. |
+| Task packet | `specs/GH1064/tasks.md:14-16` at the baseline | Stable T1-T3 exist, with T1/T2 complete and T3 open, but fields and verification are not machine-precise. | IDs and meanings must be preserved. |
+
+## Historical and Current Evidence
+
+- PR #1084 merged at final head
+  `1d5502fdba342a53df8f766720d1affa4e344384` as merge commit
+  `e1e2907e3e1e62da733901eaf751dca1faaa21fd`.
+- Its exact changed paths were the roadmap and the three GH1064 packet files;
+  no production or child-spec file changed.
+- The two inline comments were resolved and outdated on the final head. The only
+  submitted review was on old head `88a20e8dfaa9435d573241bd7e86814faf4c3cd9`,
+  and the Codex reviewer lane reported a usage-limit failure. Therefore PR #1084
+  supplies no reusable independent exact-head PASS.
+- Fresh issue evidence on 2026-07-19 reports #1064 as `OPEN`. Historical merge
+  and resolved comments do not satisfy the new PR's review, gate, merge, or
+  closure requirements.
+
+## Planned Changes
+
+This is the complete GH1064 lifecycle path set. The structural reconciliation
+PR is narrower and may change only the three packet files; the roadmap is
+listed because it is the durable artifact already delivered by PR #1068 and
+updated by PR #1084.
+
+```specrail-planned-changes
+{
+  "issue": 1064,
+  "complete": true,
+  "paths": [
+    "docs/plan/2026-07-18-best-gateway-gap-analysis.md",
+    "specs/GH1064/product.md",
+    "specs/GH1064/tech.md",
+    "specs/GH1064/tasks.md"
+  ],
+  "spec_refs": [
+    "B-001",
+    "B-002",
+    "B-003",
+    "B-004",
+    "B-005"
+  ]
+}
+```
 
 ## Proposed Design
 
-Add a small GH1064 SpecRail packet that treats the issue as a planning
-umbrella. Add a closure-status section to the existing roadmap that records:
+Reconcile the existing packet without changing product scope:
 
-- the roadmap delivery PR (#1068),
-- the focused issue ownership model,
-- the meaning of closing #1064, and
-- the prohibition on interpreting parent closure as child completion.
-
-No production source, configuration, schema, API, workflow policy, or child
-spec packet changes.
+1. Assign stable `B-001` through `B-005` to the five published invariants and
+   record every boundary category as covered or N/A.
+2. Bind the technical mapping and task coverage to those same IDs.
+3. Preserve `SP1064-T1` through `SP1064-T3`, their meanings, and their truth:
+   T1/T2 remain complete from PR #1084; T3 remains open.
+4. Treat this new PR as docs-only structural reconciliation. Its body owns
+   `Refs`/`Fixes`; this commit does not modify the roadmap or child packets.
+5. After the new PR head is frozen, collect a new independent exact-head review,
+   required PR-gate evidence, and merge evidence. After merge, record T3 in the
+   runtime ledger and a separate issue-closure audit without another head edit.
 
 ## Product-to-Test Mapping
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| P1: durable fact/inference/advice separation | Existing roadmap plus closure section | Review the rendered Markdown and run SpecRail checks. |
-| P2: focused implementation ownership | GH1064 packet and roadmap closure section | Confirm linked ownership is descriptive and no child files/issues are changed. |
-| P3: parent closure does not imply child completion | Explicit closure semantics | Independent review of the diff and PR body. |
-| P4: future gaps use focused issues | Product invariant and roadmap guidance | Independent review. |
-| P5: documentation-only behavior | Git diff scope | `git diff --name-only origin/main...HEAD` contains only `docs/plan/2026-07-18-best-gateway-gap-analysis.md` and the three files under `specs/GH1064/`. |
+| `B-001` durable classified roadmap | Roadmap method and sections | `rg -n '^> 方法：|^### 事实|^### 推断$|^### 建议' docs/plan/2026-07-18-best-gateway-gap-analysis.md` |
+| `B-002` focused ownership | Roadmap lifecycle and ownership table | `sed -n '8,17p;102,110p' docs/plan/2026-07-18-best-gateway-gap-analysis.md` plus manual confirmation that each implementation-sized row names an issue. |
+| `B-003` parent closure semantics | Roadmap lifecycle, new PR body, post-merge audit | `sed -n '8,17p' docs/plan/2026-07-18-best-gateway-gap-analysis.md`; after merge, verify `$CLOSURE_AUDIT` records `issue_state=CLOSED` and no linked-issue mutation. |
+| `B-004` future discoveries use focused work | Roadmap lifecycle | `rg -n 'Future implementation-sized discoveries' docs/plan/2026-07-18-best-gateway-gap-analysis.md` |
+| `B-005` documentation-only change | Reconciliation diff scope | `base="$(git merge-base origin/main HEAD)"; test -z "$(git diff --name-only "$base"..HEAD -- . ':(exclude)specs/GH1064/product.md' ':(exclude)specs/GH1064/tech.md' ':(exclude)specs/GH1064/tasks.md')"` |
 
 ## Data Flow
 
-There is no runtime data flow. The GitHub issue points to the repository
-roadmap; the GH1064 packet defines its acceptance and closure contract; the
-closing PR links both and closes only #1064.
+There is no gateway runtime data flow. Repository roadmap and packet content
+define the planning contract; the new PR carries linkage and exact-head review
+evidence; after merge, the runtime checkpoint records T3 completion and a
+read-only issue audit records remote closure. Those post-merge artifacts do not
+modify the merged head.
 
 ## Alternatives Considered
 
-- Keep #1064 open until every linked issue completes: rejected because it
-  conflates roadmap planning with independently scoped implementation and
-  creates no stable terminal for the planning deliverable.
-- Implement one roadmap gap under #1064: rejected because each gap requires a
-  focused issue/spec and several already have explicit owners.
-- Close #1064 without repository changes: rejected because the missing closure
-  semantics would remain implicit and the SpecRail coverage gap would persist.
+- Mark T3 complete in this packet: rejected because review, PR gate, merge, and
+  closure have not happened for the new head and changing the checkbox after
+  them would create a self-referential head.
+- Reuse PR #1084 review: rejected because its only review targeted an older head
+  and the independent Codex reviewer lane failed.
+- Modify the roadmap or child specs again: rejected because reconciliation is
+  structural and their content remains owned by prior/focused work.
 
 ## Risks
 
-- Security: None; no runtime or security behavior changes.
-- Compatibility: Readers could misread parent closure as product completion;
-  explicit wording and independent review mitigate this.
-- Performance: None.
-- Maintenance: Ownership links can age; focused issues remain authoritative.
+- Security: none; no runtime or security behavior changes.
+- Compatibility: parent closure can be misread as child completion; stable
+  invariants and the closure audit prevent that claim.
+- Performance: none.
+- Maintenance: external ledger/audit evidence can drift from repository prose;
+  evidence must bind the new PR exact head and merge SHA.
 
 ## Test Plan
 
-- [ ] `python3 checks/check_workflow.py --repo .`
-- [ ] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1064`
-- [ ] `python3 checks/route_gate.py --repo . --route implement --issue 1064 --state ready_to_implement --artifact product_spec=specs/GH1064/product.md --artifact tech_spec=specs/GH1064/tech.md --artifact task_plan=specs/GH1064/tasks.md --duplicate-evidence .specrail/runtime/evidence/duplicate-1064.json --json`
-- [ ] `git diff --check`
-- [ ] Independent exact-head documentation/spec review.
-- [ ] Fresh PR CI, review-thread, merge-state, and PR-gate evidence.
+- [x] Deterministic packet check:
+      `python3 checks/check_workflow.py --repo . --spec-dir "$PWD/specs/GH1064"`
+      passed in the reconciliation session.
+- [x] Diff syntax and reconciliation path scope:
+      `git diff --check` and the `B-005` command passed in the reconciliation
+      session.
+- [x] Historical path evidence: PR #1084 merge commit
+      `e1e2907e3e1e62da733901eaf751dca1faaa21fd` changes exactly the roadmap and
+      three GH1064 packet files.
+- [x] Historical review-comment resolution: both PR #1084 inline threads are
+      resolved and outdated at final head `1d5502fdba342a53df8f766720d1affa4e344384`.
+- [ ] A new independent reviewer has returned a clean verdict bound to the
+      structural reconciliation PR exact head.
+- [ ] Fresh required `pr_gate.py` evidence for that exact head is allowed.
+- [ ] The new PR is merged and post-merge runtime-ledger plus issue-closure
+      audit evidence is complete.
 
 ## Rollback Plan
 
-Revert the closing PR and reopen #1064 if the parent must again serve as the
-active planning umbrella. Reverting does not affect any child issue or runtime
-behavior.
+Revert only the structural reconciliation commit if the packet format is
+incorrect. The roadmap and PR #1084 history remain intact; reopening or closing
+#1064 is a separate maintainer action backed by the closure audit.

--- a/specs/GH1064/tech.md
+++ b/specs/GH1064/tech.md
@@ -181,17 +181,35 @@ python3 checks/runtime_ledger_gate.py --checkpoint "$CHECKPOINT" --json
 jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expected_merge" '
   .pr == $pr
   and .head_sha == $head
-  and .merge_record.remote_confirmed == true
-  and .merge_record.merge_commit_sha == $merge
+  and (
+    .merge_record
+    | if . then
+        if type == "object" then
+          (.remote_confirmed == true and .merge_commit_sha == $merge)
+        else
+          false
+        end
+      else
+        false
+      end
+  )
 ' "$PR_EVIDENCE" >/dev/null
 
 jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expected_merge" '
-  [.items[] | select(.issue == 1064)] as $matches
+  (if .items then
+    [
+      .items[]?
+      | select(if type == "object" then .issue == 1064 else false end)
+    ]
+  else
+    []
+  end) as $matches
+  | ($matches[0]? // {}) as $match
   | ($matches | length) == 1
-    and $matches[0].pr == $pr
-    and $matches[0].head_sha == $head
-    and $matches[0].merge_commit == $merge
-    and $matches[0].state == "merged"
+    and $match.pr == $pr
+    and $match.head_sha == $head
+    and $match.merge_commit == $merge
+    and $match.state == "merged"
 ' "$CHECKPOINT" >/dev/null
 
 live_pr="$(
@@ -203,11 +221,40 @@ jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expe
   .number == $pr
   and .state == "MERGED"
   and .headRefOid == $head
-  and .mergeCommit.oid == $merge
-  and (.body | contains("Refs #1068"))
-  and (.body | contains("Refs #1084"))
-  and (.body | contains("Fixes #1064"))
-  and (([.closingIssuesReferences[].number] | sort) == [1064])
+  and (
+    .mergeCommit
+    | if type == "object" then .oid == $merge else false end
+  )
+  and (
+    .body
+    | if type == "string" then
+        (
+          contains("Refs #1068")
+          and contains("Refs #1084")
+          and contains("Fixes #1064")
+        )
+      else
+        false
+      end
+  )
+  and (
+    .closingIssuesReferences
+    | if type == "array" then
+        (
+          [
+            .[]?
+            | if type == "object" then
+                (.number | select(type == "number"))
+              else
+                empty
+              end
+          ]
+          | sort
+        ) == [1064]
+      else
+        false
+      end
+  )
 ' <<<"$live_pr" >/dev/null
 
 live_issue="$(

--- a/specs/GH1064/tech.md
+++ b/specs/GH1064/tech.md
@@ -28,10 +28,16 @@ Anchors below were verified against `origin/main@bdc06ba364e8b9e095bb91f1c75572a
   `e1e2907e3e1e62da733901eaf751dca1faaa21fd`.
 - Its exact changed paths were the roadmap and the three GH1064 packet files;
   no production or child-spec file changed.
-- The two inline comments were resolved and outdated on the final head. The only
-  submitted review was on old head `88a20e8dfaa9435d573241bd7e86814faf4c3cd9`,
-  and the Codex reviewer lane reported a usage-limit failure. Therefore PR #1084
-  supplies no reusable independent exact-head PASS.
+- The two GitHub inline comments were resolved and outdated on the final head.
+  GitHub's only submitted review was on old head
+  `88a20e8dfaa9435d573241bd7e86814faf4c3cd9`. Separately, the current `implx`
+  run performed an independent post-merge exact-head review of
+  `1d5502fdba342a53df8f766720d1affa4e344384`; its verdict was `FAIL` with
+  structural findings: missing stable `B-xxx` IDs, missing ten-category boundary
+  coverage, missing single complete planned-changes manifest, missing per-B
+  mapping, and missing task `Covers:` fields. PR #1084 therefore has no clean,
+  reusable exact-head `PASS`; the failed review remains durable evidence and is
+  not erased by this reconciliation.
 - Fresh issue evidence on 2026-07-19 reports #1064 as `OPEN`. Historical merge
   and resolved comments do not satisfy the new PR's review, gate, merge, or
   closure requirements.
@@ -84,7 +90,7 @@ Reconcile the existing packet without changing product scope:
 | --- | --- | --- |
 | `B-001` durable classified roadmap | Roadmap method and sections | `rg -n '^> 方法：|^### 事实|^### 推断$|^### 建议' docs/plan/2026-07-18-best-gateway-gap-analysis.md` |
 | `B-002` focused ownership | Roadmap lifecycle and ownership table | `sed -n '8,17p;102,110p' docs/plan/2026-07-18-best-gateway-gap-analysis.md` plus manual confirmation that each implementation-sized row names an issue. |
-| `B-003` parent closure semantics | Roadmap lifecycle, new PR body, post-merge audit | `sed -n '8,17p' docs/plan/2026-07-18-best-gateway-gap-analysis.md`; after merge, verify `$CLOSURE_AUDIT` records `issue_state=CLOSED` and no linked-issue mutation. |
+| `B-003` parent closure semantics | Roadmap lifecycle, new PR body, post-merge audit | `sed -n '8,17p' docs/plan/2026-07-18-best-gateway-gap-analysis.md`; after merge, run the complete `verify_t3_closure.sh` command block below. |
 | `B-004` future discoveries use focused work | Roadmap lifecycle | `rg -n 'Future implementation-sized discoveries' docs/plan/2026-07-18-best-gateway-gap-analysis.md` |
 | `B-005` documentation-only change | Reconciliation diff scope | `base="$(git merge-base origin/main HEAD)"; test -z "$(git diff --name-only "$base"..HEAD -- . ':(exclude)specs/GH1064/product.md' ':(exclude)specs/GH1064/tech.md' ':(exclude)specs/GH1064/tasks.md')"` |
 
@@ -101,8 +107,10 @@ modify the merged head.
 - Mark T3 complete in this packet: rejected because review, PR gate, merge, and
   closure have not happened for the new head and changing the checkbox after
   them would create a self-referential head.
-- Reuse PR #1084 review: rejected because its only review targeted an older head
-  and the independent Codex reviewer lane failed.
+- Reuse PR #1084 review: rejected because GitHub's submitted review targeted an
+  older head and the independent post-merge exact-head review returned `FAIL`.
+  Resolved/outdated threads and this structural repair do not convert or erase
+  that failure.
 - Modify the roadmap or child specs again: rejected because reconciliation is
   structural and their content remains owned by prior/focused work.
 
@@ -128,11 +136,87 @@ modify the merged head.
       three GH1064 packet files.
 - [x] Historical review-comment resolution: both PR #1084 inline threads are
       resolved and outdated at final head `1d5502fdba342a53df8f766720d1affa4e344384`.
+- [x] Historical exact-head review truth: the current `implx` run's independent
+      post-merge review of that final head returned `FAIL` with the five packet
+      structure findings listed above; no clean/reusable `PASS` exists.
 - [ ] A new independent reviewer has returned a clean verdict bound to the
       structural reconciliation PR exact head.
 - [ ] Fresh required `pr_gate.py` evidence for that exact head is allowed.
 - [ ] The new PR is merged and post-merge runtime-ledger plus issue-closure
       audit evidence is complete.
+
+### `verify_t3_closure.sh` canonical command block
+
+Run this complete block from the repository root after merge. `PR_EVIDENCE`,
+`CHECKPOINT`, and `CLOSURE_AUDIT` are coordinator-owned external JSON artifacts;
+any missing field, duplicate issue-1064 checkpoint item, mismatch, API failure,
+or nonzero exit blocks T3.
+
+```bash
+set -euo pipefail
+
+: "${PR_EVIDENCE:?set PR_EVIDENCE to post-merge PR evidence JSON}"
+: "${CHECKPOINT:?set CHECKPOINT to the runtime checkpoint JSON}"
+: "${CLOSURE_AUDIT:?set CLOSURE_AUDIT to the post-merge issue audit JSON}"
+
+expected_pr="$(jq -er '.pr | select(type == "number" and . > 0)' "$CLOSURE_AUDIT")"
+expected_head="$(jq -er '.head_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$CLOSURE_AUDIT")"
+expected_merge="$(jq -er '.merge_sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$CLOSURE_AUDIT")"
+
+jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expected_merge" '
+  .issue == 1064
+  and .pr == $pr
+  and .head_sha == $head
+  and .merge_sha == $merge
+  and .pr_state == "MERGED"
+  and .issue_state == "CLOSED"
+  and .closing_issue_numbers == [1064]
+  and ((.queried_at | type) == "string")
+  and ((.queried_at | length) > 0)
+' "$CLOSURE_AUDIT" >/dev/null
+
+python3 checks/pr_gate.py --repo . --evidence "$PR_EVIDENCE" --mode required --json
+python3 checks/runtime_ledger_gate.py --checkpoint "$CHECKPOINT" --json
+
+jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expected_merge" '
+  .pr == $pr
+  and .head_sha == $head
+  and .merge_record.remote_confirmed == true
+  and .merge_record.merge_commit_sha == $merge
+' "$PR_EVIDENCE" >/dev/null
+
+jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expected_merge" '
+  [.items[] | select(.issue == 1064)] as $matches
+  | ($matches | length) == 1
+    and $matches[0].pr == $pr
+    and $matches[0].head_sha == $head
+    and $matches[0].merge_commit == $merge
+    and $matches[0].state == "merged"
+' "$CHECKPOINT" >/dev/null
+
+live_pr="$(
+  gh pr view "$expected_pr" \
+    --repo majiayu000/litellm-rs \
+    --json number,state,headRefOid,mergeCommit,body,closingIssuesReferences
+)"
+jq -e --argjson pr "$expected_pr" --arg head "$expected_head" --arg merge "$expected_merge" '
+  .number == $pr
+  and .state == "MERGED"
+  and .headRefOid == $head
+  and .mergeCommit.oid == $merge
+  and (.body | contains("Refs #1068"))
+  and (.body | contains("Refs #1084"))
+  and (.body | contains("Fixes #1064"))
+  and (([.closingIssuesReferences[].number] | sort) == [1064])
+' <<<"$live_pr" >/dev/null
+
+live_issue="$(
+  gh issue view 1064 \
+    --repo majiayu000/litellm-rs \
+    --json number,state
+)"
+jq -e '.number == 1064 and .state == "CLOSED"' <<<"$live_issue" >/dev/null
+```
 
 ## Rollback Plan
 


### PR DESCRIPTION
## Summary

- reconcile the existing GH1064 packet with current SpecRail structure
- preserve #1064 as a planning-only umbrella without claiming child delivery
- bind post-merge T3 evidence across the PR, runtime checkpoint, closure audit, and live GitHub state

Refs #1068
Refs #1084
Fixes #1064

## Scope

This PR changes only:

- `specs/GH1064/product.md`
- `specs/GH1064/tech.md`
- `specs/GH1064/tasks.md`

It does not modify the roadmap, production code, configuration, workflows, or child specs.

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir "$PWD/specs/GH1064"` — passed
- `git diff --check` — passed
- exact B-ID / mapping / manifest / Covers set check — passed (`B-001..B-005`)
- independent exact-head review at `d44f14417fd6a473f8ffbe670e122d4293d3c852` — PASS

`SP1064-T3` remains unchecked in the repository packet. Merge and remote closure evidence are recorded after merge in the runtime ledger and closure audit so the reviewed head is not changed to attest to its own merge.
