### PR TITLE
docs(spec): correct GH1107 T1 boundary

### DIFF
--- a/specs/GH1107/product.md
+++ b/specs/GH1107/product.md
@@ -75,8 +75,10 @@ Tier 2 可以在同一 issue 的后续 tranche 中实现；在实现前必须返
 5. **B-005** 当一次请求含多个并行 call 时，call/output 按 `call_id` 关联，
    output item 按模型产生的稳定顺序返回；并发完成顺序不得造成串线或覆盖。
 6. **B-006** Tier 2 或未知 item/tool 必须在上游调用前返回 4xx
-   `unsupported_codex_feature`，并指出 feature、selected provider 和 model；
-   不得通过 `serde(other)`、空消息、warning 或普通文本 fallback 表示成功。
+   `unsupported_codex_feature`，并指出 feature、model 和 provider context：若 provider
+   已选择则给出 selected provider；若请求在 provider 选择前被 wire gate 拒绝，则明确
+   返回 `provider=unselected`，不得为补齐错误文本而触发 provider 选择。不得通过
+   `serde(other)`、空消息、warning 或普通文本 fallback 表示成功。
 7. **B-007** 只有同时满足请求所需 transport、streaming 与 tool capability 的
    provider/model 才可执行；能力声明缺失或不一致时按不支持处理，不尝试未声明
    的降级路径。

--- a/specs/GH1107/tasks.md
+++ b/specs/GH1107/tasks.md
@@ -15,7 +15,7 @@ GH-1107 / #1107
 
 ## 实现任务
 
-- [ ] `SP1107-T1` Covers: B-002, B-006, B-015, B-018. Owner: responses wire owner. Dependencies: spec approved + `ready_to_implement`. Files: `src/core/models/openai/responses_api.rs`, `src/server/routes/ai/responses/codex_compat_tests.rs`. Done when: Tier 1/Tier 2/unknown wire types 按 tech contract 可解析或返回稳定错误，output union 的 string/structured form round-trip，fixtures 固定 Codex commit，正负例均 schema valid. Verify: `cargo test --locked codex_wire`，fixture source/count guard，fmt/check。
+- [ ] `SP1107-T1` Covers: B-002, B-006, B-015, B-018. Owner: responses wire owner. Dependencies: spec approved + `ready_to_implement`. Files: `src/core/models/openai/responses_api.rs`, `src/server/routes/ai/openai_errors.rs`, `src/server/routes/ai/responses.rs`, `src/server/routes/ai/responses/codex_compat_tests.rs`, `src/server/routes/ai/responses/lifecycle.rs`, `src/server/routes/ai/responses/lifecycle_tests.rs`. Done when: Tier 1/Tier 2/unknown wire types 按 tech contract 可解析；Tier 1 的 `id`/`call_id`/`name`/`namespace`/payload 与 string/structured output form round-trip；unknown 只保留 metadata allowlist；非 message item、custom/Tier 2/unknown tool 和 `additional_tools` 在 call ledger 合并前统一返回 400 `unsupported_codex_feature`（message 含 feature/model/`provider=unselected`），且不进入 provider 执行路径。route/lifecycle 改动仅用于 fail-closed 与新增 optional 字段的编译适配，不得加入 call ledger、provider projection 或 previous-response call 恢复。fixtures 固定 Codex commit，正负例均 schema valid. Verify: `cargo test --locked codex_wire`，HTTP error envelope/upstream=0、missing/null/empty、unknown redaction、fixture source/count guard，fmt/check/strict Clippy。
 
 - [ ] `SP1107-T2` Covers: B-002, B-003, B-005, B-006, B-015, B-018, B-020. Owner: canonical turn owner. Dependencies: SP1107-T1 merged. Files: `src/core/types/codex.rs`, `src/core/types/mod.rs`, `src/server/routes/ai/responses/codex_compat.rs`, `src/server/routes/ai/responses/codex_compat_tests.rs`. Done when: ordered CodexTurn、closed call kind、call ledger 和 execution requirements 完成，unknown/duplicate/missing/type mismatch 在 provider 前拒绝，且没有新 router 或 tool executor. Verify: `cargo test --locked codex_turn codex_call_ledger`，property/negative tests、source guard、fmt/check/Clippy。
 
@@ -34,6 +34,8 @@ GH-1107 / #1107
 ## 并行拆分
 
 - SP1107-T1 → T2 → T3 严格串行，共同定义 wire/canonical/sync 语义。
+- T1 与后续 T3/T4 会串行触碰 `responses.rs` / lifecycle；T1 仅做 enum 编译适配和
+  pre-provider fail-closed，禁止提前实现后续 owner 的 projection 或 context 行为。
 - T4 与 T5 都依赖 T3；T5 还依赖 T4 的 context contract，因此默认串行，避免共享 `codex_compat.rs`。
 - T6 在 T5 后只写 matrix + integration fixture。
 - T7 在 T6 exact behavior 稳定后由 docs owner 独立写，不与 production owner 共享文件。

