### PR TITLE
fix(guardrails): enforce streaming output checks

### DIFF
--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -140,7 +140,7 @@ auth:
     default_role: "user"
     admin_roles: ["admin", "superuser"]
 
-# Content safety is enforced on LLM request input and non-streaming output.
+# Content safety is enforced on LLM request input and output, including SSE.
 # Prompt-injection protection is enabled by default; this explicit switch is
 # the operational escape hatch for deployments that accept that risk.
 guardrails:
@@ -152,6 +152,10 @@ guardrails:
     use_heuristics: true
   check_input: true
   check_output: true
+  # Streaming text is withheld for at most this many new characters per check.
+  # Routes may check sooner at an output-event boundary.
+  # Smaller windows reduce latency and increase guardrail check frequency.
+  stream_output_check_chars: 256
   fail_open: false
 
 # Empty/default rules preserve allow-all behavior. Enable a configured

--- a/src/config/models/guardrails.rs
+++ b/src/config/models/guardrails.rs
@@ -23,6 +23,7 @@ struct GatewayGuardrailsWire {
     default_action: Option<GuardrailAction>,
     check_input: Option<bool>,
     check_output: Option<bool>,
+    stream_output_check_chars: Option<usize>,
     exclude_paths: Option<Vec<String>>,
     fail_open: Option<bool>,
 }
@@ -98,6 +99,9 @@ where
     if let Some(value) = wire.check_output {
         config.check_output = value;
     }
+    if let Some(value) = wire.stream_output_check_chars {
+        config.stream_output_check_chars = value;
+    }
     if let Some(value) = wire.exclude_paths {
         config.exclude_paths = value;
     }
@@ -153,5 +157,25 @@ mod tests {
 
         assert!(serde_json::from_value::<GatewayConfig>(guardrail_typo).is_err());
         assert!(serde_json::from_value::<GatewayConfig>(ip_typo).is_err());
+    }
+
+    #[test]
+    fn gateway_stream_output_window_defaults_and_validates_bounds() {
+        let config = GatewayConfig::default();
+        assert_eq!(config.guardrails.stream_output_check_chars, 256);
+
+        for valid in [1, 4096] {
+            let mut value = serde_json::to_value(GatewayConfig::default()).unwrap();
+            value["guardrails"] = serde_json::json!({"stream_output_check_chars": valid});
+            let config: GatewayConfig = serde_json::from_value(value).unwrap();
+            assert!(config.guardrails.validate().is_ok());
+        }
+
+        for invalid in [0, 4097] {
+            let mut value = serde_json::to_value(GatewayConfig::default()).unwrap();
+            value["guardrails"] = serde_json::json!({"stream_output_check_chars": invalid});
+            let config: GatewayConfig = serde_json::from_value(value).unwrap();
+            assert!(config.guardrails.validate().is_err());
+        }
     }
 }

--- a/src/core/guardrails/config.rs
+++ b/src/core/guardrails/config.rs
@@ -6,6 +6,11 @@ use std::collections::HashSet;
 
 use super::types::{GuardrailAction, ModerationCategory, PIIType};
 
