### PR TITLE
docs(spec): define GH1129 usage billing contract

### DIFF
--- a/specs/GH1129/product.md
+++ b/specs/GH1129/product.md
@@ -1,0 +1,91 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1129 / #1129
+
+complexity: high
+
+## 用户问题
+
+部分 provider 的非流式响应在 `usage` 存在但字段缺失、类型错误或无法解析时，
+会把对应 token 数默认为 `0`，最终生成看似有效的零 usage。下游因此跳过
+“provider 未返回 usage”的显式保护，把成功请求记录成零 token、零费用，预算也
+可能不扣减。合法但超过内部范围的计数还会被截断成更小值。
+
+## 目标
+
+- 对受影响的非流式 provider 使用一致、可测试的 usage 有效性规则。
+- 明确区分合法的单字段零值、字段缺失、字段类型错误和整体零 usage。
+- 对部分字段漂移采取 fail closed 行为，不猜测或拼接不可信 usage。
+- 以饱和语义处理合法的大整数，并保证 `total_tokens` 与分量一致。
+- 让不可信 usage 进入既有的缺失 usage 结算保护，避免静默免费调用。
+
+## 非目标
+
+- 改变模型价格、预算上限、预留算法或 provider 请求协议。
+- 猜测未声明的新字段名、字符串数字、浮点数、负数或任意嵌套数字的含义。
+- 重写已经具有显式错误处理的流式 usage 解析。
+- 扩大公开 `Usage` 字段的整数类型或改变公开响应 schema。
+
+## Behavior Invariants
+
+1. **B-001** Azure chat/embed、Azure AI chat/embed、Vertex AI、Bedrock 和
+   Mistral embedding 的受影响非流式 usage 必须遵循同一可信度规则。
+2. **B-002** usage 容器不存在时，响应必须表现为 `usage: None`；不得构造默认
+   零 usage。
+3. **B-003** 每种已声明 provider 格式的必需 token 分量必须存在且为 JSON
+   unsigned integer；任一必需分量缺失、为 `null`、字符串、浮点、负数或其他
+   类型时，整条 usage 必须 fail closed 为 `None`。
+4. **B-004** 合法解析出的单个零分量不得单独导致 usage 被丢弃：chat 的
+   prompt-only 或 completion-only 非零 usage 必须保留；embedding 中不适用的
+   completion 分量必须保持合法零值。
+5. **B-005** 所有适用分量均合法但 prompt 与 completion 都为零时，整条 usage
+   必须表现为 `None`，不得进入零费用成功记账路径。
+6. **B-006** provider 报告的 `total_tokens` 不得替代缺失的 prompt 或 completion
+   分量；输出 `total_tokens` 必须由归一化后的分量重新计算。
+7. **B-007** 对声明包含 total 的 provider 格式，total 缺失、类型错误或与重算值
+   不一致时，整条 usage 必须 fail closed 为 `None`；对声明不包含 total 的格式，
+   系统只使用重算值。
+8. **B-008** 合法的 `u64` token 数超过 `u32::MAX` 时必须饱和为
+   `u32::MAX`，不得回绕、截断为更小值或 panic。
+9. **B-009** `total_tokens` 必须使用饱和加法；即使两个分量各自可表示，相加也
+   不得溢出为更小值。
+10. **B-010** `usage: None` 必须继续触发现有缺失 usage 结算行为：有预算预留时
+    按既有规则结算预留并记录显式错误；无预留时不得伪造零费用 spend。
+11. **B-011** 合法、范围内且 total 一致的 provider usage，其公开 token 值和
+    既有计费结果必须保持兼容。
+12. **B-012** 解析失败不得仅记录低级别日志后继续生成成功的零 token、零费用
+    账单副作用。
+
+## 验收标准
+
+- [ ] 每个受影响 provider 格式均覆盖合法 usage、容器缺失、必需字段缺失、
+      错误类型、部分字段漂移和全零 usage。
+- [ ] prompt-only、completion-only 以及 embedding 合法零 completion 的行为符合
+      B-004。
+- [ ] `u32::MAX`、`u32::MAX + 1`、`u64::MAX` 和分量相加溢出场景均证明饱和且
+      不回绕。
+- [ ] 对带 total 的格式覆盖一致、缺失、错误类型和不一致 total；对不带 total
+      的格式证明输出 total 来自重算。
+- [ ] 下游验证证明不可信 usage 进入既有缺失 usage 结算路径，而不是记录
+      `$0` 成功计费。
+- [ ] 未声明字段名和嵌套形状不会被猜测为 usage。
+- [ ] 合法非零 usage 的兼容性回归测试通过。
+
+## 边界情况
+
+- chat 可能合法报告 prompt 为零或 completion 为零，但不能缺少该格式规定的字段。
+- embedding 没有 completion 计费分量；该零值是格式语义，不是解析 fallback。
+- JSON unsigned integer 可能刚好等于或远大于 `u32::MAX`。
+- 两个归一化分量都可表示时，它们的和仍可能超过 `u32::MAX`。
+- provider 可能提供 total 但遗漏一个分量，或提供与分量和不一致的 total；两种
+  情况都不能被当作可信 usage。
+- 极少数真实响应可能明确报告全零 usage；在计费边界上仍按无可信 usage 处理，
+  以避免静默免费调用。
+
+## 发布说明
+
+这是计费正确性收紧。过去被默认为零 token、零费用的 malformed、partial 或
+all-zero usage 将进入既有缺失 usage 保护。合法非零 usage 无需迁移；若上游
+provider 已发生字段漂移，运营日志将显式暴露该问题。

