### PR TITLE
fix(vertex-ai): unify Google pricing authority

### DIFF
--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -81,36 +81,37 @@ impl PricingService {
             );
         }
 
-        match crate::core::pricing::normalize_pricing_provider(&model_info.litellm_provider)
-            .as_str()
+        let requested_provider = crate::core::pricing::normalize_pricing_provider(provider);
+        let catalog_provider =
+            crate::core::pricing::normalize_pricing_provider(&model_info.litellm_provider);
+        if super::google::uses_google_completion_calculator(&requested_provider, &catalog_provider)
         {
-            "vertex_ai" => self.calculate_google_cost(
+            self.calculate_google_cost(
                 &resolved_model,
                 &model_info,
                 input_tokens,
                 output_tokens,
                 prompt,
                 completion,
-            ),
-            _ => {
-                let usage = PricingUsage::new(input_tokens, output_tokens);
-                let breakdown = calculate_usage_cost_with_pricing(
-                    &model_info.litellm_provider,
-                    &resolved_model,
-                    &model_info,
-                    &usage,
-                )?;
-                Ok(CostResult {
-                    input_cost: breakdown.input_cost,
-                    output_cost: breakdown.output_cost,
-                    total_cost: breakdown.total_cost,
-                    input_tokens,
-                    output_tokens,
-                    model: resolved_model,
-                    provider: model_info.litellm_provider,
-                    cost_type: CostType::TokenBased,
-                })
-            }
+            )
+        } else {
+            let usage = PricingUsage::new(input_tokens, output_tokens);
+            let breakdown = calculate_usage_cost_with_pricing(
+                &model_info.litellm_provider,
+                &resolved_model,
+                &model_info,
+                &usage,
+            )?;
+            Ok(CostResult {
+                input_cost: breakdown.input_cost,
+                output_cost: breakdown.output_cost,
+                total_cost: breakdown.total_cost,
+                input_tokens,
+                output_tokens,
+                model: resolved_model,
+                provider: model_info.litellm_provider,
+                cost_type: CostType::TokenBased,
+            })
         }
     }
 

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -261,6 +261,14 @@ fn resolve_model_info_for_provider(
         {
             return Some((provider_prefixed_model, info.clone()));
         }
+        if let Some(alias_model) =
+            exact_google_pricing_alias(&normalized_provider, normalized_model)
+            && let Some(info) = models
+                .get(alias_model)
+                .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+        {
+            return Some((alias_model.to_string(), info.clone()));
+        }
         return None;
     }
 
@@ -451,7 +459,25 @@ fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
     let aliases = match normalized.as_str() {
         "anthropic" if is_xiaomi_mimo_model(model) => vec!["xiaomi_mimo", "xiaomi", "mimo"],
         "gemini" => vec!["gemini", "vertex_ai"],
-        "vertex_ai" => vec!["vertex_ai", "google"],
+        "vertex_ai" => vec![
+            "vertex_ai",
+            "google",
+            "vertex_ai-ai21_models",
+            "vertex_ai-anthropic_models",
+            "vertex_ai-deepseek_models",
+            "vertex_ai-embedding-models",
+            "vertex_ai-image-models",
+            "vertex_ai-language-models",
+            "vertex_ai-llama_models",
+            "vertex_ai-minimax_models",
+            "vertex_ai-mistral_models",
+            "vertex_ai-moonshot_models",
+            "vertex_ai-openai_models",
+            "vertex_ai-qwen_models",
+            "vertex_ai-text-models",
+            "vertex_ai-video-models",
+            "vertex_ai-zai_models",
+        ],
         "xiaomi_mimo" => vec!["xiaomi_mimo", "xiaomi", "mimo"],
         "zhipuai" => vec!["zhipuai", "glm"],
         "amazon_nova" => vec!["amazon_nova", "bedrock"],
@@ -466,6 +492,14 @@ fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
             }
             unique
         })
+}
+
+fn exact_google_pricing_alias<'a>(provider: &str, model: &'a str) -> Option<&'a str> {
+    match (provider, model) {
+        ("vertex_ai", "gemini-1.5-pro-001" | "gemini-1.5-pro-002") => Some("gemini-1.5-pro"),
+        ("vertex_ai", "gemini-1.5-flash-001" | "gemini-1.5-flash-002") => Some("gemini-1.5-flash"),
+        _ => None,
+    }
 }
 
 fn provider_prefixed_model(model: &str) -> Option<(&str, &str)> {

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -6,6 +6,8 @@ use super::types::{
 };
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::collections::HashMap;
+#[cfg(any(feature = "providers-extended", feature = "providers-extra"))]
+use std::sync::LazyLock;
 use std::time::SystemTime;
 
 impl PricingService {
@@ -22,6 +24,21 @@ impl PricingService {
             data.last_updated = SystemTime::now();
         }
         Ok(service)
+    }
+
+    /// Return the process-wide embedded pricing authority for compatibility
+    /// adapters that cannot access the runtime service in `AppState`.
+    #[cfg(any(feature = "providers-extended", feature = "providers-extra"))]
+    pub(crate) fn shared_embedded_default() -> Result<&'static Self> {
+        static SERVICE: LazyLock<std::result::Result<PricingService, String>> =
+            LazyLock::new(|| {
+                PricingService::with_embedded_default().map_err(|error| error.to_string())
+            });
+        SERVICE.as_ref().map_err(|error| {
+            GatewayError::Internal(format!(
+                "failed to initialize shared embedded pricing authority: {error}"
+            ))
+        })
     }
 
     /// Resolve pricing metadata for a provider/model pair using provider aliases
