### PR TITLE
fix(factory): auto-detect private network for localhost

### DIFF
--- a/src/core/providers/factory/endpoint_access_tests.rs
+++ b/src/core/providers/factory/endpoint_access_tests.rs
@@ -318,3 +318,76 @@ async fn gateway_selector_normalization_preserves_endpoint_alias_policy() {
         .await
         .expect("normalized Azure selector must retain its endpoint alias");
 }
+
+/// Regression for #1123: a catalog provider whose default base URL is localhost
+/// must start with zero endpoint configuration, while a user-supplied endpoint
+/// still goes through the SSRF guard under the configured access policy.
+#[tokio::test]
+async fn localhost_catalog_default_starts_without_endpoint_config() {
+    use crate::core::providers::registry as provider_registry;
+
+    let mut covered = 0usize;
+    for name in ["vllm", "hosted_vllm", "lm_studio", "llamafile"] {
+        let Some(def) = provider_registry::get_definition(name) else {
+            continue;
+        };
+        if !def.base_url.contains("localhost") {
+            continue;
+        }
+        covered += 1;
+
+        let config = ProviderConfig {
+            name: format!("local-{name}"),
+            provider_type: name.to_string(),
+            api_key: String::new(),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.endpoint_access,
+            crate::core::net::ProviderEndpointAccess::PublicOnly,
+            "the repro relies on the default access policy staying PublicOnly"
+        );
+        create_provider(config)
+            .await
+            .unwrap_or_else(|error| panic!("zero-config '{name}' must start: {error}"));
+
+        let explicit = ProviderConfig {
+            name: format!("local-{name}-explicit"),
+            provider_type: name.to_string(),
+            api_key: String::new(),
+            base_url: Some(def.base_url.to_string()),
+            ..Default::default()
+        };
+        assert!(
+            create_provider(explicit).await.is_err(),
+            "explicit localhost base_url under PublicOnly must stay blocked for {name}"
+        );
+    }
+    assert!(
+        covered > 0,
+        "no localhost catalog provider was exercised; the regression would be vacuous"
+    );
+}
+
+/// Auto-detection must not widen access for catalog providers whose default
+/// base URL is public.
+#[tokio::test]
+async fn public_catalog_default_is_not_widened_to_private() {
+    use crate::core::providers::registry as provider_registry;
+
+    for (name, def) in provider_registry::PROVIDER_CATALOG.iter() {
+        if def.base_url.contains("localhost") {
+            continue;
+        }
+        let config = ProviderConfig {
+            name: (*name).to_string(),
+            provider_type: (*name).to_string(),
+            api_key: "test-key".into(),
+            ..Default::default()
+        };
+        let provider = create_provider(config)
+            .await
+            .unwrap_or_else(|error| panic!("Catalog provider '{name}': {error}"));
+        assert!(matches!(&provider, Provider::OpenAILike(_)));
+    }
+}

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -142,6 +142,18 @@ pub async fn create_provider(
             base_endpoint.or(settings_base_url.as_deref()),
         );
         oai_config.base.endpoint_access = endpoint_access;
+        // Auto-detect private network access for catalog providers whose default
+        // base URL is localhost (e.g. vllm, lm_studio, ollama).  When the user
+        // relies on the catalog default and has not explicitly set the endpoint
+        // access policy, switch to PrivateNetwork so the SSRF guard permits the
+        // outbound connection to localhost.
+        if endpoint_access == ProviderEndpointAccess::PublicOnly
+            && base_endpoint.is_none()
+            && settings_base_url.is_none()
+            && selector_allows_implicit_private(provider_selector)
+        {
+            oai_config.base.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        }
         oai_config.base.timeout = timeout;
         oai_config.base.max_retries = max_retries;
 
@@ -298,6 +310,10 @@ mod tests {
             let mut opposite = config.clone();
             opposite.endpoint_access = if is_local { PublicOnly } else { PrivateNetwork };
             if is_local {
+                // Use an explicit base URL matching the catalog default so the
+                // auto-detection of catalog-default localhost does not kick in;
+                // the SSRF guard must still block PublicOnly + localhost.
+                opposite.base_url = Some(def.base_url.to_string());
                 assert!(create_provider(opposite).await.is_err());
             } else {
                 assert!(crate::config::Validate::validate(&opposite).is_err());


### PR DESCRIPTION
fix #1123 
## What

Auto-detect PrivateNetwork endpoint access for catalog providers whose default base URL is localhost (e.g. vllm, lm_studio, llamafile). Previously, the SSRF guard blocked all localhost connections under the default PublicOnly policy, causing startup failures for local inference providers.

## Why

Without this change, users must manually set endpoint_access: private_network in their config for every local provider — even when relying on the catalog's default localhost URL. This is a poor developer experience and a common stumbling block, especially for first-time users running the dev config. The catalog already marks these providers as local (def_local_chat), and selector_allows_implicit_private already recognizes them; the factory just wasn't using that information to set the correct access policy.

## Test Plan

- [x] Tests pass
- [x] Tested manually