+/// Default maximum number of new Unicode characters buffered between streaming checks.
+pub const DEFAULT_STREAM_OUTPUT_CHECK_CHARS: usize = 256;
+/// Upper bound for the streaming output buffer between checks.
+pub const MAX_STREAM_OUTPUT_CHECK_CHARS: usize = 4096;
+
 /// Main configuration for the guardrails system
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GuardrailConfig {
@@ -41,6 +46,10 @@ pub struct GuardrailConfig {
     #[serde(default = "default_true")]
     pub check_output: bool,
 
+    /// Maximum new Unicode characters to buffer before checking streaming output.
+    #[serde(default = "default_stream_output_check_chars")]
+    pub stream_output_check_chars: usize,
+
     /// Paths to exclude from guardrail checks
     #[serde(default)]
     pub exclude_paths: Vec<String>,
@@ -61,6 +70,7 @@ impl Default for GuardrailConfig {
             default_action: GuardrailAction::Block,
             check_input: true,
             check_output: true,
+            stream_output_check_chars: DEFAULT_STREAM_OUTPUT_CHECK_CHARS,
             exclude_paths: Vec::new(),
             fail_open: false,
         }
@@ -128,6 +138,11 @@ impl GuardrailConfig {
 
     /// Validate the configuration
     pub fn validate(&self) -> Result<(), String> {
+        if !(1..=MAX_STREAM_OUTPUT_CHECK_CHARS).contains(&self.stream_output_check_chars) {
+            return Err(format!(
+                "guardrails.stream_output_check_chars must be between 1 and {MAX_STREAM_OUTPUT_CHECK_CHARS}"
+            ));
+        }
         if let Some(ref moderation) = self.openai_moderation
             && moderation.enabled
             && moderation.api_key.is_none()
@@ -136,6 +151,10 @@ impl GuardrailConfig {
         }
         Ok(())
     }
+}
+
+fn default_stream_output_check_chars() -> usize {
+    DEFAULT_STREAM_OUTPUT_CHECK_CHARS
 }
 
 /// OpenAI Moderation API configuration

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -162,9 +162,12 @@ pub(super) async fn handle_streaming_chat_completion(
         Ok(((mut stream, mut settlement), lease)) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
+            let guardrails = Arc::clone(&state.guardrails);
 
             tokio::spawn(async move {
                 let mut lease = Some(lease);
+                let mut output_guardrail =
+                    super::super::stream_output_guardrail::StreamOutputGuardrail::new(guardrails);
                 let mut tokens_used = 0_u64;
                 let mut final_usage = None;
                 let mut saw_upstream_output = false;
@@ -174,6 +177,23 @@ pub(super) async fn handle_streaming_chat_completion(
                             settlement.record_disconnect(final_usage.as_ref()).await;
                         }
                     };
+                }
+                macro_rules! return_after_guardrail_error {
+                    ($error:expr) => {{
+                        let guardrail_error = $error;
+                        let error_bytes = super::format_sse_error(
+                            guardrail_error.message(),
+                            guardrail_error.error_type(),
+                            guardrail_error.code(),
+                        );
+                        if tx.send(error_bytes).await.is_err() {
+                            info!("Client disconnected before guardrail error could be sent");
+                        }
+                        drop(lease.take());
+                        callback.fail(guardrail_error.message(), "guardrail_output");
+                        settle_after_upstream_output!();
+                        return;
+                    }};
                 }
 
                 loop {
@@ -239,7 +259,7 @@ pub(super) async fn handle_streaming_chat_completion(
                         break;
                     };
 
-                    let bytes = match chunk_result {
+                    let (output_deltas, bytes) = match chunk_result {
                         Ok(chunk) => {
                             let has_candidate_output =
                                 spend::stream_chunk_has_candidate_output(&chunk);
@@ -285,7 +305,18 @@ pub(super) async fn handle_streaming_chat_completion(
                                     continue;
                                 }
                             }
-                            match serde_json::to_string(&chat_chunk) {
+                            let output_deltas = chat_chunk
+                                .choices
+                                .iter()
+                                .filter_map(|choice| {
+                                    choice
+                                        .delta
+                                        .content
+                                        .as_ref()
+                                        .map(|text| (choice.index, text.clone()))
+                                })
+                                .collect::<Vec<_>>();
+                            let bytes = match serde_json::to_string(&chat_chunk) {
                                 Ok(json) => {
                                     let event = Event::default().data(&json);
                                     event.to_bytes()
@@ -316,7 +347,8 @@ pub(super) async fn handle_streaming_chat_completion(
                                     settle_after_upstream_output!();
                                     return;
                                 }
-                            }
+                            };
+                            (output_deltas, bytes)
                         }
                         Err(e) => {
                             error!("Stream chunk error: {}", e);
@@ -335,8 +367,39 @@ pub(super) async fn handle_streaming_chat_completion(
                         }
                     };
 
+                    let pending = match output_guardrail
+                        .push_many_until_closed(&tx, output_deltas, bytes)
+                        .await
+                    {
+                        Ok(Some(pending)) => pending,
+                        Ok(None) => {
+                            callback.fail("client disconnected", "client_disconnect");
+                            settle_after_upstream_output!();
+                            return;
+                        }
+                        Err(error) => return_after_guardrail_error!(error),
+                    };
+                    for bytes in pending {
+                        if tx.send(bytes).await.is_err() {
+                            info!("Client disconnected during streaming, cancelling upstream");
+                            callback.fail("client disconnected", "client_disconnect");
+                            settle_after_upstream_output!();
+                            return;
+                        }
+                    }
+                }
+
+                let pending = match output_guardrail.finish_until_closed(&tx).await {
+                    Ok(Some(pending)) => pending,
+                    Ok(None) => {
+                        callback.fail("client disconnected", "client_disconnect");
+                        settle_after_upstream_output!();
+                        return;
+                    }
+                    Err(error) => return_after_guardrail_error!(error),
+                };
+                for bytes in pending {
                     if tx.send(bytes).await.is_err() {
-                        info!("Client disconnected during streaming, cancelling upstream");
                         callback.fail("client disconnected", "client_disconnect");
                         settle_after_upstream_output!();
                         return;

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -195,6 +195,19 @@ pub(super) async fn handle_streaming_chat_completion(
                         return;
                     }};
                 }
+                macro_rules! flush_guardrail {
+                    () => {
+                        match output_guardrail.flush_to_until_closed(&tx).await {
+                            Ok(Some(())) => {}
+                            Ok(None) => {
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_after_upstream_output!();
+                                return;
+                            }
+                            Err(error) => return_after_guardrail_error!(error),
+                        }
+                    };
+                }
 
                 loop {
                     let chunk_result = if idle_timeout_secs == 0 {
@@ -223,6 +236,7 @@ pub(super) async fn handle_streaming_chat_completion(
                         match timed_result {
                             Ok(result) => result,
                             Err(_) => {
+                                flush_guardrail!();
                                 warn!(
                                     "SSE stream idle timeout after {}s, closing connection",
                                     idle_timeout_secs
@@ -278,6 +292,7 @@ pub(super) async fn handle_streaming_chat_completion(
                             {
                                 Ok(chat_chunk) => chat_chunk,
                                 Err(e) => {
+                                    flush_guardrail!();
                                     error!("Stream chunk conversion error: {}", e);
                                     let (error_type, error_code) =
                                         super::sse_error_classification(&e);
@@ -322,6 +337,7 @@ pub(super) async fn handle_streaming_chat_completion(
                                     event.to_bytes()
                                 }
                                 Err(e) => {
+                                    flush_guardrail!();
                                     error!("Stream serialization error: {}", e);
                                     let error_bytes = super::format_sse_error(
                                         &format!("Serialization error: {}", e),
@@ -351,6 +367,7 @@ pub(super) async fn handle_streaming_chat_completion(
                             (output_deltas, bytes)
                         }
                         Err(e) => {
+                            flush_guardrail!();
                             error!("Stream chunk error: {}", e);
                             let (error_type, error_code) = super::sse_error_classification(&e);
                             let error_bytes =
@@ -389,22 +406,7 @@ pub(super) async fn handle_streaming_chat_completion(
                     }
                 }
 
-                let pending = match output_guardrail.finish_until_closed(&tx).await {
-                    Ok(Some(pending)) => pending,
-                    Ok(None) => {
-                        callback.fail("client disconnected", "client_disconnect");
-                        settle_after_upstream_output!();
-                        return;
-                    }
-                    Err(error) => return_after_guardrail_error!(error),
-                };
-                for bytes in pending {
-                    if tx.send(bytes).await.is_err() {
-                        callback.fail("client disconnected", "client_disconnect");
-                        settle_after_upstream_output!();
-                        return;
-                    }
-                }
+                flush_guardrail!();
 
                 let done_event = Event::default().data("[DONE]");
                 if tx.send(done_event.to_bytes()).await.is_err() {

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -191,6 +191,19 @@ pub(super) async fn handle_streaming_completion(
                         return;
                     }};
                 }
+                macro_rules! flush_guardrail {
+                    () => {
+                        match output_guardrail.flush_to_until_closed(&tx).await {
+                            Ok(Some(())) => {}
+                            Ok(None) => {
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_if_chargeable!();
+                                return;
+                            }
+                            Err(error) => return_after_guardrail_error!(error),
+                        }
+                    };
+                }
 
                 loop {
                     let chunk_result = if idle_timeout_secs == 0 {
@@ -219,6 +232,7 @@ pub(super) async fn handle_streaming_completion(
                         match timed_result {
                             Ok(result) => result,
                             Err(_) => {
+                                flush_guardrail!();
                                 warn!(
                                     "Completion SSE stream idle timeout after {}s",
                                     idle_timeout_secs
@@ -292,6 +306,7 @@ pub(super) async fn handle_streaming_completion(
                             let bytes = match serde_json::to_string(&completion_chunk) {
                                 Ok(json) => Event::default().data(&json).to_bytes(),
                                 Err(error) => {
+                                    flush_guardrail!();
                                     error!("Completion stream serialization error: {}", error);
                                     send_stream_error(
                                         &tx,
@@ -318,6 +333,7 @@ pub(super) async fn handle_streaming_completion(
                             (output_deltas, bytes)
                         }
                         Err(error) => {
+                            flush_guardrail!();
                             error!("Completion stream chunk error: {}", error);
                             let (error_type, error_code) = chat::sse_error_classification(&error);
                             send_stream_error(&tx, &error.to_string(), error_type, error_code)
@@ -352,22 +368,7 @@ pub(super) async fn handle_streaming_completion(
                     }
                 }
 
-                let pending = match output_guardrail.finish_until_closed(&tx).await {
-                    Ok(Some(pending)) => pending,
-                    Ok(None) => {
-                        callback.fail("client disconnected", "client_disconnect");
-                        settle_if_chargeable!();
-                        return;
-                    }
-                    Err(error) => return_after_guardrail_error!(error),
-                };
-                for bytes in pending {
-                    if tx.send(bytes).await.is_err() {
-                        callback.fail("client disconnected", "client_disconnect");
-                        settle_if_chargeable!();
-                        return;
-                    }
-                }
+                flush_guardrail!();
 
                 if tx
                     .send(Event::default().data("[DONE]").to_bytes())

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -159,9 +159,12 @@ pub(super) async fn handle_streaming_completion(
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let include_usage = adapter_request.include_usage;
             let mut echo_prefix = adapter_request.echo.then_some(adapter_request.prompt);
+            let guardrails = Arc::clone(&state.guardrails);
 
             tokio::spawn(async move {
                 let mut lease = Some(lease);
+                let mut output_guardrail =
+                    super::super::stream_output_guardrail::StreamOutputGuardrail::new(guardrails);
                 let mut tokens_used = 0_u64;
                 let mut final_usage = None;
                 let mut saw_upstream_output = false;
@@ -171,6 +174,22 @@ pub(super) async fn handle_streaming_completion(
                             settlement.record_disconnect(final_usage.as_ref()).await;
                         }
                     };
+                }
+                macro_rules! return_after_guardrail_error {
+                    ($error:expr) => {{
+                        let guardrail_error = $error;
+                        send_stream_error(
+                            &tx,
+                            guardrail_error.message(),
+                            guardrail_error.error_type(),
+                            guardrail_error.code(),
+                        )
+                        .await;
+                        drop(lease.take());
+                        callback.fail(guardrail_error.message(), "guardrail_output");
+                        settle_if_chargeable!();
+                        return;
+                    }};
                 }
 
                 loop {
@@ -232,7 +251,7 @@ pub(super) async fn handle_streaming_completion(
                         break;
                     };
 
-                    let bytes = match chunk_result {
+                    let (output_deltas, bytes) = match chunk_result {
                         Ok(chunk) => {
                             let has_candidate_output =
                                 spend::stream_chunk_has_candidate_output(&chunk);
@@ -252,6 +271,16 @@ pub(super) async fn handle_streaming_completion(
                             } else {
                                 None
                             };
+                            let output_deltas = chunk
+                                .choices
+                                .iter()
+                                .map(|choice| {
+                                    (
+                                        choice.index,
+                                        choice.delta.content.clone().unwrap_or_default(),
+                                    )
+                                })
+                                .collect::<Vec<_>>();
                             let completion_chunk = completion_chunk_from_core(
                                 chunk,
                                 prefix_for_chunk.as_deref(),
@@ -260,7 +289,7 @@ pub(super) async fn handle_streaming_completion(
                             if !include_usage && completion_chunk.choices.is_empty() {
                                 continue;
                             }
-                            match serde_json::to_string(&completion_chunk) {
+                            let bytes = match serde_json::to_string(&completion_chunk) {
                                 Ok(json) => Event::default().data(&json).to_bytes(),
                                 Err(error) => {
                                     error!("Completion stream serialization error: {}", error);
@@ -285,7 +314,8 @@ pub(super) async fn handle_streaming_completion(
                                     settle_if_chargeable!();
                                     return;
                                 }
-                            }
+                            };
+                            (output_deltas, bytes)
                         }
                         Err(error) => {
                             error!("Completion stream chunk error: {}", error);
@@ -301,6 +331,37 @@ pub(super) async fn handle_streaming_completion(
                         }
                     };
 
+                    let pending = match output_guardrail
+                        .push_many_until_closed(&tx, output_deltas, bytes)
+                        .await
+                    {
+                        Ok(Some(pending)) => pending,
+                        Ok(None) => {
+                            callback.fail("client disconnected", "client_disconnect");
+                            settle_if_chargeable!();
+                            return;
+                        }
+                        Err(error) => return_after_guardrail_error!(error),
+                    };
+                    for bytes in pending {
+                        if tx.send(bytes).await.is_err() {
+                            callback.fail("client disconnected", "client_disconnect");
+                            settle_if_chargeable!();
+                            return;
+                        }
+                    }
+                }
+
+                let pending = match output_guardrail.finish_until_closed(&tx).await {
+                    Ok(Some(pending)) => pending,
+                    Ok(None) => {
+                        callback.fail("client disconnected", "client_disconnect");
+                        settle_if_chargeable!();
+                        return;
+                    }
+                    Err(error) => return_after_guardrail_error!(error),
+                };
+                for bytes in pending {
                     if tx.send(bytes).await.is_err() {
                         callback.fail("client disconnected", "client_disconnect");
                         settle_if_chargeable!();

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -28,6 +28,7 @@ mod responses;
 mod responses_stream;
 mod route_http;
 mod spend;
+mod stream_output_guardrail;
 mod token_policy;
 
 // Public re-exports for backward compatibility

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -276,6 +276,7 @@ pub(crate) async fn handle_streaming_response(
                                 callback.fail("client disconnected", "client_disconnect");
                             }
                             ResponseStreamEmitError::Serialization(error) => {
+                                flush_guardrail!();
                                 let message = format!("stream serialization failed: {error}");
                                 if let Some(lease) = lease.take() {
                                     let provider_error =
@@ -334,6 +335,7 @@ pub(crate) async fn handle_streaming_response(
                         match timed_result {
                             Ok(r) => r,
                             Err(_) => {
+                                flush_guardrail!();
                                 warn!("Responses API stream idle timeout after {idle_timeout}s");
                                 let _ = tx
                                     .send(sse_error(
@@ -513,7 +515,6 @@ pub(crate) async fn handle_streaming_response(
                                     for tc in tc_deltas {
                                         let idx = tc.index;
 
-                                        // First chunk for this call (has an id): emit placeholder
                                         if let (
                                             Some(call_id),
                                             std::collections::hash_map::Entry::Vacant(entry),
@@ -568,7 +569,6 @@ pub(crate) async fn handle_streaming_response(
                                             {
                                                 state.name.clone_from(n);
                                             }
-                                            // Emit argument deltas
                                             if let Some(args) = &fn_delta.arguments
                                                 && !args.is_empty()
                                             {
@@ -594,6 +594,7 @@ pub(crate) async fn handle_streaming_response(
                             }
                         }
                         Err(e) => {
+                            flush_guardrail!();
                             error!("Responses API stream error: {e}");
                             let (et, ec) = classify(&e);
                             let _ = tx.send(sse_error(&e.to_string(), et, ec)).await;

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -34,33 +34,18 @@ use super::{openai_errors, spend};
 #[path = "responses_stream_budget.rs"]
 mod responses_stream_budget;
 use responses_stream_budget::StreamBudgetSettlement;
+#[path = "responses_stream_state.rs"]
+mod responses_stream_state;
+#[cfg(test)]
+use responses_stream_state::response_stream_total_tokens;
+use responses_stream_state::{ToolCallAccum, response_stream_budget_usage};
 #[path = "responses_stream_support.rs"]
 mod responses_stream_support;
 use responses_stream_support::{
-    ResponseStreamEmitError, classify, completed_reasoning_item, emit, in_progress_reasoning_item,
-    make_shell, output_items_in_stream_order, response_usage_from_chat_usage, sse_error,
+    ResponseStreamEmitError, classify, completed_reasoning_item, emit, encode,
+    flush_output_guardrail, in_progress_reasoning_item, make_shell, output_items_in_stream_order,
+    response_usage_from_chat_usage, send_encoded, send_guardrail_error, sse_error,
 };
-
-fn response_stream_total_tokens(
-    final_usage: Option<&ChatUsage>,
-    input_tokens: u32,
-    output_tokens: u32,
-) -> u32 {
-    final_usage.map_or_else(
-        || input_tokens.saturating_add(output_tokens),
-        |usage| usage.total_tokens,
-    )
-}
-
-/// Accumulated state for one in-progress tool call during streaming.
-struct ToolCallAccum {
-    item_id: String,
-    call_id: String,
-    name: String,
-    arguments: String,
-    output_index: u32,
-}
-
 /// Streaming path for POST /v1/responses.
 pub(crate) async fn handle_streaming_response(
     state: &AppState,
@@ -87,7 +72,6 @@ pub(crate) async fn handle_streaming_response(
     let model_name = chat_request.model.clone();
     let resp_id = format!("resp_{}", uuid_v4_hex());
     let created_at = current_unix_ts();
-
     let core_request =
         match build_core_chat_request(chat_request.as_ref(), model_name.clone(), true) {
             Ok(r) => r,
@@ -95,7 +79,6 @@ pub(crate) async fn handle_streaming_response(
                 return Ok(openai_errors::gateway_error_response(&e));
             }
         };
-
     let requested_model = core_request.model.clone();
     let callback = CallbackLifecycle::new(
         &state.callbacks,
@@ -112,7 +95,6 @@ pub(crate) async fn handle_streaming_response(
     let api_key_budget_id = context.api_key_budget_id();
     let settlement_budgeted = state.budgeted.clone();
     let callback_for_execution = callback.clone();
-
     match run_stream(
         state.unified_router.clone(),
         &requested_model,
@@ -210,6 +192,7 @@ pub(crate) async fn handle_streaming_response(
         )) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout = state.config.load().gateway.server.stream_idle_timeout;
+            let guardrails = Arc::clone(&state.guardrails);
             let settlement = StreamBudgetSettlement {
                 pricing_service: settlement_budgeted.pricing(),
                 pricing_config: state.config().gateway.pricing.clone(),
@@ -227,6 +210,8 @@ pub(crate) async fn handle_streaming_response(
             tokio::spawn(async move {
                 let mut lease = Some(lease);
                 let mut settlement = settlement;
+                let mut output_guardrail =
+                    super::stream_output_guardrail::StreamOutputGuardrail::new(guardrails);
 
                 let shell = make_shell(&resp_id, created_at, &model_name, "in_progress", &original);
                 if let Err(error) = emit(
@@ -271,21 +256,21 @@ pub(crate) async fn handle_streaming_response(
                 let mut reasoning_output_index: u32 = 0;
                 let mut reasoning_started = false;
                 macro_rules! settle_if_chargeable {
-                    () => {
+                    () => {{
                         if final_usage.is_some() || saw_upstream_output {
                             settlement.record_disconnect(final_usage.as_ref()).await;
                         }
-                    };
+                    }};
                 }
                 macro_rules! return_after_disconnect {
-                    () => {
+                    () => {{
                         callback.fail("client disconnected", "client_disconnect");
                         settle_if_chargeable!();
                         return;
-                    };
+                    }};
                 }
                 macro_rules! return_after_emit_error {
-                    ($error:expr) => {
+                    ($error:expr) => {{
                         match $error {
                             ResponseStreamEmitError::ClientDisconnected => {
                                 callback.fail("client disconnected", "client_disconnect");
@@ -302,6 +287,27 @@ pub(crate) async fn handle_streaming_response(
                         }
                         settle_if_chargeable!();
                         return;
+                    }};
+                }
+                macro_rules! return_after_guardrail_error {
+                    ($error:expr) => {{
+                        let error = $error;
+                        if send_guardrail_error(&tx, error).await {
+                            info!("Client disconnected before guardrail error could be sent");
+                        }
+                        drop(lease.take());
+                        callback.fail(error.message(), "guardrail_output");
+                        settle_if_chargeable!();
+                        return;
+                    }};
+                }
+                macro_rules! flush_guardrail {
+                    () => {
+                        match flush_output_guardrail(&tx, &mut output_guardrail).await {
+                            Ok(true) => {}
+                            Ok(false) => return_after_disconnect!(),
+                            Err(error) => return_after_guardrail_error!(error),
+                        }
                     };
                 }
 
@@ -383,6 +389,7 @@ pub(crate) async fn handle_streaming_response(
                                     && let Some(reasoning_text) = thinking.content.as_deref()
                                     && !reasoning_text.is_empty()
                                 {
+                                    flush_guardrail!();
                                     saw_upstream_output = true;
                                     if !reasoning_started {
                                         if text_started {
@@ -474,22 +481,33 @@ pub(crate) async fn handle_streaming_response(
                                     }
 
                                     full_text.push_str(text);
-                                    if let Err(error) = emit(
-                                        &tx,
-                                        &ResponseStreamEvent::ResponseOutputTextDelta {
-                                            output_index: text_output_index,
-                                            content_index: 0,
-                                            delta: text.to_string(),
-                                        },
-                                    )
-                                    .await
+                                    let event = ResponseStreamEvent::ResponseOutputTextDelta {
+                                        output_index: text_output_index,
+                                        content_index: 0,
+                                        delta: text.to_string(),
+                                    };
+                                    let encoded = match encode(&event) {
+                                        Ok(encoded) => encoded,
+                                        Err(error) => return_after_emit_error!(error),
+                                    };
+                                    let pending = match output_guardrail
+                                        .push_until_closed(&tx, text, encoded)
+                                        .await
                                     {
-                                        return_after_emit_error!(error);
+                                        Ok(Some(pending)) => pending,
+                                        Ok(None) => return_after_disconnect!(),
+                                        Err(error) => return_after_guardrail_error!(error),
+                                    };
+                                    for encoded in pending {
+                                        if let Err(error) = send_encoded(&tx, encoded).await {
+                                            return_after_emit_error!(error);
+                                        }
                                     }
                                 }
 
                                 if let Some(tc_deltas) = &choice.delta.tool_calls {
                                     if !tc_deltas.is_empty() {
+                                        flush_guardrail!();
                                         saw_upstream_output = true;
                                     }
                                     for tc in tc_deltas {
@@ -532,13 +550,12 @@ pub(crate) async fn handle_streaming_response(
                                                 return_after_emit_error!(error);
                                             }
 
-                                            entry.insert(ToolCallAccum {
+                                            entry.insert(ToolCallAccum::new(
                                                 item_id,
-                                                call_id: call_id.clone(),
+                                                call_id.clone(),
                                                 name,
-                                                arguments: String::new(),
-                                                output_index: out_idx,
-                                            });
+                                                out_idx,
+                                            ));
                                             tool_order.push(idx);
                                         }
 
@@ -589,7 +606,7 @@ pub(crate) async fn handle_streaming_response(
                         }
                     }
                 }
-
+                flush_guardrail!();
                 let item_status = final_status;
                 let mut all_output: Vec<(u32, ResponseOutputItem)> = Vec::new();
 
@@ -693,13 +710,7 @@ pub(crate) async fn handle_streaming_response(
                             return_after_emit_error!(error);
                         }
 
-                        let fc_done = ResponseOutputItem::FunctionCall(ResponseFunctionCall {
-                            id: state.item_id.clone(),
-                            name: state.name.clone(),
-                            arguments: state.arguments.clone(),
-                            status: "completed".to_string(),
-                            call_id: Some(state.call_id.clone()),
-                        });
+                        let fc_done = state.completed_item();
                         if let Err(error) = emit(
                             &tx,
                             &ResponseStreamEvent::ResponseOutputItemDone {
@@ -717,18 +728,8 @@ pub(crate) async fn handle_streaming_response(
 
                 let output_items = output_items_in_stream_order(all_output);
 
-                let total =
-                    response_stream_total_tokens(final_usage.as_ref(), in_tokens, out_tokens);
-                let budget_usage = final_usage.clone().or_else(|| {
-                    (total > 0).then_some(ChatUsage {
-                        prompt_tokens: in_tokens,
-                        completion_tokens: out_tokens,
-                        total_tokens: total,
-                        prompt_tokens_details: None,
-                        completion_tokens_details: None,
-                        thinking_usage: None,
-                    })
-                });
+                let (total, budget_usage) =
+                    response_stream_budget_usage(final_usage.clone(), in_tokens, out_tokens);
                 let usage = budget_usage.as_ref().map(response_usage_from_chat_usage);
                 let completed = ResponsesApiResponse {
                     id: resp_id,

--- a/src/server/routes/ai/responses_stream_state.rs
+++ b/src/server/routes/ai/responses_stream_state.rs
@@ -1,0 +1,63 @@
+use crate::core::models::openai::responses_api::{ResponseFunctionCall, ResponseOutputItem};
+use crate::core::types::responses::Usage as ChatUsage;
+
+pub(super) fn response_stream_total_tokens(
+    final_usage: Option<&ChatUsage>,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> u32 {
+    final_usage.map_or_else(
+        || input_tokens.saturating_add(output_tokens),
+        |usage| usage.total_tokens,
+    )
+}
+
+/// Accumulated state for one in-progress tool call during streaming.
+pub(super) struct ToolCallAccum {
+    pub(super) item_id: String,
+    pub(super) call_id: String,
+    pub(super) name: String,
+    pub(super) arguments: String,
+    pub(super) output_index: u32,
+}
+
+impl ToolCallAccum {
+    pub(super) fn new(item_id: String, call_id: String, name: String, output_index: u32) -> Self {
+        Self {
+            item_id,
+            call_id,
+            name,
+            arguments: String::new(),
+            output_index,
+        }
+    }
+
+    pub(super) fn completed_item(&self) -> ResponseOutputItem {
+        ResponseOutputItem::FunctionCall(ResponseFunctionCall {
+            id: self.item_id.clone(),
+            name: self.name.clone(),
+            arguments: self.arguments.clone(),
+            status: "completed".to_string(),
+            call_id: Some(self.call_id.clone()),
+        })
+    }
+}
+
+pub(super) fn response_stream_budget_usage(
+    final_usage: Option<ChatUsage>,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> (u32, Option<ChatUsage>) {
+    let total = response_stream_total_tokens(final_usage.as_ref(), input_tokens, output_tokens);
+    let usage = final_usage.or_else(|| {
+        (total > 0).then_some(ChatUsage {
+            prompt_tokens: input_tokens,
+            completion_tokens: output_tokens,
+            total_tokens: total,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+            thinking_usage: None,
+        })
+    });
+    (total, usage)
+}

--- a/src/server/routes/ai/responses_stream_support.rs
+++ b/src/server/routes/ai/responses_stream_support.rs
@@ -131,15 +131,10 @@ pub(super) async fn flush_output_guardrail(
     tx: &mpsc::Sender<Bytes>,
     guardrail: &mut StreamOutputGuardrail,
 ) -> Result<bool, StreamGuardrailError> {
-    let Some(pending) = guardrail.finish_until_closed(tx).await? else {
-        return Ok(false);
-    };
-    for event in pending {
-        if send_encoded(tx, event).await.is_err() {
-            return Ok(false);
-        }
-    }
-    Ok(true)
+    guardrail
+        .flush_to_until_closed(tx)
+        .await
+        .map(|result| result.is_some())
 }
 
 pub(super) fn sse_error(message: &str, error_type: &str, code: &str) -> Bytes {

--- a/src/server/routes/ai/responses_stream_support.rs
+++ b/src/server/routes/ai/responses_stream_support.rs
@@ -13,6 +13,8 @@ use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
 use crate::core::types::responses::Usage as ChatUsage;
 
+use super::super::stream_output_guardrail::{StreamGuardrailError, StreamOutputGuardrail};
+
 pub(super) fn completed_reasoning_item(
     item_id: String,
     status: &str,
@@ -108,10 +110,36 @@ async fn emit_serialized<T: Serialize + ?Sized>(
     tx: &mpsc::Sender<Bytes>,
     event: &T,
 ) -> Result<(), ResponseStreamEmitError> {
+    send_encoded(tx, encode(event)?).await
+}
+
+pub(super) fn encode<T: Serialize + ?Sized>(event: &T) -> Result<Bytes, ResponseStreamEmitError> {
     let json = serde_json::to_string(event).map_err(ResponseStreamEmitError::Serialization)?;
-    tx.send(Event::default().data(&json).to_bytes())
+    Ok(Event::default().data(&json).to_bytes())
+}
+
+pub(super) async fn send_encoded(
+    tx: &mpsc::Sender<Bytes>,
+    event: Bytes,
+) -> Result<(), ResponseStreamEmitError> {
+    tx.send(event)
         .await
         .map_err(|_| ResponseStreamEmitError::ClientDisconnected)
+}
+
+pub(super) async fn flush_output_guardrail(
+    tx: &mpsc::Sender<Bytes>,
+    guardrail: &mut StreamOutputGuardrail,
+) -> Result<bool, StreamGuardrailError> {
+    let Some(pending) = guardrail.finish_until_closed(tx).await? else {
+        return Ok(false);
+    };
+    for event in pending {
+        if send_encoded(tx, event).await.is_err() {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 pub(super) fn sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
@@ -121,6 +149,15 @@ pub(super) fn sse_error(message: &str, error_type: &str, code: &str) -> Bytes {
     let mut bytes = error_event.to_bytes().to_vec();
     bytes.extend_from_slice(&done_event.to_bytes());
     Bytes::from(bytes)
+}
+
+pub(super) async fn send_guardrail_error(
+    tx: &mpsc::Sender<Bytes>,
+    error: StreamGuardrailError,
+) -> bool {
+    tx.send(sse_error(error.message(), error.error_type(), error.code()))
+        .await
+        .is_err()
 }
 
 pub(super) fn classify(error: &ProviderError) -> (&'static str, &'static str) {

--- a/src/server/routes/ai/stream_output_guardrail.rs
+++ b/src/server/routes/ai/stream_output_guardrail.rs
@@ -1,0 +1,451 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use tokio::sync::mpsc;
+
+use crate::core::guardrails::{CheckResult, GuardrailEngine};
+
+const MAX_CONTEXT_CHARS: usize = 1024 * 1024;
+const MAX_PENDING_BYTES: usize = 1024 * 1024;
+const MAX_SURFACES: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StreamGuardrailError {
+    Violation,
+    Execution,
+}
+
+impl StreamGuardrailError {
+    pub(super) fn error_type(self) -> &'static str {
+        match self {
+            Self::Violation => "content_policy_error",
+            Self::Execution => "server_error",
+        }
+    }
+
+    pub(super) fn code(self) -> &'static str {
+        match self {
+            Self::Violation => "guardrail_violation",
+            Self::Execution => "guardrail_error",
+        }
+    }
+
+    pub(super) fn message(self) -> &'static str {
+        match self {
+            Self::Violation => "Response blocked by output guardrails",
+            Self::Execution => "Output guardrail check failed",
+        }
+    }
+}
+
+#[derive(Default)]
+struct SurfaceState {
+    context: String,
+    chars_since_check: usize,
+}
+
+pub(super) struct StreamOutputGuardrail {
+    engine: Arc<GuardrailEngine>,
+    active: bool,
+    check_chars: usize,
+    surfaces: BTreeMap<u32, SurfaceState>,
+    context_chars: usize,
+    pending: Vec<Bytes>,
+    pending_bytes: usize,
+}
+
+impl StreamOutputGuardrail {
+    pub(super) fn new(engine: Arc<GuardrailEngine>) -> Self {
+        let config = engine.config();
+        Self {
+            active: engine.is_enabled() && config.check_output,
+            check_chars: config.stream_output_check_chars,
+            engine,
+            surfaces: BTreeMap::new(),
+            context_chars: 0,
+            pending: Vec::new(),
+            pending_bytes: 0,
+        }
+    }
+
+    pub(super) async fn push(
+        &mut self,
+        text: &str,
+        event: Bytes,
+    ) -> Result<Vec<Bytes>, StreamGuardrailError> {
+        self.push_many(vec![(0, text.to_string())], event).await
+    }
+
+    pub(super) async fn push_many(
+        &mut self,
+        deltas: Vec<(u32, String)>,
+        event: Bytes,
+    ) -> Result<Vec<Bytes>, StreamGuardrailError> {
+        if !self.active {
+            return Ok(vec![event]);
+        }
+
+        if deltas.iter().all(|(_, text)| text.is_empty()) {
+            if self.pending.is_empty() {
+                return Ok(vec![event]);
+            }
+            let mut released = self.finish().await?;
+            released.push(event);
+            return Ok(released);
+        }
+
+        if event.len() > MAX_PENDING_BYTES {
+            return Err(StreamGuardrailError::Execution);
+        }
+        let mut released = if self.pending_bytes.saturating_add(event.len()) > MAX_PENDING_BYTES {
+            self.finish().await?
+        } else {
+            Vec::new()
+        };
+        for (surface, text) in deltas {
+            self.append_and_check(surface, &text).await?;
+        }
+        self.pending_bytes = self.pending_bytes.saturating_add(event.len());
+        self.pending.push(event);
+
+        if !self
+            .surfaces
+            .values()
+            .all(|state| state.chars_since_check == 0)
+            && self.pending_bytes < MAX_PENDING_BYTES
+        {
+            return Ok(released);
+        }
+        if self
+            .surfaces
+            .values()
+            .any(|state| state.chars_since_check > 0)
+        {
+            released.extend(self.finish().await?);
+            return Ok(released);
+        }
+        released.extend(self.release_pending()?);
+        Ok(released)
+    }
+
+    pub(super) async fn finish(&mut self) -> Result<Vec<Bytes>, StreamGuardrailError> {
+        if self.active {
+            let dirty = self
+                .surfaces
+                .iter()
+                .filter_map(|(surface, state)| (state.chars_since_check > 0).then_some(*surface))
+                .collect::<Vec<_>>();
+            for surface in dirty {
+                self.check_surface(surface).await?;
+            }
+        }
+        self.release_pending()
+    }
+
+    pub(super) async fn push_many_until_closed(
+        &mut self,
+        tx: &mpsc::Sender<Bytes>,
+        deltas: Vec<(u32, String)>,
+        event: Bytes,
+    ) -> Result<Option<Vec<Bytes>>, StreamGuardrailError> {
+        tokio::select! {
+            biased;
+            _ = tx.closed() => Ok(None),
+            result = self.push_many(deltas, event) => result.map(Some),
+        }
+    }
+
+    pub(super) async fn push_until_closed(
+        &mut self,
+        tx: &mpsc::Sender<Bytes>,
+        text: &str,
+        event: Bytes,
+    ) -> Result<Option<Vec<Bytes>>, StreamGuardrailError> {
+        tokio::select! {
+            biased;
+            _ = tx.closed() => Ok(None),
+            result = self.push(text, event) => result.map(Some),
+        }
+    }
+
+    pub(super) async fn finish_until_closed(
+        &mut self,
+        tx: &mpsc::Sender<Bytes>,
+    ) -> Result<Option<Vec<Bytes>>, StreamGuardrailError> {
+        tokio::select! {
+            biased;
+            _ = tx.closed() => Ok(None),
+            result = self.finish() => result.map(Some),
+        }
+    }
+
+    async fn append_and_check(
+        &mut self,
+        surface: u32,
+        text: &str,
+    ) -> Result<(), StreamGuardrailError> {
+        if !text.is_empty() && !self.surfaces.contains_key(&surface) {
+            if self.surfaces.len() >= MAX_SURFACES {
+                return Err(StreamGuardrailError::Execution);
+            }
+            self.surfaces.insert(surface, SurfaceState::default());
+        }
+        let added_chars = text.chars().count();
+        if self.context_chars.saturating_add(added_chars) > MAX_CONTEXT_CHARS {
+            return Err(StreamGuardrailError::Execution);
+        }
+        self.context_chars += added_chars;
+
+        let mut start = 0;
+        while start < text.len() {
+            let remaining = self
+                .check_chars
+                .saturating_sub(self.surfaces.entry(surface).or_default().chars_since_check)
+                .max(1);
+            let end = prefix_end(text, start, remaining);
+            let state = self.surfaces.entry(surface).or_default();
+            state.context.push_str(&text[start..end]);
+            state.chars_since_check += text[start..end].chars().count();
+            start = end;
+            if state.chars_since_check >= self.check_chars {
+                self.check_surface(surface).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_surface(&mut self, surface: u32) -> Result<(), StreamGuardrailError> {
+        let content = self
+            .surfaces
+            .get(&surface)
+            .map(|state| state.context.as_str())
+            .unwrap_or_default();
+        let result = self
+            .engine
+            .check_output(content)
+            .await
+            .map_err(|_| StreamGuardrailError::Execution)?;
+        enforce(result)?;
+
+        if let Some(state) = self.surfaces.get_mut(&surface) {
+            state.chars_since_check = 0;
+        }
+        Ok(())
+    }
+
+    fn release_pending(&mut self) -> Result<Vec<Bytes>, StreamGuardrailError> {
+        self.pending_bytes = 0;
+        Ok(std::mem::take(&mut self.pending))
+    }
+}
+
+fn prefix_end(text: &str, start: usize, max_chars: usize) -> usize {
+    text[start..]
+        .char_indices()
+        .nth(max_chars)
+        .map_or(text.len(), |(offset, _)| start + offset)
+}
+
+fn enforce(result: CheckResult) -> Result<(), StreamGuardrailError> {
+    if result.is_blocked() {
+        Err(StreamGuardrailError::Violation)
+    } else if result.is_modified() {
+        Err(StreamGuardrailError::Execution)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::models::gateway::GatewayConfig;
+
+    fn guardrail(check_chars: usize, enabled: bool) -> StreamOutputGuardrail {
+        let mut config = GatewayConfig::default().guardrails;
+        config.enabled = enabled;
+        config.stream_output_check_chars = check_chars;
+        let engine = GuardrailEngine::new(config).expect("test guardrails should compile");
+        StreamOutputGuardrail::new(Arc::new(engine))
+    }
+
+    #[tokio::test]
+    async fn safe_event_is_released_after_reaching_the_window() {
+        let mut guardrail = guardrail(4, true);
+        let event = Bytes::from_static(b"safe-event");
+
+        let released = guardrail
+            .push("safe", event.clone())
+            .await
+            .expect("safe output should pass");
+
+        assert_eq!(released, vec![event]);
+        assert!(guardrail.finish().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn split_violation_is_blocked_before_pending_events_are_released() {
+        let mut guardrail = guardrail(256, true);
+
+        assert!(
+            guardrail
+                .push("System ", Bytes::from_static(b"first"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            guardrail
+                .push("prompt: hidden policy", Bytes::from_static(b"second"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            guardrail.finish().await.unwrap_err(),
+            StreamGuardrailError::Violation
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_guardrails_do_not_buffer_events() {
+        let mut guardrail = guardrail(256, false);
+        let event = Bytes::from_static(b"event");
+
+        assert_eq!(
+            guardrail
+                .push("System prompt: hidden policy", event.clone())
+                .await
+                .unwrap(),
+            vec![event]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_text_event_cannot_overtake_pending_text() {
+        let mut guardrail = guardrail(256, true);
+        let text = Bytes::from_static(b"text");
+        let terminal = Bytes::from_static(b"terminal");
+
+        assert!(
+            guardrail
+                .push("safe", text.clone())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            guardrail.push("", terminal.clone()).await.unwrap(),
+            vec![text, terminal]
+        );
+        assert!(guardrail.finish().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interleaved_choices_keep_independent_detection_contexts() {
+        let mut guardrail = guardrail(256, true);
+
+        assert!(
+            guardrail
+                .push_many(
+                    vec![(0, "System ".to_string()), (1, "safe ".to_string())],
+                    Bytes::from_static(b"first"),
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            guardrail
+                .push_many(
+                    vec![(1, "text".to_string()), (0, "prompt: hidden".to_string())],
+                    Bytes::from_static(b"second"),
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            guardrail.finish().await.unwrap_err(),
+            StreamGuardrailError::Violation
+        );
+    }
+
+    #[tokio::test]
+    async fn cumulative_context_is_bounded_and_oversized_events_fail_closed() {
+        let mut guardrail = guardrail(4096, true);
+        let oversized_event = Bytes::from(vec![b'x'; MAX_PENDING_BYTES + 1]);
+
+        assert_eq!(
+            guardrail
+                .push("safe", oversized_event.clone())
+                .await
+                .unwrap_err(),
+            StreamGuardrailError::Execution
+        );
+        assert!(guardrail.pending.is_empty());
+
+        assert_eq!(
+            guardrail
+                .push(
+                    &"a".repeat(MAX_CONTEXT_CHARS + 1),
+                    Bytes::from_static(b"long")
+                )
+                .await
+                .unwrap_err(),
+            StreamGuardrailError::Execution
+        );
+        assert!(guardrail.pending.is_empty());
+        assert_eq!(guardrail.pending_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn surface_count_is_bounded() {
+        let mut guardrail = guardrail(4096, true);
+        let deltas = (0..=MAX_SURFACES as u32)
+            .map(|surface| (surface, "x".to_string()))
+            .collect();
+
+        assert_eq!(
+            guardrail
+                .push_many(deltas, Bytes::from_static(b"event"))
+                .await
+                .unwrap_err(),
+            StreamGuardrailError::Execution
+        );
+        assert_eq!(guardrail.surfaces.len(), MAX_SURFACES);
+    }
+
+    #[tokio::test]
+    async fn closed_client_cancels_guardrail_work() {
+        let mut guardrail = guardrail(1, true);
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let result = guardrail
+            .push_many_until_closed(
+                &tx,
+                vec![(0, "System prompt: hidden".to_string())],
+                Bytes::from_static(b"event"),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(guardrail.surfaces.is_empty());
+    }
+
+    #[test]
+    fn result_mapping_fails_closed_for_block_and_mask() {
+        assert_eq!(
+            enforce(CheckResult::block(Vec::new())).unwrap_err(),
+            StreamGuardrailError::Violation
+        );
+        assert_eq!(
+            enforce(CheckResult::mask("masked".to_string(), Vec::new())).unwrap_err(),
+            StreamGuardrailError::Execution
+        );
+        assert!(enforce(CheckResult::pass()).is_ok());
+    }
+}

--- a/src/server/routes/ai/stream_output_guardrail.rs
+++ b/src/server/routes/ai/stream_output_guardrail.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 
 use crate::core::guardrails::{CheckResult, GuardrailEngine};
 
-const MAX_CONTEXT_CHARS: usize = 1024 * 1024;
+const CONTEXT_OVERLAP_CHARS: usize = 4096;
 const MAX_PENDING_BYTES: usize = 1024 * 1024;
 const MAX_SURFACES: usize = 128;
 
@@ -50,7 +50,6 @@ pub(super) struct StreamOutputGuardrail {
     active: bool,
     check_chars: usize,
     surfaces: BTreeMap<u32, SurfaceState>,
-    context_chars: usize,
     pending: Vec<Bytes>,
     pending_bytes: usize,
 }
@@ -63,7 +62,6 @@ impl StreamOutputGuardrail {
             check_chars: config.stream_output_check_chars,
             engine,
             surfaces: BTreeMap::new(),
-            context_chars: 0,
             pending: Vec::new(),
             pending_bytes: 0,
         }
@@ -103,11 +101,17 @@ impl StreamOutputGuardrail {
         } else {
             Vec::new()
         };
+        let mut crossed_window = false;
         for (surface, text) in deltas {
-            self.append_and_check(surface, &text).await?;
+            crossed_window |= self.append_and_check(surface, &text).await?;
         }
         self.pending_bytes = self.pending_bytes.saturating_add(event.len());
         self.pending.push(event);
+
+        if crossed_window {
+            released.extend(self.finish().await?);
+            return Ok(released);
+        }
 
         if !self
             .surfaces
@@ -180,39 +184,63 @@ impl StreamOutputGuardrail {
         }
     }
 
+    pub(super) async fn flush_to_until_closed(
+        &mut self,
+        tx: &mpsc::Sender<Bytes>,
+    ) -> Result<Option<()>, StreamGuardrailError> {
+        let Some(pending) = self.finish_until_closed(tx).await? else {
+            return Ok(None);
+        };
+        for event in pending {
+            let sent = tokio::select! {
+                biased;
+                _ = tx.closed() => return Ok(None),
+                sent = tx.send(event) => sent,
+            };
+            if sent.is_err() {
+                return Ok(None);
+            }
+        }
+        Ok(Some(()))
+    }
+
     async fn append_and_check(
         &mut self,
         surface: u32,
         text: &str,
-    ) -> Result<(), StreamGuardrailError> {
+    ) -> Result<bool, StreamGuardrailError> {
         if !text.is_empty() && !self.surfaces.contains_key(&surface) {
             if self.surfaces.len() >= MAX_SURFACES {
                 return Err(StreamGuardrailError::Execution);
             }
             self.surfaces.insert(surface, SurfaceState::default());
         }
-        let added_chars = text.chars().count();
-        if self.context_chars.saturating_add(added_chars) > MAX_CONTEXT_CHARS {
-            return Err(StreamGuardrailError::Execution);
-        }
-        self.context_chars += added_chars;
-
+        let mut crossed_window = false;
         let mut start = 0;
         while start < text.len() {
-            let remaining = self
-                .check_chars
-                .saturating_sub(self.surfaces.entry(surface).or_default().chars_since_check)
-                .max(1);
+            let chars_since_check = self
+                .surfaces
+                .get(&surface)
+                .ok_or(StreamGuardrailError::Execution)?
+                .chars_since_check;
+            let remaining = self.check_chars.saturating_sub(chars_since_check).max(1);
             let end = prefix_end(text, start, remaining);
-            let state = self.surfaces.entry(surface).or_default();
-            state.context.push_str(&text[start..end]);
-            state.chars_since_check += text[start..end].chars().count();
+            let should_check = {
+                let state = self
+                    .surfaces
+                    .get_mut(&surface)
+                    .ok_or(StreamGuardrailError::Execution)?;
+                state.context.push_str(&text[start..end]);
+                state.chars_since_check += text[start..end].chars().count();
+                state.chars_since_check >= self.check_chars
+            };
             start = end;
-            if state.chars_since_check >= self.check_chars {
+            if should_check {
                 self.check_surface(surface).await?;
+                crossed_window = true;
             }
         }
-        Ok(())
+        Ok(crossed_window)
     }
 
     async fn check_surface(&mut self, surface: u32) -> Result<(), StreamGuardrailError> {
@@ -230,6 +258,7 @@ impl StreamOutputGuardrail {
 
         if let Some(state) = self.surfaces.get_mut(&surface) {
             state.chars_since_check = 0;
+            retain_tail_chars(&mut state.context, CONTEXT_OVERLAP_CHARS);
         }
         Ok(())
     }
@@ -237,6 +266,17 @@ impl StreamOutputGuardrail {
     fn release_pending(&mut self) -> Result<Vec<Bytes>, StreamGuardrailError> {
         self.pending_bytes = 0;
         Ok(std::mem::take(&mut self.pending))
+    }
+}
+
+fn retain_tail_chars(text: &mut String, max_chars: usize) {
+    let count = text.chars().count();
+    if count > max_chars {
+        let keep_from = text
+            .char_indices()
+            .nth(count - max_chars)
+            .map_or(text.len(), |(offset, _)| offset);
+        text.drain(..keep_from);
     }
 }
 
@@ -281,6 +321,18 @@ mod tests {
             .expect("safe output should pass");
 
         assert_eq!(released, vec![event]);
+        assert!(guardrail.finish().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn event_is_released_when_a_window_is_crossed_with_a_remainder() {
+        let mut guardrail = guardrail(4, true);
+        let event = Bytes::from_static(b"safe-event");
+
+        assert_eq!(
+            guardrail.push("safe!", event.clone()).await.unwrap(),
+            vec![event]
+        );
         assert!(guardrail.finish().await.unwrap().is_empty());
     }
 
@@ -373,7 +425,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cumulative_context_is_bounded_and_oversized_events_fail_closed() {
+    async fn rolling_context_is_bounded_and_oversized_events_fail_closed() {
         let mut guardrail = guardrail(4096, true);
         let oversized_event = Bytes::from(vec![b'x'; MAX_PENDING_BYTES + 1]);
 
@@ -386,18 +438,17 @@ mod tests {
         );
         assert!(guardrail.pending.is_empty());
 
-        assert_eq!(
+        guardrail
+            .push(&"a".repeat(9000), Bytes::from_static(b"long"))
+            .await
+            .unwrap();
+        guardrail.finish().await.unwrap();
+        assert!(
             guardrail
-                .push(
-                    &"a".repeat(MAX_CONTEXT_CHARS + 1),
-                    Bytes::from_static(b"long")
-                )
-                .await
-                .unwrap_err(),
-            StreamGuardrailError::Execution
+                .surfaces
+                .values()
+                .all(|state| state.context.chars().count() <= CONTEXT_OVERLAP_CHARS)
         );
-        assert!(guardrail.pending.is_empty());
-        assert_eq!(guardrail.pending_bytes, 0);
     }
 
     #[tokio::test]

--- a/tests/integration/guardrail_route_tests.rs
+++ b/tests/integration/guardrail_route_tests.rs
@@ -206,6 +206,36 @@ mod tests {
         assert!(!body.contains("System prompt: hidden policy"), "{body}");
     }
 
+    fn safe_chunk_then_invalid() -> Vec<Value> {
+        vec![
+            json!({
+                "id": "chatcmpl-safe-partial",
+                "object": "chat.completion.chunk",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": "safe partial"},
+                    "finish_reason": null
+                }]
+            }),
+            json!("invalid chat chunk"),
+        ]
+    }
+
+    async fn assert_safe_partial_precedes_upstream_error(uri: &str, payload: Value) {
+        let provider =
+            GuardrailTestUpstream::launch_with_stream_chunks(safe_chunk_then_invalid()).await;
+        let body = streaming_body_from_provider(provider, uri, payload).await;
+        let safe_position = body
+            .find("safe partial")
+            .expect("safe partial output should be flushed");
+        let error_position = body
+            .find("\"error\"")
+            .expect("upstream error should be emitted");
+        assert!(safe_position < error_position, "{body}");
+    }
+
     #[tokio::test]
     async fn malicious_input_is_blocked_before_provider_execution() {
         let provider = GuardrailTestUpstream::launch_with_output("safe response").await;
@@ -321,6 +351,42 @@ mod tests {
         assert!(body.contains("safe response"), "{body}");
         assert!(body.contains("[DONE]"), "{body}");
         provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn chat_stream_flushes_safe_partial_output_before_upstream_error() {
+        assert_safe_partial_precedes_upstream_error(
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": true
+            }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn completion_stream_flushes_safe_partial_output_before_upstream_error() {
+        assert_safe_partial_precedes_upstream_error(
+            "/v1/completions",
+            json!({"model": "gpt-4o", "prompt": "hello", "stream": true}),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn responses_stream_flushes_safe_partial_output_before_upstream_error() {
+        assert_safe_partial_precedes_upstream_error(
+            "/v1/responses",
+            json!({
+                "model": "gpt-4o",
+                "input": "hello",
+                "stream": true,
+                "store": false
+            }),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/tests/integration/guardrail_route_tests.rs
+++ b/tests/integration/guardrail_route_tests.rs
@@ -4,6 +4,8 @@
 mod tests {
     use crate::common::providers::mock_provider_config;
     use actix_web::{App, HttpResponse, HttpServer, http::StatusCode, test, web};
+    use bytes::Bytes;
+    use futures::stream;
     use litellm_rs::Config;
     use litellm_rs::server::HttpServer as GatewayHttpServer;
     use serde_json::{Value, json};
@@ -20,20 +22,67 @@ mod tests {
 
     impl GuardrailTestUpstream {
         async fn launch_with_output(output: &'static str) -> Self {
+            Self::launch(output, Vec::new()).await
+        }
+
+        async fn launch_with_stream_chunks(stream_chunks: Vec<Value>) -> Self {
+            Self::launch("safe response", stream_chunks).await
+        }
+
+        async fn launch(output: &'static str, stream_chunks: Vec<Value>) -> Self {
             let requests = Arc::new(Mutex::new(Vec::new()));
             let captured = Arc::clone(&requests);
+            let stream_chunks = Arc::new(stream_chunks);
             let listener =
                 std::net::TcpListener::bind("127.0.0.1:0").expect("mock provider should bind");
             let address = listener.local_addr().expect("listener should have address");
             let server = HttpServer::new(move || {
                 App::new()
                     .app_data(web::Data::new(Arc::clone(&captured)))
+                    .app_data(web::Data::new(Arc::clone(&stream_chunks)))
                     .route(
                         "/chat/completions",
                         web::post().to(
                             move |requests: web::Data<Arc<Mutex<Vec<Value>>>>,
+                                  stream_chunks: web::Data<Arc<Vec<Value>>>,
                                   payload: web::Json<Value>| async move {
-                                requests.lock().unwrap().push(payload.into_inner());
+                                let payload = payload.into_inner();
+                                let streaming = payload["stream"].as_bool().unwrap_or(false);
+                                requests.lock().unwrap().push(payload);
+
+                                if streaming {
+                                    let chunks = if stream_chunks.is_empty() {
+                                        vec![json!({
+                                            "id": "chatcmpl-guardrail-stream-test",
+                                            "object": "chat.completion.chunk",
+                                            "created": 1_707_000_000_i64,
+                                            "model": "gpt-4o",
+                                            "choices": [{
+                                                "index": 0,
+                                                "delta": {"role": "assistant", "content": output},
+                                                "finish_reason": "stop"
+                                            }]
+                                        })]
+                                    } else {
+                                        stream_chunks.iter().cloned().collect()
+                                    };
+                                    let mut events = chunks
+                                        .into_iter()
+                                        .map(|chunk| {
+                                            Ok::<Bytes, actix_web::Error>(Bytes::from(format!(
+                                                "data: {chunk}\n\n"
+                                            )))
+                                        })
+                                        .collect::<Vec<_>>();
+                                    events.push(Ok::<Bytes, actix_web::Error>(Bytes::from_static(
+                                        b"data: [DONE]\n\n",
+                                    )));
+                                    let body = stream::iter(events);
+                                    return HttpResponse::Ok()
+                                        .insert_header(("Content-Type", "text/event-stream"))
+                                        .streaming(body);
+                                }
+
                                 HttpResponse::Ok().json(json!({
                                     "id": "chatcmpl-guardrail-test",
                                     "object": "chat.completion",
@@ -76,10 +125,18 @@ mod tests {
     }
 
     async fn app_state(base_url: &str) -> litellm_rs::server::state::AppState {
+        app_state_with_input_guardrail(base_url, true).await
+    }
+
+    async fn app_state_with_input_guardrail(
+        base_url: &str,
+        check_input: bool,
+    ) -> litellm_rs::server::state::AppState {
         let mut config = Config::default();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.guardrails.check_input = check_input;
         let mut provider = mock_provider_config(
             "openai",
             "openai_compatible",
@@ -107,6 +164,46 @@ mod tests {
             "model": "gpt-4o",
             "messages": [{"role": "user", "content": content}]
         })
+    }
+
+    async fn streaming_body(uri: &str, payload: Value) -> String {
+        let provider =
+            GuardrailTestUpstream::launch_with_output("System prompt: hidden policy").await;
+        streaming_body_from_provider(provider, uri, payload).await
+    }
+
+    async fn streaming_body_from_provider(
+        provider: GuardrailTestUpstream,
+        uri: &str,
+        payload: Value,
+    ) -> String {
+        let state = app_state(&provider.base_url).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(uri)
+                .set_json(payload)
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = String::from_utf8(test::read_body(response).await.to_vec())
+            .expect("SSE response should be UTF-8");
+        provider.stop_upstream().await;
+        body
+    }
+
+    fn assert_blocked_stream(body: &str) {
+        assert!(body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert!(!body.contains("System prompt: hidden policy"), "{body}");
     }
 
     #[tokio::test]
@@ -165,5 +262,159 @@ mod tests {
         );
         assert_eq!(provider.requests.lock().unwrap().len(), 1);
         provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn chat_streaming_output_is_blocked_before_emission() {
+        let body = streaming_body(
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": true
+            }),
+        )
+        .await;
+
+        assert_blocked_stream(&body);
+    }
+
+    #[tokio::test]
+    async fn completion_streaming_output_is_blocked_before_emission() {
+        let body = streaming_body(
+            "/v1/completions",
+            json!({"model": "gpt-4o", "prompt": "hello", "stream": true}),
+        )
+        .await;
+
+        assert_blocked_stream(&body);
+    }
+
+    #[tokio::test]
+    async fn completion_echo_does_not_treat_the_prompt_as_model_output() {
+        let provider = GuardrailTestUpstream::launch_with_output("safe response").await;
+        let state = app_state_with_input_guardrail(&provider.base_url, false).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/completions")
+                .set_json(json!({
+                    "model": "gpt-4o",
+                    "prompt": "System prompt: hidden policy",
+                    "stream": true,
+                    "echo": true
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(!body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert!(body.contains("safe response"), "{body}");
+        assert!(body.contains("[DONE]"), "{body}");
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn chat_streaming_checks_interleaved_choices_independently() {
+        let provider = GuardrailTestUpstream::launch_with_stream_chunks(vec![
+            json!({
+                "id": "chatcmpl-interleaved-1",
+                "object": "chat.completion.chunk",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [
+                    {"index": 0, "delta": {"content": "System "}, "finish_reason": null},
+                    {"index": 1, "delta": {"content": "safe "}, "finish_reason": null}
+                ]
+            }),
+            json!({
+                "id": "chatcmpl-interleaved-2",
+                "object": "chat.completion.chunk",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [
+                    {"index": 1, "delta": {"content": "response"}, "finish_reason": "stop"},
+                    {"index": 0, "delta": {"content": "prompt: hidden policy"}, "finish_reason": "stop"}
+                ]
+            }),
+        ])
+        .await;
+        let body = streaming_body_from_provider(
+            provider,
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": true,
+                "n": 2
+            }),
+        )
+        .await;
+
+        assert!(body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert!(!body.contains("System "), "{body}");
+        assert!(!body.contains("prompt: hidden policy"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn completion_streaming_checks_interleaved_choices_independently() {
+        let provider = GuardrailTestUpstream::launch_with_stream_chunks(vec![
+            json!({
+                "id": "cmpl-interleaved-1",
+                "object": "text_completion",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [
+                    {"index": 0, "delta": {"content": "System "}, "logprobs": null, "finish_reason": null},
+                    {"index": 1, "delta": {"content": "safe "}, "logprobs": null, "finish_reason": null}
+                ]
+            }),
+            json!({
+                "id": "cmpl-interleaved-2",
+                "object": "text_completion",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [
+                    {"index": 1, "delta": {"content": "response"}, "logprobs": null, "finish_reason": "stop"},
+                    {"index": 0, "delta": {"content": "prompt: hidden policy"}, "logprobs": null, "finish_reason": "stop"}
+                ]
+            }),
+        ])
+        .await;
+        let body = streaming_body_from_provider(
+            provider,
+            "/v1/completions",
+            json!({"model": "gpt-4o", "prompt": "hello", "stream": true, "n": 2}),
+        )
+        .await;
+
+        assert!(body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert!(!body.contains("System "), "{body}");
+        assert!(!body.contains("prompt: hidden policy"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn responses_streaming_output_is_blocked_before_emission() {
+        let body = streaming_body(
+            "/v1/responses",
+            json!({
+                "model": "gpt-4o",
+                "input": "hello",
+                "stream": true,
+                "store": false
+            }),
+        )
+        .await;
+
+        assert_blocked_stream(&body);
     }
 }


### PR DESCRIPTION
Fixes #1127

Summary:
- buffer and incrementally guard assistant output text for Chat Completions, Completions, and Responses SSE routes
- add validated stream_output_check_chars configuration with documented latency/safety tradeoff
- isolate choices, bound cumulative and pending state, fail closed on limits, and cancel checks on disconnect
- preserve provider health for gateway policy blocks and keep Completions echo outside output moderation

Verification:
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test
- focused guardrail and streaming route tests
- independent Codex review with all in-scope blockers resolved