### PR TITLE
fix(config): make the dev pricing example usable

### DIFF
--- a/config/gateway.dev.yaml.example
+++ b/config/gateway.dev.yaml.example
@@ -100,10 +100,17 @@ cache:
   similarity_threshold: 0.95
 
 pricing:
-  source: null
+  # Bundled pricing data is cwd-independent and available offline, so known
+  # provider models still get accurate cost accounting in local runs.
+  source: "embedded://model_prices_extended"
   allow_degraded: false
-  unpriced_model_policy: reject
-  unpriced_fallback_cost_per_1k_tokens: null
+  # Development deliberately differs from config/gateway.yaml.example: the
+  # provider above is a self-hosted vLLM model with no upstream price, so the
+  # fail-closed `reject` policy would reject every local request before the
+  # provider call. Local inference has no vendor cost, hence the explicit zero
+  # fallback below. Keep `reject` for production configurations.
+  unpriced_model_policy: allow_unpriced
+  unpriced_fallback_cost_per_1k_tokens: 0.0
 
 rate_limit:
   enabled: false

--- a/specs/GH1132/tasks.md
+++ b/specs/GH1132/tasks.md
@@ -15,9 +15,9 @@ GH-1132 / #1132
 
 ## 实现任务
 
-- [ ] `SP1132-T1` Covers: B-001 ～ B-005. Owner: config implementation owner. Dependencies: SP1132-T0. Done when: dev example 使用 embedded source、`allow_unpriced`、`0.0` fallback、`allow_degraded: false`，production example 不变且注释限定 dev scope. Verify: focused YAML field assertions and production regression.
-- [ ] `SP1132-T2` Covers: B-006, B-007, B-008. Owner: config test owner. Dependencies: SP1132-T1. Done when: 两个 shipped examples 都从 manifest-stable path parse/deny unknown/validate，所有 enabled dev models 满足 priced-or-explicit-fallback. Verify: focused config conformance tests from non-repo cwd.
-- [ ] `SP1132-T3` Covers: B-002, B-003, B-004. Owner: pricing test owner. Dependencies: SP1132-T2. Done when: dev vLLM 使用显式 zero fallback 而非 `model_not_priced`，embedded 已知模型使用真实 price，加载失败不静默归零. Verify: focused spend/pricing service tests without network.
+- [x] `SP1132-T1` Covers: B-001 ～ B-005. Owner: config implementation owner. Dependencies: SP1132-T0. Done when: dev example 使用 embedded source、`allow_unpriced`、`0.0` fallback、`allow_degraded: false`，production example 不变且注释限定 dev scope. Verify: focused YAML field assertions and production regression.
+- [x] `SP1132-T2` Covers: B-006, B-007, B-008. Owner: config test owner. Dependencies: SP1132-T1. Done when: 两个 shipped examples 都从 manifest-stable path parse/deny unknown/validate，所有 enabled dev models 满足 priced-or-explicit-fallback. Verify: focused config conformance tests from non-repo cwd.
+- [x] `SP1132-T3` Covers: B-002, B-003, B-004. Owner: pricing test owner. Dependencies: SP1132-T2. Done when: dev vLLM 使用显式 zero fallback 而非 `model_not_priced`，embedded 已知模型使用真实 price，加载失败不静默归零. Verify: focused spend/pricing service tests without network.
 - [ ] `SP1132-T4` Covers: B-001 ～ B-008. Owner: verification owner. Dependencies: SP1132-T3. Done when: Claude 保留 diff 按规格修正，完整 Rust/SpecRail gate 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
@@ -34,7 +34,7 @@ owner 在 `.claude/worktrees/agent-a15f4c7ae5c967721` 串行完成。
 
 ## Handoff Notes
 
-- Claude 原 diff 的方向正确，但当前测试只证明 policy/模型集合，尚缺实际 unpriced
-  cost path 与 known-model non-fallback 证明。
+- 实现已通过 production reservation helper 覆盖实际 unpriced zero fallback 与
+  known-model non-fallback；最终 head 仍须保留 exact-head 全量验证证据。
 - 不把 `allow_degraded` 当成 missing model price 的修复。
 - 不自动合并、不 force-push。