--- a/specs/GH1107/tech.md
+++ b/specs/GH1107/tech.md
@@ -118,8 +118,9 @@ match 点，但范围严格限于：
 - lifecycle 只补齐新增 optional wire 字段的构造与穷尽匹配，T1 不改变 previous response
   的 call/output 恢复语义。
 
-T1 禁止新增 `CodexTurn`、call ledger、projection map 或 provider-facing tool/message；这些
-仍分别属于严格串行的 T2、T3 和 T4。
+T1 禁止新增 `CodexTurn`、call ledger、projection map、provider-facing tool/message 或
+previous-response call 恢复：`CodexTurn` 与 call ledger 属于 T2，projection map 与
+provider-facing tool/message 属于 T3，previous-response call 恢复属于 T4。
 
 ### 2. Canonical Codex turn
 
@@ -202,13 +203,13 @@ completed。现有 `[DONE]` 行为由 fixture 锁定。
 
 新增 `codex_compatibility_error` 构造器，通过现有 OpenAI envelope 返回：
 
-- status: 400 或 422（由现有仓库错误政策确定一种并 fixture 固定）；
+- status: 400；
 - type: `invalid_request_error`；
 - code: `unsupported_codex_feature`、`invalid_codex_call_graph` 或
   `codex_stream_state_error`；
 - message: 仅 feature/provider/model/call-id digest，不含 credential、tool output
-  全文或 upstream body；若 wire gate 在选择 provider 前拒绝，provider context 固定为
-  `unselected`，不得为了生成错误消息提前触发 provider 选择。
+  全文或 upstream body；若 wire gate 在选择 provider 前拒绝，message 中的 provider
+  context 固定为 `provider=unselected`，不得为了生成错误消息提前触发 provider 选择。
 
 日志只记录 request id、feature、provider/model 和 call 数量。SEC-11 要求
 `openai_errors.rs`、payload redaction 与任何 header/URL 修改接受人工安全审查。
@@ -321,13 +322,16 @@ Codex /v1/responses JSON
 
 ## 实施分段
 
-- **D1 Wire + ledger**：DTO、CodexTurn、验证、错误；不接 provider。
-- **D2 Sync projection**：function/custom sync loop、capability preflight、lifecycle。
-- **D3 Streaming**：shared projector、SSE state machine、disconnect/settlement。
-- **D4 Provider conformance**：三类 adapter loopback matrix 与 support surface。
-- **D5 Docs + closure**：文档、全量 regression、人工安全 review。
+- **D1 / T1 Wire**：DTO、unknown redaction、pre-provider wire error；不接 provider。
+- **D2 / T2 Canonical ledger**：CodexTurn、call ledger、execution requirements；不接 provider。
+- **D3 / T3 Sync projection**：function/custom sync loop 与 capability preflight。
+- **D4 / T4 Lifecycle**：previous-response call/output context 与 storage regression。
+- **D5 / T5 Streaming**：shared projector、SSE state machine、disconnect/settlement。
+- **D6 / T6 Provider conformance**：三类 adapter loopback matrix 与 support surface。
+- **D7 / T7 Docs**：配置、smoke、支持矩阵与恢复文档。
+- **D8 / T8 Closure**：merged-main 全量 regression 与独立人工安全 review。
 
-D1→D2→D3 严格串行；D4 只能在 D3 语义稳定后写 conformance；D5 最后。每个 tranche
+D1→D2→D3→D4→D5→D6→D7→D8 按 `tasks.md` 的依赖严格串行。每个 tranche
 使用独立 implementation PR、`Refs #1107`，最终 closure PR 才使用
 `Fixes #1107`。实现前必须由维护者把 issue 转为 `ready_to_implement`。
 

--- a/specs/GH1107/tech.md
+++ b/specs/GH1107/tech.md
@@ -93,13 +93,33 @@ amendment；不得边实现边扩大 allowlist。
 
 - Tier 1 使用强类型 variant，所有 machine-facing 字段保持 snake_case。
 - Tier 2 使用强类型“recognized but unsupported” variant，不能直接丢弃。
-- 真正未知类型由自定义反序列化保留 `type` 和受限元数据；不保留/记录完整敏感
-  payload。route 返回 `unsupported_codex_feature`。
+- Tier 1 完整保留当前 Codex wire 的 `id`、`call_id`、`name`、`namespace`、
+  `status` 和 payload；structured tool output 覆盖 `input_text`、`input_image`、
+  `input_audio` 与 `encrypted_content`。
+- 真正未知类型由自定义反序列化只保留 `type` 以及 allowlist 元数据
+  `id` / `call_id` / `name` / `namespace` / `status`；其他字段在 DTO 边界丢弃，
+  不保留/记录完整敏感 payload。route 返回 `unsupported_codex_feature`。
 - `function_call_output.output` 与 `custom_tool_call_output.output` 支持 Codex
   当前 wire 的 string 或 structured content items，规范化时保留原始 form。
 
 这里不使用 `serde(other)`，因为它无法携带原始 type，也会把 schema 合法的未来
 类型伪装成空 variant。
