### PR TITLE
docs(config): specify aliases and provider priority

### DIFF
--- a/specs/GH1105/product.md
+++ b/specs/GH1105/product.md
@@ -28,18 +28,18 @@ Gateway operators cannot configure the runtime router's existing model-alias beh
 ## Behavior Invariants
 
 1. B-001 A non-empty configured model alias resolves to its configured target for normal and streaming routed requests.
-2. B-002 Configured aliases are included once in the OpenAI-compatible model inventory while canonical deployment models remain available.
+2. B-002 Configured aliases are included once in the OpenAI-compatible model inventory while canonical deployment models remain available; startup rejects an alias name that equals any enabled canonical deployment model instead of shadowing that model.
 3. B-003 Empty alias names, empty targets, self-aliases, and direct or transitive alias cycles fail configuration/startup explicitly without serving traffic.
-4. B-004 Alias declaration order does not affect resolution, including valid transitive alias chains.
+4. B-004 Alias declaration order does not affect resolution. Every valid transitive chain is flattened to its final enabled canonical model before publication, including chains longer than the runtime resolver's current 16-hop bound.
 5. B-005 A configured provider priority is copied to every deployment created for that provider, and lower numeric priority wins under `priority_based` routing.
-6. B-006 Omitted provider priority defaults to `0`; omitted or empty alias configuration installs no aliases, preserving existing configuration behavior.
-7. B-007 Disabled providers create no deployments, so their priority cannot affect routing; aliases whose final target has no enabled deployment are rejected before serving traffic.
+6. B-006 Omitted provider priority defaults to `0`. Layered alias maps merge key by key with the later overlay value winning for the same alias; an omitted or empty overlay contributes no keys and therefore preserves base aliases. A standalone omitted or empty map installs no aliases.
+7. B-007 Disabled providers create no deployments, so their priority cannot affect routing. Alias shape and graph errors are rejected during configuration validation; canonical-name collisions and final targets without an enabled deployment are rejected after enabled provider models are expanded but before health checks, router publication, or serving traffic.
 8. B-008 Unknown YAML fields remain rejected, and alias/priority values are configuration data only: they trigger no network calls, persistence, permissions, or background work.
 
 ## Acceptance Criteria
 
-- [ ] YAML parsing tests cover aliases, provider priority, defaults, and unknown fields.
-- [ ] Router construction tests cover direct/transitive aliases, cycles, missing targets, disabled providers, and priority propagation.
+- [ ] YAML parsing and layered-merge tests cover aliases, provider priority, defaults, overlay wins, empty-overlay preservation, and unknown fields.
+- [ ] Router construction tests cover direct/transitive aliases, chains longer than 16 hops, cycles, canonical-name collisions, dynamically expanded targets, missing targets, disabled providers, and priority propagation.
 - [ ] Route/model inventory tests prove aliases are routable and discoverable.
 - [ ] Existing example configuration remains valid without either new field.
 - [ ] Configuration documentation contains a working alias plus primary/fallback example.
@@ -48,7 +48,9 @@ Gateway operators cannot configure the runtime router's existing model-alias beh
 ## Edge Cases
 
 - Duplicate YAML mapping keys follow the parser's existing duplicate-key behavior; this feature does not add silent merge rules.
-- Alias chains may target another alias but must terminate at a model served by an enabled deployment.
+- Layered configuration does not define an alias-deletion sentinel: omitted or explicit `{}` overlays preserve base aliases, while a repeated alias key replaces only that key's target.
+- Alias chains may target another alias but must terminate at a model served by an enabled deployment. The installed runtime snapshot maps each alias directly to that final model.
+- An alias key may not equal an enabled canonical model name, even when the alias would point back to that same model through another alias.
 - Equal provider priorities continue to use the router's existing within-tier selection behavior.
 - Very large numeric priorities are valid `u32` values and remain ordered without arithmetic.
 

