### PR TITLE
docs(spec): define GH1128 guardrail coverage contract

### DIFF
--- a/specs/GH1128/product.md
+++ b/specs/GH1128/product.md
@@ -1,0 +1,64 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1128 / #1128
+
+complexity: high
+
+## 用户问题
+
+输入 guardrail 当前只读取普通文本 content，忽略 document、tool result、
+tool use input、tool-call arguments 和 message name。攻击者可以把同一提示注入或
+敏感内容放进这些结构化字段，从而在 agent/tool 循环中绕过已配置的输入策略。
+
+## 目标
+
+- 覆盖聊天请求中所有由 Issue 明确列出的文本或结构化文本载体，以及同一公开
+  DTO 中等价的 legacy function-call 载体。
+- 对等价内容提供与普通文本相同的 guardrail 接受、修改或拒绝语义。
+- 保持扫描输入确定、有限且可测试，不静默丢弃序列化失败。
+- 兼容没有这些字段的现有请求。
+
+## 非目标
+
+- 下载 document URL、image URL 或其他远端资源后再扫描。
+- 对图片、音频或任意二进制内容增加 OCR、转写或恶意软件检测。
+- 改变 provider 请求转换、tool 执行或 guardrail provider 协议。
+- 扩大到 Issue 未列出的响应输出面；流式输出由 GH-1127 处理。
+
+## Behavior Invariants
+
+1. B-001 普通文本、`Document.source`、`ToolResult.content`、`ToolUse.input`、`function_call`、`tool_calls[].function` 和 `ChatMessage.name` 都必须进入输入 guardrail。
+2. B-002 多条 message、多段 content 和多个 tool call 必须按稳定顺序组合，并以明确边界分隔，不能因字符串直接拼接制造或消除敏感模式。
+3. B-003 字符串字段保留原文本；结构化 JSON 字段使用确定性、完整的 JSON 表示，不得只扫描部分 key 或 value。文本型 document 必须扫描 base64 解码后的 UTF-8 正文，而不是无意义地只扫描编码字符串。
+4. B-004 任一列入范围的字段包含被拒内容时，整个请求在调用 provider 前被拒绝。
+5. B-005 guardrail 返回修改后文本时，不得把扁平扫描文本错误回写到原有多模态或 tool 结构；不支持安全回写的结构必须有明确契约而非静默改变请求含义。
+6. B-006 无法构造完整扫描载荷时必须返回显式错误；禁止跳过失败字段后继续请求。
+7. B-007 未列入范围的图片、音频和远端资源只保留现有行为，扫描过程不得发起网络访问；输入 guardrail 开启时，无法安全解码或不属于支持文本媒体类型的 document 必须 fail-closed，而不是作为“已扫描”放行。
+8. B-008 没有配置输入 guardrail 时，请求结构和 provider 可见内容保持不变。
+
+## 验收标准
+
+- [ ] 每个列入范围的 content variant 都有接受与拒绝测试。
+- [ ] modern/legacy function call 的 name/arguments、`ChatMessage.name` 各有独立覆盖。
+- [ ] 文本 document fixture 证明扫描解码后正文；malformed base64、非 UTF-8 和不支持媒体类型 fail-closed。
+- [ ] 多 message、多 content part、多 tool call 的稳定顺序与边界有测试。
+- [ ] 嵌套 JSON、数组、空值、Unicode 和跨字段边界有测试。
+- [ ] 测试证明 guardrail 拒绝发生在 provider 调用前。
+- [ ] 测试证明扫描不会下载 URL 或改变未配置 guardrail 的请求。
+- [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过。
+
+## 边界情况
+
+- `ToolResult.content` 可能是字符串、对象、数组或空值。
+- `ToolUse.input` 与 function arguments 可能包含深层嵌套 JSON。
+- `Document.source.data` 是 base64；媒体类型可能是 `text/*`、JSON、PDF 或其他二进制。
+- message name 或参数可能为空；空值不应制造虚假内容。
+- 相邻字段的末尾和开头可能共同形成敏感词，边界策略必须固定并测试。
+- guardrail provider 可能只支持纯文本修改，不能安全地重建任意结构化输入。
+
+## 发布说明
+
+这是安全收紧：过去可通过结构化 tool/document 字段发送的内容现在可能被已有
+guardrail 拒绝。无需新增配置；未启用输入 guardrail 的部署保持兼容。

--- a/specs/GH1128/tasks.md
+++ b/specs/GH1128/tasks.md
@@ -1,0 +1,40 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1128 / #1128
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 决策门
+
+- [ ] `SP1128-T0` Covers: B-001 ～ B-008. Owner: maintainer/spec owner. Dependencies: none. Done when: 最终 product/tech/tasks SHA 获得内容绑定批准，公开 security Issue 的范围保持在已披露事实内，并添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+
+## 实现任务
+
+- [ ] `SP1128-T1` Covers: B-001, B-002, B-003, B-006. Owner: guardrail implementation owner. Dependencies: SP1128-T0. Done when: `content_text` 被 fallible owned fragment builder 替代，覆盖 message name、普通 content、legacy/modern function、tool result/use，并以稳定标签/边界组合. Verify: focused fragment order/boundary/JSON tests.
+- [ ] `SP1128-T2` Covers: B-003, B-006, B-007. Owner: same implementation owner. Dependencies: SP1128-T1. Done when: 支持文本 MIME 的 document base64 解码为 UTF-8 正文；bad base64/UTF-8/unsupported MIME 在 input guardrail 开启时 fail-closed；无网络和二进制解析. Verify: document MIME/base64 table tests.
+- [ ] `SP1128-T3` Covers: B-004, B-005, B-008. Owner: test owner. Dependencies: SP1128-T2. Done when: provider-before-block、modified/mask fail-closed、disabled guardrail DTO 兼容与无网络证据完整. Verify: focused async guardrail tests and mock provider boundary test.
+- [ ] `SP1128-T4` Covers: B-001 ～ B-008. Owner: verification owner. Dependencies: SP1128-T3. Done when: Claude 保留 diff 已按批准规格审计/修正，完整 Rust/SpecRail gate 与安全人工 review 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+
+## 并行拆分
+
+不并行。实现集中在 `src/server/guardrails.rs` 与同一组测试，独立 owner 串行处理。
+现有 `.claude/worktrees/agent-a9318fa5b8e2ddbdd` 仅作为待审 diff，不视为已验证实现。
+
+## 验证
+
+- Product invariant 与 tasks `Covers:` 的并集必须都是 B-001 ～ B-008。
+- 对每个结构化载体至少有 allow/block 两条 fixture。
+- 测试必须扫描解码后的 document 文本，不能仅断言 base64/JSON 字符串被拼接。
+- PR 在最终 slice 使用 `Fixes #1128`，需要 security 人工 review。
+
+## Handoff Notes
+
+- Claude 原 diff 未处理 document base64 的语义性解码，不能直接提交。
+- 不支持的二进制 document 在启用 input guardrail 时按规格 fail-closed。
+- 保留现有 mask/modified 非可变边界的显式错误。
+- 不自动合并、不 force-push。

--- a/specs/GH1128/tech.md
+++ b/specs/GH1128/tech.md
@@ -1,0 +1,86 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1128 / #1128
+
+## Product Spec
+
+见 `product.md`（B-001 ～ B-008）。
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Guardrail adapter | `src/server/guardrails.rs` | `content_text` 只借用普通 text part | 根因与唯一 enforcement boundary |
+| Chat DTO | `src/core/models/openai/messages.rs` | `ContentPart` 包含 document/tool result/tool use | 列出必须规范化的载体 |
+| Function DTO | `src/core/models/openai/tools.rs` | legacy/modern function arguments 都会发给 provider | 等价结构化输入不能继续遗漏 |
+| Guardrail engine | `src/core/guardrails/*` | 接收 `&str`，mask 在 gateway boundary fail-closed | 新适配器必须保留错误语义 |
+
+## 设计方案
+
+1. 用一个返回 owned `Result<Vec<String>, GatewayError>` 的规范化函数替代
+   `content_text -> Vec<&str>`。owned 结果允许安全容纳 JSON 序列化和 base64 解码
+   后的正文，错误不能被 iterator/filter 静默丢弃。
+2. 每条 message 以带稳定标签的片段加入扫描载荷：message name、普通 content、
+   legacy `function_call` name/arguments、modern `tool_calls[].function`
+   name/arguments。标签与换行分隔避免字段直接拼接，迭代顺序严格跟随请求顺序。
+3. `ToolResult.content` 与 `ToolUse.input` 使用 `serde_json::to_string` 的完整 JSON
+   表示；同时扫描 `ToolUse.name`。序列化错误映射为显式 gateway internal error。
+4. `Document.source.data` 先按 base64 解码。仅接受明确文本媒体类型：
+   `text/*`、`application/json`、`application/*+json`、`application/xml` 和
+   `application/*+xml`；解码结果必须是 UTF-8。malformed base64、非 UTF-8 或
+   其他媒体类型在 input guardrail 开启且 `check_input` 为 true 时 fail-closed。
+   不读取 URL、不解析 PDF/Office、不扫描 image/audio base64。
+5. 新规范化只改变传给 guardrail 的扫描字符串，绝不重写原 DTO。现有
+   `GuardrailAction::Mask`/modified 结果继续由 `enforce` 显式失败，避免把扁平文本
+   错误回写到结构。
+6. 在 `check_input` 中先构造全部载荷，成功后调用一次 engine；任何字段失败都在
+   provider 选择/调用前结束。engine disabled 或 `check_input: false` 时可直接
+   保持现有无检查行为，避免因未启用策略拒绝二进制 document。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | message/function/content 规范化 | 每种载体独立 blocked fixture |
+| B-002/B-003 | labelled fragment builder | 顺序、边界、嵌套 JSON 与 Unicode snapshot |
+| B-004 | `check_input` 调用顺序 | mock provider 未被调用 |
+| B-005 | `enforce` modified 分支 | mask 仍 fail-closed 且请求 DTO 未改变 |
+| B-006 | fallible builder | malformed document/serialization 错误不调用 engine/provider 后续 |
+| B-007 | document media gate | 文本正文解码；PDF/image/audio/URL 无网络且 fail-closed/保持范围 |
+| B-008 | disabled fast path | 同一多模态请求在未启用 guardrail 时保持兼容 |
+
+## 数据流
+
+`ChatCompletionRequest.messages` 按顺序进入 fallible fragment builder；文本字段原样
+复制，JSON 字段确定性序列化，允许的 document base64 解码为 UTF-8。片段带标签与
+边界拼成单个扫描载荷，交给现有 `GuardrailEngine::check_input`，再由 `enforce`
+统一映射 allow/block/modified/error。原请求对象始终不变。
+
+## 备选方案
+
+- 对整个 `ChatCompletionRequest` 直接 JSON 序列化：拒绝，因为会扫描 image/audio
+  base64、混入无关配置，并且 document 正文仍是编码数据。
+- 只扫描 JSON/base64 原字符串：拒绝，因为不能识别 document 解码后的自然语言。
+- 对不支持 document 类型放行：拒绝，因为输入 guardrail 会继续存在公开 bypass。
+- 自动提取 PDF/Office：超出范围且会新增复杂解析/资源消耗面。
+
+## 风险
+
+- Security: 支持媒体类型列表必须 fail-closed，不能被 MIME 大小写/参数绕过。
+- Compatibility: 启用 input guardrail 的二进制 document 将被拒绝；发布说明需明确。
+- Performance: 文档解码和 owned 载荷增加内存；沿用请求大小限制并避免重复复制。
+- Maintenance: DTO 新增文本载体时应在 exhaustiveness test 中显式分类。
+
+## 测试计划
+
+- [ ] Unit tests: 全 variant、legacy/modern function、嵌套 JSON、标签边界、Unicode。
+- [ ] Document tests: textual MIME、`+json/+xml`、MIME 参数、bad base64、bad UTF-8、PDF。
+- [ ] Integration tests: blocked 发生在 provider 前，disabled 配置保持 DTO。
+- [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`。
+
+## 回滚方案
+
+回滚规范化函数与测试即可，无持久化迁移。若二进制 document 兼容性需要恢复，
+必须另行设计可审核的解析器或按端点禁用 input guardrail；不得重新静默放行。


### PR DESCRIPTION
## 摘要

为 #1128 增加 SpecRail product/tech/tasks 三件套，覆盖结构化 tool/function 输入与文本 document 的语义性扫描、fail-closed 行为和完整测试矩阵。

## 边界

本 PR 仅包含规格，不包含 Claude 留下的未验证实现；实施需在最终 spec SHA 获批后进行。

## 验证

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1128`
- `git diff --check origin/main...HEAD`

Refs #1128