+
+#### T1 落地边界
+
+Rust enum 的新增 variant 会使 crate 内既有穷尽匹配无法编译，因此 T1 除 DTO 与 fixture
+外，允许修改 `responses.rs`、`openai_errors.rs` 和 lifecycle 的 struct construction /
+match 点，但范围严格限于：
+
+- 新 wire variant 在 canonical call ledger 合并前一律 fail closed，不投影为
+  assistant/tool chat message，也不发送 provider 请求；
+- 使用现有 OpenAI error envelope 返回 400、code=`unsupported_codex_feature`，message
+  只含 feature、model 与 `provider=unselected`；
+- lifecycle 只补齐新增 optional wire 字段的构造与穷尽匹配，T1 不改变 previous response
+  的 call/output 恢复语义。
+
+T1 禁止新增 `CodexTurn`、call ledger、projection map 或 provider-facing tool/message；这些
+仍分别属于严格串行的 T2、T3 和 T4。
 
 ### 2. Canonical Codex turn
 
@@ -187,7 +207,8 @@ completed。现有 `[DONE]` 行为由 fixture 锁定。
 - code: `unsupported_codex_feature`、`invalid_codex_call_graph` 或
   `codex_stream_state_error`；
 - message: 仅 feature/provider/model/call-id digest，不含 credential、tool output
-  全文或 upstream body。
+  全文或 upstream body；若 wire gate 在选择 provider 前拒绝，provider context 固定为
+  `unselected`，不得为了生成错误消息提前触发 provider 选择。
 
 日志只记录 request id、feature、provider/model 和 call 数量。SEC-11 要求
 `openai_errors.rs`、payload redaction 与任何 header/URL 修改接受人工安全审查。
@@ -225,11 +246,11 @@ redaction。负例必须 schema 合法且到达业务 gate，不能只测试 ser
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
 | B-001 | existing Chat/Responses delegate paths | `cargo test --locked responses_api chat_completion` 加 snapshot regression；现有 request fixture 输出不变。 |
-| B-002 | Responses DTO + `CodexTurn` | unit fixtures round-trip 每个 Tier 1 字段，并分别覆盖 missing/null/empty。 |
+| B-002 | Responses DTO + `CodexTurn` | unit fixtures round-trip 每个 Tier 1 字段（含 output `id`、custom `namespace`、`input_audio`），并分别覆盖 missing/null/empty。 |
 | B-003 | `CodexCallLedger` | negative fixtures: unknown、duplicate、missing、kind mismatch call_id 均在 upstream request count=0 时 4xx。 |
 | B-004 | custom projection/projector | round-trip property test：任意合法 name/namespace/input 经 provider envelope 后恢复相同 custom item。 |
 | B-005 | ledger + output ordering | parallel two-call fixture 逆序 provider chunks 后仍按稳定 output_index 且 call_id 不串线。 |
-| B-006 | custom DTO deserialize + compatibility gate | 每个 Tier 2/unknown schema-valid fixture 返回 `unsupported_codex_feature`，mock upstream requests=0。 |
+| B-006 | custom DTO deserialize + compatibility gate | 每个 Tier 2/unknown schema-valid fixture 返回 `unsupported_codex_feature`，wire-stage error 固定 `provider=unselected`，unknown 非 allowlist payload 不出现在 error/round-trip，mock upstream requests=0。 |
 | B-007 | capability preflight + support matrix | provider/model capability table test；缺 ToolCalling 或 stream capability 的 deployment 被拒绝。 |
 | B-008 | selected-attempt preflight | mock budget/callback/upstream counters 全为零的 unsupported fixture。 |
 | B-009 | event state machine | table-driven allowed/illegal transitions；terminal count=1；index-before-added 失败。 |


### PR DESCRIPTION
## 关联

Refs #1107

Blocks implementation PR #1110 until this amendment is approved and merged.

## 根因

独立 merge review 发现，原 SP1107-T1 要求扩展 Responses enum，却只允许修改 DTO 与测试文件。Rust crate 内的穷尽匹配和 struct literals 使这个文件边界不可实施；#1110 因而提前写入了属于 T2/T3/T4 的 projection/ledger 前置逻辑。

## 本 amendment

- 明确 T1 可触碰 route/error/lifecycle 的编译适配点，但只允许 pre-provider fail-closed
- 明确 T1 禁止 call ledger、provider projection 和 previous-response call 恢复
- unknown item/tool 只保留 `id`、`call_id`、`name`、`namespace`、`status` 诊断 allowlist，丢弃其他 payload
- 补齐 pinned Codex wire 必须覆盖的 output `id`、custom `namespace` 和 `input_audio`
- provider 尚未选择时，错误稳定返回 `provider=unselected`，不得为了诊断触发 provider 选择

产品目标、Tier 1/Tier 2 范围、provider 范围和 T1→T2→T3 严格串行关系均未扩大。

## 验证

- `python3 checks/route_gate.py --repo . --route write_spec --issue 1107 --state ready_to_spec --json` — allowed
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1107` — passed
- `python3 checks/check_workflow.py --repo .` — passed
- `git diff --check` — passed

## 后续

本 PR 合并后，#1110 将缩回修订后的纯 T1：移除 provider projection 与 T2 canonical types，补齐 wire 字段、unknown redaction、稳定 HTTP error envelope 和负例。