--- a/specs/GH1105/product.md
+++ b/specs/GH1105/product.md
@@ -1,0 +1,57 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1105 / #1105
+
+complexity: medium
+
+## User Problem
+
+Gateway operators cannot configure the runtime router's existing model-alias behavior from YAML. They also cannot assign provider priority, even though priority-based routing reads deployment priorities. This prevents stable public model names and deterministic primary/fallback provider tiers from being represented in deployable configuration.
+
+## Goals
+
+- Allow YAML configuration to map public model aliases to routed model names.
+- Allow every provider deployment to inherit an optional provider priority.
+- Keep existing configurations and routing behavior unchanged when both fields are omitted.
+- Expose configured aliases through the OpenAI model inventory so clients can discover routable names.
+- Fail startup explicitly for malformed or cyclic aliases.
+
+## Non-Goals
+
+- Changing provider-specific outbound model mappings.
+- Adding new routing strategies or changing weight semantics.
+- Adding request-time alias mutation or an alias administration API.
+- Defining automatic failover across different model capabilities.
+
+## Behavior Invariants
+
+1. B-001 A non-empty configured model alias resolves to its configured target for normal and streaming routed requests.
+2. B-002 Configured aliases are included once in the OpenAI-compatible model inventory while canonical deployment models remain available.
+3. B-003 Empty alias names, empty targets, self-aliases, and direct or transitive alias cycles fail configuration/startup explicitly without serving traffic.
+4. B-004 Alias declaration order does not affect resolution, including valid transitive alias chains.
+5. B-005 A configured provider priority is copied to every deployment created for that provider, and lower numeric priority wins under `priority_based` routing.
+6. B-006 Omitted provider priority defaults to `0`; omitted or empty alias configuration installs no aliases, preserving existing configuration behavior.
+7. B-007 Disabled providers create no deployments, so their priority cannot affect routing; aliases whose final target has no enabled deployment are rejected before serving traffic.
+8. B-008 Unknown YAML fields remain rejected, and alias/priority values are configuration data only: they trigger no network calls, persistence, permissions, or background work.
+
+## Acceptance Criteria
+
+- [ ] YAML parsing tests cover aliases, provider priority, defaults, and unknown fields.
+- [ ] Router construction tests cover direct/transitive aliases, cycles, missing targets, disabled providers, and priority propagation.
+- [ ] Route/model inventory tests prove aliases are routable and discoverable.
+- [ ] Existing example configuration remains valid without either new field.
+- [ ] Configuration documentation contains a working alias plus primary/fallback example.
+- [ ] Formatting, all-target/all-feature build, strict Clippy, and full tests pass.
+
+## Edge Cases
+
+- Duplicate YAML mapping keys follow the parser's existing duplicate-key behavior; this feature does not add silent merge rules.
+- Alias chains may target another alias but must terminate at a model served by an enabled deployment.
+- Equal provider priorities continue to use the router's existing within-tier selection behavior.
+- Very large numeric priorities are valid `u32` values and remain ordered without arithmetic.
+
+## Rollout Notes
+
+The schema additions are optional and default to current behavior. Operators can deploy the new binary first, then add aliases or priorities. Rollback requires removing the new fields before starting an older binary because configuration parsing rejects unknown fields.

