### PR TITLE
feat(config): expose model aliases and per-provider upstream names in config

### DIFF
--- a/src/config/builder/config_builder.rs
+++ b/src/config/builder/config_builder.rs
@@ -76,6 +76,7 @@ impl GatewayConfigBuilder {
             rate_limit: crate::config::models::rate_limit::RateLimitConfig::default(),
             enterprise: crate::config::models::enterprise::EnterpriseConfig::default(),
             pricing: crate::config::models::gateway::GatewayPricingConfig::default(),
+            model_aliases: HashMap::new(),
         };
 
         let config = Config { gateway };

--- a/src/config/builder/provider_builder.rs
+++ b/src/config/builder/provider_builder.rs
@@ -128,7 +128,7 @@ impl ProviderConfigBuilder {
             retry: crate::config::models::provider::RetryConfig::default(),
             health_check: crate::config::models::provider::ProviderHealthCheckConfig::default(),
             settings: std::collections::HashMap::new(),
-            models: self.models,
+            models: self.models.into_iter().map(Into::into).collect(),
             enabled: self.enabled,
             tags: Vec::new(),
         })
@@ -447,7 +447,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.models.len(), 2);
-        assert!(config.models.contains(&"gpt-4".to_string()));
+        assert!(config.model_groups().contains(&"gpt-4".to_string()));
     }
 
     #[test]

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -224,7 +224,7 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
             provider.enabled = enabled;
         }
         if let Some(models) = parse_env_list(&provider_env_name(&name, "MODELS")) {
-            provider.models = models;
+            provider.models = models.into_iter().map(Into::into).collect();
         }
         if let Some(tags) = parse_env_list(&provider_env_name(&name, "TAGS")) {
             provider.tags = tags;
@@ -483,6 +483,25 @@ pub struct GatewayConfig {
     /// Pricing configuration
     #[serde(default)]
     pub pricing: GatewayPricingConfig,
+    /// Model aliases: request-facing name -> target model (or another alias).
+    ///
+    /// The router already resolves aliases at lookup time, including multi-hop
+    /// chains and cycle detection (see `RoutingSnapshot::resolve_model_name`).
+    /// This field is what makes that capability reachable from configuration:
+    ///
+    /// ```yaml
+    /// model_aliases:
+    ///   fast: "gpt-4o-mini"
+    ///   smart: "anthropic/claude-opus-4.7"
+    /// ```
+    ///
+    /// Aliases resolve to a *model group*, so a single alias can fan out over
+    /// several weighted deployments that serve the same model, which is how
+    /// load balancing across providers is expressed.
+    ///
+    /// Defaults to empty, so existing configurations are unaffected.
+    #[serde(default)]
+    pub model_aliases: HashMap<String, String>,
 }
 
 fn default_schema_version() -> String {
@@ -503,6 +522,7 @@ impl Default for GatewayConfig {
             rate_limit: RateLimitConfig::default(),
             enterprise: EnterpriseConfig::default(),
             pricing: GatewayPricingConfig::default(),
+            model_aliases: HashMap::new(),
         }
     }
 }

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -785,3 +785,148 @@ fn test_gateway_config_from_env_invalid_cache_enabled() {
 
     clear_test_env();
 }