--- a/specs/GH1132/tasks.md
+++ b/specs/GH1132/tasks.md
@@ -11,7 +11,7 @@ GH-1132 / #1132
 
 ## 决策门
 
-- [ ] `SP1132-T0` Covers: B-001 ～ B-008. Owner: maintainer/spec owner. Dependencies: none. Done when: dev-only embedded source + explicit zero fallback 行为绑定最终 spec SHA 获批，Issue 添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+- [x] `SP1132-T0` Covers: B-001 ～ B-008. Owner: maintainer/spec owner. Dependencies: none. Done when: 维护者在 `user-2026-07-27-approve-all-specs` 批准 dev-only embedded source + explicit zero fallback 行为，Issue 已添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
 
 ## 实现任务
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -563,6 +563,7 @@ typo_field: true
             gateway.pricing.source.as_deref(),
             Some(DEFAULT_PRICING_SOURCE)
         );
+        assert!(!gateway.pricing.allow_degraded);
 
         let priced_models = embedded_default_pricing_models().unwrap();
         let unpriced_models: Vec<&str> = gateway

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -517,6 +517,8 @@ typo_field: true
 
     #[test]
     fn test_gateway_yaml_example_matches_config_schema() {
+        use crate::config::models::gateway::UnpricedModelPolicy;
+
         let example_path =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("config/gateway.yaml.example");
         let content = std::fs::read_to_string(example_path).unwrap();
@@ -529,7 +531,58 @@ typo_field: true
             );
 
         let gateway: GatewayConfig = serde_yml::from_str(&content).unwrap();
-        Config { gateway }.validate().unwrap();
+        Config {
+            gateway: gateway.clone(),
+        }
+        .validate()
+        .unwrap();
+        assert_eq!(
+            gateway.pricing.unpriced_model_policy,
+            UnpricedModelPolicy::Reject
+        );
+        assert_eq!(gateway.pricing.unpriced_fallback_cost_per_1k_tokens, None);
+    }
+
+    #[test]
+    fn test_gateway_dev_yaml_example_matches_config_schema_and_prices_all_models() {
+        use crate::config::models::gateway::UnpricedModelPolicy;
+        use crate::core::pricing::embedded_default_pricing_models;
+        use crate::core::pricing_service::DEFAULT_PRICING_SOURCE;
+
+        let example_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("config/gateway.dev.yaml.example");
+        let content = std::fs::read_to_string(example_path).unwrap();
+        let gateway: GatewayConfig = serde_yml::from_str(&content).unwrap();
+
+        Config {
+            gateway: gateway.clone(),
+        }
+        .validate()
+        .unwrap();
+        assert_eq!(
+            gateway.pricing.source.as_deref(),
+            Some(DEFAULT_PRICING_SOURCE)
+        );
+
+        let priced_models = embedded_default_pricing_models().unwrap();
+        let unpriced_models: Vec<&str> = gateway
+            .providers
+            .iter()
+            .filter(|provider| provider.enabled)
+            .flat_map(|provider| provider.models.iter())
+            .filter(|model| !priced_models.contains_key(*model))
+            .map(String::as_str)
+            .collect();
+
+        assert!(
+            unpriced_models.is_empty()
+                || (gateway.pricing.unpriced_model_policy == UnpricedModelPolicy::AllowUnpriced
+                    && gateway
+                        .pricing
+                        .unpriced_fallback_cost_per_1k_tokens
+                        .is_some()),
+            "enabled dev models {unpriced_models:?} need embedded prices or an explicit fallback"
+        );
     }
 
     #[test]

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::models::gateway::{GatewayPricingConfig, UnpricedModelPolicy};
+use crate::config::models::gateway::{GatewayConfig, GatewayPricingConfig, UnpricedModelPolicy};
 use crate::core::budget::{ModelLimitConfig, ProviderLimitConfig, ResetPeriod};
 use crate::core::keys::InMemoryKeyRepository;
 use crate::core::pricing_service::LiteLLMModelInfo;
@@ -41,6 +41,72 @@ fn runtime_test_pricing_service(provider: &str) -> PricingService {
         },
     );
     service