--- a/specs/GH1105/tasks.md
+++ b/specs/GH1105/tasks.md
@@ -12,15 +12,15 @@ GH-1105 / #1105
 ## Implementation Tasks
 
 - [ ] `SP1105-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008. Owner: coordinator. Dependencies: none. Done when: product/tech/tasks exist, behavior invariants are contiguous, and every invariant maps to implementation and tests. Verify: SpecRail workflow checks and `git diff --check`.
-- [ ] `SP1105-T2` Covers: B-003, B-004, B-006, B-007, B-008. Owner: implementation owner. Dependencies: SP1105-T1. Done when: gateway/provider schema, defaults, merge, debug, and deterministic alias validation are implemented with negative cases. Verify: focused config model and validator tests.
-- [ ] `SP1105-T3` Covers: B-001, B-004, B-005, B-006, B-007. Owner: implementation owner. Dependencies: SP1105-T2. Done when: router construction atomically installs validated aliases and propagates priority without breaking the existing public constructor. Verify: focused gateway-config and priority-routing tests.
+- [ ] `SP1105-T2` Covers: B-003, B-004, B-006, B-007, B-008. Owner: implementation owner. Dependencies: SP1105-T1. Done when: gateway/provider schema and defaults exist; alias overlays merge key by key with overlay wins and omitted/explicit-empty overlays preserving base entries; Phase A rejects empty/self/cyclic graphs without checking provider-expanded targets. Verify: focused config model merge/default/export tests and graph-validator negative tests.
+- [ ] `SP1105-T3` Covers: B-001, B-002, B-004, B-005, B-006, B-007. Owner: implementation owner. Dependencies: SP1105-T2. Done when: router construction expands enabled configured/dynamic/fallback canonical models, rejects alias-key collisions and absent final targets, flattens every chain to one hop, and publishes the complete deployment/alias state before health checks while propagating priority and preserving the existing public constructor. Verify: focused gateway-config tests for dynamic targets, disabled/missing targets, canonical collision, reversed declaration order, a chain longer than 16 hops, atomic failure, and priority routing.
 - [ ] `SP1105-T4` Covers: B-002. Owner: implementation owner. Dependencies: SP1105-T3. Done when: alias names are read from router state and appear once in deterministic OpenAI model inventory output. Verify: focused model-route tests.
 - [ ] `SP1105-T5` Covers: B-001, B-002, B-005, B-006. Owner: documentation owner. Dependencies: SP1105-T2. Done when: example YAML and README document alias, primary/fallback priority, defaults, and rollback ordering. Verify: example config parse test and documentation diff review.
 - [ ] `SP1105-T6` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008. Owner: verification owner. Dependencies: SP1105-T3, SP1105-T4, SP1105-T5. Done when: focused and repository-wide gates pass and the diff remains scoped to GH1105. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; workflow/spec checks; `git diff --check`.
 
 ## Parallelization
 
-Schema/validation and docs share example expectations and should follow the approved spec serially. Model inventory work can proceed after the router accessor contract is fixed. One implementation owner should handle the tightly coupled config and router files; verification remains independent.
+Schema/Phase-A validation and docs share example expectations and should follow the approved spec serially. Phase-B expansion/flattening owns router construction and must finish before model inventory work. One implementation owner should handle the tightly coupled config and router files; verification remains independent.
 
 ## Verification
 
@@ -32,6 +32,9 @@ Schema/validation and docs share example expectations and should follow the appr
 ## Handoff Notes
 
 - Preserve `Router::from_gateway_config` for external callers; use an additive constructor/helper for aliases.
-- Alias validation must be independent of `HashMap` iteration order.
+- Alias graph validation and flattening must be independent of `HashMap` iteration order.
+- Treat omitted and explicit-empty overlay alias maps identically: both preserve base aliases; this version has no clearing sentinel.
+- Derive canonical-model collisions and final-target validity from staged enabled deployments after dynamic model expansion, not only from YAML model lists.
+- Install only single-hop alias-to-canonical mappings so runtime resolution never depends on the 16-hop bound.
 - Lower numeric priority is selected first; equal-priority behavior remains unchanged.
 - Do not merge or give final approval automatically; repository policy reserves those gates for a human.

--- a/specs/GH1105/tasks.md
+++ b/specs/GH1105/tasks.md
@@ -1,0 +1,37 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1105 / #1105
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1105-T1` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008. Owner: coordinator. Dependencies: none. Done when: product/tech/tasks exist, behavior invariants are contiguous, and every invariant maps to implementation and tests. Verify: SpecRail workflow checks and `git diff --check`.
+- [ ] `SP1105-T2` Covers: B-003, B-004, B-006, B-007, B-008. Owner: implementation owner. Dependencies: SP1105-T1. Done when: gateway/provider schema, defaults, merge, debug, and deterministic alias validation are implemented with negative cases. Verify: focused config model and validator tests.
+- [ ] `SP1105-T3` Covers: B-001, B-004, B-005, B-006, B-007. Owner: implementation owner. Dependencies: SP1105-T2. Done when: router construction atomically installs validated aliases and propagates priority without breaking the existing public constructor. Verify: focused gateway-config and priority-routing tests.
+- [ ] `SP1105-T4` Covers: B-002. Owner: implementation owner. Dependencies: SP1105-T3. Done when: alias names are read from router state and appear once in deterministic OpenAI model inventory output. Verify: focused model-route tests.
+- [ ] `SP1105-T5` Covers: B-001, B-002, B-005, B-006. Owner: documentation owner. Dependencies: SP1105-T2. Done when: example YAML and README document alias, primary/fallback priority, defaults, and rollback ordering. Verify: example config parse test and documentation diff review.
+- [ ] `SP1105-T6` Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008. Owner: verification owner. Dependencies: SP1105-T3, SP1105-T4, SP1105-T5. Done when: focused and repository-wide gates pass and the diff remains scoped to GH1105. Verify: `cargo fmt --all -- --check`; `cargo check --all-targets --all-features --locked`; `cargo clippy --all-targets --all-features --locked -- -D warnings`; `cargo test --all-features --locked -- --test-threads=1`; workflow/spec checks; `git diff --check`.
+
+## Parallelization
+
+Schema/validation and docs share example expectations and should follow the approved spec serially. Model inventory work can proceed after the router accessor contract is fixed. One implementation owner should handle the tightly coupled config and router files; verification remains independent.
+
+## Verification
+
+- Run `python3 checks/check_workflow.py --repo .`.
+- Run `python3 checks/check_workflow.py --repo . --spec-dir=specs/GH1105`.
+- Confirm the product invariant set and task `Covers:` union both equal B-001 through B-008.
+- Require the implementation PR to use `Fixes #1105`, target the spec branch, and report only current-head CI evidence.
+
+## Handoff Notes
+
+- Preserve `Router::from_gateway_config` for external callers; use an additive constructor/helper for aliases.
+- Alias validation must be independent of `HashMap` iteration order.
+- Lower numeric priority is selected first; equal-priority behavior remains unchanged.
+- Do not merge or give final approval automatically; repository policy reserves those gates for a human.