@@ -234,6 +251,10 @@ fn resolve_model_info_for_provider(
             .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
     {
         return Some((normalized_model.to_string(), info.clone()));
+    }
+
+    if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
+        return None;
     }
 
     let requested = normalized_model.to_lowercase();

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -232,6 +232,7 @@ fn resolve_model_info_for_provider(
     let provider_aliases = pricing_provider_aliases(provider, model);
     if let Some((prefixed_provider, _)) = provider_prefixed_model(model)
         && crate::core::providers::registry::selector_has_matrix_entry(prefixed_provider)
+        && !super::google::is_vertex_publisher_prefix(&normalized_provider, prefixed_provider)
         && !provider_name_matches(prefixed_provider, &provider_aliases)
     {
         return None;
@@ -254,20 +255,15 @@ fn resolve_model_info_for_provider(
     }
 
     if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
-        let provider_prefixed_model = format!("{normalized_provider}/{normalized_model}");
-        if let Some(info) = models
-            .get(&provider_prefixed_model)
-            .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+        for candidate in
+            super::google::exact_pricing_candidates(&normalized_provider, model, normalized_model)
         {
-            return Some((provider_prefixed_model, info.clone()));
-        }
-        if let Some(alias_model) =
-            exact_google_pricing_alias(&normalized_provider, normalized_model)
-            && let Some(info) = models
-                .get(alias_model)
+            if let Some(info) = models
+                .get(&candidate)
                 .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-        {
-            return Some((alias_model.to_string(), info.clone()));
+            {
+                return Some((candidate, info.clone()));
+            }
         }
         return None;
     }
@@ -459,25 +455,7 @@ fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
     let aliases = match normalized.as_str() {
         "anthropic" if is_xiaomi_mimo_model(model) => vec!["xiaomi_mimo", "xiaomi", "mimo"],
         "gemini" => vec!["gemini", "vertex_ai"],
-        "vertex_ai" => vec![
-            "vertex_ai",
-            "google",
-            "vertex_ai-ai21_models",
-            "vertex_ai-anthropic_models",
-            "vertex_ai-deepseek_models",
-            "vertex_ai-embedding-models",
-            "vertex_ai-image-models",
-            "vertex_ai-language-models",
-            "vertex_ai-llama_models",
-            "vertex_ai-minimax_models",
-            "vertex_ai-mistral_models",
-            "vertex_ai-moonshot_models",
-            "vertex_ai-openai_models",
-            "vertex_ai-qwen_models",
-            "vertex_ai-text-models",
-            "vertex_ai-video-models",
-            "vertex_ai-zai_models",
-        ],
+        "vertex_ai" => super::google::VERTEX_PROVIDER_ALIASES.to_vec(),
         "xiaomi_mimo" => vec!["xiaomi_mimo", "xiaomi", "mimo"],
         "zhipuai" => vec!["zhipuai", "glm"],
         "amazon_nova" => vec!["amazon_nova", "bedrock"],
@@ -492,14 +470,6 @@ fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
             }
             unique
         })
-}
-
-fn exact_google_pricing_alias<'a>(provider: &str, model: &'a str) -> Option<&'a str> {
-    match (provider, model) {
-        ("vertex_ai", "gemini-1.5-pro-001" | "gemini-1.5-pro-002") => Some("gemini-1.5-pro"),
-        ("vertex_ai", "gemini-1.5-flash-001" | "gemini-1.5-flash-002") => Some("gemini-1.5-flash"),
-        _ => None,
-    }
 }
 
 fn provider_prefixed_model(model: &str) -> Option<(&str, &str)> {

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -455,7 +455,7 @@ fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
     let normalized = crate::core::pricing::normalize_pricing_provider(provider);
     let aliases = match normalized.as_str() {
         "anthropic" if is_xiaomi_mimo_model(model) => vec!["xiaomi_mimo", "xiaomi", "mimo"],
-        "gemini" => vec!["gemini", "vertex_ai"],
+        "gemini" => vec!["gemini"],
         "vertex_ai" => super::google::VERTEX_PROVIDER_ALIASES.to_vec(),
         "xiaomi_mimo" => vec!["xiaomi_mimo", "xiaomi", "mimo"],
         "zhipuai" => vec!["zhipuai", "glm"],

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -254,6 +254,13 @@ fn resolve_model_info_for_provider(
     }
 
     if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
+        let provider_prefixed_model = format!("{normalized_provider}/{normalized_model}");
+        if let Some(info) = models
+            .get(&provider_prefixed_model)
+            .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+        {
+            return Some((provider_prefixed_model, info.clone()));
+        }
         return None;
     }
 

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -78,14 +78,14 @@ fn google_authority_uses_specialized_character_pricing() {
             "medlm-large",
             0,
             0,
-            Some("abcd"),
-            Some("xy"),
+            Some("é中"),
+            Some("🙂"),
             None,
         )
         .unwrap_or_else(|error| panic!("specialized Vertex row should be priced: {error}"));
 
     assert_eq!(cost.cost_type, CostType::CharacterBased);
-    assert!((cost.total_cost - 0.00005).abs() < 1e-12);
+    assert!((cost.total_cost - 0.000025).abs() < 1e-12);
 }
 
 #[test]

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -69,6 +69,43 @@ fn provider_aware_authority_resolves_anthropic_mimo_alias() {
 }
 
 #[test]
