### PR TITLE
docs(spec): allow GH1107 T1 review evidence

### DIFF
--- a/specs/GH1107/tasks.md
+++ b/specs/GH1107/tasks.md
@@ -41,7 +41,7 @@ GH-1107 / #1107
 - T7 在 T6 exact behavior 稳定后由 docs owner 独立写，不与 production owner 共享文件。
 - T8 是只读 reviewer/coordinator lane，不写 production/spec 文件。
 - 每个 writable task 使用独立 worktree 和单一 owner。若必须多 agent，文件所有权严格按 Files 列表分离；共享文件出现时改为串行。
-- 任一 tranche 超过 10 个非文档文件或 500 changed lines，先合并 spec amendment，禁止删除测试、压缩断言或扩大 allowlist 规避。
+- 任一 tranche 超过 10 个非文档文件或 500 changed lines，先合并 spec amendment，禁止删除测试、压缩断言或扩大 allowlist 规避。SP1107-T1 因独立复审新增完整 Tier 2 handler matrix 与 provider-dispatch=0 证据，并恢复正常 rustfmt、独立断言及注释，单独批准至最多 550 changed lines；仍限既有 8 个文件，且不得借此实现 T2/T3/T4 行为。
 
 ## 验证
 

--- a/specs/GH1107/tech.md
+++ b/specs/GH1107/tech.md
@@ -83,8 +83,8 @@ GH-1107 / #1107
 清单是 GH-1107 当前设计的完整候选路径。任一 implementation tranche 发现必须修改
 清单外文件，或任一 tranche 超过 10 个非文档文件 / 500 changed lines，先提交 spec
 amendment；不得边实现边扩大 allowlist。SP1107-T1 经独立复审要求补齐完整 Tier 2
-handler matrix、provider-dispatch=0 证据并恢复正常 rustfmt/注释后，单独批准至最多
-550 changed lines；该例外不改变文件 allowlist，也不适用于后续 tranche。
+handler matrix、provider-dispatch=0 证据并恢复正常 rustfmt、独立断言及注释后，单独
+批准至最多 550 changed lines；该例外不改变文件 allowlist，也不适用于后续 tranche。
 
 ## 设计方案
 

--- a/specs/GH1107/tech.md
+++ b/specs/GH1107/tech.md
@@ -82,7 +82,9 @@ GH-1107 / #1107
 
 清单是 GH-1107 当前设计的完整候选路径。任一 implementation tranche 发现必须修改
 清单外文件，或任一 tranche 超过 10 个非文档文件 / 500 changed lines，先提交 spec
-amendment；不得边实现边扩大 allowlist。
+amendment；不得边实现边扩大 allowlist。SP1107-T1 经独立复审要求补齐完整 Tier 2
+handler matrix、provider-dispatch=0 证据并恢复正常 rustfmt/注释后，单独批准至最多
+550 changed lines；该例外不改变文件 allowlist，也不适用于后续 tranche。
 
 ## 设计方案
 


### PR DESCRIPTION
## Summary

- grant SP1107-T1 a narrow 550 changed-line ceiling
- preserve the existing 8-file allowlist and T1-only behavior boundary
- require normal rustfmt, independent assertions, comments, the full Tier 2 handler matrix, and provider-dispatch=0 evidence

This amendment is required by the independent review of PR #1110. It does not expand T2/T3/T4 behavior.

Refs #1107