--- a/specs/GH1105/tech.md
+++ b/specs/GH1105/tech.md
@@ -21,9 +21,9 @@ See `product.md`.
 
 ## Proposed Design
 
-1. Add `model_aliases: HashMap<String, String>` to `GatewayConfig` with `#[serde(default)]`, include it in defaults/merge/export behavior, and add `priority: u32` to `ProviderConfig` with `#[serde(default)]` and debug/default handling.
-2. Extend gateway validation to reject trimmed-empty aliases/targets, self references, cycles, and chains whose final canonical target is not served by an enabled provider. Use map traversal with a per-alias visited set; do not depend on hash iteration order.
-3. Add a backward-compatible router constructor that accepts aliases, or extend construction through a private helper while preserving the existing public `from_gateway_config` API. Build enabled deployments first, propagate `ProviderConfig.priority` into `DeploymentConfig`, then install all validated aliases before health checks start.
+1. Add `model_aliases: HashMap<String, String>` to `GatewayConfig` with `#[serde(default)]`, include it in defaults/export behavior, and add `priority: u32` to `ProviderConfig` with `#[serde(default)]` and debug/default handling. `GatewayConfig::merge` starts with the base alias map and inserts every overlay entry, so overlay values win per key. Because serde maps omitted and explicit `{}` to the same empty map, either form preserves all base entries; this version defines no clearing sentinel. Add focused tests for disjoint union, same-key override, omitted overlay, and explicit-empty overlay.
+2. Split validation into two deterministic phases. Phase A, in configuration validation, rejects trimmed-empty aliases/targets, self references, and direct or transitive cycles using per-alias traversal independent of `HashMap` iteration order. It does not decide target availability. Phase B, during router construction, first creates enabled provider instances and expands each deployment's canonical models from configured `models`, otherwise `provider.list_models()`, otherwise the existing provider-name fallback. From that staged deployment set, reject alias keys colliding with any canonical model and reject chains whose final target is absent.
+3. Add a backward-compatible router constructor that accepts aliases, or extend construction through a private helper while preserving the existing public `from_gateway_config` API. Propagate `ProviderConfig.priority` into every staged `DeploymentConfig`. Resolve every Phase-A-valid alias chain against the Phase-B canonical model set and build a normalized map in which every alias points directly to its final canonical model. Install the staged deployments and complete normalized alias map as one unpublished construction result before starting health checks; no partially validated router reaches `AppState`.
 4. Expose a read-only router alias snapshot/accessor and merge alias names into `/v1/models`, sorted and deduplicated using the route's existing deterministic output behavior.
 5. Document direct aliases, transitive aliases, priority ordering, default `0`, and rollback compatibility in the example config and README.
 
