### PR TITLE
docs(spec): define GH1127 streaming guardrail contract

### DIFF
--- a/specs/GH1127/product.md
+++ b/specs/GH1127/product.md
@@ -16,7 +16,7 @@ complexity: high
 ## 目标
 
 - 让三条流式文本路径执行与非流式路径一致的输出 guardrail 策略。
-- 在任何模型生成文本对客户端可见前完成整段审核，覆盖跨 chunk 规则。
+- 在每个待发送窗口对客户端可见前完成累计审核，覆盖跨 chunk 规则。
 - 明确审核粒度、缓冲上限、额外延迟、SSE 错误与取消语义。
 - 保持预算结算、provider lease、callback 和客户端断连语义完整且恰好终止一次。
 
@@ -26,37 +26,38 @@ complexity: high
 - 对图片、音频或其他二进制增量执行 OCR、转写或内容识别。
 - 撤回已经离开网关进程的历史响应。
 - 改变 provider 的上游 SSE 协议、重试策略或计费模型。
-- 在本 Issue 引入低延迟但允许部分内容先行泄漏的 windowed 模式。
+- 提供 `full_response`、per-event 或运行时可切换的审核模式；本 Issue 固定为
+  `windowed_cumulative`。
 
 ## Behavior Invariants
 
 1. B-001 当输出 guardrail 生效时，`/v1/chat/completions`、`/v1/completions` 和 `/v1/responses` 的模型生成文本必须在发送给客户端前通过输出检查。
-2. B-002 审核粒度固定为 `full_response`：网关必须等待上游流结束，对本次响应的完整文本执行一次检查；禁止按 provider chunk 边界独立审核。
-3. B-003 跨 chunk 敏感词、跨 chunk PII、多字节 UTF-8 以及任意 provider chunk 切分不得改变接受或拒绝结果。
-4. B-004 审核期间不得发送模型文本、reasoning summary 或 tool/function arguments；允许的客户端可见内容仅限不包含模型数据的连接级元数据或 SSE 注释。
-5. B-005 缓冲必须有可配置且非零的 `max_buffer_bytes`。达到上限前不得无界增长；超过上限时必须按输出 guardrail 错误 fail-closed，且不得发送已缓冲内容。
+2. B-002 审核粒度固定为 `windowed_cumulative`：三条路径使用 `guardrails.stream_output_check_chars` 作为 event-aligned 检查触发阈值，默认 `256` 个新增 Unicode 字符，合法范围 `1..=4096`；包含使新增字符数达到或超过阈值的完整 provider event，并对截至该 event 的累计模型文本执行检查，禁止只检查独立 provider chunk。
+3. B-003 跨 chunk 敏感词、跨 chunk PII 与多字节 UTF-8 必须通过累计文本检测；provider chunk 切分不得造成独立 chunk 扫描绕过。由于原 SSE event 不拆分，单个 event 可使实际 pending 窗口超过配置字符阈值。
+4. B-004 当前 pending 窗口通过审核前不得发送其中的模型文本、reasoning summary 或 tool/function arguments；允许立即发送的内容仅限不包含模型数据且不破坏事件顺序的连接级元数据或 SSE 注释。
+5. B-005 pending event 与累计扫描文本都必须有固定、非零的内部字节上限。达到上限前不得无界增长；超过上限时必须按输出 guardrail 错误 fail-closed，且不得发送当前 pending 内容。
 6. B-006 审核通过后，原有 SSE events、usage event、`response.completed` 与 `[DONE]` 必须按原顺序和原字段回放，不得合并、重排或重复模型 delta。
 7. B-007 guardrail 明确拒绝时，客户端只收到不含被拒内容的稳定错误 envelope，随后收到一个传输终止 `[DONE]`；不得发送成功 `response.completed` 或成功 callback。
 8. B-008 guardrail 执行错误、超时或不可解释结果必须交由现有 engine 的 `fail_open` 契约处理；streaming 层不得将 `Err` 静默转换为通过。默认 `fail_open: false` 时必须按 `guardrail_error` 终止。
 9. B-009 provider 在审核前失败或 idle timeout 时，必须保留现有 provider error envelope 与结算语义；不得把上游错误误报为 guardrail violation。
-10. B-010 guardrail 拒绝或执行错误发生在 provider 已完成后时，已发生的 provider 用量仍按现有完成结算规则记录；callback 以 `guardrail_output` 失败，provider lease 不得被错误惩罚为 provider failure。
+10. B-010 guardrail 拒绝或执行错误时，已发生的 provider 用量仍按现有 partial/final usage 与 reservation fallback 结算；callback 以 `guardrail_output` 失败，provider lease 不得被错误惩罚为 provider failure。
 11. B-011 客户端在上游读取、guardrail 等待或审核通过后的回放阶段断连时，等待检查与上游读取必须可取消，且 lease、callback、预算 reservation 恰好结束一次。
-12. B-012 纯 usage、role、空 delta、heartbeat、finish reason 与 `[DONE]` 不作为模型文本扫描，但必须保留；completion 的 `echo` 文本属于客户端可见文本，必须包含在完整审核载荷中。
-13. B-013 `/v1/responses` 的 output text、reasoning summary 与 function-call arguments 都属于客户端可见模型文本，必须进入同一次完整审核。
-14. B-014 输出 guardrail 未启用或 `check_output: false` 时，三条路径继续逐事件转发，不增加完整响应缓冲或额外 guardrail 延迟。
-15. B-015 `full_response` 模式的首内容延迟等于上游生成完成时间加一次输出 guardrail 检查时间；该兼容性变化必须在配置文档和发布说明中明确。
+12. B-012 纯 usage、role、空 delta、heartbeat、finish reason 与 `[DONE]` 不作为模型文本扫描，但必须保留；completion 的 `echo` 文本属于客户端可见文本，必须包含在累计审核载荷中。
+13. B-013 `/v1/responses` 的 output text、reasoning summary 与 function-call arguments 都属于客户端可见模型文本，必须进入同一累计扫描序列。
+14. B-014 输出 guardrail 未启用或 `check_output: false` 时，三条路径继续逐事件转发，不增加窗口缓冲或额外 guardrail 延迟。
+15. B-015 `windowed_cumulative` 的首内容延迟至少为首个窗口生成时间加一次输出 guardrail 检查时间；已审核并释放的前缀无法因后续窗口形成的新违规上下文而撤回，该风险必须在配置文档和发布说明中明确。
 16. B-016 只有通过输出 guardrail 的 `/v1/responses` 结果才能进入 response persistence；拒绝、错误、超限或取消的结果不得保存为成功响应。
 
 ## 验收标准
 