+fn google_authority_uses_specialized_character_pricing() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+    let cost = service
+        .calculate_loaded_completion_cost_for_provider(
+            "vertex_ai",
+            "medlm-large",
+            0,
+            0,
+            Some("abcd"),
+            Some("xy"),
+            None,
+        )
+        .unwrap_or_else(|error| panic!("specialized Vertex row should be priced: {error}"));
+
+    assert_eq!(cost.cost_type, CostType::CharacterBased);
+    assert!((cost.total_cost - 0.00005).abs() < 1e-12);
+}
+
+#[test]
+fn google_authority_is_case_insensitive_but_not_suffix_fuzzy() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    assert!(
+        service
+            .get_model_info_for_provider("vertex_ai", "GEMINI-1.5-PRO")
+            .is_some()
+    );
+    assert!(
+        service
+            .get_model_info_for_provider("vertex_ai", "GEMINI-1.5-PRO-9999")
+            .is_none()
+    );
+}
+
+#[test]
 fn provider_aware_authority_resolves_loaded_openai_like_model_without_prefix() {
     let service = PricingService::new(None);
     service.add_custom_model(

--- a/src/core/pricing_service/google.rs
+++ b/src/core/pricing_service/google.rs
@@ -1,0 +1,63 @@
+//! Exact catalog resolution rules for Google pricing surfaces.
+
+pub(super) const VERTEX_PROVIDER_ALIASES: &[&str] = &[
+    "vertex_ai",
+    "google",
+    "vertex_ai-ai21_models",
+    "vertex_ai-anthropic_models",
+    "vertex_ai-deepseek_models",
+    "vertex_ai-embedding-models",
+    "vertex_ai-image-models",
+    "vertex_ai-language-models",
+    "vertex_ai-llama_models",
+    "vertex_ai-minimax_models",
+    "vertex_ai-mistral_models",
+    "vertex_ai-moonshot_models",
+    "vertex_ai-openai_models",
+    "vertex_ai-qwen_models",
+    "vertex_ai-text-models",
+    "vertex_ai-video-models",
+    "vertex_ai-zai_models",
+];
+
+pub(super) fn is_vertex_publisher_prefix(provider: &str, prefix: &str) -> bool {
+    provider == "vertex_ai" && matches!(prefix, "ai21" | "meta" | "mistral")
+}
+
+pub(super) fn exact_pricing_candidates(
+    provider: &str,
+    model: &str,
+    normalized_model: &str,
+) -> Vec<String> {
+    let mut candidates = vec![format!("{provider}/{model}")];
+    let normalized_candidate = format!("{provider}/{normalized_model}");
+    if !candidates.contains(&normalized_candidate) {
+        candidates.push(normalized_candidate);
+    }
+
+    if provider == "vertex_ai"
+        && let Some(alias) = vertex_pricing_alias(model)
+        && !candidates.iter().any(|candidate| candidate == alias)
+    {
+        candidates.push(alias.to_string());
+    }
+    candidates
+}
+
+fn vertex_pricing_alias(model: &str) -> Option<&'static str> {
+    match model {
+        "gemini-1.5-pro-001" | "gemini-1.5-pro-002" => Some("gemini-1.5-pro"),
+        "gemini-1.5-flash-001" | "gemini-1.5-flash-002" => Some("gemini-1.5-flash"),
+        "claude-opus-4-6@20260114" => Some("vertex_ai/claude-opus-4-6"),
+        "claude-opus-4-5@20251110" => Some("vertex_ai/claude-opus-4-5"),
+        "claude-3-5-sonnet@20241022" => Some("vertex_ai/claude-3-5-sonnet"),
+        "meta/llama-4-scout-17b-16e-instruct" => {
+            Some("vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas")
+        }
+        "meta/llama-4-maverick-17b-128e-instruct" => {
+            Some("vertex_ai/meta/llama-4-maverick-17b-128e-instruct-maas")
+        }
+        "mistral/mistral-nemo" => Some("vertex_ai/mistral-nemo@latest"),
+        _ => None,
+    }
+}

--- a/src/core/pricing_service/google.rs
+++ b/src/core/pricing_service/google.rs
@@ -24,19 +24,36 @@ pub(super) fn is_vertex_publisher_prefix(provider: &str, prefix: &str) -> bool {
     provider == "vertex_ai" && matches!(prefix, "ai21" | "meta" | "mistral")
 }
 
+pub(super) fn uses_google_completion_calculator(
+    requested_provider: &str,
+    catalog_provider: &str,
+) -> bool {
+    matches!(requested_provider, "gemini" | "vertex_ai")
+        || catalog_provider == "vertex_ai"
+        || catalog_provider.starts_with("vertex_ai_")
+}
+
 pub(super) fn exact_pricing_candidates(
     provider: &str,
     model: &str,
     normalized_model: &str,
 ) -> Vec<String> {
-    let mut candidates = vec![format!("{provider}/{model}")];
-    let normalized_candidate = format!("{provider}/{normalized_model}");
-    if !candidates.contains(&normalized_candidate) {
-        candidates.push(normalized_candidate);
+    let model = model.to_ascii_lowercase();
+    let normalized_model = normalized_model.to_ascii_lowercase();
+    let mut candidates = Vec::with_capacity(5);
+    for candidate in [
+        model.clone(),
+        normalized_model.clone(),
+        format!("{provider}/{model}"),
+        format!("{provider}/{normalized_model}"),
+    ] {
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
     }
 
     if provider == "vertex_ai"
-        && let Some(alias) = vertex_pricing_alias(model)
+        && let Some(alias) = vertex_pricing_alias(&model)
         && !candidates.iter().any(|candidate| candidate == alias)
     {
         candidates.push(alias.to_string());

--- a/src/core/pricing_service/google.rs
+++ b/src/core/pricing_service/google.rs
@@ -21,7 +21,11 @@ pub(super) const VERTEX_PROVIDER_ALIASES: &[&str] = &[
 ];
 
 pub(super) fn is_vertex_publisher_prefix(provider: &str, prefix: &str) -> bool {
-    provider == "vertex_ai" && matches!(prefix, "ai21" | "meta" | "mistral")
+    provider == "vertex_ai"
+        && matches!(
+            prefix.to_ascii_lowercase().as_str(),
+            "ai21" | "meta" | "mistral"
+        )
 }
 
 pub(super) fn uses_google_completion_calculator(

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -6,6 +6,7 @@
 mod authority;
 mod cache;
 mod events;
+mod google;
 mod image_pricing;
 mod loader;
 mod service;

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -219,8 +219,8 @@ impl PricingService {
                 "output_cost_per_character",
             )?;
 
-            let input_chars = prompt.map(|p| p.len()).unwrap_or(0) as f64;
-            let output_chars = completion.map(|c| c.len()).unwrap_or(0) as f64;
+            let input_chars = prompt.map(|p| p.chars().count()).unwrap_or(0) as f64;
+            let output_chars = completion.map(|c| c.chars().count()).unwrap_or(0) as f64;
 
             let input_cost = input_chars * input_cost_per_char;
             let output_cost = output_chars * output_cost_per_char;

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn calculate_gemini_cost(
     input_tokens: u32,
     output_tokens: u32,
 ) -> Result<f64, ProviderError> {
-    let (service, _) = gemini_chat_pricing(model)?;
+    let (service, _) = gemini_completion_pricing(model)?;
     service
         .calculate_loaded_usage_cost_for_provider(
             "gemini",
@@ -53,7 +53,7 @@ pub(crate) fn calculate_gemini_cost(
         .map_err(|error| gemini_pricing_error(model, error))
 }
 
-fn gemini_chat_pricing(
+fn gemini_completion_pricing(
     model: &str,
 ) -> Result<(&'static PricingService, LiteLLMModelInfo), ProviderError> {
     let service = PricingService::shared_embedded_default()
@@ -61,7 +61,7 @@ fn gemini_chat_pricing(
     let (_, pricing) = service
         .get_model_info_for_provider("gemini", model)
         .ok_or_else(|| ProviderError::model_not_found("gemini", model))?;
-    if pricing.mode != "chat" {
+    if pricing.mode == "embedding" {
         return Err(ProviderError::model_not_found("gemini", model));
     }
     Ok((service, pricing))
@@ -106,7 +106,7 @@ pub fn is_model_supported(model_id: &str) -> bool {
 
 /// Get model pricing
 pub fn get_model_pricing(model_id: &str) -> Result<(f64, f64), ProviderError> {
-    let (_, pricing) = gemini_chat_pricing(model_id)?;
+    let (_, pricing) = gemini_completion_pricing(model_id)?;
     let input = pricing
         .input_cost_per_token
         .ok_or_else(|| ProviderError::Other {

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -18,6 +18,10 @@
 //! - Batch processing
 //! - Real-time streaming responses
 
+use crate::core::pricing_service::{PricingService, PricingUsage};
+use crate::core::providers::unified_provider::ProviderError;
+use crate::utils::error::gateway_error::GatewayError;
+
 pub mod client;
 pub mod config;
 pub mod error;
@@ -32,6 +36,33 @@ pub use error::GeminiError;
 pub use models::{GeminiModelFamily, ModelFeature, get_gemini_registry};
 pub use provider::GeminiProvider;
 pub use streaming::GeminiStream;
+
+pub(crate) fn calculate_gemini_cost(
+    model: &str,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> Result<f64, ProviderError> {
+    PricingService::shared_embedded_default()
+        .and_then(|service| {
+            service.calculate_loaded_usage_cost_for_provider(
+                "gemini",
+                model,
+                &PricingUsage::new(input_tokens, output_tokens),
+            )
+        })
+        .map(|cost| cost.total_cost)
+        .map_err(|error| gemini_pricing_error(model, error))
+}
+
+fn gemini_pricing_error(model: &str, error: GatewayError) -> ProviderError {
+    match error {
+        GatewayError::NotFound(_) => ProviderError::model_not_found("gemini", model),
+        error => ProviderError::Other {
+            provider: "gemini",
+            message: format!("pricing authority failed for model '{model}': {error}"),
+        },
+    }
+}
 
 // Convenience functions
 
@@ -61,11 +92,39 @@ pub fn is_model_supported(model_id: &str) -> bool {
 }
 
 /// Get model pricing
-pub fn get_model_pricing(model_id: &str) -> Option<(f64, f64)> {
-    get_gemini_registry().get_model_pricing(model_id).map(|p| {
-        (
-            p.input_cost_per_1k_tokens * 1000.0,
-            p.output_cost_per_1k_tokens * 1000.0,
-        )
-    })
+pub fn get_model_pricing(model_id: &str) -> Result<(f64, f64), ProviderError> {
+    let (_, pricing) = PricingService::shared_embedded_default()
+        .map_err(|error| gemini_pricing_error(model_id, error))?
+        .get_model_info_for_provider("gemini", model_id)
+        .ok_or_else(|| ProviderError::model_not_found("gemini", model_id))?;
+    let input = pricing
+        .input_cost_per_token
+        .ok_or_else(|| ProviderError::Other {
+            provider: "gemini",
+            message: format!("missing input token pricing for model '{model_id}'"),
+        })?;
+    let output = pricing
+        .output_cost_per_token
+        .ok_or_else(|| ProviderError::Other {
+            provider: "gemini",
+            message: format!("missing output token pricing for model '{model_id}'"),
+        })?;
+    Ok((input * 1_000_000.0, output * 1_000_000.0))
+}
+
+#[cfg(test)]
+mod pricing_tests {
+    use super::*;
+
+    #[test]
+    fn public_pricing_uses_per_million_catalog_units() {
+        let (input, output) =
+            get_model_pricing("gemini-1.5-flash").expect("catalogued model should be priced");
+        assert!((input - 0.075).abs() < 1e-12);
+        assert!((output - 0.30).abs() < 1e-12);
+        assert!(matches!(
+            get_model_pricing("unknown-google-model"),
+            Err(ProviderError::ModelNotFound { .. })
+        ));
+    }
 }

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -18,7 +18,7 @@
 //! - Batch processing
 //! - Real-time streaming responses
 
-use crate::core::pricing_service::{PricingService, PricingUsage};
+use crate::core::pricing_service::{LiteLLMModelInfo, PricingService, PricingUsage};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::error::gateway_error::GatewayError;
 
@@ -42,16 +42,29 @@ pub(crate) fn calculate_gemini_cost(
     input_tokens: u32,
     output_tokens: u32,
 ) -> Result<f64, ProviderError> {
-    PricingService::shared_embedded_default()
-        .and_then(|service| {
-            service.calculate_loaded_usage_cost_for_provider(
-                "gemini",
-                model,
-                &PricingUsage::new(input_tokens, output_tokens),
-            )
-        })
+    let (service, _) = gemini_chat_pricing(model)?;
+    service
+        .calculate_loaded_usage_cost_for_provider(
+            "gemini",
+            model,
+            &PricingUsage::new(input_tokens, output_tokens),
+        )
         .map(|cost| cost.total_cost)
         .map_err(|error| gemini_pricing_error(model, error))
+}
+
+fn gemini_chat_pricing(
+    model: &str,
+) -> Result<(&'static PricingService, LiteLLMModelInfo), ProviderError> {
+    let service = PricingService::shared_embedded_default()
+        .map_err(|error| gemini_pricing_error(model, error))?;
+    let (_, pricing) = service
+        .get_model_info_for_provider("gemini", model)
+        .ok_or_else(|| ProviderError::model_not_found("gemini", model))?;
+    if pricing.mode != "chat" {
+        return Err(ProviderError::model_not_found("gemini", model));
+    }
+    Ok((service, pricing))
 }
 
 fn gemini_pricing_error(model: &str, error: GatewayError) -> ProviderError {
@@ -93,10 +106,7 @@ pub fn is_model_supported(model_id: &str) -> bool {
 
 /// Get model pricing
 pub fn get_model_pricing(model_id: &str) -> Result<(f64, f64), ProviderError> {
-    let (_, pricing) = PricingService::shared_embedded_default()
-        .map_err(|error| gemini_pricing_error(model_id, error))?
-        .get_model_info_for_provider("gemini", model_id)
-        .ok_or_else(|| ProviderError::model_not_found("gemini", model_id))?;
+    let (_, pricing) = gemini_chat_pricing(model_id)?;
     let input = pricing
         .input_cost_per_token
         .ok_or_else(|| ProviderError::Other {
@@ -119,9 +129,13 @@ mod pricing_tests {
     #[test]
     fn public_pricing_uses_per_million_catalog_units() {
         let (input, output) =
-            get_model_pricing("gemini-1.5-flash").expect("catalogued model should be priced");
-        assert!((input - 0.075).abs() < 1e-12);
-        assert!((output - 0.30).abs() < 1e-12);
+            get_model_pricing("gemini-2.5-flash").expect("catalogued model should be priced");
+        assert!((input - 0.30).abs() < 1e-12);
+        assert!((output - 2.50).abs() < 1e-12);
+        assert!(matches!(
+            get_model_pricing("gemini-1.5-flash"),
+            Err(ProviderError::ModelNotFound { .. })
+        ));
         assert!(matches!(
             get_model_pricing("unknown-google-model"),
             Err(ProviderError::ModelNotFound { .. })

--- a/src/core/providers/gemini/models/mod.rs
+++ b/src/core/providers/gemini/models/mod.rs
@@ -421,12 +421,12 @@ mod tests {
 
     #[test]
     fn test_cost_calculation() {
-        let cost = CostCalculator::calculate_cost("gemini-1.5-flash", 1000, 500);
+        let cost = CostCalculator::calculate_cost("gemini-2.5-flash", 1000, 500);
         assert!(cost.is_ok());
 
         let cost_value = cost.unwrap();
-        // Expected: (1000/1M * $0.075) + (500/1M * $0.30) = $0.000075 + $0.00015 = $0.000225
-        assert!((cost_value - 0.000225).abs() < 0.000001);
+        // Expected: (1000/1M * $0.30) + (500/1M * $2.50) = $0.0003 + $0.00125 = $0.00155
+        assert!((cost_value - 0.00155).abs() < 0.000001);
     }
 
     #[test]

--- a/src/core/providers/gemini/models/mod.rs
+++ b/src/core/providers/gemini/models/mod.rs
@@ -294,21 +294,8 @@ impl CostCalculator {
         model_id: &str,
         prompt_tokens: u32,
         completion_tokens: u32,
-    ) -> Option<f64> {
-        let usage = crate::core::cost::types::UsageTokens::new(prompt_tokens, completion_tokens);
-        if let Ok(breakdown) =
-            crate::core::cost::calculator::generic_cost_per_token(model_id, &usage, "vertex_ai")
-        {
-            return Some(breakdown.total_cost);
-        }
-
-        let registry = get_gemini_registry();
-        let pricing = registry.get_core_model_pricing(model_id)?;
-
-        let input_cost = (prompt_tokens as f64 / 1000.0) * pricing.input_cost_per_1k_tokens;
-        let output_cost = (completion_tokens as f64 / 1000.0) * pricing.output_cost_per_1k_tokens;
-
-        Some(input_cost + output_cost)
+    ) -> Result<f64, crate::ProviderError> {
+        super::calculate_gemini_cost(model_id, prompt_tokens, completion_tokens)
     }
 
     /// Calculate multimodal cost
@@ -435,7 +422,7 @@ mod tests {
     #[test]
     fn test_cost_calculation() {
         let cost = CostCalculator::calculate_cost("gemini-1.5-flash", 1000, 500);
-        assert!(cost.is_some());
+        assert!(cost.is_ok());
 
         let cost_value = cost.unwrap();
         // Expected: (1000/1M * $0.075) + (500/1M * $0.30) = $0.000075 + $0.00015 = $0.000225
@@ -443,11 +430,11 @@ mod tests {
     }
 
     #[test]
-    fn test_cost_calculation_keeps_registry_fallback() {
-        let cost = CostCalculator::calculate_cost("gemini-1.0-pro", 1000, 500)
-            .expect("Gemini registry fallback should price gemini-1.0-pro");
-
-        assert!((cost - 0.00125).abs() < 0.000001);
+    fn test_cost_calculation_does_not_use_registry_fallback() {
+        assert!(matches!(
+            CostCalculator::calculate_cost("gemini-1.0-pro", 1000, 500),
+            Err(crate::ProviderError::ModelNotFound { .. })
+        ));
     }
 
     #[test]
@@ -692,7 +679,10 @@ mod tests {
     #[test]
     fn test_cost_calculation_unknown_model() {
         let cost = CostCalculator::calculate_cost("unknown-model", 1000, 500);
-        assert!(cost.is_none());
+        assert!(matches!(
+            cost,
+            Err(crate::ProviderError::ModelNotFound { .. })
+        ));
     }
 
     #[test]

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -118,7 +118,7 @@ impl GeminiProvider {
         model: &str,
         input_tokens: u32,
         output_tokens: u32,
-    ) -> Option<f64> {
+    ) -> Result<f64, ProviderError> {
         super::models::CostCalculator::calculate_cost(model, input_tokens, output_tokens)
     }
 }
@@ -391,10 +391,7 @@ impl LLMProvider for GeminiProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        Ok(
-            super::models::CostCalculator::calculate_cost(model, input_tokens, output_tokens)
-                .unwrap_or(0.0),
-        )
+        super::calculate_gemini_cost(model, input_tokens, output_tokens)
     }
 }
 

--- a/src/core/providers/gemini/provider_tests.rs
+++ b/src/core/providers/gemini/provider_tests.rs
@@ -370,6 +370,11 @@ async fn async_calculate_cost_uses_shared_pricing_units() {
         .await
         .expect("provider-prefixed exact Gemini row should be priced");
     assert!((preview - 0.002).abs() < 1e-12);
+
+    let image = LLMProvider::calculate_cost(&provider, "gemini-3-pro-image-preview", 1_000, 500)
+        .await
+        .expect("chat-capable Gemini image row should be token priced");
+    assert!((image - 0.008).abs() < 1e-12);
 }
 
 #[tokio::test]

--- a/src/core/providers/gemini/provider_tests.rs
+++ b/src/core/providers/gemini/provider_tests.rs
@@ -324,9 +324,8 @@ fn test_calculate_cost() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = provider.calculate_cost("gemini-1.0-pro", 1000, 500);
-    // Cost should be Some value (may be 0 for free models)
-    assert!(cost.is_some());
+    let cost = provider.calculate_cost("gemini-1.5-flash", 1000, 500);
+    assert!(cost.is_ok());
 }
 
 #[test]
@@ -335,7 +334,7 @@ fn test_calculate_cost_unknown_model() {
     let provider = GeminiProvider::new(config).unwrap();
 
     let cost = provider.calculate_cost("unknown-model", 1000, 500);
-    assert!(cost.is_none());
+    assert!(matches!(cost, Err(ProviderError::ModelNotFound { .. })));
 }
 
 #[test]
@@ -343,10 +342,8 @@ fn test_calculate_cost_zero_tokens() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = provider.calculate_cost("gemini-1.0-pro", 0, 0);
-    if let Some(c) = cost {
-        assert!((c - 0.0).abs() < 0.0001);
-    }
+    let cost = provider.calculate_cost("gemini-1.5-flash", 0, 0);
+    assert_eq!(cost.expect("catalogued model should be priced"), 0.0);
 }
 
 #[tokio::test]
@@ -354,8 +351,31 @@ async fn test_async_calculate_cost() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = LLMProvider::calculate_cost(&provider, "gemini-1.0-pro", 1000, 500).await;
+    let cost = LLMProvider::calculate_cost(&provider, "gemini-1.5-flash", 1000, 500).await;
     assert!(cost.is_ok());
+}
+
+#[tokio::test]
+async fn async_calculate_cost_uses_shared_pricing_units() {
+    let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
+    let provider = GeminiProvider::new(config).unwrap();
+
+    let cost = LLMProvider::calculate_cost(&provider, "gemini-1.5-flash", 1_000, 500)
+        .await
+        .expect("catalogued Gemini model should be priced");
+
+    assert!((cost - 0.000225).abs() < 1e-12);
+}
+
+#[tokio::test]
+async fn async_calculate_cost_unknown_model_returns_typed_error() {
+    let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
+    let provider = GeminiProvider::new(config).unwrap();
+
+    for model in ["unknown-google-model", "gemini-1.5-flash-9999"] {
+        let result = LLMProvider::calculate_cost(&provider, model, 1_000, 500).await;
+        assert!(matches!(result, Err(ProviderError::ModelNotFound { .. })));
+    }
 }
 
 // ==================== Unsupported Feature Tests ====================

--- a/src/core/providers/gemini/provider_tests.rs
+++ b/src/core/providers/gemini/provider_tests.rs
@@ -365,6 +365,11 @@ async fn async_calculate_cost_uses_shared_pricing_units() {
         .expect("catalogued Gemini model should be priced");
 
     assert!((cost - 0.000225).abs() < 1e-12);
+
+    let preview = LLMProvider::calculate_cost(&provider, "gemini-3-flash-preview", 1_000, 500)
+        .await
+        .expect("provider-prefixed exact Gemini row should be priced");
+    assert!((preview - 0.002).abs() < 1e-12);
 }
 
 #[tokio::test]

--- a/src/core/providers/gemini/provider_tests.rs
+++ b/src/core/providers/gemini/provider_tests.rs
@@ -324,7 +324,7 @@ fn test_calculate_cost() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = provider.calculate_cost("gemini-1.5-flash", 1000, 500);
+    let cost = provider.calculate_cost("gemini-2.5-flash", 1000, 500);
     assert!(cost.is_ok());
 }
 
@@ -342,7 +342,7 @@ fn test_calculate_cost_zero_tokens() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = provider.calculate_cost("gemini-1.5-flash", 0, 0);
+    let cost = provider.calculate_cost("gemini-2.5-flash", 0, 0);
     assert_eq!(cost.expect("catalogued model should be priced"), 0.0);
 }
 
@@ -351,7 +351,7 @@ async fn test_async_calculate_cost() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = LLMProvider::calculate_cost(&provider, "gemini-1.5-flash", 1000, 500).await;
+    let cost = LLMProvider::calculate_cost(&provider, "gemini-2.5-flash", 1000, 500).await;
     assert!(cost.is_ok());
 }
 
@@ -360,11 +360,11 @@ async fn async_calculate_cost_uses_shared_pricing_units() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let cost = LLMProvider::calculate_cost(&provider, "gemini-1.5-flash", 1_000, 500)
+    let cost = LLMProvider::calculate_cost(&provider, "gemini-2.5-flash", 1_000, 500)
         .await
         .expect("catalogued Gemini model should be priced");
 
-    assert!((cost - 0.000225).abs() < 1e-12);
+    assert!((cost - 0.00155).abs() < 1e-12);
 
     let preview = LLMProvider::calculate_cost(&provider, "gemini-3-flash-preview", 1_000, 500)
         .await
@@ -377,7 +377,11 @@ async fn async_calculate_cost_unknown_model_returns_typed_error() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    for model in ["unknown-google-model", "gemini-1.5-flash-9999"] {
+    for model in [
+        "unknown-google-model",
+        "gemini-1.5-flash-9999",
+        "gemini-1.5-flash",
+    ] {
         let result = LLMProvider::calculate_cost(&provider, model, 1_000, 500).await;
         assert!(matches!(result, Err(ProviderError::ModelNotFound { .. })));
     }

--- a/src/core/providers/vertex_ai/client.rs
+++ b/src/core/providers/vertex_ai/client.rs
@@ -286,6 +286,14 @@ impl LLMProvider for VertexAIProvider {
     fn models(&self) -> &[ModelInfo] {
         use std::sync::LazyLock;
         static MODELS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
+            let prices = |model| {
+                super::vertex_prices_per_1k(model).unwrap_or_else(|error| {
+                    tracing::error!(model, %error, "Vertex AI model pricing is unavailable");
+                    (None, None)
+                })
+            };
+            let pro_prices = prices("gemini-1.5-pro");
+            let flash_prices = prices("gemini-1.5-flash");
             vec![
                 ModelInfo {
                     id: "gemini-1.5-pro".to_string(),
@@ -296,8 +304,8 @@ impl LLMProvider for VertexAIProvider {
                     supports_streaming: true,
                     supports_tools: true,
                     supports_multimodal: true,
-                    input_cost_per_1k_tokens: Some(1.25),
-                    output_cost_per_1k_tokens: Some(3.75),
+                    input_cost_per_1k_tokens: pro_prices.0,
+                    output_cost_per_1k_tokens: pro_prices.1,
                     currency: "USD".to_string(),
                     capabilities: vec![
                         ProviderCapability::ChatCompletion,
@@ -318,8 +326,8 @@ impl LLMProvider for VertexAIProvider {
                     supports_streaming: true,
                     supports_tools: true,
                     supports_multimodal: true,
-                    input_cost_per_1k_tokens: Some(0.0625),
-                    output_cost_per_1k_tokens: Some(0.25),
+                    input_cost_per_1k_tokens: flash_prices.0,
+                    output_cost_per_1k_tokens: flash_prices.1,
                     currency: "USD".to_string(),
                     capabilities: vec![
                         ProviderCapability::ChatCompletion,
@@ -412,20 +420,7 @@ impl LLMProvider for VertexAIProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        // Basic cost calculation for Vertex AI models (per 1M tokens)
-        let cost = match model {
-            m if m.contains("gemini-pro") => {
-                (input_tokens as f64 * 0.0005 + output_tokens as f64 * 0.0015) / 1000.0
-            }
-            m if m.contains("gemini-1.5-pro") => {
-                (input_tokens as f64 * 0.00125 + output_tokens as f64 * 0.00375) / 1000.0
-            }
-            m if m.contains("gemini-1.5-flash") => {
-                (input_tokens as f64 * 0.000075 + output_tokens as f64 * 0.0003) / 1000.0
-            }
-            _ => 0.0, // Default cost for unknown models
-        };
-        Ok(cost)
+        super::calculate_vertex_cost(model, input_tokens, output_tokens)
     }
 
     /// Model

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -18,6 +18,11 @@ async fn vertex_cost_uses_shared_per_token_pricing() {
         .expect("catalogued Vertex model should be priced");
 
     assert!((cost - 0.00875).abs() < 1e-12);
+
+    let preview = LLMProvider::calculate_cost(&provider, "gemini-3-flash-preview", 1_000, 500)
+        .await
+        .expect("provider-prefixed exact Vertex row should be priced");
+    assert!((preview - 0.002).abs() < 1e-12);
 }
 
 #[tokio::test]

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -29,6 +29,15 @@ async fn vertex_cost_uses_shared_per_token_pricing() {
         ("gemini-1.5-pro-002", 0.00875),
         ("gemini-1.5-flash-002", 0.000225),
         ("claude-3-opus@20240229", 0.0525),
+        ("claude-opus-4-6@20260114", 0.0175),
+        ("claude-opus-4-5@20251110", 0.0175),
+        ("claude-3-5-sonnet@20241022", 0.0105),
+        ("meta/llama3-70b-instruct-maas", 0.0),
+        ("meta/llama-4-scout-17b-16e-instruct", 0.0006),
+        ("meta/llama-4-maverick-17b-128e-instruct", 0.000925),
+        ("ai21/jamba-1.5-large", 0.006),
+        ("mistral/mistral-large-2411", 0.005),
+        ("mistral/mistral-nemo", 0.000225),
     ] {
         let cost = LLMProvider::calculate_cost(&provider, model, 1_000, 500)
             .await

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -23,6 +23,18 @@ async fn vertex_cost_uses_shared_per_token_pricing() {
         .await
         .expect("provider-prefixed exact Vertex row should be priced");
     assert!((preview - 0.002).abs() < 1e-12);
+
+    for (model, expected) in [
+        ("gemini-2.0-flash", 0.0003),
+        ("gemini-1.5-pro-002", 0.00875),
+        ("gemini-1.5-flash-002", 0.000225),
+        ("claude-3-opus@20240229", 0.0525),
+    ] {
+        let cost = LLMProvider::calculate_cost(&provider, model, 1_000, 500)
+            .await
+            .expect("canonical Vertex model should be priced");
+        assert!((cost - expected).abs() < 1e-12, "model: {model}");
+    }
 }
 
 #[tokio::test]

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -1,6 +1,54 @@
 use super::*;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
+async fn pricing_test_provider() -> VertexAIProvider {
+    VertexAIProvider::new(VertexAIProviderConfig {
+        project_id: "pricing-test-project".to_string(),
+        ..Default::default()
+    })
+    .await
+    .expect("Vertex AI provider should initialize")
+}
+
+#[tokio::test]
+async fn vertex_cost_uses_shared_per_token_pricing() {
+    let provider = pricing_test_provider().await;
+    let cost = LLMProvider::calculate_cost(&provider, "gemini-1.5-pro", 1_000, 500)
+        .await
+        .expect("catalogued Vertex model should be priced");
+
+    assert!((cost - 0.00875).abs() < 1e-12);
+}
+
+#[tokio::test]
+async fn vertex_unknown_model_returns_typed_error() {
+    let provider = pricing_test_provider().await;
+
+    for model in ["unknown-google-model", "gemini-1.5-flash-9999"] {
+        let result = LLMProvider::calculate_cost(&provider, model, 1_000, 500).await;
+        assert!(matches!(result, Err(ProviderError::ModelNotFound { .. })));
+    }
+}
+
+#[tokio::test]
+async fn vertex_model_metadata_uses_per_1k_units() {
+    let provider = pricing_test_provider().await;
+    let pro = provider
+        .models()
+        .iter()
+        .find(|model| model.id == "gemini-1.5-pro")
+        .expect("Gemini 1.5 Pro metadata should exist");
+
+    let input = pro
+        .input_cost_per_1k_tokens
+        .expect("input pricing should be present");
+    let output = pro
+        .output_cost_per_1k_tokens
+        .expect("output pricing should be present");
+    assert!((input - 0.0035).abs() < 1e-12);
+    assert!((output - 0.0105).abs() < 1e-12);
+}
+
 #[test]
 fn test_client_vertex_usage_parser_is_strict_and_endpoint_aware() {
     let valid = serde_json::json!({"usageMetadata": {
@@ -318,44 +366,6 @@ fn test_model_info_structure() {
     assert_eq!(model_info.id, "gemini-1.5-pro");
     assert_eq!(model_info.max_context_length, 2_097_152);
     assert!(model_info.supports_tools);
-}
-
-// ==================== Cost Calculation Tests ====================
-
-#[test]
-fn test_cost_calculation_gemini_pro() {
-    let input_tokens = 1000_u32;
-    let output_tokens = 500_u32;
-    let cost = (input_tokens as f64 * 0.0005 + output_tokens as f64 * 0.0015) / 1000.0;
-    assert!(cost > 0.0);
-    // 1000 * 0.0005 + 500 * 0.0015 = 0.5 + 0.75 = 1.25 / 1000 = 0.00125
-    assert!((cost - 0.00125).abs() < 0.0001);
-}
-
-#[test]
-fn test_cost_calculation_gemini_1_5_pro() {
-    let input_tokens = 1000_u32;
-    let output_tokens = 500_u32;
-    let cost = (input_tokens as f64 * 0.00125 + output_tokens as f64 * 0.00375) / 1000.0;
-    assert!(cost > 0.0);
-    // 1000 * 0.00125 + 500 * 0.00375 = 1.25 + 1.875 = 3.125 / 1000 = 0.003125
-    assert!((cost - 0.003125).abs() < 0.0001);
-}
-
-#[test]
-fn test_cost_calculation_gemini_1_5_flash() {
-    let input_tokens = 1000_u32;
-    let output_tokens = 500_u32;
-    let cost = (input_tokens as f64 * 0.000075 + output_tokens as f64 * 0.0003) / 1000.0;
-    assert!(cost > 0.0);
-    // 1000 * 0.000075 + 500 * 0.0003 = 0.075 + 0.15 = 0.225 / 1000 = 0.000225
-    assert!((cost - 0.000225).abs() < 0.0001);
-}
-
-#[test]
-fn test_cost_calculation_unknown_model() {
-    let cost = 0.0_f64;
-    assert_eq!(cost, 0.0);
 }
 
 // ==================== URL Building Tests (logic only) ====================

--- a/src/core/providers/vertex_ai/gemini/mod.rs
+++ b/src/core/providers/vertex_ai/gemini/mod.rs
@@ -343,20 +343,33 @@ pub struct GeminiCostCalculator;
 
 impl GeminiCostCalculator {
     /// Calculate cost for Gemini models
-    pub fn calculate_cost(model: &str, input_tokens: usize, output_tokens: usize) -> f64 {
-        let (input_rate, output_rate) = match model {
-            "gemini-1.5-pro" | "gemini-1.5-pro-001" | "gemini-1.5-pro-002" => (3.50, 10.50),
-            "gemini-1.5-flash" | "gemini-1.5-flash-001" | "gemini-1.5-flash-002" => (0.075, 0.30),
-            "gemini-2.0-flash-thinking-exp" => (0.0, 0.0), // Free during experimental
-            "gemini-ultra" | "gemini-ultra-1.0" => (10.0, 30.0),
-            "gemini-pro" => (0.50, 1.50),
-            "gemini-pro-vision" => (0.50, 1.50),
-            _ => (0.075, 0.30), // Default to Flash pricing
-        };
+    pub fn calculate_cost(
+        model: &str,
+        input_tokens: usize,
+        output_tokens: usize,
+    ) -> Result<f64, crate::ProviderError> {
+        let input_tokens = u32::try_from(input_tokens).map_err(|_| {
+            crate::ProviderError::invalid_request("vertex_ai", "input token count exceeds u32")
+        })?;
+        let output_tokens = u32::try_from(output_tokens).map_err(|_| {
+            crate::ProviderError::invalid_request("vertex_ai", "output token count exceeds u32")
+        })?;
+        super::calculate_vertex_cost(model, input_tokens, output_tokens)
+    }
+}
 
-        let input_cost = (input_tokens as f64 / 1_000_000.0) * input_rate;
-        let output_cost = (output_tokens as f64 / 1_000_000.0) * output_rate;
+#[cfg(test)]
+mod cost_tests {
+    use super::GeminiCostCalculator;
+    use crate::ProviderError;
 
-        input_cost + output_cost
+    #[test]
+    fn calculator_uses_vertex_authority_and_rejects_unknown_models() {
+        let cost = GeminiCostCalculator::calculate_cost("gemini-1.5-pro", 1_000, 500)
+            .expect("catalogued Vertex model should be priced");
+        assert!((cost - 0.00875).abs() < 1e-12);
+
+        let unknown = GeminiCostCalculator::calculate_cost("unknown-google-model", 1_000, 500);
+        assert!(matches!(unknown, Err(ProviderError::ModelNotFound { .. })));
     }
 }

--- a/src/core/providers/vertex_ai/mod.rs
+++ b/src/core/providers/vertex_ai/mod.rs
@@ -40,6 +40,49 @@ pub use common_utils::VertexAIConfig;
 pub use error::VertexAIError;
 
 use crate::core::net::{ProviderEndpointAccess, ProviderEndpointPolicy};
+use crate::core::pricing_service::{PricingService, PricingUsage};
+use crate::core::providers::unified_provider::ProviderError;
+use crate::utils::error::gateway_error::GatewayError;
+
+pub(crate) fn calculate_vertex_cost(
+    model: &str,
+    input_tokens: u32,
+    output_tokens: u32,
+) -> Result<f64, ProviderError> {
+    PricingService::shared_embedded_default()
+        .and_then(|service| {
+            service.calculate_loaded_usage_cost_for_provider(
+                "vertex_ai",
+                model,
+                &PricingUsage::new(input_tokens, output_tokens),
+            )
+        })
+        .map(|cost| cost.total_cost)
+        .map_err(|error| vertex_pricing_error(model, error))
+}
+
+pub(crate) fn vertex_prices_per_1k(
+    model: &str,
+) -> Result<(Option<f64>, Option<f64>), ProviderError> {
+    let (_, pricing) = PricingService::shared_embedded_default()
+        .map_err(|error| vertex_pricing_error(model, error))?
+        .get_model_info_for_provider("vertex_ai", model)
+        .ok_or_else(|| ProviderError::model_not_found("vertex_ai", model))?;
+    Ok((
+        pricing.input_cost_per_token.map(|price| price * 1_000.0),
+        pricing.output_cost_per_token.map(|price| price * 1_000.0),
+    ))
+}
+
+fn vertex_pricing_error(model: &str, error: GatewayError) -> ProviderError {
+    match error {
+        GatewayError::NotFound(_) => ProviderError::model_not_found("vertex_ai", model),
+        error => ProviderError::Other {
+            provider: "vertex_ai",
+            message: format!("pricing authority failed for model '{model}': {error}"),
+        },
+    }
+}
 
 /// Main VertexAI Provider Configuration
 #[derive(Debug, Clone)]

--- a/src/server/routes/ai/spend_runtime_pricing_tests.rs
+++ b/src/server/routes/ai/spend_runtime_pricing_tests.rs
@@ -260,6 +260,78 @@ async fn record_completion_spend_uses_runtime_pricing_service() {
 }
 
 #[tokio::test]
+async fn google_providers_reserve_and_settle_from_runtime_pricing() {
+    for provider in ["vertex_ai", "gemini"] {
+        let pricing = runtime_test_pricing_service(provider);
+        let budget = UnifiedBudgetLimits::new();
+        budget.providers.set_provider_limit(
+            provider,
+            ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
+        );
+        budget.models.set_model_limit(
+            "runtime-only-priced-model",
+            ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
+        );
+        let keys = KeyManager::new(InMemoryKeyRepository::new());
+        assert!(
+            reserve_completion_budget_with_pricing(
+                &pricing,
+                &budget,
+                provider,
+                "runtime-only-priced-model-9999",
+                1_000,
+                Some(500),
+            )
+            .is_err(),
+            "provider: {provider}"
+        );
+        let reservation = reserve_completion_budget_with_pricing(
+            &pricing,
+            &budget,
+            provider,
+            "runtime-only-priced-model",
+            1_000,
+            Some(500),
+        )
+        .expect("Google model reservation should use runtime pricing")
+        .expect("non-zero runtime price should reserve budget");
+        assert!((reservation.reserved_amount() - 0.025).abs() < f64::EPSILON);
+
+        record_completion_spend_with_reservation_with_pricing(
+            &pricing,
+            usage_spend_settlement(
+                (&budget, &keys, None),
+                (
+                    provider,
+                    "runtime-only-priced-model",
+                    Some(&response_usage(1_000, 500)),
+                ),
+                Some(reservation),
+                None,
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            budget
+                .providers
+                .get_provider_usage(provider)
+                .map(|usage| usage.current_spend),
+            Some(0.025),
+            "provider: {provider}"
+        );
+        assert_eq!(
+            budget
+                .models
+                .get_model_usage("runtime-only-priced-model")
+                .map(|usage| usage.current_spend),
+            Some(0.025),
+            "provider: {provider}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn record_completion_spend_settles_text_cost_when_modal_price_is_missing() {
     let pricing = runtime_test_pricing_service("runtime_provider");
     let budget = UnifiedBudgetLimits::new();


### PR DESCRIPTION
Closes #1113

## Summary
- route Vertex AI and Gemini basic token cost APIs through the shared provider-aware pricing authority
- require exact Google model IDs and return typed ModelNotFound errors instead of zero or Flash fallback pricing
- source Vertex model metadata from the same catalog with explicit per-1k conversion
- cover runtime pricing injection through budget reservation and provider/model spend settlement

## Verification
- cargo fmt --all -- --check
- cargo check --all-features
- cargo clippy --all-targets --features providers-extra,providers-extended -- -D warnings
- cargo test --features providers-extra,providers-extended
- repository schema, API/runtime, subsystem registry, outbound HTTP, and log PII guards