### PR TITLE
feat(providers): add Amazon Nova catalog policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking behavior: runtime requests for unpriced models now fail closed by default even when `pricing.allow_degraded=true`; deployments that intentionally allow unpriced traffic must set `pricing.unpriced_model_policy=allow_unpriced` and configure a finite `pricing.unpriced_fallback_cost_per_1k_tokens`.
 
 ### Deprecated
+- Deprecated the `providers-extended` public `amazon_nova` native module for the 0.6.0 line while preserving its symbols, constructors, and runtime behavior. The catalog policy now records the same Amazon Nova endpoint/auth contract, five canonical models, token pricing, multimodal/tool metadata, and provider capabilities as the native implementation. Direct Rust imports should migrate to the `amazon_nova` catalog selector before the planned 0.7.0 native demotion; see `docs/providers/GH837-migration-0.6-to-0.7.md`.
 - Deprecated the `providers-extended` public `custom_api` module and its `CustomHttpxConfig`, `CustomApiErrorMapper`, and `CustomHttpxProvider` exports for the 0.6.0 line. Existing symbols, signatures, and runtime behavior remain available in 0.6.x, but arbitrary URL/method/template/parser support is no longer a product goal and the surface is scheduled for removal in 0.7.0. See `docs/providers/GH837-migration-0.6-to-0.7.md` for alternatives.
 
 ### Removed

--- a/docs/providers/GH837-migration-0.6-to-0.7.md
+++ b/docs/providers/GH837-migration-0.6-to-0.7.md
@@ -19,10 +19,11 @@ Catalog route 保留 native 的固定 endpoint
 `AMAZON_NOVA_API_KEY` contract，并只声明 native provider 已实现的 chat、
 streaming chat 与 tool-calling capabilities。
 
-Catalog policy 以 native registry 为权威，保留五个 canonical model：
-Nova 2 Lite、Pro、Lite、Micro 与 Premier，以及各自的 context/output limits、
-token pricing、tool 和 multimodal metadata。缺少其中任一项都不满足后续
-0.7.0 demotion gate。
+Catalog policy 是模型、能力、价格与 alias 的唯一权威；保留的 native registry
+仅是 0.6 compatibility projection。Catalog 保留五个 canonical model：Nova 2
+Lite、Pro、Lite、Micro 与 Premier，以及各自的 context/output limits、token
+pricing、tool 和 multimodal metadata。缺少其中任一项都不满足后续 0.7.0
+demotion gate。
 
 ### 迁移
 

--- a/docs/providers/GH837-migration-0.6-to-0.7.md
+++ b/docs/providers/GH837-migration-0.6-to-0.7.md
@@ -1,6 +1,39 @@
-# `custom_api` 0.6 → 0.7 迁移
+# GH837 provider 0.6 → 0.7 迁移
 
-## 时间线
+## `amazon_nova`
+
+### 时间线
+
+- 0.6.x：`providers-extended` 下的 native `amazon_nova` module 已标记
+  deprecated，但 `AmazonNovaConfig`、`AmazonNovaErrorMapper`、
+  `AmazonNovaModel`、`AmazonNovaModelRegistry` 与 `AmazonNovaProvider`
+  的公开 symbol、构造签名和既有运行时行为保持不变。
+- 0.7.0：在 version workflow 与 public compatibility gate 通过后，移除
+  duplicate native module，保留 `amazon_nova` catalog route。这是公开 Rust
+  API 的 breaking change，不是运行时 provider 降级。
+
+### Catalog 等价策略
+
+Catalog route 保留 native 的固定 endpoint
+`https://api.nova.amazon.com/v1`、Bearer auth 与
+`AMAZON_NOVA_API_KEY` contract，并只声明 native provider 已实现的 chat、
+streaming chat 与 tool-calling capabilities。
+
+Catalog policy 以 native registry 为权威，保留五个 canonical model：
+Nova 2 Lite、Pro、Lite、Micro 与 Premier，以及各自的 context/output limits、
+token pricing、tool 和 multimodal metadata。缺少其中任一项都不满足后续
+0.7.0 demotion gate。
+
+### 迁移
+
+通过 gateway/provider configuration 使用 `amazon_nova` selector 的调用方无需
+更改 selector。直接 import native Rust types 的下游 crate 应在 0.7.0 前迁移到
+registry/catalog construction path；不要复制 native module 或依赖其内部 macro
+实现。
+
+## `custom_api`
+
+### 时间线
 
 - 0.6.x：`providers-extended` 下的 `custom_api` module、`CustomHttpxConfig`、
   `CustomApiErrorMapper` 与 `CustomHttpxProvider` 已标记 deprecated。公开
@@ -8,13 +41,13 @@
 - 0.7.0：在 version workflow 与 public compatibility gate 通过后，删除该公开
   module 和 native implementation。这是明确的 breaking change。
 
-## 产品边界
+### 产品边界
 
 把任意 URL、任意 HTTP method、自由格式 request template 或任意 response parser
 组合成 provider，不再是 LiteLLM-RS 的产品目标。0.6.x 的 deprecation 不扩展、
 修补或承诺这些通用适配能力，也不改变现有 dispatch；它只提供迁移窗口。
 
