### PR TITLE
docs(spec): split GH837 remaining provider tasks

### DIFF
--- a/specs/GH837/product.md
+++ b/specs/GH837/product.md
@@ -15,12 +15,20 @@ GH-837 / #837
 并使 README/文档的 provider 数量宣传与真实能力脱节。#137 曾以同样理由删除 39 个孤儿实现并标记完成，
 但当前主干上孤儿目录再次达到 ~41 个——说明除了一次性清理，还需要防回归的守护测试。
 
+本修订在 `main@12faaf56` 复核 remaining-six，并以维护者 2026-07-15 的
+[#837 决策评论](https://github.com/majiayu000/litellm-rs/issues/837#issuecomment-4982855968)
+为权威输入。评论包含 `ready_to_implement` 并随后重申 ordering gates；原 T5/T6 umbrella
+缺少逐 provider 的先决条件与独立验证，因此追加 remaining-six tasks，不改写 T1–T9 历史含义。
+该评论只批准 remaining six，不等于批准历史 66 行矩阵中的全部 delete/non-LLM lane，原 T2/T3 保持开放。
+
 ## 目标
 
 - 每个 native provider 目录要么有真实构造/dispatch 路径，要么被删除、降级为 catalog-only 后移除 native 模块，
   或进入带理由的显式豁免；catalog 条目不能在重复 native 模块仍存在时算作 native 可达。
 - 建立防回归守护：不可达的 literal 或 macro-generated `LLMProvider` 无法再无声进入主干。
 - 处置决策逐目录显式记录，维护者审批后才动手删除（U-05：不确认不删除）。
+- `amazon_nova`、`github`、`meta_llama`、`v0` 各自严格执行 catalog policy/equivalence → demotion；
+  `ollama` 独立 native wiring；`custom_api` 严格执行 0.6.0 deprecation → version workflow gate → 0.7.0 removal。
 
 ## 非目标
 
@@ -32,42 +40,61 @@ GH-837 / #837
 
 ## Behavior Invariants
 
-1. 处置清单批准前，不删除任何目录（分类清单本身是第一个交付物）。
-2. 「wire」处置的 native 目录：接线后存在至少一条端到端可构造路径（enum/factory/dispatch 或等价构造点），
+1. **B-001** 处置清单批准前，不删除任何目录（分类清单本身是第一个交付物）。
+2. **B-002** 「wire」处置的 native 目录：接线后存在至少一条端到端可构造路径（enum/factory/dispatch 或等价构造点），
    并有 conformance 测试覆盖；docs、tests、raw text hit 不算可达性证据。
-3. 「delete」处置的目录：删除后 `cargo check --all-features` 与全量测试通过，无 dangling `pub mod`。
-4. 「demote」处置的目录：只有在 catalog runtime 能保持 endpoint 构造、auth env fallback、provider-specific
+3. **B-003** 「delete」处置的目录：删除后 `cargo check --all-features` 与全量测试通过，无 dangling `pub mod`。
+4. **B-004** 「demote」处置的目录：只有在 catalog runtime 能保持 endpoint 构造、auth env fallback、provider-specific
    endpoint、capability set 与现有 native 行为等价时，才可转为 `registry/catalog.rs` 条目；
    native 目录必须随后删除或进入带 issue/期限的豁免，不能让 catalog backing 掩盖重复 native 实现。
-5. 守护测试常驻：枚举 `src/core/providers/*/` 中的 literal `impl LLMProvider` 与
+5. **B-005** 守护测试常驻：枚举 `src/core/providers/*/` 中的 literal `impl LLMProvider` 与
    `define_http_provider_with_hooks!` 等 macro-generated provider，断言均可达或在显式豁免清单
    （带 issue 引用与期限）中。
-6. 每个删除 PR 遵守仓库 PR 限制（≤10 文件 / ≤500 行规则对删除类 PR 按 tranche 拆分执行，Cargo.lock/纯删除行不计）。
-7. 删除任何 `src/core/providers/mod.rs` 导出的 `pub mod` 前，必须记录 public API / semver 影响：
+6. **B-006** 每个删除 PR 遵守仓库 PR 限制（≤10 文件 / ≤500 行规则对删除类 PR 按 tranche 拆分执行，Cargo.lock/纯删除行不计）。
+7. **B-007** 删除任何 `src/core/providers/mod.rs` 导出的 `pub mod` 前，必须记录 public API / semver 影响：
    若下游 crate 可直接 import/instantiate，该 tranche 需要 breaking-change 说明或先走 deprecation lane。
-8. `custom_api` 不属于 shared infra；必须在矩阵中作为 provider lane（wire/delete/demote/exempt）单独决策。
-9. image/video/translation/embedding-only/non-chat provider 不进入 LLM delete lane，除非 non-LLM 产品决策明确批准；
+8. **B-008** `custom_api` 不属于 shared infra；必须在矩阵中作为 provider lane（wire/delete/demote/exempt）单独决策。
+9. **B-009** image/video/translation/embedding-only/non-chat provider 不进入 LLM delete lane，除非 non-LLM 产品决策明确批准；
    任何声明 `ProviderCapability::ChatCompletion` 的 adapter 必须走 LLM wire/delete/demote/exempt 矩阵，不能靠名称归入 non-LLM。
+10. **B-010** 四个 demote provider 均先完成独立 catalog policy/equivalence 与 0.6.0 deprecation，再经 version-workflow 与 T9 compatibility gates 执行 0.7.0 demotion。
+11. **B-011** 等价证据必须 provider-specific：Amazon model/pricing/capability；GitHub `GITHUB_MODELS_API_BASE` +
+    model/pricing/capability/health；Meta auth/identity/filtering/streaming/model metadata/capability；V0 authoritative
+    aliases/model metadata/pricing/health/error policy，禁止 no-model/zero-cost canonical fallback。
+12. **B-012** `ollama` 先让普通与 streaming 请求都使用 policy-aware client，覆盖 `api_base`、
+    SSRF/private-network authority 并移除 unwired raw-HTTP exception；source boundary guard 通过后，
+    才使用既有 native protocol 接入 `ProviderType`/registry/factory/dispatch，且不新增 generic OpenAI catalog route。
+13. **B-013** `custom_api` 先在 0.6.0 deprecate；version-bump workflow 能验证 breaking 0.7.0 bump 后才可删除。
+14. **B-014** 每 task/provider 一个 PR；hard cap 为 ≤500 non-doc changed lines（按 B-006 排除纯删除行，
+    non-doc additions/edits 绝不豁免），可建议 ≤4 个非纯删除文件；单一 provider directory 的纯删除
+    只可例外物理 file count，且不得混入第二 provider；T7/T8 最后执行。
 
 ## 验收标准
 
-- [ ] `specs/GH837/` 附录形成 66 目录全量处置矩阵（wired-native / delete-native / demote-to-catalog /
-      keep-infra / non-llm-lane / exempt），并获维护者批复。
-- [ ] 守护测试合入并能在 CI 捕获「新增不可达 provider」。
+- [ ] 历史 66 目录 baseline 的每行完整证据已补齐，且全量 delete/non-LLM/remaining lane 获维护者批复。
+- [x] 守护测试合入并能在 CI 捕获「新增不可达 provider」。
+- [ ] 四个 demote provider 的 policy/equivalence 与 demotion tasks 均独立完成且依赖方向正确。
+- [ ] `ollama` HTTP hardening predecessor 与 native wiring 按序完成且无 generic catalog route；
+      `custom_api` deprecation → workflow → T9 compatibility → removal 按序完成。
 - [ ] 处置执行完成后，`src/core/providers/` 无 factory/dispatch 不可达的 native `LLMProvider`
       （含 macro-generated provider；已 demote 且 native 目录删除者除外；豁免清单除外）。
+- [ ] T5/T6/T9 汇总后，T7 closure 与 T8 full verification 依次完成。
 - [ ] README / CLAUDE.md 的 provider 能力描述与处置结果一致。
 
 ## 边界情况
 
-- 目录被 `providers-extra` / `providers-extended` feature gate 但 gate 后仍不可达：按不可达处理。
-- 仅被其他死目录引用的目录（死代码引用死代码）：连带处置。
-- 半迁移目录（CLAUDE.md 提到的 `DU` 状态遗留）：按 CLAUDE.md「Resolving half-migrated providers」流程归类。
-- catalog 已有同名条目但 native 目录仍存在（如 v0 / meta_llama）：catalog 只能证明 catalog path 可用，
-  不能证明 native module 可达。
+- Empty/missing：缺 catalog model/auth/pricing/health/error data 即不满足等价，不得 fallback 后 demote。
+- Duplicate/conflict：catalog 已有同名条目但 native 目录仍存在（如 v0 / meta_llama），不得据此判定 native 可达。
+- Concurrency：共享 catalog/lifecycle/CHANGELOG/migration files 的任务串行；并行 agent 必须文件 ownership 不相交。
+- Ordering/time：0.6.0 deprecation 先于 0.7.0 removal；T7/T8 最后。
+- Permission/auth：不记录真实 token，只验证 env-key contract；workflow test 不执行 release。
+- Partial failure：任一 policy、compatibility 或 workflow gate 失败即阻止后继 removal。
+- Retry/idempotency：重复运行 guard/catalog/workflow checks 不改变 repo/release state。
+- Migration/backward compatibility：0.6.0 保留公开 surface；0.7.0 breaking removal 提供 CHANGELOG/migration notes。
+- Observability：每个 PR 记录 head SHA、命令、结果与 provider-specific evidence。
+- Feature/dependency/migration：feature-gated 仍不可达、只被死代码引用或处于 `DU` 半迁移状态者，继续按原 GH837/CLAUDE.md 规则处置。
 - 只被文档、测试、注释、README 或无关同名类型命中的 provider：不得据此判定为可达。
 
 ## 发布说明
 
-删除类变更不影响 gateway 可构造路径的运行时行为；若删除了对下游 crate 可见的 `pub mod` 或类型导出，
-按 public API 变更记录 semver/compatibility 说明，否则在 CHANGELOG 以 refactor 记录，并注明恢复方式（git history）。
+0.6.0 只加入 deprecation/迁移说明；0.7.0 public removal 是显式 breaking change，须经 workflow 与 T9 gates。
+`ollama` native wiring 是独立运行时能力变化；所有变更分别记录 release evidence。

--- a/specs/GH837/tasks.md
+++ b/specs/GH837/tasks.md
@@ -8,36 +8,51 @@ GH-837 / #837
 
 - Product: `product.md`
 - Tech: `tech.md`
+- Remaining-six authority: <https://github.com/majiayu000/litellm-rs/issues/837#issuecomment-4982855968>
 
-## 实现任务
+## 历史任务（T1–T9 ID/含义不变）
 
-- [ ] `SP837-T1` Owner: coordinator. Done when: `specs/GH837/` 三件套通过 SpecRail packet validation. Verify: `SPEC_RAIL=/path/to/specrail; python3 "$SPEC_RAIL/checks/check_workflow.py" --repo "$SPEC_RAIL" --spec-dir "$PWD/specs/GH837"`.
-- [ ] `SP837-T2` Owner: coordinator. Done when: 66 目录全量处置矩阵（wired-native/delete-native/demote-to-catalog/keep-infra/non-llm-lane/exempt + 每行 construction/dispatch、catalog、public export、macro、capability、internal dependency/metadata-use、endpoint/auth/capability equivalence 证据）作为附录追加到本 spec. Verify: `git diff -- specs/GH837/`; 每目录一行且附判定命令输出，裸 `rg "<TypeName>" src` 文本命中不得作为可达性证据；声明 `ProviderCapability::ChatCompletion` 的 adapter 不得进入 non-LLM baseline；demote 候选必须记录 static/dynamic endpoint、alternate auth env vars、provider-specific non-chat endpoint、capability equality。
-- [ ] `SP837-T3` Owner: maintainer. Done when: 维护者在 #837 批复处置矩阵（SpecRail human gate `spec_approval`），特别是 non-llm-lane 的产品定位与 delete 清单. Verify: #837 issue thread 中的明确批复。
-- [ ] `SP837-T4` Owner: coordinator. Done when: registry conformance 守护测试合入——扫描 literal `impl LLMProvider`、`define_http_provider_with_hooks!`、`define_pooled_http_provider_with_hooks!` 等 macro-generated provider，并与「native enum/factory/dispatch + catalog-only 完成状态 + 维护者批复的临时 orphan baseline + 豁免清单」求差集，新增非 baseline orphan 即失败；catalog 条目不得抵消仍存在的重复 native module. Verify: `cargo test core::providers::registry --lib --all-features`; 人为添加 literal impl、macro provider、pooled macro provider、catalog/native duplicate 四类孤儿 fixture 的负测试通过验证后移除。
-- [ ] `SP837-T5` Owner: coordinator. Done when: delete-native lane 按 tranche 执行完毕，每 PR 一个目录家族，`pub mod` 与 registry 元数据同步清理；有 internal dependency/metadata-use 的目录先迁移依赖或拆出 shared metadata；image/video/translation/search/vector/embedding-only provider 不进入此 lane，除非 non-LLM 产品决策明确批准，且 chat-capable adapter 不得按 non-LLM 删除. Verify: 每 tranche `cargo check --all-features` + `cargo test --all-features`; `rg -n "pub mod (petals|nlp_cloud|spark|gigachat)" src/core/providers/mod.rs` 无残留（以批复清单为准）。
-- [ ] `SP837-T6` Owner: coordinator. Done when: demote-to-catalog lane 执行完毕，每 provider 一个 PR（已有 catalog route 或维护者批准新增 catalog route + `def()`/完整 `ProviderDefinition` + 删 native 目录 + smoke 等价验证）；Snowflake、自定义/dynamic endpoint、native-only FIM/非 chat endpoint、catalog 无法表达 alternate auth env vars 或 capability set 不等价的 provider 不可 plain demote，必须 wire/delete/exempt 或先扩展 catalog；若 native 目录暂留，必须进入带 issue/owner/期限的豁免清单. Verify: `cargo test core::providers::registry::catalog --lib --all-features`; 每 PR 附 base_url/env-key/alternate env vars、是否新增 route 的产品批准、capability equality、provider-specific endpoint 检查、无重复 native impl 证据。
-- [ ] `SP837-T7` Owner: verification owner. Done when: 收尾扫描确认无不可达 `impl LLMProvider`（豁免清单除外），README / CLAUDE.md provider 描述已同步. Verify: conformance 测试绿色; `rg -c "impl LLMProvider" src/core/providers | wc -l` 与矩阵一致。
-- [ ] `SP837-T9` Owner: coordinator. Done when: 删除任何 `pub mod` provider 前完成 public API / semver 影响表，标明 refactor、deprecation、或 breaking-change 路径. Verify: 每个 delete/demote tranche PR 描述或 CHANGELOG 草案包含 compatibility 决策；`src/core/providers/mod.rs` 删除项均能追溯到矩阵行。
+- [x] `SP837-T1` Owner: coordinator. Covers: B-001. Dependencies: none. Done when: `specs/GH837/` 三件套通过 SpecRail packet validation. Verify: `env PYTHONDONTWRITEBYTECODE=1 python3 checks/check_workflow.py --repo . --spec-dir specs/GH837`.
+- [ ] `SP837-T2` Owner: coordinator. Covers: B-001, B-004, B-008, B-009. Dependencies: T1. Done when: 历史 66 目录 baseline 的每行均有 construction/dispatch、catalog、public export、macro、capability、internal dependency/metadata-use、endpoint/auth/capability equivalence 完整证据. Verify: 运行 Appendix 66-row check 并逐行核验 evidence ledger；当前短摘要不满足 done-when。
+- [ ] `SP837-T3` Owner: maintainer. Covers: B-001. Dependencies: T2. Done when: 维护者批准历史 66 行全量处置矩阵，特别是全部 delete 与 non-LLM lane. Verify: #837 issue thread 中明确覆盖全矩阵的批复；comment `4982855968` 只批准 remaining six，不满足本 task。
+- [x] `SP837-T4` Owner: coordinator. Covers: B-005. Dependencies: T1. Done when: registry conformance guard 扫描 literal/macro provider、duplicate catalog/native 和有期限 baseline，新增 orphan 会失败. Verify: `git merge-base --is-ancestor c4f5e9f7 HEAD && cargo test core::providers::registry --lib --all-features`.
+- [ ] `SP837-T5` Owner: coordinator. Covers: B-003, B-006, B-008, B-009. Dependencies: T2, T3, T23. Done when: 原 delete-native lane 按 tranche 完成，每 PR 一个目录家族并同步 `pub mod`/registry；internal dependency 先迁移；未经产品批准不混入 non-LLM/chat-capable adapter. Verify: 每 tranche `cargo check --all-features && cargo test --all-features`，且 `custom_api` 的 T23 removal evidence 完整。
+- [ ] `SP837-T6` Owner: coordinator. Covers: B-004, B-006, B-007, B-010, B-011. Dependencies: T2, T3, T12, T14, T16, T18. Done when: 原 demote lane 每 provider 一个 PR，获批 catalog route 与 endpoint/auth/capability 等价，native directory 删除或进入时限豁免；remaining four child removals 完成. Verify: `for p in amazon_nova github meta_llama v0; do test ! -d "src/core/providers/$p" || exit 1; done; cargo test core::providers::registry::catalog --lib --all-features`.
+- [ ] `SP837-T7` Owner: verification owner. Covers: B-002, B-003, B-005, B-008, B-012, B-014. Dependencies: T2, T3, T5, T6, T9, T20. Done when: 最终扫描无不可达 `LLMProvider`（批准豁免除外），baseline 与 README/CLAUDE 已按最终矩阵同步. Verify: `cargo test core::providers::registry --lib --all-features && rg -n 'amazon_nova|github|meta_llama|v0|ollama|custom_api' README.md CLAUDE.md src/core/providers/registry/lifecycle.rs`.
+- [ ] `SP837-T9` Owner: coordinator. Covers: B-007, B-010, B-013. Dependencies: T11, T13, T15, T17, T21, T22. Done when: 所有计划删除的 public surfaces 已在 0.6 deprecate，compatibility table/CHANGELOG/migration 与 breaking workflow evidence 完整；此 gate 必须先于任何 removal. Verify: `rg -n 'amazon_nova|github|meta_llama|v0|custom_api' CHANGELOG.md docs/providers && bash scripts/guards/check_version_bump.sh`.
 
-## 并行拆分
+## Remaining-six amendment and implementation
 
-- SP837-T4（守护测试，只动 `registry/`）与 SP837-T2（纯文档附录）可并行。
-- SP837-T5 各 tranche 之间文件不相交，可多 lane 并行（W-14：每 tranche 独占自己的目录集）。
-- SP837-T5/T6 依赖 T3 批复与 T9 compatibility 决策；T4 可在 T5/T6 前合入，但必须把 T3 批复矩阵中的当前 orphan 列为带 issue/owner/期限的临时 baseline，只对新增或未批准 orphan hard-fail。T5/T6 完成后逐步清空 baseline。
+Hard cap：每 task ≤500 non-doc changed lines（按 B-006 排除纯删除行，non-doc additions/edits 绝不豁免）；可建议 ≤4 个非纯删除文件。单一 provider 的纯删除只可例外物理 file count；一个 task/PR 不得混入第二 provider。
+
+- [x] `SP837-T10` Owner: coordinator. Covers: B-010, B-011, B-012, B-013, B-014. Dependencies: T1, T4. Done when: remaining-six maintainer decision 已与 `main@12faaf56` 当前 packet/source reconciliation，且未冒充全 66 matrix approval. Verify: `gh api repos/majiayu000/litellm-rs/issues/comments/4982855968 --jq '[.user.login,.author_association,.created_at,.html_url,.body] | @tsv' && env PYTHONDONTWRITEBYTECODE=1 python3 checks/check_workflow.py --repo . --spec-dir specs/GH837`.
+- [ ] `SP837-T11` Owner: amazon_nova provider owner. Covers: B-004, B-007, B-010, B-011, B-014. Dependencies: T10. Done when: catalog model/pricing/capability policy/equivalence 与 0.6 deprecation/notes 完成，native 保留. Verify: `test -d src/core/providers/amazon_nova && cargo test --lib --all-features amazon_nova_catalog_policy && rg -n '0\.6\.0|deprecat' src/core/providers/amazon_nova CHANGELOG.md docs/providers`.
+- [ ] `SP837-T12` Owner: amazon_nova provider owner. Covers: B-003, B-004, B-006, B-007, B-010, B-014. Dependencies: T11, T9. Done when: 仅该 provider native surface 在 0.7 删除且 baseline 收缩，catalog tests 仍绿. Verify: `test ! -d src/core/providers/amazon_nova && ! rg -n 'pub mod amazon_nova|AmazonNovaProvider' src/core/providers/mod.rs src/core/providers/registry && cargo test --lib --all-features amazon_nova`.
+- [ ] `SP837-T13` Owner: github provider owner. Covers: B-004, B-007, B-010, B-011, B-014. Dependencies: T10. Done when: catalog 保留 `GITHUB_MODELS_API_BASE`、model/pricing/capability/health 且完成 0.6 deprecation/notes，native 保留. Verify: `test -d src/core/providers/github && cargo test --lib --all-features github_catalog_policy && rg -n 'GITHUB_MODELS_API_BASE|0\.6\.0|deprecat' src/core/providers/github src/core/providers/registry/catalog.rs CHANGELOG.md docs/providers`.
+- [ ] `SP837-T14` Owner: github provider owner. Covers: B-003, B-004, B-006, B-007, B-010, B-014. Dependencies: T13, T9. Done when: 仅 `github` native surface 在 0.7 删除，`github_copilot` 不变. Verify: `test ! -d src/core/providers/github && test -d src/core/providers/github_copilot && ! rg -n 'pub mod github;' src/core/providers/mod.rs && cargo test --lib --all-features github_catalog_policy`.
+- [ ] `SP837-T15` Owner: meta_llama provider owner. Covers: B-004, B-007, B-010, B-011, B-014. Dependencies: T10. Done when: catalog auth/identity/filtering/streaming/model metadata/capability equivalence 与 0.6 deprecation/notes 完成，native 保留. Verify: `test -d src/core/providers/meta_llama && cargo test --lib --all-features meta_llama_catalog_policy && rg -n '0\.6\.0|deprecat' src/core/providers/meta_llama CHANGELOG.md docs/providers`.
+- [ ] `SP837-T16` Owner: meta_llama provider owner. Covers: B-003, B-004, B-006, B-007, B-010, B-014. Dependencies: T15, T9. Done when: 仅该 provider native surface 在 0.7 删除且 policy tests 仍绿. Verify: `test ! -d src/core/providers/meta_llama && ! rg -n 'pub mod meta_llama|MetaLlamaProvider' src/core/providers/mod.rs src/core/providers/registry && cargo test --lib --all-features meta_llama_catalog_policy`.
+- [ ] `SP837-T17` Owner: v0 provider owner. Covers: B-004, B-007, B-010, B-011, B-014. Dependencies: T10. Done when: authoritative aliases/model metadata/pricing/health/error policy 拒绝 no-model/zero-cost canonical fallback，并完成 0.6 deprecation/notes，native 保留. Verify: `test -d src/core/providers/v0 && cargo test --lib --all-features v0_catalog_policy && rg -n 'aliases|pricing|health|error|0\.6\.0|deprecat' src/core/providers/v0 src/core/providers/registry/catalog.rs CHANGELOG.md docs/providers`.
+- [ ] `SP837-T18` Owner: v0 provider owner. Covers: B-003, B-004, B-006, B-007, B-010, B-014. Dependencies: T17, T9. Done when: 仅该 provider native surface 在 0.7 删除且 authoritative policy tests 仍绿. Verify: `test ! -d src/core/providers/v0 && ! rg -n 'pub mod v0|V0Provider' src/core/providers/mod.rs src/core/providers/registry && cargo test --lib --all-features v0_catalog_policy`.
+- [ ] `SP837-T19` Owner: ollama provider owner. Covers: B-002, B-012, B-014. Dependencies: T10. Done when: 普通与 streaming Ollama 请求均使用 policy-aware client；`api_base`、SSRF 与 private-network authority tests 完整；移除 `ollama/provider.rs` unwired raw-HTTP exception. Verify: `cargo test --lib --all-features ollama && cargo test --lib --all-features endpoint_access && ! rg -n 'src/core/providers/ollama/provider.rs' src/core/providers/base/http/source_boundary_tests.rs && bash scripts/guards/check_outbound_http_clients.sh`.
+- [ ] `SP837-T20` Owner: ollama provider owner. Covers: B-002, B-012, B-014. Dependencies: T19. Done when: hardened native protocol 接入 core `ProviderType`/registry/factory/dispatch 并覆盖 request/response/streaming，无 generic catalog route. Verify: wiring exact head 必须重跑 `cargo test --lib --all-features ollama && cargo test --lib --all-features endpoint_access && ! rg -n 'src/core/providers/ollama/provider.rs' src/core/providers/base/http/source_boundary_tests.rs && bash scripts/guards/check_outbound_http_clients.sh`，再运行 `rg -n 'Ollama' src/core/providers/{mod.rs,factory,registry} && ! rg -n 'def\([^\n]*ollama|provider_id: "ollama"' src/core/providers/registry/catalog.rs`.
+- [ ] `SP837-T21` Owner: custom_api provider owner. Covers: B-007, B-008, B-013, B-014. Dependencies: T10. Done when: public module/types 在 0.6 deprecate 但仍可编译，notes 说明任意 URL/method/template/parser 不再是产品目标. Verify: `test -d src/core/providers/custom_api && cargo test --test public_api_compat custom_api_deprecated_in_0_6 && rg -n 'custom_api|0\.6\.0|deprecat' src/core/providers/custom_api src/core/providers/mod.rs CHANGELOG.md docs/providers`.
+- [ ] `SP837-T22` Owner: release workflow owner. Covers: B-007, B-010, B-013, B-014. Dependencies: T11, T13, T15, T17, T21. Done when: version workflow 显式验证 0.6.x→0.7.0 breaking bump并拒绝把 public removal 伪装成 non-breaking，测试无发布副作用. Verify: `bash scripts/guards/check_version_bump.sh && ruby -e 'require "yaml"; YAML.safe_load(File.read(".github/workflows/version-bump.yml"), aliases: true)'`.
+- [ ] `SP837-T23` Owner: custom_api provider owner. Covers: B-003, B-006, B-007, B-008, B-013, B-014. Dependencies: T21, T9. Done when: 0.7 删除该 public/native surface、registry/lifecycle entries，并有 migration alternative. Verify: `test ! -d src/core/providers/custom_api && ! rg -n 'custom_api|CustomApi' src/core/providers/mod.rs src/core/providers/registry && cargo check --all-features && cargo test --all-features`.
+
+## 执行顺序
+
+- T11/T13/T15/T17/T21 在 T10 后准备 0.6 compatibility；共享 catalog/docs files 时串行。
+- T22 在上述五个 0.6 tasks 后执行；T9 汇总并验证 compatibility evidence。
+- T12/T14/T16/T18/T23 仅在 T9 后 removal；T19 hardening 完成后才可 T20 Ollama wiring。
+- T5/T6 仍被开放 T2/T3 fail-closed；T7 closure 后才执行 T8。
 
 ## 验证
 
-- [ ] `SP837-T8` Owner: verification owner. Done when: 全部 tranche 合并后全量验证通过且编译时间对比有记录. Verify: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`; `cargo build --all-features --timings` 前后对比。
+- [ ] `SP837-T8` Owner: verification owner. Covers: B-003, B-005, B-014. Dependencies: T2, T3, T7. Done when: 全部 tranche 合并后全量验证通过且编译时间对比有记录. Verify: `cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features && cargo build --all-features --timings`.
 
 ## Handoff Notes
 
-- U-05 约束：任何目录在 SP837-T3 批复前不得删除；「看起来没用」不是删除依据，零构造路径 + 维护者批复才是。
-- catalog 条目只能证明 `Provider::OpenAILike` 路径；当同名 native module 仍存在（如 v0 / meta_llama）时，
-  不能把 catalog 计为 native impl 可达。
-- `custom_api` 是 macro-generated provider，不是 shared infra；必须 wire/delete/demote/exempt 明确归类。
-- non-llm-lane（搜索/向量/语音/image/video/translation/embedding-only 目录）本质是产品范围问题：
-  litellm-rs 是否要做非 LLM 网关能力。必须先按 declared capability 过滤；声明 chat completion
-  的 adapter 即使名称像 search/translation，也必须走 LLM provider 矩阵。建议维护者在 #837 一并表态。
-- 可达性证据只接受 construction/dispatch/symbol/capability 证据；文档、注释、tests 或无关同名 raw text hit 只能作为旁证。
-- 与 #519 A-4 的边界：本 issue 不改 dispatch 架构；若 A-4 先落地（enum → trait object），wire lane 的接线方式随之变化，处置矩阵仍然有效。
+- 缺 catalog data 等于“不满足等价”，不得以空 model/zero pricing 或猜测值降级。
+- 每 task/PR 只处理一个 provider；`github` 与 `github_copilot` 是不同 scope。
+- T2/T3/T5/T6/T7/T8 开放期间不得把 GH837 标记 complete。

--- a/specs/GH837/tech.md
+++ b/specs/GH837/tech.md
@@ -18,9 +18,24 @@ Link to `product.md`.
 | Public exports | `src/core/providers/mod.rs` | 多个孤儿目录仍以 `pub mod` 导出，feature gate 后下游 crate 可能直接 import | 删除前必须评估 public API / semver |
 | Macro providers | `src/core/providers/*/provider.rs` + `src/core/providers/macros/` | `custom_api`、`deepl` 等通过 `define_http_provider_with_hooks!` 生成 `LLMProvider` impl | 守护测试不能只搜 literal `impl LLMProvider` |
 | Non-LLM surfaces | `runwayml`、`recraft`、`stability`、audio/vector/embedding-only 目录 | 可能暴露 image/video/audio/vector/embedding capability，而非 chat LLM；声明 `ProviderCapability::ChatCompletion` 的 translation/search adapter 必须回到 LLM lane | 进入 non-llm-lane 前必须用 capability 证据排除 chat surface |
-| Orphan dirs | `src/core/providers/{custom_api,deepgram,ollama,elevenlabs,huggingface,sagemaker,watsonx,voyage,databricks,triton,jina,...}` | `pub mod` 声明 + 完整实现，但无 native factory/dispatch 构造点 | 处置对象（~41 个） |
+| Historical orphan baseline | `src/core/providers/{custom_api,deepgram,ollama,elevenlabs,huggingface,sagemaker,watsonx,voyage,databricks,triton,jina,...}` | 原 baseline 中为 `pub mod` + 完整实现但无 native factory/dispatch；部分目录后来已删除 | 历史审计记录，不代表当前目录计数 |
 | Registry types | `src/core/providers/registry/{types.rs,lifecycle.rs,support_matrix.rs}` | `PROVIDER_TYPE_REGISTRY` 等元数据 | 守护测试挂载点 |
 | Prior art | #137 / #140 / #714（均 CLOSED） | 清理过一轮后回归 | 说明需要守护测试 |
+
+## Maintainer decision and remaining-six gap
+
+权威输入是维护者 2026-07-15 的 [#837 评论](https://github.com/majiayu000/litellm-rs/issues/837#issuecomment-4982855968)：
+
+- `amazon_nova`: catalog model/pricing/capability equivalence → demote。
+- `github`: 保留 `GITHUB_MODELS_API_BASE` 与 model/pricing/capability/health → demote。
+- `meta_llama`: auth/identity/filtering/streaming/model metadata/capability equivalence → demote。
+- `v0`: authoritative aliases/model metadata/pricing/health/error policy（禁止 empty/zero-cost canonical fallback）→ demote。
+- `ollama`: existing native protocol → core `ProviderType`/registry/factory/dispatch；无 generic catalog。
+- `custom_api`: 0.6 deprecation → verified breaking version workflow → 0.7 removal。
+
+同一评论要求 demote/delete public surfaces 先 0.6 deprecate，再 0.7 breaking remove，并提供 CHANGELOG/migration notes。
+它只批准 remaining six，不批准历史 66 行的全部 delete/non-LLM lane；T2/T3 保持开放。T10 记录本次
+reconciliation，implementation 使用 T11–T23，且保持 T1–T9 历史含义。
 
 ## 设计方案
 
@@ -83,25 +98,42 @@ Link to `product.md`.
 - 豁免清单与临时 baseline 为带 issue 引用、owner、期限和退出条件的常量表，CI 可见；T5/T6
   每删除或 demote 一个目录必须同步收缩 baseline，最终收尾时 baseline 为空。
 
-**Phase 3 — 分批执行**
+**Phase 3 — remaining-six preparation (0.6.0 + Ollama hardening)**
 
-- delete lane：按目录家族分 tranche（每 PR 一个或数个小目录），纯删除 + `pub mod` 清理；每个 tranche
-  先记录 public API/semver 影响，必要时使用 breaking-change commit 或 deprecation 过渡。
-- demote lane：每 PR 一个 provider：确认已有 catalog route 或取得维护者对新增 catalog route 的产品批准 →
-  证明 endpoint/auth/capability/non-chat endpoint 等价 → 使用 `def()` 或完整 `ProviderDefinition`
-  （需要 alternate auth env vars 等时不得强行用 `def()`）→ 删 native 目录 → smoke 验证模型列表、
-  鉴权头、capability 与 provider-specific endpoint 等价；若 native 目录暂留，必须在豁免清单登记，
-  不能把 catalog 当 native 可达。新增 catalog-backed selector 属于 runtime behavior change，不能作为纯清理默认发生。
-- wire lane（如维护者选择保留个别）：按 CLAUDE.md Tier-2 流程补 enum/factory/dispatch。
+- `amazon_nova`、`github`、`meta_llama`、`v0` 各有一个 provider-scoped policy/equivalence PR。
+  测试直接编码上表各自的差异化 contract；同一 PR 加入 0.6.0 deprecation 与兼容性说明，但保留 native module。
+- `custom_api` 使用独立 PR 加入 0.6.0 deprecation 和 migration note，保持 public import 可编译。
+- `ollama` 先让 ordinary/streaming 请求使用 policy-aware client，覆盖 `api_base`、SSRF、
+  private-network authority，移除 `source_boundary_tests.rs` 中的 unwired raw-HTTP exception，并运行
+  `scripts/guards/check_outbound_http_clients.sh`；随后才接入 `ProviderType`/registry/factory/dispatch。
 
-## Appendix A - Provider Disposition Matrix
+**Phase 4 — breaking release gate**
 
-This matrix covers every directory currently under `src/core/providers`. The lane is a proposed GH837 disposition before the T3 maintainer approval gate; it is not a deletion or demotion approval by itself.
+- `.github/workflows/version-bump.yml` 必须显式支持并验证 0.6.x → 0.7.0 breaking bump。
+- repository guard 对包含批准 public removals 的 diff 拒绝 patch/minor non-breaking 标记；
+  guard tests 只验证 workflow/metadata，不触发真实发布。
+- 只有四个 policy/deprecation task 与 `custom_api` deprecation task 都完成后，才执行此 gate。
 
-| Directory | Proposed lane before T3 | Evidence summary | Follow-up |
+**Phase 5 — 0.7.0 removal/demotion**
+
+- 四个 catalog provider 各用一个 PR 删除自己的 duplicate native directory、`pub mod`、过时 registry
+  metadata并收缩 lifecycle baseline；不得在同一 PR 混入第二个 provider。
+- `custom_api` 用一个独立 PR 删除 public/native surface。
+- 每 task hard cap 为 500 non-doc changed lines（按 B-006 排除纯删除行，non-doc additions/edits
+  绝不豁免），可建议不超过 4 个非纯删除文件。单一 provider directory 的纯删除只可例外物理 file count。
+- T5/T6/T9 只汇总 child evidence；T7 closure audit 与 T8 full verification 最后依次执行。
+
+## Appendix A - Historical 66-directory Baseline and Remaining-Six Reconciliation
+
+The 66 rows preserve the original `origin/main@c47596a4` directory baseline, including rows for directories removed
+later; they do not assert the current directory count. Only the six amended rows reconcile the 2026-07-15
+remaining-six decision with `main@12faaf56`. The short evidence summaries do not complete T2, and the decision
+comment does not complete T3 approval for the full delete/non-LLM matrix.
+
+| Directory | Historical/reconciled lane | Evidence summary | Follow-up |
 | --- | --- | --- | --- |
 | `ai21` | `delete-native` | `providers-extended` public module with `define_pooled_http_provider_with_hooks!`; no native `ProviderType`/factory dispatch. | Delete native directory and `pub mod`, or reclassify after T3. |
-| `amazon_nova` | `demote-to-catalog` | Catalog-backed `ProviderType::AmazonNova`; native macro provider still exported, so catalog does not make the native module reachable. | Prove catalog equivalence, then delete native directory and shrink baseline. |
+| `amazon_nova` | `demote-to-catalog` | Maintainer approved Path A; catalog-backed `ProviderType::AmazonNova` coexists with exported native macro provider. | T11 proves model/pricing/capability policy and adds 0.6 deprecation; T12 demotes only after T9. |
 | `anthropic` | `wired-native` | Native `Provider` enum/factory dispatch and literal `LLMProvider` impl. | Keep wired module. |
 | `azure` | `wired-native` | `providers-extra` native enum/factory dispatch and literal `LLMProvider` impl. | Keep gated native module. |
 | `azure_ai` | `wired-native` | `providers-extra` native enum/factory dispatch and literal `LLMProvider` impl. | Keep gated native module. |
@@ -112,7 +144,7 @@ This matrix covers every directory currently under `src/core/providers`. The lan
 | `cloudflare` | `wired-native` | Native enum/factory dispatch and literal `LLMProvider` impl. | Keep wired module. |
 | `codestral` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch; native FIM/auth behavior prevents plain catalog demote. | Delete or reclassify after T3. |
 | `cohere` | `wired-native` | `providers-extended` native dispatch and literal `LLMProvider` impl. | Keep gated native module. |
-| `custom_api` | `exempt` | Macro-generated custom endpoint provider; not shared infra and not native-dispatched. | Requires explicit product/architecture decision before final lane. |
+| `custom_api` | `delete-native` | Maintainer decided arbitrary URL/method/template/parser is not a product goal; macro-generated public provider is not shared infra. | T21 deprecates; T22 verifies breaking bump; T9 checks compatibility; T23 removes. |
 | `databricks` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
 | `datarobot` | `delete-native` | `providers-extended` public module with `define_pooled_http_provider_with_hooks!`; no native dispatch. | Delete or reclassify after T3. |
 | `deepgram` | `non-llm-lane` | Audio transcription provider; public module but no `LLMProvider` marker in the guard scan. | Decide non-LLM product support separately. |
@@ -125,7 +157,7 @@ This matrix covers every directory currently under `src/core/providers`. The lan
 | `firecrawl` | `delete-native` | `providers-extended` public module with `define_pooled_http_provider_with_hooks!`; no native dispatch. | Delete or reclassify after T3. |
 | `gemini` | `wired-native` | `providers-extended` native dispatch and literal `LLMProvider` impl. | Keep gated native module. |
 | `gigachat` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
-| `github` | `demote-to-catalog` | Catalog-backed `ProviderType::GitHub`; native provider still exported. | Prove catalog equivalence, then delete native directory and shrink baseline. |
+| `github` | `demote-to-catalog` | Maintainer approved Path A; catalog-backed `ProviderType::GitHub` coexists with exported native provider. | T13 preserves `GITHUB_MODELS_API_BASE` and model/pricing/capability/health; T14 demotes after T9. |
 | `github_copilot` | `wired-native` | `providers-extended` native dispatch and literal `LLMProvider` impl. | Keep gated native module. |
 | `google_pse` | `delete-native` | Search provider declares `ProviderCapability::ChatCompletion` through an `LLMProvider` surface but has no native LLM dispatch. | Delete or reclassify after T3. |
 | `gradient_ai` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
@@ -134,13 +166,13 @@ This matrix covers every directory currently under `src/core/providers`. The lan
 | `langgraph` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
 | `macros` | `keep-infra` | Macro definitions only; guard ignores definitions and scans invocations in provider directories. | Keep. |
 | `manus` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
-| `meta_llama` | `demote-to-catalog` | Catalog-backed `ProviderType::MetaLlama`; native provider still exported under `providers-extra`. | Prove catalog equivalence, then delete native directory and shrink baseline. |
+| `meta_llama` | `demote-to-catalog` | Maintainer approved extended provider-scoped catalog policy; exported native module remains under `providers-extra`. | T15 proves auth/identity/filtering/streaming/model/capability equivalence; T16 demotes after T9. |
 | `milvus` | `non-llm-lane` | Vector-store provider exposes literal `LLMProvider` impl but is outside LLM factory dispatch. | Decide vector product lane before delete/wire. |
 | `mistral` | `wired-native` | Native enum/factory dispatch and literal `LLMProvider` impl. | Keep wired module. |
 | `morph` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
 | `nlp_cloud` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
 | `oci` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
-| `ollama` | `demote-to-catalog` | OpenAI-compatible local provider candidate, but no current catalog-backed `ProviderType` route was found. | Requires T3 approval before adding catalog runtime behavior or deleting native code. |
+| `ollama` | `wired-native` | Maintainer selected existing native protocol; current source-boundary ledger still exempts its unwired raw-HTTP path. | T19 hardens ordinary/streaming endpoint policy and removes the exception; T20 then wires core dispatch. |
 | `openai` | `wired-native` | Native enum/factory dispatch and literal `LLMProvider` impl. | Keep wired module. |
 | `openai_like` | `keep-infra` | Shared OpenAI-compatible runtime provider used by explicit and catalog paths. | Keep shared runtime module. |
 | `petals` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
@@ -161,7 +193,7 @@ This matrix covers every directory currently under `src/core/providers`. The lan
 | `thinking` | `keep-infra` | Shared reasoning trait support. | Keep. |
 | `topaz` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
 | `triton` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch. | Delete or reclassify after T3. |
-| `v0` | `demote-to-catalog` | Catalog-backed `ProviderType::V0`; native provider still exported under `providers-extra`. | Prove catalog equivalence, then delete native directory and shrink baseline. |
+| `v0` | `demote-to-catalog` | Maintainer approved Path A only after authoritative catalog data replaces the current no-model/zero-cost state; native module remains exported. | T17 proves aliases/model metadata/pricing/health/error policy; T18 demotes after T9. |
 | `vercel_ai` | `delete-native` | `providers-extended` public module with literal `LLMProvider` impl; no native dispatch; auth/endpoint behavior requires explicit decision. | Delete or reclassify after T3. |
 | `vertex_ai` | `wired-native` | `providers-extra` native dispatch and literal `LLMProvider` impl. | Keep gated native module. |
 | `voyage` | `non-llm-lane` | Embedding provider exposes literal `LLMProvider` impl. | Decide embedding product lane before delete/wire. |
@@ -171,16 +203,53 @@ This matrix covers every directory currently under `src/core/providers`. The lan
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| P2 wire 可达 | factory/enum | conformance 测试 + 单测构造 |
-| P3 delete 干净 | providers/mod.rs | `cargo check --all-features` + `rg` 无 dangling mod |
-| P4 demote 等价 | catalog.rs + native dir removal | catalog smoke 测试（base_url/env key/alternate env/capability/non-chat endpoint）+ 无重复 native impl |
-| P5 守护常驻 | registry conformance test | CI 上人为引入 literal impl 与 macro provider 孤儿目录的负测试 |
-| P7 public API | providers/mod.rs / CHANGELOG | 删除导出模块前有 semver/compatibility 记录 |
-| P9 non-LLM 范围 | capability scan / matrix | image/video/translation/embedding-only provider 未进入 LLM delete lane |
+| B-001 approval before deletion | historical matrix / issue approval evidence | T2 full per-row evidence + T3 full-matrix approval; both remain open |
+| B-002 native wiring | endpoint policy + enum/factory/registry/dispatch | T19 hardening/source guard, then T20 constructibility |
+| B-003 clean deletion | provider dirs / `mod.rs` / lifecycle | all-feature check/test + provider-specific no-reference commands |
+| B-004 catalog equivalence | `registry/catalog.rs` + provider policy tests | T11/T13/T15/T17 policy tests, then T12/T14/T16/T18 |
+| B-005 persistent guard | `registry/lifecycle_tests.rs` | registry test suite and final T7 audit |
+| B-006 bounded deletion | per-provider PR diff | file/line scope evidence in each demotion/removal PR |
+| B-007 public API compatibility | deprecation attrs / CHANGELOG / migration / workflow | public API compatibility test + version-bump guard |
+| B-008 custom_api lane | `custom_api/**` + lifecycle | T21 deprecation and T23 no-reference/removal checks |
+| B-009 non-LLM boundary | capability scan / approved matrix | matrix lane check; no remaining-six task changes non-LLM providers |
+| B-010 ordered demotions | task dependencies + per-provider PRs | T11→T9→T12, T13→T9→T14, T15→T9→T16, T17→T9→T18 |
+| B-011 provider-specific equivalence | named catalog policy tests | Amazon/GitHub/Meta/V0 assertions in T11/T13/T15/T17 |
+| B-012 Ollama native only | `ollama/**`, endpoint policy, source guard, core dispatch | T19 hardening → T20 exact-head safety-gate rerun + wiring/constructibility/catalog absence |
+| B-013 custom_api release order | public API test / workflow guard / compatibility / removal | T21→T22→T9→T23 |
+| B-014 delivery granularity and closure | PR scope evidence / task graph | B-006-counted ≤500 gate, provider isolation, open T2/T3, then T7→T8 |
+
+## Planned Changes Manifest
+
+| Path or path scope | Intended change | Task ownership |
+| --- | --- | --- |
+| `src/core/providers/amazon_nova/**` | 0.6 deprecation/equivalence fixtures, then pure native removal | T11, then T12 |
+| `src/core/providers/github/**` | 0.6 deprecation/equivalence fixtures, then pure native removal | T13, then T14 |
+| `src/core/providers/meta_llama/**` | 0.6 deprecation/equivalence fixtures, then pure native removal | T15, then T16 |
+| `src/core/providers/v0/**` | 0.6 deprecation/equivalence fixtures, then pure native removal | T17, then T18 |
+| `src/core/providers/ollama/**` | policy-aware ordinary/streaming HTTP, then native wiring/tests | T19, then T20 |
+| `src/core/providers/custom_api/**` | 0.6 deprecation, then 0.7 pure native removal | T21, then T23 |
+| `src/core/providers/mod.rs` | deprecation exports, Ollama construction surface, later provider export removals | T11–T21, T23 |
+| `src/core/providers/base/{http.rs,connection_pool.rs}` | policy-aware request helpers used by Ollama ordinary/streaming paths | T19 |
+| `src/core/providers/base/http/source_boundary_tests.rs` | remove Ollama unwired raw-HTTP exception | T19 |
+| `src/core/providers/factory/{mod.rs,registry.rs,builder.rs,endpoint_policy.rs,endpoint_access_tests.rs}` | Ollama endpoint authority tests and native construction/dispatch | T19, T20 |
+| `src/core/providers/registry/catalog.rs` | four provider-scoped catalog policies/tests; explicit no-Ollama policy | T11, T13, T15, T17 |
+| `src/core/providers/registry/{types.rs,support_matrix.rs}` | Ollama `ProviderType`/registry wiring and support metadata | T20 |
+| `src/core/providers/registry/{lifecycle.rs,lifecycle_tests.rs}` | shrink duplicate/orphan baselines and preserve guard assertions | T12, T14, T16, T18, T20, T23 |
+| `tests/public_api_compat.rs` | compile/deprecation compatibility assertions for 0.6 surfaces | T11, T13, T15, T17, T21 |
+| `.github/workflows/version-bump.yml` | explicit breaking 0.7 bump mode and guard invocation | T22 |
+| `scripts/guards/check_version_bump.sh` | deterministic, side-effect-free workflow/version policy checks | T22 |
+| `CHANGELOG.md` | 0.6 deprecations, 0.7 removals and Ollama user-visible change | T11, T13, T15, T17, T20, T21, T23 |
+| `docs/providers/GH837-migration-0.6-to-0.7.md` | migration guidance and alternatives for removed public surfaces | T11, T13, T15, T17, T21, T23 |
+| `README.md` | final provider capability synchronization | T7 |
+| `CLAUDE.md` | final provider architecture/capability synchronization | T7 |
+| `specs/GH837/{product.md,tech.md,tasks.md}` | this task-granularity amendment and later evidence-only status updates | current amendment, T7/T8 |
 
 ## 数据流
 
-无运行时数据流变化；delete/demote 仅移除不可达代码路径。
+T19 first moves Ollama ordinary/streaming traffic behind the policy-aware client so configured `api_base` and
+private-network authority are revalidated on every path; only then T20 makes `ProviderType::Ollama` constructible
+through factory/dispatch. The four catalog policies change metadata/selection only after provider-specific tests;
+T9 then gates all duplicate-native removals. `custom_api` remains callable in 0.6 and is removed only after T9.
 
 ## 备选方案
 
@@ -190,20 +259,28 @@ This matrix covers every directory currently under `src/core/providers`. The lan
 
 ## 风险
 
-- Security: 无；删除减少攻击面。
-- Compatibility: gateway routing 不受不可达 native module 删除影响；但 `pub mod` 导出的 provider 可能被下游 crate
-  直接 import/instantiate，删除属于潜在 public API break，必须逐 tranche 记录 semver/compatibility 决策。
-- Performance: 编译时间预期显著下降（删除数万行 + 各目录 tests）。
-- Maintenance: 主要风险是误删 keep-infra 依赖，靠 `cargo check --all-features` 与全量测试兜底。
+- Security: policy tests 只验证 env-key contract，不记录真实 token；workflow guard 不执行 release。
+- Compatibility: 五个公开 surface 的 removal 是明确的 0.7 breaking change。0.6 deprecation 与 migration
+  notes 不得被跳过，且 `github_copilot` 不受 `github` demotion 影响。
+- Behavior: catalog policy 缺失数据时存在 silent degradation 风险，尤其 `v0` 的 no-model/zero-cost
+  当前状态；因此缺数据必须 hard-fail equivalence，不能 fallback 后继续 demote。
+- Performance: duplicate native removal 预期降低编译/review 面；`ollama` wiring 会增加一条可达 native path。
+- Maintenance: shared catalog/lifecycle/docs files 形成并行冲突面；coordinator 必须串行安排相交 ownership。
 
 ## 测试计划
 
-- [ ] Unit tests: conformance 守护测试（含豁免清单机制、macro-generated provider fixture、
-      catalog/native duplicate fixture）。
-- [ ] Integration tests: demote 后 catalog smoke 测试。
-- [ ] Manual verification: 处置矩阵逐行与 construction/dispatch/public-export/capability 证据核对；
-      raw text hits 不作为通过条件。
+- [x] Existing guard: conformance 守护测试（含 macro provider、catalog/native duplicate 和 baseline）。
+- [ ] Catalog unit tests: 四个 provider 分别测试 B-011，不使用共享的“catalog entry exists”弱断言。
+- [ ] Ollama hardening tests: ordinary/streaming policy-aware client、`api_base`、SSRF/private-network authority、
+      raw-HTTP exception absence 与 `check_outbound_http_clients.sh`。
+- [ ] Native unit/integration tests: hardening 后的 Ollama construct/request/response/streaming，外加 catalog absence 负断言。
+- [ ] Compatibility tests: 0.6 public imports 仍编译并带 deprecation；0.7 removal 后无 dangling references。
+- [ ] Workflow tests: breaking 0.7 mode 通过，patch/minor disguise 失败，且测试无 release side effect。
+- [ ] Full verification: T7 guard/docs closure 后执行 T8 fmt/clippy/test/build/timings。
 
 ## 回滚方案
 
-删除类 PR 逐个 revert 即可恢复；git history 保留全部实现。守护测试可通过豁免清单临时放行。
+每个 provider/task 一个 PR，因此可逐 provider revert。0.6 policy/deprecation PR 与后续 0.7 removal PR
+分离：equivalence 或 workflow gate 失败时不启动 removal，而不是放宽测试。已发布 0.7 的 API removal
+不能靠 silent re-export 回滚；需要新版本、CHANGELOG 与 migration update。Ollama hardening/wiring 可按 T20、T19 顺序独立 revert，
+不影响四个 catalog policy 或 `custom_api` release chain。


### PR DESCRIPTION
## Summary

- reconcile the approved remaining-six GH837 decisions with the current packet
- preserve the historical 66-directory matrix without claiming full approval
- split catalog preparation, compatibility gates, removals, and Ollama hardening/wiring into stable tasks

Refs #837

## Scope

This spec-only PR changes exactly:

- `specs/GH837/product.md`
- `specs/GH837/tech.md`
- `specs/GH837/tasks.md`

It does not change production code, tests, workflows, provider lifecycle state, or release behavior.

## Key gates

- `SP837-T2` and `SP837-T3` remain open for the historical full-matrix evidence and approval
- four catalog providers require 0.6 preparation, T9 compatibility evidence, and only then 0.7 removal
- Ollama endpoint-policy/raw-HTTP hardening must merge before native wiring, and wiring reruns the safety gates
- `custom_api` requires 0.6 deprecation, the breaking-version workflow gate, and only then 0.7 removal
- each implementation task keeps the GH837 500 non-doc-line hard cap and one-provider-per-PR boundary

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir "$PWD/specs/GH837"` — passed
- full repository SpecRail check — passed
- historical matrix row count — 66
- B-ID mapping — 14/14
- task graph — 23 unique IDs, no missing dependencies, acyclic
- `git diff --check origin/main...HEAD` — passed
- exact scope — 3 docs files, `+202/-83`
- independent exact-head review at `ee649ef85be3a983655e43b5e5402adf8e394a13` — PASS