+}
+
+fn dev_gateway_config() -> GatewayConfig {
+    let path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("config/gateway.dev.yaml.example");
+    let content = std::fs::read_to_string(path).expect("dev gateway example should be readable");
+    serde_yml::from_str(&content).expect("dev gateway example should match the schema")
+}
+
+#[test]
+fn dev_example_unpriced_vllm_model_uses_explicit_zero_fallback() {
+    let gateway = dev_gateway_config();
+    let provider = gateway
+        .providers
+        .iter()
+        .find(|provider| provider.enabled)
+        .expect("dev example should have an enabled provider");
+    let model = provider
+        .models
+        .first()
+        .expect("dev provider should declare a model");
+    let pricing =
+        PricingService::with_embedded_default().expect("embedded pricing should load offline");
+    assert!(
+        pricing.get_model_info(model).is_none(),
+        "fixture must exercise the unpriced path"
+    );
+
+    let reservation = reserve_completion_budget_with_policy(
+        &pricing,
+        &gateway.pricing,
+        &UnifiedBudgetLimits::new(),
+        &provider.provider_type,
+        model,
+        1000,
+        Some(500),
+    )
+    .expect("allow_unpriced should not return model_not_priced");
+
+    assert!(
+        reservation.is_none(),
+        "the explicit zero fallback must not reserve spend"
+    );
+}
+
+#[test]
+fn dev_example_known_model_uses_embedded_price_instead_of_zero_fallback() {
+    let gateway = dev_gateway_config();
+    let pricing =
+        PricingService::with_embedded_default().expect("embedded pricing should load offline");
+    let budget = UnifiedBudgetLimits::new();
+
+    let reservation = reserve_completion_budget_with_policy(
+        &pricing,
+        &gateway.pricing,
+        &budget,
+        "openai",
+        "gpt-4o",
+        1000,
+        Some(500),
+    )
+    .expect("known embedded model should be priced")
+    .expect("known embedded price must create a non-zero reservation");
+
+    assert!(reservation.reserved_amount() > 0.0);
+    reservation.cancel();
 }
 
 #[test]

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -47,6 +47,7 @@ mod tests {
             config.gateway.pricing.source.as_deref(),
             Some("embedded://model_prices_extended")
         );
+        assert!(!config.gateway.pricing.allow_degraded);
         assert_eq!(
             config.gateway.pricing.unpriced_model_policy,
             UnpricedModelPolicy::AllowUnpriced

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -7,7 +7,7 @@
 #[cfg(test)]
 mod tests {
     use litellm_rs::Config;
-    use litellm_rs::config::models::gateway::GatewayConfig;
+    use litellm_rs::config::models::gateway::{GatewayConfig, UnpricedModelPolicy};
     use litellm_rs::config::models::provider::{
         ProviderConfig, ProviderHealthCheckConfig, RetryConfig,
     };
@@ -43,7 +43,18 @@ mod tests {
         assert!(!config.auth().enable_jwt);
         assert!(!config.auth().enable_api_key);
         assert!(config.auth().allow_anonymous);
-        assert!(config.gateway.pricing.source.is_none());
+        assert_eq!(
+            config.gateway.pricing.source.as_deref(),
+            Some("embedded://model_prices_extended")
+        );
+        assert_eq!(
+            config.gateway.pricing.unpriced_model_policy,
+            UnpricedModelPolicy::AllowUnpriced
+        );
+        assert_eq!(
+            config.gateway.pricing.unpriced_fallback_cost_per_1k_tokens,
+            Some(0.0)
+        );
         assert_eq!(config.server().port, 8080);
         assert_eq!(config.providers()[0].provider_type, "vllm");
         assert!(config.providers()[0].base_url.is_none());


### PR DESCRIPTION
Fixes #1132

## Summary

- load the bundled pricing catalog in the shipped development example
- allow the example's unpriced self-hosted vLLM model with an explicit zero-cost fallback
- keep the production example fail-closed
- validate every enabled development model and exercise both the real unpriced fallback and known-model pricing paths

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1132`
- `git diff --check origin/main...HEAD`

The full test suite was serialized after an unrelated existing API-key budget test stalled during a machine-wide concurrent test run; the stalled test passed independently, and the serialized full suite passed.
