### PR TITLE
docs(config): correct stale claim that response cache is unwired

### DIFF
--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -189,8 +189,18 @@ monitoring:
     backends: []
 
 cache:
-  # NOT YET IMPLEMENTED: the response cache is not wired into the request
-  # path; all cache settings below currently have no effect.
+  # The deterministic response cache is wired into the request path. With
+  # enabled: true (and ttl > 0) non-streaming /v1/chat/completions and
+  # /v1/embeddings responses are stored and replayed. Cache entries are scoped
+  # to the authenticated api key or user, so responses are never shared across
+  # callers. ttl: 0 with enabled: true logs an error and leaves the cache off.
+  #
+  # Chat has bypass conditions that embeddings do not. The chat cache is
+  # skipped, for both lookup and store and without any log line, when the
+  # request carries a per-key budget, when the request sets store: true, or
+  # when an upstream handler marked the context as bypassed. In a deployment
+  # where every key has a budget attached, chat therefore stays at a 0% hit
+  # rate while embeddings still cache normally.
   enabled: false
   ttl: 3600
   max_size: 1000

--- a/specs/GH1131/product.md
+++ b/specs/GH1131/product.md
@@ -1,0 +1,56 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1131 / #1131
+
+complexity: low
+
+## 用户问题
+
+示例配置和校验注释声称 response cache 没有接入请求路径，但运行时已经在
+非流式 chat 与 embeddings 中读取和写入缓存。操作员可能把启用缓存误认为
+无效果，并在不知情时改变响应来源。
+
+## 目标
+
+- 让示例配置与代码注释准确描述当前 response cache 接线。
+- 明确 chat 与 embeddings 的适用范围和差异。
+- 明确 budgeted key、`store: true`、context bypass、`ttl: 0` 等关键行为。
+- 不改变任何运行时缓存行为。
+
+## 非目标
+
+- 修改 cache key、隔离、淘汰、TTL 或存储后端。
+- 接入 semantic cache 或新增缓存端点。
+- 为现有静默 bypass 增加日志；该行为只在本 Issue 中如实记录。
+- 改变流式请求、预算或 `store` 语义。
+
+## Behavior Invariants
+
+1. B-001 文档必须说明 `cache.enabled: true` 且 `ttl > 0` 时，非流式 chat 与 embeddings 会进行确定性 response cache lookup/store。
+2. B-002 文档不得再把已接线的 response cache 描述为“未实现”或“无效果”。
+3. B-003 文档必须说明 chat 在 per-key budget、`store: true` 或 context bypass 条件下同时跳过 lookup 与 store。
+4. B-004 文档必须说明 embeddings 没有与 chat 相同的 budget bypass，避免暗示两个端点行为一致。
+5. B-005 文档必须说明 `enabled: true` 与 `ttl: 0` 不会启用缓存，并会产生显式配置错误日志。
+6. B-006 未接线的 semantic cache 仍必须被准确标记，不能因修正文案而宣称其已可用。
+7. B-007 所有修改仅限文档和注释，运行时行为及默认值保持不变。
+
+## 验收标准
+
+- [ ] `config/gateway.yaml.example` 准确描述启用条件、端点范围和 bypass。
+- [ ] `GatewayConfig::validate` 附近注释不再声称 response cache 未接线。
+- [ ] 文案与 AppState、chat、embeddings、response_cache 和 cache config 的当前实现逐项核对。
+- [ ] 示例 YAML 仍可解析并通过配置验证。
+- [ ] `cargo fmt --check`、`cargo check` 和相关 config 测试通过。
+
+## 边界情况
+
+- 所有 key 都带 budget 的部署中，chat 命中率为零，但 embeddings 仍可能命中。
+- `cache.enabled` 与 `semantic_cache.enabled` 代表不同成熟度。
+- `ttl: 0` 与 `enabled: false` 都不会构造有效缓存，但原因和日志不同。
+
+## 发布说明
+
+仅修正文档；升级不会改变缓存运行时行为。操作员应重新检查已有
+`cache.enabled: true` 配置是否符合预期。