@@ -32,17 +32,17 @@ See `product.md`.
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
 | B-001 | gateway config plus router construction | direct alias completion-selection and streaming-selection focused tests |
-| B-002 | router alias accessor plus model route | inventory contains alias and canonical model exactly once |
+| B-002 | Phase-B collision validation, router alias accessor, and model route | canonical-key collision fails; otherwise inventory contains alias and canonical model exactly once |
 | B-003 | gateway validation and runtime alias installation | empty/self/direct-cycle/transitive-cycle negative tests |
-| B-004 | deterministic graph validation/installation | reversed-order transitive alias test resolves identically |
+| B-004 | deterministic graph validation, chain flattening, and batch installation | reversed-order and greater-than-16-hop chains install identical single-hop mappings |
 | B-005 | provider config to deployment config | configured tiers select lower priority first |
-| B-006 | serde/defaults and legacy constructor | old YAML parses and creates priority-zero deployments with no aliases |
-| B-007 | validation against enabled-provider models | disabled-only/missing canonical target fails before server state creation |
+| B-006 | serde/defaults, key-wise merge, and legacy constructor | disjoint/same-key/omitted/explicit-empty overlay tests plus old YAML with priority-zero deployments and no aliases |
+| B-007 | two-phase validation against expanded enabled-provider models | configured and dynamic model targets succeed; canonical collision and disabled-only/missing targets fail before health checks or server state creation |
 | B-008 | deny-unknown schema and pure validation | unknown-field regression and no-I/O unit coverage |
 
 ## Data Flow
 
-YAML is environment-substituted and deserialized into `GatewayConfig`. Validation checks the alias graph against models declared by enabled providers. Server startup converts provider entries into runtime deployments, copying priority, then installs aliases into the router snapshot before health checks and `AppState` publication. Routed requests resolve aliases through the existing snapshot path. The model route reads deployment models and configured alias names from the same router state.
+YAML is environment-substituted and deserialized into `GatewayConfig`; layered configs merge alias entries key by key. Phase A validates alias shape and graph structure without assuming that YAML declares every model. Server startup then instantiates enabled providers, expands each provider's effective models, and stages the corresponding deployments while copying priority. Phase B derives the canonical model set from those staged deployments, rejects alias-key collisions and missing final targets, and flattens each valid alias to that final canonical model. The complete deployments-plus-aliases state is installed before health checks and `AppState` publication. Routed requests therefore need at most one alias lookup, and the model route reads canonical models and alias names from that same router state.
 
 ## Alternatives Considered
 