+
+#[cfg(test)]
+mod model_alias_config_tests {
+    use crate::config::models::gateway::GatewayConfig;
+    use std::collections::HashMap;
+
+    /// A config without `model_aliases` must still parse: the field defaults to
+    /// empty, so existing deployments are unaffected by the new schema entry.
+    #[test]
+    fn config_without_aliases_defaults_to_empty() {
+        let cfg = GatewayConfig::default();
+        assert!(cfg.model_aliases.is_empty());
+    }
+
+    /// `GatewayConfig` sets `deny_unknown_fields`, so before this field existed
+    /// a `model_aliases:` block was a hard parse error. Round-tripping proves
+    /// the key is now both emitted and accepted, including a chained alias
+    /// (alias -> alias -> model), which the router resolves at lookup time
+    /// under `MAX_ALIAS_HOPS`.
+    #[test]
+    fn model_aliases_round_trip_through_yaml() {
+        let mut cfg = GatewayConfig::default();
+        cfg.model_aliases = HashMap::from([
+            ("apex-code".to_string(), "anthropic/claude-opus-4.7".to_string()),
+            ("fast".to_string(), "apex-code".to_string()),
+        ]);
+
+        let yaml = serde_yml::to_string(&cfg).expect("config should serialize");
+        assert!(yaml.contains("model_aliases"), "alias key must be emitted");
+
+        let parsed: GatewayConfig =
+            serde_yml::from_str(&yaml).expect("config with model_aliases should parse");
+        assert_eq!(
+            parsed.model_aliases.get("apex-code").map(String::as_str),
+            Some("anthropic/claude-opus-4.7")
+        );
+        assert_eq!(
+            parsed.model_aliases.get("fast").map(String::as_str),
+            Some("apex-code")
+        );
+    }
+}
+
+/// A provider's `models` list accepts either a plain string (group == upstream)
+/// or an explicit `{group, upstream}` mapping. The mapped form exists because
+/// Vercel and OpenRouter serve the same model group under different upstream
+/// IDs, which a flat alias -> model map cannot express.
+mod provider_model_entry_tests {
+    use crate::config::models::gateway::GatewayConfig;
+    use crate::config::models::provider::{ProviderConfig, ProviderModelEntry};
+
+    fn provider_with_models(models: &str) -> ProviderConfig {
+        let yaml = format!(
+            r#"
+name: openrouter
+provider_type: openai
+api_key: sk-test-key
+models:
+{models}
+"#
+        );
+        serde_yml::from_str(&yaml).expect("provider config should parse")
+    }
+
+    /// Top priority: configs written before this change must behave identically.
+    #[test]
+    fn plain_string_entry_keeps_group_and_upstream_identical() {
+        let provider = provider_with_models("  - \"anthropic/claude-opus-4.7\"");
+        let entry = &provider.models[0];
+
+        assert_eq!(entry, &ProviderModelEntry::Plain("anthropic/claude-opus-4.7".to_string()));
+        assert_eq!(entry.group(), "anthropic/claude-opus-4.7");
+        assert_eq!(entry.upstream(), "anthropic/claude-opus-4.7");
+    }
+
+    /// The mapped form is what lets OpenRouter answer the `apex-verify` group
+    /// with its own `x-ai/grok-4.3` spelling.
+    #[test]
+    fn mapped_entry_parses_group_and_upstream_separately() {
+        let provider =
+            provider_with_models("  - { group: \"apex-verify\", upstream: \"x-ai/grok-4.3\" }");
+        let entry = &provider.models[0];
+
+        assert_eq!(entry.group(), "apex-verify");
+        assert_eq!(entry.upstream(), "x-ai/grok-4.3");
+    }
+
+    /// Both forms must be mixable inside a single provider, since only 5 of the
+    /// 29 real aliases need the explicit mapping.
+    #[test]
+    fn plain_and_mapped_entries_coexist_in_one_provider() {
+        let provider = provider_with_models(
+            "  - \"anthropic/claude-opus-4.7\"\n  - { group: \"lean-code\", upstream: \"qwen/qwen3.7-plus\" }",
+        );
+
+        assert_eq!(provider.models.len(), 2);
+        assert_eq!(
+            provider.model_groups(),
+            vec!["anthropic/claude-opus-4.7".to_string(), "lean-code".to_string()]
+        );
+        assert_eq!(
+            provider.upstream_models(),
+            vec!["anthropic/claude-opus-4.7".to_string(), "qwen/qwen3.7-plus".to_string()]
+        );
+    }
+
+    /// `GatewayConfig` sets `deny_unknown_fields`, so an untagged enum that
+    /// emitted a wrapper key would break re-parsing. Round-tripping proves both
+    /// forms survive serialize -> deserialize.
+    #[test]
+    fn model_entries_round_trip_through_yaml() {
+        let mut cfg = GatewayConfig::default();
+        cfg.providers = vec![ProviderConfig {
+            name: "vercel".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test-key".to_string(),
+            models: vec![
+                ProviderModelEntry::Plain("anthropic/claude-opus-4.7".to_string()),
+                ProviderModelEntry::Mapped {
+                    group: "core-generalist".to_string(),
+                    upstream: "zai/glm-5.2".to_string(),
+                },
+            ],
+            ..ProviderConfig::default()
+        }];
+
+        let yaml = serde_yml::to_string(&cfg).expect("config should serialize");
+        let parsed: GatewayConfig =
+            serde_yml::from_str(&yaml).expect("config with model entries should parse");
+        assert_eq!(parsed.providers[0].models, cfg.providers[0].models);
+    }
+
+    /// Existing `models.iter().any(|m| m == requested)` checks compare against
+    /// the user-facing group, not the upstream name.
+    #[test]
+    fn entries_compare_equal_to_their_group() {
+        let mapped = ProviderModelEntry::Mapped {
+            group: "apex-verify".to_string(),
+            upstream: "x-ai/grok-4.3".to_string(),
+        };
+
+        assert!(mapped == *"apex-verify");
+        assert!(mapped != *"x-ai/grok-4.3");
+    }
+}