-- [ ] 三条端点均有测试证明安全文本在完整审核后按原 SSE 顺序回放。
-- [ ] 三条端点均有测试证明被拒文本、reasoning 与 function arguments 不出现在任何已发送 event 中。
-- [ ] 跨 chunk 敏感模式、多字节 UTF-8 和 provider 不同切分产生相同审核结果。
-- [ ] buffer overflow、guardrail 拒绝、默认 fail-closed 错误与显式 `fail_open` 均有确定测试。
+- [ ] 三条端点均有测试证明每个安全窗口在累计审核后按原 SSE 顺序回放。
+- [ ] 三条端点均有测试证明被拒窗口中的文本、reasoning 与 function arguments 不出现在任何已发送 event 中。
+- [ ] 跨 chunk 敏感模式与多字节 UTF-8 使用累计文本检测；测试证明阈值按 Unicode 字符计数、触发 event 不拆分且其完整模型文本先审核后释放。
+- [ ] pending/cumulative buffer overflow、guardrail 拒绝、默认 fail-closed 错误与显式 `fail_open` 均有确定测试。
 - [ ] violation/error 只发送稳定错误 envelope 与一个 `[DONE]`，且不发送成功完成事件。
 - [ ] usage-only、空 delta、provider error、idle timeout 与三个阶段的客户端断连均保持正确结算和单一 terminal callback。