@@ -50,18 +50,20 @@ YAML is environment-substituted and deserialized into `GatewayConfig`. Validatio
 - Put aliases in runtime-only `RouterConfig`: rejected because that type is also used by SDK/runtime callers and should not acquire deployment inventory policy.
 - Install aliases after `AppState` creation: rejected because a partially initialized router could become observable if alias installation fails.
 - Treat missing targets as valid future aliases: rejected because a typo would make startup succeed while every request fails at runtime.
+- Validate final targets only from YAML `models`: rejected because an empty list is expanded from `provider.list_models()` during construction and would falsely reject valid dynamic models.
+- Keep transitive chains in the runtime map: rejected because the current resolver stops after 16 hops and could silently return an intermediate alias.
 
 ## Risks
 
 - Security: aliases and priorities are local configuration only; validation must not resolve URLs or emit secrets.
 - Compatibility: older binaries reject the new fields, so rollback requires reverting config first; omitted fields preserve current behavior.
-- Performance: startup validation is linear in aliases times maximum chain length; request resolution remains the existing router snapshot lookup.
+- Performance: startup validation is linear in aliases times maximum chain length; flattening makes configured-alias resolution a single map hop at request time.
 - Maintenance: model inventory must use the same router alias state as routing to avoid config/runtime drift.
 
 ## Test Plan
 
-- [ ] Unit tests: serde/default/debug/merge, graph validation, priority propagation, alias accessor.
-- [ ] Integration tests: gateway construction, request selection, and model inventory using test providers without external calls.
+- [ ] Unit tests: serde/default/debug, key-wise overlay merge, Phase-A graph validation, priority propagation, normalized alias accessor.
+- [ ] Integration tests: gateway construction with configured and dynamically expanded models, Phase-B collision/target failures, a greater-than-16-hop chain, request selection, and model inventory using test providers without external calls.
 - [ ] Manual verification: start with example YAML, query `/v1/models`, and send a completion through an alias.
 - [ ] Repository gates: format, all-target/all-feature check, strict Clippy, and serial full test.
 

