### PR TITLE
docs(spec): allow GH1107 T1 review follow-ups

### DIFF
--- a/specs/GH1107/tasks.md
+++ b/specs/GH1107/tasks.md
@@ -41,7 +41,7 @@ GH-1107 / #1107
 - T7 在 T6 exact behavior 稳定后由 docs owner 独立写，不与 production owner 共享文件。
 - T8 是只读 reviewer/coordinator lane，不写 production/spec 文件。
 - 每个 writable task 使用独立 worktree 和单一 owner。若必须多 agent，文件所有权严格按 Files 列表分离；共享文件出现时改为串行。
-- 任一 tranche 超过 10 个非文档文件或 500 changed lines，先合并 spec amendment，禁止删除测试、压缩断言或扩大 allowlist 规避。SP1107-T1 因独立复审新增完整 Tier 2 handler matrix 与 provider-dispatch=0 证据，并恢复正常 rustfmt、独立断言及注释，单独批准至最多 550 changed lines；仍限既有 8 个文件，且不得借此实现 T2/T3/T4 行为。
+- 任一 tranche 超过 10 个非文档文件或 500 changed lines，先合并 spec amendment，禁止删除测试、压缩断言或扩大 allowlist 规避。SP1107-T1 因独立复审新增完整 Tier 2 handler matrix 与 provider-dispatch=0 证据，并恢复正常 rustfmt、独立断言及注释，先批准至最多 550 changed lines；合并门禁的后续 review 又要求修复 input-list 重复 ID、空 `additional_tools`、Codex passthrough metadata、message `input_audio` 和 flat function `strict` 的 wire/fail-closed 缺口，最终上限调整为 650 changed lines。该例外仍限既有 8 个文件，且不得借此实现 T2/T3/T4 行为。
 
 ## 验证
 

--- a/specs/GH1107/tech.md
+++ b/specs/GH1107/tech.md
@@ -84,7 +84,10 @@ GH-1107 / #1107
 清单外文件，或任一 tranche 超过 10 个非文档文件 / 500 changed lines，先提交 spec
 amendment；不得边实现边扩大 allowlist。SP1107-T1 经独立复审要求补齐完整 Tier 2
 handler matrix、provider-dispatch=0 证据并恢复正常 rustfmt、独立断言及注释后，单独
-批准至最多 550 changed lines；该例外不改变文件 allowlist，也不适用于后续 tranche。
+批准至最多 550 changed lines。合并门禁的后续 review 又要求修复 input-list 重复 ID、
+空 `additional_tools`、Codex passthrough metadata、message `input_audio` 和 flat function
+`strict` 的 wire/fail-closed 缺口，因此 SP1107-T1 最终上限调整为 650 changed lines；
+该例外不改变文件 allowlist，也不适用于后续 tranche。
 
 ## 设计方案
 


### PR DESCRIPTION
## Summary

- raise only SP1107-T1's reviewed changed-line allowance from 550 to 650
- record the five merge-gate follow-ups that require the extra evidence budget
- keep the existing eight-file allowlist and T1/T2/T3/T4 boundaries unchanged

## Why

The final review gate on #1110 found five additional wire/fail-closed gaps: input-list duplicate IDs, explicit empty `additional_tools`, Codex passthrough metadata, message `input_audio`, and flat function `strict`. Addressing them with normal rustfmt and explicit regression tests would exceed the current 550-line exception. This amendment prevents shrinking or removing tests merely to satisfy the numeric cap.

## Verification

- `git diff --check`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1107`
- `python3 checks/check_workflow.py --repo .`

Refs #1107
Refs #1110
