### PR TITLE
docs(spec): close GH1130 tenant isolation gaps

### DIFF
--- a/specs/GH1130/product.md
+++ b/specs/GH1130/product.md
@@ -26,6 +26,8 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 - 增加跨租户共享、ACL、转移所有权或公开链接。
 - 回填或猜测历史文件的 owner。
 - 改变 auth 关闭时的本地开发兼容行为。
+- 为 API key 的 persisted `team_id` 新增 team-deletion/membership lifecycle 联动；
+  本 Issue 继续把它视为 key 自身的 trusted association，撤销同步另开 Issue。
 
 ## Behavior Invariants
 
@@ -39,17 +41,84 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 8. B-008 owner 信息是内部授权元数据，不得出现在 OpenAI-compatible File 响应或错误正文中。
 9. B-009 auth 明确关闭并允许匿名访问时，Files API 保持现有单租户行为，不伪造 owner。
 10. B-010 所有权检查必须发生在返回内容或执行删除之前；失败不得静默降级为无过滤访问。
+11. B-011 access token 的 team provenance 是闭集状态：marker 缺失时是 legacy
+    token，必须忽略其中任何 `team_id` 并使用 User scope；marker 为 version 1 且
+    `team_id` 缺失时使用 User scope；marker 为 version 1 且 `team_id` 存在时，只有
+    当前 active membership 复验成功才使用 Team scope；任何其他 marker 值都使整个
+    bearer token 无效。未知 version、stale team 或无效 membership 均不得回退到
+    User、API-key 或其他 team。
+12. B-012 `/auth/login` 与 `/auth/refresh` 的 optional `team_id` 只接受 UUID
+    格式且必须对应该 user 的当前 active membership。字段缺失时签发 version 1
+    User-scope token；malformed、foreign、missing、inactive 或 suspended selection
+    均返回稳定 400，且不得签发 access 或 refresh token。
+13. B-013 已签发 version 1 team token 的 membership 缺失或不再 active 时返回稳定
+    401；user/team/membership repository、RBAC、API-key policy 或 file metadata 的
+    读取、解析、转换错误返回 generic 5xx。上述错误不得被转成“无 membership”、空权限、
+    User scope、legacy store、跳过坏 metadata 或部分成功 list。
+14. B-014 下列既有 public Rust method call、handler signature 与 struct literal
+    保持 source-compatible：Files storage 的
+    `store`、`store_with_purpose`、`StorageLayer::store_file`，JWT 的
+    `create_access_token`、`create_token_pair`，以及 `AuthSystem::login` 的参数和
+    返回类型不变；public `FileMetadata`、`Claims`、`LoginRequest` 与
+    `RefreshTokenRequest` 字段集合不变；既有 public login/refresh handler 签名不变。
+    既有五个 public Files handler 的参数/返回类型也不变。新
+    owner/provenance/team-selection/request-proof 能力必须是 additive internal API，
+    不得要求外部 Rust caller 构造内部授权证据。
+15. B-015 只有服务端完成 current active membership 校验后产生的 typed
+    `VerifiedActiveTeam` 才能授权或签发 version 1 team-scoped access token。既有
+    raw `team_id: Some(...)` JWT 入口必须在 encode 前显式拒绝，不能制造可信
+    provenance；no-team 旧签名仍签发 version 1 User-scope token。
+16. B-016 internal persisted envelope 中的 owner 是且仅是一个 canonical UUID scope
+    `{Team(Uuid), User(Uuid), ApiKey(Uuid)}`。auth-enabled Files upload 必须走 owner
+    非 optional 的 additive owned-store；无效/缺失 UUID 不得变成字符串 owner 或
+    退回 legacy `owner: None`。既有非 HTTP storage 调用继续产生 legacy
+    `owner: None`；public `FileMetadata` 只呈现既有非授权字段，auth-disabled anonymous
+    route 也保持 B-009 行为。
+17. B-017 caller scope 的认证来源必须互斥。存在 API key 时只能按该 key 的
+    `team_id -> user_id -> key UUID` 选择一个 scope，并忽略任何残留 JWT/context team；
+    不存在 API key 时才按复验通过的 JWT Team -> authenticated User UUID 选择。typed
+    principal 与 request context 的 user/key identity 不一致或可信 UUID 损坏时返回
+    generic 5xx，不得尝试下一种身份。
+18. B-018 “返回全部已授权文件”只覆盖 owner 合法且现有公开 File object 必需字段可表示
+    的记录。历史 metadata 的 `purpose` 缺失或无效时，list/get 必须保持显式错误并使
+    整个请求失败；不得猜测 purpose、静默跳过该记录或把成功数组伪装成完整结果。
+19. B-019 auth-enabled HTTP Files routes 必须只注册可读取 request proof 的 internal
+    adapter。为保持 Rust signature 而保留的 proofless public Files wrappers 在 auth
+    开启时必须 fail-closed，不得访问 storage；只有 auth disabled +
+    allow-anonymous 时才可复用 legacy 单租户行为。任何 route 都不得继续指向 proofless
+    wrapper。
 
 ## 验收标准
 
 - [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete；login/refresh 的可选 `team_id` 必须验证 membership，新 token 带 provenance marker；multi-team 且无选择时签发 `team_id: None`，旧 token 缺 marker 时忽略其 guessed team，Files 均使用 User scope。
+- [ ] JWT 矩阵分别覆盖 legacy marker 缺失、version 1 team/no-team、unknown version
+  team/no-team；unknown version 与 stale membership 均为 401 且没有身份 fallback。
+- [ ] login/refresh 的 malformed、foreign、missing、inactive、suspended team
+  selection 均为同一公开 400 且没有任何新 token；membership/team repository
+  故障为 generic 5xx。
 - [ ] team-scoped 文件不能仅因相同 `user_id` 从另一个 team 访问；有效范围优先级有测试。
 - [ ] 非 owner 与随机不存在 ID 的状态码和公开错误形状一致。
 - [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件；直接 `*`/`system.admin`、runtime `is_admin`、受限 key + admin owner、空权限 key + admin owner、无 key admin JWT 各有测试。
+- [ ] malformed API-key runtime policy 与 RBAC/storage conversion error 返回 generic
+  5xx，不得回退 admin owner role 或普通 allow；错误正文不包含持久化 policy 细节。
 - [ ] 无身份的已启用 auth 请求在上传和对象操作上 fail-closed。
+- [ ] 既有 public storage/JWT/login 方法、public login/refresh handlers，以及
+  `FileMetadata`、`Claims`、`LoginRequest`、`RefreshTokenRequest` struct literals
+  与五个 public Files handler signatures 的 compile fixture 保持通过；raw
+  `team_id: Some` JWT 调用不生成 token，typed verified 路径可生成 team token；
+  auth-enabled HTTP upload 只调用 owner 非 optional 的 owned-store，并只用 internal
+  metadata-with-owner 结果授权。
 - [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；S3 HeadObject HTTP 404 与 foreign 的公开 404 等价，非 404 S3 故障仍显式失败。
-- [ ] S3 超过 1000 个对象时遍历 continuation token 到结束，返回全部已授权文件且不泄露其他 owner；不存在公共 limit/count 断言。
+- [ ] S3 超过 1000 个对象时以稳定 prefix 遍历 continuation token 到结束，返回全部已授权文件且不泄露其他 owner；`Some(0)` 零请求且为空，单页大小为 `min(1000, remaining)`；truncated page 的 token 缺失、为空或重复，以及任意 later-page error 都使整个请求失败；既有 internal `Some(limit)` 是跨页总上限；不存在公共 limit/count 断言。
 - [ ] OpenAI File JSON 与错误日志不泄露 owner。
+- [ ] API-key 与 JWT 同时留下 context 字段时 scope 来源互斥；API key 的 team/user/key
+  fallback 矩阵和无 key JWT team/user 矩阵逐项覆盖，identity mismatch/invalid UUID
+  为 5xx 且不 fallback。
+- [ ] legacy owner-less metadata 的 valid purpose 可按管理员规则列出；missing/invalid
+  purpose 使 list/get 显式失败，不 skip、不猜测、不返回部分成功。
+- [ ] source-boundary test 证明五个 HTTP Files routes 全部注册 internal proof-aware
+  adapter；直接调用 proofless public wrapper 时，auth enabled 不触碰 storage，
+  auth disabled + allow-anonymous 才保持 legacy 行为。
 - [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过；S3 路径至少用 `--all-features`（或等价 `--features s3`）完成 check、Clippy 与相关测试。
 
 ## 边界情况
@@ -60,8 +129,16 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
   才回退到 API key。
 - 旧 access token 可能包含历史 guessed `team_id`；缺 provenance marker 时该字段
   必须被忽略，token 可继续作为 user-scope 身份使用。
+- access token 可能包含未来或损坏的非 1 marker；即使 `team_id` 缺失也必须整体
+  拒绝，不能把 unknown version 当 legacy。
+- version 1 token 的 membership 可能在签发后被删除、暂停或对应 team 被停用；
+  下一次认证必须 401，读取基础设施失败则必须 5xx。
 - admin owner 可能使用受限或空权限 API key；key 是权限衰减边界，不能因 owner
   的用户角色提权。
+- API-key runtime policy 可能是 malformed JSON；不能把解析失败当作空 policy。
+- API key 的 persisted `team_id` 在本 Issue 中代表 key 自身的 trusted team
+  association，不读取或继承 key owner 的 active-team selection；team/key lifecycle
+  同步与撤销策略不在本 Issue 扩展。
 - 文件可能在升级前创建且没有 owner。
 - metadata 存在但内容丢失，或删除时后端失败；S3 missing 使用 canonical NotFound，
   其他后端错误仍需遵循现有显式失败语义。
@@ -70,10 +147,29 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 - 大 bucket 的完整分页与逐对象 metadata 读取可能触发 S3 throttling/`503 Slow Down`；
   当前请求必须显式失败而不是返回未过滤或不完整列表，后续索引/缓存优化不能弱化授权。
 
+## Boundary Checklist
+
+| Category | Verdict |
+| --- | --- |
+| Empty / missing input | covered: B-005, B-007, B-009, B-011, B-012, B-016, B-018 |
+| Error and failure paths | covered: B-003, B-006, B-010, B-013, B-017, B-018 |
+| Authorization / permission | covered: B-001, B-003, B-004, B-005, B-011, B-012, B-015, B-016, B-017, B-019 |
+| Concurrency / race / ordering | covered: B-010；授权必须先于内容返回或删除，owner 不可由 caller 更新 |
+| Retry / repetition / idempotency | covered: B-002, B-006, B-013；S3 continuation 重复或缺失必须失败，不得返回部分结果 |
+| Illegal state transitions | covered: B-011, B-012, B-013, B-015 |
+| Compatibility / migration | covered: B-007, B-009, B-014, B-016, B-018, B-019；listed public structs/handlers 不改变 shape/signature |
+| Degradation / fallback | covered: B-005, B-010, B-011, B-013, B-016, B-017, B-018, B-019 |
+| Evidence and audit integrity | N/A：本 Issue 不产生审批或审计 ledger；B-008 仍约束公开响应与日志不得泄露 owner |
+| Cancellation / interruption / partial completion | covered: B-002, B-010, B-013；失败请求不得返回部分未过滤 list 或执行未授权 delete |
+
 ## 发布说明
 
 升级后新文件带有内部 owner 元数据。历史无 owner 文件仅管理员可访问；如需普通
 租户继续使用，必须由单独、经审计的迁移显式归属。升级前签发且缺 active-team
 provenance marker 的 access token 仍可认证，但其历史 `team_id` 被忽略并使用
 user scope；客户端可通过 login/refresh 的可选 `team_id` 获取经验证的新 team-scope
-token。auth 关闭的单租户开发部署保持现有行为。
+token。unknown marker 的客户端必须重新登录，不能自动降级。既有 public Rust
+method/handler signatures 与 listed public struct shapes 保留，但 raw
+`team_id: Some` access-token 签发会被安全拒绝；HTTP 客户端使用 optional `team_id`
+wire field，Rust 内部 route adapter 将其转换为既有 public request DTO。auth 关闭的
+单租户开发部署保持现有行为。

--- a/specs/GH1130/product.md
+++ b/specs/GH1130/product.md
@@ -29,12 +29,12 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 
 ## Behavior Invariants
 
-1. B-001 auth 开启时，每个新文件必须绑定一个有效租户范围；优先级为 `team_id`、其次 `user_id`、最后 `api_key_id`，不得把多个范围作为“任一匹配即可”的并列授权。
-2. B-002 非管理员只能列出与当前有效租户范围完全匹配的文件；其他租户和历史无 owner 文件不得出现在列表或计数中。
+1. B-001 auth 开启时，每个新文件必须绑定一个有效租户范围；优先级为可信 `active_team_id`、其次 `user_id`、最后 `api_key_id`，不得把多个范围作为“任一匹配即可”的并列授权。API key 的 team 来自该 key 自身；JWT/session 的 team 只能来自经服务端验证属于该 user 的 token/session active-team claim。access-token 签发和认证读取两端都禁止用 `user.team_ids.first()` 猜测；没有经验证的显式 active-team 选择时必须签发/保留 `team_id: None`，再按 user/key 回退。
+2. B-002 非管理员只能列出与当前有效租户范围完全匹配的文件；其他租户和历史无 owner 文件不得出现在列表或计数中。后端必须遍历完整分页结果，授权过滤发生在公开 limit/count 之前。
 3. B-003 metadata、content 和 delete 对非 owner 的结果必须与不存在文件不可区分，不得泄露目标文件是否存在、owner 或其他元数据。
-4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。
+4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。API key 请求只有 key 自身的直接或运行时权限明确包含 admin 能力时才是管理员；admin user 持有的受限或无 admin 能力 key 不得继承用户管理员权限。无 API key 的 JWT/session 才可按用户 admin role/RBAC 判定。
 5. B-005 auth 开启但无法解析任何有效 owner 范围时，上传和对象访问必须 fail-closed。
-6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。
+6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。S3 HeadObject 的 `NoSuchKey`/`NotFound`/HTTP 404 必须进入 canonical storage NotFound，其他 S3 错误保持 5xx。
 7. B-007 旧元数据缺少 owner 时仍可反序列化，但只对管理员可见；不得自动归属给第一个访问者。
 8. B-008 owner 信息是内部授权元数据，不得出现在 OpenAI-compatible File 响应或错误正文中。
 9. B-009 auth 明确关闭并允许匿名访问时，Files API 保持现有单租户行为，不伪造 owner。
@@ -42,22 +42,28 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 
 ## 验收标准
 
-- [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete。
+- [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete；JWT active-team claim 必须验证 membership，multi-team 且无显式 active-team 选择的登录 token 解码为 `team_id: None`，Files 使用 User scope 而非第一项。
 - [ ] team-scoped 文件不能仅因相同 `user_id` 从另一个 team 访问；有效范围优先级有测试。
 - [ ] 非 owner 与随机不存在 ID 的状态码和公开错误形状一致。
-- [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件。
+- [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件；直接 `*`/`system.admin`、runtime `is_admin`、受限 key + admin owner、无 key admin JWT 各有测试。
 - [ ] 无身份的已启用 auth 请求在上传和对象操作上 fail-closed。
-- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试。
+- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；S3 `NoSuchKey`/404 与 foreign 的公开 404 等价，非 404 S3 故障仍为 5xx。
+- [ ] S3 超过 1000 个对象时遍历 continuation token 到结束，先按 owner 过滤再应用公开 limit/count。
 - [ ] OpenAI File JSON 与错误日志不泄露 owner。
-- [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过。
+- [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过；S3 路径至少用 `--all-features`（或等价 `--features s3`）完成 check、Clippy 与相关测试。
 
 ## 边界情况
 
 - 同一 user 可能通过不同 team 或不同 API key 调用；team 范围不得被 user 匹配绕过。
-- team 缺失但 user 存在时使用 user；两者都缺失时才回退到 API key。
+- JWT user 可能属于多个 team；没有经过 membership 验证的 active-team claim 时使用
+  user scope，不得选择列表第一项。team 缺失但 user 存在时使用 user；两者都缺失时
+  才回退到 API key。
+- admin owner 可能使用受限 API key；key 是权限衰减边界，不能因 owner 的用户角色提权。
 - 文件可能在升级前创建且没有 owner。
-- metadata 存在但内容丢失，或删除时后端失败；错误仍需遵循现有显式失败语义。
+- metadata 存在但内容丢失，或删除时后端失败；S3 missing 使用 canonical NotFound，
+  其他后端错误仍需遵循现有显式失败语义。
 - list 期间单个 metadata 损坏不得导致未过滤内容泄露。
+- S3 一页最多返回有限对象，授权代码不能把第一页或 backend max_keys 当公开 limit。
 
 ## 发布说明
 

--- a/specs/GH1130/product.md
+++ b/specs/GH1130/product.md
@@ -36,25 +36,35 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 3. B-003 metadata、content 和 delete 对非 owner 的结果必须与不存在文件不可区分，不得泄露目标文件是否存在、owner 或其他元数据。
 4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。API key 请求只有 key 自身的直接或运行时权限明确包含 admin 能力时才是管理员；admin user 持有的受限、空权限或无 admin 能力 key 都不得继承用户管理员权限。无 API key 的 JWT/session 才可按用户 admin role/RBAC 判定。
 5. B-005 auth 开启但无法解析任何有效 owner 范围时，上传和对象访问必须 fail-closed。
-6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。S3 HeadObject 只有 HTTP 404 进入 canonical storage NotFound；HEAD 错误没有可依赖的响应正文或精确 exception，403、transport、timeout 与 5xx 等其他 S3 错误保持显式失败。
-7. B-007 旧元数据缺少 owner 时仍可反序列化，但只对管理员可见；不得自动归属给第一个访问者。
+6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。Local owned write 只有在 content 与完整 owner metadata 都可用后才可被 list 或对象读取看见；写入失败或发布中断不得留下可枚举但缺少完整 metadata 的 content，也不得让遗留 staging 或仅有 metadata 的记录毒化重启后的 list。S3 HeadObject 只有 HTTP 404 进入 canonical storage NotFound；HEAD 错误没有可依赖的响应正文或精确 exception，403、transport、timeout 与 5xx 等其他 S3 错误保持显式失败。
+7. B-007 只有旧元数据中 owner 字段物理缺失时才按 legacy `owner: None` 反序列化，并且只对管理员可见；owner 字段存在但为 `null`、malformed 或非 canonical scope 时是损坏 metadata，必须返回 generic 5xx，不得自动归属或降级为 legacy。
 8. B-008 owner 信息是内部授权元数据，不得出现在 OpenAI-compatible File 响应或错误正文中。
 9. B-009 auth 明确关闭并允许匿名访问时，Files API 保持现有单租户行为，不伪造 owner。
 10. B-010 所有权检查必须发生在返回内容或执行删除之前；失败不得静默降级为无过滤访问。
-11. B-011 access token 的 team provenance 是闭集状态：marker 缺失时是 legacy
-    token，必须忽略其中任何 `team_id` 并使用 User scope；marker 为 version 1 且
-    `team_id` 缺失时使用 User scope；marker 为 version 1 且 `team_id` 存在时，只有
-    当前 active membership 复验成功才使用 Team scope；任何其他 marker 值都使整个
-    bearer token 无效。未知 version、stale team 或无效 membership 均不得回退到
+11. B-011 access token 的 team provenance 是闭集状态：只有 marker 字段物理缺失时
+    才是 legacy token，必须忽略其中任何 `team_id` 并使用 User scope；marker 为
+    version 1 且 `team_id` 缺失时使用 User scope；marker 为 version 1 且 `team_id`
+    存在时，只有当前 active membership 复验成功才使用 Team scope。marker 字段存在
+    但为 `null`、non-integer、malformed 或任何非 1 数值时，整个 bearer token 都以
+    401 拒绝。上述 invalid marker、stale team 或无效 membership 均不得回退到
     User、API-key 或其他 team。
 12. B-012 `/auth/login` 与 `/auth/refresh` 的 optional `team_id` 只接受 UUID
-    格式且必须对应该 user 的当前 active membership。字段缺失时签发 version 1
-    User-scope token；malformed、foreign、missing、inactive 或 suspended selection
-    均返回稳定 400，且不得签发 access 或 refresh token。
+    格式且必须对应该 user 的当前 active membership。JSON/UUID syntactic parse
+    完成后，password 或 refresh-token primary verification 以及适用的 active-user
+    gate 必须先于任何 team/member repository 读取；错误 password、无效 refresh
+    token 或 user gate failure 的既有 generic auth 结果优先于 valid/foreign team
+    selection，且不得触发 team lookup 或 token encode。有效 refresh token 重载到
+    missing/inactive user 时统一返回稳定 generic 401，并在 team/RBAC/encode 前结束。
+    primary verification 与 user gate 成功后，字段缺失签发 version 1 User-scope
+    token；well-formed foreign、missing、inactive 或 suspended selection 统一返回稳定
+    generic 400。JSON/UUID malformed 仍由 syntactic request boundary 返回 400；所有
+    selection failure 都不得签发 access 或 refresh token。
 13. B-013 已签发 version 1 team token 的 membership 缺失或不再 active 时返回稳定
     401；user/team/membership repository、RBAC、API-key policy 或 file metadata 的
     读取、解析、转换错误返回 generic 5xx。上述错误不得被转成“无 membership”、空权限、
-    User scope、legacy store、跳过坏 metadata 或部分成功 list。
+    User scope、legacy store、跳过坏 metadata 或部分成功 list；primary credential
+    failure 也不得被后续 selection 400/5xx 覆盖，显式 null owner/marker 不得被缺失字段
+    兼容逻辑吞掉。
 14. B-014 下列既有 public Rust method call、handler signature 与 struct literal
     保持 source-compatible：Files storage 的
     `store`、`store_with_purpose`、`StorageLayer::store_file`，JWT 的
@@ -71,9 +81,9 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 16. B-016 internal persisted envelope 中的 owner 是且仅是一个 canonical UUID scope
     `{Team(Uuid), User(Uuid), ApiKey(Uuid)}`。auth-enabled Files upload 必须走 owner
     非 optional 的 additive owned-store；无效/缺失 UUID 不得变成字符串 owner 或
-    退回 legacy `owner: None`。既有非 HTTP storage 调用继续产生 legacy
-    `owner: None`；public `FileMetadata` 只呈现既有非授权字段，auth-disabled anonymous
-    route 也保持 B-009 行为。
+    退回 legacy `owner: None`，present `null` 也不是 owner 缺失。既有非 HTTP storage
+    调用继续产生字段物理缺失的 legacy `owner: None`；public `FileMetadata` 只呈现
+    既有非授权字段，auth-disabled anonymous route 也保持 B-009 行为。
 17. B-017 caller scope 的认证来源必须互斥。存在 API key 时只能按该 key 的
     `team_id -> user_id -> key UUID` 选择一个 scope，并忽略任何残留 JWT/context team；
     不存在 API key 时才按复验通过的 JWT Team -> authenticated User UUID 选择。typed
@@ -91,11 +101,17 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 ## 验收标准
 
 - [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete；login/refresh 的可选 `team_id` 必须验证 membership，新 token 带 provenance marker；multi-team 且无选择时签发 `team_id: None`，旧 token 缺 marker 时忽略其 guessed team，Files 均使用 User scope。
-- [ ] JWT 矩阵分别覆盖 legacy marker 缺失、version 1 team/no-team、unknown version
-  team/no-team；unknown version 与 stale membership 均为 401 且没有身份 fallback。
+- [ ] JWT 矩阵分别覆盖 marker 字段物理缺失、signed explicit `null`、non-integer/
+  malformed、version 1 team/no-team、unknown numeric version team/no-team；除字段物理
+  缺失可作为 legacy 外，其余 invalid marker 与 stale membership 均为 401 且没有
+  身份 fallback。
 - [ ] login/refresh 的 malformed、foreign、missing、inactive、suspended team
   selection 均为同一公开 400 且没有任何新 token；membership/team repository
   故障为 generic 5xx。
+- [ ] wrong password 与 invalid refresh token 分别搭配 valid/foreign `team_id` 时，
+  返回各自既有 generic auth failure，team/member repository call count 为 0、token
+  encode count 为 0；valid refresh token 对 missing/inactive user 在有/无 `team_id`
+  时均为同一 generic 401，并且 team/RBAC/encode call count 为 0。
 - [ ] team-scoped 文件不能仅因相同 `user_id` 从另一个 team 访问；有效范围优先级有测试。
 - [ ] 非 owner 与随机不存在 ID 的状态码和公开错误形状一致。
 - [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件；直接 `*`/`system.admin`、runtime `is_admin`、受限 key + admin owner、空权限 key + admin owner、无 key admin JWT 各有测试。
@@ -108,7 +124,12 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
   `team_id: Some` JWT 调用不生成 token，typed verified 路径可生成 team token；
   auth-enabled HTTP upload 只调用 owner 非 optional 的 owned-store，并只用 internal
   metadata-with-owner 结果授权。
-- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；S3 HeadObject HTTP 404 与 foreign 的公开 404 等价，非 404 S3 故障仍显式失败。
+- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；Local owned
+  write 的 metadata publish failure，以及 metadata 已完成但 content 尚未可见时的中断，
+  在 reopen 后都不产生可枚举或可按 ID 读取的不完整 content、不毒化 list；owner
+  字段 missing、explicit `null`、malformed 与 valid scope 四态分别得到 legacy、
+  5xx、5xx 与正常 round-trip。S3 HeadObject HTTP 404 与 foreign 的公开 404 等价，
+  非 404 S3 故障仍显式失败。
 - [ ] S3 超过 1000 个对象时以稳定 prefix 遍历 continuation token 到结束，返回全部已授权文件且不泄露其他 owner；`Some(0)` 零请求且为空，单页大小为 `min(1000, remaining)`；truncated page 的 token 缺失、为空或重复，以及任意 later-page error 都使整个请求失败；既有 internal `Some(limit)` 是跨页总上限；不存在公共 limit/count 断言。
 - [ ] OpenAI File JSON 与错误日志不泄露 owner。
 - [ ] API-key 与 JWT 同时留下 context 字段时 scope 来源互斥；API key 的 team/user/key
@@ -131,8 +152,14 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
   必须被忽略，token 可继续作为 user-scope 身份使用。
 - access token 可能包含未来或损坏的非 1 marker；即使 `team_id` 缺失也必须整体
   拒绝，不能把 unknown version 当 legacy。
+- access token 的 marker key 可能存在但值为 JSON `null`、字符串、浮点数或其他
+  malformed value；这些状态不是字段缺失，必须整体 401。
 - version 1 token 的 membership 可能在签发后被删除、暂停或对应 team 被停用；
   下一次认证必须 401，读取基础设施失败则必须 5xx。
+- login password 或 refresh token 可能无效，同时携带 valid/foreign team selection；
+  syntactic parse 后必须先返回 primary auth failure，不得查询 membership 或暴露其状态。
+- refresh token 可能签名有效但 user 已被删除或停用；必须在 team/RBAC/token encode
+  前统一 401，不能延长 refresh-token 生命周期。
 - admin owner 可能使用受限或空权限 API key；key 是权限衰减边界，不能因 owner
   的用户角色提权。
 - API-key runtime policy 可能是 malformed JSON；不能把解析失败当作空 policy。
@@ -140,6 +167,10 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
   association，不读取或继承 key owner 的 active-team selection；team/key lifecycle
   同步与撤销策略不在本 Issue 扩展。
 - 文件可能在升级前创建且没有 owner。
+- Local owned write 可能在 metadata failure 或发布中断时只留下 staging/metadata；
+  reopen 后这些非完整记录不得变成可枚举 content 或使 list 永久失败。
+- Local metadata 的 owner key 可能显式为 `null` 或 malformed；这不是历史字段缺失，
+  必须显式 5xx，不能变成管理员可见的 legacy 文件。
 - metadata 存在但内容丢失，或删除时后端失败；S3 missing 使用 canonical NotFound，
   其他后端错误仍需遵循现有显式失败语义。
 - list 期间单个 metadata 损坏不得导致未过滤内容泄露。
@@ -154,13 +185,13 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 | Empty / missing input | covered: B-005, B-007, B-009, B-011, B-012, B-016, B-018 |
 | Error and failure paths | covered: B-003, B-006, B-010, B-013, B-017, B-018 |
 | Authorization / permission | covered: B-001, B-003, B-004, B-005, B-011, B-012, B-015, B-016, B-017, B-019 |
-| Concurrency / race / ordering | covered: B-010；授权必须先于内容返回或删除，owner 不可由 caller 更新 |
+| Concurrency / race / ordering | covered: B-006, B-010, B-012, B-013；primary auth 先于 membership lookup，Local 完整 metadata 先于 content 可见，授权先于内容返回或删除 |
 | Retry / repetition / idempotency | covered: B-002, B-006, B-013；S3 continuation 重复或缺失必须失败，不得返回部分结果 |
 | Illegal state transitions | covered: B-011, B-012, B-013, B-015 |
 | Compatibility / migration | covered: B-007, B-009, B-014, B-016, B-018, B-019；listed public structs/handlers 不改变 shape/signature |
 | Degradation / fallback | covered: B-005, B-010, B-011, B-013, B-016, B-017, B-018, B-019 |
 | Evidence and audit integrity | N/A：本 Issue 不产生审批或审计 ledger；B-008 仍约束公开响应与日志不得泄露 owner |
-| Cancellation / interruption / partial completion | covered: B-002, B-010, B-013；失败请求不得返回部分未过滤 list 或执行未授权 delete |
+| Cancellation / interruption / partial completion | covered: B-002, B-006, B-010, B-013；Local 中断不得发布 ownerless content，失败请求不得返回部分未过滤 list 或执行未授权 delete |
 
 ## 发布说明
 

--- a/specs/GH1130/product.md
+++ b/specs/GH1130/product.md
@@ -34,7 +34,7 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 3. B-003 metadata、content 和 delete 对非 owner 的结果必须与不存在文件不可区分，不得泄露目标文件是否存在、owner 或其他元数据。
 4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。API key 请求只有 key 自身的直接或运行时权限明确包含 admin 能力时才是管理员；admin user 持有的受限或无 admin 能力 key 不得继承用户管理员权限。无 API key 的 JWT/session 才可按用户 admin role/RBAC 判定。
 5. B-005 auth 开启但无法解析任何有效 owner 范围时，上传和对象访问必须 fail-closed。
-6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。S3 HeadObject 的 `NoSuchKey`/`NotFound`/HTTP 404 必须进入 canonical storage NotFound，其他 S3 错误保持 5xx。
+6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。S3 HeadObject 只有 HTTP 404 进入 canonical storage NotFound；HEAD 错误没有可依赖的响应正文或精确 exception，403、transport、timeout 与 5xx 等其他 S3 错误保持显式失败。
 7. B-007 旧元数据缺少 owner 时仍可反序列化，但只对管理员可见；不得自动归属给第一个访问者。
 8. B-008 owner 信息是内部授权元数据，不得出现在 OpenAI-compatible File 响应或错误正文中。
 9. B-009 auth 明确关闭并允许匿名访问时，Files API 保持现有单租户行为，不伪造 owner。
@@ -47,7 +47,7 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 - [ ] 非 owner 与随机不存在 ID 的状态码和公开错误形状一致。
 - [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件；直接 `*`/`system.admin`、runtime `is_admin`、受限 key + admin owner、无 key admin JWT 各有测试。
 - [ ] 无身份的已启用 auth 请求在上传和对象操作上 fail-closed。
-- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；S3 `NoSuchKey`/404 与 foreign 的公开 404 等价，非 404 S3 故障仍为 5xx。
+- [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；S3 HeadObject HTTP 404 与 foreign 的公开 404 等价，非 404 S3 故障仍显式失败。
 - [ ] S3 超过 1000 个对象时遍历 continuation token 到结束，先按 owner 过滤再应用公开 limit/count。
 - [ ] OpenAI File JSON 与错误日志不泄露 owner。
 - [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过；S3 路径至少用 `--all-features`（或等价 `--features s3`）完成 check、Clippy 与相关测试。
@@ -64,6 +64,8 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
   其他后端错误仍需遵循现有显式失败语义。
 - list 期间单个 metadata 损坏不得导致未过滤内容泄露。
 - S3 一页最多返回有限对象，授权代码不能把第一页或 backend max_keys 当公开 limit。
+- 大 bucket 的完整分页与逐对象 metadata 读取可能触发 S3 throttling/`503 Slow Down`；
+  当前请求必须显式失败而不是返回未过滤或不完整列表，后续索引/缓存优化不能弱化授权。
 
 ## 发布说明
 

--- a/specs/GH1130/product.md
+++ b/specs/GH1130/product.md
@@ -29,10 +29,10 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 
 ## Behavior Invariants
 
-1. B-001 auth 开启时，每个新文件必须绑定一个有效租户范围；优先级为可信 `active_team_id`、其次 `user_id`、最后 `api_key_id`，不得把多个范围作为“任一匹配即可”的并列授权。API key 的 team 来自该 key 自身；JWT/session 的 team 只能来自经服务端验证属于该 user 的 token/session active-team claim。access-token 签发和认证读取两端都禁止用 `user.team_ids.first()` 猜测；没有经验证的显式 active-team 选择时必须签发/保留 `team_id: None`，再按 user/key 回退。
-2. B-002 非管理员只能列出与当前有效租户范围完全匹配的文件；其他租户和历史无 owner 文件不得出现在列表或计数中。后端必须遍历完整分页结果，授权过滤发生在公开 limit/count 之前。
+1. B-001 auth 开启时，每个新文件必须绑定一个有效租户范围；优先级为可信 `active_team_id`、其次 `user_id`、最后 `api_key_id`，不得把多个范围作为“任一匹配即可”的并列授权。API key 的 team 来自该 key 自身；JWT 的 team 只能来自 `/auth/login` 或 `/auth/refresh` 可选 `team_id` 经服务端验证属于该 user 后签发的 active-team claim。新 access token 必须带版本化 provenance marker；旧 token 缺 marker 时即使含 `team_id` 也忽略该 team 并回退 user scope。签发和认证读取两端都禁止用 `user.team_ids.first()` 猜测。
+2. B-002 非管理员只能列出与当前有效租户范围完全匹配的文件；其他租户和历史无 owner 文件不得出现在返回数组中。当前 Files list 没有公共 pagination/limit/count 参数，必须遍历后端完整分页并返回全部已授权文件，不得发明隐式 public limit。
 3. B-003 metadata、content 和 delete 对非 owner 的结果必须与不存在文件不可区分，不得泄露目标文件是否存在、owner 或其他元数据。
-4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。API key 请求只有 key 自身的直接或运行时权限明确包含 admin 能力时才是管理员；admin user 持有的受限或无 admin 能力 key 不得继承用户管理员权限。无 API key 的 JWT/session 才可按用户 admin role/RBAC 判定。
+4. B-004 管理员可以列出和操作所有文件，包括历史无 owner 文件。API key 请求只有 key 自身的直接或运行时权限明确包含 admin 能力时才是管理员；admin user 持有的受限、空权限或无 admin 能力 key 都不得继承用户管理员权限。无 API key 的 JWT/session 才可按用户 admin role/RBAC 判定。
 5. B-005 auth 开启但无法解析任何有效 owner 范围时，上传和对象访问必须 fail-closed。
 6. B-006 Local 与 S3 后端必须持久化、读取和列举一致的 owner 信息；进程重启后授权结果不变。S3 HeadObject 只有 HTTP 404 进入 canonical storage NotFound；HEAD 错误没有可依赖的响应正文或精确 exception，403、transport、timeout 与 5xx 等其他 S3 错误保持显式失败。
 7. B-007 旧元数据缺少 owner 时仍可反序列化，但只对管理员可见；不得自动归属给第一个访问者。
@@ -42,13 +42,13 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 
 ## 验收标准
 
-- [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete；JWT active-team claim 必须验证 membership，multi-team 且无显式 active-team 选择的登录 token 解码为 `team_id: None`，Files 使用 User scope 而非第一项。
+- [ ] 两个 API key、两个 user、两个 team 的矩阵测试覆盖 list/get/content/delete；login/refresh 的可选 `team_id` 必须验证 membership，新 token 带 provenance marker；multi-team 且无选择时签发 `team_id: None`，旧 token 缺 marker 时忽略其 guessed team，Files 均使用 User scope。
 - [ ] team-scoped 文件不能仅因相同 `user_id` 从另一个 team 访问；有效范围优先级有测试。
 - [ ] 非 owner 与随机不存在 ID 的状态码和公开错误形状一致。
-- [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件；直接 `*`/`system.admin`、runtime `is_admin`、受限 key + admin owner、无 key admin JWT 各有测试。
+- [ ] 管理员可以访问所有 owner 与 legacy 文件，普通调用者看不到 legacy 文件；直接 `*`/`system.admin`、runtime `is_admin`、受限 key + admin owner、空权限 key + admin owner、无 key admin JWT 各有测试。
 - [ ] 无身份的已启用 auth 请求在上传和对象操作上 fail-closed。
 - [ ] Local 与 S3 元数据 round-trip、旧元数据兼容和重启后读取有测试；S3 HeadObject HTTP 404 与 foreign 的公开 404 等价，非 404 S3 故障仍显式失败。
-- [ ] S3 超过 1000 个对象时遍历 continuation token 到结束，先按 owner 过滤再应用公开 limit/count。
+- [ ] S3 超过 1000 个对象时遍历 continuation token 到结束，返回全部已授权文件且不泄露其他 owner；不存在公共 limit/count 断言。
 - [ ] OpenAI File JSON 与错误日志不泄露 owner。
 - [ ] `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试及完整测试通过；S3 路径至少用 `--all-features`（或等价 `--features s3`）完成 check、Clippy 与相关测试。
 
@@ -58,7 +58,10 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 - JWT user 可能属于多个 team；没有经过 membership 验证的 active-team claim 时使用
   user scope，不得选择列表第一项。team 缺失但 user 存在时使用 user；两者都缺失时
   才回退到 API key。
-- admin owner 可能使用受限 API key；key 是权限衰减边界，不能因 owner 的用户角色提权。
+- 旧 access token 可能包含历史 guessed `team_id`；缺 provenance marker 时该字段
+  必须被忽略，token 可继续作为 user-scope 身份使用。
+- admin owner 可能使用受限或空权限 API key；key 是权限衰减边界，不能因 owner
+  的用户角色提权。
 - 文件可能在升级前创建且没有 owner。
 - metadata 存在但内容丢失，或删除时后端失败；S3 missing 使用 canonical NotFound，
   其他后端错误仍需遵循现有显式失败语义。
@@ -70,5 +73,7 @@ Files API 的存储元数据没有所有者，所有已认证调用者都可以�
 ## 发布说明
 
 升级后新文件带有内部 owner 元数据。历史无 owner 文件仅管理员可访问；如需普通
-租户继续使用，必须由单独、经审计的迁移显式归属。auth 关闭的单租户开发部署
-保持现有行为。
+租户继续使用，必须由单独、经审计的迁移显式归属。升级前签发且缺 active-team
+provenance marker 的 access token 仍可认证，但其历史 `team_id` 被忽略并使用
+user scope；客户端可通过 login/refresh 的可选 `team_id` 获取经验证的新 team-scope
+token。auth 关闭的单租户开发部署保持现有行为。

--- a/specs/GH1130/tasks.md
+++ b/specs/GH1130/tasks.md
@@ -11,14 +11,14 @@ GH-1130 / #1130
 
 ## 决策门
 
-- [ ] `SP1130-T0` Covers: B-001 ～ B-010. Owner: maintainer/spec owner. Dependencies: none. Done when: 原规格已在 `user-2026-07-27-approve-all-specs` 获批；本 amendment 的可信 active-team、API-key admin attenuation、S3 精确 NotFound 与全分页 filter-before-limit 契约再次获得内容绑定批准，Issue 保持 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+- [ ] `SP1130-T0` Covers: B-001 ～ B-010. Owner: maintainer/spec owner. Dependencies: none. Done when: amendment 审查期间 Issue 移出 `ready_to_implement`；本 amendment exact head 的可信 active-team provenance、API-key admin attenuation、S3 精确 NotFound 与全分页授权过滤契约获得内容绑定批准并合并后，才恢复 `ready_to_implement`. Verify: SpecRail workflow/spec checks 与 implement route gate。
 
 ## 实现任务
 
-- [ ] `SP1130-T1` Covers: B-001, B-004, B-005, B-009. Owner: auth implementation owner. Dependencies: SP1130-T0. Done when: `FileOwnerScope` 为单值 enum；API-key team 来自 key；`src/auth/user_management.rs` 等 token issuer 无显式 validated active-team 时签 `None`，`src/auth/system.rs` 认证 claim 时验证 membership，签发/读取均禁止 `team_ids.first()`；无可信 team 时 user/key 回退；admin 复用 canonical key permission parser且 key 不继承 owner admin role；auth-disabled 与缺身份分支明确. Verify: multi-team login token decode/scope provenance/key attenuation/RBAC/auth-disabled unit matrix.
-- [ ] `SP1130-T2` Covers: B-002, B-006, B-007, B-008. Owner: storage implementation owner. Dependencies: SP1130-T1. Done when: dispatch、Local、S3 持久化同一 owner enum；legacy `None` 兼容；S3 list 遍历 continuation 到结束；HeadObject 仅精确 404/NoSuchKey 映射 NotFound；公开 `FileObject` 不含 owner. Verify: Local/S3 round-trip、legacy、bad metadata、>1000 pagination、404/5xx tests.
-- [ ] `SP1130-T3` Covers: B-002, B-003, B-004, B-005, B-010. Owner: route implementation owner. Dependencies: SP1130-T2. Done when: list/get/content/delete 全部复用唯一授权 helper；完整候选集先授权过滤再应用公开 limit/count；foreign 与真实 missing 公开响应相同；unauthorized 不调用 backend content/delete. Verify: route mock/backend call-count tenant/filter-limit matrix.
-- [ ] `SP1130-T4` Covers: B-001 ～ B-010. Owner: security test owner. Dependencies: SP1130-T3. Done when: multi-team login no-claim token 解码和 User-scope fallback、validated active-team、same-user cross-team、multiple keys/users/teams、key direct/runtime admin、restricted key + admin owner、admin JWT、legacy、auth-disabled、日志/JSON 泄露矩阵完整. Verify: focused auth/files route/storage security tests.
+- [ ] `SP1130-T1` Covers: B-001, B-004, B-005, B-009. Owner: auth implementation owner. Dependencies: SP1130-T0. Done when: `FileOwnerScope` 为单值 enum；API-key team 来自 key；`/auth/login` 与 `/auth/refresh` 接受可选 snake_case `team_id` 并以当前 server-side membership 校验，只有 typed `VerifiedActiveTeam` 可签发 `team_id` + `team_scope_version = 1`；旧 token 缺少 marker 时忽略历史 team claim 并安全回退 user scope；签发/读取均禁止 `team_ids.first()`；admin 使用 shared crate-private direct/runtime permission parser，empty/restricted key 不继承 owner admin role；auth-disabled 与缺身份分支明确. Verify: login/refresh selection、legacy token、multi-team scope provenance、key attenuation/RBAC/auth-disabled unit matrix.
+- [ ] `SP1130-T2` Covers: B-002, B-006, B-007, B-008. Owner: storage implementation owner. Dependencies: SP1130-T1. Done when: dispatch、Local、S3 持久化同一 owner enum；legacy `None` 兼容；S3 list 遍历 continuation 到结束；HeadObject 仅以 AWS SDK `is_not_found()` 分类或 HTTP 404 映射 NotFound，不依赖 HeadObject 不提供的错误正文；公开 `FileObject` 不含 owner. Verify: Local/S3 round-trip、legacy、bad metadata、>1000 pagination、404/5xx tests.
+- [ ] `SP1130-T3` Covers: B-002, B-003, B-004, B-005, B-010. Owner: route implementation owner. Dependencies: SP1130-T2. Done when: list/get/content/delete 全部复用唯一授权 helper；全部分页候选集完成授权过滤后返回完整 authorized set，因当前 public Files API 没有 list limit/count 字段而不得虚构该契约；foreign 与真实 missing 公开响应相同；unauthorized 不调用 backend content/delete. Verify: route mock/backend call-count tenant/full-list matrix.
+- [ ] `SP1130-T4` Covers: B-001 ～ B-010. Owner: security test owner. Dependencies: SP1130-T3. Done when: login/refresh active-team 选择、invalid/stale membership、legacy unversioned claim、multi-team no-selection User-scope fallback、same-user cross-team、multiple keys/users/teams、key direct/runtime admin、empty/restricted key + admin owner、admin JWT、legacy file metadata、auth-disabled、日志/JSON 泄露矩阵完整. Verify: focused auth/files route/storage security tests.
 - [ ] `SP1130-T5` Covers: B-001 ～ B-010. Owner: verification owner. Dependencies: SP1130-T4. Done when: 既有 OR-matching/403/first-team/first-page 方案均已移除，完整 Rust/SpecRail gate 与 auth 安全人工 review 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo check --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; focused S3 tests; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
@@ -31,8 +31,8 @@ Files API 契约。实现与验证只在本 session 的 issue worktree 串行完
 
 - foreign 与 nonexistent 的 status、error type/code 和正文必须逐字等价或经稳定字段比较等价。
 - S3 测试不得访问真实 AWS；使用 feature-aware mock/fixture。
-- S3 pagination fixture 必须超过单页容量，验证 continuation token 到结束且授权过滤
-  先于公开 limit/count；S3 404 与非 404 错误分别断言。
+- S3 pagination fixture 必须超过单页容量，验证 continuation token 到结束、完整 authorized
+  list 返回且无虚构 limit/count；S3 404 与非 404 错误分别断言。
 - list 对损坏 metadata 显式失败，不允许 skip 后静默返回。
 - 最终 PR 使用 `Fixes #1130`，必须有人审查 auth/security 代码。
 

--- a/specs/GH1130/tasks.md
+++ b/specs/GH1130/tasks.md
@@ -11,26 +11,28 @@ GH-1130 / #1130
 
 ## 决策门
 
-- [ ] `SP1130-T0` Covers: B-001 ～ B-010. Owner: maintainer/spec owner. Dependencies: none. Done when: 单一 effective scope、legacy admin-only 与 foreign-as-not-found 绑定最终 spec SHA 获批，Issue 添加 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
+- [ ] `SP1130-T0` Covers: B-001 ～ B-010. Owner: maintainer/spec owner. Dependencies: none. Done when: 原规格已在 `user-2026-07-27-approve-all-specs` 获批；本 amendment 的可信 active-team、API-key admin attenuation、S3 精确 NotFound 与全分页 filter-before-limit 契约再次获得内容绑定批准，Issue 保持 `ready_to_implement`. Verify: SpecRail workflow/spec checks与 implement route gate。
 
 ## 实现任务
 
-- [ ] `SP1130-T1` Covers: B-001, B-004, B-005, B-009. Owner: auth implementation owner. Dependencies: SP1130-T0. Done when: `FileOwnerScope` 为单值 enum，caller 只从可信 context/extensions 解析 team -> user -> API key，admin 与 auth-disabled 分支明确，缺身份 fail-closed. Verify: scope priority/RBAC/auth-disabled unit matrix.
-- [ ] `SP1130-T2` Covers: B-006, B-007, B-008. Owner: storage implementation owner. Dependencies: SP1130-T1. Done when: dispatch、Local、S3 持久化同一 owner enum；legacy `None` 兼容；公开 `FileObject` 不含 owner. Verify: Local/S3 round-trip、legacy、bad metadata tests.
-- [ ] `SP1130-T3` Covers: B-002, B-003, B-004, B-005, B-010. Owner: route implementation owner. Dependencies: SP1130-T2. Done when: list/get/content/delete 全部复用唯一授权 helper；foreign 与 missing 公开响应相同；unauthorized 不调用 backend content/delete. Verify: route mock/backend call-count tenant matrix.
-- [ ] `SP1130-T4` Covers: B-001 ～ B-010. Owner: security test owner. Dependencies: SP1130-T3. Done when: same-user cross-team、multiple keys/users/teams、admin、legacy、auth-disabled、日志/JSON 泄露矩阵完整. Verify: focused files route/storage security tests.
-- [ ] `SP1130-T5` Covers: B-001 ～ B-010. Owner: verification owner. Dependencies: SP1130-T4. Done when: Claude 原 OR-matching/403 方案已移除，完整 Rust/SpecRail gate 与 auth 安全人工 review 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo clippy --all-targets -- -D warnings`; `cargo test`; workflow/spec checks; `git diff --check`.
+- [ ] `SP1130-T1` Covers: B-001, B-004, B-005, B-009. Owner: auth implementation owner. Dependencies: SP1130-T0. Done when: `FileOwnerScope` 为单值 enum；API-key team 来自 key；`src/auth/user_management.rs` 等 token issuer 无显式 validated active-team 时签 `None`，`src/auth/system.rs` 认证 claim 时验证 membership，签发/读取均禁止 `team_ids.first()`；无可信 team 时 user/key 回退；admin 复用 canonical key permission parser且 key 不继承 owner admin role；auth-disabled 与缺身份分支明确. Verify: multi-team login token decode/scope provenance/key attenuation/RBAC/auth-disabled unit matrix.
+- [ ] `SP1130-T2` Covers: B-002, B-006, B-007, B-008. Owner: storage implementation owner. Dependencies: SP1130-T1. Done when: dispatch、Local、S3 持久化同一 owner enum；legacy `None` 兼容；S3 list 遍历 continuation 到结束；HeadObject 仅精确 404/NoSuchKey 映射 NotFound；公开 `FileObject` 不含 owner. Verify: Local/S3 round-trip、legacy、bad metadata、>1000 pagination、404/5xx tests.
+- [ ] `SP1130-T3` Covers: B-002, B-003, B-004, B-005, B-010. Owner: route implementation owner. Dependencies: SP1130-T2. Done when: list/get/content/delete 全部复用唯一授权 helper；完整候选集先授权过滤再应用公开 limit/count；foreign 与真实 missing 公开响应相同；unauthorized 不调用 backend content/delete. Verify: route mock/backend call-count tenant/filter-limit matrix.
+- [ ] `SP1130-T4` Covers: B-001 ～ B-010. Owner: security test owner. Dependencies: SP1130-T3. Done when: multi-team login no-claim token 解码和 User-scope fallback、validated active-team、same-user cross-team、multiple keys/users/teams、key direct/runtime admin、restricted key + admin owner、admin JWT、legacy、auth-disabled、日志/JSON 泄露矩阵完整. Verify: focused auth/files route/storage security tests.
+- [ ] `SP1130-T5` Covers: B-001 ～ B-010. Owner: verification owner. Dependencies: SP1130-T4. Done when: 既有 OR-matching/403/first-team/first-page 方案均已移除，完整 Rust/SpecRail gate 与 auth 安全人工 review 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo check --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; focused S3 tests; `cargo test`; workflow/spec checks; `git diff --check`.
 
 ## 并行拆分
 
 不并行。auth scope、storage schema 和 route enforcement 是串行依赖，且共同触碰
-Files API 契约。单一 owner 在 `.claude/worktrees/agent-a5c5acb27baefcb98`
-完成，避免共享文件并发编辑。
+Files API 契约。实现与验证只在本 session 的 issue worktree 串行完成，避免共享文件
+并发编辑。
 
 ## 验证
 
 - foreign 与 nonexistent 的 status、error type/code 和正文必须逐字等价或经稳定字段比较等价。
 - S3 测试不得访问真实 AWS；使用 feature-aware mock/fixture。
+- S3 pagination fixture 必须超过单页容量，验证 continuation token 到结束且授权过滤
+  先于公开 limit/count；S3 404 与非 404 错误分别断言。
 - list 对损坏 metadata 显式失败，不允许 skip 后静默返回。
 - 最终 PR 使用 `Fixes #1130`，必须有人审查 auth/security 代码。
 

--- a/specs/GH1130/tasks.md
+++ b/specs/GH1130/tasks.md
@@ -11,34 +11,173 @@ GH-1130 / #1130
 
 ## 决策门
 
-- [ ] `SP1130-T0` Covers: B-001 ～ B-010. Owner: maintainer/spec owner. Dependencies: none. Done when: amendment 审查期间 Issue 移出 `ready_to_implement`；本 amendment exact head 的可信 active-team provenance、API-key admin attenuation、S3 精确 NotFound 与全分页授权过滤契约获得内容绑定批准并合并后，才恢复 `ready_to_implement`. Verify: SpecRail workflow/spec checks 与 implement route gate。
+- [ ] `SP1130-T0` Owner: maintainer/spec owner. Done when: the detailed exact-head spec gate below is satisfied. Verify: the SpecRail and exact-head evidence commands below.
+  Owner: maintainer/spec owner.
+  Dependencies: none.
+  Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
+  B-009, B-010, B-011, B-012, B-013, B-014, B-015, B-016, B-017,
+  B-018, B-019.
+  Files: spec packet only；implementation manifest 保持只读。
+  Done when: Issue 在 amendment 期间保持 `ready_to_spec`；本 amendment exact head 的
+  provenance 三态、400/401/5xx 分流、subject-bound `VerifiedActiveTeam`、public
+  struct/handler/method compatibility、互斥 caller scope、UUID owner exact wire、
+  proof-aware route adapters、legacy purpose、API-key policy fail-closed、S3 exact 404
+  与完整 pagination 通过 spec CI、独立内容复核和 content-bound human approval，
+  spec PR 合并后才设置 `ready_to_implement`。
+  Verify: `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1130`;
+  `python3 checks/route_gate.py --repo . --route write_spec --issue 1130 --state ready_to_spec --json`;
+  exact-head review evidence 与合并后 implement route gate。
 
 ## 实现任务
 
-- [ ] `SP1130-T1` Covers: B-001, B-004, B-005, B-009. Owner: auth implementation owner. Dependencies: SP1130-T0. Done when: `FileOwnerScope` 为单值 enum；API-key team 来自 key；`/auth/login` 与 `/auth/refresh` 接受可选 snake_case `team_id` 并以当前 server-side membership 校验，只有 typed `VerifiedActiveTeam` 可签发 `team_id` + `team_scope_version = 1`；旧 token 缺少 marker 时忽略历史 team claim 并安全回退 user scope；签发/读取均禁止 `team_ids.first()`；admin 使用 shared crate-private direct/runtime permission parser，empty/restricted key 不继承 owner admin role；auth-disabled 与缺身份分支明确. Verify: login/refresh selection、legacy token、multi-team scope provenance、key attenuation/RBAC/auth-disabled unit matrix.
-- [ ] `SP1130-T2` Covers: B-002, B-006, B-007, B-008. Owner: storage implementation owner. Dependencies: SP1130-T1. Done when: dispatch、Local、S3 持久化同一 owner enum；legacy `None` 兼容；S3 list 遍历 continuation 到结束；HeadObject 仅以 AWS SDK `is_not_found()` 分类或 HTTP 404 映射 NotFound，不依赖 HeadObject 不提供的错误正文；公开 `FileObject` 不含 owner. Verify: Local/S3 round-trip、legacy、bad metadata、>1000 pagination、404/5xx tests.
-- [ ] `SP1130-T3` Covers: B-002, B-003, B-004, B-005, B-010. Owner: route implementation owner. Dependencies: SP1130-T2. Done when: list/get/content/delete 全部复用唯一授权 helper；全部分页候选集完成授权过滤后返回完整 authorized set，因当前 public Files API 没有 list limit/count 字段而不得虚构该契约；foreign 与真实 missing 公开响应相同；unauthorized 不调用 backend content/delete. Verify: route mock/backend call-count tenant/full-list matrix.
-- [ ] `SP1130-T4` Covers: B-001 ～ B-010. Owner: security test owner. Dependencies: SP1130-T3. Done when: login/refresh active-team 选择、invalid/stale membership、legacy unversioned claim、multi-team no-selection User-scope fallback、same-user cross-team、multiple keys/users/teams、key direct/runtime admin、empty/restricted key + admin owner、admin JWT、legacy file metadata、auth-disabled、日志/JSON 泄露矩阵完整. Verify: focused auth/files route/storage security tests.
-- [ ] `SP1130-T5` Covers: B-001 ～ B-010. Owner: verification owner. Dependencies: SP1130-T4. Done when: 既有 OR-matching/403/first-team/first-page 方案均已移除，完整 Rust/SpecRail gate 与 auth 安全人工 review 通过. Verify: `cargo fmt --check`; `cargo check`; `cargo check --all-features`; `cargo clippy --all-targets --all-features -- -D warnings`; focused S3 tests; `cargo test`; workflow/spec checks; `git diff --check`.
+- [ ] `SP1130-T1` Owner: auth/JWT implementation owner. Done when: every detailed auth/provenance condition below is satisfied. Verify: the focused auth commands below.
+  Owner: auth/JWT implementation owner.
+  Dependencies: SP1130-T0.
+  Covers: B-001, B-005, B-011, B-012, B-013, B-014, B-015, B-016.
+  Files: `src/auth/jwt/{types,handler,tests}.rs`,
+  `src/auth/{user_management,system,tests}.rs`,
+  `src/server/routes/auth/{models,login,token,mod}.rs`（10 paths）。
+  Done when: public `Claims` 与 auth request DTO/handler signatures 不变，internal
+  access envelope 实现 exact marker 三态，private wire adapters 接收 selection 且是
+  auth route 唯一 registration；legacy 忽略 guessed team；unknown version
+  team/no-team 与 stale membership 均为 401 且不 fallback；login/refresh optional
+  UUID selection 的 malformed/foreign/missing/inactive/suspended 为 400 且 encode count
+  为零；repository/RBAC `Err` 为 5xx；只有字段私有、共享 validator 构造的
+  `VerifiedActiveTeam { user_id, team_id }` 可走 typed Team issuer，issuer 在 encode
+  前验证 proof user 等于 token subject；existing public JWT/AuthSystem 方法
+  参数/返回类型不变，raw `team_id: Some` 在 encode 前拒绝，team 与 membership 都须
+  active，所有 `team_ids.first()` 路径消失。
+  Verify: `cargo test --lib auth::jwt::tests -- --nocapture`;
+  `cargo test --lib auth::tests -- --nocapture`;
+  login/token inline tests；public signature compile fixture。
+
+- [ ] `SP1130-T2` Owner: file-storage implementation owner. Done when: every detailed storage/wire/pagination condition below is satisfied. Verify: the focused storage and S3 commands below.
+  Owner: file-storage implementation owner.
+  Dependencies: SP1130-T1.
+  Covers: B-002, B-006, B-007, B-009, B-010, B-014, B-016, B-018.
+  Files: `src/storage/files/{mod,types,storage,local,s3,tests}.rs`（6 paths）。
+  Done when: `FileOwnerScope` 仅有 Team/User/ApiKey UUID variants；public
+  `FileMetadata` 字段集合与 struct literal 保持不变；crate-private flat
+  `StoredFileMetadata` envelope 的 owner serde-defaulted，兼容 legacy bare metadata；
+  existing public Local/S3/FileStorage/StorageLayer store/metadata 方法签名不变并写
+  legacy `None`；owner adjacent-tag wire 精确为 `scope + id`；新增 owner 非 optional
+  的 crate-internal owned-store 与 metadata-with-owner；Local/S3 round-trip 一致；
+  S3 key 固定 `litellm-owner`，value 为 version 1/scope/id，只有 missing key 是
+  legacy；Local/S3 list 对 `Some(0)` 都是零 I/O/空结果；S3 稳定 prefix，以
+  `min(1000, remaining)` 遍历所有 continuation pages，检测 missing/empty/repeated
+  token，later-page error 整体失败；shared HeadObject mapper 只按 modeled
+  `is_not_found()`/raw service 404 映射 NotFound，其余保持 error。
+  Verify: `cargo test --lib storage::files::tests -- --nocapture`;
+  `cargo test --features s3 --lib storage::files::s3::tests -- --nocapture`;
+  `cargo check --all-features`。
+
+- [ ] `SP1130-T3` Owner: Files authorization/policy implementation owner. Done when: every detailed caller/route/concealment condition below is satisfied. Verify: the focused policy/route commands below.
+  Owner: Files authorization/policy implementation owner.
+  Dependencies: SP1130-T2.
+  Covers: B-001, B-002, B-003, B-004, B-005, B-008, B-009, B-010,
+  B-013, B-014, B-016, B-017, B-018, B-019.
+  Files: `src/server/routes/ai/context.rs`,
+  `src/server/middleware/auth.rs`, `src/server/routes/ai/{files,mod}.rs`（4 paths）。
+  Done when: checked API-key helper 对 direct/runtime admin、empty/restricted key 与
+  malformed policy 返回精确 Result；任何 API key 都阻止 admin-owner role fallback；
+  middleware policy/check `Err` 为 generic 5xx；FileCaller 的 ApiKey 与 JWT branches
+  互斥，key branch 只按 key team/user/id，JWT branch 只按 verified team/user，
+  principal/context mismatch 或 invalid UUID 为 5xx 且不 fallback；auth-enabled
+  upload 只调用 owned-store；list/get/content/delete 共用唯一 authorization helper；
+  legacy missing/invalid purpose 整体显式失败；完整 candidates 过滤后才返回；
+  metadata error 不 skip；foreign 与 missing 公开 404 完全等价；unauthorized 不读取
+  content、不删除。五个 public Files handlers 保持签名，proofless call 在 auth-enabled
+  时零 storage calls；HTTP routes 只注册 private proof-aware adapters。
+  Verify: `cargo test --lib server::routes::ai::context::tests -- --nocapture`;
+  focused route mock call-count/error-shape tests；source review 证明没有 legacy-store
+  fallback。
+
+- [ ] `SP1130-T4` Owner: security integration-test owner. Done when: the complete detailed security matrix below is implemented. Verify: the integration targets below.
+  Owner: security integration-test owner.
+  Dependencies: SP1130-T3.
+  Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
+  B-009, B-010, B-011, B-012, B-013, B-014, B-015, B-016, B-017,
+  B-018, B-019.
+  Files: `tests/files_routes.rs`,
+  `tests/integration/auth_middleware_tests_parts/mod.rs`,
+  `tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs`,
+  `tests/public_api_compat.rs`（4 paths）。
+  Done when: integration matrix 覆盖 two users/teams/keys、same-user cross-team、
+  multi-team no-selection、legacy/1/unknown markers（team Some/None）、stale/inactive
+  membership、selection 400、token 401、repository/RBAC/policy/metadata 5xx、direct/
+  runtime/empty/restricted/corrupt key + admin owner、admin JWT、legacy files、
+  auth-disabled、key-vs-JWT exclusive scope/mismatch、legacy purpose、完整 list、
+  foreign/missing、owner/policy redaction、public struct/handler/method compile、
+  private adapter registration 与 proofless-wrapper backend call counts；S3 fixture
+  不访问真实 AWS。
+  Verify: `cargo test --all-features --test files_routes -- --nocapture`;
+  `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture`;
+  `cargo test --all-features --test public_api_compat -- --nocapture`;
+  T1/T2 的完整 module commands。
+
+- [ ] `SP1130-T5` Owner: verification owner + independent human security reviewer. Done when: every detailed current-head gate below is green. Verify: the complete verification set below.
+  Owner: verification owner + independent human security reviewer.
+  Dependencies: SP1130-T4.
+  Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008,
+  B-009, B-010, B-011, B-012, B-013, B-014, B-015, B-016, B-017,
+  B-018, B-019.
+  Files: read-only verification；findings 返回对应 owner，不新增 manifest path。
+  Done when: implementation diff 恰好是 tech manifest 的 24 paths；OR matching、
+  foreign 403、first-team、unknown-version fallback、first-page、policy-error 403/detail、
+  metadata skip 与 destructive public signature changes 全部不存在；focused/full Rust
+  gates、SpecRail checks、current-head CI、resolved review threads 与 independent
+  auth/security human review 全部通过；listed public structs/handlers 未改变，
+  proofless route bypass 不存在，legacy bare/new envelope compatibility 有 fresh
+  evidence。最终实现 PR 使用
+  `Fixes #1130`；未经 human merge authorization 不合并。
+  Verify: 下列完整 verification set 与 current-head PR gate evidence。
 
 ## 并行拆分
 
-不并行。auth scope、storage schema 和 route enforcement 是串行依赖，且共同触碰
-Files API 契约。实现与验证只在本 session 的 issue worktree 串行完成，避免共享文件
-并发编辑。
+不并行写。T1 → T2 → T3 → T4 是串行依赖；每步只有一个 writer，文件 ownership
+如上且无重叠并发。T5 只读。任何新发现若需要 manifest 外文件，停止实现并回到
+SP1130-T0 的 spec amendment/human approval gate。
 
 ## 验证
 
-- foreign 与 nonexistent 的 status、error type/code 和正文必须逐字等价或经稳定字段比较等价。
-- S3 测试不得访问真实 AWS；使用 feature-aware mock/fixture。
-- S3 pagination fixture 必须超过单页容量，验证 continuation token 到结束、完整 authorized
-  list 返回且无虚构 limit/count；S3 404 与非 404 错误分别断言。
-- list 对损坏 metadata 显式失败，不允许 skip 后静默返回。
-- 最终 PR 使用 `Fixes #1130`，必须有人审查 auth/security 代码。
+- `cargo fmt --check`
+- `cargo check`
+- `cargo check --all-features`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --lib auth::jwt::tests -- --nocapture`
+- `cargo test --lib auth::tests -- --nocapture`
+- `cargo test --lib storage::files::tests -- --nocapture`
+- `cargo test --features s3 --lib storage::files::s3::tests -- --nocapture`
+- `cargo test --all-features --test files_routes -- --nocapture`
+- `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture`
+- `cargo test --all-features --test public_api_compat -- --nocapture`
+- `cargo test`
+- `python3 checks/check_workflow.py --repo .`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1130`
+- `python3 checks/route_gate.py --repo . --route write_spec --issue 1130 --state ready_to_spec --json`
+- `git diff --check`
+- manifest JSON 必须 parse、`issue == 1130`、`complete == true`、path count/set
+  恰好为 24、全部存在且无重复，`spec_refs` 与 product B-ID set 完全相等。
+- product B-ID set、tech mapping set、task `Covers:` union 必须都是
+  B-001 ～ B-019，无 orphan/missing ID。
+- focused test filter 若匹配 0 tests 不算通过；必须同时有完整 module/target output。
+- foreign/nonexistent status、error type/code/body 必须等价；unknown/stale token
+  为 401；selection 为 400；repository/RBAC/policy/storage `Err` 为 generic 5xx。
+- S3 pagination fixture 必须超过一页并验证 continuation 到结束、missing/repeat token
+  failure 与 cross-page `Some(limit)`；不得访问真实 AWS。
+- compile/source-boundary fixture 必须证明 existing public
+  `FileMetadata`/`Claims`/auth request struct literals、store/metadata/JWT/auth/Files
+  handler call signatures 不变，且 auth/Files HTTP routes 只注册 private wire/proof
+  adapters；proofless Files wrappers 在 auth-enabled 时零 storage calls。
 
 ## Handoff Notes
 
-- Claude 原 `FileOwner { user_id, team_id, api_key_id }` + 任一匹配会产生跨 team bypass。
-- Claude 原 foreign `403` 可被用作文件存在性 oracle；按规格改为 uniform not-found。
-- 旧文件不自动归属，只有 admin 可见。
-- 不自动合并、不 force-push。
+- 被否决的 `FileOwner { user_id, team_id, api_key_id }` + 任一匹配方案会产生
+  same-user cross-team bypass。
+- 被否决的 raw-team JWT issuer 无法证明 provenance；只有
+  `VerifiedActiveTeam` typed path 可签 Team token。
+- 被否决的 foreign 403 是存在性 oracle；按规格使用 uniform 404。
+- legacy 文件不自动归属；auth-enabled 时仅 admin 可见。
+- 当前 human gate 未满足：本 amendment exact head 尚无 content-bound approval、
+  未合并，Issue 必须保持 `ready_to_spec`，不得启动实现。
+- 本 task edit 不 commit、push、comment、resolve thread 或 merge。

--- a/specs/GH1130/tasks.md
+++ b/specs/GH1130/tasks.md
@@ -19,11 +19,15 @@ GH-1130 / #1130
   B-018, B-019.
   Files: spec packet only；implementation manifest 保持只读。
   Done when: Issue 在 amendment 期间保持 `ready_to_spec`；本 amendment exact head 的
-  provenance 三态、400/401/5xx 分流、subject-bound `VerifiedActiveTeam`、public
-  struct/handler/method compatibility、互斥 caller scope、UUID owner exact wire、
-  proof-aware route adapters、legacy purpose、API-key policy fail-closed、S3 exact 404
-  与完整 pagination 通过 spec CI、独立内容复核和 content-bound human approval，
-  spec PR 合并后才设置 `ready_to_implement`。
+  provenance/owner presence-aware 状态、primary-auth-before-team 顺序、inactive refresh
+  拒绝、Local staged atomic visibility、400/401/5xx 分流、subject-bound
+  `VerifiedActiveTeam`、public struct/handler/method compatibility、互斥 caller
+  scope、UUID owner exact wire、proof-aware route adapters、legacy purpose、API-key
+  policy fail-closed、S3 exact 404 与完整 pagination 通过 spec CI、独立内容复核和
+  content-bound human approval；本 exact head 的五条 review findings 均在对应
+  B-ID、设计与测试任务中闭合，但 review thread 仍由 human/process 决定是否
+  resolve，human approval gate 保持 open；spec PR 合并后才设置
+  `ready_to_implement`。
   Verify: `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1130`;
   `python3 checks/route_gate.py --repo . --route write_spec --issue 1130 --state ready_to_spec --json`;
   exact-head review evidence 与合并后 implement route gate。
@@ -38,11 +42,18 @@ GH-1130 / #1130
   `src/auth/{user_management,system,tests}.rs`,
   `src/server/routes/auth/{models,login,token,mod}.rs`（10 paths）。
   Done when: public `Claims` 与 auth request DTO/handler signatures 不变，internal
-  access envelope 实现 exact marker 三态，private wire adapters 接收 selection 且是
-  auth route 唯一 registration；legacy 忽略 guessed team；unknown version
-  team/no-team 与 stale membership 均为 401 且不 fallback；login/refresh optional
-  UUID selection 的 malformed/foreign/missing/inactive/suspended 为 400 且 encode count
-  为零；repository/RBAC `Err` 为 5xx；只有字段私有、共享 validator 构造的
+  access envelope 以 crate-private presence-aware 状态区分 marker
+  `Absent` 与 `Present(valid)`；只有物理字段缺失走 legacy，显式 null、非整数、
+  malformed 与 unknown numeric value 均为 401 且不 fallback；private wire adapters
+  接收 selection 且是 auth route 唯一 registration。request JSON 与 UUID 完成语法
+  解析后，login 必须先校验 password 及 applicable active-user gate，refresh 必须先
+  校验 refresh token、reload user 并要求 user active，之后才允许任何 team/member
+  repository call；wrong password/invalid refresh × valid/foreign team 全部以 primary
+  auth 结果优先，team repository count 与 encode count 均为零；valid refresh 的
+  missing/inactive user × selection `Some`/`None` 全部返回稳定 generic 401，team/RBAC/
+  encode count 均为零。primary auth 通过后，selection 的 foreign/missing/inactive/
+  suspended 才为 400 且 encode count 为零；repository/RBAC `Err` 为 5xx；legacy
+  token 忽略 guessed team；只有字段私有、共享 validator 构造的
   `VerifiedActiveTeam { user_id, team_id }` 可走 typed Team issuer，issuer 在 encode
   前验证 proof user 等于 token subject；existing public JWT/AuthSystem 方法
   参数/返回类型不变，raw `team_id: Some` 在 encode 前拒绝，team 与 membership 都须
@@ -58,15 +69,28 @@ GH-1130 / #1130
   Files: `src/storage/files/{mod,types,storage,local,s3,tests}.rs`（6 paths）。
   Done when: `FileOwnerScope` 仅有 Team/User/ApiKey UUID variants；public
   `FileMetadata` 字段集合与 struct literal 保持不变；crate-private flat
-  `StoredFileMetadata` envelope 的 owner serde-defaulted，兼容 legacy bare metadata；
+  `StoredFileMetadata` envelope 以 `OwnerField::Absent | Present(valid)` 区分物理
+  owner key 缺失与存在；只有 `Absent` 兼容 legacy bare metadata，显式 null、
+  malformed、unknown scope 或 invalid UUID 都是 generic 5xx，不能降级为 legacy。
   existing public Local/S3/FileStorage/StorageLayer store/metadata 方法签名不变并写
-  legacy `None`；owner adjacent-tag wire 精确为 `scope + id`；新增 owner 非 optional
-  的 crate-internal owned-store 与 metadata-with-owner；Local/S3 round-trip 一致；
-  S3 key 固定 `litellm-owner`，value 为 version 1/scope/id，只有 missing key 是
-  legacy；Local/S3 list 对 `Some(0)` 都是零 I/O/空结果；S3 稳定 prefix，以
-  `min(1000, remaining)` 遍历所有 continuation pages，检测 missing/empty/repeated
-  token，later-page error 整体失败；shared HeadObject mapper 只按 modeled
-  `is_not_found()`/raw service 404 映射 NotFound，其余保持 error。
+  legacy `Absent`；owner adjacent-tag wire 精确为 `scope + id`；新增 owner 非
+  optional 的 crate-internal owned-store 与 metadata-with-owner；Local legacy/owned
+  写入共用 same-filesystem、current list traversal 不可枚举的 private staging：
+  content 与完整 metadata 均写完并 close 后，先 atomic rename 发布 final `.meta`，
+  再 atomic rename final content，且 content rename 是唯一可见性 commit。metadata
+  write/publish 失败必须清理且不能留下 final content；metadata 已发布而 content
+  commit 前中断只可留下 staging/meta-only，reopen/list 必须忽略（允许清理）这些
+  残留；list 同时忽略 staging 与 `.meta`，direct metadata/object lookup 也必须把
+  meta-only 当未提交记录而不公开。测试须注入 metadata failure 与
+  meta-published-before-content interruption，并重建 storage 验证不会枚举、不能按
+  ID 读取且不阻塞后续操作。Local/S3 owned round-trip 一致；S3 contract 不受 Local
+  协议影响：
+  key 固定 `litellm-owner`，value 为 version 1/scope/id，只有 missing key 是
+  legacy，严格 metadata 错误保持不变；Local/S3 list 对 `Some(0)` 都是零 I/O/空
+  结果；S3 稳定 prefix，以 `min(1000, remaining)` 遍历所有 continuation pages，
+  检测 missing/empty/repeated token，later-page error 整体失败；shared HeadObject
+  mapper 只按 modeled `is_not_found()`/raw service 404 映射 NotFound，其余保持
+  error。
   Verify: `cargo test --lib storage::files::tests -- --nocapture`;
   `cargo test --features s3 --lib storage::files::s3::tests -- --nocapture`;
   `cargo check --all-features`。
@@ -103,13 +127,20 @@ GH-1130 / #1130
   `tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs`,
   `tests/public_api_compat.rs`（4 paths）。
   Done when: integration matrix 覆盖 two users/teams/keys、same-user cross-team、
-  multi-team no-selection、legacy/1/unknown markers（team Some/None）、stale/inactive
-  membership、selection 400、token 401、repository/RBAC/policy/metadata 5xx、direct/
-  runtime/empty/restricted/corrupt key + admin owner、admin JWT、legacy files、
-  auth-disabled、key-vs-JWT exclusive scope/mismatch、legacy purpose、完整 list、
-  foreign/missing、owner/policy redaction、public struct/handler/method compile、
-  private adapter registration 与 proofless-wrapper backend call counts；S3 fixture
-  不访问真实 AWS。
+  multi-team no-selection、marker physical absence/1/explicit-null/noninteger/malformed/
+  unknown numeric（team Some/None）、stale/inactive membership、owner physical
+  absence/explicit-null/malformed/valid、selection 400、token 401、repository/RBAC/
+  policy/metadata 5xx；wrong password/invalid refresh × valid/foreign selection 验证
+  primary auth 响应优先且 team repository/encode count 为零；valid refresh 的
+  missing/inactive user × selection `Some`/`None` 验证 stable generic 401 且 team/
+  RBAC/encode count 为零；Local metadata failure 与 meta-published-before-content
+  interruption 后以新 storage instance 验证 staging/meta-only 不可枚举且不可按 ID
+  读取。matrix 同时覆盖 direct/runtime/empty/restricted/corrupt key + admin owner、
+  admin JWT、legacy files、auth-disabled、key-vs-JWT exclusive scope/mismatch、legacy
+  purpose、完整 list、foreign/missing、owner/policy redaction、public
+  struct/handler/method compile、private adapter registration 与 proofless-wrapper
+  backend call counts；S3 fixture 不访问真实 AWS，且 missing-key-only legacy、strict
+  metadata、完整 pagination 与 HeadObject exact 404 contract 全部保持。
   Verify: `cargo test --all-features --test files_routes -- --nocapture`;
   `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture`;
   `cargo test --all-features --test public_api_compat -- --nocapture`;
@@ -124,12 +155,17 @@ GH-1130 / #1130
   Files: read-only verification；findings 返回对应 owner，不新增 manifest path。
   Done when: implementation diff 恰好是 tech manifest 的 24 paths；OR matching、
   foreign 403、first-team、unknown-version fallback、first-page、policy-error 403/detail、
-  metadata skip 与 destructive public signature changes 全部不存在；focused/full Rust
-  gates、SpecRail checks、current-head CI、resolved review threads 与 independent
-  auth/security human review 全部通过；listed public structs/handlers 未改变，
-  proofless route bypass 不存在，legacy bare/new envelope compatibility 有 fresh
-  evidence。最终实现 PR 使用
-  `Fixes #1130`；未经 human merge authorization 不合并。
+  metadata skip、marker/owner null-as-absent、pre-auth team lookup、inactive refresh
+  issuance、Local final-content-first publish 与 destructive public signature changes
+  全部不存在；所有 focused/full Rust gates 与 SpecRail checks 都使用本 session、
+  exact current head 的 fresh output，current-head CI、reviewer/process disposition
+  的全部 review threads 与 independent auth/security human review 全部通过；agent
+  不自行 resolve thread 或关闭 human approval gate。listed public
+  `Claims`/`FileMetadata`/DTO/handlers/methods 未改变，proofless route bypass 不存在，
+  legacy bare/new envelope compatibility、四态 owner、六态 marker、primary-auth
+  precedence、inactive refresh rejection 与 Local failure/interruption recovery 均有
+  fresh evidence。最终实现 PR 使用 `Fixes #1130`；未经 human merge authorization
+  不合并。
   Verify: 下列完整 verification set 与 current-head PR gate evidence。
 
 ## 并行拆分
@@ -163,6 +199,20 @@ SP1130-T0 的 spec amendment/human approval gate。
 - focused test filter 若匹配 0 tests 不算通过；必须同时有完整 module/target output。
 - foreign/nonexistent status、error type/code/body 必须等价；unknown/stale token
   为 401；selection 为 400；repository/RBAC/policy/storage `Err` 为 generic 5xx。
+- marker matrix 必须区分物理 absent、valid `1`、explicit null、noninteger、
+  malformed 与 unknown numeric；只有 absent 可 legacy fallback，其余非法状态均为
+  401。owner matrix 必须区分物理 missing、explicit null、malformed 与 valid；只有
+  missing 是 legacy，null/malformed 都是 generic 5xx。
+- 完成 request JSON/UUID 语法解析后必须先验证 primary credential 与 applicable
+  active-user gate，再访问 team/member repository。wrong password/invalid refresh ×
+  valid/foreign team 必须验证 team repository count = 0、encode count = 0；
+  valid refresh 的 missing/inactive user × selection `Some`/`None` 必须验证 generic
+  401 且 team/RBAC/encode count = 0。
+- Local fixture 必须分别注入 metadata write/publish failure，以及 final `.meta`
+  publish 后、final content rename 前的 interruption；重建 storage 后 list/reopen
+  与 direct lookup 必须忽略 staging/meta-only，且没有 incomplete content 可见。S3 的
+  missing-key-only legacy、strict metadata、pagination 与 exact 404 测试不得因该
+  Local 修复改变。
 - S3 pagination fixture 必须超过一页并验证 continuation 到结束、missing/repeat token
   failure 与 cross-page `Some(limit)`；不得访问真实 AWS。
 - compile/source-boundary fixture 必须证明 existing public
@@ -176,8 +226,17 @@ SP1130-T0 的 spec amendment/human approval gate。
   same-user cross-team bypass。
 - 被否决的 raw-team JWT issuer 无法证明 provenance；只有
   `VerifiedActiveTeam` typed path 可签 Team token。
+- 被否决的 serde-defaulted `Option` 会把 explicit null 与字段缺失合并；owner 与
+  provenance 都必须使用 crate-private presence-aware state，public
+  `FileMetadata`/`Claims` 不变。
+- 被否决的 pre-auth team lookup 会让 selection 400/5xx 覆盖 wrong-password/
+  invalid-refresh 结果；语法解析后必须先完成 primary auth 与 active-user gate。
+- 被否决的 inactive refresh user token renewal，以及 Local final-content-first
+  publish，分别会续签失效主体与暴露 incomplete content；两者都必须由上述
+  negative/call-count/failure-injection matrix 拦截。
 - 被否决的 foreign 403 是存在性 oracle；按规格使用 uniform 404。
 - legacy 文件不自动归属；auth-enabled 时仅 admin 可见。
 - 当前 human gate 未满足：本 amendment exact head 尚无 content-bound approval、
-  未合并，Issue 必须保持 `ready_to_spec`，不得启动实现。
+  五条 review thread 仍需 reviewer/process disposition，spec PR 未合并，Issue 必须
+  保持 `ready_to_spec`，不得启动实现。
 - 本 task edit 不 commit、push、comment、resolve thread 或 merge。

--- a/specs/GH1130/tech.md
+++ b/specs/GH1130/tech.md
@@ -12,7 +12,7 @@ GH-1130 / #1130
 
 | Area | Files | Current behavior | Why relevant |
 | --- | --- | --- | --- |
-| Request identity | `src/auth/user_management.rs`, `src/auth/system.rs`, `src/server/routes/ai/context.rs`, `src/core/types/context.rs` | JWT 签发与认证当前都可能把 `user.team_ids.first()` 当 team；API key 带自身 team；权限 helper 已实现 key attenuation | token 签发和读取两端都必须消除 guessed team，owner/admin 来自可信、无提权的 extension/context |
+| Request identity | `src/auth/{user_management,system}.rs`, `src/auth/jwt/{types,handler}.rs`, `src/server/routes/auth/{models,login,token}.rs`, `src/server/routes/ai/context.rs`, `src/core/types/context.rs` | 一个内部 login 路径签发 first-team，JWT 认证读取也重新选择 first-team；HTTP login/refresh 没有 active-team 输入；旧 token 无 provenance；空权限 key 会回退 admin owner | 增加服务端验证的 login/refresh team selection 与版本化 claim，旧 guessed claim 安全降级；Files admin 必须把任何 API key 当 attenuation boundary |
 | Files routes | `src/server/routes/ai/files.rs` | handler 只按裸 `file_id` 操作 | 所有对象级 bypass |
 | Metadata | `src/storage/files/types.rs` | `FileMetadata` 没有 owner | 持久化根因 |
 | Storage dispatch | `src/storage/files/storage.rs` | store API 不接收 owner | Local/S3 必须一致 |
@@ -29,16 +29,23 @@ GH-1130 / #1130
 2. 在 files route 的 crate-private helper 中从可信 request extensions/context 解析
    `FileCaller { auth_enforced, is_admin, effective_scope }`：
    - API key 请求的 active team 只能是已验证 `ApiKey.team_id`。
-   - JWT/session 的 active team 只能是签发时写入、认证时再次验证属于该 user 的
-     token/session claim；现有 `user.team_ids.first()` 不是 active-team 事实，Files
-     路径不得读取它。`user_management.rs` 等 access-token 签发路径也不得从
-     membership 列表选择第一项；没有服务端已验证的显式 active-team selection 时
-     必须签发 `team_id: None`。认证时 claim 缺失、无 membership 或存在歧义时不设置
-     team，并按 non-empty user -> API key 回退；不得新增或信任客户端自报 header。
+   - `LoginRequest` 与 `RefreshTokenRequest` 增加 optional snake_case `team_id`。
+     login/refresh handler 读取数据库中的 current user memberships；缺失时签发
+     user-scope token，存在时只在 exact membership match 后签发，否则稳定拒绝且
+     不生成 token。`AuthSystem::login` 同步接受 optional selection 并复用同一
+     validator，禁止 `user.team_ids.first()`。
+   - access-token `Claims` 增加 `#[serde(default)] team_scope_version: Option<u8>`；
+     本 tranche 唯一接受值为 `Some(1)`。只有通过上述 validator 的 typed
+     `VerifiedActiveTeam` 才能同时写入 `team_id` 与 version 1；无选择的新 token
+     写 `team_id: None`/version 1。旧 token 因字段缺失解码为 `None`：即使其中有
+     历史 guessed `team_id`，认证也忽略该 team，但 token 仍作为 user-scope 身份。
+     version 1 的 team 仍须在认证时再次验证 current membership；失败时拒绝 token，
+     不得静默切换其他 team。不得新增或信任客户端自报 header。
    - API key 存在时，admin 只能由该 key 的直接 `*`/`system.admin` 或 runtime
-     `is_admin`/等价 admin permission 授予，复用/暴露 `context.rs` 现有 canonical
-     key-permission parser，禁止再实现一套解析，也禁止回退到 key owner 的用户角色。
-     无 API key 的 JWT/session 才按 canonical user admin role/RBAC 判定。
+     `is_admin`/等价 admin permission 授予。把 `context.rs` 现有 direct/runtime
+     admin parser 暴露为唯一 crate-private helper 供 Files caller 复用；只要 API key
+     存在，受限、空 permissions、runtime payload absent 都不得回退到 key owner 的
+     用户角色。无 API key 的 JWT/session 才按 canonical user admin role/RBAC 判定。
    有效 scope 严格按 trusted team -> non-empty user -> API key 优先；auth 开启且
    普通调用者没有 scope 时返回显式 auth/permission error。
 3. 扩展 `FileStorage::{store,store_with_purpose}` 及 Local/S3 对应入口接收 owner。
@@ -48,11 +55,12 @@ GH-1130 / #1130
    admin 允许全部；普通调用者仅当单一 effective scope 与 owner 完全相等时允许；
    `owner: None` 仅 admin。该 helper 供 list/get/content/delete 共同使用。
 5. list 读取 metadata 后先过滤再构造公开 `FileObject`；任何 metadata 解析错误显式
-   返回 error，禁止跳过损坏项并给出不完整/未过滤结果。Local/S3 storage listing
-   必须返回完整候选集：S3 循环 `ListObjectsV2` continuation token 直到
-   `is_truncated=false`，检测 token 缺失/重复并显式失败。route 对完整候选集完成
-   metadata 读取和 owner 过滤后，才应用 API 的 limit/count；不得把 `max_keys=limit`
-   下推到未授权候选集。公开对象不序列化 owner。
+   返回 error，禁止跳过损坏项并给出不完整/未过滤结果。当前 route 没有 query
+   pagination/limit/count，公开响应只有 `object` 与 `data`，因此返回全部已授权文件，
+   不新增 public limit。Local/S3 storage listing 必须返回完整候选集：S3 循环
+   `ListObjectsV2` continuation token 直到 `is_truncated=false`，检测 token
+   缺失/重复并显式失败；Files route 保持调用 `list(None, None)`，不得把内部
+   `max_keys` 当公开截断。公开对象不序列化 owner。
 6. get/content/delete 对非 owner 使用与 missing file 相同的 canonical `NotFound`
    状态、错误 type/code 和不含 file/owner 细节的正文。S3 `HeadObject` mapper 使用
    Rust SDK `HeadObjectError::is_not_found()` 判定服务 HTTP 404；HEAD 错误响应没有
@@ -68,8 +76,8 @@ GH-1130 / #1130
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | effective scope resolver + enum | API-key team、JWT validated active team、multi-team no-claim、user/key fallback |
-| B-002 | paginated list + filter | 多 tenant + legacy + >1000 S3 objects；过滤后 limit/count |
+| B-001 | token selection/provenance + effective scope resolver + enum | login/refresh valid/foreign/no team、version 1、legacy no-marker、API-key team、multi-team no-claim、user/key fallback |
+| B-002 | paginated list + filter | 多 tenant + legacy + >1000 S3 objects；返回全部 authorized data，无 public limit/count |
 | B-003 | uniform concealment response | foreign 与 Local/S3 random missing 的 status/body 等价 |
 | B-004/B-005 | caller resolver/canonical RBAC | key direct/runtime admin、restricted key + admin owner、admin JWT、无 scope |
 | B-006/B-007 | Local/S3 serialization + error mapper | round-trip、legacy、restart、S3 404/非 404 |
@@ -79,14 +87,17 @@ GH-1130 / #1130
 
 ## 数据流
 
-token issuer 仅把服务端已验证的显式 active-team selection 写入 JWT，否则写
-`team_id: None`。auth middleware 将可信 user/API key 与 `RequestContext` 放入 request
-extensions；JWT active-team claim 只有在验证 user membership 后才进入 Files caller，
-签发/读取两端都不能复用 `team_ids.first()`。Files handler 解析一个有效 caller scope；upload 把该 scope随
-metadata 交给 storage。
+login/refresh 接收 optional `team_id` 并验证 current membership；token issuer 只把
+typed verified selection 与 `team_scope_version=1` 写入 JWT，否则写
+`team_id: None`。旧 access token 缺 version 时忽略历史 team claim并保持 user-scope
+认证。auth middleware 将可信 user/API key 与 `RequestContext` 放入 request
+extensions；version 1 JWT active-team claim 只有在再次验证 membership 后才进入
+Files caller，签发/读取两端都不能复用 `team_ids.first()`。Files handler 解析一个
+有效 caller scope；upload 把该 scope随 metadata 交给 storage。
 后续 list 或 object 操作先读取 metadata，使用唯一授权 helper 判定，再返回公开对象、
-content 或执行 delete。S3 list 先遍历全部 continuation pages，再由 route 过滤/limit；
-Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None` 只能通过 admin 路径。
+content 或执行 delete。S3 list 先遍历全部 continuation pages，再由 route 过滤并返回
+完整 authorized set；Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None`
+只能通过 admin 路径。
 
 ## 备选方案
 
@@ -100,9 +111,12 @@ Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None` 只能通过
 
 - Security: owner scope、admin 判定和 concealment 是 auth 敏感面，必须人工 review。
 - Security: API key 是 permission attenuation boundary；不得让 admin user 身份抬高
-  受限 key 权限，也不得把任意 team membership 当 active team。
-- Compatibility: 历史文件普通用户将不可见；这是明确的 fail-closed 迁移。
-- Performance/Availability: 正确的跨租户 limit 要先遍历/过滤 S3 candidates，
+  受限/空权限 key 权限，也不得把任意 team membership 当 active team。旧 token 的
+  guessed team 必须因缺 version marker 被忽略。
+- Compatibility: 历史文件普通用户将不可见；这是明确的 fail-closed 迁移。旧 access
+  token 继续作为 user-scope 身份有效，但不再保留 guessed team scope；需要 team
+  scope 的客户端通过 login/refresh 的 optional `team_id` 获取新 token。
+- Performance/Availability: 完整的跨租户授权列表要先遍历/过滤全部 S3 candidates，
   可能增加大量分页与逐对象 `HeadObject`，在大 bucket/高并发下可能触发
   throttling 或 `503 Slow Down` 并使整个 list 显式失败。实现应保持 bounded
   concurrency/retry 与 fail-closed，不得为可用性跳过 metadata 或返回部分未过滤
@@ -112,10 +126,10 @@ Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None` 只能通过
 
 ## 测试计划
 
-- [ ] Unit tests: enum serde、trusted active-team scope priority、key attenuation、ownership、uniform not-found。
+- [ ] Unit tests: enum serde、login/refresh team membership、versioned/legacy claims、trusted active-team scope priority、empty/restricted key attenuation、ownership、uniform not-found。
 - [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata、HeadObject SDK `is_not_found()`/非 404、>1000 object pagination，以及 throttling/503 保持显式失败。
-- [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵、filter-before-limit 与 backend call count。
-- [ ] Security tests: multi-team login token 解码为 no-team 且 Files 回退 User scope、validated active-team claim、cross-team same-user、restricted key + admin owner、日志/JSON owner 泄露、unauthorized delete no-op。
+- [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵、完整 authorized list 与 backend call count。
+- [ ] Security tests: login/refresh valid/foreign/no-team selection、legacy no-marker token 回退 User scope、version 1 active-team claim、cross-team same-user、restricted/empty key + admin owner、日志/JSON owner 泄露、unauthorized delete no-op。
 - [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`；S3 feature 用 `cargo check --all-features`、`cargo clippy --all-targets --all-features -- -D warnings` 与相关 S3 tests。
 
 ## 回滚方案

--- a/specs/GH1130/tech.md
+++ b/specs/GH1130/tech.md
@@ -12,7 +12,7 @@ GH-1130 / #1130
 
 | Area | Files | Current behavior | Why relevant |
 | --- | --- | --- | --- |
-| Request identity | `src/server/routes/ai/context.rs`, `src/core/types/context.rs` | middleware 暴露 user、team、API key 与 admin 权限 | owner 必须来自可信 extension/context |
+| Request identity | `src/auth/user_management.rs`, `src/auth/system.rs`, `src/server/routes/ai/context.rs`, `src/core/types/context.rs` | JWT 签发与认证当前都可能把 `user.team_ids.first()` 当 team；API key 带自身 team；权限 helper 已实现 key attenuation | token 签发和读取两端都必须消除 guessed team，owner/admin 来自可信、无提权的 extension/context |
 | Files routes | `src/server/routes/ai/files.rs` | handler 只按裸 `file_id` 操作 | 所有对象级 bypass |
 | Metadata | `src/storage/files/types.rs` | `FileMetadata` 没有 owner | 持久化根因 |
 | Storage dispatch | `src/storage/files/storage.rs` | store API 不接收 owner | Local/S3 必须一致 |
@@ -27,9 +27,20 @@ GH-1130 / #1130
    `Option<FileOwnerScope>` 并带 `#[serde(default)]`，从而旧 Local metadata
    反序列化为 `None`。禁止保存三个 optional ID 并使用 OR 匹配。
 2. 在 files route 的 crate-private helper 中从可信 request extensions/context 解析
-   `FileCaller { auth_enforced, is_admin, effective_scope }`。有效 scope 严格按
-   team -> non-empty user -> API key 优先；auth 开启且普通调用者没有 scope 时返回
-   显式 auth/permission error。admin 由现有 RBAC helper 判定，不读取客户端 header。
+   `FileCaller { auth_enforced, is_admin, effective_scope }`：
+   - API key 请求的 active team 只能是已验证 `ApiKey.team_id`。
+   - JWT/session 的 active team 只能是签发时写入、认证时再次验证属于该 user 的
+     token/session claim；现有 `user.team_ids.first()` 不是 active-team 事实，Files
+     路径不得读取它。`user_management.rs` 等 access-token 签发路径也不得从
+     membership 列表选择第一项；没有服务端已验证的显式 active-team selection 时
+     必须签发 `team_id: None`。认证时 claim 缺失、无 membership 或存在歧义时不设置
+     team，并按 non-empty user -> API key 回退；不得新增或信任客户端自报 header。
+   - API key 存在时，admin 只能由该 key 的直接 `*`/`system.admin` 或 runtime
+     `is_admin`/等价 admin permission 授予，复用/暴露 `context.rs` 现有 canonical
+     key-permission parser，禁止再实现一套解析，也禁止回退到 key owner 的用户角色。
+     无 API key 的 JWT/session 才按 canonical user admin role/RBAC 判定。
+   有效 scope 严格按 trusted team -> non-empty user -> API key 优先；auth 开启且
+   普通调用者没有 scope 时返回显式 auth/permission error。
 3. 扩展 `FileStorage::{store,store_with_purpose}` 及 Local/S3 对应入口接收 owner。
    Files route 在写 content 前完成 caller 解析。Local 把 enum 写入 `.meta`；S3 使用
    一个版本化 JSON metadata key（避免三个 key 产生组合歧义），读取时严格解析。
@@ -37,10 +48,18 @@ GH-1130 / #1130
    admin 允许全部；普通调用者仅当单一 effective scope 与 owner 完全相等时允许；
    `owner: None` 仅 admin。该 helper 供 list/get/content/delete 共同使用。
 5. list 读取 metadata 后先过滤再构造公开 `FileObject`；任何 metadata 解析错误显式
-   返回 error，禁止跳过损坏项并给出不完整/未过滤结果。公开对象不序列化 owner。
-6. get/content/delete 对非 owner 使用与 missing file 相同的 `NotFound` 状态、错误
-   type/code 和不含 file/owner 细节的正文。日志只记录 request ID 与拒绝类别，不记录
-   owner 值。delete 必须先取 metadata 并授权，再调用 backend delete。
+   返回 error，禁止跳过损坏项并给出不完整/未过滤结果。Local/S3 storage listing
+   必须返回完整候选集：S3 循环 `ListObjectsV2` continuation token 直到
+   `is_truncated=false`，检测 token 缺失/重复并显式失败。route 对完整候选集完成
+   metadata 读取和 owner 过滤后，才应用 API 的 limit/count；不得把 `max_keys=limit`
+   下推到未授权候选集。公开对象不序列化 owner。
+6. get/content/delete 对非 owner 使用与 missing file 相同的 canonical `NotFound`
+   状态、错误 type/code 和不含 file/owner 细节的正文。S3 `HeadObject` mapper 仅将
+   service code `NoSuchKey`/`NotFound` 或 HTTP 404 归入 canonical storage NotFound；
+   transport、credential、timeout、5xx 与其他 service errors 保持显式 5xx，禁止
+   blanket 映射。route 对 foreign 与 storage NotFound 使用同一公开 404 mapper。
+   日志只记录 request ID 与拒绝类别，不记录 owner 值。delete 必须先取 metadata
+   并授权，再调用 backend delete。
 7. S3 的 object key 继续不可由调用者指定，owner metadata 仅由服务端写入。测试使用
    backend fixture/mock，不访问真实 AWS。
 
@@ -48,22 +67,25 @@ GH-1130 / #1130
 
 | Product invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | effective scope resolver + enum | team/user/key 优先级矩阵 |
-| B-002 | list filter | 多 tenant + legacy + limit 结果 |
-| B-003 | uniform concealment response | foreign 与 random missing 的 status/body 等价 |
-| B-004/B-005 | caller resolver/RBAC | admin 全访问；无 scope fail-closed |
-| B-006/B-007 | Local/S3 serialization | round-trip、legacy、restart-style reopen |
+| B-001 | effective scope resolver + enum | API-key team、JWT validated active team、multi-team no-claim、user/key fallback |
+| B-002 | paginated list + filter | 多 tenant + legacy + >1000 S3 objects；过滤后 limit/count |
+| B-003 | uniform concealment response | foreign 与 Local/S3 random missing 的 status/body 等价 |
+| B-004/B-005 | caller resolver/canonical RBAC | key direct/runtime admin、restricted key + admin owner、admin JWT、无 scope |
+| B-006/B-007 | Local/S3 serialization + error mapper | round-trip、legacy、restart、S3 404/非 404 |
 | B-008 | FileObject/error mapping | JSON/log capture 无 owner |
 | B-009 | auth-disabled branch | anonymous CRUD 兼容测试 |
 | B-010 | route call order | mock backend 证明 unauthorized 不调用 get/delete |
 
 ## 数据流
 
-auth middleware 将可信 user/API key 与 `RequestContext` 放入 request extensions。
-Files handler 解析一个有效 caller scope；upload 把该 scope 随 metadata 交给 storage。
+token issuer 仅把服务端已验证的显式 active-team selection 写入 JWT，否则写
+`team_id: None`。auth middleware 将可信 user/API key 与 `RequestContext` 放入 request
+extensions；JWT active-team claim 只有在验证 user membership 后才进入 Files caller，
+签发/读取两端都不能复用 `team_ids.first()`。Files handler 解析一个有效 caller scope；upload 把该 scope随
+metadata 交给 storage。
 后续 list 或 object 操作先读取 metadata，使用唯一授权 helper 判定，再返回公开对象、
-content 或执行 delete。Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None`
-只能通过 admin 路径。
+content 或执行 delete。S3 list 先遍历全部 continuation pages，再由 route 过滤/limit；
+Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None` 只能通过 admin 路径。
 
 ## 备选方案
 
@@ -76,17 +98,20 @@ content 或执行 delete。Local/S3 都从持久化 metadata 恢复相同 enum�
 ## 风险
 
 - Security: owner scope、admin 判定和 concealment 是 auth 敏感面，必须人工 review。
+- Security: API key 是 permission attenuation boundary；不得让 admin user 身份抬高
+  受限 key 权限，也不得把任意 team membership 当 active team。
 - Compatibility: 历史文件普通用户将不可见；这是明确的 fail-closed 迁移。
-- Performance: list 可能为每个 S3 object 做 metadata 读取；先保证正确性，优化需另开 Issue。
+- Performance: 正确的跨租户 limit 要先遍历/过滤 S3 candidates，可能增加分页与
+  metadata 读取；先保证正确性，索引优化需另开 Issue。
 - Maintenance: 所有新 Files handler 必须复用 caller/ownership helper。
 
 ## 测试计划
 
-- [ ] Unit tests: enum serde、scope priority、ownership、uniform not-found。
-- [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata。
-- [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵与 backend call count。
-- [ ] Security tests: cross-team same-user、日志/JSON owner 泄露、unauthorized delete no-op。
-- [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`。
+- [ ] Unit tests: enum serde、trusted active-team scope priority、key attenuation、ownership、uniform not-found。
+- [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata、HeadObject 404/非 404、>1000 object pagination。
+- [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵、filter-before-limit 与 backend call count。
+- [ ] Security tests: multi-team login token 解码为 no-team 且 Files 回退 User scope、validated active-team claim、cross-team same-user、restricted key + admin owner、日志/JSON owner 泄露、unauthorized delete no-op。
+- [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`；S3 feature 用 `cargo check --all-features`、`cargo clippy --all-targets --all-features -- -D warnings` 与相关 S3 tests。
 
 ## 回滚方案
 

--- a/specs/GH1130/tech.md
+++ b/specs/GH1130/tech.md
@@ -6,134 +6,428 @@ GH-1130 / #1130
 
 ## Product Spec
 
-见 `product.md`（B-001 ～ B-010）。
+见 [`product.md`](./product.md)（B-001 ～ B-019）。
 
 ## Codebase Context
 
-| Area | Files | Current behavior | Why relevant |
+以下锚点均在本 amendment 基线
+`ae26d9d54254124b0942d3b7765ef67ea6fdc9e6` 上核对。
+
+| Area | Verified anchors | Current behavior | Why relevant |
 | --- | --- | --- | --- |
-| Request identity | `src/auth/{user_management,system}.rs`, `src/auth/jwt/{types,handler}.rs`, `src/server/routes/auth/{models,login,token}.rs`, `src/server/routes/ai/context.rs`, `src/core/types/context.rs` | 一个内部 login 路径签发 first-team，JWT 认证读取也重新选择 first-team；HTTP login/refresh 没有 active-team 输入；旧 token 无 provenance；空权限 key 会回退 admin owner | 增加服务端验证的 login/refresh team selection 与版本化 claim，旧 guessed claim 安全降级；Files admin 必须把任何 API key 当 attenuation boundary |
-| Files routes | `src/server/routes/ai/files.rs` | handler 只按裸 `file_id` 操作 | 所有对象级 bypass |
-| Metadata | `src/storage/files/types.rs` | `FileMetadata` 没有 owner | 持久化根因 |
-| Storage dispatch | `src/storage/files/storage.rs` | store API 不接收 owner | Local/S3 必须一致 |
-| Local backend | `src/storage/files/local.rs` | `.meta` JSON 持久化基础 metadata | 可向后兼容 `owner: None` |
-| S3 backend | `src/storage/files/s3.rs` | 使用 object metadata，list/head 获取 metadata | owner 需稳定编码并 round-trip |
-| Route tests | `tests/files_routes.rs`, `src/storage/files/tests.rs` | 只覆盖基础 CRUD | 需要租户矩阵与 legacy |
+| JWT claims / public issuer | `src/auth/jwt/types.rs:34-59`; `src/auth/jwt/handler.rs:25-58,92-133`; `src/auth/jwt/tokens.rs:10-155`; `src/auth/jwt/utils.rs:58-76` | public `Claims` 无 provenance version；public issuer 直接接受 raw `Option<Uuid>` team；specialized tokens 共用 `Claims` | 保持 public `Claims` shape，用 internal access envelope 承载 marker；specialized token 文件无需修改 |
+| AuthSystem login / JWT read | `src/auth/user_management.rs:29-69`; `src/auth/system.rs:85-153`; `src/auth/tests.rs:260-316` | internal login 与认证读取都使用 `user.team_ids.first()`；数据库 `Err` 已通过 `?` 保留 | 共享 current-active membership validator 与 `VerifiedActiveTeam` 的唯一创建点 |
+| HTTP login / refresh | `src/server/routes/auth/models.rs:16-21,49-53`; `src/server/routes/auth/login.rs:69-185`; `src/server/routes/auth/token.rs:10-82`; `src/server/routes/auth/mod.rs:16-45` | public request DTO 没有 `team_id`；routes 直接注册 public handlers；refresh 的 RBAC `Err` 被 `unwrap_or_default` 吞成空权限 | private wire DTO/route adapter 接收 selection，public DTO/handler signature 保持，固定 400/5xx |
+| Middleware status boundary | `src/server/middleware/auth.rs:211-295,333-369` | `AuthSystem::authenticate` 的 `Err` 已是 generic 500；但 API-key endpoint-policy parse `Err` 被公开成 403 与内部细节 | 保留认证 401/5xx 分流，收紧 policy/check error 为 generic 5xx |
+| Canonical team state | `src/core/teams/repository.rs:14-40`; `src/core/models/team/member.rs:45-76`; `src/server/state.rs:31-48,84-86` | repository 已提供 `get`/`get_member`，team/member 都有 active 状态；AppState 已持有同一数据库上的 manager | 复用既有 canonical repository；这些文件无需修改，不新增平行 membership 存储 |
+| API-key policy / identity | `src/server/routes/ai/context.rs:86-185,214-246`; `src/core/types/context.rs:61-80,140-159` | bool permission helpers用 `matches!` 吞 runtime-policy parse error；context 的 user 字段是 String，但 authenticated User/API key IDs 本身是 UUID | Files 使用 result-returning checked helper，只从 typed principal 构造 UUID scope；`RequestContext` 结构无需改 |
+| Files routes | `src/server/routes/ai/files.rs:60-171`; `src/server/routes/ai/mod.rs:43,155-166` | 五个 public handlers 无 request proof 且直接注册；upload 调用 legacy store；读删只按裸 `file_id` | 保留 public signatures 但 auth-enabled fail closed；HTTP routes 改注册 private proof-aware adapters |
+| Metadata / dispatch | `src/storage/files/types.rs:14-32`; `src/storage/files/storage.rs:41-101`; `src/storage/mod.rs:326-334` | public `FileMetadata` 无 owner；`metadata` 与三个 public store 入口不提供 owner | 保持 public struct literal 与方法签名，owner 只进入 internal persisted envelope/additive API |
+| Local backend | `src/storage/files/local.rs:34-80,137-225` | `.meta` JSON round-trip 基础 metadata；list 的 `Some(limit)` 是总结果上限 | 增加 internal flat owner envelope 并保留 public/legacy/list 语义 |
+| S3 backend | `src/storage/files/s3.rs:104-150,217-254,256-312,314-353` | owner 未写 metadata；metadata HEAD 把所有错误映射 Internal；list 只取第一页并把 `max_keys` 当完整 limit | 严格 owner metadata、精确 HEAD 404、完整 continuation 与跨页总 limit |
+| Existing test surfaces | `src/storage/files/tests.rs:1-78`; `tests/files_routes.rs:1-80`; `tests/integration/auth_middleware_tests_parts/mod.rs:1-202`; `tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs:1-225`; `tests/public_api_compat.rs:1-64` | 已有 storage CRUD、Files route、middleware 500 与 public API compile harness | 扩充 security/status/source-boundary/compatibility 矩阵，不访问真实 AWS |
+
+## Planned Changes
+
+以下是完整实现边界，恰好 24 个 repository-relative path。实现若必须修改表外文件，
+先停止并提交新的 spec amendment；不得把未申报文件塞入实现 PR。
+
+```specrail-planned-changes
+{
+  "issue": 1130,
+  "complete": true,
+  "paths": [
+    "src/auth/jwt/types.rs",
+    "src/auth/jwt/handler.rs",
+    "src/auth/jwt/tests.rs",
+    "src/auth/user_management.rs",
+    "src/auth/system.rs",
+    "src/auth/tests.rs",
+    "src/server/routes/auth/models.rs",
+    "src/server/routes/auth/login.rs",
+    "src/server/routes/auth/token.rs",
+    "src/server/routes/auth/mod.rs",
+    "src/server/routes/ai/context.rs",
+    "src/server/middleware/auth.rs",
+    "src/server/routes/ai/files.rs",
+    "src/server/routes/ai/mod.rs",
+    "src/storage/files/mod.rs",
+    "src/storage/files/types.rs",
+    "src/storage/files/storage.rs",
+    "src/storage/files/local.rs",
+    "src/storage/files/s3.rs",
+    "src/storage/files/tests.rs",
+    "tests/files_routes.rs",
+    "tests/integration/auth_middleware_tests_parts/mod.rs",
+    "tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs",
+    "tests/public_api_compat.rs"
+  ],
+  "spec_refs": [
+    "B-001",
+    "B-002",
+    "B-003",
+    "B-004",
+    "B-005",
+    "B-006",
+    "B-007",
+    "B-008",
+    "B-009",
+    "B-010",
+    "B-011",
+    "B-012",
+    "B-013",
+    "B-014",
+    "B-015",
+    "B-016",
+    "B-017",
+    "B-018",
+    "B-019"
+  ]
+}
+```
 
 ## 设计方案
 
-1. 定义单值 `FileOwnerScope`，推荐 serde tagged enum：
-   `Team(Uuid)`、`User(String)`、`ApiKey(Uuid)`。`FileMetadata.owner` 为
-   `Option<FileOwnerScope>` 并带 `#[serde(default)]`，从而旧 Local metadata
-   反序列化为 `None`。禁止保存三个 optional ID 并使用 OR 匹配。
-2. 在 files route 的 crate-private helper 中从可信 request extensions/context 解析
-   `FileCaller { auth_enforced, is_admin, effective_scope }`：
-   - API key 请求的 active team 只能是已验证 `ApiKey.team_id`。
-   - `LoginRequest` 与 `RefreshTokenRequest` 增加 optional snake_case `team_id`。
-     login/refresh handler 读取数据库中的 current user memberships；缺失时签发
-     user-scope token，存在时只在 exact membership match 后签发，否则稳定拒绝且
-     不生成 token。`AuthSystem::login` 同步接受 optional selection 并复用同一
-     validator，禁止 `user.team_ids.first()`。
-   - access-token `Claims` 增加 `#[serde(default)] team_scope_version: Option<u8>`；
-     本 tranche 唯一接受值为 `Some(1)`。只有通过上述 validator 的 typed
-     `VerifiedActiveTeam` 才能同时写入 `team_id` 与 version 1；无选择的新 token
-     写 `team_id: None`/version 1。旧 token 因字段缺失解码为 `None`：即使其中有
-     历史 guessed `team_id`，认证也忽略该 team，但 token 仍作为 user-scope 身份。
-     version 1 的 team 仍须在认证时再次验证 current membership；失败时拒绝 token，
-     不得静默切换其他 team。不得新增或信任客户端自报 header。
-   - API key 存在时，admin 只能由该 key 的直接 `*`/`system.admin` 或 runtime
-     `is_admin`/等价 admin permission 授予。把 `context.rs` 现有 direct/runtime
-     admin parser 暴露为唯一 crate-private helper 供 Files caller 复用；只要 API key
-     存在，受限、空 permissions、runtime payload absent 都不得回退到 key owner 的
-     用户角色。无 API key 的 JWT/session 才按 canonical user admin role/RBAC 判定。
-   有效 scope 严格按 trusted team -> non-empty user -> API key 优先；auth 开启且
-   普通调用者没有 scope 时返回显式 auth/permission error。
-3. 扩展 `FileStorage::{store,store_with_purpose}` 及 Local/S3 对应入口接收 owner。
-   Files route 在写 content 前完成 caller 解析。Local 把 enum 写入 `.meta`；S3 使用
-   一个版本化 JSON metadata key（避免三个 key 产生组合歧义），读取时严格解析。
-4. 建立唯一 `can_access_file(caller, metadata)`：auth disabled 允许现有单租户行为；
-   admin 允许全部；普通调用者仅当单一 effective scope 与 owner 完全相等时允许；
-   `owner: None` 仅 admin。该 helper 供 list/get/content/delete 共同使用。
-5. list 读取 metadata 后先过滤再构造公开 `FileObject`；任何 metadata 解析错误显式
-   返回 error，禁止跳过损坏项并给出不完整/未过滤结果。当前 route 没有 query
-   pagination/limit/count，公开响应只有 `object` 与 `data`，因此返回全部已授权文件，
-   不新增 public limit。Local/S3 storage listing 必须返回完整候选集：S3 循环
-   `ListObjectsV2` continuation token 直到 `is_truncated=false`，检测 token
-   缺失/重复并显式失败；Files route 保持调用 `list(None, None)`，不得把内部
-   `max_keys` 当公开截断。公开对象不序列化 owner。
-6. get/content/delete 对非 owner 使用与 missing file 相同的 canonical `NotFound`
-   状态、错误 type/code 和不含 file/owner 细节的正文。S3 `HeadObject` mapper 使用
-   Rust SDK `HeadObjectError::is_not_found()` 判定服务 HTTP 404；HEAD 错误响应没有
-   可依赖的 body/精确 exception，不得解析 `NoSuchKey` 字符串。transport、
-   credential、timeout、403、5xx 与其他 service errors 保持显式 5xx，禁止
-   blanket 映射。route 对 foreign 与 storage NotFound 使用同一公开 404 mapper。
-   日志只记录 request ID 与拒绝类别，不记录 owner 值。delete 必须先取 metadata
-   并授权，再调用 backend delete。
-7. S3 的 object key 继续不可由调用者指定，owner metadata 仅由服务端写入。测试使用
-   backend fixture/mock，不访问真实 AWS。
+### 1. 单值 UUID owner
+
+在 `src/storage/files/types.rs` 定义 crate-private adjacent-tag enum，wire 必须精确为：
+
+```text
+#[serde(tag = "scope", content = "id", rename_all = "snake_case")]
+FileOwnerScope = Team(Uuid) | User(Uuid) | ApiKey(Uuid)
+
+{"scope":"team","id":"<uuid>"}
+{"scope":"user","id":"<uuid>"}
+{"scope":"api_key","id":"<uuid>"}
+```
+
+public `FileMetadata` 的字段集合保持原样。新增 crate-private flat persisted envelope：
+
+```text
+StoredFileMetadata {
+  #[serde(flatten)] public: FileMetadata,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  owner: Option<FileOwnerScope>
+}
+```
+
+Local 新 `.meta` 仍把既有 public fields 放在顶层；旧 bare `FileMetadata` 因 owner
+default 解码为 `None`，旧 reader 也可忽略新 owner 字段。S3 internal metadata result
+同样返回 `{ public, owner }`，public `metadata()` 只投影 `public`。不保存三个 optional
+ID，不做 OR matching，不从任意 String 制造 User owner。Files caller 只使用已认证
+`User::id()`、`ApiKey.user_id`、`ApiKey.team_id` 与 `ApiKey.metadata.id` 的 UUID。
+
+### 2. Provenance 三态与唯一 typed issuer
+
+public `Claims` 字段集合保持不变。`src/auth/jwt/types.rs` 新增 crate-private access
+envelope：
+
+```text
+AccessTokenClaims {
+  #[serde(flatten)] public: Claims,
+  #[serde(default)] team_scope_version: Option<u8>
+}
+```
+
+只有 access-token encode/decode 使用该 envelope；refresh/password-reset/email/
+invitation 继续直接使用 public `Claims`，因此 `jwt/tokens.rs` 与 `jwt/utils.rs` 不在
+manifest。public `verify_access_token` 的签名不变并只返回其中的 `Claims`；新增
+crate-internal `verify_access_token_with_provenance` 供 `AuthSystem` 使用完整 envelope。
+access-token 状态机固定为：
+
+| Marker / team claim | Authentication result |
+| --- | --- |
+| `None` / any `team_id` | legacy；忽略 team，active user 成功后只建立 User scope |
+| `Some(1)` / `None` | active user 的 User scope |
+| `Some(1)` / `Some(team_id)` | current team 与 membership 都 active 时建立 Team scope；missing/inactive/stale 为 401 |
+| `Some(v != 1)` / any `team_id` | 401；在 scope fallback 前拒绝整个 bearer token |
+
+在 `src/auth/system.rs` 定义
+`VerifiedActiveTeam { user_id: Uuid, team_id: Uuid }`：类型可供 crate-internal typed
+issuer 接受，但两个字段与 constructor 都私有于 `auth::system` module。唯一 constructor
+由共享 validator 在 canonical `TeamRepository::get` 与 `get_member` 均成功、
+`Team::is_active()` 与 `TeamMember::is_active()` 都为真、member/user UUID exact match
+后调用。repository `Err` 原样传播；
+成功读取但 team/member 不存在或不 active 由调用边界分类：
+
+- login/refresh 的显式 selection：400，且在任何 token encode 前结束；
+- version 1 bearer token 的复验：认证失败 401；
+- repository/反序列化/连接错误：generic 5xx。
+
+`JwtHandler::{create_access_token,create_token_pair}` 的 public 参数和返回类型不改：
+raw `team_id: None` 签发 version 1 User token；raw `team_id: Some` 在 encode 前返回
+显式错误。新增 crate-internal typed issuer，只接受 `&VerifiedActiveTeam`，并在
+encode 前强制 `proof.user_id == token subject`；不相等时显式拒绝，不能把 user A 的
+proof 配给 user B。校验通过后才签发 version 1 Team token。生产 login/refresh
+只能走 typed path；没有第二个 raw-team encode helper。
+
+`AuthSystem::login(&str, &str)` 保留原签名并成为 no-selection User-scope 入口；
+新增 additive `login_with_active_team`，与 HTTP login/refresh 共用同一个 validator。
+所有 `team_ids.first()` 签发/读取路径删除。
+
+### 3. HTTP selection 与错误分类
+
+public `LoginRequest`、`RefreshTokenRequest` 字段集合和既有 public login/refresh
+handler signatures 保持不变。新增 private wire DTO：
+
+```text
+LoginWireRequest {
+  #[serde(flatten)] public: LoginRequest,
+  team_id: Option<Uuid>
+}
+RefreshWireRequest {
+  #[serde(flatten)] public: RefreshTokenRequest,
+  team_id: Option<Uuid>
+}
+```
+
+`src/server/routes/auth/mod.rs` 的 HTTP registration 只指向 private wire-aware
+adapters；existing public handlers 继续作为 no-selection wrappers，调用同一个
+internal implementation。wire behavior 为：
+
+- 字段缺失保持兼容，签发 version 1 User token；
+- JSON/UUID malformed 由 request boundary 返回 400；
+- well-formed foreign/missing/inactive/suspended selection 统一 generic 400；
+- user/team/membership/RBAC storage `Err` 返回 generic 5xx；
+- 失败时 access 与 refresh token 都不得生成。
+
+refresh 删除 `unwrap_or_default`；RBAC `Err` 不能变成空 permissions。
+
+认证 middleware 已将 `AuthSystem::authenticate` 的 `Err` 映射 generic 500，保留该
+边界。它对 `api_key_allows_endpoint` 的 parse/check `Err` 改为同样的 generic 500，
+不再返回含内部 policy 细节的 403。普通 deny 仍为 403，无效 credential/token 仍为
+401。
+
+### 4. API-key attenuation 与 caller resolver
+
+在 `src/server/routes/ai/context.rs` 增加 result-returning crate-private checked
+helper，复用现有 direct permissions 与 runtime-policy parser：
+
+- API key 存在时，只有该 key 的 direct `*`/`system.admin` 或成功解析的 runtime
+  `is_admin`/等价 custom permission 可授予 Files admin；
+- restricted、empty、runtime payload absent 都是 non-admin，且不得回退 key owner
+  的 Admin/SuperAdmin role；
+- malformed runtime policy 是 `Err`，由 middleware/Files route 变成 generic 5xx，
+  不能伪装 non-admin 后继续 fallback；
+- 无 API key 的 JWT/session 才按 canonical user role/RBAC 判定。
+
+`FileCaller { auth_enforced, is_admin, effective_scope }` 的 principal 分支互斥：
+
+1. request extensions 存在 `ApiKey` 时，不读取任何 JWT/context residual team。
+   先验证 context 的 API-key/user identity 与 typed key exact match；然后只在该 key
+   内按 `team_id -> user_id -> metadata.id` 取一个 UUID scope。
+2. 不存在 `ApiKey` 时，要求 typed authenticated `User` 与 context user UUID exact
+   match；只有 `AuthSystem` 复验后写入的 JWT team 才优先于 `User::id()`。
+3. typed principal/context mismatch、缺失的必需 identity 或 invalid UUID 都是
+   consistency/storage error，返回 generic 5xx；不得尝试下一种 principal/scope。
+
+本 Issue 把已认证且 active 的 API key 上持久化 `team_id` 视为 key 自身的 trusted
+team association，不把它当 key owner 的 active-team selection，也不查询 owner
+membership。team 删除与 key association 撤销/同步属于独立 lifecycle Issue；该风险
+不允许通过读取 residual JWT team 来“修复”。
+
+### 5. Additive storage API
+
+以下 public 方法和 public `FileMetadata` struct shape 保留，并继续代表显式
+non-HTTP legacy/admin/migration caller，写 `owner: None`：
+
+- `FileStorage::{store,store_with_purpose,metadata}`
+- `LocalStorage::{store,store_with_purpose,metadata}`
+- `S3Storage::{store,store_with_purpose,metadata}`
+- `StorageLayer::{store_file,get_file}`（该文件不改）
+
+新增 owner 非 optional 的 crate-internal
+`store_owned_with_purpose(..., owner: FileOwnerScope)`，以及对应 Local/S3 dispatch
+；另新增 crate-internal `metadata_with_owner` 返回 `StoredFileMetadata`。
+auth-enabled Files HTTP upload 在读取
+multipart content 后、backend write 前解析 caller，并且只能调用 owned 方法；scope
+失败不得调用 legacy store。auth-disabled + allow-anonymous route 才走兼容入口。
+
+Local 用 flat internal envelope 把 owner 写入 `.meta`，同时兼容 legacy bare
+`FileMetadata`。S3 metadata key 固定为 `litellm-owner`，value 固定为：
+
+```json
+{"version":1,"scope":"team|user|api_key","id":"<uuid>"}
+```
+
+S3 只有整个 key 缺失才表示 legacy `owner: None`；value malformed、unknown version、
+unknown scope、missing/extra required field 或 invalid UUID 都是 5xx。public metadata
+result 不含 owner，不得用三个独立 metadata key 拼接 owner。
+
+### 6. 完整 listing 与统一授权
+
+建立唯一 `can_access_file(caller, metadata)`：
+
+- auth disabled：保持现有单租户行为；
+- admin：允许所有 owner 与 legacy `None`；
+- 普通 caller：只有 effective scope 与 metadata 的单一 owner 完全相等才允许；
+- legacy `None`：auth-enabled 时仅 admin。
+
+list 必须先得到完整候选集、逐个读取并验证 metadata，再构造公开
+`OpenAiFileObject`。任一 metadata failure 使整个请求 5xx，不 skip、不返回部分 data。
+Files route 继续调用 `list(None, None)`，因为公开 API 没有 limit/count。
+
+S3 `ListObjectsV2` 对每一页保持同一个 prefix，并循环 continuation token 到
+`is_truncated=false`：
+
+- `Some(0)` 不发 S3 请求并返回空结果；
+- `None` 返回所有 candidates；每页 `max_keys=1000`；
+- `Some(limit > 0)` 是跨页总上限；每页
+  `max_keys=min(1000, remaining)`，达到后停止；
+- truncated page 必须提供 fresh、non-empty next token；缺失、空值或重复 token
+  显式失败；
+- 任意 later-page error 使整个 list 失败，不得返回已经收集的 prefix/部分结果。
+
+Local 的 existing `Some(limit)` 总上限语义保持不变，并修正为 `Some(0)` 直接返回空
+结果、零目录扫描。
+
+### 7. Concealment 与精确 S3 NotFound
+
+get/content/delete 都先取 metadata 并授权；delete 只有授权成功后才调用 backend
+delete。foreign owner 与真实 missing 使用同一 canonical OpenAI-compatible 404
+status、type、code 和不含 file/owner 细节的正文。
+
+S3 metadata/exists 共用一个 HeadObject error mapper。只有 SDK modeled
+`is_not_found()` 或 raw service response status 404 生成 canonical
+`GatewayError::NotFound`；不得读取或假设 HEAD body、`NoSuchKey` code 或 exception
+字符串。transport、credential、timeout、403、throttling 与 5xx 保持显式 error，
+最终为 generic 5xx。日志只记录 request ID 与拒绝类别，不记录 owner 或持久化 policy。
+
+legacy owner-less metadata 只有 `purpose` 仍是当前公开 File object 支持的值时才可被
+list/get 表示。missing/invalid purpose 保持现有显式 error，并使整个 list/get 失败；
+不得默认成 `assistants`、skip 或返回部分成功。
+
+### 8. Proof-aware Files route adapters
+
+`src/server/routes/ai/files.rs` 保留五个 public handler signatures，并新增 private
+`HttpRequest`-aware adapters 与共享 internal implementation：
+
+- `src/server/routes/ai/mod.rs` 的五个 HTTP routes 只注册 private adapters；
+- adapters 解析 request extensions/context 后调用 shared implementation；
+- proofless public wrappers 传入 `None` proof：auth enabled 时在任何 storage call 前
+  fail closed；只有 auth disabled + allow-anonymous 才进入 legacy behavior。
+
+source-boundary test 读取 route registration，断言不再存在 `.to(create_file)`、
+`.to(list_files)`、`.to(get_file)`、`.to(delete_file)` 或
+`.to(get_file_content)`，并断言五个 private adapter 都已注册。route test 同时用
+call-count 证明 auth-enabled direct wrapper 不触碰 storage。
+
+### 9. 文件级实现边界
+
+24 个 manifest path 的职责划分如下：
+
+- JWT/auth/selection：10 个 auth/JWT/route path；
+- API-key policy status：`src/server/routes/ai/context.rs` 与
+  `src/server/middleware/auth.rs`；
+- Files authorization/registration：`src/server/routes/ai/{files,mod}.rs`；
+- owner/storage：6 个 `src/storage/files/**` path；
+- integration/status/public-compat fixtures：4 个 `tests/**` path。
+
+`src/core/types/context.rs`、`src/core/teams/**`、`src/server/state.rs` 与 database
+repository 不修改：当前 typed UUID accessors、canonical TeamRepository 和 AppState
+manager 已足够。若实现证明此判断错误，必须先回到 spec review，而不是越界修改。
 
 ## Product-to-Test Mapping
 
-| Product invariant | Implementation area | Verification |
+| Product invariant | Implementation area | Deterministic verification |
 | --- | --- | --- |
-| B-001 | token selection/provenance + effective scope resolver + enum | login/refresh valid/foreign/no team、version 1、legacy no-marker、API-key team、multi-team no-claim、user/key fallback |
-| B-002 | paginated list + filter | 多 tenant + legacy + >1000 S3 objects；返回全部 authorized data，无 public limit/count |
-| B-003 | uniform concealment response | foreign 与 Local/S3 random missing 的 status/body 等价 |
-| B-004/B-005 | caller resolver/canonical RBAC | key direct/runtime admin、restricted key + admin owner、admin JWT、无 scope |
-| B-006/B-007 | Local/S3 serialization + error mapper | round-trip、legacy、restart、S3 404/非 404 |
-| B-008 | FileObject/error mapping | JSON/log capture 无 owner |
-| B-009 | auth-disabled branch | anonymous CRUD 兼容测试 |
-| B-010 | route call order | mock backend 证明 unauthorized 不调用 get/delete |
+| B-001 | FileCaller + owner enum + typed team context | `cargo test --all-features --test files_routes gh1130_scope_priority -- --nocapture` |
+| B-002 | S3 continuation + Files filter | `cargo test --features s3 --lib storage::files::s3::tests -- --nocapture`，包含 `Some(0)`、>1000、stable prefix、repeat/missing/empty token、later-page error 与 `Some(limit)` |
+| B-003 | canonical concealment mapper | `cargo test --all-features --test files_routes gh1130_foreign_matches_missing -- --nocapture` |
+| B-004 | checked API-key admin parser | `cargo test --lib server::routes::ai::context::tests -- --nocapture`，覆盖 direct/runtime/empty/restricted + admin owner |
+| B-005 | FileCaller / upload pre-write gate | `cargo test --all-features --test files_routes gh1130_missing_scope -- --nocapture` |
+| B-006 | Local/S3 internal envelope serde + HeadObject mapper | `cargo test --lib storage::files::tests -- --nocapture`; `cargo test --features s3 --lib storage::files::s3::tests -- --nocapture` |
+| B-007 | serde-defaulted legacy owner | `cargo test --lib storage::files::tests gh1130_legacy_owner -- --nocapture` |
+| B-008 | public object/error/log capture | `cargo test --all-features --test files_routes gh1130_owner_redaction -- --nocapture` |
+| B-009 | auth-disabled route + legacy store | `cargo test --all-features --test files_routes gh1130_auth_disabled -- --nocapture` |
+| B-010 | route call order / failure propagation | `cargo test --all-features --test files_routes gh1130_backend_call_order -- --nocapture` |
+| B-011 | Claims state table + authenticate_jwt | `cargo test --lib auth::jwt::tests -- --nocapture`; `cargo test --lib auth::tests -- --nocapture` |
+| B-012 | login/refresh selection boundary | inline login tests plus `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture` |
+| B-013 | auth/policy/storage 401/5xx matrix | `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture` |
+| B-014 | unchanged public method/handler signatures + unchanged public struct fields | `cargo test --all-features --test public_api_compat -- --nocapture`; `cargo check --all-features` |
+| B-015 | system-private constructor + subject-bound typed issuer | `cargo test --lib auth::jwt::tests gh1130_verified_team -- --nocapture`; negative proof-subject mismatch；source review confirms no raw-team encode path |
+| B-016 | UUID owner envelope + owned-store-only upload | `cargo test --lib storage::files::tests gh1130_owned_store -- --nocapture`; legacy bare/new envelope round-trip；Files mock asserts legacy store call count zero |
+| B-017 | mutually exclusive caller resolver | `cargo test --all-features --test files_routes gh1130_exclusive_principal_scope -- --nocapture`，覆盖 key team/user/id、JWT team/user 与 mismatch |
+| B-018 | legacy purpose compatibility | `cargo test --all-features --test files_routes gh1130_legacy_purpose -- --nocapture`，valid visible、missing/invalid whole-request failure |
+| B-019 | private route adapters + proofless wrapper gate | source-boundary/compile fixture in `tests/public_api_compat.rs`; route call-count tests in `tests/files_routes.rs` |
+
+所有计划新增的 GH1130 test 名使用 `gh1130_` 前缀；focused command 若没有匹配测试，
+不构成完成证据，最终还必须运行对应完整 module/target。
 
 ## 数据流
 
-login/refresh 接收 optional `team_id` 并验证 current membership；token issuer 只把
-typed verified selection 与 `team_scope_version=1` 写入 JWT，否则写
-`team_id: None`。旧 access token 缺 version 时忽略历史 team claim并保持 user-scope
-认证。auth middleware 将可信 user/API key 与 `RequestContext` 放入 request
-extensions；version 1 JWT active-team claim 只有在再次验证 membership 后才进入
-Files caller，签发/读取两端都不能复用 `team_ids.first()`。Files handler 解析一个
-有效 caller scope；upload 把该 scope随 metadata 交给 storage。
-后续 list 或 object 操作先读取 metadata，使用唯一授权 helper 判定，再返回公开对象、
-content 或执行 delete。S3 list 先遍历全部 continuation pages，再由 route 过滤并返回
-完整 authorized set；Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None`
-只能通过 admin 路径。
+1. private login/refresh wire adapters 解析 optional UUID selection；共享 validator
+   查询 canonical team 与 membership；public request DTO/handlers 保持 no-selection。
+2. no-selection 签发 version 1 User token；valid selection 产生
+   `VerifiedActiveTeam` 并走 typed Team issuer；selection rejection 在 encode 前结束。
+3. middleware 验证 JWT：legacy 忽略 team；version 1 team 复验 membership；unknown
+   version/stale membership 为 401，repository `Err` 为 generic 5xx。
+4. middleware 插入 typed User/API key 与只含可信 team 的 RequestContext；policy parse
+   error 在 route 前 generic 5xx。
+5. private Files route adapter 提供 request proof；caller resolver 先选互斥 principal，
+   再解析一个 UUID scope。proofless public wrapper 在 auth-enabled 时 fail closed。
+6. Local/S3 通过 internal envelope 持久化 tagged owner；list 完整遍历 candidates
+   并逐个调用 internal metadata-with-owner，public `FileMetadata` 不变。
+7. 唯一授权 helper 在公开对象/content/delete 前判断；foreign 与 missing 统一 404，
+   storage/policy failure 统一 generic 5xx。
 
 ## 备选方案
 
-- 保存 user/team/key 三个字段并任一相等即允许：拒绝，会让同一 user 跨 team 绕过。
-- 只绑定 API key：隔离最强但会破坏同 team/user 合法共享，且忽略已有租户层次。
-- foreign 返回 `403`：拒绝，与 missing `404` 可区分并泄露对象存在性。
-- 自动把 legacy 文件归给首个访问者：拒绝，存在可抢占所有权风险。
-- 只在 route 内存映射 owner：拒绝，重启和多实例会丢失授权事实。
+- 保存 user/team/key 三个 optional 字段并任一相等即允许：拒绝，会产生 same-user
+  cross-team bypass。
+- 继续让 raw `Option<Uuid>` issuer 签 team token：拒绝，无法证明 provenance。
+- 修改既有 public storage/JWT/handler signature 或 public DTO/metadata/claims fields：
+  拒绝，会造成不必要 Rust source break；使用 internal envelope/wire adapter。
+- unknown version 当 legacy 或 stale membership 回退 User：拒绝，会把未来/损坏状态
+  当可信降级。
+- foreign 返回 403：拒绝，会成为文件存在性 oracle。
+- 只取 S3 第一页或 metadata 错误时 skip：拒绝，会返回不完整且可能泄露的成功结果。
+- 自动归属 legacy 文件：拒绝，存在 owner 抢占。
 
 ## 风险
 
-- Security: owner scope、admin 判定和 concealment 是 auth 敏感面，必须人工 review。
-- Security: API key 是 permission attenuation boundary；不得让 admin user 身份抬高
-  受限/空权限 key 权限，也不得把任意 team membership 当 active team。旧 token 的
-  guessed team 必须因缺 version marker 被忽略。
-- Compatibility: 历史文件普通用户将不可见；这是明确的 fail-closed 迁移。旧 access
-  token 继续作为 user-scope 身份有效，但不再保留 guessed team scope；需要 team
-  scope 的客户端通过 login/refresh 的 optional `team_id` 获取新 token。
-- Performance/Availability: 完整的跨租户授权列表要先遍历/过滤全部 S3 candidates，
-  可能增加大量分页与逐对象 `HeadObject`，在大 bucket/高并发下可能触发
-  throttling 或 `503 Slow Down` 并使整个 list 显式失败。实现应保持 bounded
-  concurrency/retry 与 fail-closed，不得为可用性跳过 metadata 或返回部分未过滤
-  结果；可扩展性需另开 Issue，以按 owner 建立可信索引或缓存（例如数据库/Redis），
-  且索引失效时仍回到安全失败而非全局放行。
-- Maintenance: 所有新 Files handler 必须复用 caller/ownership helper。
+- Security: auth、owner、API-key attenuation 与 concealment 都是高风险边界；实现 PR
+  必须有独立人工 security review，不能由 agent 自批。
+- Compatibility: legacy token 继续 User-scope；unknown version 必须重新登录。列出的
+  public methods/handlers 与 `FileMetadata`/`Claims`/auth request struct literals 保留；
+  marker/selection/owner 由 internal envelope/wire 承载。raw team signing 从可用变为
+  显式拒绝，这是有意的 runtime 安全收紧。
+- Compatibility: 历史 owner-less 文件在 auth-enabled 部署仅 admin 可见；不自动迁移。
+- Compatibility: 历史 missing/invalid purpose 不被本 Issue 猜测；对应 list/get
+  继续显式失败，可能需要单独迁移。
+- Security/Lifecycle: API-key `team_id` 被视为 key-owned trusted association；本
+  Issue 不新增 team deletion 与 key revocation 的联动。该 lifecycle gap 需单独跟踪，
+  但不得通过 key owner/JWT fallback 扩权。
+- Performance/Availability: 完整 S3 listing + per-object HeadObject 可能触发
+  throttling/503；本 tranche 必须整体失败。owner index/cache 另开 Issue，且 cache
+  失效不能降级为全局放行。
+- Maintenance: typed validator、checked policy helper 与 ownership helper 各保持单一
+  owner；不得新增平行 auth/storage module。
 
 ## 测试计划
 
-- [ ] Unit tests: enum serde、login/refresh team membership、versioned/legacy claims、trusted active-team scope priority、empty/restricted key attenuation、ownership、uniform not-found。
-- [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata、HeadObject SDK `is_not_found()`/非 404、>1000 object pagination，以及 throttling/503 保持显式失败。
-- [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵、完整 authorized list 与 backend call count。
-- [ ] Security tests: login/refresh valid/foreign/no-team selection、legacy no-marker token 回退 User scope、version 1 active-team claim、cross-team same-user、restricted/empty key + admin owner、日志/JSON owner 泄露、unauthorized delete no-op。
-- [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`；S3 feature 用 `cargo check --all-features`、`cargo clippy --all-targets --all-features -- -D warnings` 与相关 S3 tests。
+- [ ] Unit: exact provenance state table、typed issuer、active/inactive membership、
+  UUID owner serde、legacy metadata、checked admin/policy error、call ordering。
+- [ ] Route: two users/teams/keys + admin/legacy/auth-disabled 的
+  list/get/content/delete/upload 矩阵；foreign/missing 公开错误完全等价。
+- [ ] S3 feature: owner round-trip、strict malformed metadata、HeadObject exact 404、
+  403/timeout/5xx、`Some(0)`、>1000 continuation、stable prefix、repeat/missing/empty
+  token、later-page failure、cross-page `Some(limit)`。
+- [ ] Middleware: unknown version/stale membership 401；repository/RBAC/policy error
+  generic 5xx 且不泄露内部 detail。
+- [ ] Compatibility/source boundary: existing public method/handler 与
+  `FileMetadata`/`Claims`/auth request struct-literal compile fixtures；legacy bare/new
+  envelope round-trip；raw team issuer 拒绝；private auth/Files adapters 是唯一 route
+  registration；proofless Files wrappers 在 auth-enabled 时不调用 storage。
+- [ ] Repository: `cargo fmt --check`; `cargo check`; `cargo check --all-features`;
+  `cargo clippy --all-targets --all-features -- -D warnings`; focused tests;
+  `cargo test`; SpecRail packet/workflow checks；`git diff --check`。
 
 ## 回滚方案
 
-代码可回滚，但新 metadata 的额外 owner 字段必须由旧反序列化器是否拒绝未知字段来决定；
-回滚演练先验证兼容。不得通过忽略 owner 恢复全局访问。若必须回滚服务版本，应先暂停
-Files API 或保持对象授权补丁，避免重新暴露跨租户读取。
+代码可整体 revert，但不得恢复未授权跨租户访问。回滚前验证旧 reader 是否接受新增
+metadata 字段；若不确定，暂停 auth-enabled Files API 或保留 authorization patch。
+已经写入 owner 的 metadata 不自动删除，legacy 文件不自动归属。若 JWT provenance
+逻辑需紧急回滚，先撤销 team-scoped login/refresh issuance 并只允许 User scope，
+不得重新启用 first-team guessing。Spec approval、implementation、security review、
+merge 与 release 仍是独立 human gates。

--- a/specs/GH1130/tech.md
+++ b/specs/GH1130/tech.md
@@ -54,9 +54,10 @@ GH-1130 / #1130
    metadata 读取和 owner 过滤后，才应用 API 的 limit/count；不得把 `max_keys=limit`
    下推到未授权候选集。公开对象不序列化 owner。
 6. get/content/delete 对非 owner 使用与 missing file 相同的 canonical `NotFound`
-   状态、错误 type/code 和不含 file/owner 细节的正文。S3 `HeadObject` mapper 仅将
-   service code `NoSuchKey`/`NotFound` 或 HTTP 404 归入 canonical storage NotFound；
-   transport、credential、timeout、5xx 与其他 service errors 保持显式 5xx，禁止
+   状态、错误 type/code 和不含 file/owner 细节的正文。S3 `HeadObject` mapper 使用
+   Rust SDK `HeadObjectError::is_not_found()` 判定服务 HTTP 404；HEAD 错误响应没有
+   可依赖的 body/精确 exception，不得解析 `NoSuchKey` 字符串。transport、
+   credential、timeout、403、5xx 与其他 service errors 保持显式 5xx，禁止
    blanket 映射。route 对 foreign 与 storage NotFound 使用同一公开 404 mapper。
    日志只记录 request ID 与拒绝类别，不记录 owner 值。delete 必须先取 metadata
    并授权，再调用 backend delete。
@@ -101,14 +102,18 @@ Local/S3 都从持久化 metadata 恢复相同 enum；legacy `None` 只能通过
 - Security: API key 是 permission attenuation boundary；不得让 admin user 身份抬高
   受限 key 权限，也不得把任意 team membership 当 active team。
 - Compatibility: 历史文件普通用户将不可见；这是明确的 fail-closed 迁移。
-- Performance: 正确的跨租户 limit 要先遍历/过滤 S3 candidates，可能增加分页与
-  metadata 读取；先保证正确性，索引优化需另开 Issue。
+- Performance/Availability: 正确的跨租户 limit 要先遍历/过滤 S3 candidates，
+  可能增加大量分页与逐对象 `HeadObject`，在大 bucket/高并发下可能触发
+  throttling 或 `503 Slow Down` 并使整个 list 显式失败。实现应保持 bounded
+  concurrency/retry 与 fail-closed，不得为可用性跳过 metadata 或返回部分未过滤
+  结果；可扩展性需另开 Issue，以按 owner 建立可信索引或缓存（例如数据库/Redis），
+  且索引失效时仍回到安全失败而非全局放行。
 - Maintenance: 所有新 Files handler 必须复用 caller/ownership helper。
 
 ## 测试计划
 
 - [ ] Unit tests: enum serde、trusted active-team scope priority、key attenuation、ownership、uniform not-found。
-- [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata、HeadObject 404/非 404、>1000 object pagination。
+- [ ] Storage tests: Local/S3 owner round-trip、legacy、损坏 metadata、HeadObject SDK `is_not_found()`/非 404、>1000 object pagination，以及 throttling/503 保持显式失败。
 - [ ] Route tests: tenant/admin/auth-disabled list/get/content/delete 矩阵、filter-before-limit 与 backend call count。
 - [ ] Security tests: multi-team login token 解码为 no-team 且 Files 回退 User scope、validated active-team claim、cross-team same-user、restricted key + admin owner、日志/JSON owner 泄露、unauthorized delete no-op。
 - [ ] Repository gates: `cargo fmt --check`、`cargo check`、严格 Clippy、相关测试、`cargo test`；S3 feature 用 `cargo check --all-features`、`cargo clippy --all-targets --all-features -- -D warnings` 与相关 S3 tests。

--- a/specs/GH1130/tech.md
+++ b/specs/GH1130/tech.md
@@ -17,13 +17,13 @@ GH-1130 / #1130
 | --- | --- | --- | --- |
 | JWT claims / public issuer | `src/auth/jwt/types.rs:34-59`; `src/auth/jwt/handler.rs:25-58,92-133`; `src/auth/jwt/tokens.rs:10-155`; `src/auth/jwt/utils.rs:58-76` | public `Claims` 无 provenance version；public issuer 直接接受 raw `Option<Uuid>` team；specialized tokens 共用 `Claims` | 保持 public `Claims` shape，用 internal access envelope 承载 marker；specialized token 文件无需修改 |
 | AuthSystem login / JWT read | `src/auth/user_management.rs:29-69`; `src/auth/system.rs:85-153`; `src/auth/tests.rs:260-316` | internal login 与认证读取都使用 `user.team_ids.first()`；数据库 `Err` 已通过 `?` 保留 | 共享 current-active membership validator 与 `VerifiedActiveTeam` 的唯一创建点 |
-| HTTP login / refresh | `src/server/routes/auth/models.rs:16-21,49-53`; `src/server/routes/auth/login.rs:69-185`; `src/server/routes/auth/token.rs:10-82`; `src/server/routes/auth/mod.rs:16-45` | public request DTO 没有 `team_id`；routes 直接注册 public handlers；refresh 的 RBAC `Err` 被 `unwrap_or_default` 吞成空权限 | private wire DTO/route adapter 接收 selection，public DTO/handler signature 保持，固定 400/5xx |
+| HTTP login / refresh | `src/server/routes/auth/models.rs:16-21,49-53`; `src/server/routes/auth/login.rs:69-185`; `src/server/routes/auth/token.rs:10-82`; `src/server/routes/auth/mod.rs:16-45` | public request DTO 没有 `team_id`；routes 直接注册 public handlers；refresh 重载 user 后未检查 active，且 RBAC `Err` 被 `unwrap_or_default` 吞成空权限 | private wire DTO/route adapter 接收 selection，固定 primary-auth-before-team 顺序和 active-user 401，public DTO/handler signature 保持 |
 | Middleware status boundary | `src/server/middleware/auth.rs:211-295,333-369` | `AuthSystem::authenticate` 的 `Err` 已是 generic 500；但 API-key endpoint-policy parse `Err` 被公开成 403 与内部细节 | 保留认证 401/5xx 分流，收紧 policy/check error 为 generic 5xx |
 | Canonical team state | `src/core/teams/repository.rs:14-40`; `src/core/models/team/member.rs:45-76`; `src/server/state.rs:31-48,84-86` | repository 已提供 `get`/`get_member`，team/member 都有 active 状态；AppState 已持有同一数据库上的 manager | 复用既有 canonical repository；这些文件无需修改，不新增平行 membership 存储 |
 | API-key policy / identity | `src/server/routes/ai/context.rs:86-185,214-246`; `src/core/types/context.rs:61-80,140-159` | bool permission helpers用 `matches!` 吞 runtime-policy parse error；context 的 user 字段是 String，但 authenticated User/API key IDs 本身是 UUID | Files 使用 result-returning checked helper，只从 typed principal 构造 UUID scope；`RequestContext` 结构无需改 |
 | Files routes | `src/server/routes/ai/files.rs:60-171`; `src/server/routes/ai/mod.rs:43,155-166` | 五个 public handlers 无 request proof 且直接注册；upload 调用 legacy store；读删只按裸 `file_id` | 保留 public signatures 但 auth-enabled fail closed；HTTP routes 改注册 private proof-aware adapters |
 | Metadata / dispatch | `src/storage/files/types.rs:14-32`; `src/storage/files/storage.rs:41-101`; `src/storage/mod.rs:326-334` | public `FileMetadata` 无 owner；`metadata` 与三个 public store 入口不提供 owner | 保持 public struct literal 与方法签名，owner 只进入 internal persisted envelope/additive API |
-| Local backend | `src/storage/files/local.rs:34-80,137-225` | `.meta` JSON round-trip 基础 metadata；list 的 `Some(limit)` 是总结果上限 | 增加 internal flat owner envelope 并保留 public/legacy/list 语义 |
+| Local backend | `src/storage/files/local.rs:34-80,137-225,278-310` | content 先写入 final 可枚举路径，随后才写 `.meta`；两步间失败会留下 content orphan；list 的 `Some(limit)` 是总结果上限 | 增加 presence-aware owner envelope 与 private staged publication，final content 只在完整 metadata 后可见 |
 | S3 backend | `src/storage/files/s3.rs:104-150,217-254,256-312,314-353` | owner 未写 metadata；metadata HEAD 把所有错误映射 Internal；list 只取第一页并把 `max_keys` 当完整 limit | 严格 owner metadata、精确 HEAD 404、完整 continuation 与跨页总 limit |
 | Existing test surfaces | `src/storage/files/tests.rs:1-78`; `tests/files_routes.rs:1-80`; `tests/integration/auth_middleware_tests_parts/mod.rs:1-202`; `tests/integration/auth_middleware_tests_parts/rejection_rate_limit.rs:1-225`; `tests/public_api_compat.rs:1-64` | 已有 storage CRUD、Files route、middleware 500 与 public API compile harness | 扩充 security/status/source-boundary/compatibility 矩阵，不访问真实 AWS |
 
@@ -101,33 +101,59 @@ FileOwnerScope = Team(Uuid) | User(Uuid) | ApiKey(Uuid)
 {"scope":"api_key","id":"<uuid>"}
 ```
 
-public `FileMetadata` 的字段集合保持原样。新增 crate-private flat persisted envelope：
+public `FileMetadata` 的字段集合保持原样。owner wire 使用 crate-private、
+presence-aware state，只有 JSON key 缺失才产生 `Absent`：
 
 ```text
+OwnerField = Absent | Present(FileOwnerScope)
+
 StoredFileMetadata {
   #[serde(flatten)] public: FileMetadata,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  owner: Option<FileOwnerScope>
+  #[serde(
+    default,
+    skip_serializing_if = "OwnerField::is_absent",
+    serialize_with = "serialize_owner_field",
+    deserialize_with = "deserialize_owner_field"
+  )]
+  owner: OwnerField
 }
 ```
 
-Local 新 `.meta` 仍把既有 public fields 放在顶层；旧 bare `FileMetadata` 因 owner
-default 解码为 `None`，旧 reader 也可忽略新 owner 字段。S3 internal metadata result
-同样返回 `{ public, owner }`，public `metadata()` 只投影 `public`。不保存三个 optional
-ID，不做 OR matching，不从任意 String 制造 User owner。Files caller 只使用已认证
-`User::id()`、`ApiKey.user_id`、`ApiKey.team_id` 与 `ApiKey.metadata.id` 的 UUID。
+field-level `default` 只处理 key absence；key 存在时 custom decoder 必须把 valid
+adjacent-tag object 解成 `Present`，并对 explicit `null`、malformed object、unknown
+scope 或 invalid UUID 返回 error，不能产生 `Absent`。serializer 对 `Absent` 省略整个
+key，对 `Present` 只写 exact adjacent-tag object。Local 新 `.meta` 仍把既有 public
+fields 放在顶层；旧 bare `FileMetadata` 解码为 `Absent`，旧 reader 也可忽略新 owner
+字段。internal API 可把 `Absent` 投影为 legacy `owner: None`，但损坏值不得进入该投影。
+S3 internal metadata result 同样返回 `{ public, owner }`，public `metadata()` 只投影
+`public`。不保存三个 optional ID，不做 OR matching，不从任意 String 制造 User
+owner。Files caller 只使用已认证 `User::id()`、`ApiKey.user_id`、`ApiKey.team_id`
+与 `ApiKey.metadata.id` 的 UUID。
 
 ### 2. Provenance 三态与唯一 typed issuer
 
-public `Claims` 字段集合保持不变。`src/auth/jwt/types.rs` 新增 crate-private access
-envelope：
+public `Claims` 字段集合保持不变。`src/auth/jwt/types.rs` 新增 crate-private、
+presence-aware marker 与 access envelope：
 
 ```text
+TeamScopeMarker = Absent | Present(u8)
+
 AccessTokenClaims {
   #[serde(flatten)] public: Claims,
-  #[serde(default)] team_scope_version: Option<u8>
+  #[serde(
+    default,
+    skip_serializing_if = "TeamScopeMarker::is_absent",
+    serialize_with = "serialize_team_scope_marker",
+    deserialize_with = "deserialize_team_scope_marker"
+  )]
+  team_scope_version: TeamScopeMarker
 }
 ```
+
+与 owner 一样，field-level `default` 只在 key absence 时产生 `Absent`；key 存在时
+custom decoder 只接受 integer `u8` 并产生 `Present`。explicit `null`、string、
+fractional/out-of-range number 或其他 malformed value 是 JWT decode/auth error。
+新 access-token issuer 永远写 `Present(1)`；`Absent` 只来自 legacy decode。
 
 只有 access-token encode/decode 使用该 envelope；refresh/password-reset/email/
 invitation 继续直接使用 public `Claims`，因此 `jwt/tokens.rs` 与 `jwt/utils.rs` 不在
@@ -137,10 +163,11 @@ access-token 状态机固定为：
 
 | Marker / team claim | Authentication result |
 | --- | --- |
-| `None` / any `team_id` | legacy；忽略 team，active user 成功后只建立 User scope |
-| `Some(1)` / `None` | active user 的 User scope |
-| `Some(1)` / `Some(team_id)` | current team 与 membership 都 active 时建立 Team scope；missing/inactive/stale 为 401 |
-| `Some(v != 1)` / any `team_id` | 401；在 scope fallback 前拒绝整个 bearer token |
+| key `Absent` / any `team_id` | legacy；忽略 team，active user 成功后只建立 User scope |
+| `Present(1)` / `None` | active user 的 User scope |
+| `Present(1)` / `Some(team_id)` | current team 与 membership 都 active 时建立 Team scope；missing/inactive/stale 为 401 |
+| `Present(v != 1)` / any `team_id` | 401；在 scope fallback 前拒绝整个 bearer token |
+| key present with `null`/non-integer/malformed value | decode/auth 401；不得产生 `Absent` 或进入任何 scope fallback |
 
 在 `src/auth/system.rs` 定义
 `VerifiedActiveTeam { user_id: Uuid, team_id: Uuid }`：类型可供 crate-internal typed
@@ -150,7 +177,8 @@ issuer 接受，但两个字段与 constructor 都私有于 `auth::system` modul
 后调用。repository `Err` 原样传播；
 成功读取但 team/member 不存在或不 active 由调用边界分类：
 
-- login/refresh 的显式 selection：400，且在任何 token encode 前结束；
+- primary auth 与 active-user gate 已成功的 login/refresh 显式 selection：400，且在任何
+  token encode 前结束；
 - version 1 bearer token 的复验：认证失败 401；
 - repository/反序列化/连接错误：generic 5xx。
 
@@ -162,8 +190,9 @@ proof 配给 user B。校验通过后才签发 version 1 Team token。生产 log
 只能走 typed path；没有第二个 raw-team encode helper。
 
 `AuthSystem::login(&str, &str)` 保留原签名并成为 no-selection User-scope 入口；
-新增 additive `login_with_active_team`，与 HTTP login/refresh 共用同一个 validator。
-所有 `team_ids.first()` 签发/读取路径删除。
+新增 additive `login_with_active_team`，它必须先完成与 public login 相同的 password/
+active-user gate，再与 HTTP login/refresh 共用同一个 membership validator。所有
+`team_ids.first()` 签发/读取路径删除。
 
 ### 3. HTTP selection 与错误分类
 
@@ -183,15 +212,32 @@ RefreshWireRequest {
 
 `src/server/routes/auth/mod.rs` 的 HTTP registration 只指向 private wire-aware
 adapters；existing public handlers 继续作为 no-selection wrappers，调用同一个
-internal implementation。wire behavior 为：
+internal implementation。private wire DTO 的 JSON/UUID syntactic parse 可以先发生；
+parse 成功后，team selection 的 semantic validation 必须遵循固定顺序：
+
+1. login 先完成既有 user/password verification 与 active-user gate；wrong password
+   或 user gate failure 立即返回既有 generic auth response。
+2. refresh 先验证 refresh token，再重载 user 并要求 `user.is_active()`；missing 或
+   inactive user 统一 generic 401。
+3. 只有上述 primary verification 与 user gate 成功后，才可调用 shared team/member
+   validator；随后才读取 RBAC 并 encode token。
+
+因此 wrong password 或 invalid refresh 搭配 valid/foreign `team_id` 时，primary auth
+结果优先，team/member repository call count 与 token encode count 都为 0。inactive/
+missing refresh user 在有/无 `team_id` 时都在 team/RBAC/encode 前返回 401。team
+repository error 也只能在 primary auth 成功后对外成为 generic 5xx，不能覆盖错误
+credential/token 的结果。其余 wire behavior 为：
 
 - 字段缺失保持兼容，签发 version 1 User token；
-- JSON/UUID malformed 由 request boundary 返回 400；
-- well-formed foreign/missing/inactive/suspended selection 统一 generic 400；
-- user/team/membership/RBAC storage `Err` 返回 generic 5xx；
-- 失败时 access 与 refresh token 都不得生成。
+- JSON/UUID malformed 由 request boundary 返回 400，不查询 team repository；
+- primary auth 成功后的 well-formed foreign/missing/inactive/suspended selection
+  统一 generic 400；
+- primary auth 成功后的 user/team/membership/RBAC storage `Err` 返回 generic 5xx；
+- 任一失败都不得生成 access 或 refresh token。
 
-refresh 删除 `unwrap_or_default`；RBAC `Err` 不能变成空 permissions。
+refresh 删除 `unwrap_or_default`；RBAC `Err` 不能变成空 permissions。错误顺序测试必须
+同时断言 wrong-password/invalid-refresh 两类请求各自搭配 valid/foreign selection，
+以及 inactive/missing refresh user 搭配 team Some/None 的 call counts。
 
 认证 middleware 已将 `AuthSystem::authenticate` 的 `Err` 映射 generic 500，保留该
 边界。它对 `api_key_allows_endpoint` 的 parse/check `Err` 改为同样的 generic 500，
@@ -243,8 +289,32 @@ auth-enabled Files HTTP upload 在读取
 multipart content 后、backend write 前解析 caller，并且只能调用 owned 方法；scope
 失败不得调用 legacy store。auth-disabled + allow-anonymous route 才走兼容入口。
 
-Local 用 flat internal envelope 把 owner 写入 `.meta`，同时兼容 legacy bare
-`FileMetadata`。S3 metadata key 固定为 `litellm-owner`，value 固定为：
+Local legacy 与 owned store 共享一个 crate-private、same-filesystem staged writer；
+public signatures 和 legacy `Absent` wire 均不改变。写入协议固定为：
+
+1. 先在 base path 下、且位于现有 two-character shard/list traversal 之外的 private
+   staging location 生成 content 与完整 `StoredFileMetadata`；temp names 不能被
+   `list` 当作 file ID。
+2. content 与 metadata 都 write-complete 并 close 后，才进入 publish。先把 staged
+   metadata 原子 rename 到 final `<file_id>.meta`，再把 staged content 原子 rename
+   到 final `<file_id>`；两次 rename 位于同一 filesystem，final content rename 是
+   唯一 list-visible commit point。
+3. metadata serialize/write/close/rename 任一步失败时绝不 publish final content；
+   同步错误对本次 staging 与已发布 sidecar 做 best-effort cleanup 后返回 error。
+   content commit 失败同样返回 error并清理可清理的 sidecar。
+4. 进程在 commit 前中断只可能留下 private staging 或 meta-only sidecar；reopen/list
+   必须忽略（并可安全清理）两者。由于 final content 永不先于 final metadata 出现，
+   metadata failure 或中断不能产生可枚举的 ownerless content、也不能永久 poison list。
+
+owned path 的 envelope 必须是 `OwnerField::Present(valid scope)`；legacy public path
+才可写 `OwnerField::Absent` 并省略 key。读取时 owner key explicit `null` 或 malformed
+由 presence-aware decoder 返回 generic 5xx，不得进入 legacy/admin-visible flow。
+Local public/internal metadata 与对象读取以 final content 存在作为 committed
+precondition：已知 ID 指向 meta-only sidecar 时按未提交记录忽略/NotFound，不得公开
+sidecar 内容；final content 存在但 metadata 缺失或损坏时仍显式失败，不能降级为
+legacy。
+这些 Local 规则不改变 S3 wire 或 publish behavior。S3 metadata key 固定为
+`litellm-owner`，value 固定为：
 
 ```json
 {"version":1,"scope":"team|user|api_key","id":"<uuid>"}
@@ -279,7 +349,8 @@ S3 `ListObjectsV2` 对每一页保持同一个 prefix，并循环 continuation t
 - 任意 later-page error 使整个 list 失败，不得返回已经收集的 prefix/部分结果。
 
 Local 的 existing `Some(limit)` 总上限语义保持不变，并修正为 `Some(0)` 直接返回空
-结果、零目录扫描。
+结果、零目录扫描。所有 limit 模式都只遍历 final content namespace，忽略 private
+staging 与 `.meta` sidecar；meta-only interruption residue 不能成为 candidate。
 
 ### 7. Concealment 与精确 S3 NotFound
 
@@ -336,17 +407,17 @@ manager 已足够。若实现证明此判断错误，必须先回到 spec review
 | B-003 | canonical concealment mapper | `cargo test --all-features --test files_routes gh1130_foreign_matches_missing -- --nocapture` |
 | B-004 | checked API-key admin parser | `cargo test --lib server::routes::ai::context::tests -- --nocapture`，覆盖 direct/runtime/empty/restricted + admin owner |
 | B-005 | FileCaller / upload pre-write gate | `cargo test --all-features --test files_routes gh1130_missing_scope -- --nocapture` |
-| B-006 | Local/S3 internal envelope serde + HeadObject mapper | `cargo test --lib storage::files::tests -- --nocapture`; `cargo test --features s3 --lib storage::files::s3::tests -- --nocapture` |
-| B-007 | serde-defaulted legacy owner | `cargo test --lib storage::files::tests gh1130_legacy_owner -- --nocapture` |
+| B-006 | Local staged publication + Local/S3 envelope + HeadObject mapper | `cargo test --lib storage::files::tests -- --nocapture`，含 metadata publish failure、meta-before-content interruption、reopen/list/direct lookup；`cargo test --features s3 --lib storage::files::s3::tests -- --nocapture` |
+| B-007 | presence-aware legacy owner decoder | `cargo test --lib storage::files::tests gh1130_owner_presence -- --nocapture`，覆盖 key missing/null/malformed/valid |
 | B-008 | public object/error/log capture | `cargo test --all-features --test files_routes gh1130_owner_redaction -- --nocapture` |
 | B-009 | auth-disabled route + legacy store | `cargo test --all-features --test files_routes gh1130_auth_disabled -- --nocapture` |
 | B-010 | route call order / failure propagation | `cargo test --all-features --test files_routes gh1130_backend_call_order -- --nocapture` |
-| B-011 | Claims state table + authenticate_jwt | `cargo test --lib auth::jwt::tests -- --nocapture`; `cargo test --lib auth::tests -- --nocapture` |
-| B-012 | login/refresh selection boundary | inline login tests plus `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture` |
-| B-013 | auth/policy/storage 401/5xx matrix | `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture` |
+| B-011 | presence-aware Claims state table + authenticate_jwt | `cargo test --lib auth::jwt::tests -- --nocapture`; `cargo test --lib auth::tests -- --nocapture`，含 signature-valid explicit-null/non-integer marker |
+| B-012 | primary-auth-before-selection + active refresh boundary | inline login/token tests plus `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture`，覆盖 wrong password/invalid refresh × valid/foreign team 及 inactive/missing refresh user × team Some/None 的 call counts |
+| B-013 | auth ordering + policy/storage/corruption 401/5xx matrix | `cargo test --all-features --test lib integration::auth_middleware_tests -- --nocapture`; `cargo test --lib storage::files::tests -- --nocapture` |
 | B-014 | unchanged public method/handler signatures + unchanged public struct fields | `cargo test --all-features --test public_api_compat -- --nocapture`; `cargo check --all-features` |
 | B-015 | system-private constructor + subject-bound typed issuer | `cargo test --lib auth::jwt::tests gh1130_verified_team -- --nocapture`; negative proof-subject mismatch；source review confirms no raw-team encode path |
-| B-016 | UUID owner envelope + owned-store-only upload | `cargo test --lib storage::files::tests gh1130_owned_store -- --nocapture`; legacy bare/new envelope round-trip；Files mock asserts legacy store call count zero |
+| B-016 | UUID owner envelope + owned-store-only atomic publication | `cargo test --lib storage::files::tests gh1130_owned_store -- --nocapture`; missing/null/malformed/valid owner round-trip；publish interruption；Files mock asserts legacy store call count zero |
 | B-017 | mutually exclusive caller resolver | `cargo test --all-features --test files_routes gh1130_exclusive_principal_scope -- --nocapture`，覆盖 key team/user/id、JWT team/user 与 mismatch |
 | B-018 | legacy purpose compatibility | `cargo test --all-features --test files_routes gh1130_legacy_purpose -- --nocapture`，valid visible、missing/invalid whole-request failure |
 | B-019 | private route adapters + proofless wrapper gate | source-boundary/compile fixture in `tests/public_api_compat.rs`; route call-count tests in `tests/files_routes.rs` |
@@ -356,19 +427,25 @@ manager 已足够。若实现证明此判断错误，必须先回到 spec review
 
 ## 数据流
 
-1. private login/refresh wire adapters 解析 optional UUID selection；共享 validator
-   查询 canonical team 与 membership；public request DTO/handlers 保持 no-selection。
-2. no-selection 签发 version 1 User token；valid selection 产生
-   `VerifiedActiveTeam` 并走 typed Team issuer；selection rejection 在 encode 前结束。
-3. middleware 验证 JWT：legacy 忽略 team；version 1 team 复验 membership；unknown
-   version/stale membership 为 401，repository `Err` 为 generic 5xx。
-4. middleware 插入 typed User/API key 与只含可信 team 的 RequestContext；policy parse
+1. private login/refresh wire adapters 只完成 optional UUID syntactic parse；public
+   request DTO/handlers 保持 no-selection，parse error 在 request boundary 400。
+2. login 完成 password/active-user gate；refresh 完成 token verification、user reload
+   与 active-user gate。任何 primary auth failure 在 team/RBAC/encode 前结束。
+3. primary auth 成功后，共享 validator 才查询 canonical team 与 membership；
+   no-selection 签 version 1 User token，valid selection 产生 `VerifiedActiveTeam` 并走
+   typed Team issuer，selection rejection 在 encode 前结束。
+4. middleware 用 presence-aware marker 验证 JWT：key absent 的 legacy 忽略 team；
+   version 1 team 复验 membership；explicit null/malformed/unknown version 与 stale
+   membership 为 401，repository `Err` 为 generic 5xx。
+5. middleware 插入 typed User/API key 与只含可信 team 的 RequestContext；policy parse
    error 在 route 前 generic 5xx。
-5. private Files route adapter 提供 request proof；caller resolver 先选互斥 principal，
+6. private Files route adapter 提供 request proof；caller resolver 先选互斥 principal，
    再解析一个 UUID scope。proofless public wrapper 在 auth-enabled 时 fail closed。
-6. Local/S3 通过 internal envelope 持久化 tagged owner；list 完整遍历 candidates
-   并逐个调用 internal metadata-with-owner，public `FileMetadata` 不变。
-7. 唯一授权 helper 在公开对象/content/delete 前判断；foreign 与 missing 统一 404，
+7. Local 用 presence-aware envelope 写 hidden staging，final `.meta` 先 publish、final
+   content 后 publish；final content 是 list 与 direct lookup 的 commit precondition。
+   S3 保持 exact metadata wire。list 只遍历 committed candidates 并逐个调用 internal
+   metadata-with-owner，public `FileMetadata` 不变。
+8. 唯一授权 helper 在公开对象/content/delete 前判断；foreign 与 missing 统一 404，
    storage/policy failure 统一 generic 5xx。
 
 ## 备选方案
@@ -376,6 +453,12 @@ manager 已足够。若实现证明此判断错误，必须先回到 spec review
 - 保存 user/team/key 三个 optional 字段并任一相等即允许：拒绝，会产生 same-user
   cross-team bypass。
 - 继续让 raw `Option<Uuid>` issuer 签 team token：拒绝，无法证明 provenance。
+- 用 defaulted `Option` 表示 owner/marker presence：拒绝，会把 explicit `null` 与 key
+  absence 合并成 legacy fail-open。
+- 在 password/refresh verification 前查询 team selection：拒绝，会形成 membership/
+  repository-state oracle；inactive refresh user 也不得续签。
+- Local 先写 final content 再写 `.meta`：拒绝，中断会留下可枚举 orphan 并 poison
+  fail-closed list；使用 metadata-first、content-last staged publication。
 - 修改既有 public storage/JWT/handler signature 或 public DTO/metadata/claims fields：
   拒绝，会造成不必要 Rust source break；使用 internal envelope/wire adapter。
 - unknown version 当 legacy 或 stale membership 回退 User：拒绝，会把未来/损坏状态
@@ -388,11 +471,14 @@ manager 已足够。若实现证明此判断错误，必须先回到 spec review
 
 - Security: auth、owner、API-key attenuation 与 concealment 都是高风险边界；实现 PR
   必须有独立人工 security review，不能由 agent 自批。
-- Compatibility: legacy token 继续 User-scope；unknown version 必须重新登录。列出的
+- Compatibility: key-absent legacy token 继续 User-scope；explicit-null/malformed/
+  unknown marker 必须重新登录。列出的
   public methods/handlers 与 `FileMetadata`/`Claims`/auth request struct literals 保留；
   marker/selection/owner 由 internal envelope/wire 承载。raw team signing 从可用变为
   显式拒绝，这是有意的 runtime 安全收紧。
 - Compatibility: 历史 owner-less 文件在 auth-enabled 部署仅 admin 可见；不自动迁移。
+- Compatibility: 只有 owner key absent 是历史格式；present null/malformed metadata
+  现在显式 5xx，不再被当作 legacy admin-visible record。
 - Compatibility: 历史 missing/invalid purpose 不被本 Issue 猜测；对应 list/get
   继续显式失败，可能需要单独迁移。
 - Security/Lifecycle: API-key `team_id` 被视为 key-owned trusted association；本
@@ -401,20 +487,27 @@ manager 已足够。若实现证明此判断错误，必须先回到 spec review
 - Performance/Availability: 完整 S3 listing + per-object HeadObject 可能触发
   throttling/503；本 tranche 必须整体失败。owner index/cache 另开 Issue，且 cache
   失效不能降级为全局放行。
+- Availability: Local staged publish 可能因进程中断留下 private staging 或 meta-only
+  sidecar；list/reopen 必须忽略它们，cleanup 失败也不能重新暴露为 committed content。
 - Maintenance: typed validator、checked policy helper 与 ownership helper 各保持单一
   owner；不得新增平行 auth/storage module。
 
 ## 测试计划
 
-- [ ] Unit: exact provenance state table、typed issuer、active/inactive membership、
-  UUID owner serde、legacy metadata、checked admin/policy error、call ordering。
+- [ ] Unit: marker absent/null/non-integer/malformed/1/unknown exact state table、typed
+  issuer、active/inactive membership；owner missing/null/malformed/valid exact decoder；
+  Local staged metadata failure/interruption/reopen/list/direct lookup；checked
+  admin/policy error 与 call ordering。
+- [ ] Auth route: wrong password/invalid refresh × valid/foreign team 均保持 primary
+  auth result且 team-repository/encode count 为零；valid refresh 的 inactive/missing
+  user × team Some/None 均 generic 401 且 team/RBAC/encode count 为零。
 - [ ] Route: two users/teams/keys + admin/legacy/auth-disabled 的
   list/get/content/delete/upload 矩阵；foreign/missing 公开错误完全等价。
 - [ ] S3 feature: owner round-trip、strict malformed metadata、HeadObject exact 404、
   403/timeout/5xx、`Some(0)`、>1000 continuation、stable prefix、repeat/missing/empty
   token、later-page failure、cross-page `Some(limit)`。
-- [ ] Middleware: unknown version/stale membership 401；repository/RBAC/policy error
-  generic 5xx 且不泄露内部 detail。
+- [ ] Middleware: explicit-null/non-integer/malformed/unknown marker 与 stale membership
+  401；repository/RBAC/policy error generic 5xx 且不泄露内部 detail。
 - [ ] Compatibility/source boundary: existing public method/handler 与
   `FileMetadata`/`Claims`/auth request struct-literal compile fixtures；legacy bare/new
   envelope round-trip；raw team issuer 拒绝；private auth/Files adapters 是唯一 route
@@ -427,7 +520,9 @@ manager 已足够。若实现证明此判断错误，必须先回到 spec review
 
 代码可整体 revert，但不得恢复未授权跨租户访问。回滚前验证旧 reader 是否接受新增
 metadata 字段；若不确定，暂停 auth-enabled Files API 或保留 authorization patch。
-已经写入 owner 的 metadata 不自动删除，legacy 文件不自动归属。若 JWT provenance
-逻辑需紧急回滚，先撤销 team-scoped login/refresh issuance 并只允许 User scope，
-不得重新启用 first-team guessing。Spec approval、implementation、security review、
-merge 与 release 仍是独立 human gates。
+已经写入 owner 的 metadata 不自动删除，legacy 文件不自动归属。即使其余代码回滚，
+也不得恢复 owner/marker explicit-null → absent 的降级，或 Local final-content-first
+publication；必要时保留 fail-closed decoder 与 staged writer。若 JWT provenance 逻辑
+需紧急回滚，先撤销 team-scoped login/refresh issuance 并只允许 User scope，不得重新
+启用 first-team guessing或 inactive-user refresh。Spec approval、implementation、
+security review、merge 与 release 仍是独立 human gates。


### PR DESCRIPTION
## 摘要

修订 GH1130 已合并规格，补齐实现前必须固定的 Files 租户隔离契约：

- JWT/session 仅接受经 membership 验证的显式 active-team，禁止 `team_ids.first()` 猜测
- API key 作为权限衰减边界，不继承 owner 的 admin role
- S3 仅把精确 404/NoSuchKey 映射为 NotFound，其他错误保持 5xx
- S3 list 必须遍历全部分页，授权过滤先于公开 limit/count
- 扩充 multi-team、restricted-key/admin、pagination 和 404/5xx 测试矩阵

## 边界

本 PR 仅修改 `specs/GH1130/`，不包含实现代码。Implementation 必须等待本 amendment 获得内容绑定批准并合并。

## 验证

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1130`
- `git diff --check origin/main...HEAD`

Refs #1130