--- a/specs/GH1105/tech.md
+++ b/specs/GH1105/tech.md
@@ -1,0 +1,70 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1105 / #1105
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Gateway schema | `src/config/models/gateway.rs`, `src/config/models/provider.rs` | Gateway has no alias map; providers have weight but no priority | B-003/B-006/B-008 schema and defaults |
+| Config validation | `src/config/validation/config_validators.rs` | Validates providers and router independently | Alias shape and target validation must fail before startup |
+| Router construction | `src/core/router/gateway_config.rs` | Creates deployments, hardcodes priority `0`, installs no aliases | B-001/B-004/B-005/B-007 root behavior |
+| Server startup | `src/server/http.rs` | Builds the unified router from providers and runtime router settings | Must pass validated aliases into construction atomically |
+| Model route | `src/server/routes/ai/models.rs` | Lists deployment model names only | B-002 discoverability |
+| Examples/docs | `config/gateway.yaml.example`, `README.md` | Documents providers and router fields | Migration and operator contract |
+
+## Proposed Design
+
+1. Add `model_aliases: HashMap<String, String>` to `GatewayConfig` with `#[serde(default)]`, include it in defaults/merge/export behavior, and add `priority: u32` to `ProviderConfig` with `#[serde(default)]` and debug/default handling.
+2. Extend gateway validation to reject trimmed-empty aliases/targets, self references, cycles, and chains whose final canonical target is not served by an enabled provider. Use map traversal with a per-alias visited set; do not depend on hash iteration order.
+3. Add a backward-compatible router constructor that accepts aliases, or extend construction through a private helper while preserving the existing public `from_gateway_config` API. Build enabled deployments first, propagate `ProviderConfig.priority` into `DeploymentConfig`, then install all validated aliases before health checks start.
+4. Expose a read-only router alias snapshot/accessor and merge alias names into `/v1/models`, sorted and deduplicated using the route's existing deterministic output behavior.
+5. Document direct aliases, transitive aliases, priority ordering, default `0`, and rollback compatibility in the example config and README.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | gateway config plus router construction | direct alias completion-selection and streaming-selection focused tests |
+| B-002 | router alias accessor plus model route | inventory contains alias and canonical model exactly once |
+| B-003 | gateway validation and runtime alias installation | empty/self/direct-cycle/transitive-cycle negative tests |
+| B-004 | deterministic graph validation/installation | reversed-order transitive alias test resolves identically |
+| B-005 | provider config to deployment config | configured tiers select lower priority first |
+| B-006 | serde/defaults and legacy constructor | old YAML parses and creates priority-zero deployments with no aliases |
+| B-007 | validation against enabled-provider models | disabled-only/missing canonical target fails before server state creation |
+| B-008 | deny-unknown schema and pure validation | unknown-field regression and no-I/O unit coverage |
+
+## Data Flow
+
+YAML is environment-substituted and deserialized into `GatewayConfig`. Validation checks the alias graph against models declared by enabled providers. Server startup converts provider entries into runtime deployments, copying priority, then installs aliases into the router snapshot before health checks and `AppState` publication. Routed requests resolve aliases through the existing snapshot path. The model route reads deployment models and configured alias names from the same router state.
+
+## Alternatives Considered
+
+- Put aliases in each provider: rejected because inbound public names belong to routing, while provider model mappings translate outbound names.
+- Put aliases in runtime-only `RouterConfig`: rejected because that type is also used by SDK/runtime callers and should not acquire deployment inventory policy.
+- Install aliases after `AppState` creation: rejected because a partially initialized router could become observable if alias installation fails.
+- Treat missing targets as valid future aliases: rejected because a typo would make startup succeed while every request fails at runtime.
+
+## Risks
+
+- Security: aliases and priorities are local configuration only; validation must not resolve URLs or emit secrets.
+- Compatibility: older binaries reject the new fields, so rollback requires reverting config first; omitted fields preserve current behavior.
+- Performance: startup validation is linear in aliases times maximum chain length; request resolution remains the existing router snapshot lookup.
+- Maintenance: model inventory must use the same router alias state as routing to avoid config/runtime drift.
+
+## Test Plan
+
+- [ ] Unit tests: serde/default/debug/merge, graph validation, priority propagation, alias accessor.
+- [ ] Integration tests: gateway construction, request selection, and model inventory using test providers without external calls.
+- [ ] Manual verification: start with example YAML, query `/v1/models`, and send a completion through an alias.
+- [ ] Repository gates: format, all-target/all-feature check, strict Clippy, and serial full test.
+
+## Rollback Plan
+
+Remove `model_aliases` and `priority` from deployed YAML, verify the old configuration parses, then roll back the binary. No data migration or persistent state rollback is required.


### PR DESCRIPTION
# Summary

Defines the product, technical, and task contract for YAML-configurable model aliases and provider priority.

## Linked Work

- Issue: Relates to #1105
- Spec packet: specs/GH1105/

## Readiness Gate

- [x] Linked issue is in ready_to_spec.
- [x] Product and tech specs are included.
- [x] Change contains no credentials or private deployment details.

## Review Gate

- [x] Agent first-pass review completed.
- [ ] Human final review requested.
- [ ] Maintainer approval recorded.

## Verification

- [x] python3 checks/check_workflow.py --repo .
- [x] python3 checks/check_workflow.py --repo . --spec-dir=specs/GH1105
- [x] cargo fmt --all -- --check
- [x] git diff --check

## Release Notes

- [x] Not user-visible; specification only.

## Agent Disclosure

- [x] Agent assisted; human author review is requested.

Refs #1105