-- [ ] 输出 guardrail 关闭时有测试证明首 chunk 仍可立即转发，且不分配完整响应缓冲。
-- [ ] `max_buffer_bytes` 的默认值、合法范围、延迟影响和 `full_response` 固定粒度有文档。
+- [ ] 输出 guardrail 关闭时有测试证明首 chunk 仍可立即转发，且不分配窗口或累计响应缓冲。
+- [ ] `stream_output_check_chars` 的默认值 `256`、合法范围 `1..=4096`、延迟影响、内部字节上限和 `windowed_cumulative` 固定粒度有文档。
 - [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过。
 
 ## 边界情况
@@ -71,7 +72,7 @@ complexity: high
 
 ## 发布说明
 
-启用输出 guardrail 的流式请求采用安全优先的 `full_response` 粒度，因此不会继续
-表现为低延迟逐 token 输出。发布说明必须公开 `max_buffer_bytes`、首内容延迟、
-buffer overflow 的 fail-closed 行为以及 error + `[DONE]` 终止契约。未启用输出
-guardrail 的部署保持现有低延迟流式行为。
+启用输出 guardrail 的流式请求采用 `windowed_cumulative` 粒度。发布说明必须公开
+`stream_output_check_chars` 默认值 `256` 与范围 `1..=4096`、首窗口延迟、已批准
+前缀不可撤回、buffer overflow 的 fail-closed 行为以及 error + `[DONE]` 终止契约。
+未启用输出 guardrail 的部署保持现有低延迟流式行为。

--- a/specs/GH1127/product.md
+++ b/specs/GH1127/product.md
@@ -1,0 +1,77 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1127 / #1127
+
+complexity: high
+
+## 用户问题
+
+网关只在非流式响应上执行输出 guardrail。相同请求一旦启用 `stream: true`，
+`/v1/chat/completions`、`/v1/completions` 和 `/v1/responses` 就会把模型输出
+直接发送给客户端，使已配置的内容审核、PII 与 secret-leak 策略失去作用。
+流式调用不能成为绕过输出安全策略的等价开关。
+
+## 目标
+
+- 让三条流式文本路径执行与非流式路径一致的输出 guardrail 策略。
+- 在任何模型生成文本对客户端可见前完成整段审核，覆盖跨 chunk 规则。
+- 明确审核粒度、缓冲上限、额外延迟、SSE 错误与取消语义。
+- 保持预算结算、provider lease、callback 和客户端断连语义完整且恰好终止一次。
+
+## 非目标
+
+- 改变 guardrail provider 的检测规则、action 或 `fail_open` 策略。
+- 对图片、音频或其他二进制增量执行 OCR、转写或内容识别。
+- 撤回已经离开网关进程的历史响应。
+- 改变 provider 的上游 SSE 协议、重试策略或计费模型。
+- 在本 Issue 引入低延迟但允许部分内容先行泄漏的 windowed 模式。
+
+## Behavior Invariants
+
+1. B-001 当输出 guardrail 生效时，`/v1/chat/completions`、`/v1/completions` 和 `/v1/responses` 的模型生成文本必须在发送给客户端前通过输出检查。
+2. B-002 审核粒度固定为 `full_response`：网关必须等待上游流结束，对本次响应的完整文本执行一次检查；禁止按 provider chunk 边界独立审核。
+3. B-003 跨 chunk 敏感词、跨 chunk PII、多字节 UTF-8 以及任意 provider chunk 切分不得改变接受或拒绝结果。
+4. B-004 审核期间不得发送模型文本、reasoning summary 或 tool/function arguments；允许的客户端可见内容仅限不包含模型数据的连接级元数据或 SSE 注释。
+5. B-005 缓冲必须有可配置且非零的 `max_buffer_bytes`。达到上限前不得无界增长；超过上限时必须按输出 guardrail 错误 fail-closed，且不得发送已缓冲内容。
+6. B-006 审核通过后，原有 SSE events、usage event、`response.completed` 与 `[DONE]` 必须按原顺序和原字段回放，不得合并、重排或重复模型 delta。
+7. B-007 guardrail 明确拒绝时，客户端只收到不含被拒内容的稳定错误 envelope，随后收到一个传输终止 `[DONE]`；不得发送成功 `response.completed` 或成功 callback。
+8. B-008 guardrail 执行错误、超时或不可解释结果必须交由现有 engine 的 `fail_open` 契约处理；streaming 层不得将 `Err` 静默转换为通过。默认 `fail_open: false` 时必须按 `guardrail_error` 终止。
+9. B-009 provider 在审核前失败或 idle timeout 时，必须保留现有 provider error envelope 与结算语义；不得把上游错误误报为 guardrail violation。
+10. B-010 guardrail 拒绝或执行错误发生在 provider 已完成后时，已发生的 provider 用量仍按现有完成结算规则记录；callback 以 `guardrail_output` 失败，provider lease 不得被错误惩罚为 provider failure。
+11. B-011 客户端在上游读取、guardrail 等待或审核通过后的回放阶段断连时，等待检查与上游读取必须可取消，且 lease、callback、预算 reservation 恰好结束一次。
+12. B-012 纯 usage、role、空 delta、heartbeat、finish reason 与 `[DONE]` 不作为模型文本扫描，但必须保留；completion 的 `echo` 文本属于客户端可见文本，必须包含在完整审核载荷中。
+13. B-013 `/v1/responses` 的 output text、reasoning summary 与 function-call arguments 都属于客户端可见模型文本，必须进入同一次完整审核。
+14. B-014 输出 guardrail 未启用或 `check_output: false` 时，三条路径继续逐事件转发，不增加完整响应缓冲或额外 guardrail 延迟。
+15. B-015 `full_response` 模式的首内容延迟等于上游生成完成时间加一次输出 guardrail 检查时间；该兼容性变化必须在配置文档和发布说明中明确。
+16. B-016 只有通过输出 guardrail 的 `/v1/responses` 结果才能进入 response persistence；拒绝、错误、超限或取消的结果不得保存为成功响应。
+
+## 验收标准
+
+- [ ] 三条端点均有测试证明安全文本在完整审核后按原 SSE 顺序回放。
+- [ ] 三条端点均有测试证明被拒文本、reasoning 与 function arguments 不出现在任何已发送 event 中。
+- [ ] 跨 chunk 敏感模式、多字节 UTF-8 和 provider 不同切分产生相同审核结果。
+- [ ] buffer overflow、guardrail 拒绝、默认 fail-closed 错误与显式 `fail_open` 均有确定测试。
+- [ ] violation/error 只发送稳定错误 envelope 与一个 `[DONE]`，且不发送成功完成事件。
+- [ ] usage-only、空 delta、provider error、idle timeout 与三个阶段的客户端断连均保持正确结算和单一 terminal callback。
+- [ ] 输出 guardrail 关闭时有测试证明首 chunk 仍可立即转发，且不分配完整响应缓冲。
+- [ ] `max_buffer_bytes` 的默认值、合法范围、延迟影响和 `full_response` 固定粒度有文档。
+- [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过。
+
+## 边界情况
+
+- 敏感模式可能从一个 chunk 的末尾延伸到下一个 chunk 的开头。
+- provider 可能先发送 role、usage 或空 delta，再发送文本。
+- upstream EOF 可能没有 usage；仍须使用既有 reserved-spend fallback。
+- guardrail 可能在上游已经产生完整 usage 后拒绝内容；拒绝不免除已发生费用。
+- 客户端可能在等待上游、等待 guardrail 或回放安全事件时断开。
+- 回放阶段断连可能让客户端只看到已经审核通过的部分安全文本；不得重试或重复结算。
+- 一个响应可能包含多个 choice、reasoning 与并行 tool call；边界和顺序必须确定。
+
+## 发布说明
+
+启用输出 guardrail 的流式请求采用安全优先的 `full_response` 粒度，因此不会继续
+表现为低延迟逐 token 输出。发布说明必须公开 `max_buffer_bytes`、首内容延迟、
+buffer overflow 的 fail-closed 行为以及 error + `[DONE]` 终止契约。未启用输出
+guardrail 的部署保持现有低延迟流式行为。

--- a/specs/GH1127/tasks.md
+++ b/specs/GH1127/tasks.md
@@ -1,0 +1,40 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1127 / #1127
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 决策门
+
+- [ ] `SP1127-T0` Covers: B-001 ～ B-009, HD-1127-1. Owner: maintainer/spec owner. Dependencies: none. Done when: 维护者在 `full_buffer`、`per_event_cumulative`、`windowed_cumulative` 中选择一种并绑定最终 spec SHA；若选 windowed，确定 YAML 字段、默认字符数和合法范围；Issue 获得 `ready_to_implement`. Verify: `python3 checks/check_workflow.py --repo . --spec-dir=specs/GH1127`; `python3 checks/route_gate.py --repo . --route implement --issue 1127 --state ready_to_implement --duplicate-evidence <evidence> --json`.
+
+## 实现任务
+
+- [ ] `SP1127-T1` Covers: B-001, B-002, B-003, B-005, B-008, B-009. Owner: stream guardrail implementation owner. Dependencies: SP1127-T0. Done when: `src/server/guardrails.rs` 提供唯一纯文本 output enforcement 与共享 `StreamOutputGuard`，实现已批准模式、有限内存、UTF-8 安全和 disabled fast path. Verify: focused `server::guardrails` state-machine tests.
+- [ ] `SP1127-T2` Covers: B-001, B-004, B-006, B-007. Owner: same implementation owner. Dependencies: SP1127-T1. Done when: chat/completions/Responses 三条 stream loop 在发送前接入共享状态机；blocked/error 不泄露原文、不发 `[DONE]`，非文本 event 顺序与 usage 保持. Verify: 三 handler focused stream tests.
+- [ ] `SP1127-T3` Covers: B-003, B-004, B-005, B-007, B-009. Owner: test owner. Dependencies: SP1127-T2. Done when: 跨 chunk、UTF-8、guardrail timeout/error/malformed、provider error、disconnect 和所有 lifecycle exactly-once fixture 完整. Verify: focused route/lifecycle test filters.
+- [ ] `SP1127-T4` Covers: B-001 ～ B-009. Owner: verification owner. Dependencies: SP1127-T3. Done when: diff 只覆盖已批准设计，完整 Rust/SpecRail gate 通过且有安全人工 review. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+
+## 并行拆分
+
+不并行。三条 stream loop 与共享生命周期状态紧密耦合，由一个 implementation owner
+串行完成；验证也在同一 worktree 单路运行，避免重复冷构建和共享文件冲突。
+
+## 验证
+
+- 先运行状态机和三端点 focused tests，再对最终 head 运行一次完整命令集。
+- 对每条失败路径断言已发送 SSE bytes 不包含被拒文本。
+- 人工安全 review 必须确认 `HD-1127-1` 的不可撤回前缀风险与实现一致。
+- PR 使用 `Fixes #1127` 仅在全部 invariants 完成时关闭 Issue。
+
+## Handoff Notes
+
+- 当前没有 GH1127 实现；不要从 GH1128 的输入扫描工作推断输出审核模式。
+- 禁止先发送后审核或逐独立 chunk 扫描。
+- 维护者尚未批准 `HD-1127-1`，在此之前不得开始代码实现。
+- 不自动合并、不 force-push。

--- a/specs/GH1127/tasks.md
+++ b/specs/GH1127/tasks.md
@@ -11,14 +11,14 @@ GH-1127 / #1127
 
 ## 决策门
 
-- [ ] `SP1127-T0` Covers: B-001 ～ B-009, HD-1127-1. Owner: maintainer/spec owner. Dependencies: none. Done when: 维护者在 `full_buffer`、`per_event_cumulative`、`windowed_cumulative` 中选择一种并绑定最终 spec SHA；若选 windowed，确定 YAML 字段、默认字符数和合法范围；Issue 获得 `ready_to_implement`. Verify: `python3 checks/check_workflow.py --repo . --spec-dir=specs/GH1127`; `python3 checks/route_gate.py --repo . --route implement --issue 1127 --state ready_to_implement --duplicate-evidence <evidence> --json`.
+- [x] `SP1127-T0` Covers: B-001 ～ B-016, HD-1127-1. Owner: maintainer/spec owner. Dependencies: none. Done when: 维护者在 `user-2026-07-27-approve-all-specs` 批准全部规格并选择 `windowed_cumulative`；YAML 字段为 `guardrails.stream_output_check_chars`，默认 `256`，合法范围 `1..=4096`；Issue 已获得 `ready_to_implement`. Verify: `python3 checks/check_workflow.py --repo . --spec-dir=specs/GH1127`; `python3 checks/route_gate.py --repo . --route implement --issue 1127 --state ready_to_implement --duplicate-evidence <evidence> --json`.
 
 ## 实现任务
 
-- [ ] `SP1127-T1` Covers: B-001, B-002, B-003, B-005, B-008, B-009. Owner: stream guardrail implementation owner. Dependencies: SP1127-T0. Done when: `src/server/guardrails.rs` 提供唯一纯文本 output enforcement 与共享 `StreamOutputGuard`，实现已批准模式、有限内存、UTF-8 安全和 disabled fast path. Verify: focused `server::guardrails` state-machine tests.
-- [ ] `SP1127-T2` Covers: B-001, B-004, B-006, B-007. Owner: same implementation owner. Dependencies: SP1127-T1. Done when: chat/completions/Responses 三条 stream loop 在发送前接入共享状态机；blocked/error 不泄露原文、不发 `[DONE]`，非文本 event 顺序与 usage 保持. Verify: 三 handler focused stream tests.
-- [ ] `SP1127-T3` Covers: B-003, B-004, B-005, B-007, B-009. Owner: test owner. Dependencies: SP1127-T2. Done when: 跨 chunk、UTF-8、guardrail timeout/error/malformed、provider error、disconnect 和所有 lifecycle exactly-once fixture 完整. Verify: focused route/lifecycle test filters.
-- [ ] `SP1127-T4` Covers: B-001 ～ B-009. Owner: verification owner. Dependencies: SP1127-T3. Done when: diff 只覆盖已批准设计，完整 Rust/SpecRail gate 通过且有安全人工 review. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+- [ ] `SP1127-T1` Covers: B-001, B-002, B-003, B-005, B-008, B-012, B-013, B-014, B-015. Owner: stream guardrail implementation owner. Dependencies: SP1127-T0. Done when: config 与 `check_output_text`、共享 `StreamOutputGuard` 完成 fixed windowed cumulative、256/1..=4096、8 MiB 双上限、UTF-8 安全和 disabled fast path. Verify: focused config/guardrail/state-machine tests.
+- [ ] `SP1127-T2` Covers: B-001, B-004, B-006, B-007, B-009, B-010, B-011, B-012, B-013, B-016. Owner: same implementation owner. Dependencies: SP1127-T1. Done when: chat/completions/Responses 三条 stream loop 在每个窗口发送前接入累计检查；blocked/error 不泄露当前 pending，发送稳定 error + 一个 `[DONE]`，事件顺序、usage、lease/callback/settlement/persistence 保持. Verify: 三 handler focused stream/lifecycle tests.
+- [ ] `SP1127-T3` Covers: B-002 ～ B-016. Owner: test owner. Dependencies: SP1127-T2. Done when: 单/多窗口、后续窗口违规、跨 chunk、UTF-8、reasoning/function args、guardrail timeout/error/fail_open、overflow、provider error、disconnect 和 lifecycle exactly-once fixture 完整. Verify: focused route/lifecycle test filters.
+- [ ] `SP1127-T4` Covers: B-001 ～ B-016. Owner: verification owner. Dependencies: SP1127-T3. Done when: diff 只覆盖已批准设计，完整 Rust/SpecRail gate 通过且有安全人工 review. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
 
@@ -29,12 +29,13 @@ GH-1127 / #1127
 
 - 先运行状态机和三端点 focused tests，再对最终 head 运行一次完整命令集。
 - 对每条失败路径断言已发送 SSE bytes 不包含被拒文本。
-- 人工安全 review 必须确认 `HD-1127-1` 的不可撤回前缀风险与实现一致。
+- 人工安全 review 必须确认 `HD-1127-1` 的不可撤回前缀风险、当前 pending 不泄露、
+  累计而非独立窗口检查与实现一致。
 - PR 使用 `Fixes #1127` 仅在全部 invariants 完成时关闭 Issue。
 
 ## Handoff Notes
 
 - 当前没有 GH1127 实现；不要从 GH1128 的输入扫描工作推断输出审核模式。
 - 禁止先发送后审核或逐独立 chunk 扫描。
-- 维护者尚未批准 `HD-1127-1`，在此之前不得开始代码实现。
+- `HD-1127-1` 已批准为 `windowed_cumulative`；不得改成其他模式或扩大配置范围。
 - 不自动合并、不 force-push。

--- a/specs/GH1127/tech.md
+++ b/specs/GH1127/tech.md
@@ -15,10 +15,10 @@ complexity: high
 | Area | Files | Current behavior | Why relevant |
 | --- | --- | --- | --- |
 | Canonical guardrail boundary | `src/server/guardrails.rs` | `check_chat_output` only accepts a completed `ChatCompletionResponse` and extracts non-streaming message content. | Streaming needs a text-oriented entrypoint that preserves the same `enforce` semantics. |
-| Guardrail config | `src/core/guardrails/config.rs`, `src/config/models/guardrails.rs` | `check_output` and `fail_open` exist, but there is no bounded streaming-output buffer policy. Gateway deserialization rejects unknown fields. | `full_response` buffering requires an explicit, validated byte ceiling and secure default. |
-| Chat SSE | `src/server/routes/ai/chat_streaming.rs`, `src/server/routes/ai/chat_sse.rs` | Each converted `ChatCompletionChunk` is serialized and sent immediately; errors currently include `[DONE]`. | Must hold model events until the full output passes, while retaining OpenAI error shape. |
+| Guardrail config | `src/core/guardrails/config.rs`, `src/config/models/guardrails.rs` | `check_output` and `fail_open` exist, but there is no streaming-output window policy. Gateway deserialization rejects unknown fields. | `windowed_cumulative` requires an explicit, validated character threshold and fixed memory ceiling. |
+| Chat SSE | `src/server/routes/ai/chat_streaming.rs`, `src/server/routes/ai/chat_sse.rs` | Each converted `ChatCompletionChunk` is serialized and sent immediately; errors currently include `[DONE]`. | Must hold each pending event window until its cumulative output passes, while retaining OpenAI error shape. |
 | Completion SSE | `src/server/routes/ai/completions_streaming.rs`, `src/server/routes/ai/completions_sse.rs` | Each text completion event, including `echo`, is sent immediately. | Must scan exactly the client-visible completion text and preserve echo/event order. |
-| Responses SSE | `src/server/routes/ai/responses_stream.rs`, `src/server/routes/ai/responses_stream_support.rs` | Text, reasoning and function arguments are emitted while `full_text`/tool state is still accumulating; success is persisted after `response.completed`. | All model-bearing events must be held, checked together, and only then emitted/persisted. |
+| Responses SSE | `src/server/routes/ai/responses_stream.rs`, `src/server/routes/ai/responses_stream_support.rs` | Text, reasoning and function arguments are emitted while `full_text`/tool state is still accumulating; success is persisted after `response.completed`. | Each pending model-bearing window must pass a cumulative check before emission; persistence remains final-success-only. |
 | Stream lifecycle | `src/server/routes/ai/budgeted.rs`, `src/server/routes/ai/callbacks.rs` | Streaming workers own reservation settlement, callback terminal state and provider lease. | Guardrail rejection is a gateway-policy failure after chargeable provider success, not a free or retryable provider failure. |
 | Existing coverage | `tests/integration/guardrail_route_tests.rs`, `tests/integration/completions_route_tests.rs`, `tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs`, `src/server/routes/ai/responses_stream_tests.rs` | Unary guardrails and normal streaming/error/settlement are covered separately; no streaming-output guardrail fixture exists. | Cross-route behavior and lifecycle assertions require deterministic SSE integration tests. |
 
@@ -26,45 +26,52 @@ complexity: high
 
 ### 1. 配置契约
 
-在 `GuardrailConfig` 增加 `streaming_output.max_buffer_bytes`，gateway 默认值为
-`8_388_608` bytes。配置必须使用 snake_case，值必须大于 0；未知字段、0 或无法
-表示为 `usize` 的值在启动验证阶段失败。该配置只在
+在 `GuardrailConfig` 增加 `stream_output_check_chars: usize`，gateway 默认值为
+`256`，启动验证只接受 `1..=4096`。配置必须使用 snake_case，未知字段、0 或
+超过 4096 的值显式失败。该配置只在
 `enabled && check_output && guardrail_count > 0` 时生效。
 
-审核粒度不开放不安全别名或 windowed 模式；稳定 ID 固定为 `full_response`。
-`fail_open` 继续由 `GuardrailEngine::check_output` 决定，streaming 层不得增加
-第二套 fallback。
+审核模式不暴露运行时 enum；稳定行为固定为 `windowed_cumulative`。pending SSE
+bytes 与累计扫描文本分别受内部常量 `8_388_608` bytes 限制，避免引入第二个公开
+配置。`fail_open` 继续由 `GuardrailEngine::check_output` 决定，streaming 层不得
+增加第二套 fallback。
 
 ### 2. 共享缓冲器
 
 新增 route-private `StreamOutputGuardrail`：
 
-- 创建时记录是否需要输出检查和 `max_buffer_bytes`；
-- 按到达顺序保存待回放的完整 SSE `Bytes`，并单独累积带字段边界的扫描文本；
-- 对 buffered SSE bytes 与 scan text 使用 checked/saturating accounting，在追加前
-  检查上限，超限返回 typed `BufferLimitExceeded`；
+- 创建时记录是否需要输出检查和 `stream_output_check_chars`；
+- 按到达顺序保存当前 pending 窗口的完整 SSE `Bytes`，并单独累积带字段边界的
+  全部历史扫描文本；
+- 对 pending SSE bytes 与累计 scan text 使用 checked accounting，在追加前检查
+  8 MiB 内部上限，超限返回 typed `BufferLimitExceeded`；
 - active=false 时不保存历史 event，调用方继续原有 immediate-send 分支；
-- active=true 时 upstream EOF 后只调用一次 `check_output_text`；
-- 检查通过后按原顺序 drain events；拒绝或错误时丢弃全部 buffered events。
+- active=true 时自上次通过检查后新增的模型文本达到配置字符数或 upstream EOF 时，
+  对截至当前 event 的累计文本调用 `check_output_text`；阈值按 Unicode scalar
+  value 计数，是触发下限而非硬切分边界，触发 event 不得拆分；
+- 检查通过后按原顺序 drain 当前 pending events 并清空 pending；拒绝或错误时丢弃
+  当前 pending events，取消上游并进入 terminal。
 
-扫描文本采用稳定的 choice/surface 边界，不能依赖 provider chunk。Chat 扫描
+扫描文本采用稳定的 choice/surface 边界，不能按 provider chunk 独立判断。Chat 扫描
 `delta.content`；Completion 扫描最终 client-visible `text`（包含一次 `echo`）；
 Responses 扫描 output text、reasoning summary 和 function-call arguments。role、
 usage、finish reason、IDs 与 transport markers 只缓冲、不进入扫描文本。
 
 ### 3. 三条 route 的状态机
 
-每条 worker 明确经过：
+每条 worker 在上游循环内重复：
 
-`upstream_reading -> guardrail_check -> replaying -> terminal`
+`upstream_reading -> window_guardrail_check -> window_replay -> upstream_reading`
+
+最终进入 `terminal`。
 
 - `upstream_reading`：继续执行现有 idle timeout、usage 累积、provider error 与
-  `tx.closed()` cancellation；active 时 event 进入缓冲器。
-- `guardrail_check`：upstream EOF 后执行一次完整检查，并在 future 等待期间同时
-  监听 `tx.closed()`；取消时不回放。
-- `replaying`：只回放已通过的 event；任一 send 失败立即进入 client-disconnect
+  `tx.closed()` cancellation；active 时 event 进入 pending buffer。
+- `window_guardrail_check`：达到字符阈值或 EOF 后执行累计检查，并在 future 等待
+  期间同时监听 `tx.closed()`；取消时不回放。
+- `window_replay`：只回放当前已通过窗口的 event；任一 send 失败立即进入 client-disconnect
   terminal path，不重试。
-- `terminal`：成功才发送原成功 event/`[DONE]` 并调用 success callback；guardrail
+- `terminal`：最后一个窗口通过后才发送原成功 event/`[DONE]` 并调用 success callback；guardrail
   失败发送 endpoint-compatible error + 一个 `[DONE]`，不发送
   `response.completed`。
 
@@ -81,21 +88,21 @@ usage、finish reason、IDs 与 transport markers 只缓冲、不进入扫描文
   `ResponseStreamEvent::ResponseFailed`，其 `ResponsesApiResponse.status` 为 `failed`
   且 `error.code` 使用上述稳定 code。两者随后发送一个 `[DONE]` 作为 transport
   sentinel。
-- provider 已成功完成时，无论 guardrail pass/block/error，均按
-  `record_completion(final_usage, saw_upstream_output)` 结算；callback 在 block/error
-  使用 `guardrail_output`，lease 记录 provider success。provider/idle/disconnect
-  仍走既有分支。
+- guardrail 在中途 block/error 时取消上游，按已观察 usage 或 reservation fallback
+  执行现有 disconnect/partial settlement；callback 使用 `guardrail_output`，lease
+  不记录 provider failure。上游已完成后发生的最终窗口结果按 completion settlement。
+  provider/idle/disconnect 仍走既有分支。
 - Responses persistence 只能发生在 pass + replay success 后。
 
 ## Planned Change Manifest
 
 | File | Planned change |
 | --- | --- |
-| `src/core/guardrails/config.rs` | 定义、默认化并验证 `streaming_output.max_buffer_bytes`。 |
+| `src/core/guardrails/config.rs` | 定义、默认化并验证 `stream_output_check_chars`。 |
 | `src/config/models/guardrails.rs` | 将新字段接入 deny-unknown gateway wire、merge/default 与配置测试。 |
 | `src/server/guardrails.rs` | 增加 crate-private `check_output_text`，复用既有 `enforce`，并测试 pass/block/error。 |
 | `src/server/routes/ai/mod.rs` | 声明共享 `stream_output_guardrail` 模块。 |
-| `src/server/routes/ai/stream_output_guardrail.rs` | 新增 bounded full-response buffer、surface accumulator、typed errors 与 replay API。 |
+| `src/server/routes/ai/stream_output_guardrail.rs` | 新增 bounded pending window、cumulative surface accumulator、typed errors 与 replay API。 |
 | `src/server/routes/ai/stream_output_guardrail_tests.rs` | 覆盖边界、UTF-8、上限、disabled fast path、drop/replay 顺序。 |
 | `src/server/routes/ai/chat_streaming.rs` | 接入 Chat 状态机、完整检查、取消与 terminal lifecycle。 |
 | `src/server/routes/ai/chat_sse.rs` | 提供 guardrail error envelope，保证错误后恰好一个 `[DONE]`。 |
@@ -115,49 +122,57 @@ usage、finish reason、IDs 与 transport markers 只缓冲、不进入扫描文
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001, B-002 | 三条 streaming route + shared buffer | 三端点 safe/block 集成测试；断言 guardrail 只调用一次且发生在 EOF 后。 |
-| B-003, B-013 | surface accumulator | split-pattern、UTF-8、reasoning、function args fixtures。 |
+| B-001, B-002 | 三条 streaming route + shared buffer | 三端点多窗口 safe/block 集成测试；断言 guardrail 在阈值/EOF 调用且输入为累计文本。 |
+| B-003, B-013 | surface accumulator | split-pattern、UTF-8、触发 event 超过阈值、reasoning、function args fixtures。 |
 | B-004, B-007 | buffer + SSE helpers | 断言 blocked body 不含任一模型片段，只含 error 与一个 `[DONE]`。 |
-| B-005 | config + buffer | 0 配置启动失败、边界成功、超一 byte fail-closed。 |
+| B-005 | config + buffer | 0/4097 配置启动失败，1/4096 成功，pending/cumulative 超限 fail-closed。 |
 | B-006, B-012 | replay | safe fixture 逐 event byte/order 对比，usage/empty/done 不丢失。 |
 | B-008, B-009 | engine + route error branches | fail-open/fail-closed、provider error、idle timeout 测试。 |
 | B-010, B-011 | settlement/callback/lease | block/error/disconnect 每种场景断言一次 terminal callback 与一次结算。 |
 | B-014 | disabled fast path | 延迟上游 fixture 证明首 chunk 在 EOF 前可见，buffer history 为 0。 |
-| B-015 | timing contract | controlled clock 测试证明 active 模式在 EOF/check 前无模型 event。 |
+| B-015 | timing contract | controlled clock 测试证明 active 模式在首窗口 check 前无模型 event，之后按窗口释放。 |
 | B-016 | Responses persistence | block/error 不可 GET，pass 才可持久化。 |
 
 ## 数据流
 
 provider `ChatChunk` 先完成现有 conversion 和 usage 累积。输出检查关闭时 event 直接
-进入 `mpsc::Sender<Bytes>`。输出检查开启时，event bytes 与对应模型文本进入 bounded
-buffer；upstream EOF 后完整文本交给 `GuardrailEngine::check_output`。pass 后按序
-drain 至客户端并完成结算/callback/persistence；block/error/overflow 丢弃 buffer，
-发送安全 terminal error，但仍结算已经发生的 provider usage。无新增数据库状态或
-外部调用；外部 moderation 调用仍由现有 guardrail engine 管理。
+进入 `mpsc::Sender<Bytes>`。输出检查开启时，event bytes 进入 pending buffer，模型
+文本追加到 cumulative accumulator；自上次通过检查后新增文本达到 256 默认字符
+阈值或 EOF 时，把触发 event 的完整文本纳入累计载荷并交给
+`GuardrailEngine::check_output`。pass 后按序 drain 当前 event-aligned 窗口并继续上游；
+block/error/overflow 丢弃当前 pending、取消上游并发送安全 terminal error，同时
+结算已经发生的 provider usage。Responses 只在最终窗口 pass 后持久化。无新增数据库
+状态或 guardrail 外部调用类型；调用次数会随窗口数增加。
 
 ## 备选方案
 
 - Per-chunk 检查：拒绝。provider chunk 可切开 regex、PII 或 Unicode 序列。
-- Sliding window：拒绝作为本 Issue 默认。custom rule 与外部 moderation 没有可证明
-  的有限 look-behind，窗口会保留绕过面。
+- Full-response buffer：能避免已释放前缀风险，但维护者在
+  `user-2026-07-27-approve-all-specs` 明确选择 windowed cumulative，以保留有限
+  流式延迟。
+- 只检查独立 sliding window：拒绝。custom rule 与外部 moderation 没有可证明的
+  有限 look-behind；实现必须每次检查累计文本。
 - 检测后撤回：拒绝。SSE 已发送 bytes 不可撤回。
 - 禁止所有 guarded streaming：安全但破坏面更大，且不能保留 SSE compatibility。
 
 ## 风险
 
-- Security: buffer overflow、错误消息泄露、跨 surface 拼接和 `fail_open` 配置可能
-  重新形成绕过；必须 bounded、稳定分隔、默认 fail-closed 且不记录被拒正文。
-- Compatibility: guarded streaming 的首内容延迟变为完整响应延迟；错误仍保留
-  endpoint envelope 与 `[DONE]`，但 Responses 不再发送成功 `response.completed`。
-- Performance: active 请求额外持有最多 `max_buffer_bytes` SSE bytes 和扫描文本，并
-  执行一次完整检查；disabled fast path 不得复制整个流。
+- Security: buffer overflow、错误消息泄露、跨 surface 拼接、已释放前缀不可撤回和
+  `fail_open` 配置可能形成风险；当前 pending 必须 bounded、稳定分隔、默认
+  fail-closed 且不记录被拒正文。
+- Compatibility: guarded streaming 的首内容延迟变为首窗口生成+检查延迟；错误仍
+  保留 endpoint envelope 与 `[DONE]`，Responses 失败时不发送成功
+  `response.completed`。
+- Performance: active 请求额外持有最多 8 MiB pending SSE bytes 和最多 8 MiB
+  cumulative scan text，并对随输出增长的累计文本执行多次检查；disabled fast path
+  不得复制整个流。
 - Maintenance: 三条 route 的 lifecycle 容易漂移；共享 buffer/error 类型和映射测试
   必须作为单一契约。
 
 ## 测试计划
 
-- [ ] Unit tests: config validation、buffer accounting、surface ordering、UTF-8、error envelope。
-- [ ] Integration tests: Chat/Completion/Responses safe、block、error、overflow、disabled。
+- [ ] Unit tests: `stream_output_check_chars` validation、pending/cumulative accounting、surface ordering、UTF-8、error envelope。
+- [ ] Integration tests: Chat/Completion/Responses 单窗口/多窗口 safe、后续窗口 block、跨阈值完整 event、error、overflow、disabled。
 - [ ] Lifecycle tests: usage、预算、provider lease、callback、idle timeout、三阶段断连。
 - [ ] Deterministic checks: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; focused guardrail/stream tests; `cargo test`。
 - [ ] Manual verification: 使用慢速 SSE fixture 比较 guardrail on/off 的首内容时间与最终 event 顺序；不得依赖真实 provider 或密钥。
@@ -165,6 +180,6 @@ drain 至客户端并完成结算/callback/persistence；block/error/overflow �
 ## 回滚方案
 
 回滚本 Issue 的实现 commit 即恢复原 streaming 行为；新增配置具有默认值，回滚前先从
-部署配置移除 `guardrails.streaming_output`，避免旧版本 deny-unknown 启动失败。
+部署配置移除 `guardrails.stream_output_check_chars`，避免旧版本 deny-unknown 启动失败。
 不得通过把 `fail_open` 改为 true 作为回滚。若上线后出现内存或延迟风险，应暂停
 guarded streaming 请求并回滚，而不是绕过输出检查。

--- a/specs/GH1127/tech.md
+++ b/specs/GH1127/tech.md
@@ -1,0 +1,170 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1127 / #1127
+
+complexity: high
+
+## Product Spec
+
+[`product.md`](product.md)
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Canonical guardrail boundary | `src/server/guardrails.rs` | `check_chat_output` only accepts a completed `ChatCompletionResponse` and extracts non-streaming message content. | Streaming needs a text-oriented entrypoint that preserves the same `enforce` semantics. |
+| Guardrail config | `src/core/guardrails/config.rs`, `src/config/models/guardrails.rs` | `check_output` and `fail_open` exist, but there is no bounded streaming-output buffer policy. Gateway deserialization rejects unknown fields. | `full_response` buffering requires an explicit, validated byte ceiling and secure default. |
+| Chat SSE | `src/server/routes/ai/chat_streaming.rs`, `src/server/routes/ai/chat_sse.rs` | Each converted `ChatCompletionChunk` is serialized and sent immediately; errors currently include `[DONE]`. | Must hold model events until the full output passes, while retaining OpenAI error shape. |
+| Completion SSE | `src/server/routes/ai/completions_streaming.rs`, `src/server/routes/ai/completions_sse.rs` | Each text completion event, including `echo`, is sent immediately. | Must scan exactly the client-visible completion text and preserve echo/event order. |
+| Responses SSE | `src/server/routes/ai/responses_stream.rs`, `src/server/routes/ai/responses_stream_support.rs` | Text, reasoning and function arguments are emitted while `full_text`/tool state is still accumulating; success is persisted after `response.completed`. | All model-bearing events must be held, checked together, and only then emitted/persisted. |
+| Stream lifecycle | `src/server/routes/ai/budgeted.rs`, `src/server/routes/ai/callbacks.rs` | Streaming workers own reservation settlement, callback terminal state and provider lease. | Guardrail rejection is a gateway-policy failure after chargeable provider success, not a free or retryable provider failure. |
+| Existing coverage | `tests/integration/guardrail_route_tests.rs`, `tests/integration/completions_route_tests.rs`, `tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs`, `src/server/routes/ai/responses_stream_tests.rs` | Unary guardrails and normal streaming/error/settlement are covered separately; no streaming-output guardrail fixture exists. | Cross-route behavior and lifecycle assertions require deterministic SSE integration tests. |
+
+## 设计方案
+
+### 1. 配置契约
+
+在 `GuardrailConfig` 增加 `streaming_output.max_buffer_bytes`，gateway 默认值为
+`8_388_608` bytes。配置必须使用 snake_case，值必须大于 0；未知字段、0 或无法
+表示为 `usize` 的值在启动验证阶段失败。该配置只在
+`enabled && check_output && guardrail_count > 0` 时生效。
+
+审核粒度不开放不安全别名或 windowed 模式；稳定 ID 固定为 `full_response`。
+`fail_open` 继续由 `GuardrailEngine::check_output` 决定，streaming 层不得增加
+第二套 fallback。
+
+### 2. 共享缓冲器
+
+新增 route-private `StreamOutputGuardrail`：
+
+- 创建时记录是否需要输出检查和 `max_buffer_bytes`；
+- 按到达顺序保存待回放的完整 SSE `Bytes`，并单独累积带字段边界的扫描文本；
+- 对 buffered SSE bytes 与 scan text 使用 checked/saturating accounting，在追加前
+  检查上限，超限返回 typed `BufferLimitExceeded`；
+- active=false 时不保存历史 event，调用方继续原有 immediate-send 分支；
+- active=true 时 upstream EOF 后只调用一次 `check_output_text`；
+- 检查通过后按原顺序 drain events；拒绝或错误时丢弃全部 buffered events。
+
+扫描文本采用稳定的 choice/surface 边界，不能依赖 provider chunk。Chat 扫描
+`delta.content`；Completion 扫描最终 client-visible `text`（包含一次 `echo`）；
+Responses 扫描 output text、reasoning summary 和 function-call arguments。role、
+usage、finish reason、IDs 与 transport markers 只缓冲、不进入扫描文本。
+
+### 3. 三条 route 的状态机
+
+每条 worker 明确经过：
+
+`upstream_reading -> guardrail_check -> replaying -> terminal`
+
+- `upstream_reading`：继续执行现有 idle timeout、usage 累积、provider error 与
+  `tx.closed()` cancellation；active 时 event 进入缓冲器。
+- `guardrail_check`：upstream EOF 后执行一次完整检查，并在 future 等待期间同时
+  监听 `tx.closed()`；取消时不回放。
+- `replaying`：只回放已通过的 event；任一 send 失败立即进入 client-disconnect
+  terminal path，不重试。
+- `terminal`：成功才发送原成功 event/`[DONE]` 并调用 success callback；guardrail
+  失败发送 endpoint-compatible error + 一个 `[DONE]`，不发送
+  `response.completed`。
+
+为避免 `responses_stream.rs` 超过 800 行硬上限，缓冲、扫描、错误分类和测试 helper
+必须放入新模块，route 文件只保留状态机接线。
+
+### 4. SSE 与 lifecycle 语义
+
+- violation: `type=content_policy_error`, `code=guardrail_violation`,
+  message=`Response blocked by output guardrails`。
+- engine/buffer error: `type=server_error`, `code=guardrail_error`，消息不得包含模型
+  文本、规则命中内容或 provider secret。
+- Chat/Completion 使用现有 OpenAI error envelope；Responses 使用
+  `ResponseStreamEvent::ResponseFailed`，其 `ResponsesApiResponse.status` 为 `failed`
+  且 `error.code` 使用上述稳定 code。两者随后发送一个 `[DONE]` 作为 transport
+  sentinel。
+- provider 已成功完成时，无论 guardrail pass/block/error，均按
+  `record_completion(final_usage, saw_upstream_output)` 结算；callback 在 block/error
+  使用 `guardrail_output`，lease 记录 provider success。provider/idle/disconnect
+  仍走既有分支。
+- Responses persistence 只能发生在 pass + replay success 后。
+
+## Planned Change Manifest
+
+| File | Planned change |
+| --- | --- |
+| `src/core/guardrails/config.rs` | 定义、默认化并验证 `streaming_output.max_buffer_bytes`。 |
+| `src/config/models/guardrails.rs` | 将新字段接入 deny-unknown gateway wire、merge/default 与配置测试。 |
+| `src/server/guardrails.rs` | 增加 crate-private `check_output_text`，复用既有 `enforce`，并测试 pass/block/error。 |
+| `src/server/routes/ai/mod.rs` | 声明共享 `stream_output_guardrail` 模块。 |
+| `src/server/routes/ai/stream_output_guardrail.rs` | 新增 bounded full-response buffer、surface accumulator、typed errors 与 replay API。 |
+| `src/server/routes/ai/stream_output_guardrail_tests.rs` | 覆盖边界、UTF-8、上限、disabled fast path、drop/replay 顺序。 |
+| `src/server/routes/ai/chat_streaming.rs` | 接入 Chat 状态机、完整检查、取消与 terminal lifecycle。 |
+| `src/server/routes/ai/chat_sse.rs` | 提供 guardrail error envelope，保证错误后恰好一个 `[DONE]`。 |
+| `src/server/routes/ai/completions_streaming.rs` | 接入 Completion 状态机，并把 client-visible echo 纳入扫描。 |
+| `src/server/routes/ai/completions_sse.rs` | 复用稳定 guardrail error code，避免重复 terminal marker。 |
+| `src/server/routes/ai/responses_stream.rs` | 缓冲 text/reasoning/function arguments，pass 后 replay/persist，失败时完成 lifecycle。 |
+| `src/server/routes/ai/responses_stream_support.rs` | 构造 typed `response.failed` 与安全错误消息。 |
+| `src/server/routes/ai/responses_stream_tests.rs` | 覆盖 Responses event/error/settlement/persistence 契约。 |
+| `tests/integration/guardrail_route_tests.rs` | 增加 Chat SSE safe/block/cross-chunk/disabled fixtures。 |
+| `tests/integration/completions_route_tests.rs` | 扩展 mock provider 的 safe、blocked、split-pattern 与 idle scenarios。 |
+| `tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs` | 覆盖 Completion 和 Responses 的回放顺序、error、callback、lease、结算与断连。 |
+
+除上述文件外不得修改源码、配置、workflow 或持久化 schema；若实现发现新增文件，
+必须先更新 tech spec manifest 并重新取得 spec approval。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001, B-002 | 三条 streaming route + shared buffer | 三端点 safe/block 集成测试；断言 guardrail 只调用一次且发生在 EOF 后。 |
+| B-003, B-013 | surface accumulator | split-pattern、UTF-8、reasoning、function args fixtures。 |
+| B-004, B-007 | buffer + SSE helpers | 断言 blocked body 不含任一模型片段，只含 error 与一个 `[DONE]`。 |
+| B-005 | config + buffer | 0 配置启动失败、边界成功、超一 byte fail-closed。 |
+| B-006, B-012 | replay | safe fixture 逐 event byte/order 对比，usage/empty/done 不丢失。 |
+| B-008, B-009 | engine + route error branches | fail-open/fail-closed、provider error、idle timeout 测试。 |
+| B-010, B-011 | settlement/callback/lease | block/error/disconnect 每种场景断言一次 terminal callback 与一次结算。 |
+| B-014 | disabled fast path | 延迟上游 fixture 证明首 chunk 在 EOF 前可见，buffer history 为 0。 |
+| B-015 | timing contract | controlled clock 测试证明 active 模式在 EOF/check 前无模型 event。 |
+| B-016 | Responses persistence | block/error 不可 GET，pass 才可持久化。 |
+
+## 数据流
+
+provider `ChatChunk` 先完成现有 conversion 和 usage 累积。输出检查关闭时 event 直接
+进入 `mpsc::Sender<Bytes>`。输出检查开启时，event bytes 与对应模型文本进入 bounded
+buffer；upstream EOF 后完整文本交给 `GuardrailEngine::check_output`。pass 后按序
+drain 至客户端并完成结算/callback/persistence；block/error/overflow 丢弃 buffer，
+发送安全 terminal error，但仍结算已经发生的 provider usage。无新增数据库状态或
+外部调用；外部 moderation 调用仍由现有 guardrail engine 管理。
+
+## 备选方案
+
+- Per-chunk 检查：拒绝。provider chunk 可切开 regex、PII 或 Unicode 序列。
+- Sliding window：拒绝作为本 Issue 默认。custom rule 与外部 moderation 没有可证明
+  的有限 look-behind，窗口会保留绕过面。
+- 检测后撤回：拒绝。SSE 已发送 bytes 不可撤回。
+- 禁止所有 guarded streaming：安全但破坏面更大，且不能保留 SSE compatibility。
+
+## 风险
+
+- Security: buffer overflow、错误消息泄露、跨 surface 拼接和 `fail_open` 配置可能
+  重新形成绕过；必须 bounded、稳定分隔、默认 fail-closed 且不记录被拒正文。
+- Compatibility: guarded streaming 的首内容延迟变为完整响应延迟；错误仍保留
+  endpoint envelope 与 `[DONE]`，但 Responses 不再发送成功 `response.completed`。
+- Performance: active 请求额外持有最多 `max_buffer_bytes` SSE bytes 和扫描文本，并
+  执行一次完整检查；disabled fast path 不得复制整个流。
+- Maintenance: 三条 route 的 lifecycle 容易漂移；共享 buffer/error 类型和映射测试
+  必须作为单一契约。
+
+## 测试计划
+
+- [ ] Unit tests: config validation、buffer accounting、surface ordering、UTF-8、error envelope。
+- [ ] Integration tests: Chat/Completion/Responses safe、block、error、overflow、disabled。
+- [ ] Lifecycle tests: usage、预算、provider lease、callback、idle timeout、三阶段断连。
+- [ ] Deterministic checks: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; focused guardrail/stream tests; `cargo test`。
+- [ ] Manual verification: 使用慢速 SSE fixture 比较 guardrail on/off 的首内容时间与最终 event 顺序；不得依赖真实 provider 或密钥。
+
+## 回滚方案
+
+回滚本 Issue 的实现 commit 即恢复原 streaming 行为；新增配置具有默认值，回滚前先从
+部署配置移除 `guardrails.streaming_output`，避免旧版本 deny-unknown 启动失败。
+不得通过把 `fail_open` 改为 true 作为回滚。若上线后出现内存或延迟风险，应暂停
+guarded streaming 请求并回滚，而不是绕过输出检查。


### PR DESCRIPTION
## 摘要

为 #1127 增加 SpecRail product/tech/tasks 三件套，定义三条 SSE 输出 guardrail 的共同安全契约、生命周期要求和验证矩阵。

## 人工决策门

实施前必须从 `full_buffer`、`per_event_cumulative`、`windowed_cumulative` 中选择一种 `HD-1127-1` 审核模式；本 PR 不实现代码。

## 验证

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1127`
- `git diff --check origin/main...HEAD`

Refs #1127