### PR TITLE
docs(spec): define GH1130 Files tenant isolation contract

### DIFF
--- a/specs/GH1130/product.md
+++ b/specs/GH1130/product.md
@@ -1,0 +1,66 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1130 / #1130
+
+complexity: high
+
+## 用户问题
+
+Files API 的存储元数据没有所有者，所有已认证调用者都可以列出、读取、下载或
+删除其他租户文件。文件内容可能包含 batch 输入、训练数据或 assistant 文档，
+因此对象级授权必须在每个入口一致执行。
+
+## 目标
+
+- 上传时为文件记录一个确定的有效租户范围。
+- list、metadata、content 和 delete 全部执行同一对象所有权规则。
+- 管理员保留运维访问，历史无 owner 文件仅管理员可见。
+- 在 Local 与 S3 后端持久保存相同 owner 语义。
+- 防止未授权调用者通过响应差异枚举其他租户文件。
+
+## 非目标
+
+- 改变文件 ID、purpose、内容类型或上传大小限制。
+- 增加跨租户共享、ACL、转移所有权或公开链接。
+- 回填或猜测历史文件的 owner。
+- 改变 auth 关闭时的本地开发兼容行为。
+
+## Behavior Invariants
+
+1. B-001 auth 开启时，每个新文件必须绑定一个有效租户范围；优先级为 `team_id`、其次 `user_id`、最后 `api_key_id`，不得把多个范围作为“任一匹配即可”的并列授权。
+2. B-002 非管理员只能列出与当前有效租户范围完全匹配的文件；其他租户和历史无 owner 文件不得出现在列表或计数中。
+3. B-003 metadata、content 和 delete 对非 owner 的结果必须与不存在文件不可区分，不得泄露目标文件是否存在、owner 或其他元数据。
+4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。
+5. B-005 auth 开启但无法解析任何有效 owner 范围时，上传和对象访问必须 fail-closed。
+6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。
+7. B-007 旧元数据缺少 owner 时仍可反序列化，但只对管理员可见；不得自动归属给第一个访问者。
+8. B-008 owner 信息是内部授权元数据，不得出现在 OpenAI-compatible File 响应或错误正文中。
+9. B-009 auth 明确关闭并允许匿名访问时，Files API 保持现有单租户行为，不伪造 owner。
+10. B-010 所有权检查必须发生在返回内容或执行删除之前；失败不得静默降级为无过滤访问。
+
+## 验收标准
+
+- [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete。
+- [ ] team-scoped 文件不能仅因相同 `user_id` 从另一个 team 访问；有效范围优先级有测试。
+- [ ] 非 owner 与随机不存在 ID 的状态码和公开错误形状一致。
+- [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件。
+- [ ] 无身份的已启用 auth 请求在上传和对象操作上 fail-closed。
+- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试。
+- [ ] OpenAI File JSON 与错误日志不泄露 owner。
+- [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过。
+
+## 边界情况
+
+- 同一 user 可能通过不同 team 或不同 API key 调用；team 范围不得被 user 匹配绕过。
+- team 缺失但 user 存在时使用 user；两者都缺失时才回退到 API key。
+- 文件可能在升级前创建且没有 owner。
+- metadata 存在但内容丢失，或删除时后端失败；错误仍需遵循现有显式失败语义。
+- list 期间单个 metadata 损坏不得导致未过滤内容泄露。
+
+## 发布说明
+
+升级后新文件带有内部 owner 元数据。历史无 owner 文件仅管理员可访问；如需普通
+租户继续使用，必须由单独、经审计的迁移显式归属。auth 关闭的单租户开发部署
+保持现有行为。

--- a/specs/GH1130/tasks.md
+++ b/specs/GH1130/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1130 / #1130
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 决策门
+
+- [ ] `SP1130-T0` Covers: B-001 ～ B-010. Owner: maintainer/spec owner. Dependencies: none. Done when: 单一 effective scope、legacy admin-only 与 foreign-as-not-found 绑定最终 spec SHA 获批，Issue 添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+
+## 实现任务
+
+- [ ] `SP1130-T1` Covers: B-001, B-004, B-005, B-009. Owner: auth implementation owner. Dependencies: SP1130-T0. Done when: `FileOwnerScope` 为单值 enum，caller 只从可信 context/extensions 解析 team -> user -> API key，admin 与 auth-disabled 分支明确，缺身份 fail-closed. Verify: scope priority/RBAC/auth-disabled unit matrix.
+- [ ] `SP1130-T2` Covers: B-006, B-007, B-008. Owner: storage implementation owner. Dependencies: SP1130-T1. Done when: dispatch、Local、S3 持久化同一 owner enum；legacy `None` 兼容；公开 `FileObject` 不含 owner. Verify: Local/S3 round-trip、legacy、bad metadata tests.
+- [ ] `SP1130-T3` Covers: B-002, B-003, B-004, B-005, B-010. Owner: route implementation owner. Dependencies: SP1130-T2. Done when: list/get/content/delete 全部复用唯一授权 helper；foreign 与 missing 公开响应相同；unauthorized 不调用 backend content/delete. Verify: route mock/backend call-count tenant matrix.
+- [ ] `SP1130-T4` Covers: B-001 ～ B-010. Owner: security test owner. Dependencies: SP1130-T3. Done when: same-user cross-team、multiple keys/users/teams、admin、legacy、auth-disabled、日志/JSON 泄露矩阵完整. Verify: focused files route/storage security tests.
+- [ ] `SP1130-T5` Covers: B-001 ～ B-010. Owner: verification owner. Dependencies: SP1130-T4. Done when: Claude 原 OR-matching/403 方案已移除，完整 Rust/SpecRail gate 与 auth 安全人工 review 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+
+## 并行拆分
+
+不并行。auth scope、storage schema 和 route enforcement 是串行依赖，且共同触碰
+Files API 契约。单一 owner 在 `.claude/worktrees/agent-a5c5acb27baefcb98`
+完成，避免共享文件并发编辑。
+
+## 验证
+
+- foreign 与 nonexistent 的 status、error type/code 和正文必须逐字等价或经稳定字段比较等价。
+- S3 测试不得访问真实 AWS；使用 feature-aware mock/fixture。
+- list 对损坏 metadata 显式失败，不允许 skip 后静默返回。
+- 最终 PR 使用 `Fixes #1130`，必须有人审查 auth/security 代码。
+
+## Handoff Notes
+
+- Claude 原 `FileOwner { user_id, team_id, api_key_id }` + 任一匹配会产生跨 team bypass。
+- Claude 原 foreign `403` 可被用作文件存在性 oracle；按规格改为 uniform not-found。
+- 旧文件不自动归属，只有 admin 可见。
+- 不自动合并、不 force-push。

--- a/specs/GH1130/tech.md
+++ b/specs/GH1130/tech.md
@@ -1,0 +1,95 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1130 / #1130
+
+## Product Spec
+
+见 `product.md`（B-001 ～ B-010）。
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Request identity | `src/server/routes/ai/context.rs`, `src/core/types/context.rs` | middleware 暴露 user、team、API key 与 admin 权限 | owner 必须来自可信 extension/context |
+| Files routes | `src/server/routes/ai/files.rs` | handler 只按裸 `file_id` 操作 | 所有对象级 bypass |
+| Metadata | `src/storage/files/types.rs` | `FileMetadata` 没有 owner | 持久化根因 |
+| Storage dispatch | `src/storage/files/storage.rs` | store API 不接收 owner | Local/S3 必须一致 |
+| Local backend | `src/storage/files/local.rs` | `.meta` JSON 持久化基础 metadata | 可向后兼容 `owner: None` |
+| S3 backend | `src/storage/files/s3.rs` | 使用 object metadata，list/head 获取 metadata | owner 需稳定编码并 round-trip |
+| Route tests | `tests/files_routes.rs`, `src/storage/files/tests.rs` | 只覆盖基础 CRUD | 需要租户矩阵与 legacy |
+
+## 设计方案
+
+1. 定义单值 `FileOwnerScope`，推荐 serde tagged enum：
+   `Team(Uuid)`、`User(String)`、`ApiKey(Uuid)`。`FileMetadata.owner` 为
+   `Option<FileOwnerScope>` 并带 `#[serde(default)]`，从而旧 Local metadata
+   反序列化为 `None`。禁止保存三个 optional ID 并使用 OR 匹配。
+2. 在 files route 的 crate-private helper 中从可信 request extensions/context 解析
+   `FileCaller { auth_enforced, is_admin, effective_scope }`。有效 scope 严格按
+   team -> non-empty user -> API key 优先；auth 开启且普通调用者没有 scope 时返回
+   显式 auth/permission error。admin 由现有 RBAC helper 判定，不读取客户端 header。
+3. 扩展 `FileStorage::{store,store_with_purpose}` 及 Local/S3 对应入口接收 owner。
+   Files route 在写 content 前完成 caller 解析。Local 把 enum 写入 `.meta`；S3 使用
+   一个版本化 JSON metadata key（避免三个 key 产生组合歧义），读取时严格解析。
+4. 建立唯一 `can_access_file(caller, metadata)`：auth disabled 允许现有单租户行为；
+   admin 允许全部；普通调用者仅当单一 effective scope 与 owner 完全相等时允许；
+   `owner: None` 仅 admin。该 helper 供 list/get/content/delete 共同使用。
+5. list 读取 metadata 后先过滤再构造公开 `FileObject`；任何 metadata 解析错误显式
+   返回 error，禁止跳过损坏项并给出不完整/未过滤结果。公开对象不序列化 owner。
+6. get/content/delete 对非 owner 使用与 missing file 相同的 `NotFound` 状态、错误
+   type/code 和不含 file/owner 细节的正文。日志只记录 request ID 与拒绝类别，不记录
+   owner 值。delete 必须先取 metadata 并授权，再调用 backend delete。
+7. S3 的 object key 继续不可由调用者指定，owner metadata 仅由服务端写入。测试使用
+   backend fixture/mock，不访问真实 AWS。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | effective scope resolver + enum | team/user/key 优先级矩阵 |
+| B-002 | list filter | 多 tenant + legacy + limit 结果 |
+| B-003 | uniform concealment response | foreign 与 random missing 的 status/body 等价 |
+| B-004/B-005 | caller resolver/RBAC | admin 全访问；无 scope fail-closed |
+| B-006/B-007 | Local/S3 serialization | round-trip、legacy、restart-style reopen |
+| B-008 | FileObject/error mapping | JSON/log capture 无 owner |
+| B-009 | auth-disabled branch | anonymous CRUD 兼容测试 |
+| B-010 | route call order | mock backend 证明 unauthorized 不调用 get/delete |
+
+## 数据流
+
+auth middleware 将可信 user/API key 与 `RequestContext` 放入 request extensions。
+Files handler 解析一个有效 caller scope；upload 把该 scope 随 metadata 交给 storage。
+后续 list 或 object 操作先读取 metadata，使用唯一授权 helper 判定，再返回公开对象、
+content 或执行 delete。Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None`
+只能通过 admin 路径。
+
+## 备选方案
+
+- 保存 user/team/key 三个字段并任一相等即允许：拒绝，会让同一 user 跨 team 绕过。
+- 只绑定 API key：隔离最强但会破坏同 team/user 合法共享，且忽略已有租户层次。
+- foreign 返回 `403`：拒绝，与 missing `404` 可区分并泄露对象存在性。
+- 自动把 legacy 文件归给首个访问者：拒绝，存在可抢占所有权风险。
+- 只在 route 内存映射 owner：拒绝，重启和多实例会丢失授权事实。
+
+## 风险
+
+- Security: owner scope、admin 判定和 concealment 是 auth 敏感面，必须人工 review。
+- Compatibility: 历史文件普通用户将不可见；这是明确的 fail-closed 迁移。
+- Performance: list 可能为每个 S3 object 做 metadata 读取；先保证正确性，优化需另开 Issue。
+- Maintenance: 所有新 Files handler 必须复用 caller/ownership helper。
+
+## 测试计划
+
+- [ ] Unit tests: enum serde、scope priority、ownership、uniform not-found。
+- [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata。
+- [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵与 backend call count。
+- [ ] Security tests: cross-team same-user、日志/JSON owner 泄露、unauthorized delete no-op。
+- [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`。
+
+## 回滚方案
+
+代码可回滚，但新 metadata 的额外 owner 字段必须由旧反序列化器是否拒绝未知字段来决定；
+回滚演练先验证兼容。不得通过忽略 owner 恢复全局访问。若必须回滚服务版本，应先暂停
+Files API 或保持对象授权补丁，避免重新暴露跨租户读取。


### PR DESCRIPTION
## 摘要

为 #1130 增加 SpecRail product/tech/tasks 三件套，定义单一 effective tenant scope、legacy admin-only、跨租户 not-found concealment 以及 Local/S3 一致持久化。

## 已纠正的原方案风险

规格明确拒绝 user/team/key 任一匹配授权和跨租户 `403` existence oracle；本 PR 不实现代码。

## 验证

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1130`
- `git diff --check origin/main...HEAD`

Refs #1130