--- a/specs/GH1131/tasks.md
+++ b/specs/GH1131/tasks.md
@@ -1,0 +1,37 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1131 / #1131
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## 决策门
+
+- [ ] `SP1131-T0` Covers: B-001 ～ B-007. Owner: maintainer/spec owner. Dependencies: none. Done when: 文案范围与当前 runtime 事实绑定最终 spec SHA 获批，Issue 添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+
+## 实现任务
+
+- [ ] `SP1131-T1` Covers: B-001 ～ B-007. Owner: docs implementation owner. Dependencies: SP1131-T0. Done when: example cache 注释和 validation 注释准确覆盖 enabled/ttl、chat/embedding、bypass 与 semantic cache，且无运行时逻辑变化. Verify: `git diff --word-diff`; cache wiring 代码路径逐项核对.
+- [ ] `SP1131-T2` Covers: B-001 ～ B-007. Owner: verification owner. Dependencies: SP1131-T1. Done when: YAML parse/validate、cache warning tests、格式和 check 通过，diff 保持 docs/comment-only. Verify: focused config/cache tests; `cargo fmt --check`; `cargo check`; workflow/spec checks; `git diff --check`.
+
+## 并行拆分
+
+不并行。两处文案必须由同一 owner 对照同一运行时事实，验证在
+`.claude/worktrees/agent-ab891b554a7c27682` 串行完成。
+
+## 验证
+
+- 现有 staged diff 必须先 unstaged/read-only 审查，不丢失用户内容。
+- 关键否定事实测试不能锁定整段自然语言。
+- mixed PR 最终使用 `Fixes #1131`；不声称 semantic cache 已实现。
+
+## Handoff Notes
+
+- Claude 已确认 `cargo fmt` 与 `cargo check --all-features`，但这些是旧 agent 输出；
+  本会话必须重新运行才能作为完成证据。
+- 不顺带增加 bypass 日志或修改 cache behavior。
+- 不自动合并、不 force-push。

