### PR TITLE
refactor(router): normalize credential provenance (GH965 T013b)

### DIFF
--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -59,13 +59,12 @@ fn has_custom_authorization(config: &ProviderConfig) -> bool {
 
 fn catalog_definition(selector: &str) -> Option<&'static provider_registry::ProviderDefinition> {
     let normalized = selector.trim().to_ascii_lowercase();
-    let definition = provider_registry::get_definition(&normalized)?;
     match provider_registry::entry_for_name(&normalized) {
         Some(entry) if entry.dispatch_kind == ProviderDispatchKind::CatalogOpenAiLike => {
-            Some(definition)
+            provider_registry::get_definition(entry.canonical_name)
         }
         Some(_) => None,
-        None => Some(definition),
+        None => provider_registry::get_definition(&normalized),
     }
 }
 
@@ -90,6 +89,7 @@ fn normalize_provider_construction(config: &ProviderConfig) -> NormalizedProvide
         match selector.parse::<ProviderType>() {
             Ok(ProviderType::Cloudflare) => setting(config, "api_token")
                 .or(top_level)
+                .or_else(|| setting(config, "api_key"))
                 .or_else(|| environment(&["CLOUDFLARE_API_TOKEN"])),
             Ok(ProviderType::Replicate) => top_level
                 .or_else(|| setting(config, "api_key"))
@@ -106,8 +106,8 @@ fn normalize_provider_construction(config: &ProviderConfig) -> NormalizedProvide
                 .or_else(|| setting(config, "google_api_key"))
                 .or_else(|| setting(config, "gemini_api_key"))
                 .or_else(|| environment(&["GEMINI_API_KEY", "GOOGLE_API_KEY"])),
+            Ok(ProviderType::Bedrock) | Err(_) => None,
             Ok(_) => top_level.or_else(|| setting(config, "api_key")),
-            Err(_) => None,
         }
     };
 

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -1,7 +1,9 @@
 //! Gateway configuration integration
-//!
-//! This module contains the from_gateway_config method for creating
 //! a Router from gateway configuration.