--- a/specs/GH1129/tasks.md
+++ b/specs/GH1129/tasks.md
@@ -1,0 +1,40 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1129 / #1129
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 决策门
+
+- [ ] `SP1129-T0` Covers: B-001 ～ B-008. Owner: maintainer/spec owner. Dependencies: none. Done when: 计费语义、all-zero -> `None` 与饱和规则绑定最终 spec SHA 获批，Issue 添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+
+## 实现任务
+
+- [ ] `SP1129-T1` Covers: B-002, B-003, B-004, B-005. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/base/usage.rs` 提供唯一 crate-private normalizer，覆盖 partial/nonzero/None 和 `u32` 饱和/total 饱和. Verify: focused helper boundary tests.
+- [ ] `SP1129-T2` Covers: B-001, B-006, B-007. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex、Bedrock 各模型族、Mistral parser 只解析已声明字段并全部调用 helper；删除直接 `as u32` 与手写零 Usage. Verify: provider-specific valid/malformed/all-zero tests.
+- [ ] `SP1129-T3` Covers: B-008. Owner: spend test owner. Dependencies: SP1129-T2. Done when: `None` 进入现有显式错误/settlement，测试证明不产生成功的零 token/$0 记录. Verify: focused spend reservation/usage tests.
+- [ ] `SP1129-T4` Covers: B-001 ～ B-008. Owner: verification owner. Dependencies: SP1129-T3. Done when: Claude 保留 diff 全量审计，所有 provider 路径和完整 Rust/SpecRail gate 通过，计费安全人工 review 完成. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+
+## 并行拆分
+
+不并行。共享 usage helper 与各 provider parser 有直接依赖，单一 owner 串行修改；
+验证在 `.claude/worktrees/agent-ab21c6241a85e84ba` 单路运行。
+
+## 验证
+
+- 对 Issue 列出的每个具体 parser 返回点建立覆盖清单，禁止只测一个样本。
+- `u32::MAX + 1`、`u64::MAX` 与 total overflow 必须有新鲜输出。
+- 不修改测试断言来接受 silent zero billing。
+- 最终 PR 使用 `Fixes #1129`，需要 billing 人工 review。
+
+## Handoff Notes
+
+- Claude diff 改动约 600 行且未完成构建，不能把“代码已写”当作验证。
+- 不新增 provider 字段 alias，不接受数字字符串猜测。
+- `None` 的下游错误/结算语义必须通过端到端 focused test。
+- 不自动合并、不 force-push。

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -1,0 +1,176 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1129 / #1129
+
+## Product Spec
+
+[`product.md`](./product.md)
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| 统一响应类型 | `src/core/types/responses/usage.rs` | `Usage` 使用 `u32` 分量；`Usage::new` 直接相加，但本 Issue 的 provider 解析器大多手工构造该类型 | 公开 schema 保持不变；解析边界必须在进入 `Usage` 前完成合法性与范围归一化 |
+| 共享 provider 工具 | `src/core/providers/shared.rs` | 已承载跨 provider 的响应解析工具，但尚无严格 token usage helper | 搜索后确认这是复用逻辑的既有位置，不新增平行 utility 文件 |
+| Azure | `src/core/providers/azure/chat.rs`, `src/core/providers/azure/embed.rs`, `src/core/providers/azure/chat_tests.rs` | 缺失或错误类型通过 `unwrap_or(0)` 退化为零，`as u32` 可截断 | chat 与 embedding 都在账单入口前产生 `Option<Usage>` |
+| Azure AI | `src/core/providers/azure_ai/chat.rs`, `src/core/providers/azure_ai/embed.rs`, `src/core/providers/azure_ai/chat_tests.rs` | 与 Azure 相同；embedding completion 固定为不适用的零 | 需要保留格式差异，同时移除静默 fallback |
+| Vertex AI | `src/core/providers/vertex_ai/transformers.rs` | `usageMetadata` 与 legacy `tokenMetadata` 都会默认零；legacy 路径甚至把缺失 usage 展开为全零 `Usage` | 两种格式的必需字段和 total 策略不同 |
+| Bedrock | `src/core/providers/bedrock/transformation.rs` | 多种模型族各自解析，部分路径已有 all-zero → `None`，其他路径仍默认零并直接相加 | 需要统一 OpenAI-compatible、runtime alias、Claude、Converse、Titan 的边界语义 |
+| Mistral embedding | `src/core/providers/mistral/embedding.rs` | 缺失或错误字段默认为零并截断 | completion 为不适用零，prompt/total 仍需严格验证 |
+| 结算保护 | `src/server/routes/ai/spend.rs`, `src/server/routes/ai/spend_no_usage_tests.rs` | `usage: None` 会进入 `record_reserved_spend_without_usage`；有预留时按预留结算，无预留时显式报错且不记录 spend | provider 层必须把不可信 usage 路由到此既有保护，并补充账单副作用回归证明 |
+| 流式解析 | `src/core/providers/base/sse/openai.rs` | 已对 usage 反序列化失败显式报错并返回 `None` | 本 Issue 不修改，作为既有 fail-closed 参考 |
+
+## 设计方案
+
+### 1. 统一严格解析原语
+
+在既有 `src/core/providers/shared.rs` 中增加 crate-private helper，不改变公开 API：
+
+- 只接受 `serde_json::Value::as_u64()` 成功的 JSON unsigned integer。
+- 合法 `u64` 通过 `u32::try_from(value).unwrap_or(u32::MAX)` 饱和到内部范围。
+- 由合法 prompt/completion 构造 `Usage` 时：
+  - 两者均为零则返回 `None`；
+  - `total_tokens = prompt_tokens.saturating_add(completion_tokens)`；
+  - provider total 若该格式声明存在，则必须同样是合法 unsigned integer，归一化后
+    与重算 total 一致，否则返回 `None`。
+- helper 不猜测字段名；各 provider 适配器负责传入其格式声明的精确字段。
+- completion 不适用的 embedding 路径显式传入合法常量 `0`，而不是把字段读取失败
+  映射成 `0`。
+
+### 2. Provider 字段契约
+
+| Provider format | Required prompt | Required completion | Reported total |
+| --- | --- | --- | --- |
+| Azure / Azure AI chat | `usage.prompt_tokens` | `usage.completion_tokens` | `usage.total_tokens` 必需且必须一致 |
+| Azure / Azure AI embedding | `usage.prompt_tokens` | 不适用，显式 `0`；若响应带 completion，则必须是合法 `0` | `usage.total_tokens` 必需且必须一致 |
+| Vertex `usageMetadata` | `promptTokenCount` | `candidatesTokenCount` | `totalTokenCount` 必需且必须一致 |
+| Vertex legacy `metadata.tokenMetadata` | `inputTokens.totalTokens` | `outputTokens.totalTokens` | 格式不声明 total，统一重算 |
+| Bedrock OpenAI-compatible | `prompt_tokens` | `completion_tokens` | `total_tokens` 必需且必须一致 |
+| Bedrock runtime aliases | 已识别的 input 字段之一 | 对应格式的 output 字段 | 格式无 total 时统一重算；不得跨不完整 alias 组合拼接 |
+| Bedrock Claude / Converse / Titan | 各模型族声明的 input 字段 | 各模型族声明的 output 字段 | 统一重算 |
+| Mistral embedding | `usage.prompt_tokens` | 不适用，显式 `0` | `usage.total_tokens` 必需且必须一致 |
+
+usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺失或类型错误都使用 `?`
+传播为 `None`；不得保留另一半字段形成 partial usage。
+
+### 3. Total 一致性
+
+内部账单只信任归一化后的 prompt/completion 分量。reported total 不参与计算，只用于
+检测 provider schema 或数据漂移。比较在饱和后的 `u32` 域完成，因此超大但合法的
+计数仍保持“不低估”的内部上限语义。所有调用方移除普通 `+` 和 provider total
+直赋值，统一使用 helper 的 `saturating_add` 结果。
+
+### 4. Billing 副作用
+
+不修改 `src/server/routes/ai/spend.rs` 的生产结算算法。转换器返回 `None` 后沿现有
+路径进入 `record_reserved_spend_without_usage`：
+
+1. 有 `UnifiedBudgetReservation` 时以 reserved amount 结算，避免免费调用；
+2. 有 key budget reservation 时同步结算该预留；
+3. 有 API key 时记录零 token 与 reserved cost，而不是零 token/零 cost；
+4. 无预留时记录 error，且不伪造成功 spend。
+
+在 `spend_no_usage_tests.rs` 扩充下游测试，固定这些副作用，避免未来 provider 修复
+再次被结算层弱化。
+
+## Planned Change Manifest
+
+| File | Planned change | Product invariants |
+| --- | --- | --- |
+| `src/core/providers/shared.rs` | 增加严格 unsigned token 读取、饱和 `u64 → u32`、all-zero 拒绝、reported-total 校验和饱和 total 重算 helper 及单元测试 | B-003–B-009 |
+| `src/core/providers/azure/chat.rs` | 用共享 helper 替换三个默认零/截断读取 | B-001–B-009, B-011 |
+| `src/core/providers/azure/chat_tests.rs` | 增加合法零分量、missing/type drift、全零、total mismatch、范围边界 fixture | B-003–B-009, B-011 |
+| `src/core/providers/azure/embed.rs` | 严格读取 prompt/total，显式处理 embedding completion=0 | B-001–B-009 |
+| `src/core/providers/azure_ai/chat.rs` | 应用与 Azure chat 相同的严格契约 | B-001–B-009, B-011 |
+| `src/core/providers/azure_ai/chat_tests.rs` | 覆盖 Azure AI chat 的 drift、total、范围与兼容性 | B-003–B-009, B-011 |
+| `src/core/providers/azure_ai/embed.rs` | 严格读取 prompt/total，completion 仅按格式语义为零 | B-001–B-009 |
+| `src/core/providers/vertex_ai/transformers.rs` | 分别收紧 `usageMetadata` 与 legacy `tokenMetadata`，移除缺失 usage 的默认 `Usage`，统一重算 total，并扩充本文件测试 | B-001–B-009, B-011 |
+| `src/core/providers/bedrock/transformation.rs` | 收敛所有模型族 usage parser，禁止 partial alias 拼接，移除默认零和普通加法，并扩充本文件测试 | B-001–B-009, B-011 |
+| `src/core/providers/mistral/embedding.rs` | 严格读取 prompt/total、显式 completion=0，并扩充本文件测试 | B-001–B-009, B-011 |
+| `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
+
+不计划修改 `src/server/routes/ai/spend.rs`、公开 `Usage` schema、流式 SSE 解析或价格/预算
+配置；若实现发现必须修改 manifest 外文件，应停止并回到 spec review。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | 所有 manifest 中 provider parser | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
+| B-002 | provider 容器入口 | 缺失 usage / usageMetadata / tokenMetadata fixture 返回 `None` |
+| B-003 | shared helper 与每种字段映射 | missing、`null`、string、float、negative、object/array fixture；partial 字段返回 `None` |
+| B-004 | chat 与 embedding 格式策略 | prompt=0/completion>0、prompt>0/completion=0、embedding completion=0 fixture |
+| B-005 | shared builder | prompt=0/completion=0 返回 `None`，所有 provider 至少一条集成 fixture |
+| B-006 | total 重算 | total 不能补齐缺失分量；无 total 格式得到分量饱和和 |
+| B-007 | reported-total validator | total 缺失、错误类型、不一致均返回 `None`；一致 total 保留 |
+| B-008 | token conversion helper | `u32::MAX`、`u32::MAX + 1`、`u64::MAX` |
+| B-009 | total builder | `u32::MAX + 1` 与 `u32::MAX + u32::MAX` 均得到 `u32::MAX` |
+| B-010 | `spend_no_usage_tests.rs` | 验证 provider/model spend、API-key usage、reservation 和 key-budget settlement |
+| B-011 | 现有 provider happy-path tests | 保持合法 fixture 的 prompt/completion/total 和费用断言 |
+| B-012 | provider → spend handoff | malformed provider fixture 返回 `None`，下游 no-usage 测试证明不产生 `$0` 成功 spend |
+
+## 数据流
+
+1. provider 非流式响应被解析为 JSON。
+2. 对应适配器按格式选择精确 usage 容器和必需字段。
+3. 共享 helper 验证 JSON unsigned integer、执行饱和转换、拒绝 partial/all-zero usage、
+   重算 total 并校验 reported total。
+4. 可信数据生成 `Some(Usage)`；不可信或缺失数据生成 `None`。
+5. `Some(Usage)` 进入现有定价与实际 usage 结算；`None` 进入现有 reserved
+   no-usage 结算与 error 日志。
+6. 不新增持久化字段或外部调用。
+
+## 备选方案
+
+- **在每个 provider 内复制修复**：改动直观，但容易再次出现字段、溢出和 total
+  语义漂移，拒绝。
+- **仅在 spend 层把 `Some(0,0,0)` 转成 `None`**：能挡住 all-zero，但无法识别
+  partial drift、截断和 total 不一致，也会丢失 provider 诊断上下文，拒绝。
+- **错误类型直接让成功响应失败**：最严格，但改变用户可见请求成功语义；当前选择
+  保留响应并通过既有 no-usage 结算 fail closed。
+
+## 风险
+
+- Security: 计费与预算属于高风险边界；任一 fallback-to-zero 都可能恢复免费调用。
+  必须人工审查 provider 字段映射和所有账单副作用测试。
+- Compatibility: malformed、partial、all-zero 或 total 不一致的响应将从
+  `Some(Usage)` 变为 `None`；这是有意收紧。合法非零响应和公开 schema 不变。
+- Performance: 每个响应增加常数级字段检查、`try_from` 和一次饱和加法，无额外 I/O
+  或分配，影响可忽略。
+- Maintenance: provider 字段策略必须保留在显式表驱动/局部映射中；不得让共享
+  helper 猜测任意 alias。
+
+## 测试计划
+
+- [ ] Unit tests: shared helper 的类型、边界、all-zero、total consistency 全分支；
+      每个 provider 格式的 happy path 与 drift fixture。
+- [ ] Integration tests: provider parser 输出 `None` 后复用
+      `spend_no_usage_tests.rs` 验证 reservation、key budget 和 key usage 副作用。
+- [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、Bedrock、Mistral 相关测试。
+- [ ] Static checks: `cargo fmt --check`、`cargo check`、
+      `cargo clippy --all-targets -- -D warnings`。
+- [ ] Full verification: `cargo test`；关键 usage helper 与结算分支要求 100% 覆盖，
+      新增代码整体至少 80% line coverage。
+- [ ] Manual verification: 使用一份合法 usage 与一份 partial/malformed usage 的
+      provider fixture，确认前者正常计费，后者产生显式 no-usage error 且不记录
+      `$0` 成功 spend。
+
+## Security / Compatibility / Performance / Rollback
+
+- **Security**：实现不得吞掉 malformed usage；review 必须检查所有列出的转换点、
+  `as u32`、普通 token 加法和账单副作用。
+- **Compatibility**：不改变外部 JSON schema、provider 请求或合法 usage；仅收紧
+  不可信响应。
+- **Performance**：保持 O(1) CPU、O(1) 内存，不引入网络、锁或持久化。
+- **Rollback**：代码可按单一实现提交整体 revert。若上线后某 provider 因真实格式
+  差异大量进入 `None`，先通过日志确认字段事实，再补充明确格式映射；不得回退为
+  `unwrap_or(0)`。紧急回滚时预算风险会恢复，必须同步告警并限制相关 provider。
+
+## 回滚方案
+
+回滚仅撤销严格 provider usage normalization 和对应测试，不迁移数据。回滚前需确认
+是否会重新暴露零费用调用；若风险不可接受，应临时停用受影响 provider 或收紧其预算，
+而不是恢复静默 fallback。Spec approval、实现、PR final review 和 merge 仍需各自的人类
+门禁。


### PR DESCRIPTION
## 摘要

为 #1129 增加 SpecRail product/tech/tasks 三件套，统一 all-zero/malformed usage、饱和转换、provider 覆盖和下游结算验证契约。

## 边界

本 PR 仅包含规格，不包含未完成构建的 provider 实现；实施需在最终 spec SHA 获批后进行。

## 验证

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1129`
- `git diff --check origin/main...HEAD`

Refs #1129