### PR TITLE
docs(spec): close GH1129 billing normalization gaps

### DIFF
--- a/specs/GH1129/product.md
+++ b/specs/GH1129/product.md
@@ -49,6 +49,10 @@ complexity: high
    API 的可选零语义处理。`thoughtsTokenCount` 已包含在公开 `completion_tokens`
    与 output token 费用中，本 Issue 不再把它写入会另行计价的
    `completion_tokens_details.reasoning_tokens` 或其他 thinking details，禁止重复计费。
+   该四项关系以
+   [Google Vertex AI v1 `UsageMetadata`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#usagemetadata)
+   的公开契约为准：`totalTokenCount` 是 prompt、candidates、tool-use prompt 与
+   thoughts 四项之和；不得把扩展字段误认为已包含在前两项中。
 7. **B-007** 对声明包含 total 的 provider 格式（包括 Bedrock Converse），total
    缺失、类型错误或与原始分量之和不一致时，整条 usage 必须 fail closed 为
    `None`；对声明不包含 total 的格式，系统只使用重算值。

--- a/specs/GH1129/product.md
+++ b/specs/GH1129/product.md
@@ -43,18 +43,28 @@ complexity: high
 5. **B-005** 所有适用分量均合法但 prompt 与 completion 都为零时，整条 usage
    必须表现为 `None`，不得进入零费用成功记账路径。
 6. **B-006** provider 报告的 `total_tokens` 不得替代缺失的 prompt 或 completion
-   分量；输出 `total_tokens` 必须由归一化后的分量重新计算。
-7. **B-007** 对声明包含 total 的 provider 格式，total 缺失、类型错误或与重算值
-   不一致时，整条 usage 必须 fail closed 为 `None`；对声明不包含 total 的格式，
-   系统只使用重算值。
-8. **B-008** 合法的 `u64` token 数超过 `u32::MAX` 时必须饱和为
+   分量；输出 `total_tokens` 必须由可信原始分量重新计算。Vertex
+   `usageMetadata` 的有效 input 为 `promptTokenCount + toolUsePromptTokenCount`，
+   output 为 `candidatesTokenCount + thoughtsTokenCount`，后两个扩展字段缺失时按该
+   API 的可选零语义处理。`thoughtsTokenCount` 已包含在公开 `completion_tokens`
+   与 output token 费用中，本 Issue 不再把它写入会另行计价的
+   `completion_tokens_details.reasoning_tokens` 或其他 thinking details，禁止重复计费。
+7. **B-007** 对声明包含 total 的 provider 格式（包括 Bedrock Converse），total
+   缺失、类型错误或与原始分量之和不一致时，整条 usage 必须 fail closed 为
+   `None`；对声明不包含 total 的格式，系统只使用重算值。
+8. **B-008** 合法的 `u64` token 数超过 `u32::MAX` 时必须在 raw-domain total
+   校验完成后饱和为
    `u32::MAX`，不得回绕、截断为更小值或 panic。
 9. **B-009** `total_tokens` 必须使用饱和加法；即使两个分量各自可表示，相加也
    不得溢出为更小值。
-10. **B-010** `usage: None` 必须继续触发现有缺失 usage 结算行为：有预算预留时
-    按既有规则结算预留并记录显式错误；无预留时不得伪造零费用 spend。
-11. **B-011** 合法、范围内且 total 一致的 provider usage，其公开 token 值和
-    既有计费结果必须保持兼容。
+10. **B-010** `usage: None` 必须触发完整缺失 usage 结算：provider/model reservation
+    存在时按其 reserved amount 结算；只有 API-key reservation 时按 key reserved
+    amount 结算并记录 key usage；两者都不存在时记录显式错误且不得伪造零费用
+    spend。任一 reservation 不得因另一种 reservation 缺失而提前返回或泄漏。
+11. **B-011** 合法、范围内且 total 一致的既有 provider usage，在 Vertex 扩展字段
+    缺失或为零时，其公开 token 值和既有计费结果必须保持兼容。Vertex 扩展字段
+    非零时，公开 input/output 必须包含这些真实 token，费用按归一化后的 input/output
+    各计一次；这是从漏计到正确计费的有意修正。
 12. **B-012** 解析失败不得仅记录低级别日志后继续生成成功的零 token、零费用
     账单副作用。
 
@@ -66,12 +76,16 @@ complexity: high
       B-004。
 - [ ] `u32::MAX`、`u32::MAX + 1`、`u64::MAX` 和分量相加溢出场景均证明饱和且
       不回绕。
-- [ ] 对带 total 的格式覆盖一致、缺失、错误类型和不一致 total；对不带 total
+- [ ] 对带 total 的格式覆盖一致、缺失、错误类型和 raw-domain 不一致 total；对不带 total
       的格式证明输出 total 来自重算。
-- [ ] 下游验证证明不可信 usage 进入既有缺失 usage 结算路径，而不是记录
-      `$0` 成功计费。
+- [ ] Vertex 两条非流式 parser 都覆盖 thoughts/tool-use prompt 扩展计数；
+      cost 断言证明 input/output 各计一次且 thoughts 不产生额外 reasoning 费用；
+      Bedrock Converse 覆盖必需 `totalTokens`。
+- [ ] 下游验证证明不可信 usage 的 provider+key、provider-only、key-only 与无
+      reservation 四种路径都终止正确，不记录 `$0` 成功计费或遗留 reservation。
 - [ ] 未声明字段名和嵌套形状不会被猜测为 usage。
-- [ ] 合法非零 usage 的兼容性回归测试通过。
+- [ ] 不含 Vertex 扩展计数的合法非零 usage 兼容性回归测试通过；扩展计数非零的
+      token/cost 修正有精确断言。
 
 ## 边界情况
 
@@ -88,4 +102,5 @@ complexity: high
 
 这是计费正确性收紧。过去被默认为零 token、零费用的 malformed、partial 或
 all-zero usage 将进入既有缺失 usage 保护。合法非零 usage 无需迁移；若上游
-provider 已发生字段漂移，运营日志将显式暴露该问题。
+provider 已发生字段漂移，运营日志将显式暴露该问题。Vertex tool-use prompt 与
+thoughts token 现在分别计入 input/output 费用一次。

--- a/specs/GH1129/product.md
+++ b/specs/GH1129/product.md
@@ -25,13 +25,15 @@ complexity: high
 
 - 改变模型价格、预算上限、预留算法或 provider 请求协议。
 - 猜测未声明的新字段名、字符串数字、浮点数、负数或任意嵌套数字的含义。
-- 重写已经具有显式错误处理的流式 usage 解析。
+- 重写已经具有显式错误处理的 OpenAI SSE usage 解析；native Gemini SDK 的 unary
+  与 SSE 当前复用同一不严格 parser，因此该共享入口在本 Issue 范围内。
 - 扩大公开 `Usage` 字段的整数类型或改变公开响应 schema。
 
 ## Behavior Invariants
 
-1. **B-001** Azure chat/embed、Azure AI chat/embed、Vertex AI、direct Gemini、Bedrock 和
-   Mistral embedding 的受影响非流式 usage 必须遵循同一可信度规则。
+1. **B-001** Azure chat/embed、Azure AI chat/embed、Vertex AI、direct Gemini
+   provider client、native Gemini SDK unary/SSE shared parser、Bedrock 和
+   Mistral embedding 的受影响 usage 必须遵循同一可信度规则。
 2. **B-002** usage 容器不存在时，响应必须表现为 `usage: None`；不得构造默认
    零 usage。
 3. **B-003** 每种已声明 provider 格式的必需 token 分量必须存在且为 JSON
@@ -48,7 +50,8 @@ complexity: high
    output 为 `candidatesTokenCount + thoughtsTokenCount`，后两个扩展字段缺失时按该
    API 的可选零语义处理。`thoughtsTokenCount` 已包含在公开 `completion_tokens`
    与 output token 费用中，本 Issue 不再把它写入会另行计价的
-   `completion_tokens_details.reasoning_tokens` 或其他 thinking details，禁止重复计费。
+   `completion_tokens_details.reasoning_tokens`，禁止重复计费；现有 user-visible
+   `thinking_usage` breakdown 不参与 pricing，必须保留。
    Vertex reported-total 的四项关系以
    [Google Vertex AI v1 `UsageMetadata`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#usagemetadata)
    的公开契约为准：`totalTokenCount` 是 prompt、candidates、tool-use prompt 与
@@ -71,11 +74,15 @@ complexity: high
     预留额不同时不得复用另一方金额。API-key usage 使用 key reservation 金额，
     key reservation 缺失时才使用 provider reservation 金额；两者都不存在时记录
     显式错误且不得伪造零费用 spend。任一 reservation 不得因另一种 reservation
-    缺失而提前返回或泄漏。
-11. **B-011** 合法、范围内且 total 一致的既有 provider usage，在 Vertex 扩展字段
-    缺失或为零时，其公开 token 值和既有计费结果必须保持兼容。Vertex 扩展字段
-    非零时，公开 input/output 必须包含这些真实 token，费用按归一化后的 input/output
-    各计一次；这是从漏计到正确计费的有意修正。
+    缺失而提前返回或泄漏。native Gemini SDK 独立 settlement 路径必须委托同一
+    结算 helper，不得恢复 key-only `0.0` 或把 unified amount 复用于 key。
+11. **B-011** 合法、范围内且 total 一致的既有 provider usage，在 Google 扩展字段
+    缺失或为零时，其公开 token 值和既有计费结果必须保持兼容。非零扩展字段时，
+    公开 input/output 必须包含真实 tool-use/thoughts token；可选
+    `cachedContentTokenCount` 必须严格解析、不得超过 raw prompt、饱和后保留到
+    cache-read pricing details；direct Gemini user-visible `thinking_usage` 保留，
+    但 separately-priced reasoning details 为空。费用按归一化 input/output 各计
+    一次，这是从漏计到正确计费的有意修正。
 12. **B-012** 解析失败不得仅记录低级别日志后继续生成成功的零 token、零费用
     账单副作用。
 
@@ -89,16 +96,19 @@ complexity: high
       不回绕。
 - [ ] 对带 total 的格式覆盖一致、缺失、错误类型和 raw-domain 不一致 total；对不带 total
       的格式证明输出 total 来自重算。
-- [ ] Vertex 两条及 direct Gemini 非流式 parser 都覆盖 thoughts/tool-use prompt 扩展计数；
+- [ ] Vertex 两条、direct Gemini provider client 与 native Gemini SDK unary/SSE
+      shared parser 都覆盖 thoughts/tool-use prompt 扩展计数；
       cost 断言证明 input/output 各计一次且 thoughts 不产生额外 reasoning 费用；
       Bedrock Converse 覆盖必需 `totalTokens`。
 - [ ] 下游验证证明不可信 usage 的 provider+key、provider-only、key-only 与无
       reservation 四种路径都终止正确；provider+key 使用不同预留额时各自按自身
-      金额结算，不记录 `$0` 成功计费或遗留 reservation。
+      金额结算；common 与 native Gemini SDK settlement 都不记录 `$0` 成功计费或
+      遗留 reservation。
 - [ ] 未声明字段名和嵌套形状不会被猜测为 usage。
 - [ ] 不含 Vertex/direct Gemini 扩展计数的合法非零 usage 兼容性回归测试通过；
       扩展计数非零的 token/cost 修正，以及两条 endpoint 各自的 reported-total
-      公式都有精确断言。
+      公式都有精确断言；cached count 保持 cache-read price，`thinking_usage`
+      保留而 reasoning cost 为零。
 
 ## 边界情况
 

--- a/specs/GH1129/product.md
+++ b/specs/GH1129/product.md
@@ -15,7 +15,8 @@ complexity: high
 
 ## 目标
 
-- 对受影响的非流式 provider 使用一致、可测试的 usage 有效性规则。
+- 对受影响的 provider 非流式与明确列出的 Gemini 流式入口使用一致、可测试的
+  usage 有效性规则。
 - 明确区分合法的单字段零值、字段缺失、字段类型错误和整体零 usage。
 - 对部分字段漂移采取 fail closed 行为，不猜测或拼接不可信 usage。
 - 以饱和语义处理合法的大整数，并保证 `total_tokens` 与分量一致。
@@ -25,15 +26,17 @@ complexity: high
 
 - 改变模型价格、预算上限、预留算法或 provider 请求协议。
 - 猜测未声明的新字段名、字符串数字、浮点数、负数或任意嵌套数字的含义。
-- 重写已经具有显式错误处理的 OpenAI SSE usage 解析；native Gemini SDK 的 unary
-  与 SSE 当前复用同一不严格 parser，因此该共享入口在本 Issue 范围内。
+- 重写已经具有显式错误处理的 OpenAI SSE usage 解析；标准 chat-completions Gemini
+  stream 与 native Gemini SDK SSE 仍经过不严格 Google usage parser，因此这两条
+  流式入口在本 Issue 范围内。
 - 扩大公开 `Usage` 字段的整数类型或改变公开响应 schema。
 
 ## Behavior Invariants
 
 1. **B-001** Azure chat/embed、Azure AI chat/embed、Vertex AI、direct Gemini
-   provider client、native Gemini SDK unary/SSE shared parser、Bedrock 和
-   Mistral embedding 的受影响 usage 必须遵循同一可信度规则。
+   provider client、标准 chat-completions Gemini stream、native Gemini SDK
+   unary/SSE shared parser、Bedrock 和 Mistral embedding 的受影响 usage 必须遵循
+   同一可信度规则。
 2. **B-002** usage 容器不存在时，响应必须表现为 `usage: None`；不得构造默认
    零 usage。
 3. **B-003** 每种已声明 provider 格式的必需 token 分量必须存在且为 JSON
@@ -75,7 +78,10 @@ complexity: high
     key reservation 缺失时才使用 provider reservation 金额；两者都不存在时记录
     显式错误且不得伪造零费用 spend。任一 reservation 不得因另一种 reservation
     缺失而提前返回或泄漏。native Gemini SDK 独立 settlement 路径必须委托同一
-    结算 helper，不得恢复 key-only `0.0` 或把 unified amount 复用于 key。
+    结算 helper，不得恢复 key-only `0.0` 或把 unified amount 复用于 key。native
+    Gemini SSE 一旦已收到任意 upstream output，随后即使在 usage 到达前发生 read
+    error，也必须把真实 `saw_upstream_output=true` 传入 settlement 并按无 usage
+    保护结算；无 upstream output 的 read error 不得伪报为已产生输出。
 11. **B-011** 合法、范围内且 total 一致的既有 provider usage，在 Google 扩展字段
     缺失或为零时，其公开 token 值和既有计费结果必须保持兼容。非零扩展字段时，
     公开 input/output 必须包含真实 tool-use/thoughts token；可选
@@ -96,14 +102,18 @@ complexity: high
       不回绕。
 - [ ] 对带 total 的格式覆盖一致、缺失、错误类型和 raw-domain 不一致 total；对不带 total
       的格式证明输出 total 来自重算。
-- [ ] Vertex 两条、direct Gemini provider client 与 native Gemini SDK unary/SSE
-      shared parser 都覆盖 thoughts/tool-use prompt 扩展计数；
+- [ ] Vertex 两条、direct Gemini provider client、标准 chat-completions Gemini
+      stream 与 native Gemini SDK unary/SSE shared parser 都覆盖
+      malformed/overflow/thoughts/tool-use prompt/cache；
       cost 断言证明 input/output 各计一次且 thoughts 不产生额外 reasoning 费用；
       Bedrock Converse 覆盖必需 `totalTokens`。
 - [ ] 下游验证证明不可信 usage 的 provider+key、provider-only、key-only 与无
       reservation 四种路径都终止正确；provider+key 使用不同预留额时各自按自身
       金额结算；common 与 native Gemini SDK settlement 都不记录 `$0` 成功计费或
       遗留 reservation。
+- [ ] native Gemini route-level SSE 测试证明：先收到 output、再发生 upstream read
+      error 且没有 usage 时，caller 传递真实 output 状态并按各 reservation 自有金额
+      结算；error 发生在任何 output 前时不伪造已输出结算。
 - [ ] 未声明字段名和嵌套形状不会被猜测为 usage。
 - [ ] 不含 Vertex/direct Gemini 扩展计数的合法非零 usage 兼容性回归测试通过；
       扩展计数非零的 token/cost 修正，以及两条 endpoint 各自的 reported-total
@@ -120,11 +130,15 @@ complexity: high
   情况都不能被当作可信 usage。
 - 极少数真实响应可能明确报告全零 usage；在计费边界上仍按无可信 usage 处理，
   以避免静默免费调用。
+- 流式响应可能在已发送 candidate/output 后、最终 usage chunk 前断开；是否进入
+  no-usage settlement 必须取决于真实 upstream output 状态，而不是终止分支常量。
 
 ## 发布说明
 
 这是计费正确性收紧。过去被默认为零 token、零费用的 malformed、partial 或
 all-zero usage 将进入既有缺失 usage 保护。合法非零 usage 无需迁移；若上游
-provider 已发生字段漂移，运营日志将显式暴露该问题。Vertex 与 direct Gemini 的
-tool-use prompt/thoughts token 现在分别计入 input/output 费用一次，并各自使用
-官方 endpoint-specific reported-total 公式校验。
+provider 已发生字段漂移，运营日志将显式暴露该问题。Vertex 与 direct Gemini
+非流式、标准 chat stream、native SDK unary/SSE 的 tool-use prompt/thoughts token
+现在分别计入 input/output 费用一次，并各自使用官方 endpoint-specific
+reported-total 公式校验。native Gemini SSE 在已输出后遇到 read error 时不再释放
+未记账的 reservation。

--- a/specs/GH1129/product.md
+++ b/specs/GH1129/product.md
@@ -30,7 +30,7 @@ complexity: high
 
 ## Behavior Invariants
 
-1. **B-001** Azure chat/embed、Azure AI chat/embed、Vertex AI、Bedrock 和
+1. **B-001** Azure chat/embed、Azure AI chat/embed、Vertex AI、direct Gemini、Bedrock 和
    Mistral embedding 的受影响非流式 usage 必须遵循同一可信度规则。
 2. **B-002** usage 容器不存在时，响应必须表现为 `usage: None`；不得构造默认
    零 usage。
@@ -43,16 +43,21 @@ complexity: high
 5. **B-005** 所有适用分量均合法但 prompt 与 completion 都为零时，整条 usage
    必须表现为 `None`，不得进入零费用成功记账路径。
 6. **B-006** provider 报告的 `total_tokens` 不得替代缺失的 prompt 或 completion
-   分量；输出 `total_tokens` 必须由可信原始分量重新计算。Vertex
+   分量；输出 `total_tokens` 必须由可信原始分量重新计算。Vertex/direct Gemini
    `usageMetadata` 的有效 input 为 `promptTokenCount + toolUsePromptTokenCount`，
    output 为 `candidatesTokenCount + thoughtsTokenCount`，后两个扩展字段缺失时按该
    API 的可选零语义处理。`thoughtsTokenCount` 已包含在公开 `completion_tokens`
    与 output token 费用中，本 Issue 不再把它写入会另行计价的
    `completion_tokens_details.reasoning_tokens` 或其他 thinking details，禁止重复计费。
-   该四项关系以
+   Vertex reported-total 的四项关系以
    [Google Vertex AI v1 `UsageMetadata`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#usagemetadata)
    的公开契约为准：`totalTokenCount` 是 prompt、candidates、tool-use prompt 与
-   thoughts 四项之和；不得把扩展字段误认为已包含在前两项中。
+   thoughts 四项之和。Direct Gemini 当前
+   [Gemini API `UsageMetadata`](https://ai.google.dev/api/generate-content#v1beta.GenerateContentResponse.UsageMetadata)
+   则把 reported `totalTokenCount` 定义为 prompt、thoughts 与 candidates 三项之和，
+   不含单列的 tool-use prompt；因此两条 endpoint 必须共享严格字段解析，但使用
+   各自明确的 raw-domain reported-total policy。不得把扩展字段误认为已包含在
+   前两项中，也不得把 Vertex 的四项公式套到 direct Gemini。
 7. **B-007** 对声明包含 total 的 provider 格式（包括 Bedrock Converse），total
    缺失、类型错误或与原始分量之和不一致时，整条 usage 必须 fail closed 为
    `None`；对声明不包含 total 的格式，系统只使用重算值。
@@ -62,9 +67,11 @@ complexity: high
 9. **B-009** `total_tokens` 必须使用饱和加法；即使两个分量各自可表示，相加也
    不得溢出为更小值。
 10. **B-010** `usage: None` 必须触发完整缺失 usage 结算：provider/model reservation
-    存在时按其 reserved amount 结算；只有 API-key reservation 时按 key reserved
-    amount 结算并记录 key usage；两者都不存在时记录显式错误且不得伪造零费用
-    spend。任一 reservation 不得因另一种 reservation 缺失而提前返回或泄漏。
+    与 API-key reservation 各自按自身 `reserved_amount()` 结算；两者同时存在但
+    预留额不同时不得复用另一方金额。API-key usage 使用 key reservation 金额，
+    key reservation 缺失时才使用 provider reservation 金额；两者都不存在时记录
+    显式错误且不得伪造零费用 spend。任一 reservation 不得因另一种 reservation
+    缺失而提前返回或泄漏。
 11. **B-011** 合法、范围内且 total 一致的既有 provider usage，在 Vertex 扩展字段
     缺失或为零时，其公开 token 值和既有计费结果必须保持兼容。Vertex 扩展字段
     非零时，公开 input/output 必须包含这些真实 token，费用按归一化后的 input/output
@@ -82,14 +89,16 @@ complexity: high
       不回绕。
 - [ ] 对带 total 的格式覆盖一致、缺失、错误类型和 raw-domain 不一致 total；对不带 total
       的格式证明输出 total 来自重算。
-- [ ] Vertex 两条非流式 parser 都覆盖 thoughts/tool-use prompt 扩展计数；
+- [ ] Vertex 两条及 direct Gemini 非流式 parser 都覆盖 thoughts/tool-use prompt 扩展计数；
       cost 断言证明 input/output 各计一次且 thoughts 不产生额外 reasoning 费用；
       Bedrock Converse 覆盖必需 `totalTokens`。
 - [ ] 下游验证证明不可信 usage 的 provider+key、provider-only、key-only 与无
-      reservation 四种路径都终止正确，不记录 `$0` 成功计费或遗留 reservation。
+      reservation 四种路径都终止正确；provider+key 使用不同预留额时各自按自身
+      金额结算，不记录 `$0` 成功计费或遗留 reservation。
 - [ ] 未声明字段名和嵌套形状不会被猜测为 usage。
-- [ ] 不含 Vertex 扩展计数的合法非零 usage 兼容性回归测试通过；扩展计数非零的
-      token/cost 修正有精确断言。
+- [ ] 不含 Vertex/direct Gemini 扩展计数的合法非零 usage 兼容性回归测试通过；
+      扩展计数非零的 token/cost 修正，以及两条 endpoint 各自的 reported-total
+      公式都有精确断言。
 
 ## 边界情况
 
@@ -106,5 +115,6 @@ complexity: high
 
 这是计费正确性收紧。过去被默认为零 token、零费用的 malformed、partial 或
 all-zero usage 将进入既有缺失 usage 保护。合法非零 usage 无需迁移；若上游
-provider 已发生字段漂移，运营日志将显式暴露该问题。Vertex tool-use prompt 与
-thoughts token 现在分别计入 input/output 费用一次。
+provider 已发生字段漂移，运营日志将显式暴露该问题。Vertex 与 direct Gemini 的
+tool-use prompt/thoughts token 现在分别计入 input/output 费用一次，并各自使用
+官方 endpoint-specific reported-total 公式校验。

--- a/specs/GH1129/tasks.md
+++ b/specs/GH1129/tasks.md
@@ -15,9 +15,9 @@ GH-1129 / #1129
 
 ## 实现任务
 
-- [ ] `SP1129-T1` Covers: B-002 ～ B-009. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/shared.rs` 提供唯一 crate-private normalizer，覆盖 raw `u64/u128` 校验、partial/nonzero/None、缩窄与 total 饱和. Verify: focused helper raw-domain/boundary tests.
-- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条与 direct Gemini 非流式 parser（含 thoughts/tool-use）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；Vertex 使用四项 reported-total policy，direct Gemini 使用 prompt+candidates+thoughts policy；删除直接 `as u32` 与手写零 Usage；Google thoughts 仅包含在 completion、不填 reasoning/thinking details. Verify: provider-specific valid/malformed/all-zero/endpoint-total tests and Vertex/direct-Gemini exact-cost/no-double-charge assertions.
-- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: `None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次；provider+key 金额不同时各按自身 reserved amount 结算，API-key usage 使用 key-first fallback cost；测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused spend reservation/usage tests.
+- [ ] `SP1129-T1` Covers: B-002 ～ B-009, B-011. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/shared.rs` 提供唯一 crate-private normalizer，覆盖 raw `u64/u128` 校验、partial/nonzero/None、endpoint-specific total、缩窄/饱和，以及 optional cached raw 校验、`cached <= prompt` 与 details 映射. Verify: focused helper raw-domain/cache/boundary tests.
+- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条、direct Gemini provider client 与 native SDK unary/SSE shared parser（含 thoughts/tool-use/cache）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；Vertex 使用四项 reported-total policy，direct Gemini 使用 prompt+candidates+thoughts policy；删除直接 `as u32` 与手写零 Usage；Google thoughts 仅包含在 completion、reasoning details 为空，provider client 的 `thinking_usage` 与两条路径 cached pricing 保留. Verify: provider-specific valid/malformed/all-zero/endpoint-total/cache tests and Vertex/direct-Gemini exact-cost/no-double-charge assertions.
+- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: common 与 native Gemini SDK no-usage 路径统一委托同一 helper；`None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次；provider+key 金额不同时各按自身 reserved amount 结算，API-key usage 使用 key-first fallback cost；测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused common/native-SDK spend reservation/usage tests.
 - [ ] `SP1129-T4` Covers: B-001 ～ B-012. Owner: verification owner. Dependencies: SP1129-T3. Done when: 最终 diff 全量审计，所有 provider 路径和完整 Rust/SpecRail gate 通过，计费安全人工 review 完成. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
@@ -28,10 +28,10 @@ GH-1129 / #1129
 ## 验证
 
 - 对 Issue 列出的每个具体 parser 返回点建立覆盖清单，禁止只测一个样本。
-- Vertex `transformers.rs`、`client.rs` 与 direct Gemini `client.rs` 三条路径必须
-  使用共享严格 helper 并分别有扩展 token fixture；Vertex 四项与 direct Gemini
-  三项 reported-total fixture 都必须覆盖，thoughts 的 output cost 恰好一次、
-  reasoning cost 为零。
+- Vertex `transformers.rs`、`client.rs`、direct Gemini `client.rs` 与 native SDK
+  `gemini/spend.rs` 必须使用共享严格 helper 并分别有扩展 token fixture；Vertex
+  四项与 direct Gemini 三项 reported-total fixture 都必须覆盖，thoughts 的 output
+  cost 恰好一次、reasoning cost 为零，cached pricing 与 `thinking_usage` 保持。
 - `u32::MAX + 1`、`u64::MAX` 与 total overflow 必须有新鲜输出。
 - 不修改测试断言来接受 silent zero billing。
 - 最终 PR 使用 `Fixes #1129`，需要 billing 人工 review。

--- a/specs/GH1129/tasks.md
+++ b/specs/GH1129/tasks.md
@@ -16,8 +16,8 @@ GH-1129 / #1129
 ## 实现任务
 
 - [ ] `SP1129-T1` Covers: B-002 ～ B-009. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/shared.rs` 提供唯一 crate-private normalizer，覆盖 raw `u64/u128` 校验、partial/nonzero/None、缩窄与 total 饱和. Verify: focused helper raw-domain/boundary tests.
-- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条非流式 parser（含 thoughts/tool-use）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；删除直接 `as u32` 与手写零 Usage；Vertex thoughts 仅包含在 completion、不填 reasoning/thinking details. Verify: provider-specific valid/malformed/all-zero/total tests and Vertex exact-cost/no-double-charge assertion.
-- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: `None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次，测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused spend reservation/usage tests.
+- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条与 direct Gemini 非流式 parser（含 thoughts/tool-use）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；Vertex 使用四项 reported-total policy，direct Gemini 使用 prompt+candidates+thoughts policy；删除直接 `as u32` 与手写零 Usage；Google thoughts 仅包含在 completion、不填 reasoning/thinking details. Verify: provider-specific valid/malformed/all-zero/endpoint-total tests and Vertex/direct-Gemini exact-cost/no-double-charge assertions.
+- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: `None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次；provider+key 金额不同时各按自身 reserved amount 结算，API-key usage 使用 key-first fallback cost；测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused spend reservation/usage tests.
 - [ ] `SP1129-T4` Covers: B-001 ～ B-012. Owner: verification owner. Dependencies: SP1129-T3. Done when: 最终 diff 全量审计，所有 provider 路径和完整 Rust/SpecRail gate 通过，计费安全人工 review 完成. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
@@ -28,8 +28,10 @@ GH-1129 / #1129
 ## 验证
 
 - 对 Issue 列出的每个具体 parser 返回点建立覆盖清单，禁止只测一个样本。
-- Vertex `transformers.rs` 与 `client.rs` 两条路径必须使用同一 helper 并分别有扩展
-  token fixture；thoughts 的 output cost 恰好一次、reasoning cost 为零。
+- Vertex `transformers.rs`、`client.rs` 与 direct Gemini `client.rs` 三条路径必须
+  使用共享严格 helper 并分别有扩展 token fixture；Vertex 四项与 direct Gemini
+  三项 reported-total fixture 都必须覆盖，thoughts 的 output cost 恰好一次、
+  reasoning cost 为零。
 - `u32::MAX + 1`、`u64::MAX` 与 total overflow 必须有新鲜输出。
 - 不修改测试断言来接受 silent zero billing。
 - 最终 PR 使用 `Fixes #1129`，需要 billing 人工 review。

--- a/specs/GH1129/tasks.md
+++ b/specs/GH1129/tasks.md
@@ -11,23 +11,25 @@ GH-1129 / #1129
 
 ## 决策门
 
-- [ ] `SP1129-T0` Covers: B-001 ～ B-008. Owner: maintainer/spec owner. Dependencies: none. Done when: 计费语义、all-zero -> `None` 与饱和规则绑定最终 spec SHA 获批，Issue 添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+- [ ] `SP1129-T0` Covers: B-001 ～ B-012. Owner: maintainer/spec owner. Dependencies: none. Done when: 原规格已在 `user-2026-07-27-approve-all-specs` 获批；本 amendment 的 raw-domain total、Vertex 双 parser 与 thoughts 单次 output 计费、Converse total、key-only settlement 再次获得内容绑定批准，Issue 保持 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
 
 ## 实现任务
 
-- [ ] `SP1129-T1` Covers: B-002, B-003, B-004, B-005. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/base/usage.rs` 提供唯一 crate-private normalizer，覆盖 partial/nonzero/None 和 `u32` 饱和/total 饱和. Verify: focused helper boundary tests.
-- [ ] `SP1129-T2` Covers: B-001, B-006, B-007. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex、Bedrock 各模型族、Mistral parser 只解析已声明字段并全部调用 helper；删除直接 `as u32` 与手写零 Usage. Verify: provider-specific valid/malformed/all-zero tests.
-- [ ] `SP1129-T3` Covers: B-008. Owner: spend test owner. Dependencies: SP1129-T2. Done when: `None` 进入现有显式错误/settlement，测试证明不产生成功的零 token/$0 记录. Verify: focused spend reservation/usage tests.
-- [ ] `SP1129-T4` Covers: B-001 ～ B-008. Owner: verification owner. Dependencies: SP1129-T3. Done when: Claude 保留 diff 全量审计，所有 provider 路径和完整 Rust/SpecRail gate 通过，计费安全人工 review 完成. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+- [ ] `SP1129-T1` Covers: B-002 ～ B-009. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/shared.rs` 提供唯一 crate-private normalizer，覆盖 raw `u64/u128` 校验、partial/nonzero/None、缩窄与 total 饱和. Verify: focused helper raw-domain/boundary tests.
+- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条非流式 parser（含 thoughts/tool-use）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；删除直接 `as u32` 与手写零 Usage；Vertex thoughts 仅包含在 completion、不填 reasoning/thinking details. Verify: provider-specific valid/malformed/all-zero/total tests and Vertex exact-cost/no-double-charge assertion.
+- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: `None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次，测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused spend reservation/usage tests.
+- [ ] `SP1129-T4` Covers: B-001 ～ B-012. Owner: verification owner. Dependencies: SP1129-T3. Done when: 最终 diff 全量审计，所有 provider 路径和完整 Rust/SpecRail gate 通过，计费安全人工 review 完成. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
 
 不并行。共享 usage helper 与各 provider parser 有直接依赖，单一 owner 串行修改；
-验证在 `.claude/worktrees/agent-ab21c6241a85e84ba` 单路运行。
+验证只在本 session 最终实现 worktree 单路运行。
 
 ## 验证
 
 - 对 Issue 列出的每个具体 parser 返回点建立覆盖清单，禁止只测一个样本。
+- Vertex `transformers.rs` 与 `client.rs` 两条路径必须使用同一 helper 并分别有扩展
+  token fixture；thoughts 的 output cost 恰好一次、reasoning cost 为零。
 - `u32::MAX + 1`、`u64::MAX` 与 total overflow 必须有新鲜输出。
 - 不修改测试断言来接受 silent zero billing。
 - 最终 PR 使用 `Fixes #1129`，需要 billing 人工 review。

--- a/specs/GH1129/tasks.md
+++ b/specs/GH1129/tasks.md
@@ -11,13 +11,13 @@ GH-1129 / #1129
 
 ## 决策门
 
-- [ ] `SP1129-T0` Covers: B-001 ～ B-012. Owner: maintainer/spec owner. Dependencies: none. Done when: amendment 审查期间 Issue 移出 `ready_to_implement`；本 amendment exact head 的 raw-domain total、Vertex 双 parser 与 thoughts 单次 output 计费、Converse total、key-only settlement 获得内容绑定批准并合并后，才恢复 `ready_to_implement`. Verify: SpecRail workflow/spec checks 与 implement route gate。
+- [ ] `SP1129-T0` Covers: B-001 ～ B-012. Owner: maintainer/spec owner. Dependencies: none. Done when: amendment 审查期间 Issue 移出 `ready_to_implement`；本 amendment exact head 的 raw-domain total、Vertex/direct-Gemini 全 parser（含 standard chat SSE 与 native SDK）、thoughts/cache 单次计费、Converse total、各 reservation 自有金额及 output-then-read-error settlement 获得内容绑定批准并合并后，才恢复 `ready_to_implement`. Verify: SpecRail workflow/spec checks 与 implement route gate。
 
 ## 实现任务
 
 - [ ] `SP1129-T1` Covers: B-002 ～ B-009, B-011. Owner: billing implementation owner. Dependencies: SP1129-T0. Done when: `src/core/providers/shared.rs` 提供唯一 crate-private normalizer，覆盖 raw `u64/u128` 校验、partial/nonzero/None、endpoint-specific total、缩窄/饱和，以及 optional cached raw 校验、`cached <= prompt` 与 details 映射. Verify: focused helper raw-domain/cache/boundary tests.
-- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条、direct Gemini provider client 与 native SDK unary/SSE shared parser（含 thoughts/tool-use/cache）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；Vertex 使用四项 reported-total policy，direct Gemini 使用 prompt+candidates+thoughts policy；删除直接 `as u32` 与手写零 Usage；Google thoughts 仅包含在 completion、reasoning details 为空，provider client 的 `thinking_usage` 与两条路径 cached pricing 保留. Verify: provider-specific valid/malformed/all-zero/endpoint-total/cache tests and Vertex/direct-Gemini exact-cost/no-double-charge assertions.
-- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: common 与 native Gemini SDK no-usage 路径统一委托同一 helper；`None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次；provider+key 金额不同时各按自身 reserved amount 结算，API-key usage 使用 key-first fallback cost；测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused common/native-SDK spend reservation/usage tests.
+- [ ] `SP1129-T2` Covers: B-001 ～ B-009, B-011. Owner: same implementation owner. Dependencies: SP1129-T1. Done when: Azure、Azure AI、Vertex 两条、direct Gemini provider client、`gemini/streaming.rs` + `base/sse/gemini.rs` standard chat stream 与 native SDK unary/SSE shared parser（均含 malformed/overflow/thoughts/tool-use/cache）、Bedrock（含 Converse total）各模型族、Mistral parser 只解析已声明字段并全部调用 helper；Vertex 使用四项 reported-total policy，direct Gemini 使用 prompt+candidates+thoughts policy；删除直接 `as u32` 与手写零 Usage；Google thoughts 仅包含在 completion、reasoning details 为空，`Usage` 路径的 `thinking_usage` 与所有 Gemini 路径 cached pricing 保留. Verify: provider/SSE-specific valid/malformed/all-zero/overflow/endpoint-total/cache tests and Vertex/direct-Gemini exact-cost/no-double-charge assertions.
+- [ ] `SP1129-T3` Covers: B-010, B-012. Owner: spend implementation/test owner. Dependencies: SP1129-T2. Done when: common 与 native Gemini SDK no-usage 路径统一委托同一 helper；`None` 的 provider+key/provider-only/key-only/neither 四种 reservation 组合恰好终止一次；provider+key 金额不同时各按自身 reserved amount 结算，API-key usage 使用 key-first fallback cost；`gemini.rs` 所有 stream 终止分支传真实 `should_record_spend && saw_upstream_output`，route test 覆盖 output-then-read-error 与 error-before-output；测试证明不产生成功的零 token/$0 记录或 reservation 泄漏. Verify: focused common/native-SDK spend reservation/usage tests and runtime-provider stream-error route tests.
 - [ ] `SP1129-T4` Covers: B-001 ～ B-012. Owner: verification owner. Dependencies: SP1129-T3. Done when: 最终 diff 全量审计，所有 provider 路径和完整 Rust/SpecRail gate 通过，计费安全人工 review 完成. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
@@ -28,10 +28,14 @@ GH-1129 / #1129
 ## 验证
 
 - 对 Issue 列出的每个具体 parser 返回点建立覆盖清单，禁止只测一个样本。
-- Vertex `transformers.rs`、`client.rs`、direct Gemini `client.rs` 与 native SDK
-  `gemini/spend.rs` 必须使用共享严格 helper 并分别有扩展 token fixture；Vertex
-  四项与 direct Gemini 三项 reported-total fixture 都必须覆盖，thoughts 的 output
-  cost 恰好一次、reasoning cost 为零，cached pricing 与 `thinking_usage` 保持。
+- Vertex `transformers.rs`、`client.rs`、direct Gemini `client.rs`、standard stream
+  `gemini/streaming.rs` + `base/sse/gemini.rs` 与 native SDK `gemini/spend.rs` 必须使用
+  共享严格 helper 并分别有 malformed/overflow/扩展 token/cache fixture；Vertex 四项
+  与 direct Gemini 三项 reported-total fixture 都必须覆盖，thoughts 的 output cost
+  恰好一次、reasoning cost 为零，cached pricing 与 `Usage.thinking_usage` 保持。
+- native Gemini `gemini.rs` 的 output-then-read-error 测试必须证明实际
+  `saw_upstream_output` 传入 settlement、provider/key 各按自身 reservation 金额结算；
+  error-before-output 不得伪造该状态。
 - `u32::MAX + 1`、`u64::MAX` 与 total overflow 必须有新鲜输出。
 - 不修改测试断言来接受 silent zero billing。
 - 最终 PR 使用 `Fixes #1129`，需要 billing 人工 review。
@@ -41,4 +45,6 @@ GH-1129 / #1129
 - Claude diff 改动约 600 行且未完成构建，不能把“代码已写”当作验证。
 - 不新增 provider 字段 alias，不接受数字字符串猜测。
 - `None` 的下游错误/结算语义必须通过端到端 focused test。
+- 标准 chat-completions Gemini stream 与 native SDK SSE 是不同入口，二者不得因
+  非流式/parser 修复而被误判为已覆盖。
 - 不自动合并、不 force-push。

--- a/specs/GH1129/tasks.md
+++ b/specs/GH1129/tasks.md
@@ -11,7 +11,7 @@ GH-1129 / #1129
 
 ## 决策门
 
-- [ ] `SP1129-T0` Covers: B-001 ～ B-012. Owner: maintainer/spec owner. Dependencies: none. Done when: 原规格已在 `user-2026-07-27-approve-all-specs` 获批；本 amendment 的 raw-domain total、Vertex 双 parser 与 thoughts 单次 output 计费、Converse total、key-only settlement 再次获得内容绑定批准，Issue 保持 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+- [ ] `SP1129-T0` Covers: B-001 ～ B-012. Owner: maintainer/spec owner. Dependencies: none. Done when: amendment 审查期间 Issue 移出 `ready_to_implement`；本 amendment exact head 的 raw-domain total、Vertex 双 parser 与 thoughts 单次 output 计费、Converse total、key-only settlement 获得内容绑定批准并合并后，才恢复 `ready_to_implement`. Verify: SpecRail workflow/spec checks 与 implement route gate。
 
 ## 实现任务
 

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -17,6 +17,7 @@ GH-1129 / #1129
 | Azure | `src/core/providers/azure/chat.rs`, `src/core/providers/azure/embed.rs`, `src/core/providers/azure/chat_tests.rs` | 缺失或错误类型通过 `unwrap_or(0)` 退化为零，`as u32` 可截断 | chat 与 embedding 都在账单入口前产生 `Option<Usage>` |
 | Azure AI | `src/core/providers/azure_ai/chat.rs`, `src/core/providers/azure_ai/embed.rs`, `src/core/providers/azure_ai/chat_tests.rs` | 与 Azure 相同；embedding completion 固定为不适用的零 | 需要保留格式差异，同时移除静默 fallback |
 | Vertex AI | `src/core/providers/vertex_ai/transformers.rs`, `src/core/providers/vertex_ai/client.rs` | 两条非流式 response parser 都解析 `usageMetadata`/legacy metadata，存在默认零、截断或手写加法；legacy 路径还会把缺失 usage 展开为全零 `Usage` | 两条入口必须委托同一 helper，不能只修 transformer |
+| Direct Gemini | `src/core/providers/gemini/client.rs`, `src/server/routes/ai/gemini/spend.rs` | provider client 与 native SDK unary/SSE 使用不同 parser；两者都默认零/直接缩窄，SDK parser 还独立执行有缺口的 no-usage settlement | 两条 parser 都必须使用 endpoint policy；SDK settlement 委托 common helper，不能留下旁路 |
 | Bedrock | `src/core/providers/bedrock/transformation.rs` | 多种模型族各自解析，部分路径已有 all-zero → `None`，其他路径仍默认零并直接相加 | 需要统一 OpenAI-compatible、runtime alias、Claude、Converse、Titan 的边界语义 |
 | Mistral embedding | `src/core/providers/mistral/embedding.rs` | 缺失或错误字段默认为零并截断 | completion 为不适用零，prompt/total 仍需严格验证 |
 | 结算保护 | `src/server/routes/ai/spend.rs`, `src/server/routes/ai/spend_no_usage_tests.rs` | `usage: None` 会进入 `record_reserved_spend_without_usage`；有预留时按预留结算，无预留时显式报错且不记录 spend | provider 层必须把不可信 usage 路由到此既有保护，并补充账单副作用回归证明 |
@@ -42,6 +43,10 @@ GH-1129 / #1129
 - helper 不猜测字段名；各 provider 适配器负责传入其格式声明的精确字段。
 - completion 不适用的 embedding 路径显式传入合法常量 `0`，而不是把字段读取失败
   映射成 `0`。
+- Google usage 的 optional `cachedContentTokenCount` 存在时也必须是 unsigned raw
+  integer，并满足 `cached <= promptTokenCount`；raw 校验后饱和到 `u32::MAX`。
+  provider `Usage` 保留 `prompt_tokens_details.cached_tokens/cache_read_tokens`，
+  native SDK `PricingUsage` 保留 `cached_tokens`，确保 cache-read pricing 不漂移。
 
 ### 2. Provider 字段契约
 
@@ -50,7 +55,7 @@ GH-1129 / #1129
 | Azure / Azure AI chat | `usage.prompt_tokens` | `usage.completion_tokens` | `usage.total_tokens` 必需且必须一致 |
 | Azure / Azure AI embedding | `usage.prompt_tokens` | 不适用，显式 `0`；若响应带 completion，则必须是合法 `0` | `usage.total_tokens` 必需且必须一致 |
 | Vertex `usageMetadata` | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；thoughts 只包含在 completion 总量，不写 `reasoning_tokens`/`thinking_usage` | `totalTokenCount` 必需，必须在 raw `u128` 域等于四项之和 |
-| Direct Gemini `usageMetadata` | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；同样不写 separately-priced reasoning details | `totalTokenCount` 必需，但按 Gemini API 契约在 raw `u128` 域等于 prompt + candidates + thoughts，不含 tool-use prompt；公开 `Usage.total_tokens` 仍由四个 billable parts 重算 |
+| Direct Gemini `usageMetadata`（provider client + native SDK unary/SSE） | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；不写 separately-priced reasoning details，provider client 保留 user-visible `thinking_usage` | `totalTokenCount` 必需，但按 Gemini API 契约在 raw `u128` 域等于 prompt + candidates + thoughts，不含 tool-use prompt；公开/计费 total 仍由四个 billable parts 重算；optional cached count 严格保留 |
 | Vertex legacy `metadata.tokenMetadata` | `inputTokens.totalTokens` | `outputTokens.totalTokens` | 格式不声明 total，统一重算 |
 | Bedrock OpenAI-compatible | `prompt_tokens` | `completion_tokens` | `total_tokens` 必需且必须一致 |
 | Bedrock runtime aliases | 已识别的 input 字段之一 | 对应格式的 output 字段 | 格式无 total 时统一重算；不得跨不完整 alias 组合拼接 |
@@ -78,11 +83,13 @@ usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺�
 超大值即使都会缩窄为 `u32::MAX` 也不能被误判为一致。校验后才缩窄；所有调用方移除
 普通 `+` 和 provider total 直赋值，统一使用 helper 的饱和结果。
 
-Vertex `thoughtsTokenCount` 已被合入 `completion_tokens`，因此 pricing 只按标准 output
-token 单价计费一次。本 Issue 明确保持 `completion_tokens_details.reasoning_tokens=None`
-且 `thinking_usage=None`；当前 pricing authority 会在 completion cost 之外对 reasoning
-tokens 再计一笔，填充这些 details 会重复收费。若未来需要公开 thoughts breakdown，
-必须另行设计“breakdown 不重复计费”的 schema/pricing 契约。
+Google `thoughtsTokenCount` 已被合入 `completion_tokens`，因此 pricing 只按标准
+output token 单价计费一次。本 Issue 明确保持
+`completion_tokens_details.reasoning_tokens=None`；当前 pricing authority 会在
+completion cost 之外对 reasoning tokens 再计一笔，填充该 details 会重复收费。
+Direct Gemini 现有 `thinking_usage` 只是 user-visible breakdown，当前
+`PricingUsage::from` 不读取它，因此保留并断言兼容；不得把“防重复计费”扩大成删除
+该公开信息。
 
 ### 4. Billing 副作用
 
@@ -98,6 +105,10 @@ tokens 再计一笔，填充这些 details 会重复收费。若未来需要公�
    不得因 unified reservation 为 `None` 提前返回；
 4. 只有 provider reservation 时保持现有 provider/model 与 API-key usage 行为；
 5. 两种预留都没有时记录 error，且不伪造成功 spend。
+
+native Gemini SDK 的 `settle_gemini_reserved_spend_without_usage` 不再维护平行算法：
+把 common helper 调整为 crate-visible 内部入口并委托它，确保 unary/SSE 的
+provider+key、provider-only、key-only、neither 与不同金额矩阵完全相同。
 
 在 `spend_no_usage_tests.rs` 扩充下游测试，固定这些副作用，避免未来 provider 修复
 再次被结算层弱化。
@@ -118,10 +129,11 @@ tokens 再计一笔，填充这些 details 会重复收费。若未来需要公�
 | `src/core/providers/vertex_ai/client.rs` | trait response parser 的 `usageMetadata` 委托同一共享 helper，移除 `unwrap_or(0) as u32`/普通加法；覆盖扩展计数、malformed/total 与 exact token 输出 | B-001–B-009, B-011 |
 | `src/core/providers/vertex_ai/client_tests.rs` | 覆盖 trait response parser 的扩展计数、malformed、all-zero、total mismatch 与范围 fixture | B-001–B-009, B-011 |
 | `src/core/providers/gemini/client.rs` | direct Gemini 非流式 `usageMetadata` 委托共享严格 helper，但使用 Gemini-specific prompt+candidates+thoughts reported-total policy；移除默认零/直接缩窄与 separately-priced reasoning details，并在 inline tests 覆盖扩展计数、malformed/total、范围与 exact token 输出 | B-001–B-009, B-011 |
+| `src/server/routes/ai/gemini/spend.rs` | native Gemini SDK unary/SSE `gemini_usage_metadata` 委托同一 strict direct-Gemini policy，保留 cached pricing、清空 reasoning cost；no-usage settlement 委托 common helper，并扩充 inline parser/四组合/不同金额测试 | B-001–B-012 |
 | `src/core/providers/bedrock/transformation.rs` | 收敛所有模型族 usage parser，禁止 partial alias 拼接，移除默认零和普通加法，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/providers/mistral/embedding.rs` | 严格读取 prompt/total、显式 completion=0，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/pricing_service/tests.rs` | 用归一化 Vertex effective usage 做 exact cost 断言，证明 thoughts 只进入 output cost 且 reasoning cost 为零 | B-006, B-011 |
-| `src/server/routes/ai/spend.rs` | 修正 no-usage key-only reservation 的提前返回，各 reservation 按自身金额恰好结算一次，并为 API-key usage 选择 key-first fallback cost | B-010, B-012 |
+| `src/server/routes/ai/spend.rs` | 修正 no-usage key-only reservation 的提前返回，各 reservation 按自身金额恰好结算一次，为 API-key usage 选择 key-first fallback cost，并把 helper 暴露为 native Gemini SDK 可复用的 crate-internal 入口 | B-010, B-012 |
 | `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、不同 provider/key 预留额、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
 
 不计划修改公开 `Usage` schema、流式 SSE 解析或价格/预算配置；若实现发现必须修改
@@ -131,7 +143,7 @@ manifest 外文件，应停止并回到 spec review。
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | 所有 manifest 中 provider parser（含两条 Vertex 与 direct Gemini response parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
+| B-001 | 所有 manifest 中 provider parser（含两条 Vertex、direct Gemini provider client 与 native SDK unary/SSE shared parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
 | B-002 | provider 容器入口 | 缺失 usage / usageMetadata / tokenMetadata fixture 返回 `None` |
 | B-003 | shared helper 与每种字段映射 | missing、`null`、string、float、negative、object/array fixture；partial 字段返回 `None` |
 | B-004 | chat 与 embedding 格式策略 | prompt=0/completion>0、prompt>0/completion=0、embedding completion=0 fixture |
@@ -140,8 +152,8 @@ manifest 外文件，应停止并回到 spec review。
 | B-007 | endpoint-specific reported-total validator | raw `u128` 域 total 缺失、错误类型、不一致均返回 `None`；一致 total 保留；Vertex 四项、direct Gemini 三项与 Converse 专项 fixture |
 | B-008 | token conversion helper | `u32::MAX`、`u32::MAX + 1`、`u64::MAX` |
 | B-009 | total builder | `u32::MAX + 1` 与 `u32::MAX + u32::MAX` 均得到 `u32::MAX` |
-| B-010 | `spend.rs` + no-usage tests | 验证 provider+key（含不同金额）、provider-only、key-only、neither 的 spend、API-key usage 与各 reservation exactly-once/self-amount settlement |
-| B-011 | provider happy-path + Vertex pricing fixture | 扩展字段零/缺失保持既有值和费用；非零时 effective input/output 各计一次，reasoning cost 为零 |
+| B-010 | common + native Gemini SDK no-usage tests | 两条入口都验证 provider+key（含不同金额）、provider-only、key-only、neither 的 spend、API-key usage 与各 reservation exactly-once/self-amount settlement |
+| B-011 | provider happy-path + Google pricing fixtures | 扩展字段零/缺失保持既有值和费用；非零时 effective input/output 各计一次，cached 保持 cache-read price，thinking breakdown 保留且 reasoning cost 为零 |
 | B-012 | provider → spend handoff | malformed provider fixture 返回 `None`，下游 no-usage 测试证明不产生 `$0` 成功 spend |
 
 ## 数据流
@@ -182,11 +194,12 @@ manifest 外文件，应停止并回到 spec review。
       每个 provider 格式的 happy path 与 drift fixture。
 - [ ] Integration tests: provider parser 输出 `None` 后复用
       `spend_no_usage_tests.rs` 验证四种 reservation 组合和 key usage 副作用。
-- [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、direct Gemini、Bedrock、
-      Mistral 相关测试。
+- [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、direct Gemini provider
+      client/native SDK unary+SSE、Bedrock、Mistral 相关测试。
 - [ ] Pricing tests: Vertex/direct Gemini tool-use prompt/thoughts 非零时，
       input/output cost 由四个 billable parts 精确计算，`reasoning_cost == 0`
-      且 total 不重复；reported total 分别覆盖 Vertex 四项和 direct Gemini 三项。
+      且 total 不重复；reported total 分别覆盖 Vertex 四项和 direct Gemini 三项；
+      cached token 保持 cache-read price，provider client `thinking_usage` 保留。
 - [ ] Static checks: `cargo fmt --check`、`cargo check`、
       `cargo clippy --all-targets -- -D warnings`。
 - [ ] Full verification: `cargo test`；关键 usage helper 与结算分支要求 100% 覆盖，

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -16,7 +16,7 @@ GH-1129 / #1129
 | 共享 provider 工具 | `src/core/providers/shared.rs` | 已承载跨 provider 的响应解析工具，但尚无严格 token usage helper | 搜索后确认这是复用逻辑的既有位置，不新增平行 utility 文件 |
 | Azure | `src/core/providers/azure/chat.rs`, `src/core/providers/azure/embed.rs`, `src/core/providers/azure/chat_tests.rs` | 缺失或错误类型通过 `unwrap_or(0)` 退化为零，`as u32` 可截断 | chat 与 embedding 都在账单入口前产生 `Option<Usage>` |
 | Azure AI | `src/core/providers/azure_ai/chat.rs`, `src/core/providers/azure_ai/embed.rs`, `src/core/providers/azure_ai/chat_tests.rs` | 与 Azure 相同；embedding completion 固定为不适用的零 | 需要保留格式差异，同时移除静默 fallback |
-| Vertex AI | `src/core/providers/vertex_ai/transformers.rs` | `usageMetadata` 与 legacy `tokenMetadata` 都会默认零；legacy 路径甚至把缺失 usage 展开为全零 `Usage` | 两种格式的必需字段和 total 策略不同 |
+| Vertex AI | `src/core/providers/vertex_ai/transformers.rs`, `src/core/providers/vertex_ai/client.rs` | 两条非流式 response parser 都解析 `usageMetadata`/legacy metadata，存在默认零、截断或手写加法；legacy 路径还会把缺失 usage 展开为全零 `Usage` | 两条入口必须委托同一 helper，不能只修 transformer |
 | Bedrock | `src/core/providers/bedrock/transformation.rs` | 多种模型族各自解析，部分路径已有 all-zero → `None`，其他路径仍默认零并直接相加 | 需要统一 OpenAI-compatible、runtime alias、Claude、Converse、Titan 的边界语义 |
 | Mistral embedding | `src/core/providers/mistral/embedding.rs` | 缺失或错误字段默认为零并截断 | completion 为不适用零，prompt/total 仍需严格验证 |
 | 结算保护 | `src/server/routes/ai/spend.rs`, `src/server/routes/ai/spend_no_usage_tests.rs` | `usage: None` 会进入 `record_reserved_spend_without_usage`；有预留时按预留结算，无预留时显式报错且不记录 spend | provider 层必须把不可信 usage 路由到此既有保护，并补充账单副作用回归证明 |
@@ -29,12 +29,14 @@ GH-1129 / #1129
 在既有 `src/core/providers/shared.rs` 中增加 crate-private helper，不改变公开 API：
 
 - 只接受 `serde_json::Value::as_u64()` 成功的 JSON unsigned integer。
-- 合法 `u64` 通过 `u32::try_from(value).unwrap_or(u32::MAX)` 饱和到内部范围。
-- 由合法 prompt/completion 构造 `Usage` 时：
+- 各 provider 先保留合法 raw `u64` 字段；需要相加的字段提升为 `u128`，禁止先
+  饱和或缩窄。
+- 由可信 raw prompt/completion 构造 `Usage` 时：
   - 两者均为零则返回 `None`；
-  - `total_tokens = prompt_tokens.saturating_add(completion_tokens)`；
-  - provider total 若该格式声明存在，则必须同样是合法 unsigned integer，归一化后
-    与重算 total 一致，否则返回 `None`。
+  - provider total 若该格式声明存在，则必须是合法 unsigned integer，并在
+    `u128` 域与 raw prompt/completion parts 之和一致；先饱和再比较被禁止；
+  - raw-domain 校验通过后，各分量以 `min(value, u32::MAX)` 缩窄，
+    `total_tokens` 以 raw 总和饱和到 `u32::MAX`。
 - helper 不猜测字段名；各 provider 适配器负责传入其格式声明的精确字段。
 - completion 不适用的 embedding 路径显式传入合法常量 `0`，而不是把字段读取失败
   映射成 `0`。
@@ -45,11 +47,12 @@ GH-1129 / #1129
 | --- | --- | --- | --- |
 | Azure / Azure AI chat | `usage.prompt_tokens` | `usage.completion_tokens` | `usage.total_tokens` 必需且必须一致 |
 | Azure / Azure AI embedding | `usage.prompt_tokens` | 不适用，显式 `0`；若响应带 completion，则必须是合法 `0` | `usage.total_tokens` 必需且必须一致 |
-| Vertex `usageMetadata` | `promptTokenCount` | `candidatesTokenCount` | `totalTokenCount` 必需且必须一致 |
+| Vertex `usageMetadata` | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；thoughts 只包含在 completion 总量，不写 `reasoning_tokens`/`thinking_usage` | `totalTokenCount` 必需，必须在 raw `u128` 域等于四项之和 |
 | Vertex legacy `metadata.tokenMetadata` | `inputTokens.totalTokens` | `outputTokens.totalTokens` | 格式不声明 total，统一重算 |
 | Bedrock OpenAI-compatible | `prompt_tokens` | `completion_tokens` | `total_tokens` 必需且必须一致 |
 | Bedrock runtime aliases | 已识别的 input 字段之一 | 对应格式的 output 字段 | 格式无 total 时统一重算；不得跨不完整 alias 组合拼接 |
-| Bedrock Claude / Converse / Titan | 各模型族声明的 input 字段 | 各模型族声明的 output 字段 | 统一重算 |
+| Bedrock Claude / Titan | 各模型族声明的 input 字段 | 各模型族声明的 output 字段 | 格式无 total 时统一重算 |
+| Bedrock Converse | `usage.inputTokens` | `usage.outputTokens` | `usage.totalTokens` 必需且 raw-domain 一致 |
 | Mistral embedding | `usage.prompt_tokens` | 不适用，显式 `0` | `usage.total_tokens` 必需且必须一致 |
 
 usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺失或类型错误都使用 `?`
@@ -57,20 +60,28 @@ usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺�
 
 ### 3. Total 一致性
 
-内部账单只信任归一化后的 prompt/completion 分量。reported total 不参与计算，只用于
-检测 provider schema 或数据漂移。比较在饱和后的 `u32` 域完成，因此超大但合法的
-计数仍保持“不低估”的内部上限语义。所有调用方移除普通 `+` 和 provider total
-直赋值，统一使用 helper 的 `saturating_add` 结果。
+内部账单只信任通过 raw-domain 校验的 prompt/completion 分量。reported total 不参与
+计费，只用于检测 provider schema 或数据漂移。比较必须在 `u128` 域完成：两个不同的
+超大值即使都会缩窄为 `u32::MAX` 也不能被误判为一致。校验后才缩窄；所有调用方移除
+普通 `+` 和 provider total 直赋值，统一使用 helper 的饱和结果。
+
+Vertex `thoughtsTokenCount` 已被合入 `completion_tokens`，因此 pricing 只按标准 output
+token 单价计费一次。本 Issue 明确保持 `completion_tokens_details.reasoning_tokens=None`
+且 `thinking_usage=None`；当前 pricing authority 会在 completion cost 之外对 reasoning
+tokens 再计一笔，填充这些 details 会重复收费。若未来需要公开 thoughts breakdown，
+必须另行设计“breakdown 不重复计费”的 schema/pricing 契约。
 
 ### 4. Billing 副作用
 
-不修改 `src/server/routes/ai/spend.rs` 的生产结算算法。转换器返回 `None` 后沿现有
-路径进入 `record_reserved_spend_without_usage`：
+转换器返回 `None` 后进入 `record_reserved_spend_without_usage`。该函数需做最小
+修正以覆盖所有 reservation 组合：
 
 1. 有 `UnifiedBudgetReservation` 时以 reserved amount 结算，避免免费调用；
-2. 有 key budget reservation 时同步结算该预留；
-3. 有 API key 时记录零 token 与 reserved cost，而不是零 token/零 cost；
-4. 无预留时记录 error，且不伪造成功 spend。
+2. 同时有 key budget reservation 时以同一 cost 结算；
+3. 只有 key budget reservation 时使用其 `reserved_amount()` 结算并记录 API-key
+   零 token/reserved cost；不得因 unified reservation 为 `None` 提前返回；
+4. 只有 provider reservation 时保持现有 provider/model 与 API-key usage 行为；
+5. 两种预留都没有时记录 error，且不伪造成功 spend。
 
 在 `spend_no_usage_tests.rs` 扩充下游测试，固定这些副作用，避免未来 provider 修复
 再次被结算层弱化。
@@ -86,37 +97,42 @@ usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺�
 | `src/core/providers/azure_ai/chat.rs` | 应用与 Azure chat 相同的严格契约 | B-001–B-009, B-011 |
 | `src/core/providers/azure_ai/chat_tests.rs` | 覆盖 Azure AI chat 的 drift、total、范围与兼容性 | B-003–B-009, B-011 |
 | `src/core/providers/azure_ai/embed.rs` | 严格读取 prompt/total，completion 仅按格式语义为零 | B-001–B-009 |
-| `src/core/providers/vertex_ai/transformers.rs` | 分别收紧 `usageMetadata` 与 legacy `tokenMetadata`，移除缺失 usage 的默认 `Usage`，统一重算 total，并扩充本文件测试 | B-001–B-009, B-011 |
+| `src/core/providers/vertex_ai/transformers.rs` | 分别收紧 `usageMetadata` 与 legacy `tokenMetadata`，移除缺失 usage 的默认 `Usage`，统一调用共享 helper、重算 total，并扩充本文件测试 | B-001–B-009, B-011 |
+| `src/core/providers/vertex_ai/transformers/split_tests.rs` | 覆盖 transformer 的 usageMetadata/legacy 合法、malformed、total、扩展字段与范围 fixture，避免继续膨胀已接近上限的实现文件 | B-001–B-009, B-011 |
+| `src/core/providers/vertex_ai/client.rs` | trait response parser 的 `usageMetadata` 委托同一共享 helper，移除 `unwrap_or(0) as u32`/普通加法；覆盖扩展计数、malformed/total 与 exact token 输出 | B-001–B-009, B-011 |
+| `src/core/providers/vertex_ai/client_tests.rs` | 覆盖 trait response parser 的扩展计数、malformed、all-zero、total mismatch 与范围 fixture | B-001–B-009, B-011 |
 | `src/core/providers/bedrock/transformation.rs` | 收敛所有模型族 usage parser，禁止 partial alias 拼接，移除默认零和普通加法，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/providers/mistral/embedding.rs` | 严格读取 prompt/total、显式 completion=0，并扩充本文件测试 | B-001–B-009, B-011 |
+| `src/core/pricing_service/tests.rs` | 用归一化 Vertex effective usage 做 exact cost 断言，证明 thoughts 只进入 output cost 且 reasoning cost 为零 | B-006, B-011 |
+| `src/server/routes/ai/spend.rs` | 修正 no-usage key-only reservation 的提前返回，按可用 reservation 推导 reserved cost 并恰好结算一次 | B-010, B-012 |
 | `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
 
-不计划修改 `src/server/routes/ai/spend.rs`、公开 `Usage` schema、流式 SSE 解析或价格/预算
-配置；若实现发现必须修改 manifest 外文件，应停止并回到 spec review。
+不计划修改公开 `Usage` schema、流式 SSE 解析或价格/预算配置；若实现发现必须修改
+manifest 外文件，应停止并回到 spec review。
 
 ## Product-to-Test Mapping
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | 所有 manifest 中 provider parser | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
+| B-001 | 所有 manifest 中 provider parser（含两条 Vertex response parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
 | B-002 | provider 容器入口 | 缺失 usage / usageMetadata / tokenMetadata fixture 返回 `None` |
 | B-003 | shared helper 与每种字段映射 | missing、`null`、string、float、negative、object/array fixture；partial 字段返回 `None` |
 | B-004 | chat 与 embedding 格式策略 | prompt=0/completion>0、prompt>0/completion=0、embedding completion=0 fixture |
 | B-005 | shared builder | prompt=0/completion=0 返回 `None`，所有 provider 至少一条集成 fixture |
 | B-006 | total 重算 | total 不能补齐缺失分量；无 total 格式得到分量饱和和 |
-| B-007 | reported-total validator | total 缺失、错误类型、不一致均返回 `None`；一致 total 保留 |
+| B-007 | reported-total validator | raw `u128` 域 total 缺失、错误类型、不一致均返回 `None`；一致 total 保留；Vertex/Converse 专项 fixture |
 | B-008 | token conversion helper | `u32::MAX`、`u32::MAX + 1`、`u64::MAX` |
 | B-009 | total builder | `u32::MAX + 1` 与 `u32::MAX + u32::MAX` 均得到 `u32::MAX` |
-| B-010 | `spend_no_usage_tests.rs` | 验证 provider/model spend、API-key usage、reservation 和 key-budget settlement |
-| B-011 | 现有 provider happy-path tests | 保持合法 fixture 的 prompt/completion/total 和费用断言 |
+| B-010 | `spend.rs` + no-usage tests | 验证 provider+key、provider-only、key-only、neither 的 spend、API-key usage 与 exactly-once settlement |
+| B-011 | provider happy-path + Vertex pricing fixture | 扩展字段零/缺失保持既有值和费用；非零时 effective input/output 各计一次，reasoning cost 为零 |
 | B-012 | provider → spend handoff | malformed provider fixture 返回 `None`，下游 no-usage 测试证明不产生 `$0` 成功 spend |
 
 ## 数据流
 
 1. provider 非流式响应被解析为 JSON。
 2. 对应适配器按格式选择精确 usage 容器和必需字段。
-3. 共享 helper 验证 JSON unsigned integer、执行饱和转换、拒绝 partial/all-zero usage、
-   重算 total 并校验 reported total。
+3. 共享 helper 验证 JSON unsigned integer，在 raw `u128` 域重算并校验 reported
+   total、拒绝 partial/all-zero usage，然后执行饱和转换。
 4. 可信数据生成 `Some(Usage)`；不可信或缺失数据生成 `None`。
 5. `Some(Usage)` 进入现有定价与实际 usage 结算；`None` 进入现有 reserved
    no-usage 结算与 error 日志。
@@ -136,7 +152,8 @@ usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺�
 - Security: 计费与预算属于高风险边界；任一 fallback-to-zero 都可能恢复免费调用。
   必须人工审查 provider 字段映射和所有账单副作用测试。
 - Compatibility: malformed、partial、all-zero 或 total 不一致的响应将从
-  `Some(Usage)` 变为 `None`；这是有意收紧。合法非零响应和公开 schema 不变。
+  `Some(Usage)` 变为 `None`；这是有意收紧。Vertex 扩展字段缺失/零的合法非零响应
+  与公开 schema 不变；扩展字段非零时修正过去漏计的 token/cost。
 - Performance: 每个响应增加常数级字段检查、`try_from` 和一次饱和加法，无额外 I/O
   或分配，影响可忽略。
 - Maintenance: provider 字段策略必须保留在显式表驱动/局部映射中；不得让共享
@@ -147,8 +164,10 @@ usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺�
 - [ ] Unit tests: shared helper 的类型、边界、all-zero、total consistency 全分支；
       每个 provider 格式的 happy path 与 drift fixture。
 - [ ] Integration tests: provider parser 输出 `None` 后复用
-      `spend_no_usage_tests.rs` 验证 reservation、key budget 和 key usage 副作用。
+      `spend_no_usage_tests.rs` 验证四种 reservation 组合和 key usage 副作用。
 - [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、Bedrock、Mistral 相关测试。
+- [ ] Pricing tests: Vertex tool-use prompt/thoughts 非零时，input/output cost 由四项
+      effective totals 精确计算，`reasoning_cost == 0` 且 total 不重复。
 - [ ] Static checks: `cargo fmt --check`、`cargo check`、
       `cargo clippy --all-targets -- -D warnings`。
 - [ ] Full verification: `cargo test`；关键 usage helper 与结算分支要求 100% 覆盖，
@@ -161,8 +180,9 @@ usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺�
 
 - **Security**：实现不得吞掉 malformed usage；review 必须检查所有列出的转换点、
   `as u32`、普通 token 加法和账单副作用。
-- **Compatibility**：不改变外部 JSON schema、provider 请求或合法 usage；仅收紧
-  不可信响应。
+- **Compatibility**：不改变外部 JSON schema 或 provider 请求；Vertex 扩展字段
+  缺失/零的合法 usage 保持兼容，扩展字段非零时有意修正过去漏计的 token/cost；
+  其他行为变化只收紧不可信响应。
 - **Performance**：保持 O(1) CPU、O(1) 内存，不引入网络、锁或持久化。
 - **Rollback**：代码可按单一实现提交整体 revert。若上线后某 provider 因真实格式
   差异大量进入 `None`，先通过日志确认字段事实，再补充明确格式映射；不得回退为

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -34,7 +34,9 @@ GH-1129 / #1129
 - 由可信 raw prompt/completion 构造 `Usage` 时：
   - 两者均为零则返回 `None`；
   - provider total 若该格式声明存在，则必须是合法 unsigned integer，并在
-    `u128` 域与 raw prompt/completion parts 之和一致；先饱和再比较被禁止；
+    `u128` 域与该 endpoint 显式声明的 reported-total raw parts 之和一致；通常
+    与 billable prompt/completion parts 相同，但 direct Gemini 是明确例外；
+    先饱和再比较被禁止；
   - raw-domain 校验通过后，各分量以 `min(value, u32::MAX)` 缩窄，
     `total_tokens` 以 raw 总和饱和到 `u32::MAX`。
 - helper 不猜测字段名；各 provider 适配器负责传入其格式声明的精确字段。
@@ -48,6 +50,7 @@ GH-1129 / #1129
 | Azure / Azure AI chat | `usage.prompt_tokens` | `usage.completion_tokens` | `usage.total_tokens` 必需且必须一致 |
 | Azure / Azure AI embedding | `usage.prompt_tokens` | 不适用，显式 `0`；若响应带 completion，则必须是合法 `0` | `usage.total_tokens` 必需且必须一致 |
 | Vertex `usageMetadata` | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；thoughts 只包含在 completion 总量，不写 `reasoning_tokens`/`thinking_usage` | `totalTokenCount` 必需，必须在 raw `u128` 域等于四项之和 |
+| Direct Gemini `usageMetadata` | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；同样不写 separately-priced reasoning details | `totalTokenCount` 必需，但按 Gemini API 契约在 raw `u128` 域等于 prompt + candidates + thoughts，不含 tool-use prompt；公开 `Usage.total_tokens` 仍由四个 billable parts 重算 |
 | Vertex legacy `metadata.tokenMetadata` | `inputTokens.totalTokens` | `outputTokens.totalTokens` | 格式不声明 total，统一重算 |
 | Bedrock OpenAI-compatible | `prompt_tokens` | `completion_tokens` | `total_tokens` 必需且必须一致 |
 | Bedrock runtime aliases | 已识别的 input 字段之一 | 对应格式的 output 字段 | 格式无 total 时统一重算；不得跨不完整 alias 组合拼接 |
@@ -59,8 +62,11 @@ Vertex 四项相加不是推断：Google 官方 Vertex AI v1
 [`UsageMetadata`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#usagemetadata)
 明确把 `totalTokenCount` 定义为 `promptTokenCount + candidatesTokenCount +
 toolUsePromptTokenCount + thoughtsTokenCount`。因此 helper 必须按四项 raw-domain
-总和校验；把 tool-use prompt 或 thoughts 当成前两项已含 breakdown 会与官方
-`totalTokenCount` 契约冲突。
+总和校验。Direct Gemini 的官方
+[`UsageMetadata`](https://ai.google.dev/api/generate-content#v1beta.GenerateContentResponse.UsageMetadata)
+则明确把 reported total 写成 prompt + thoughts + candidates；适配器必须向共享
+helper 传入 endpoint-specific total parts，不能把 Vertex 四项公式套用过去。
+两者的 billable input/output 都分别纳入 tool-use prompt/thoughts。
 
 usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺失或类型错误都使用 `?`
 传播为 `None`；不得保留另一半字段形成 partial usage。
@@ -83,10 +89,13 @@ tokens 再计一笔，填充这些 details 会重复收费。若未来需要公�
 转换器返回 `None` 后进入 `record_reserved_spend_without_usage`。该函数需做最小
 修正以覆盖所有 reservation 组合：
 
-1. 有 `UnifiedBudgetReservation` 时以 reserved amount 结算，避免免费调用；
-2. 同时有 key budget reservation 时以同一 cost 结算；
-3. 只有 key budget reservation 时使用其 `reserved_amount()` 结算并记录 API-key
-   零 token/reserved cost；不得因 unified reservation 为 `None` 提前返回；
+1. 有 `UnifiedBudgetReservation` 时以其自身 `reserved_amount()` 结算 provider/model，
+   避免免费调用；
+2. 有 key budget reservation 时独立读取并以其自身 `reserved_amount()` 结算；
+   两者同时存在且金额不同时不得复用 unified cost；
+3. API-key usage 的零 token cost 优先使用 key reservation 自身金额；key reservation
+   缺失时才使用 unified reserved amount。只有 key reservation 时也必须结算并记录，
+   不得因 unified reservation 为 `None` 提前返回；
 4. 只有 provider reservation 时保持现有 provider/model 与 API-key usage 行为；
 5. 两种预留都没有时记录 error，且不伪造成功 spend。
 
@@ -108,11 +117,12 @@ tokens 再计一笔，填充这些 details 会重复收费。若未来需要公�
 | `src/core/providers/vertex_ai/transformers/split_tests.rs` | 覆盖 transformer 的 usageMetadata/legacy 合法、malformed、total、扩展字段与范围 fixture，避免继续膨胀已接近上限的实现文件 | B-001–B-009, B-011 |
 | `src/core/providers/vertex_ai/client.rs` | trait response parser 的 `usageMetadata` 委托同一共享 helper，移除 `unwrap_or(0) as u32`/普通加法；覆盖扩展计数、malformed/total 与 exact token 输出 | B-001–B-009, B-011 |
 | `src/core/providers/vertex_ai/client_tests.rs` | 覆盖 trait response parser 的扩展计数、malformed、all-zero、total mismatch 与范围 fixture | B-001–B-009, B-011 |
+| `src/core/providers/gemini/client.rs` | direct Gemini 非流式 `usageMetadata` 委托共享严格 helper，但使用 Gemini-specific prompt+candidates+thoughts reported-total policy；移除默认零/直接缩窄与 separately-priced reasoning details，并在 inline tests 覆盖扩展计数、malformed/total、范围与 exact token 输出 | B-001–B-009, B-011 |
 | `src/core/providers/bedrock/transformation.rs` | 收敛所有模型族 usage parser，禁止 partial alias 拼接，移除默认零和普通加法，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/providers/mistral/embedding.rs` | 严格读取 prompt/total、显式 completion=0，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/pricing_service/tests.rs` | 用归一化 Vertex effective usage 做 exact cost 断言，证明 thoughts 只进入 output cost 且 reasoning cost 为零 | B-006, B-011 |
-| `src/server/routes/ai/spend.rs` | 修正 no-usage key-only reservation 的提前返回，按可用 reservation 推导 reserved cost 并恰好结算一次 | B-010, B-012 |
-| `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
+| `src/server/routes/ai/spend.rs` | 修正 no-usage key-only reservation 的提前返回，各 reservation 按自身金额恰好结算一次，并为 API-key usage 选择 key-first fallback cost | B-010, B-012 |
+| `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、不同 provider/key 预留额、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
 
 不计划修改公开 `Usage` schema、流式 SSE 解析或价格/预算配置；若实现发现必须修改
 manifest 外文件，应停止并回到 spec review。
@@ -121,16 +131,16 @@ manifest 外文件，应停止并回到 spec review。
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | 所有 manifest 中 provider parser（含两条 Vertex response parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
+| B-001 | 所有 manifest 中 provider parser（含两条 Vertex 与 direct Gemini response parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
 | B-002 | provider 容器入口 | 缺失 usage / usageMetadata / tokenMetadata fixture 返回 `None` |
 | B-003 | shared helper 与每种字段映射 | missing、`null`、string、float、negative、object/array fixture；partial 字段返回 `None` |
 | B-004 | chat 与 embedding 格式策略 | prompt=0/completion>0、prompt>0/completion=0、embedding completion=0 fixture |
 | B-005 | shared builder | prompt=0/completion=0 返回 `None`，所有 provider 至少一条集成 fixture |
 | B-006 | total 重算 | total 不能补齐缺失分量；无 total 格式得到分量饱和和 |
-| B-007 | reported-total validator | raw `u128` 域 total 缺失、错误类型、不一致均返回 `None`；一致 total 保留；Vertex/Converse 专项 fixture |
+| B-007 | endpoint-specific reported-total validator | raw `u128` 域 total 缺失、错误类型、不一致均返回 `None`；一致 total 保留；Vertex 四项、direct Gemini 三项与 Converse 专项 fixture |
 | B-008 | token conversion helper | `u32::MAX`、`u32::MAX + 1`、`u64::MAX` |
 | B-009 | total builder | `u32::MAX + 1` 与 `u32::MAX + u32::MAX` 均得到 `u32::MAX` |
-| B-010 | `spend.rs` + no-usage tests | 验证 provider+key、provider-only、key-only、neither 的 spend、API-key usage 与 exactly-once settlement |
+| B-010 | `spend.rs` + no-usage tests | 验证 provider+key（含不同金额）、provider-only、key-only、neither 的 spend、API-key usage 与各 reservation exactly-once/self-amount settlement |
 | B-011 | provider happy-path + Vertex pricing fixture | 扩展字段零/缺失保持既有值和费用；非零时 effective input/output 各计一次，reasoning cost 为零 |
 | B-012 | provider → spend handoff | malformed provider fixture 返回 `None`，下游 no-usage 测试证明不产生 `$0` 成功 spend |
 
@@ -172,9 +182,11 @@ manifest 外文件，应停止并回到 spec review。
       每个 provider 格式的 happy path 与 drift fixture。
 - [ ] Integration tests: provider parser 输出 `None` 后复用
       `spend_no_usage_tests.rs` 验证四种 reservation 组合和 key usage 副作用。
-- [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、Bedrock、Mistral 相关测试。
-- [ ] Pricing tests: Vertex tool-use prompt/thoughts 非零时，input/output cost 由四项
-      effective totals 精确计算，`reasoning_cost == 0` 且 total 不重复。
+- [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、direct Gemini、Bedrock、
+      Mistral 相关测试。
+- [ ] Pricing tests: Vertex/direct Gemini tool-use prompt/thoughts 非零时，
+      input/output cost 由四个 billable parts 精确计算，`reasoning_cost == 0`
+      且 total 不重复；reported total 分别覆盖 Vertex 四项和 direct Gemini 三项。
 - [ ] Static checks: `cargo fmt --check`、`cargo check`、
       `cargo clippy --all-targets -- -D warnings`。
 - [ ] Full verification: `cargo test`；关键 usage helper 与结算分支要求 100% 覆盖，

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -55,6 +55,13 @@ GH-1129 / #1129
 | Bedrock Converse | `usage.inputTokens` | `usage.outputTokens` | `usage.totalTokens` 必需且 raw-domain 一致 |
 | Mistral embedding | `usage.prompt_tokens` | 不适用，显式 `0` | `usage.total_tokens` 必需且必须一致 |
 
+Vertex 四项相加不是推断：Google 官方 Vertex AI v1
+[`UsageMetadata`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#usagemetadata)
+明确把 `totalTokenCount` 定义为 `promptTokenCount + candidatesTokenCount +
+toolUsePromptTokenCount + thoughtsTokenCount`。因此 helper 必须按四项 raw-domain
+总和校验；把 tool-use prompt 或 thoughts 当成前两项已含 breakdown 会与官方
+`totalTokenCount` 契约冲突。
+
 usage 容器缺失直接返回 `None`。容器存在时，任一必需字段缺失或类型错误都使用 `?`
 传播为 `None`；不得保留另一半字段形成 partial usage。
 

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -136,8 +136,9 @@ provider+key、provider-only、key-only、neither 与不同金额矩阵完全相
 | `src/server/routes/ai/spend.rs` | 修正 no-usage key-only reservation 的提前返回，各 reservation 按自身金额恰好结算一次，为 API-key usage 选择 key-first fallback cost，并把 helper 暴露为 native Gemini SDK 可复用的 crate-internal 入口 | B-010, B-012 |
 | `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、不同 provider/key 预留额、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
 
-不计划修改公开 `Usage` schema、流式 SSE 解析或价格/预算配置；若实现发现必须修改
-manifest 外文件，应停止并回到 spec review。
+不计划修改公开 `Usage` schema、已经 fail-closed 的 OpenAI SSE usage 解析或
+价格/预算配置；native Gemini unary/SSE shared parser 按 manifest 在范围内。
+若实现发现必须修改 manifest 外文件，应停止并回到 spec review。
 
 ## Product-to-Test Mapping
 

--- a/specs/GH1129/tech.md
+++ b/specs/GH1129/tech.md
@@ -17,7 +17,8 @@ GH-1129 / #1129
 | Azure | `src/core/providers/azure/chat.rs`, `src/core/providers/azure/embed.rs`, `src/core/providers/azure/chat_tests.rs` | 缺失或错误类型通过 `unwrap_or(0)` 退化为零，`as u32` 可截断 | chat 与 embedding 都在账单入口前产生 `Option<Usage>` |
 | Azure AI | `src/core/providers/azure_ai/chat.rs`, `src/core/providers/azure_ai/embed.rs`, `src/core/providers/azure_ai/chat_tests.rs` | 与 Azure 相同；embedding completion 固定为不适用的零 | 需要保留格式差异，同时移除静默 fallback |
 | Vertex AI | `src/core/providers/vertex_ai/transformers.rs`, `src/core/providers/vertex_ai/client.rs` | 两条非流式 response parser 都解析 `usageMetadata`/legacy metadata，存在默认零、截断或手写加法；legacy 路径还会把缺失 usage 展开为全零 `Usage` | 两条入口必须委托同一 helper，不能只修 transformer |
-| Direct Gemini | `src/core/providers/gemini/client.rs`, `src/server/routes/ai/gemini/spend.rs` | provider client 与 native SDK unary/SSE 使用不同 parser；两者都默认零/直接缩窄，SDK parser 还独立执行有缺口的 no-usage settlement | 两条 parser 都必须使用 endpoint policy；SDK settlement 委托 common helper，不能留下旁路 |
+| Direct Gemini provider | `src/core/providers/gemini/client.rs`, `src/core/providers/gemini/streaming.rs`, `src/core/providers/base/sse/gemini.rs` | 非流式 client 与标准 chat-completions stream 使用不同 parser；SSE transformer 的 usage-only/candidate 两个分支都默认零、截断并忽略 tool/thoughts/cache | 三个入口必须复用同一 strict direct-Gemini endpoint policy，不能只修非流式 client |
+| Native Gemini SDK route | `src/server/routes/ai/gemini.rs`, `src/server/routes/ai/gemini/spend.rs`, `tests/gemini_sdk_routes/runtime_provider_tests.rs` | unary/SSE 复用独立不严格 parser 和 no-usage settlement；stream error arm 即使已观察 output 也硬编码传 `false` | parser 与 settlement 委托 common helper；所有终止分支传递真实 output 状态并由 route-level reservation test 固定 |
 | Bedrock | `src/core/providers/bedrock/transformation.rs` | 多种模型族各自解析，部分路径已有 all-zero → `None`，其他路径仍默认零并直接相加 | 需要统一 OpenAI-compatible、runtime alias、Claude、Converse、Titan 的边界语义 |
 | Mistral embedding | `src/core/providers/mistral/embedding.rs` | 缺失或错误字段默认为零并截断 | completion 为不适用零，prompt/total 仍需严格验证 |
 | 结算保护 | `src/server/routes/ai/spend.rs`, `src/server/routes/ai/spend_no_usage_tests.rs` | `usage: None` 会进入 `record_reserved_spend_without_usage`；有预留时按预留结算，无预留时显式报错且不记录 spend | provider 层必须把不可信 usage 路由到此既有保护，并补充账单副作用回归证明 |
@@ -55,7 +56,7 @@ GH-1129 / #1129
 | Azure / Azure AI chat | `usage.prompt_tokens` | `usage.completion_tokens` | `usage.total_tokens` 必需且必须一致 |
 | Azure / Azure AI embedding | `usage.prompt_tokens` | 不适用，显式 `0`；若响应带 completion，则必须是合法 `0` | `usage.total_tokens` 必需且必须一致 |
 | Vertex `usageMetadata` | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；thoughts 只包含在 completion 总量，不写 `reasoning_tokens`/`thinking_usage` | `totalTokenCount` 必需，必须在 raw `u128` 域等于四项之和 |
-| Direct Gemini `usageMetadata`（provider client + native SDK unary/SSE） | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；不写 separately-priced reasoning details，provider client 保留 user-visible `thinking_usage` | `totalTokenCount` 必需，但按 Gemini API 契约在 raw `u128` 域等于 prompt + candidates + thoughts，不含 tool-use prompt；公开/计费 total 仍由四个 billable parts 重算；optional cached count 严格保留 |
+| Direct Gemini `usageMetadata`（provider client + standard chat SSE + native SDK unary/SSE） | `promptTokenCount` + optional-zero `toolUsePromptTokenCount` | `candidatesTokenCount` + optional-zero `thoughtsTokenCount`；不写 separately-priced reasoning details，`Usage` 路径保留 user-visible `thinking_usage` | `totalTokenCount` 必需，但按 Gemini API 契约在 raw `u128` 域等于 prompt + candidates + thoughts，不含 tool-use prompt；公开/计费 total 仍由四个 billable parts 重算；optional cached count 严格保留 |
 | Vertex legacy `metadata.tokenMetadata` | `inputTokens.totalTokens` | `outputTokens.totalTokens` | 格式不声明 total，统一重算 |
 | Bedrock OpenAI-compatible | `prompt_tokens` | `completion_tokens` | `total_tokens` 必需且必须一致 |
 | Bedrock runtime aliases | 已识别的 input 字段之一 | 对应格式的 output 字段 | 格式无 total 时统一重算；不得跨不完整 alias 组合拼接 |
@@ -109,6 +110,11 @@ Direct Gemini 现有 `thinking_usage` 只是 user-visible breakdown，当前
 native Gemini SDK 的 `settle_gemini_reserved_spend_without_usage` 不再维护平行算法：
 把 common helper 调整为 crate-visible 内部入口并委托它，确保 unary/SSE 的
 provider+key、provider-only、key-only、neither 与不同金额矩阵完全相同。
+`src/server/routes/ai/gemini.rs` 的每个 stream 终止分支必须传递
+`should_record_spend && saw_upstream_output`，尤其 upstream read error arm 不得硬编码
+`false`。route-level fixture 先写出一个不含 usage 的 candidate/output chunk，再制造
+upstream read error，断言 provider 与 key reservation 各以自身金额结算且没有泄漏；
+另测 output 前 read error，证明 caller 不会伪造已输出状态。
 
 在 `spend_no_usage_tests.rs` 扩充下游测试，固定这些副作用，避免未来 provider 修复
 再次被结算层弱化。
@@ -129,7 +135,11 @@ provider+key、provider-only、key-only、neither 与不同金额矩阵完全相
 | `src/core/providers/vertex_ai/client.rs` | trait response parser 的 `usageMetadata` 委托同一共享 helper，移除 `unwrap_or(0) as u32`/普通加法；覆盖扩展计数、malformed/total 与 exact token 输出 | B-001–B-009, B-011 |
 | `src/core/providers/vertex_ai/client_tests.rs` | 覆盖 trait response parser 的扩展计数、malformed、all-zero、total mismatch 与范围 fixture | B-001–B-009, B-011 |
 | `src/core/providers/gemini/client.rs` | direct Gemini 非流式 `usageMetadata` 委托共享严格 helper，但使用 Gemini-specific prompt+candidates+thoughts reported-total policy；移除默认零/直接缩窄与 separately-priced reasoning details，并在 inline tests 覆盖扩展计数、malformed/total、范围与 exact token 输出 | B-001–B-009, B-011 |
+| `src/core/providers/base/sse/gemini.rs` | 标准 chat-completions Gemini stream 的 usage-only 与 candidate 两个 `usageMetadata` 分支都委托 strict direct-Gemini normalizer，移除默认零/截断并保留 tool/thoughts/cache details；增加 malformed、overflow、endpoint-total 与扩展计数测试 | B-001–B-009, B-011–B-012 |
+| `src/core/providers/gemini/streaming.rs` | 通过真实 `UnifiedSSEParser<GeminiTransformer>` fixture 覆盖标准 Gemini stream 的合法扩展 usage、malformed/partial/all-zero、overflow、cache 与 exact token/cost handoff | B-001–B-009, B-011–B-012 |
 | `src/server/routes/ai/gemini/spend.rs` | native Gemini SDK unary/SSE `gemini_usage_metadata` 委托同一 strict direct-Gemini policy，保留 cached pricing、清空 reasoning cost；no-usage settlement 委托 common helper，并扩充 inline parser/四组合/不同金额测试 | B-001–B-012 |
+| `src/server/routes/ai/gemini.rs` | native SSE 所有终止分支向 settlement 传真实 `should_record_spend && saw_upstream_output`，修正 output 后 upstream read error 硬编码 `false` 的 reservation 释放旁路 | B-010, B-012 |
+| `tests/gemini_sdk_routes/runtime_provider_tests.rs` | 增加 native SSE output-then-read-error 与 error-before-output route fixture，断言前者 self-amount settlement/exactly-once、后者不伪造已输出状态且均无 reservation 泄漏 | B-010, B-012 |
 | `src/core/providers/bedrock/transformation.rs` | 收敛所有模型族 usage parser，禁止 partial alias 拼接，移除默认零和普通加法，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/providers/mistral/embedding.rs` | 严格读取 prompt/total、显式 completion=0，并扩充本文件测试 | B-001–B-009, B-011 |
 | `src/core/pricing_service/tests.rs` | 用归一化 Vertex effective usage 做 exact cost 断言，证明 thoughts 只进入 output cost 且 reasoning cost 为零 | B-006, B-011 |
@@ -137,14 +147,15 @@ provider+key、provider-only、key-only、neither 与不同金额矩阵完全相
 | `src/server/routes/ai/spend_no_usage_tests.rs` | 扩充无 usage 的 reservation、不同 provider/key 预留额、key budget、无 reservation 账单副作用测试 | B-010, B-012 |
 
 不计划修改公开 `Usage` schema、已经 fail-closed 的 OpenAI SSE usage 解析或
-价格/预算配置；native Gemini unary/SSE shared parser 按 manifest 在范围内。
+价格/预算配置；标准 chat-completions Gemini SSE 与 native Gemini unary/SSE
+shared parser 按 manifest 在范围内。
 若实现发现必须修改 manifest 外文件，应停止并回到 spec review。
 
 ## Product-to-Test Mapping
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | 所有 manifest 中 provider parser（含两条 Vertex、direct Gemini provider client 与 native SDK unary/SSE shared parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
+| B-001 | 所有 manifest 中 provider parser（含两条 Vertex、direct Gemini provider client、standard chat SSE 与 native SDK unary/SSE shared parser） | 每个 provider 的定向 parser test；审查不再存在受影响路径的 `unwrap_or(0) as u32` |
 | B-002 | provider 容器入口 | 缺失 usage / usageMetadata / tokenMetadata fixture 返回 `None` |
 | B-003 | shared helper 与每种字段映射 | missing、`null`、string、float、negative、object/array fixture；partial 字段返回 `None` |
 | B-004 | chat 与 embedding 格式策略 | prompt=0/completion>0、prompt>0/completion=0、embedding completion=0 fixture |
@@ -153,19 +164,22 @@ provider+key、provider-only、key-only、neither 与不同金额矩阵完全相
 | B-007 | endpoint-specific reported-total validator | raw `u128` 域 total 缺失、错误类型、不一致均返回 `None`；一致 total 保留；Vertex 四项、direct Gemini 三项与 Converse 专项 fixture |
 | B-008 | token conversion helper | `u32::MAX`、`u32::MAX + 1`、`u64::MAX` |
 | B-009 | total builder | `u32::MAX + 1` 与 `u32::MAX + u32::MAX` 均得到 `u32::MAX` |
-| B-010 | common + native Gemini SDK no-usage tests | 两条入口都验证 provider+key（含不同金额）、provider-only、key-only、neither 的 spend、API-key usage 与各 reservation exactly-once/self-amount settlement |
-| B-011 | provider happy-path + Google pricing fixtures | 扩展字段零/缺失保持既有值和费用；非零时 effective input/output 各计一次，cached 保持 cache-read price，thinking breakdown 保留且 reasoning cost 为零 |
-| B-012 | provider → spend handoff | malformed provider fixture 返回 `None`，下游 no-usage 测试证明不产生 `$0` 成功 spend |
+| B-010 | common + native Gemini SDK no-usage tests | 两条入口都验证 provider+key（含不同金额）、provider-only、key-only、neither 的 spend、API-key usage 与各 reservation exactly-once/self-amount settlement；route fixture 覆盖 output 后 read error |
+| B-011 | provider happy-path + Google pricing fixtures | 非流式、standard chat SSE、native SDK 的扩展字段零/缺失保持既有值和费用；非零时 effective input/output 各计一次，cached 保持 cache-read price，thinking breakdown 保留且 reasoning cost 为零 |
+| B-012 | provider → spend handoff | malformed provider/stream fixture 返回 `None`，下游 no-usage 与 native route output-then-error 测试证明不产生 `$0` 成功 spend或 reservation 泄漏 |
 
 ## 数据流
 
-1. provider 非流式响应被解析为 JSON。
-2. 对应适配器按格式选择精确 usage 容器和必需字段。
+1. provider 非流式响应或明确列出的 Gemini SSE event 被解析为 JSON。
+2. 对应适配器按格式选择精确 usage 容器和必需字段；标准 Gemini chat stream 的
+   usage-only/candidate 两个分支与 native SDK unary/SSE 都调用同一 direct-Gemini
+   policy。
 3. 共享 helper 验证 JSON unsigned integer，在 raw `u128` 域重算并校验 reported
    total、拒绝 partial/all-zero usage，然后执行饱和转换。
 4. 可信数据生成 `Some(Usage)`；不可信或缺失数据生成 `None`。
 5. `Some(Usage)` 进入现有定价与实际 usage 结算；`None` 进入现有 reserved
-   no-usage 结算与 error 日志。
+   no-usage 结算与 error 日志。native stream 在 output 后 read error 时以真实
+   `saw_upstream_output` 触发同一保护。
 6. 不新增持久化字段或外部调用。
 
 ## 备选方案
@@ -180,14 +194,15 @@ provider+key、provider-only、key-only、neither 与不同金额矩阵完全相
 ## 风险
 
 - Security: 计费与预算属于高风险边界；任一 fallback-to-zero 都可能恢复免费调用。
-  必须人工审查 provider 字段映射和所有账单副作用测试。
+  必须人工审查 provider/SSE 字段映射、stream 终止分支和所有账单副作用测试。
 - Compatibility: malformed、partial、all-zero 或 total 不一致的响应将从
   `Some(Usage)` 变为 `None`；这是有意收紧。Vertex 扩展字段缺失/零的合法非零响应
   与公开 schema 不变；扩展字段非零时修正过去漏计的 token/cost。
 - Performance: 每个响应增加常数级字段检查、`try_from` 和一次饱和加法，无额外 I/O
   或分配，影响可忽略。
 - Maintenance: provider 字段策略必须保留在显式表驱动/局部映射中；不得让共享
-  helper 猜测任意 alias。
+  helper 猜测任意 alias。新增 Gemini stream 入口必须复用同一 normalizer，禁止再
+  复制手写 usage 构造。
 
 ## 测试计划
 
@@ -196,18 +211,22 @@ provider+key、provider-only、key-only、neither 与不同金额矩阵完全相
 - [ ] Integration tests: provider parser 输出 `None` 后复用
       `spend_no_usage_tests.rs` 验证四种 reservation 组合和 key usage 副作用。
 - [ ] Regression tests: 现有 Azure、Azure AI、Vertex AI、direct Gemini provider
-      client/native SDK unary+SSE、Bedrock、Mistral 相关测试。
+      client/standard chat SSE/native SDK unary+SSE、Bedrock、Mistral 相关测试。
 - [ ] Pricing tests: Vertex/direct Gemini tool-use prompt/thoughts 非零时，
       input/output cost 由四个 billable parts 精确计算，`reasoning_cost == 0`
       且 total 不重复；reported total 分别覆盖 Vertex 四项和 direct Gemini 三项；
-      cached token 保持 cache-read price，provider client `thinking_usage` 保留。
+      cached token 保持 cache-read price，`Usage` 路径 `thinking_usage` 保留。
+- [ ] Route tests: native Gemini SSE 在 output 后 read error 时传递真实
+      `saw_upstream_output`，provider/key reservation 按各自金额 exactly-once 结算；
+      output 前 read error 不伪造已输出状态。
 - [ ] Static checks: `cargo fmt --check`、`cargo check`、
       `cargo clippy --all-targets -- -D warnings`。
 - [ ] Full verification: `cargo test`；关键 usage helper 与结算分支要求 100% 覆盖，
       新增代码整体至少 80% line coverage。
 - [ ] Manual verification: 使用一份合法 usage 与一份 partial/malformed usage 的
-      provider fixture，确认前者正常计费，后者产生显式 no-usage error 且不记录
-      `$0` 成功 spend。
+      provider 与 standard Gemini SSE fixture，确认前者正常计费，后者产生显式
+      no-usage error 且不记录 `$0` 成功 spend；再用 output-then-read-error native
+      SSE fixture 确认 reservations 不被静默释放。
 
 ## Security / Compatibility / Performance / Rollback
 


### PR DESCRIPTION
## 摘要

修订 GH1129 已合并规格，补齐实现前必须固定的计费边界：

- 在 raw `u64/u128` 域完成 total 一致性校验后再饱和缩窄
- 覆盖 Vertex 两条非流式 parser、tool-use prompt 与 thoughts token
- 固定 thoughts 仅计入 output cost 一次，避免 reasoning 重复计费
- 要求 Bedrock Converse 的 `totalTokens` 严格一致
- 覆盖 provider+key、provider-only、key-only、无 reservation 四种 no-usage 结算路径

## 边界

本 PR 仅修改 `specs/GH1129/`，不包含实现代码。Implementation 必须等待本 amendment 获得内容绑定批准并合并。

## 验证

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1129`
- `git diff --check origin/main...HEAD`

Refs #1129