--- a/src/config/models/provider.rs
+++ b/src/config/models/provider.rs
@@ -7,6 +7,83 @@ use url::Url;
 
 use crate::core::net::ProviderEndpointAccess;
 
+/// A single entry in a provider's `models` list.
+///
+/// Two forms are accepted. A plain string means the user-facing model group and
+/// the upstream model name are identical. The mapped form lets one provider serve
+/// a shared group under its own upstream name, which is what makes it possible for
+/// Vercel to answer `apex-verify` with `xai/grok-4.3` while OpenRouter answers the
+/// same group with `x-ai/grok-4.3`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProviderModelEntry {
+    /// `- "anthropic/claude-opus-4.7"`
+    Plain(String),
+    /// `- { group: "apex-verify", upstream: "x-ai/grok-4.3" }`
+    Mapped {
+        /// User-facing model group used for routing lookups.
+        group: String,
+        /// Model name actually sent to this provider.
+        upstream: String,
+    },
+}
+
+impl ProviderModelEntry {
+    /// User-facing model group this entry serves.
+    pub fn group(&self) -> &str {
+        match self {
+            Self::Plain(name) => name,
+            Self::Mapped { group, .. } => group,
+        }
+    }
+
+    /// Model name to send upstream to the provider.
+    pub fn upstream(&self) -> &str {
+        match self {
+            Self::Plain(name) => name,
+            Self::Mapped { upstream, .. } => upstream,
+        }
+    }
+}
+
+impl From<String> for ProviderModelEntry {
+    fn from(name: String) -> Self {
+        Self::Plain(name)
+    }
+}
+
+impl From<&str> for ProviderModelEntry {
+    fn from(name: &str) -> Self {
+        Self::Plain(name.to_string())
+    }
+}
+
+impl std::fmt::Display for ProviderModelEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.group())
+    }
+}
+
+/// Entries compare against the user-facing group, so existing `models.iter().any(|m| m == requested)`
+/// checks keep matching on what the caller actually asked for.
+impl PartialEq<str> for ProviderModelEntry {
+    fn eq(&self, other: &str) -> bool {
+        self.group() == other
+    }
+}
+
+impl PartialEq<&str> for ProviderModelEntry {
+    fn eq(&self, other: &&str) -> bool {
+        self.group() == *other
+    }
+}
+
+impl PartialEq<String> for ProviderModelEntry {
+    fn eq(&self, other: &String) -> bool {
+        self.group() == other.as_str()
+    }
+}
+
 /// Provider configuration
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -57,7 +134,7 @@ pub struct ProviderConfig {
     pub settings: HashMap<String, serde_json::Value>,
     /// Supported models
     #[serde(default)]
-    pub models: Vec<String>,
+    pub models: Vec<ProviderModelEntry>,
     /// Tags for grouping providers
     #[serde(default)]
     pub tags: Vec<String>,
@@ -121,6 +198,22 @@ impl Default for ProviderConfig {
 }
 
 impl ProviderConfig {
+    /// User-facing model groups this provider serves.
+    pub fn model_groups(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .map(|entry| entry.group().to_string())
+            .collect()
+    }
+
+    /// Upstream model names this provider is addressed with.
+    pub fn upstream_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .map(|entry| entry.upstream().to_string())
+            .collect()
+    }
+
     pub(crate) fn configured_endpoint(&self) -> Option<&str> {
         let provider_selector = if self.provider_type.trim().is_empty() {
             self.name.as_str()
@@ -432,7 +525,7 @@ mod tests {
             retry: RetryConfig::default(),
             health_check: ProviderHealthCheckConfig::default(),
             settings: HashMap::new(),
-            models: vec!["gpt-4".to_string()],
+            models: vec!["gpt-4".into()],
             tags: vec!["production".to_string()],
             enabled: true,
         };
@@ -517,7 +610,7 @@ mod tests {
             retry: RetryConfig::default(),
             health_check: ProviderHealthCheckConfig::default(),
             settings: HashMap::new(),
-            models: vec!["claude-3".to_string()],
+            models: vec!["claude-3".into()],
             tags: vec!["backup".to_string()],
             enabled: true,
         };
@@ -594,9 +687,9 @@ mod tests {
     fn test_provider_config_with_models() {
         let config = ProviderConfig {
             models: vec![
-                "gpt-4".to_string(),
-                "gpt-4-turbo".to_string(),
-                "gpt-3.5-turbo".to_string(),
+                "gpt-4".into(),
+                "gpt-4-turbo".into(),
+                "gpt-3.5-turbo".into(),
             ],
             ..ProviderConfig::default()
         };

--- a/src/core/models/deployment/implementation.rs
+++ b/src/core/models/deployment/implementation.rs
@@ -180,7 +180,7 @@ mod tests {
             api_key: "test-key".to_string(),
             base_url: None,
             endpoint_access: Default::default(),
-            models: vec!["gpt-4".to_string()],
+            models: vec!["gpt-4".into()],
             timeout: 30,
             max_retries: 3,
             organization: None,

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -227,7 +227,12 @@ pub async fn create_provider(
     if !models.is_empty() {
         factory_config.insert(
             "models".to_string(),
-            Value::Array(models.into_iter().map(Value::String).collect()),
+            Value::Array(
+                models
+                    .into_iter()
+                    .map(|entry| Value::String(entry.upstream().to_string()))
+                    .collect(),
+            ),
         );
     }
 

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -64,14 +64,19 @@ impl Router {
                     ))
                 })?;
 
-            // Determine which models this deployment serves
-            let models: Vec<String> = if !provider_config.models.is_empty() {
-                provider_config.models.clone()
+            // Determine which models this deployment serves, as (group, upstream) pairs.
+            // Discovered models are their own group, same as a plain config entry.
+            let models: Vec<(String, String)> = if !provider_config.models.is_empty() {
+                provider_config
+                    .models
+                    .iter()
+                    .map(|entry| (entry.group().to_string(), entry.upstream().to_string()))
+                    .collect()
             } else {
                 provider
                     .list_models()
                     .iter()
-                    .map(|m| m.id.clone())
+                    .map(|m| (m.id.clone(), m.id.clone()))
                     .collect()
             };
 
@@ -82,17 +87,19 @@ impl Router {
                     &provider_config.name,
                     provider.clone(),
                     &provider_config.name,
+                    &provider_config.name,
                     provider_config,
                 )?;
                 router.add_deployment(deployment);
             } else {
                 // Create one deployment per model
-                for model in models {
-                    let deployment_id = format!("{}-{}", provider_config.name, model);
+                for (group, upstream) in models {
+                    let deployment_id = format!("{}-{}", provider_config.name, group);
                     let deployment = create_deployment_from_config(
                         &deployment_id,
                         provider.clone(),
-                        &model,
+                        &group,
+                        &upstream,
                         provider_config,
                     )?;
                     router.add_deployment(deployment);
@@ -109,7 +116,8 @@ impl Router {
 fn create_deployment_from_config(
     deployment_id: &str,
     provider: Provider,
-    model: &str,
+    group: &str,
+    upstream: &str,
     config: &ProviderConfig,
 ) -> Result<Deployment, RouterError> {
     let deployment_config = deployment_config_from_provider(config)?;
@@ -117,8 +125,8 @@ fn create_deployment_from_config(
     Ok(Deployment::new(
         deployment_id.to_string(),
         provider,
-        model.to_string(),
-        model.to_string(),
+        upstream.to_string(),
+        group.to_string(),
     )
     .with_config(deployment_config)
     .with_tags(config.tags.clone()))

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -339,6 +339,18 @@ impl Router {
         self.update_routing_snapshot(|snapshot| snapshot.insert_deployment(deployment));
     }
 
+    /// Replace the model alias table.
+    ///
+    /// Aliases map a request-facing model name onto a model group (or onto
+    /// another alias; chains are resolved at lookup time with a hop limit).
+    /// Installed through the same snapshot swap as deployments so readers never
+    /// observe a mixed alias/index generation.
+    pub fn set_model_aliases(&self, aliases: HashMap<String, String>) {
+        self.update_routing_snapshot(|snapshot| {
+            snapshot.model_aliases = aliases;
+        });
+    }
+
     /// Remove a deployment from the router
     pub fn remove_deployment(&self, id: &str) -> Option<Deployment> {
         self.update_routing_snapshot(|snapshot| snapshot.remove_deployment(id))

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -149,6 +149,14 @@ impl HttpServer {
             ))
         })?;
 
+        // Install configured model aliases. The router resolves these at lookup
+        // time (including chains, bounded by MAX_ALIAS_HOPS); this is what makes
+        // that existing capability reachable from `gateway.yaml`. Empty by
+        // default, so configurations without aliases are unaffected.
+        if !config.gateway.model_aliases.is_empty() {
+            unified_router.set_model_aliases(config.gateway.model_aliases.clone());
+        }
+
         let callback_runtime =
             crate::server::callbacks::build_callback_runtime(&config.gateway.monitoring.callbacks)
                 .await;

--- a/src/server/routes/ai/fine_tuning.rs
+++ b/src/server/routes/ai/fine_tuning.rs
@@ -343,7 +343,7 @@ fn fine_tuning_route_provider(
             api_base: Some(fine_tuning_api_base(provider)?),
             endpoint_access: provider.endpoint_access,
             organization_id: provider.organization.clone(),
-            supported_models: provider.models.clone(),
+            supported_models: provider.model_groups(),
             timeout_seconds: provider.timeout,
             headers: fine_tuning_provider_headers(provider)?,
         },

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -319,7 +319,7 @@ fn rerank_router_models(providers: &[ProviderConfig], requested_model: &str) -> 
 
         for model in &provider.models {
             if model == requested_model || model == served_model {
-                push_unique_model(&mut router_models, model);
+                push_unique_model(&mut router_models, model.group());
             }
         }
     }
@@ -488,7 +488,7 @@ mod tests {
             name: name.to_string(),
             provider_type: provider_type.to_string(),
             api_key: "test-key".to_string(),
-            models: models.into_iter().map(ToString::to_string).collect(),
+            models: models.into_iter().map(Into::into).collect(),
             ..ProviderConfig::default()
         }
     }


### PR DESCRIPTION
## Summary

The router already implements model aliasing in full, but none of it is reachable from configuration. This exposes it, and adds a related config form for providers that serve the same logical model under different upstream names.

Both changes are backward compatible. Existing configs parse and behave identically.

## What already exists

- `RoutingSnapshot.model_aliases: HashMap<String, String>` (`src/core/router/unified.rs`)
- `resolve_model_name()` walks the map with `MAX_ALIAS_HOPS` and cycle detection
- Both `get_deployments_for_model()` and `get_healthy_deployments()` resolve before indexing
- `Deployment` already separates `model` (sent upstream) from `model_name` (the user-facing group used for lookups)

## What was missing

`GatewayConfig` had no `model_aliases` field, so nothing populated that map from a config file. Since `GatewayConfig` sets `deny_unknown_fields`, adding a `model_aliases:` block was a hard parse error rather than a no-op.

Separately, `ProviderConfig.models` was a flat `Vec<String>`, so a deployment's group and upstream were set from the same string. There was no way to say "this provider serves group X under its own upstream name".

## Changes

**1. `GatewayConfig.model_aliases`**, defaulted empty, installed on the router at startup:

```yaml
model_aliases:
  fast: "openai/gpt-4o-mini"
  smart: "openai/gpt-4o"
```

**2. `ProviderConfig.models` entries accept a mapped form** alongside the plain string:

```yaml
models:
  - "openai/gpt-4o"                                  # group == upstream, unchanged
  - { group: "reasoning", upstream: "acme-labs/model-a" }
```

This matters when several providers serve the same logical model under different upstream names. For example, two providers may spell the same model differently (`vendor/model-x` vs `vendor-x/model-x`). Both entries can declare the same `group`, so the router registers them as sibling deployments of one model group and load-balances across them, which is what the existing weighted-deployment machinery was built for but config could not express.

`ProviderModelEntry` is an untagged enum with `group()` and `upstream()` accessors. It compares equal to a `&str` by its group, so existing membership checks of the form `models.iter().any(|m| m == requested)` keep working unchanged.

## Compatibility

- Plain-string model entries behave exactly as before.
- A config with no `model_aliases` key is unaffected; the field defaults to empty.
- No public function signatures changed.