-## 替代方案
+### 替代方案
 
 1. 对 OpenAI-compatible endpoint，使用 registry/catalog 支持的 provider；
    若目标尚未收录，提交带固定 endpoint、认证环境变量、模型与 capability metadata

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -325,22 +325,16 @@ fn get_bedrock_pricing(model: &str) -> Result<ModelPricing, CostError> {
 }
 
 fn get_amazon_nova_pricing(model: &str) -> Result<ModelPricing, CostError> {
-    #[cfg(feature = "providers-extended")]
-    {
-        let registry = crate::core::providers::amazon_nova::AmazonNovaModelRegistry::new();
-        if let Some(model_info) = registry.get(model) {
-            return Ok(ModelPricing {
-                model: model_info.id.clone(),
-                input_cost_per_1k_tokens: model_info.input_cost_per_1k,
-                output_cost_per_1k_tokens: model_info.output_cost_per_1k,
-                ..Default::default()
-            });
-        }
-    }
-
-    Err(CostError::ModelNotSupported {
-        model: model.to_string(),
-        provider: "amazon_nova".to_string(),
+    let entry = crate::core::providers::registry::catalog::amazon_nova_catalog_model(model)
+        .ok_or_else(|| CostError::ModelNotSupported {
+            model: model.to_string(),
+            provider: "amazon_nova".to_string(),
+        })?;
+    Ok(ModelPricing {
+        model: entry.model_id.to_string(),
+        input_cost_per_1k_tokens: entry.input_cost_per_million / 1_000.0,
+        output_cost_per_1k_tokens: entry.output_cost_per_million / 1_000.0,
+        ..Default::default()
     })
 }
 

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -191,7 +191,6 @@ fn amazon_nova_fallback_pricing_prefers_catalog_over_shared_bedrock() {
         assert_eq!(pricing.input_cost_per_1k_tokens, 0.0008);
     }
 }
-
 fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
     PricingUsage {
         prompt_tokens: usage.prompt_tokens,

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -124,11 +124,7 @@ fn get_fallback_model_pricing(model: &str, provider: &str) -> Result<ModelPricin
             get_pricing_with_shared_source(model, &["gemini", "vertex_ai"], get_vertex_ai_pricing)
         }
         "bedrock" => get_pricing_with_shared_source(model, &["bedrock"], get_bedrock_pricing),
-        "amazon_nova" => get_pricing_with_shared_source(
-            model,
-            &["amazon_nova", "bedrock"],
-            get_amazon_nova_pricing,
-        ),
+        "amazon_nova" => get_amazon_nova_pricing(model),
         "openai_like" => get_openai_like_pricing(model),
         "xai" => get_xai_pricing(model),
         "groq" => get_pricing_with_shared_source(model, &["groq"], |model| {
@@ -182,6 +178,17 @@ fn get_fallback_model_pricing(model: &str, provider: &str) -> Result<ModelPricin
         _ => Err(CostError::ProviderNotSupported {
             provider: provider.to_string(),
         }),
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn amazon_nova_fallback_pricing_prefers_catalog_over_shared_bedrock() {
+    assert!(get_shared_model_pricing("amazon.nova-pro-v1:0", &["bedrock"]).is_some());
+    for model in ["amazon.nova-pro-v1:0", "nova-pro"] {
+        let pricing = get_fallback_model_pricing(model, "amazon_nova").unwrap();
+        assert_eq!(pricing.model, "amazon.nova-pro-v1:0");
+        assert_eq!(pricing.input_cost_per_1k_tokens, 0.0008);
     }
 }
 

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -196,6 +196,9 @@ fn resolve_model_info_for_provider(
     model: &str,
 ) -> Option<(String, LiteLLMModelInfo)> {
     let normalized_provider = crate::core::pricing::normalize_pricing_provider(provider);
+    if normalized_provider == "amazon_nova" {
+        return amazon_nova_pricing_model_info(model);
+    }
     if normalized_provider == "openai_like"
         && let Some((prefixed_provider, stripped_model)) = provider_prefixed_model(model)
     {
@@ -265,44 +268,18 @@ fn provider_catalog_model_info(
                     core_pricing_to_litellm_model_info("bedrock", pricing),
                 )
             }),
-        "amazon_nova" => amazon_nova_pricing_model_info(model),
         "xai" => xai_pricing_model_info(model),
         _ => None,
     }
 }
 
-#[cfg(feature = "providers-extended")]
 fn amazon_nova_pricing_model_info(model: &str) -> Option<(String, LiteLLMModelInfo)> {
-    let registry = crate::core::providers::amazon_nova::AmazonNovaModelRegistry::new();
-    let model = registry.get(model)?;
-    let resolved_model = model.id.clone();
-
+    let info = crate::core::providers::registry::catalog::amazon_nova_catalog_model_info(model)?;
+    let resolved_model = info.id.clone();
     Some((
         resolved_model,
-        LiteLLMModelInfo {
-            max_tokens: Some(model.context_length),
-            max_input_tokens: Some(model.context_length),
-            max_output_tokens: Some(model.max_output_tokens),
-            input_cost_per_token: Some(model.input_cost_per_1k / 1000.0),
-            output_cost_per_token: Some(model.output_cost_per_1k / 1000.0),
-            input_cost_per_character: None,
-            output_cost_per_character: None,
-            cost_per_second: None,
-            litellm_provider: "amazon_nova".to_string(),
-            mode: "chat".to_string(),
-            supports_function_calling: Some(model.supports_tools),
-            supports_vision: Some(model.supports_vision),
-            supports_streaming: Some(model.supports_streaming),
-            supports_parallel_function_calling: Some(model.supports_tools),
-            supports_system_message: Some(true),
-            extra: HashMap::new(),
-        },
+        model_info_to_litellm_model_info("amazon_nova", info),
     ))
-}
-
-#[cfg(not(feature = "providers-extended"))]
-fn amazon_nova_pricing_model_info(_model: &str) -> Option<(String, LiteLLMModelInfo)> {
-    None
 }
 
 fn xai_pricing_model_info(model: &str) -> Option<(String, LiteLLMModelInfo)> {
@@ -705,6 +682,41 @@ fn extract_tier_threshold(key: &str) -> Option<u32> {
         number.parse::<u32>().ok().map(|value| value * 1000)
     } else {
         threshold.parse::<u32>().ok()
+    }
+}
+
+#[cfg(test)]
+mod amazon_nova_catalog_authority_tests {
+    use super::*;
+
+    #[test]
+    fn amazon_nova_catalog_authority_is_feature_independent() {
+        let Ok(service) = PricingService::with_embedded_default() else {
+            panic!("embedded pricing service must initialize");
+        };
+        for model in ["amazon.nova-pro-v1:0", "nova-pro"] {
+            let Some((resolved, info)) = service.get_model_info_for_provider("amazon_nova", model)
+            else {
+                panic!("Amazon Nova catalog authority must resolve {model}");
+            };
+            assert_eq!(resolved, "amazon.nova-pro-v1:0");
+            assert!((info.input_cost_per_token.unwrap_or_default() - 0.000_000_8).abs() < 1e-15);
+            assert!((info.output_cost_per_token.unwrap_or_default() - 0.000_003_2).abs() < 1e-15);
+
+            let Ok(pricing) =
+                crate::core::cost::calculator::get_model_pricing(model, "amazon_nova")
+            else {
+                panic!("core cost calculator must resolve {model}");
+            };
+            assert_eq!(pricing.model, "amazon.nova-pro-v1:0");
+            assert_eq!(pricing.input_cost_per_1k_tokens, 0.0008);
+            assert_eq!(pricing.output_cost_per_1k_tokens, 0.0032);
+        }
+        assert!(
+            service
+                .get_model_info_for_provider("amazon_nova", "unknown-nova")
+                .is_none()
+        );
     }
 }
 

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -691,26 +691,13 @@ mod amazon_nova_catalog_authority_tests {
 
     #[test]
     fn amazon_nova_catalog_authority_is_feature_independent() {
-        let Ok(service) = PricingService::with_embedded_default() else {
-            panic!("embedded pricing service must initialize");
-        };
+        let service = PricingService::with_embedded_default().unwrap();
         for model in ["amazon.nova-pro-v1:0", "nova-pro"] {
-            let Some((resolved, info)) = service.get_model_info_for_provider("amazon_nova", model)
-            else {
-                panic!("Amazon Nova catalog authority must resolve {model}");
-            };
+            let (resolved, info) = service
+                .get_model_info_for_provider("amazon_nova", model)
+                .unwrap();
             assert_eq!(resolved, "amazon.nova-pro-v1:0");
-            assert!((info.input_cost_per_token.unwrap_or_default() - 0.000_000_8).abs() < 1e-15);
-            assert!((info.output_cost_per_token.unwrap_or_default() - 0.000_003_2).abs() < 1e-15);
-
-            let Ok(pricing) =
-                crate::core::cost::calculator::get_model_pricing(model, "amazon_nova")
-            else {
-                panic!("core cost calculator must resolve {model}");
-            };
-            assert_eq!(pricing.model, "amazon.nova-pro-v1:0");
-            assert_eq!(pricing.input_cost_per_1k_tokens, 0.0008);
-            assert_eq!(pricing.output_cost_per_1k_tokens, 0.0032);
+            assert_eq!(info.max_output_tokens, Some(5_000));
         }
         assert!(
             service

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -688,7 +688,6 @@ fn extract_tier_threshold(key: &str) -> Option<u32> {
 #[cfg(test)]
 mod amazon_nova_catalog_authority_tests {
     use super::*;
-
     #[test]
     fn amazon_nova_catalog_authority_is_feature_independent() {
         let service = PricingService::with_embedded_default().unwrap();
@@ -698,6 +697,9 @@ mod amazon_nova_catalog_authority_tests {
                 .unwrap();
             assert_eq!(resolved, "amazon.nova-pro-v1:0");
             assert_eq!(info.max_output_tokens, Some(5_000));
+            let expected = "High-capability multimodal model for complex tasks";
+            assert_eq!(info.extra["description"], expected);
+            assert_eq!(info.extra["supports_reasoning"], true);
         }
         assert!(
             service
@@ -706,7 +708,6 @@ mod amazon_nova_catalog_authority_tests {
         );
     }
 }
-
 #[cfg(test)]
 #[path = "authority_tests.rs"]
 mod tests;

--- a/src/core/providers/amazon_nova/mod.rs
+++ b/src/core/providers/amazon_nova/mod.rs
@@ -1,10 +1,7 @@
 //! Amazon Nova Provider
 //!
 //! Provider for Amazon Nova multimodal models using an OpenAI-compatible API.
-//!
-//! The native public module is deprecated in 0.6.0 and remains fully
-//! operational until the planned 0.7.0 catalog demotion. See
-//! `docs/providers/GH837-migration-0.6-to-0.7.md`.
+//! Deprecated in 0.6.0; operational until the planned 0.7.0 catalog demotion.
 
 pub mod config;
 pub mod error;

--- a/src/core/providers/amazon_nova/mod.rs
+++ b/src/core/providers/amazon_nova/mod.rs
@@ -1,7 +1,10 @@
 //! Amazon Nova Provider
 //!
-//! Provider for Amazon Nova multimodal models
-//! Amazon Nova uses OpenAI-compatible API format
+//! Provider for Amazon Nova multimodal models using an OpenAI-compatible API.
+//!
+//! The native public module is deprecated in 0.6.0 and remains fully
+//! operational until the planned 0.7.0 catalog demotion. See
+//! `docs/providers/GH837-migration-0.6-to-0.7.md`.
 
 pub mod config;
 pub mod error;

--- a/src/core/providers/amazon_nova/models.rs
+++ b/src/core/providers/amazon_nova/models.rs
@@ -4,6 +4,11 @@
 
 use std::collections::HashMap;
 
+use crate::core::providers::registry::catalog::{
+    AMAZON_NOVA_CATALOG_MODELS, AMAZON_NOVA_MODEL_ALIASES, AMAZON_NOVA_SUPPORTS_STREAMING,
+    AMAZON_NOVA_SUPPORTS_TOOLS, AmazonNovaCatalogModel,
+};
+
 /// Amazon Nova model definition
 #[derive(Debug, Clone)]
 pub struct AmazonNovaModel {
@@ -32,6 +37,22 @@ pub struct AmazonNovaModel {
 }
 
 impl AmazonNovaModel {
+    fn from_catalog(entry: &AmazonNovaCatalogModel) -> Self {
+        Self {
+            id: entry.model_id.to_string(),
+            name: entry.display_name.to_string(),
+            description: entry.description.to_string(),
+            context_length: entry.max_context_length,
+            max_output_tokens: entry.max_output_length,
+            input_cost_per_1k: entry.input_cost_per_million / 1_000.0,
+            output_cost_per_1k: entry.output_cost_per_million / 1_000.0,
+            supports_vision: entry.supports_multimodal,
+            supports_tools: AMAZON_NOVA_SUPPORTS_TOOLS,
+            supports_reasoning: entry.supports_reasoning,
+            supports_streaming: AMAZON_NOVA_SUPPORTS_STREAMING,
+        }
+    }
+
     /// Create a new Amazon Nova model definition
     pub fn new(
         id: &str,
@@ -97,99 +118,19 @@ impl AmazonNovaModelRegistry {
     /// Create a new model registry with default models
     pub fn new() -> Self {
         let mut models = HashMap::new();
-
-        // Nova 2 Lite - Bedrock runtime multimodal model
-        let nova_2_lite = AmazonNovaModel::new(
-            "amazon.nova-2-lite-v1:0",
-            "Amazon Nova 2 Lite",
-            "Cost-efficient multimodal model for automation, documents, and support",
-            1_000_000,
-            64_000,
-        )
-        .with_pricing(0.0003, 0.0025)
-        .with_vision()
-        .with_reasoning();
-        models.insert("amazon.nova-2-lite-v1:0".to_string(), nova_2_lite.clone());
-
-        // Nova Pro - High capability model
-        models.insert(
-            "amazon.nova-pro-v1:0".to_string(),
-            AmazonNovaModel::new(
-                "amazon.nova-pro-v1:0",
-                "Amazon Nova Pro",
-                "High-capability multimodal model for complex tasks",
-                300000,
-                5000,
-            )
-            .with_pricing(0.0008, 0.0032)
-            .with_vision()
-            .with_reasoning(),
-        );
-
-        // Nova Lite - Cost-effective model
-        models.insert(
-            "amazon.nova-lite-v1:0".to_string(),
-            AmazonNovaModel::new(
-                "amazon.nova-lite-v1:0",
-                "Amazon Nova Lite",
-                "Cost-effective multimodal model for everyday tasks",
-                300000,
-                5000,
-            )
-            .with_pricing(0.00006, 0.00024)
-            .with_vision(),
-        );
-
-        // Nova Micro - Fast text-only model
-        models.insert(
-            "amazon.nova-micro-v1:0".to_string(),
-            AmazonNovaModel::new(
-                "amazon.nova-micro-v1:0",
-                "Amazon Nova Micro",
-                "Fast text-only model optimized for speed",
-                128000,
-                5000,
-            )
-            .with_pricing(0.000035, 0.00014),
-        );
-
-        // Nova Premier - Most capable model (upcoming)
-        models.insert(
-            "amazon.nova-premier-v1:0".to_string(),
-            AmazonNovaModel::new(
-                "amazon.nova-premier-v1:0",
-                "Amazon Nova Premier",
-                "Most capable model for complex reasoning and multimodal tasks",
-                1000000,
-                10000,
-            )
-            .with_pricing(0.0025, 0.0125)
-            .with_vision()
-            .with_reasoning(),
-        );
-
-        // Also register simplified names (keys were inserted above, so expect is safe)
-        let nova_pro = models
-            .get("amazon.nova-pro-v1:0")
-            .expect("nova-pro-v1:0 was just inserted")
-            .clone();
-        let nova_lite = models
-            .get("amazon.nova-lite-v1:0")
-            .expect("nova-lite-v1:0 was just inserted")
-            .clone();
-        let nova_micro = models
-            .get("amazon.nova-micro-v1:0")
-            .expect("nova-micro-v1:0 was just inserted")
-            .clone();
-        let nova_premier = models
-            .get("amazon.nova-premier-v1:0")
-            .expect("nova-premier-v1:0 was just inserted")
-            .clone();
-        models.insert("nova-2-lite".to_string(), nova_2_lite);
-        models.insert("nova-pro".to_string(), nova_pro);
-        models.insert("nova-lite".to_string(), nova_lite);
-        models.insert("nova-micro".to_string(), nova_micro);
-        models.insert("nova-premier".to_string(), nova_premier);
+        for entry in AMAZON_NOVA_CATALOG_MODELS {
+            models.insert(
+                entry.model_id.to_string(),
+                AmazonNovaModel::from_catalog(entry),
+            );
+        }
+        for (alias, canonical) in AMAZON_NOVA_MODEL_ALIASES {
+            let model = models
+                .get(*canonical)
+                .unwrap_or_else(|| panic!("missing catalog model {canonical}"))
+                .clone();
+            models.insert((*alias).to_string(), model);
+        }
 
         Self { models }
     }
@@ -264,6 +205,30 @@ mod tests {
         assert!(registry.is_supported("amazon.nova-pro-v1:0"));
         assert!(registry.is_supported("amazon.nova-lite-v1:0"));
         assert!(registry.is_supported("amazon.nova-micro-v1:0"));
+    }
+
+    #[test]
+    fn amazon_nova_native_registry_is_exact_catalog_authority_projection() {
+        let registry = AmazonNovaModelRegistry::new();
+        let native_models = registry.list_models();
+        let native_ids: std::collections::HashSet<_> = native_models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect();
+        let catalog_ids: std::collections::HashSet<_> = AMAZON_NOVA_CATALOG_MODELS
+            .iter()
+            .map(|entry| entry.model_id)
+            .collect();
+        assert_eq!(native_ids.len(), native_models.len());
+        assert_eq!(catalog_ids.len(), AMAZON_NOVA_CATALOG_MODELS.len());
+        assert_eq!(native_ids, catalog_ids);
+
+        for (alias, canonical) in AMAZON_NOVA_MODEL_ALIASES {
+            assert_eq!(
+                registry.get(alias).map(|model| model.id.as_str()),
+                Some(*canonical)
+            );
+        }
     }
 
     #[test]

--- a/src/core/providers/amazon_nova/models.rs
+++ b/src/core/providers/amazon_nova/models.rs
@@ -51,7 +51,6 @@ impl AmazonNovaModel {
             supports_streaming: AMAZON_NOVA_SUPPORTS_STREAMING,
         }
     }
-
     /// Create a new Amazon Nova model definition
     pub fn new(
         id: &str,
@@ -244,7 +243,6 @@ mod tests {
             );
         }
     }
-
     #[test]
     fn test_model_registry_aliases() {
         let registry = AmazonNovaModelRegistry::new();

--- a/src/core/providers/amazon_nova/models.rs
+++ b/src/core/providers/amazon_nova/models.rs
@@ -8,7 +8,6 @@ use crate::core::providers::registry::catalog::{
     AMAZON_NOVA_CATALOG_MODELS, AMAZON_NOVA_MODEL_ALIASES, AMAZON_NOVA_SUPPORTS_STREAMING,
     AMAZON_NOVA_SUPPORTS_TOOLS, AmazonNovaCatalogModel,
 };
-
 /// Amazon Nova model definition
 #[derive(Debug, Clone)]
 pub struct AmazonNovaModel {
@@ -210,19 +209,34 @@ mod tests {
     #[test]
     fn amazon_nova_native_registry_is_exact_catalog_authority_projection() {
         let registry = AmazonNovaModelRegistry::new();
-        let native_models = registry.list_models();
-        let native_ids: std::collections::HashSet<_> = native_models
-            .iter()
+        let native_ids: std::collections::HashSet<_> = registry
+            .list_models()
+            .into_iter()
             .map(|model| model.id.as_str())
             .collect();
         let catalog_ids: std::collections::HashSet<_> = AMAZON_NOVA_CATALOG_MODELS
             .iter()
             .map(|entry| entry.model_id)
             .collect();
-        assert_eq!(native_ids.len(), native_models.len());
+        assert_eq!(native_ids.len(), registry.list_models().len());
         assert_eq!(catalog_ids.len(), AMAZON_NOVA_CATALOG_MODELS.len());
         assert_eq!(native_ids, catalog_ids);
-
+        let native_aliases: std::collections::HashSet<_> = registry
+            .models
+            .keys()
+            .map(String::as_str)
+            .filter(|key| !catalog_ids.contains(key))
+            .collect();
+        let catalog_aliases: std::collections::HashSet<_> = AMAZON_NOVA_MODEL_ALIASES
+            .iter()
+            .map(|(alias, _)| *alias)
+            .collect();
+        assert_eq!(
+            native_aliases.len() + native_ids.len(),
+            registry.models.len()
+        );
+        assert_eq!(catalog_aliases.len(), AMAZON_NOVA_MODEL_ALIASES.len());
+        assert_eq!(native_aliases, catalog_aliases);
         for (alias, canonical) in AMAZON_NOVA_MODEL_ALIASES {
             assert_eq!(
                 registry.get(alias).map(|model| model.id.as_str()),

--- a/src/core/providers/amazon_nova/provider.rs
+++ b/src/core/providers/amazon_nova/provider.rs
@@ -255,20 +255,10 @@ impl AmazonNovaProvider {
 
     /// Normalize model name to full format
     fn normalize_model_name(&self, model: &str) -> String {
-        // If already fully qualified, return as-is
-        if model.starts_with("amazon.nova") {
-            return model.to_string();
-        }
-
-        // Map short names to full names
-        match model {
-            "nova-2-lite" => "amazon.nova-2-lite-v1:0".to_string(),
-            "nova-pro" => "amazon.nova-pro-v1:0".to_string(),
-            "nova-lite" => "amazon.nova-lite-v1:0".to_string(),
-            "nova-micro" => "amazon.nova-micro-v1:0".to_string(),
-            "nova-premier" => "amazon.nova-premier-v1:0".to_string(),
-            _ => model.to_string(),
-        }
+        crate::core::providers::registry::catalog::amazon_nova_catalog_model(model)
+            .map(|entry| entry.model_id)
+            .unwrap_or(model)
+            .to_string()
     }
 
     /// Transform Amazon Nova response to ChatResponse

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -12,7 +12,7 @@ pub mod base;
 // aleph_alpha: Tier 1 -> registry/catalog.rs
 #[cfg(feature = "providers-extended")]
 #[cfg_attr(
-    not(any(test, clippy)),
+    not(test),
     deprecated(since = "0.6.0", note = "use catalog amazon_nova before 0.7")
 )]
 pub mod amazon_nova;

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -11,6 +11,10 @@ pub mod base;
 // aiml_api: Tier 1 -> registry/catalog.rs
 // aleph_alpha: Tier 1 -> registry/catalog.rs
 #[cfg(feature = "providers-extended")]
+#[cfg_attr(
+    not(any(test, clippy)),
+    deprecated(since = "0.6.0", note = "use catalog amazon_nova before 0.7")
+)]
 pub mod amazon_nova;
 pub mod anthropic;
 // anyscale: Tier 1 -> registry/catalog.rs
@@ -110,7 +114,6 @@ pub use provider_type::ProviderType;
 // Factory: create_provider, from_config_async, config builders
 pub mod factory;
 pub use factory::{create_provider, is_provider_selector_supported};
-
 // Registry and unified provider
 pub mod contextual_error;
 pub mod failure;
@@ -118,11 +121,9 @@ pub mod provider_error_conversions;
 pub mod provider_registry;
 pub mod registry; // Data-driven Tier 1 provider catalog
 pub mod unified_provider;
-
 // Test modules (only compiled during tests)
 #[cfg(test)]
 mod unified_provider_tests;
-
 // Export main types
 pub use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::responses::{
@@ -136,7 +137,6 @@ pub use contextual_error::ContextualError;
 pub use failure::{ProviderFailureFacts, ProviderRetryHint};
 pub use provider_registry::ProviderRegistry;
 pub use unified_provider::ProviderError;
-
 #[derive(Debug, Clone)]
 pub(crate) struct GeminiNativeRequest {
     pub(crate) api_version: String,

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -567,7 +567,18 @@ impl OpenAILikeProvider {
 
     /// Get model information
     pub fn get_model_info(&self, model_id: &str) -> ModelInfo {
-        self.model_registry.get_model_info(model_id)
+        if self.provider_name == "amazon_nova"
+            && let Some(info) =
+                crate::core::providers::registry::catalog::amazon_nova_catalog_model_info(model_id)
+        {
+            return info;
+        }
+        let mut info = self.model_registry.get_model_info(model_id);
+        if self.provider_name == "amazon_nova" && super::models::is_xai_priced_model(model_id) {
+            info.input_cost_per_1k_tokens = None;
+            info.output_cost_per_1k_tokens = None;
+        }
+        info
     }
 
     /// Get the provider configuration
@@ -652,9 +663,10 @@ impl LLMProvider for OpenAILikeProvider {
     }
 
     fn models(&self) -> &[ModelInfo] {
-        // Return empty slice - any model is supported dynamically
-        static MODELS: &[ModelInfo] = &[];
-        MODELS
+        if self.provider_name == "amazon_nova" {
+            return crate::core::providers::registry::catalog::amazon_nova_catalog_model_infos();
+        }
+        &[]
     }
 
     fn supports_model(&self, _model: &str) -> bool {

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -9,7 +9,6 @@ use std::sync::LazyLock;
 use super::definition::{AuthType, ProviderDefinition};
 use crate::core::providers::openai_like::provider::OPENAI_LIKE_CATALOG_CAPABILITIES;
 use crate::core::types::model::{ModelInfo, ProviderCapability};
-
 pub(crate) const AMAZON_NOVA_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
     ProviderCapability::ChatCompletion,
     ProviderCapability::ChatCompletionStream,
@@ -17,11 +16,6 @@ pub(crate) const AMAZON_NOVA_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
 ];
 pub(crate) const AMAZON_NOVA_SUPPORTS_STREAMING: bool = true;
 pub(crate) const AMAZON_NOVA_SUPPORTS_TOOLS: bool = true;
-/// Canonical Amazon Nova models retained by the catalog after native demotion.
-///
-/// Pricing uses the shared catalog unit of USD per million tokens. The values
-/// are the single production authority projected into both catalog and native
-/// compatibility runtimes.
 pub(crate) struct AmazonNovaCatalogModel {
     pub(crate) model_id: &'static str,
     pub(crate) display_name: &'static str,
@@ -103,27 +97,21 @@ static AMAZON_NOVA_MODEL_INFOS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
         .map(amazon_nova_model_info_from_entry)
         .collect()
 });
-/// Resolve a canonical Amazon Nova model or one of its retained short aliases.
 pub(crate) fn amazon_nova_catalog_model(model: &str) -> Option<&'static AmazonNovaCatalogModel> {
     let canonical = AMAZON_NOVA_MODEL_ALIASES
         .iter()
-        .find_map(|(alias, canonical)| (*alias == model).then_some(*canonical))
-        .unwrap_or(model);
+        .find(|(alias, _)| *alias == model)
+        .map_or(model, |(_, canonical)| *canonical);
     AMAZON_NOVA_CATALOG_MODELS
         .iter()
         .find(|entry| entry.model_id == canonical)
 }
-
-/// Return the five canonical Amazon Nova models projected for catalog runtime.
 pub(crate) fn amazon_nova_catalog_model_infos() -> &'static [ModelInfo] {
     &AMAZON_NOVA_MODEL_INFOS
 }
-
-/// Project catalog authority metadata for canonical IDs and retained aliases.
 pub(crate) fn amazon_nova_catalog_model_info(model: &str) -> Option<ModelInfo> {
     amazon_nova_catalog_model(model).map(amazon_nova_model_info_from_entry)
 }
-
 fn amazon_nova_model_info_from_entry(entry: &AmazonNovaCatalogModel) -> ModelInfo {
     ModelInfo {
         id: entry.model_id.to_string(),
@@ -601,21 +589,19 @@ mod tests {
     async fn amazon_nova_catalog_runtime_exposes_models_and_pricing() {
         use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
         use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
-
-        let config =
+        let provider = OpenAILikeProvider::new_for_catalog(
             OpenAILikeConfig::with_api_key("https://8.8.8.8/v1", "catalog-runtime-test-key")
-                .with_provider_name("amazon_nova");
-        let provider =
-            OpenAILikeProvider::new_for_catalog(config, AMAZON_NOVA_CATALOG_CAPABILITIES)
-                .await
-                .expect("Amazon Nova catalog provider must construct without issuing a request");
-
+                .with_provider_name("amazon_nova"),
+            AMAZON_NOVA_CATALOG_CAPABILITIES,
+        )
+        .await
+        .expect("catalog provider must construct");
         assert_eq!(provider.models().len(), 5);
         for model in ["amazon.nova-pro-v1:0", "nova-pro"] {
             let cost = provider
                 .calculate_cost(model, 1_000, 1_000)
                 .await
-                .expect("Amazon Nova catalog pricing must calculate");
+                .expect("pricing");
             assert!((cost - 0.004).abs() < f64::EPSILON);
         }
         let unknown = provider

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -7,7 +7,73 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use super::definition::{AuthType, ProviderDefinition};
+use crate::core::providers::base::ProviderModelEntry;
 use crate::core::providers::openai_like::provider::OPENAI_LIKE_CATALOG_CAPABILITIES;
+use crate::core::types::model::ProviderCapability;
+
+const AMAZON_NOVA_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
+    ProviderCapability::ChatCompletion,
+    ProviderCapability::ChatCompletionStream,
+    ProviderCapability::ToolCalling,
+];
+
+/// Canonical Amazon Nova models retained by the catalog after native demotion.
+///
+/// Pricing uses the shared catalog unit of USD per million tokens. The values
+/// are derived from the native `AmazonNovaModelRegistry` and guarded by the
+/// provider-specific equivalence test below.
+pub static AMAZON_NOVA_CATALOG_MODELS: &[ProviderModelEntry] = &[
+    ProviderModelEntry {
+        model_id: "amazon.nova-2-lite-v1:0",
+        display_name: "Amazon Nova 2 Lite",
+        max_context_length: 1_000_000,
+        max_output_length: 64_000,
+        supports_tools: true,
+        supports_multimodal: true,
+        input_cost_per_million: 0.3,
+        output_cost_per_million: 2.5,
+    },
+    ProviderModelEntry {
+        model_id: "amazon.nova-pro-v1:0",
+        display_name: "Amazon Nova Pro",
+        max_context_length: 300_000,
+        max_output_length: 5_000,
+        supports_tools: true,
+        supports_multimodal: true,
+        input_cost_per_million: 0.8,
+        output_cost_per_million: 3.2,
+    },
+    ProviderModelEntry {
+        model_id: "amazon.nova-lite-v1:0",
+        display_name: "Amazon Nova Lite",
+        max_context_length: 300_000,
+        max_output_length: 5_000,
+        supports_tools: true,
+        supports_multimodal: true,
+        input_cost_per_million: 0.06,
+        output_cost_per_million: 0.24,
+    },
+    ProviderModelEntry {
+        model_id: "amazon.nova-micro-v1:0",
+        display_name: "Amazon Nova Micro",
+        max_context_length: 128_000,
+        max_output_length: 5_000,
+        supports_tools: true,
+        supports_multimodal: false,
+        input_cost_per_million: 0.035,
+        output_cost_per_million: 0.14,
+    },
+    ProviderModelEntry {
+        model_id: "amazon.nova-premier-v1:0",
+        display_name: "Amazon Nova Premier",
+        max_context_length: 1_000_000,
+        max_output_length: 10_000,
+        supports_tools: true,
+        supports_multimodal: true,
+        input_cost_per_million: 2.5,
+        output_cost_per_million: 12.5,
+    },
+];
 
 /// Global provider catalog, keyed by provider name.
 pub static PROVIDER_CATALOG: LazyLock<HashMap<&'static str, ProviderDefinition>> =
@@ -199,12 +265,15 @@ fn build_catalog() -> HashMap<&'static str, ProviderDefinition> {
             "META_LLAMA_API_KEY",
         ),
         def_chat("v0", "Vercel v0", "https://api.v0.dev/v1", "V0_API_KEY"),
-        def_chat(
-            "amazon_nova",
-            "Amazon Nova",
-            "https://api.nova.amazon.com/v1",
-            "AMAZON_NOVA_API_KEY",
-        ),
+        ProviderDefinition {
+            capabilities: AMAZON_NOVA_CATALOG_CAPABILITIES,
+            ..def_chat(
+                "amazon_nova",
+                "Amazon Nova",
+                "https://api.nova.amazon.com/v1",
+                "AMAZON_NOVA_API_KEY",
+            )
+        },
         def_chat(
             "github",
             "GitHub Models",
@@ -434,6 +503,12 @@ fn def_local_chat(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "providers-extended")]
+    use crate::core::providers::amazon_nova::{
+        AmazonNovaConfig, AmazonNovaProvider, config::DEFAULT_AMAZON_NOVA_API_BASE,
+    };
+    #[cfg(feature = "providers-extended")]
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
     #[test]
     fn every_catalog_capability_is_executable_and_unique() {
@@ -455,6 +530,65 @@ mod tests {
                     definition.name
                 );
             }
+        }
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[test]
+    fn amazon_nova_catalog_policy_matches_native_models_pricing_and_capabilities() {
+        let definition =
+            get_definition("amazon_nova").expect("Amazon Nova catalog definition must exist");
+        assert_eq!(definition.base_url, DEFAULT_AMAZON_NOVA_API_BASE);
+        assert_eq!(definition.auth_env_var, "AMAZON_NOVA_API_KEY");
+        assert!(definition.alternate_auth_env_vars.is_empty());
+        assert_eq!(definition.auth_type, AuthType::Bearer);
+        assert!(!definition.skip_api_key);
+
+        let mut native_config = AmazonNovaConfig::with_api_key("catalog-policy-test-key");
+        native_config.base.api_base = Some("https://8.8.8.8/v1".to_string());
+        let native_provider = AmazonNovaProvider::new(native_config)
+            .expect("native Amazon Nova provider must construct without issuing a request");
+        assert_eq!(definition.capabilities, native_provider.capabilities());
+
+        let native_models = native_provider.models();
+        assert_eq!(AMAZON_NOVA_CATALOG_MODELS.len(), native_models.len());
+        for catalog_model in AMAZON_NOVA_CATALOG_MODELS {
+            let native_model = native_models
+                .iter()
+                .find(|model| model.id == catalog_model.model_id)
+                .unwrap_or_else(|| panic!("missing native model {}", catalog_model.model_id));
+
+            assert_eq!(native_model.name, catalog_model.display_name);
+            assert_eq!(
+                native_model.max_context_length,
+                catalog_model.max_context_length
+            );
+            assert_eq!(
+                native_model.max_output_length,
+                Some(catalog_model.max_output_length)
+            );
+            assert_eq!(native_model.supports_tools, catalog_model.supports_tools);
+            assert_eq!(
+                native_model.supports_multimodal,
+                catalog_model.supports_multimodal
+            );
+
+            let native_input = native_model
+                .input_cost_per_1k_tokens
+                .expect("native Amazon Nova input pricing must be present");
+            let native_output = native_model
+                .output_cost_per_1k_tokens
+                .expect("native Amazon Nova output pricing must be present");
+            assert!(
+                (native_input * 1_000.0 - catalog_model.input_cost_per_million).abs() < 1e-12,
+                "{} input pricing differs from native",
+                catalog_model.model_id
+            );
+            assert!(
+                (native_output * 1_000.0 - catalog_model.output_cost_per_million).abs() < 1e-12,
+                "{} output pricing differs from native",
+                catalog_model.model_id
+            );
         }
     }
 

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -129,6 +129,10 @@ fn amazon_nova_model_info_from_entry(entry: &AmazonNovaCatalogModel) -> ModelInf
             ProviderCapability::ChatCompletion,
             ProviderCapability::ChatCompletionStream,
         ],
+        metadata: HashMap::from([
+            ("description".into(), entry.description.into()),
+            ("supports_reasoning".into(), entry.supports_reasoning.into()),
+        ]),
         ..Default::default()
     }
 }
@@ -610,7 +614,6 @@ mod tests {
             .unwrap();
         assert_eq!(unknown, 0.0);
     }
-
     #[test]
     fn test_xai_openai_compatible_pass_through_definition() {
         let Some(definition) = get_definition("xai") else {

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -9,9 +9,9 @@ use std::sync::LazyLock;
 use super::definition::{AuthType, ProviderDefinition};
 use crate::core::providers::base::ProviderModelEntry;
 use crate::core::providers::openai_like::provider::OPENAI_LIKE_CATALOG_CAPABILITIES;
-use crate::core::types::model::ProviderCapability;
+use crate::core::types::model::{ModelInfo, ProviderCapability};
 
-const AMAZON_NOVA_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
+pub(crate) const AMAZON_NOVA_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
     ProviderCapability::ChatCompletion,
     ProviderCapability::ChatCompletionStream,
     ProviderCapability::ToolCalling,
@@ -74,6 +74,63 @@ pub static AMAZON_NOVA_CATALOG_MODELS: &[ProviderModelEntry] = &[
         output_cost_per_million: 12.5,
     },
 ];
+
+const AMAZON_NOVA_MODEL_ALIASES: &[(&str, &str)] = &[
+    ("nova-2-lite", "amazon.nova-2-lite-v1:0"),
+    ("nova-pro", "amazon.nova-pro-v1:0"),
+    ("nova-lite", "amazon.nova-lite-v1:0"),
+    ("nova-micro", "amazon.nova-micro-v1:0"),
+    ("nova-premier", "amazon.nova-premier-v1:0"),
+];
+
+static AMAZON_NOVA_MODEL_INFOS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
+    AMAZON_NOVA_CATALOG_MODELS
+        .iter()
+        .map(amazon_nova_model_info_from_entry)
+        .collect()
+});
+
+/// Resolve a canonical Amazon Nova model or one of its retained short aliases.
+pub(crate) fn amazon_nova_catalog_model(model: &str) -> Option<&'static ProviderModelEntry> {
+    let canonical = AMAZON_NOVA_MODEL_ALIASES
+        .iter()
+        .find_map(|(alias, canonical)| (*alias == model).then_some(*canonical))
+        .unwrap_or(model);
+    AMAZON_NOVA_CATALOG_MODELS
+        .iter()
+        .find(|entry| entry.model_id == canonical)
+}
+
+/// Return the five canonical Amazon Nova models projected for catalog runtime.
+pub(crate) fn amazon_nova_catalog_model_infos() -> &'static [ModelInfo] {
+    &AMAZON_NOVA_MODEL_INFOS
+}
+
+/// Project catalog authority metadata for canonical IDs and retained aliases.
+pub(crate) fn amazon_nova_catalog_model_info(model: &str) -> Option<ModelInfo> {
+    amazon_nova_catalog_model(model).map(amazon_nova_model_info_from_entry)
+}
+
+fn amazon_nova_model_info_from_entry(entry: &ProviderModelEntry) -> ModelInfo {
+    ModelInfo {
+        id: entry.model_id.to_string(),
+        name: entry.display_name.to_string(),
+        provider: "amazon_nova".to_string(),
+        max_context_length: entry.max_context_length,
+        max_output_length: Some(entry.max_output_length),
+        supports_streaming: true,
+        supports_tools: entry.supports_tools,
+        supports_multimodal: entry.supports_multimodal,
+        input_cost_per_1k_tokens: Some(entry.input_cost_per_million / 1_000.0),
+        output_cost_per_1k_tokens: Some(entry.output_cost_per_million / 1_000.0),
+        currency: "USD".to_string(),
+        capabilities: vec![
+            ProviderCapability::ChatCompletion,
+            ProviderCapability::ChatCompletionStream,
+        ],
+        ..Default::default()
+    }
+}
 
 /// Global provider catalog, keyed by provider name.
 pub static PROVIDER_CATALOG: LazyLock<HashMap<&'static str, ProviderDefinition>> =
@@ -503,11 +560,11 @@ fn def_local_chat(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "providers-extended")]
+    #[cfg(all(feature = "providers-extended", not(clippy)))]
     use crate::core::providers::amazon_nova::{
         AmazonNovaConfig, AmazonNovaProvider, config::DEFAULT_AMAZON_NOVA_API_BASE,
     };
-    #[cfg(feature = "providers-extended")]
+    #[cfg(all(feature = "providers-extended", not(clippy)))]
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
     #[test]
@@ -533,7 +590,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "providers-extended")]
+    #[cfg(all(feature = "providers-extended", not(clippy)))]
     #[test]
     fn amazon_nova_catalog_policy_matches_native_models_pricing_and_capabilities() {
         let definition =
@@ -551,45 +608,83 @@ mod tests {
         assert_eq!(definition.capabilities, native_provider.capabilities());
 
         let native_models = native_provider.models();
-        assert_eq!(AMAZON_NOVA_CATALOG_MODELS.len(), native_models.len());
+        let catalog_ids: std::collections::HashSet<_> = AMAZON_NOVA_CATALOG_MODELS
+            .iter()
+            .map(|model| model.model_id)
+            .collect();
+        let native_ids: std::collections::HashSet<_> = native_models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect();
+        assert_eq!(catalog_ids.len(), AMAZON_NOVA_CATALOG_MODELS.len());
+        assert_eq!(native_ids.len(), native_models.len());
+        assert_eq!(catalog_ids, native_ids);
         for catalog_model in AMAZON_NOVA_CATALOG_MODELS {
             let native_model = native_models
                 .iter()
                 .find(|model| model.id == catalog_model.model_id)
                 .unwrap_or_else(|| panic!("missing native model {}", catalog_model.model_id));
+            assert_eq!(
+                (
+                    native_model.name.as_str(),
+                    native_model.max_context_length,
+                    native_model.max_output_length,
+                    native_model.supports_tools,
+                    native_model.supports_multimodal,
+                ),
+                (
+                    catalog_model.display_name,
+                    catalog_model.max_context_length,
+                    Some(catalog_model.max_output_length),
+                    catalog_model.supports_tools,
+                    catalog_model.supports_multimodal,
+                ),
+                "{} differs from catalog authority",
+                catalog_model.model_id,
+            );
+            let input = native_model.input_cost_per_1k_tokens.unwrap_or_default() * 1_000.0;
+            let output = native_model.output_cost_per_1k_tokens.unwrap_or_default() * 1_000.0;
+            assert!((input - catalog_model.input_cost_per_million).abs() < 1e-12);
+            assert!((output - catalog_model.output_cost_per_million).abs() < 1e-12);
+        }
+    }
 
-            assert_eq!(native_model.name, catalog_model.display_name);
-            assert_eq!(
-                native_model.max_context_length,
-                catalog_model.max_context_length
-            );
-            assert_eq!(
-                native_model.max_output_length,
-                Some(catalog_model.max_output_length)
-            );
-            assert_eq!(native_model.supports_tools, catalog_model.supports_tools);
-            assert_eq!(
-                native_model.supports_multimodal,
-                catalog_model.supports_multimodal
-            );
+    #[tokio::test]
+    async fn amazon_nova_catalog_runtime_exposes_models_and_pricing() {
+        use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
+        use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
-            let native_input = native_model
-                .input_cost_per_1k_tokens
-                .expect("native Amazon Nova input pricing must be present");
-            let native_output = native_model
-                .output_cost_per_1k_tokens
-                .expect("native Amazon Nova output pricing must be present");
-            assert!(
-                (native_input * 1_000.0 - catalog_model.input_cost_per_million).abs() < 1e-12,
-                "{} input pricing differs from native",
-                catalog_model.model_id
-            );
-            assert!(
-                (native_output * 1_000.0 - catalog_model.output_cost_per_million).abs() < 1e-12,
-                "{} output pricing differs from native",
-                catalog_model.model_id
+        let config =
+            OpenAILikeConfig::with_api_key("https://8.8.8.8/v1", "catalog-runtime-test-key")
+                .with_provider_name("amazon_nova");
+        let provider =
+            OpenAILikeProvider::new_for_catalog(config, AMAZON_NOVA_CATALOG_CAPABILITIES)
+                .await
+                .expect("Amazon Nova catalog provider must construct without issuing a request");
+
+        let ids: std::collections::HashSet<_> =
+            provider.models().iter().map(|model| &model.id).collect();
+        assert_eq!(ids.len(), 5, "canonical catalog IDs must be unique");
+        for (alias, canonical) in AMAZON_NOVA_MODEL_ALIASES {
+            assert_eq!(
+                amazon_nova_catalog_model(alias).unwrap().model_id,
+                *canonical
             );
         }
+        for model in ["amazon.nova-pro-v1:0", "nova-pro"] {
+            let cost = provider
+                .calculate_cost(model, 1_000, 1_000)
+                .await
+                .expect("Amazon Nova catalog pricing must calculate");
+            assert!((cost - 0.004).abs() < f64::EPSILON);
+        }
+        assert_eq!(
+            provider
+                .calculate_cost("grok-4.3", 1_000, 1_000)
+                .await
+                .unwrap(),
+            0.0
+        );
     }
 
     #[test]

--- a/src/core/providers/registry/catalog.rs
+++ b/src/core/providers/registry/catalog.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use super::definition::{AuthType, ProviderDefinition};
-use crate::core::providers::base::ProviderModelEntry;
 use crate::core::providers::openai_like::provider::OPENAI_LIKE_CATALOG_CAPABILITIES;
 use crate::core::types::model::{ModelInfo, ProviderCapability};
 
@@ -16,82 +15,96 @@ pub(crate) const AMAZON_NOVA_CATALOG_CAPABILITIES: &[ProviderCapability] = &[
     ProviderCapability::ChatCompletionStream,
     ProviderCapability::ToolCalling,
 ];
-
+pub(crate) const AMAZON_NOVA_SUPPORTS_STREAMING: bool = true;
+pub(crate) const AMAZON_NOVA_SUPPORTS_TOOLS: bool = true;
 /// Canonical Amazon Nova models retained by the catalog after native demotion.
 ///
 /// Pricing uses the shared catalog unit of USD per million tokens. The values
-/// are derived from the native `AmazonNovaModelRegistry` and guarded by the
-/// provider-specific equivalence test below.
-pub static AMAZON_NOVA_CATALOG_MODELS: &[ProviderModelEntry] = &[
-    ProviderModelEntry {
+/// are the single production authority projected into both catalog and native
+/// compatibility runtimes.
+pub(crate) struct AmazonNovaCatalogModel {
+    pub(crate) model_id: &'static str,
+    pub(crate) display_name: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) max_context_length: u32,
+    pub(crate) max_output_length: u32,
+    pub(crate) supports_multimodal: bool,
+    pub(crate) supports_reasoning: bool,
+    pub(crate) input_cost_per_million: f64,
+    pub(crate) output_cost_per_million: f64,
+}
+pub(crate) static AMAZON_NOVA_CATALOG_MODELS: &[AmazonNovaCatalogModel] = &[
+    AmazonNovaCatalogModel {
         model_id: "amazon.nova-2-lite-v1:0",
         display_name: "Amazon Nova 2 Lite",
+        description: "Cost-efficient multimodal model for automation, documents, and support",
         max_context_length: 1_000_000,
         max_output_length: 64_000,
-        supports_tools: true,
         supports_multimodal: true,
+        supports_reasoning: true,
         input_cost_per_million: 0.3,
         output_cost_per_million: 2.5,
     },
-    ProviderModelEntry {
+    AmazonNovaCatalogModel {
         model_id: "amazon.nova-pro-v1:0",
         display_name: "Amazon Nova Pro",
+        description: "High-capability multimodal model for complex tasks",
         max_context_length: 300_000,
         max_output_length: 5_000,
-        supports_tools: true,
         supports_multimodal: true,
+        supports_reasoning: true,
         input_cost_per_million: 0.8,
         output_cost_per_million: 3.2,
     },
-    ProviderModelEntry {
+    AmazonNovaCatalogModel {
         model_id: "amazon.nova-lite-v1:0",
         display_name: "Amazon Nova Lite",
+        description: "Cost-effective multimodal model for everyday tasks",
         max_context_length: 300_000,
         max_output_length: 5_000,
-        supports_tools: true,
         supports_multimodal: true,
+        supports_reasoning: false,
         input_cost_per_million: 0.06,
         output_cost_per_million: 0.24,
     },
-    ProviderModelEntry {
+    AmazonNovaCatalogModel {
         model_id: "amazon.nova-micro-v1:0",
         display_name: "Amazon Nova Micro",
+        description: "Fast text-only model optimized for speed",
         max_context_length: 128_000,
         max_output_length: 5_000,
-        supports_tools: true,
         supports_multimodal: false,
+        supports_reasoning: false,
         input_cost_per_million: 0.035,
         output_cost_per_million: 0.14,
     },
-    ProviderModelEntry {
+    AmazonNovaCatalogModel {
         model_id: "amazon.nova-premier-v1:0",
         display_name: "Amazon Nova Premier",
+        description: "Most capable model for complex reasoning and multimodal tasks",
         max_context_length: 1_000_000,
         max_output_length: 10_000,
-        supports_tools: true,
         supports_multimodal: true,
+        supports_reasoning: true,
         input_cost_per_million: 2.5,
         output_cost_per_million: 12.5,
     },
 ];
-
-const AMAZON_NOVA_MODEL_ALIASES: &[(&str, &str)] = &[
+pub(crate) const AMAZON_NOVA_MODEL_ALIASES: &[(&str, &str)] = &[
     ("nova-2-lite", "amazon.nova-2-lite-v1:0"),
     ("nova-pro", "amazon.nova-pro-v1:0"),
     ("nova-lite", "amazon.nova-lite-v1:0"),
     ("nova-micro", "amazon.nova-micro-v1:0"),
     ("nova-premier", "amazon.nova-premier-v1:0"),
 ];
-
 static AMAZON_NOVA_MODEL_INFOS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
     AMAZON_NOVA_CATALOG_MODELS
         .iter()
         .map(amazon_nova_model_info_from_entry)
         .collect()
 });
-
 /// Resolve a canonical Amazon Nova model or one of its retained short aliases.
-pub(crate) fn amazon_nova_catalog_model(model: &str) -> Option<&'static ProviderModelEntry> {
+pub(crate) fn amazon_nova_catalog_model(model: &str) -> Option<&'static AmazonNovaCatalogModel> {
     let canonical = AMAZON_NOVA_MODEL_ALIASES
         .iter()
         .find_map(|(alias, canonical)| (*alias == model).then_some(*canonical))
@@ -111,15 +124,15 @@ pub(crate) fn amazon_nova_catalog_model_info(model: &str) -> Option<ModelInfo> {
     amazon_nova_catalog_model(model).map(amazon_nova_model_info_from_entry)
 }
 
-fn amazon_nova_model_info_from_entry(entry: &ProviderModelEntry) -> ModelInfo {
+fn amazon_nova_model_info_from_entry(entry: &AmazonNovaCatalogModel) -> ModelInfo {
     ModelInfo {
         id: entry.model_id.to_string(),
         name: entry.display_name.to_string(),
         provider: "amazon_nova".to_string(),
         max_context_length: entry.max_context_length,
         max_output_length: Some(entry.max_output_length),
-        supports_streaming: true,
-        supports_tools: entry.supports_tools,
+        supports_streaming: AMAZON_NOVA_SUPPORTS_STREAMING,
+        supports_tools: AMAZON_NOVA_SUPPORTS_TOOLS,
         supports_multimodal: entry.supports_multimodal,
         input_cost_per_1k_tokens: Some(entry.input_cost_per_million / 1_000.0),
         output_cost_per_1k_tokens: Some(entry.output_cost_per_million / 1_000.0),
@@ -560,12 +573,6 @@ fn def_local_chat(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(all(feature = "providers-extended", not(clippy)))]
-    use crate::core::providers::amazon_nova::{
-        AmazonNovaConfig, AmazonNovaProvider, config::DEFAULT_AMAZON_NOVA_API_BASE,
-    };
-    #[cfg(all(feature = "providers-extended", not(clippy)))]
-    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 
     #[test]
     fn every_catalog_capability_is_executable_and_unique() {
@@ -590,65 +597,6 @@ mod tests {
         }
     }
 
-    #[cfg(all(feature = "providers-extended", not(clippy)))]
-    #[test]
-    fn amazon_nova_catalog_policy_matches_native_models_pricing_and_capabilities() {
-        let definition =
-            get_definition("amazon_nova").expect("Amazon Nova catalog definition must exist");
-        assert_eq!(definition.base_url, DEFAULT_AMAZON_NOVA_API_BASE);
-        assert_eq!(definition.auth_env_var, "AMAZON_NOVA_API_KEY");
-        assert!(definition.alternate_auth_env_vars.is_empty());
-        assert_eq!(definition.auth_type, AuthType::Bearer);
-        assert!(!definition.skip_api_key);
-
-        let mut native_config = AmazonNovaConfig::with_api_key("catalog-policy-test-key");
-        native_config.base.api_base = Some("https://8.8.8.8/v1".to_string());
-        let native_provider = AmazonNovaProvider::new(native_config)
-            .expect("native Amazon Nova provider must construct without issuing a request");
-        assert_eq!(definition.capabilities, native_provider.capabilities());
-
-        let native_models = native_provider.models();
-        let catalog_ids: std::collections::HashSet<_> = AMAZON_NOVA_CATALOG_MODELS
-            .iter()
-            .map(|model| model.model_id)
-            .collect();
-        let native_ids: std::collections::HashSet<_> = native_models
-            .iter()
-            .map(|model| model.id.as_str())
-            .collect();
-        assert_eq!(catalog_ids.len(), AMAZON_NOVA_CATALOG_MODELS.len());
-        assert_eq!(native_ids.len(), native_models.len());
-        assert_eq!(catalog_ids, native_ids);
-        for catalog_model in AMAZON_NOVA_CATALOG_MODELS {
-            let native_model = native_models
-                .iter()
-                .find(|model| model.id == catalog_model.model_id)
-                .unwrap_or_else(|| panic!("missing native model {}", catalog_model.model_id));
-            assert_eq!(
-                (
-                    native_model.name.as_str(),
-                    native_model.max_context_length,
-                    native_model.max_output_length,
-                    native_model.supports_tools,
-                    native_model.supports_multimodal,
-                ),
-                (
-                    catalog_model.display_name,
-                    catalog_model.max_context_length,
-                    Some(catalog_model.max_output_length),
-                    catalog_model.supports_tools,
-                    catalog_model.supports_multimodal,
-                ),
-                "{} differs from catalog authority",
-                catalog_model.model_id,
-            );
-            let input = native_model.input_cost_per_1k_tokens.unwrap_or_default() * 1_000.0;
-            let output = native_model.output_cost_per_1k_tokens.unwrap_or_default() * 1_000.0;
-            assert!((input - catalog_model.input_cost_per_million).abs() < 1e-12);
-            assert!((output - catalog_model.output_cost_per_million).abs() < 1e-12);
-        }
-    }
-
     #[tokio::test]
     async fn amazon_nova_catalog_runtime_exposes_models_and_pricing() {
         use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
@@ -662,15 +610,7 @@ mod tests {
                 .await
                 .expect("Amazon Nova catalog provider must construct without issuing a request");
 
-        let ids: std::collections::HashSet<_> =
-            provider.models().iter().map(|model| &model.id).collect();
-        assert_eq!(ids.len(), 5, "canonical catalog IDs must be unique");
-        for (alias, canonical) in AMAZON_NOVA_MODEL_ALIASES {
-            assert_eq!(
-                amazon_nova_catalog_model(alias).unwrap().model_id,
-                *canonical
-            );
-        }
+        assert_eq!(provider.models().len(), 5);
         for model in ["amazon.nova-pro-v1:0", "nova-pro"] {
             let cost = provider
                 .calculate_cost(model, 1_000, 1_000)
@@ -678,13 +618,11 @@ mod tests {
                 .expect("Amazon Nova catalog pricing must calculate");
             assert!((cost - 0.004).abs() < f64::EPSILON);
         }
-        assert_eq!(
-            provider
-                .calculate_cost("grok-4.3", 1_000, 1_000)
-                .await
-                .unwrap(),
-            0.0
-        );
+        let unknown = provider
+            .calculate_cost("grok-4.3", 1_000, 1_000)
+            .await
+            .unwrap();
+        assert_eq!(unknown, 0.0);
     }
 
     #[test]

--- a/tests/public_api_compat.rs
+++ b/tests/public_api_compat.rs
@@ -1,12 +1,39 @@
 #![cfg(feature = "providers-extended")]
 
-// Normal `cargo test` must compile and execute this deprecated-use lane. Clippy
-// skips it because CI promotes the expected deprecation warnings to errors while
+// Normal `cargo test` must compile and execute these deprecated-use lanes. Clippy
+// skips them because CI promotes the expected deprecation warnings to errors while
 // the repository guard correctly forbids suppressing those warnings.
+#[cfg(not(clippy))]
+use litellm_rs::core::providers::amazon_nova::{
+    AmazonNovaConfig, AmazonNovaErrorMapper, AmazonNovaModel, AmazonNovaModelRegistry,
+    AmazonNovaProvider,
+};
 #[cfg(not(clippy))]
 use litellm_rs::core::providers::custom_api::{
     CustomApiErrorMapper, CustomHttpxConfig, CustomHttpxProvider, PROVIDER_NAME,
 };
+
+#[cfg(not(clippy))]
+#[test]
+fn amazon_nova_deprecated_in_0_6() {
+    let registry = AmazonNovaModelRegistry::new();
+    assert!(registry.is_supported("amazon.nova-pro-v1:0"));
+
+    let model = AmazonNovaModel::new(
+        "compat-only",
+        "Compatibility Only",
+        "compile-time public API probe",
+        1_024,
+        128,
+    );
+    assert_eq!(model.id, "compat-only");
+
+    let _mapper = AmazonNovaErrorMapper;
+    let mut config = AmazonNovaConfig::with_api_key("compat-only-key");
+    config.base.api_base = Some("https://8.8.8.8/v1".to_string());
+    let _provider = AmazonNovaProvider::new(config)
+        .expect("0.6 public construction must remain available without issuing a request");
+}
 
 #[cfg(not(clippy))]
 #[test]

--- a/tests/public_api_compat.rs
+++ b/tests/public_api_compat.rs
@@ -23,7 +23,6 @@ fn amazon_nova_deprecated_in_0_6() {
     let _provider = AmazonNovaProvider::new(AmazonNovaConfig::with_api_key("compat-only-key"))
         .expect("0.6 public construction must remain available without issuing a request");
 }
-
 #[cfg(not(clippy))]
 #[test]
 fn custom_api_deprecated_in_0_6() {

--- a/tests/public_api_compat.rs
+++ b/tests/public_api_compat.rs
@@ -18,20 +18,9 @@ use litellm_rs::core::providers::custom_api::{
 fn amazon_nova_deprecated_in_0_6() {
     let registry = AmazonNovaModelRegistry::new();
     assert!(registry.is_supported("amazon.nova-pro-v1:0"));
-
-    let model = AmazonNovaModel::new(
-        "compat-only",
-        "Compatibility Only",
-        "compile-time public API probe",
-        1_024,
-        128,
-    );
-    assert_eq!(model.id, "compat-only");
-
+    let _model = AmazonNovaModel::new("compat-only", "Compat", "compat probe", 1_024, 128);
     let _mapper = AmazonNovaErrorMapper;
-    let mut config = AmazonNovaConfig::with_api_key("compat-only-key");
-    config.base.api_base = Some("https://8.8.8.8/v1".to_string());
-    let _provider = AmazonNovaProvider::new(config)
+    let _provider = AmazonNovaProvider::new(AmazonNovaConfig::with_api_key("compat-only-key"))
         .expect("0.6 public construction must remain available without issuing a request");
 }
 


### PR DESCRIPTION
## Summary

- make the provider catalog the single authority for Amazon Nova model metadata, capabilities, pricing, and aliases
- project the retained 0.6 native registry and model normalization from that catalog
- keep Amazon Nova pricing on the catalog path even when shared Bedrock pricing contains a matching model
- deprecate the public Amazon Nova surface for 0.6 while retaining native compatibility and documenting the 0.7 migration

## SpecRail

- Refs #837
- Implements `SP837-T11`
- Does not close the GH-837 umbrella; `SP837-T9`, removal, and closure tasks remain open
- Exact reviewed head before push: `7edaeedb598031d889865cfab26a72240e4a71b8`
- Independent heavy review: PASS, no blocking findings
- Scope: 9 non-document files / 500 changed lines

## Verification

- `cargo test --lib --all-features amazon_nova -- --nocapture` — 52 passed
- exact canonical/alias authority projection test — passed, including RED evidence for a native-only alias
- catalog-over-shared-Bedrock fallback regression — passed
- Bedrock cost tests — 50 passed
- public 0.6 deprecation compatibility test — passed with deprecation warnings
- no-default-feature catalog authority test — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo check --all-features` — passed
- `cargo test --all-features` — passed (library: 10,489 passed, 0 failed, 1 ignored; integration and doctests passed)
- SpecRail route and workflow checks — passed
- PR scope guard and `git diff --check` — passed