--- a/specs/GH1131/tech.md
+++ b/specs/GH1131/tech.md
@@ -1,0 +1,72 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1131 / #1131
+
+## Product Spec
+
+见 `product.md`（B-001 ～ B-007）。
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Example config | `config/gateway.yaml.example` | 声称 cache 未接线 | 主要错误文案 |
+| Validation comment | `src/config/models/gateway.rs` | 把 warning 循环解释为整个 cache 未接线 | 与真实 warning scope 冲突 |
+| Cache construction | `src/server/state.rs` | enabled + ttl 构造 response cache | 文案事实来源 |
+| Chat cache | `src/server/routes/ai/{chat.rs,response_cache.rs}` | 非流式 lookup/store，含 budget/store/context bypass | 必须准确说明 |
+| Embedding cache | `src/server/routes/ai/{embeddings.rs,response_cache.rs}` | 非流式 lookup/store，无 chat budget bypass | 端点差异 |
+| Cache config | `src/config/models/cache.rs` | `semantic_cache` 仍产生 not-implemented warning | 不可误报已接线 |
+
+## 设计方案
+
+1. 只修改 `config/gateway.yaml.example` 的 cache 注释和
+   `GatewayConfig::validate` warning 循环前的代码注释，不改字段、默认值或执行逻辑。
+2. 文案逐项绑定当前代码：`enabled && ttl > 0`、非流式 chat/embeddings、
+   caller-scoped key、chat 的 budget/`store`/context bypass、embeddings 差异、
+   `ttl: 0` error/off、semantic cache 未实现。
+3. 不把当前静默 bypass 描述成 warning，也不承诺未来行为。若实现与文案在审查时
+   不一致，以代码为事实并缩小文案，不顺带改 runtime。
+4. 复用现有 config example 解析/验证测试；新增或调整一个 focused 文案 guard，
+   防止“response cache unwired”旧断言再次出现，但不对自然语言做脆弱的整段 snapshot。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001/B-002 | example 注释 | 关键事实字符串 + 代码路径人工核对 |
+| B-003/B-004 | bypass 文案 | 与 `should_bypass_chat_cache`/embedding functions 对照 |
+| B-005 | ttl 文案 | `build_response_cache`/config test |
+| B-006 | validation comment | semantic warning 现有测试继续通过 |
+| B-007 | diff scope | `git diff` 只有注释/文档，无行为字节变化 |
+
+## 数据流
+
+无运行时数据流变化。配置仍由同一 parser/validator 读取，AppState 仍按当前条件构造
+cache，route 仍执行现有 lookup/store/bypass。
+
+## 备选方案
+
+- 删除全部 cache 注释：拒绝，不能向操作员暴露重要副作用和不对称行为。
+- 顺便为 bypass 增加日志：超出 docs-only Issue，需独立行为规格。
+- 把 semantic cache 也写成已接线：与当前 warning 和 registry 事实冲突。
+
+## 风险
+
+- Security: 文案涉及 caller 隔离，只描述已验证事实，不扩大保证。
+- Compatibility: 无运行时变化。
+- Performance: 无变化。
+- Maintenance: 文案可能随 cache 行为漂移，focused test 只锁定关键否定事实。
+
+## 测试计划
+
+- [ ] Unit tests: cache warning 与 enabled-wired 现有测试。
+- [ ] Config tests: example YAML parse/validate。
+- [ ] Diff audit: 仅两处注释/文档变化。
+- [ ] Repository gates: `cargo fmt --check`、`cargo check`、相关测试。
+
+## 回滚方案
+
+直接回滚文案 commit，无数据或配置迁移。若发现某条事实不准确，先修正文案并单独
+建立运行时 Issue，不在 docs PR 中静默改变 cache。

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -668,7 +668,10 @@ impl GatewayConfig {
     pub fn validate(&self) -> Result<(), String> {
         crate::config::validation::Validate::validate(self)?;
         // Surface dead cache configuration at error level without blocking
-        // startup: the response cache is not wired into the runtime yet.
+        // startup. `cache.enabled` itself is wired (the response cache is
+        // built in AppState and used by the chat and embedding routes), so
+        // only settings with no runtime effect, such as `semantic_cache`,
+        // produce a warning here.
         for warning in self.cache.not_yet_implemented_warnings() {
             tracing::error!("{}", warning);
         }


### PR DESCRIPTION
Closes #1131

## Problem

`config/gateway.yaml.example` told operators the response cache does nothing:

```yaml
cache:
  # NOT YET IMPLEMENTED: the response cache is not wired into the request
  # path; all cache settings below currently have no effect.
```

`src/config/models/gateway.rs:670-673` repeated the same claim. Both are false — the cache is built in `AppState` (`src/server/state.rs:74,132`) and used on the request path by `chat.rs:112,261` and `embeddings.rs:98,283`. `subsystem_registry.rs:110-115` already classifies it as `Wired`, and `cache.rs:213-220` has a test named `..._enabled_is_wired`. An operator flipping `cache.enabled: true` believing it was a no-op would silently start serving cached LLM responses across requests.

## Change

Documentation and comments only — no runtime behavior change.

Replaces the stale text with an accurate description, and additionally documents behavior that is genuinely surprising and was undocumented: the chat cache is skipped, for both lookup and store and with no log line, when the request carries a per-key budget, when `store: true` is set, or when an upstream handler set the bypass marker (`src/server/routes/ai/response_cache.rs:25-33`). Embeddings have no equivalent bypass, so in a deployment where every key has a budget, chat sits at a 0% hit rate while embeddings cache normally.

Also notes that `ttl: 0` with `enabled: true` logs an error and leaves the cache off (`state.rs:137-138`), and corrects the `gateway.rs` comment to say `semantic_cache` is now the only setting `not_yet_implemented_warnings()` reports.

Each documented claim was verified against the code rather than taken from the issue text.

## Verification

```
cargo fmt --all                                          # clean
cargo test --all-features test_gateway_yaml_example_matches_config_schema
test config::tests::test_gateway_yaml_example_matches_config_schema ... ok
test result: ok. 1 passed; 0 failed
```

Scope: 2 files, +16/-3.