+
+#[cfg(test)]
+#[path = "gateway_config_tests.rs"]
+mod gateway_config_tests;
 
 use super::config::RouterConfig;
 use super::deployment::{
@@ -12,40 +14,131 @@ use super::unified::Router;
 use crate::config::Validate;
 use crate::config::models::provider::ProviderConfig;
 use crate::config::models::router::GatewayRouterConfig;
+use crate::core::providers::provider_type::ProviderType;
+use crate::core::providers::registry::{self as provider_registry, ProviderDispatchKind};
 use crate::core::providers::{Provider, create_provider};
 
-/// Return the only credential provenance audited for the conservative D3Ca
-/// intermediate state.
-///
-/// The canonical OpenAI factory inserts a non-empty top-level `api_key` before
-/// merging settings and its builder consumes that exact value. A custom
-/// Authorization header makes the upstream credential ambiguous. Aliases,
-/// settings-sourced credentials, catalog dispatch and provider-specific/env
-/// fallbacks remain intentionally unpublishable until D3Cb normalizes them at
-/// the construction boundary.
-fn proven_top_level_legacy_credential(config: &ProviderConfig) -> Option<&str> {
-    let selector = config.provider_type.trim();
-    let credential = config.api_key.as_str();
-    let has_competing_credential = ["api_key", "api_token", "google_api_key", "gemini_api_key"]
-        .into_iter()
-        .any(|key| config.settings.contains_key(key));
-    let has_custom_authorization = ["headers", "custom_headers"].into_iter().any(|key| {
+/// Construction-only handoff. Raw credentials never enter a deployment or snapshot.
+struct NormalizedProviderConstruction {
+    config: ProviderConfig,
+    legacy_metadata: Option<LegacySelectorMetadata>,
+}
+
+fn non_blank(value: &str) -> Option<&str> {
+    (!value.trim().is_empty()).then_some(value)
+}
+
+fn setting(config: &ProviderConfig, key: &str) -> Option<String> {
+    config
+        .settings
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .and_then(non_blank)
+        .map(str::to_owned)
+}
+
+fn environment(keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .filter_map(|key| std::env::var(key).ok())
+        .find_map(|value| non_blank(&value).map(str::to_owned))
+}
+
+fn has_custom_authorization(config: &ProviderConfig) -> bool {
+    ["headers", "custom_headers"].into_iter().any(|key| {
         config
             .settings
             .get(key)
             .and_then(serde_json::Value::as_object)
             .is_some_and(|headers| {
-                headers.iter().any(|(name, value)| {
-                    name.eq_ignore_ascii_case("authorization") && value.is_string()
-                })
+                headers
+                    .iter()
+                    .any(|(name, _)| name.eq_ignore_ascii_case("authorization"))
             })
-    });
+    })
+}
 
-    (selector == "openai"
-        && !credential.trim().is_empty()
-        && !has_competing_credential
-        && !has_custom_authorization)
-        .then_some(credential)
+fn catalog_definition(selector: &str) -> Option<&'static provider_registry::ProviderDefinition> {
+    let normalized = selector.trim().to_ascii_lowercase();
+    let definition = provider_registry::get_definition(&normalized)?;
+    match provider_registry::entry_for_name(&normalized) {
+        Some(entry) if entry.dispatch_kind == ProviderDispatchKind::CatalogOpenAiLike => {
+            Some(definition)
+        }
+        Some(_) => None,
+        None => Some(definition),
+    }
+}
+
+fn normalize_provider_construction(config: &ProviderConfig) -> NormalizedProviderConstruction {
+    let mut normalized = config.clone();
+    let selector = if config.provider_type.trim().is_empty() {
+        config.name.trim()
+    } else {
+        config.provider_type.trim()
+    };
+    let top_level = non_blank(&config.api_key).map(str::to_owned);
+
+    let effective_credential = if let Some(definition) = catalog_definition(selector) {
+        top_level.or_else(|| {
+            environment(
+                &std::iter::once(definition.auth_env_var)
+                    .chain(definition.alternate_auth_env_vars.iter().copied())
+                    .collect::<Vec<_>>(),
+            )
+        })
+    } else {
+        match selector.parse::<ProviderType>() {
+            Ok(ProviderType::Cloudflare) => setting(config, "api_token")
+                .or(top_level)
+                .or_else(|| environment(&["CLOUDFLARE_API_TOKEN"])),
+            Ok(ProviderType::Replicate) => top_level
+                .or_else(|| setting(config, "api_key"))
+                .or_else(|| setting(config, "api_token"))
+                .or_else(|| environment(&["REPLICATE_API_TOKEN", "REPLICATE_API_KEY"])),
+            Ok(ProviderType::FalAI) => top_level
+                .or_else(|| setting(config, "api_key"))
+                .or_else(|| environment(&["FAL_AI_API_KEY"])),
+            Ok(ProviderType::Cohere) => top_level
+                .or_else(|| setting(config, "api_key"))
+                .or_else(|| environment(&["COHERE_API_KEY"])),
+            Ok(ProviderType::Gemini) => top_level
+                .or_else(|| setting(config, "api_key"))
+                .or_else(|| setting(config, "google_api_key"))
+                .or_else(|| setting(config, "gemini_api_key"))
+                .or_else(|| environment(&["GEMINI_API_KEY", "GOOGLE_API_KEY"])),
+            Ok(_) => top_level.or_else(|| setting(config, "api_key")),
+            Err(_) => None,
+        }
+    };
+
+    if let Some(credential) = effective_credential.as_ref() {
+        normalized.api_key = credential.clone();
+        for key in ["api_key", "google_api_key", "gemini_api_key"] {
+            normalized.settings.remove(key);
+        }
+        if matches!(
+            selector.parse::<ProviderType>(),
+            Ok(ProviderType::Cloudflare)
+        ) {
+            normalized.api_key.clear();
+            normalized
+                .settings
+                .insert("api_token".to_string(), credential.clone().into());
+        } else {
+            normalized.settings.remove("api_token");
+        }
+    } else if config.api_key.trim().is_empty() {
+        normalized.api_key.clear();
+    }
+
+    let legacy_metadata = (!has_custom_authorization(config))
+        .then_some(effective_credential.as_deref())
+        .flatten()
+        .map(LegacySelectorMetadata::from_stored_credential);
+    NormalizedProviderConstruction {
+        config: normalized,
+        legacy_metadata,
+    }
 }
 
 /// Build runtime router config from gateway YAML router config.
@@ -90,21 +183,24 @@ impl Router {
                 continue;
             }
 
+            let construction = normalize_provider_construction(provider_config);
+            let normalized_config = construction.config;
+            let provider_name = normalized_config.name.clone();
+            let configured_models = normalized_config.models.clone();
+            let tags = normalized_config.tags.clone();
+            let deployment_config = deployment_config_from_provider(&normalized_config)?;
             // Create provider instance via the single canonical factory.
-            let provider = create_provider(provider_config.clone())
-                .await
-                .map_err(|e| {
-                    RouterError::DeploymentNotFound(format!(
-                        "Failed to create provider {}: {}",
-                        provider_config.name, e
-                    ))
-                })?;
-            let legacy_metadata = proven_top_level_legacy_credential(provider_config)
-                .map(LegacySelectorMetadata::from_stored_credential);
+            let provider = create_provider(normalized_config).await.map_err(|e| {
+                RouterError::DeploymentNotFound(format!(
+                    "Failed to create provider {}: {}",
+                    provider_name, e
+                ))
+            })?;
+            let legacy_metadata = construction.legacy_metadata;
 
             // Determine which models this deployment serves
-            let models: Vec<String> = if !provider_config.models.is_empty() {
-                provider_config.models.clone()
+            let models: Vec<String> = if !configured_models.is_empty() {
+                configured_models
             } else {
                 provider
                     .list_models()
@@ -117,11 +213,12 @@ impl Router {
             if models.is_empty() {
                 // Create a single deployment with provider name
                 let deployment = create_deployment_from_config(
-                    &provider_config.name,
+                    &provider_name,
                     provider.clone(),
-                    &provider_config.name,
-                    provider_config,
-                )?;
+                    &provider_name,
+                    deployment_config.clone(),
+                    tags.clone(),
+                );
                 match legacy_metadata {
                     Some(metadata) => router.add_gateway_deployment(deployment, metadata),
                     None => router.add_deployment(deployment),
@@ -129,13 +226,14 @@ impl Router {
             } else {
                 // Create one deployment per model
                 for model in models {
-                    let deployment_id = format!("{}-{}", provider_config.name, model);
+                    let deployment_id = format!("{}-{}", provider_name, model);
                     let deployment = create_deployment_from_config(
                         &deployment_id,
                         provider.clone(),
                         &model,
-                        provider_config,
-                    )?;
+                        deployment_config.clone(),
+                        tags.clone(),
+                    );
                     match legacy_metadata.clone() {
                         Some(metadata) => router.add_gateway_deployment(deployment, metadata),
                         None => router.add_deployment(deployment),
@@ -154,18 +252,17 @@ fn create_deployment_from_config(
     deployment_id: &str,
     provider: Provider,
     model: &str,
-    config: &ProviderConfig,
-) -> Result<Deployment, RouterError> {
-    let deployment_config = deployment_config_from_provider(config)?;
-
-    Ok(Deployment::new(
+    deployment_config: DeploymentConfig,
+    tags: Vec<String>,
+) -> Deployment {
+    Deployment::new(
         deployment_id.to_string(),
         provider,
         model.to_string(),
         model.to_string(),
     )
     .with_config(deployment_config)
-    .with_tags(config.tags.clone()))
+    .with_tags(tags)
 }
 
 fn deployment_config_from_provider(
@@ -251,6 +348,9 @@ mod tests {
     assert_not_impl_any!(
         LegacySelectorMetadata: std::fmt::Display, serde::Serialize, serde::de::DeserializeOwned
     );
+    assert_not_impl_any!(
+        NormalizedProviderConstruction: std::fmt::Debug, std::fmt::Display, serde::Serialize
+    );
 
     fn credential_test_provider(name: &str, api_key: &str) -> ProviderConfig {
         ProviderConfig {
@@ -263,21 +363,31 @@ mod tests {
     }
 
     #[test]
-    fn conservative_provenance_rejects_alias_catalog_and_env_fallback_candidates() {
-        let canonical = credential_test_provider("canonical", "sk-canonical");
+    fn normalization_preserves_native_precedence_and_alias_identity() {
+        let mut native = credential_test_provider("native", "top-level");
+        native
+            .settings
+            .insert("api_key".to_string(), "shadowed".into());
+        let normalized = normalize_provider_construction(&native);
+        assert!(normalized.legacy_metadata.is_some());
+        assert_eq!(normalized.config.api_key, "top-level");
+        assert!(!normalized.config.settings.contains_key("api_key"));
+
+        native.api_key = " ".to_string();
+        let settings_fallback = normalize_provider_construction(&native);
+        assert_eq!(settings_fallback.config.api_key, "shadowed");
+
+        let mut canonical = credential_test_provider("canonical", "alias-key");
+        canonical.provider_type = "gemini".to_string();
+        let mut alias = canonical.clone();
+        alias.provider_type = "google-gemini".to_string();
+        let canonical = normalize_provider_construction(&canonical);
+        let alias = normalize_provider_construction(&alias);
+        assert_eq!(canonical.config.api_key, alias.config.api_key);
         assert_eq!(
-            proven_top_level_legacy_credential(&canonical),
-            Some("sk-canonical")
+            canonical.config.provider_type.parse::<ProviderType>().ok(),
+            alias.config.provider_type.parse::<ProviderType>().ok()
         );
-
-        for provider_type in ["azure-openai", "openrouter", "cohere"] {
-            let mut unproven = credential_test_provider("unproven", "sk-unproven");
-            unproven.provider_type = provider_type.to_string();
-            assert_eq!(proven_top_level_legacy_credential(&unproven), None);
-        }
-
-        let empty_top_level = credential_test_provider("env-fallback", "");
-        assert_eq!(proven_top_level_legacy_credential(&empty_top_level), None);
     }
 
     #[test]
@@ -531,7 +641,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unproven_gateway_credentials_do_not_publish_selector_metadata() {
+    async fn normalized_gateway_credentials_publish_only_effective_digest() {
         let mut settings_only = credential_test_provider("settings-only", "");
         settings_only
             .settings
@@ -544,7 +654,7 @@ mod tests {
             settings_router
                 .load_routing_snapshot()
                 .resolve_legacy_credential("credential-model", "sk-settings-only"),
-            Err(ProviderError::ModelNotFound { .. })
+            Ok(deployment) if deployment == "settings-only-credential-model"
         ));
 
         for (setting_key, authorization_header) in [
@@ -578,13 +688,14 @@ mod tests {
             Ok(router) => router,
             Err(error) => panic!("Cloudflare conflict fixture should build: {error}"),
         };
-        for unproven_credential in ["top-level-key", "settings-token"] {
-            assert!(matches!(
-                cloudflare_router
-                    .load_routing_snapshot()
-                    .resolve_legacy_credential("credential-model", unproven_credential),
-                Err(ProviderError::ModelNotFound { .. })
-            ));
-        }
+        let snapshot = cloudflare_router.load_routing_snapshot();
+        assert!(matches!(
+            snapshot.resolve_legacy_credential("credential-model", "top-level-key"),
+            Err(ProviderError::ModelNotFound { .. })
+        ));
+        assert!(matches!(
+            snapshot.resolve_legacy_credential("credential-model", "settings-token"),
+            Ok(deployment) if deployment == "cloudflare-conflict-credential-model"
+        ));
     }
 }

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -1,4 +1,6 @@
 //! Gateway configuration integration
+//!
+//! This module contains the from_gateway_config method for creating
 //! a Router from gateway configuration.
 
 #[cfg(test)]

--- a/src/core/router/gateway_config_tests.rs
+++ b/src/core/router/gateway_config_tests.rs
@@ -4,16 +4,12 @@ mod matrix {
     use crate::core::providers::unified_provider::ProviderError;
     use std::sync::{Mutex, MutexGuard};
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+    #[rustfmt::skip]
     const ENVS: &[&str] = &[
-        "MIMO_API_KEY",
-        "XIAOMI_API_KEY",
-        "CLOUDFLARE_API_TOKEN",
-        "REPLICATE_API_TOKEN",
-        "REPLICATE_API_KEY",
-        "FAL_AI_API_KEY",
-        "COHERE_API_KEY",
-        "GEMINI_API_KEY",
-        "GOOGLE_API_KEY",
+        "MIMO_API_KEY", "XIAOMI_API_KEY", "CLOUDFLARE_API_TOKEN",
+        "REPLICATE_API_TOKEN", "REPLICATE_API_KEY", "FAL_AI_API_KEY",
+        "COHERE_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+        "PERPLEXITY_API_KEY", "GITHUB_TOKEN",
     ];
     const GEM_TOP: &str = "gem-top-test-api-key-12345678901234567890";
     const GEM_SETTINGS: &str = "gem-settings-test-api-key-12345678901234567890";
@@ -156,10 +152,14 @@ mod matrix {
         Case { name: "catalog-primary", selector: "xiaomi_mimo", top: " ", settings: &[], env: &[("MIMO_API_KEY","primary"),("XIAOMI_API_KEY","alternate")], selected: Some("primary"), shadowed: &["alternate"] },
         Case { name: "catalog-alternate", selector: "xiaomi_mimo", top: "", settings: &[], env: &[("MIMO_API_KEY"," "),("XIAOMI_API_KEY","alternate")], selected: Some("alternate"), shadowed: &[] },
         Case { name: "catalog-blank", selector: "xiaomi_mimo", top: " ", settings: &[], env: &[("MIMO_API_KEY"," "),("XIAOMI_API_KEY","")], selected: None, shadowed: &[] },
+        Case { name: "catalog-alias-pplx", selector: "pplx", top: "", settings: &[], env: &[("PERPLEXITY_API_KEY","primary")], selected: Some("primary"), shadowed: &[] },
+        Case { name: "catalog-alias-github", selector: "github-models", top: "", settings: &[], env: &[("GITHUB_TOKEN","primary")], selected: Some("primary"), shadowed: &[] },
         Case { name: "cf-settings", selector: "cf", top: "top", settings: &[("api_token","settings")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("settings"), shadowed: &["top","env"] },
         Case { name: "cf-top", selector: "cloudflare", top: "top", settings: &[("api_token"," ")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("top"), shadowed: &["env"] },
         Case { name: "cf-env", selector: "workers-ai", top: " ", settings: &[("api_token","")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("env"), shadowed: &[] },
         Case { name: "cf-blank", selector: "cloudflare", top: " ", settings: &[("api_token","")], env: &[("CLOUDFLARE_API_TOKEN"," ")], selected: None, shadowed: &[] },
+        Case { name: "cf-api-key", selector: "cloudflare", top: " ", settings: &[("api_token",""),("api_key","settings")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("settings"), shadowed: &["env"] },
+        Case { name: "bedrock-api-key-ignored", selector: "bedrock", top: "stray", settings: &[("aws_access_key_id","AKIATEST123456789012"),("aws_secret_access_key","test-secret-key")], env: &[], selected: None, shadowed: &[] },
         Case { name: "rep-top", selector: "replicate", top: "top", settings: &[("api_key","settings"),("api_token","token")], env: &[("REPLICATE_API_TOKEN","env1"),("REPLICATE_API_KEY","env2")], selected: Some("top"), shadowed: &["settings","token","env1","env2"] },
         Case { name: "rep-settings", selector: "replicate-ai", top: " ", settings: &[("api_key","settings"),("api_token","token")], env: &[("REPLICATE_API_TOKEN","env1")], selected: Some("settings"), shadowed: &["token","env1"] },
         Case { name: "rep-token", selector: "replicate", top: "", settings: &[("api_key"," "),("api_token","token")], env: &[("REPLICATE_API_TOKEN","env1")], selected: Some("token"), shadowed: &["env1"] },

--- a/src/core/router/gateway_config_tests.rs
+++ b/src/core/router/gateway_config_tests.rs
@@ -1,0 +1,235 @@
+#[cfg(feature = "providers-extended")]
+mod matrix {
+    use super::super::*;
+    use crate::core::providers::unified_provider::ProviderError;
+    use std::sync::{Mutex, MutexGuard};
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const ENVS: &[&str] = &[
+        "MIMO_API_KEY",
+        "XIAOMI_API_KEY",
+        "CLOUDFLARE_API_TOKEN",
+        "REPLICATE_API_TOKEN",
+        "REPLICATE_API_KEY",
+        "FAL_AI_API_KEY",
+        "COHERE_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    ];
+    const GEM_TOP: &str = "gem-top-test-api-key-12345678901234567890";
+    const GEM_SETTINGS: &str = "gem-settings-test-api-key-12345678901234567890";
+    const GEM_GOOGLE: &str = "gem-google-test-api-key-12345678901234567890";
+    const GEM_SETTING: &str = "gem-setting-test-api-key-12345678901234567890";
+    const GEM_ENV: &str = "gem-env-test-api-key-12345678901234567890";
+    const GEM_GOOGLE_ENV: &str = "gem-google-env-test-api-key-12345678901234567890";
+    const _: () =
+        assert!(GEM_TOP.len() >= 20 && GEM_SETTINGS.len() >= 20 && GEM_GOOGLE.len() >= 20);
+    const _: () =
+        assert!(GEM_SETTING.len() >= 20 && GEM_ENV.len() >= 20 && GEM_GOOGLE_ENV.len() >= 20);
+
+    struct EnvScope {
+        previous: Vec<(&'static str, Option<String>)>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvScope {
+        fn new(values: &[(&str, &str)]) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+            let previous = ENVS
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+            for key in ENVS {
+                unsafe { std::env::remove_var(key) };
+            }
+            for &(key, value) in values {
+                unsafe { std::env::set_var(key, value) };
+            }
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvScope {
+        fn drop(&mut self) {
+            for (key, value) in self.previous.drain(..).rev() {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    struct Case {
+        name: &'static str,
+        selector: &'static str,
+        top: &'static str,
+        settings: &'static [(&'static str, &'static str)],
+        env: &'static [(&'static str, &'static str)],
+        selected: Option<&'static str>,
+        shadowed: &'static [&'static str],
+    }
+
+    fn provider(name: &str, api_key: &str) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            api_key: api_key.to_string(),
+            models: vec!["credential-model".to_string()],
+            ..ProviderConfig::default()
+        }
+    }
+
+    async fn run(case: &Case) {
+        let before = ENVS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+        {
+            let _env = EnvScope::new(case.env);
+            let mut config = provider(case.name, case.top);
+            config.provider_type = case.selector.to_string();
+            if matches!(
+                case.selector.parse::<ProviderType>(),
+                Ok(ProviderType::Cloudflare)
+            ) {
+                config.organization = Some("fixture-account".to_string());
+            }
+            for &(key, value) in case.settings {
+                config.settings.insert(key.to_string(), value.into());
+            }
+            let router = Router::from_gateway_config(&[config], None).await;
+            if let Some(selected) = case.selected {
+                let snapshot = router
+                    .unwrap_or_else(|error| panic!("{}: {error}", case.name))
+                    .load_routing_snapshot();
+                assert!(
+                    matches!(
+                        snapshot.resolve_legacy_credential("credential-model", selected),
+                        Ok(deployment) if deployment == format!("{}-credential-model", case.name)
+                    ),
+                    "{} selected wrong credential",
+                    case.name
+                );
+                for shadowed in case.shadowed {
+                    assert!(
+                        matches!(
+                            snapshot.resolve_legacy_credential("credential-model", shadowed),
+                            Err(ProviderError::ModelNotFound { .. })
+                        ),
+                        "{} accepted shadowed credential",
+                        case.name
+                    );
+                }
+            } else {
+                if let Ok(router) = router {
+                    assert!(
+                        matches!(
+                            router.load_routing_snapshot().resolve_legacy_credential(
+                                "credential-model",
+                                "unresolved-fixture"
+                            ),
+                            Err(ProviderError::ModelNotFound { .. })
+                        ),
+                        "{} published unresolved provenance",
+                        case.name
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            before,
+            ENVS.iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_construction_credential_precedence_matrix() {
+        #[rustfmt::skip]
+    let cases = [
+        Case { name: "native-top", selector: "openai", top: "sk-top-fixture", settings: &[("api_key","sk-settings-fixture")], env: &[], selected: Some("sk-top-fixture"), shadowed: &["sk-settings-fixture"] },
+        Case { name: "native-settings", selector: "openai", top: " ", settings: &[("api_key","sk-settings-fixture")], env: &[], selected: Some("sk-settings-fixture"), shadowed: &[] },
+        Case { name: "catalog-explicit", selector: "xiaomi_mimo", top: "explicit", settings: &[], env: &[("MIMO_API_KEY","primary"),("XIAOMI_API_KEY","alternate")], selected: Some("explicit"), shadowed: &["primary","alternate"] },
+        Case { name: "catalog-primary", selector: "xiaomi_mimo", top: " ", settings: &[], env: &[("MIMO_API_KEY","primary"),("XIAOMI_API_KEY","alternate")], selected: Some("primary"), shadowed: &["alternate"] },
+        Case { name: "catalog-alternate", selector: "xiaomi_mimo", top: "", settings: &[], env: &[("MIMO_API_KEY"," "),("XIAOMI_API_KEY","alternate")], selected: Some("alternate"), shadowed: &[] },
+        Case { name: "catalog-blank", selector: "xiaomi_mimo", top: " ", settings: &[], env: &[("MIMO_API_KEY"," "),("XIAOMI_API_KEY","")], selected: None, shadowed: &[] },
+        Case { name: "cf-settings", selector: "cf", top: "top", settings: &[("api_token","settings")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("settings"), shadowed: &["top","env"] },
+        Case { name: "cf-top", selector: "cloudflare", top: "top", settings: &[("api_token"," ")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("top"), shadowed: &["env"] },
+        Case { name: "cf-env", selector: "workers-ai", top: " ", settings: &[("api_token","")], env: &[("CLOUDFLARE_API_TOKEN","env")], selected: Some("env"), shadowed: &[] },
+        Case { name: "cf-blank", selector: "cloudflare", top: " ", settings: &[("api_token","")], env: &[("CLOUDFLARE_API_TOKEN"," ")], selected: None, shadowed: &[] },
+        Case { name: "rep-top", selector: "replicate", top: "top", settings: &[("api_key","settings"),("api_token","token")], env: &[("REPLICATE_API_TOKEN","env1"),("REPLICATE_API_KEY","env2")], selected: Some("top"), shadowed: &["settings","token","env1","env2"] },
+        Case { name: "rep-settings", selector: "replicate-ai", top: " ", settings: &[("api_key","settings"),("api_token","token")], env: &[("REPLICATE_API_TOKEN","env1")], selected: Some("settings"), shadowed: &["token","env1"] },
+        Case { name: "rep-token", selector: "replicate", top: "", settings: &[("api_key"," "),("api_token","token")], env: &[("REPLICATE_API_TOKEN","env1")], selected: Some("token"), shadowed: &["env1"] },
+        Case { name: "rep-env1", selector: "replicate", top: "", settings: &[], env: &[("REPLICATE_API_TOKEN","env1"),("REPLICATE_API_KEY","env2")], selected: Some("env1"), shadowed: &["env2"] },
+        Case { name: "rep-env2", selector: "replicate", top: "", settings: &[], env: &[("REPLICATE_API_TOKEN"," "),("REPLICATE_API_KEY","env2")], selected: Some("env2"), shadowed: &[] },
+        Case { name: "rep-blank", selector: "replicate", top: " ", settings: &[("api_key"," "),("api_token","")], env: &[("REPLICATE_API_TOKEN"," "),("REPLICATE_API_KEY","")], selected: None, shadowed: &[] },
+        Case { name: "fal-top", selector: "fal-ai", top: "top", settings: &[("api_key","settings")], env: &[("FAL_AI_API_KEY","env")], selected: Some("top"), shadowed: &["settings","env"] },
+        Case { name: "fal-settings", selector: "fal", top: " ", settings: &[("api_key","settings")], env: &[("FAL_AI_API_KEY","env")], selected: Some("settings"), shadowed: &["env"] },
+        Case { name: "fal-env", selector: "fal_ai", top: "", settings: &[("api_key"," ")], env: &[("FAL_AI_API_KEY","env")], selected: Some("env"), shadowed: &[] },
+        Case { name: "fal-blank", selector: "fal_ai", top: " ", settings: &[("api_key","")], env: &[("FAL_AI_API_KEY"," ")], selected: None, shadowed: &[] },
+        Case { name: "cohere-top", selector: "cohere", top: "top", settings: &[("api_key","settings")], env: &[("COHERE_API_KEY","env")], selected: Some("top"), shadowed: &["settings","env"] },
+        Case { name: "cohere-settings", selector: "cohere-ai", top: " ", settings: &[("api_key","settings")], env: &[("COHERE_API_KEY","env")], selected: Some("settings"), shadowed: &["env"] },
+        Case { name: "cohere-env", selector: "cohere", top: "", settings: &[], env: &[("COHERE_API_KEY","env")], selected: Some("env"), shadowed: &[] },
+        Case { name: "cohere-blank", selector: "cohere", top: " ", settings: &[("api_key","")], env: &[("COHERE_API_KEY"," ")], selected: None, shadowed: &[] },
+        Case { name: "gem-top", selector: "gemini", top: GEM_TOP, settings: &[("api_key",GEM_SETTINGS)], env: &[("GEMINI_API_KEY",GEM_ENV)], selected: Some(GEM_TOP), shadowed: &[GEM_SETTINGS,GEM_ENV] },
+        Case { name: "gem-settings", selector: "google-gemini", top: " ", settings: &[("api_key",GEM_SETTINGS),("google_api_key",GEM_GOOGLE)], env: &[], selected: Some(GEM_SETTINGS), shadowed: &[GEM_GOOGLE] },
+        Case { name: "gem-google", selector: "google_ai", top: "", settings: &[("api_key"," "),("google_api_key",GEM_GOOGLE),("gemini_api_key",GEM_SETTING)], env: &[], selected: Some(GEM_GOOGLE), shadowed: &[GEM_SETTING] },
+        Case { name: "gem-setting", selector: "google-ai", top: "", settings: &[("google_api_key"," "),("gemini_api_key",GEM_SETTING)], env: &[("GEMINI_API_KEY",GEM_ENV)], selected: Some(GEM_SETTING), shadowed: &[GEM_ENV] },
+        Case { name: "gem-env1", selector: "gemini", top: "", settings: &[], env: &[("GEMINI_API_KEY",GEM_ENV),("GOOGLE_API_KEY",GEM_GOOGLE_ENV)], selected: Some(GEM_ENV), shadowed: &[GEM_GOOGLE_ENV] },
+        Case { name: "gem-env2", selector: "gemini", top: "", settings: &[], env: &[("GEMINI_API_KEY"," "),("GOOGLE_API_KEY",GEM_GOOGLE_ENV)], selected: Some(GEM_GOOGLE_ENV), shadowed: &[] },
+        Case { name: "gem-blank", selector: "gemini", top: " ", settings: &[("api_key"," "),("google_api_key",""),("gemini_api_key"," ")], env: &[("GEMINI_API_KEY"," "),("GOOGLE_API_KEY","")], selected: None, shadowed: &[] },
+        Case { name: "unknown", selector: "not-a-provider", top: "unknown", settings: &[], env: &[], selected: None, shadowed: &[] },
+    ];
+        for case in cases {
+            run(&case).await;
+        }
+    }
+}
+
+fn function<'a>(source: &'a str, signature: &str) -> &'a str {
+    let start = source
+        .find(signature)
+        .unwrap_or_else(|| panic!("missing {signature}"));
+    let body = source[start..]
+        .find('{')
+        .map(|offset| start + offset)
+        .unwrap();
+    let mut depth = 0;
+    for (offset, byte) in source[body..].bytes().enumerate() {
+        depth += usize::from(byte == b'{');
+        depth -= usize::from(byte == b'}');
+        if depth == 0 {
+            return &source[start..=body + offset];
+        }
+    }
+    panic!("unclosed {signature}");
+}
+
+#[test]
+fn credential_resolver_and_construction_source_guards() {
+    let unified = include_str!("unified.rs");
+    for signature in [
+        "fn resolve_legacy_credential(",
+        "fn resolve_legacy_credential_with(",
+    ] {
+        let resolver = function(unified, signature);
+        for forbidden in [
+            "std::env",
+            "ProviderConfig",
+            "create_provider",
+            "factory",
+            "add_deployment",
+        ] {
+            assert!(
+                !resolver.contains(forbidden),
+                "{signature} contains {forbidden}"
+            );
+        }
+    }
+    let gateway = include_str!("gateway_config.rs");
+    let construction = function(gateway, "pub async fn from_gateway_config(");
+    assert_eq!(construction.matches("create_provider(").count(), 1);
+}


### PR DESCRIPTION
## Summary

完成 GH965 的 `SP965-T013b` credential provenance normalization：

- 在 canonical provider construction 边界一次解析 effective credential；
- 将同一份 normalized `ProviderConfig` move 进唯一一次 `create_provider`；
- provider 成功构造后才发布 digest-only legacy selector metadata；
- 完整锁定 native、catalog、Cloudflare、Replicate、FalAI、Cohere、Gemini 的既有 credential precedence；
- 自定义 `Authorization` header、空白值和未知 provenance 均 fail closed；
- selector source guards 禁止 env/config rescan、factory 和 deployment mutation。

这是 GH965 的部分 tranche，不关闭 issue。

## Verification

- `cargo test --locked core::router::gateway_config -- --test-threads=1`
- `cargo test --all-features --locked core::router::gateway_config -- --test-threads=1`
- `cargo check --all-targets --all-features --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH965`

全量测试：library `10514 passed / 0 failed / 1 ignored`，integration/doc targets 同样通过。

## Security

本 tranche 修改 credential provenance，合并前仍需独立 SEC-11 人工安全批准。

Refs #965
