### PR TITLE
refactor(google): share Gemini catalog with Vertex

### DIFF
--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -239,6 +239,24 @@ fn resolve_model_info_for_provider(
         return None;
     }
 
+    let normalized_model = crate::core::pricing::normalize_model_key(model);
+    if normalized_provider == "vertex_ai" {
+        for candidate in [
+            super::google::vertex_pricing_alias(model),
+            super::google::vertex_pricing_alias(normalized_model),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if let Some(info) = models
+                .get(candidate)
+                .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+            {
+                return Some((candidate.to_string(), info.clone()));
+            }
+        }
+    }
+
     if let Some(info) = models
         .get(model)
         .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
@@ -246,7 +264,6 @@ fn resolve_model_info_for_provider(
         return Some((model.to_string(), info.clone()));
     }
 
-    let normalized_model = crate::core::pricing::normalize_model_key(model);
     if normalized_model != model
         && let Some(info) = models
             .get(normalized_model)

--- a/src/core/pricing_service/google.rs
+++ b/src/core/pricing_service/google.rs
@@ -65,9 +65,12 @@ pub(super) fn exact_pricing_candidates(
     candidates
 }
 
-fn vertex_pricing_alias(model: &str) -> Option<&'static str> {
-    match model {
-        "gemini-1.5-pro-001" | "gemini-1.5-pro-002" => Some("gemini-1.5-pro"),
+pub(super) fn vertex_pricing_alias(model: &str) -> Option<&'static str> {
+    match model.to_ascii_lowercase().as_str() {
+        "gemini-1.5-pro-001"
+        | "gemini-1.5-pro-002"
+        | "gemini-1.5-pro-vision"
+        | "gemini-pro-vision" => Some("gemini-1.5-pro"),
         "gemini-1.5-flash-001" | "gemini-1.5-flash-002" => Some("gemini-1.5-flash"),
         "claude-opus-4-6@20260114" => Some("vertex_ai/claude-opus-4-6"),
         "claude-opus-4-5@20251110" => Some("vertex_ai/claude-opus-4-5"),

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -18,29 +18,41 @@
 //! - Batch processing
 //! - Real-time streaming responses
 
+#[cfg(feature = "providers-extended")]
 pub mod client;
+#[cfg(feature = "providers-extended")]
 pub mod config;
+#[cfg(feature = "providers-extended")]
 pub mod error;
 pub mod models;
+#[cfg(feature = "providers-extended")]
 pub mod provider;
+#[cfg(feature = "providers-extended")]
 pub mod streaming;
 
 // Re-export main types
+#[cfg(feature = "providers-extended")]
 pub use client::GeminiClient;
+#[cfg(feature = "providers-extended")]
 pub use config::GeminiConfig;
+#[cfg(feature = "providers-extended")]
 pub use error::GeminiError;
-pub use models::{GeminiModelFamily, ModelFeature, get_gemini_registry};
+pub use models::{GeminiModelFamily, GoogleGeminiApiSurface, ModelFeature, get_gemini_registry};
+#[cfg(feature = "providers-extended")]
 pub use provider::GeminiProvider;
+#[cfg(feature = "providers-extended")]
 pub use streaming::GeminiStream;
 
 // Convenience functions
 
 /// Create Gemini provider
+#[cfg(feature = "providers-extended")]
 pub fn create_gemini_provider(config: GeminiConfig) -> Result<GeminiProvider, error::GeminiError> {
     GeminiProvider::new(config)
 }
 
 /// Create Gemini provider from environment
+#[cfg(feature = "providers-extended")]
 pub fn create_gemini_provider_from_env() -> Result<GeminiProvider, error::GeminiError> {
     let config = GeminiConfig::from_env()?;
     GeminiProvider::new(config)

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -22,19 +22,29 @@ use crate::core::pricing_service::{LiteLLMModelInfo, PricingService, PricingUsag
 use crate::core::providers::unified_provider::ProviderError;
 use crate::utils::error::gateway_error::GatewayError;
 
+#[cfg(feature = "providers-extended")]
 pub mod client;
+#[cfg(feature = "providers-extended")]
 pub mod config;
+#[cfg(feature = "providers-extended")]
 pub mod error;
 pub mod models;
+#[cfg(feature = "providers-extended")]
 pub mod provider;
+#[cfg(feature = "providers-extended")]
 pub mod streaming;
 
 // Re-export main types
+#[cfg(feature = "providers-extended")]
 pub use client::GeminiClient;
+#[cfg(feature = "providers-extended")]
 pub use config::GeminiConfig;
+#[cfg(feature = "providers-extended")]
 pub use error::GeminiError;
-pub use models::{GeminiModelFamily, ModelFeature, get_gemini_registry};
+pub use models::{GeminiModelFamily, GoogleGeminiApiSurface, ModelFeature, get_gemini_registry};
+#[cfg(feature = "providers-extended")]
 pub use provider::GeminiProvider;
+#[cfg(feature = "providers-extended")]
 pub use streaming::GeminiStream;
 
 pub(crate) fn calculate_gemini_cost(
@@ -80,11 +90,13 @@ fn gemini_pricing_error(model: &str, error: GatewayError) -> ProviderError {
 // Convenience functions
 
 /// Create Gemini provider
+#[cfg(feature = "providers-extended")]
 pub fn create_gemini_provider(config: GeminiConfig) -> Result<GeminiProvider, error::GeminiError> {
     GeminiProvider::new(config)
 }
 
 /// Create Gemini provider from environment
+#[cfg(feature = "providers-extended")]
 pub fn create_gemini_provider_from_env() -> Result<GeminiProvider, error::GeminiError> {
     let config = GeminiConfig::from_env()?;
     GeminiProvider::new(config)

--- a/src/core/providers/gemini/models/mod.rs
+++ b/src/core/providers/gemini/models/mod.rs
@@ -42,7 +42,7 @@ pub enum ModelFeature {
 }
 
 /// Model family classification
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GeminiModelFamily {
     /// Gemini 3.5 series (2026 - Latest)
     Gemini35Flash,
@@ -139,6 +139,116 @@ pub struct ModelSpec {
     pub limits: ModelLimits,
 }
 
+/// Google Gemini API surface for provider-specific catalog overlays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoogleGeminiApiSurface {
+    /// Google AI Studio / Gemini Developer API.
+    DeveloperApi,
+    /// Google Cloud Vertex AI publisher endpoint.
+    VertexAi { include_experimental: bool },
+}
+
+impl GoogleGeminiApiSurface {
+    fn provider_name(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "gemini",
+            Self::VertexAi { .. } => "vertex_ai",
+        }
+    }
+
+    fn surface_name(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "developer_api",
+            Self::VertexAi { .. } => "vertex_ai",
+        }
+    }
+
+    fn auth_boundary(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "api_key",
+            Self::VertexAi { .. } => "bearer_token",
+        }
+    }
+
+    fn endpoint_family(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "generativelanguage",
+            Self::VertexAi { .. } => "aiplatform_publishers_google",
+        }
+    }
+
+    fn includes(self, spec: &ModelSpec) -> bool {
+        match self {
+            Self::DeveloperApi => true,
+            Self::VertexAi {
+                include_experimental,
+            } => {
+                !matches!(
+                    spec.family,
+                    GeminiModelFamily::Gemini10Pro | GeminiModelFamily::Gemini10ProVision
+                ) && (include_experimental || !is_experimental_model(spec))
+            }
+        }
+    }
+
+    fn overlay_model_info(self, spec: &ModelSpec) -> ModelInfo {
+        let mut model_info = spec.model_info.clone();
+        if matches!(self, Self::VertexAi { .. })
+            && let Some(max_context_length) = vertex_context_length(spec.family)
+        {
+            model_info.max_context_length = max_context_length;
+        }
+        model_info.provider = self.provider_name().to_string();
+        model_info.metadata.insert(
+            "google_model_catalog_surface".to_string(),
+            serde_json::json!(self.surface_name()),
+        );
+        model_info.metadata.insert(
+            "google_auth_boundary".to_string(),
+            serde_json::json!(self.auth_boundary()),
+        );
+        model_info.metadata.insert(
+            "google_endpoint_family".to_string(),
+            serde_json::json!(self.endpoint_family()),
+        );
+        model_info.metadata.insert(
+            "google_model_source_provider".to_string(),
+            serde_json::json!("gemini"),
+        );
+        model_info
+    }
+}
+
+fn is_experimental_model(spec: &ModelSpec) -> bool {
+    matches!(spec.family, GeminiModelFamily::GeminiExperimental)
+        || spec.model_info.id.contains("-exp")
+        || spec.model_info.id.contains("experimental")
+}
+
+fn vertex_context_length(family: GeminiModelFamily) -> Option<u32> {
+    match family {
+        GeminiModelFamily::Gemini35Flash
+        | GeminiModelFamily::Gemini31ProPreview
+        | GeminiModelFamily::Gemini31Flash
+        | GeminiModelFamily::Gemini31FlashLite
+        | GeminiModelFamily::Gemini25Pro
+        | GeminiModelFamily::Gemini25Flash
+        | GeminiModelFamily::Gemini25FlashLite
+        | GeminiModelFamily::Gemini20Flash
+        | GeminiModelFamily::Gemini20FlashThinking
+        | GeminiModelFamily::Gemini15Flash
+        | GeminiModelFamily::Gemini15Flash8B => Some(1_048_576),
+        GeminiModelFamily::Gemini3Pro
+        | GeminiModelFamily::Gemini3ProDeepThink
+        | GeminiModelFamily::Gemini3Flash => Some(1_000_000),
+        GeminiModelFamily::Gemini3ProImage => Some(65_536),
+        GeminiModelFamily::Gemini15Pro => Some(2_097_152),
+        GeminiModelFamily::Gemini10Pro
+        | GeminiModelFamily::Gemini10ProVision
+        | GeminiModelFamily::GeminiExperimental => None,
+    }
+}
+
 /// Model
 #[derive(Debug, Clone)]
 pub struct GeminiModelRegistry {
@@ -176,6 +286,18 @@ impl GeminiModelRegistry {
     /// Model
     pub fn list_models(&self) -> Vec<&ModelSpec> {
         self.models.values().collect()
+    }
+
+    /// List model metadata for a concrete Google API surface.
+    pub fn list_model_infos_for_surface(&self, surface: GoogleGeminiApiSurface) -> Vec<ModelInfo> {
+        let mut models = self
+            .models
+            .values()
+            .filter(|spec| surface.includes(spec))
+            .map(|spec| surface.overlay_model_info(spec))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| left.id.cmp(&right.id));
+        models
     }
 
     /// Check
@@ -462,6 +584,119 @@ mod tests {
         let models = registry.list_models();
         assert!(!models.is_empty());
         assert!(models.len() >= 10); // We have at least 10 models registered
+    }
+
+    #[test]
+    fn test_google_api_surface_model_overlays_are_stable() {
+        let registry = get_gemini_registry();
+
+        let developer_models =
+            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::DeveloperApi);
+        let vertex_models =
+            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::VertexAi {
+                include_experimental: true,
+            });
+
+        assert_eq!(developer_models.len(), registry.list_models().len());
+        assert!(
+            developer_models
+                .iter()
+                .any(|model| model.id == "gemini-1.0-pro")
+        );
+        assert!(
+            vertex_models
+                .iter()
+                .any(|model| model.id == "gemini-3.5-flash")
+        );
+        assert!(
+            !vertex_models
+                .iter()
+                .any(|model| model.id == "gemini-1.0-pro")
+        );
+
+        for models in [&developer_models, &vertex_models] {
+            let ids = models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>();
+            let mut sorted_ids = ids.clone();
+            sorted_ids.sort_unstable();
+            assert_eq!(ids, sorted_ids);
+        }
+
+        let developer_model = developer_models
+            .iter()
+            .find(|model| model.id == "gemini-3.5-flash")
+            .unwrap();
+        assert_eq!(developer_model.provider, "gemini");
+        assert_eq!(
+            developer_model.metadata["google_auth_boundary"],
+            serde_json::json!("api_key")
+        );
+
+        let vertex_model = vertex_models
+            .iter()
+            .find(|model| model.id == "gemini-3.5-flash")
+            .unwrap();
+        assert_eq!(vertex_model.provider, "vertex_ai");
+        assert_eq!(
+            vertex_model.metadata["google_auth_boundary"],
+            serde_json::json!("bearer_token")
+        );
+        assert_eq!(
+            vertex_model.metadata["google_endpoint_family"],
+            serde_json::json!("aiplatform_publishers_google")
+        );
+
+        let vertex_pro = vertex_models
+            .iter()
+            .find(|model| model.id == "gemini-1.5-pro")
+            .unwrap();
+        assert_eq!(vertex_pro.max_context_length, 2_097_152);
+        let vertex_flash = vertex_models
+            .iter()
+            .find(|model| model.id == "gemini-1.5-flash")
+            .unwrap();
+        assert_eq!(vertex_flash.max_context_length, 1_048_576);
+        let vertex_preview = vertex_models
+            .iter()
+            .find(|model| model.id == "gemini-3-flash-preview")
+            .unwrap();
+        assert_eq!(vertex_preview.max_context_length, 1_000_000);
+    }
+
+    #[test]
+    fn test_google_vertex_surface_can_filter_experimental_models() {
+        let registry = get_gemini_registry();
+        let stable_models =
+            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::VertexAi {
+                include_experimental: false,
+            });
+        let experimental_models =
+            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::VertexAi {
+                include_experimental: true,
+            });
+
+        assert!(
+            !stable_models
+                .iter()
+                .any(|model| model.id == "gemini-2.0-flash-exp")
+        );
+        assert!(
+            !stable_models
+                .iter()
+                .any(|model| model.id == "gemini-2.0-flash-thinking-exp")
+        );
+        assert!(
+            experimental_models
+                .iter()
+                .any(|model| model.id == "gemini-2.0-flash-exp")
+        );
+        assert!(
+            experimental_models
+                .iter()
+                .any(|model| model.id == "gemini-2.0-flash-thinking-exp")
+        );
     }
 
     #[test]

--- a/src/core/providers/gemini/models/mod.rs
+++ b/src/core/providers/gemini/models/mod.rs
@@ -139,6 +139,79 @@ pub struct ModelSpec {
     pub limits: ModelLimits,
 }
 
+/// Google Gemini API surface for provider-specific catalog overlays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoogleGeminiApiSurface {
+    /// Google AI Studio / Gemini Developer API.
+    DeveloperApi,
+    /// Google Cloud Vertex AI publisher endpoint.
+    VertexAi,
+}
+
+impl GoogleGeminiApiSurface {
+    fn provider_name(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "gemini",
+            Self::VertexAi => "vertex_ai",
+        }
+    }
+
+    fn surface_name(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "developer_api",
+            Self::VertexAi => "vertex_ai",
+        }
+    }
+
+    fn auth_boundary(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "api_key",
+            Self::VertexAi => "bearer_token",
+        }
+    }
+
+    fn endpoint_family(self) -> &'static str {
+        match self {
+            Self::DeveloperApi => "generativelanguage",
+            Self::VertexAi => "aiplatform_publishers_google",
+        }
+    }
+
+    fn includes(self, spec: &ModelSpec) -> bool {
+        match self {
+            Self::DeveloperApi => true,
+            Self::VertexAi => !matches!(
+                spec.family,
+                GeminiModelFamily::Gemini10Pro
+                    | GeminiModelFamily::Gemini10ProVision
+                    | GeminiModelFamily::GeminiExperimental
+            ),
+        }
+    }
+
+    fn overlay_model_info(self, spec: &ModelSpec) -> ModelInfo {
+        let mut model_info = spec.model_info.clone();
+        model_info.provider = self.provider_name().to_string();
+        model_info.metadata.insert(
+            "google_model_catalog_surface".to_string(),
+            serde_json::json!(self.surface_name()),
+        );
+        model_info.metadata.insert(
+            "google_auth_boundary".to_string(),
+            serde_json::json!(self.auth_boundary()),
+        );
+        model_info.metadata.insert(
+            "google_endpoint_family".to_string(),
+            serde_json::json!(self.endpoint_family()),
+        );
+        model_info.metadata.insert(
+            "google_model_source_provider".to_string(),
+            serde_json::json!("gemini"),
+        );
+        model_info
+    }
+}
+
 /// Model
 #[derive(Debug, Clone)]
 pub struct GeminiModelRegistry {
@@ -176,6 +249,18 @@ impl GeminiModelRegistry {
     /// Model
     pub fn list_models(&self) -> Vec<&ModelSpec> {
         self.models.values().collect()
+    }
+
+    /// List model metadata for a concrete Google API surface.
+    pub fn list_model_infos_for_surface(&self, surface: GoogleGeminiApiSurface) -> Vec<ModelInfo> {
+        let mut models = self
+            .models
+            .values()
+            .filter(|spec| surface.includes(spec))
+            .map(|spec| surface.overlay_model_info(spec))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| left.id.cmp(&right.id));
+        models
     }
 
     /// Check
@@ -475,6 +560,66 @@ mod tests {
         let models = registry.list_models();
         assert!(!models.is_empty());
         assert!(models.len() >= 10); // We have at least 10 models registered
+    }
+
+    #[test]
+    fn test_google_api_surface_model_overlays_are_stable() {
+        let registry = get_gemini_registry();
+
+        let developer_models =
+            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::DeveloperApi);
+        let vertex_models = registry.list_model_infos_for_surface(GoogleGeminiApiSurface::VertexAi);
+
+        assert_eq!(developer_models.len(), registry.list_models().len());
+        assert!(
+            developer_models
+                .iter()
+                .any(|model| model.id == "gemini-1.0-pro")
+        );
+        assert!(
+            vertex_models
+                .iter()
+                .any(|model| model.id == "gemini-3.5-flash")
+        );
+        assert!(
+            !vertex_models
+                .iter()
+                .any(|model| model.id == "gemini-1.0-pro")
+        );
+
+        for models in [&developer_models, &vertex_models] {
+            let ids = models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>();
+            let mut sorted_ids = ids.clone();
+            sorted_ids.sort_unstable();
+            assert_eq!(ids, sorted_ids);
+        }
+
+        let developer_model = developer_models
+            .iter()
+            .find(|model| model.id == "gemini-3.5-flash")
+            .unwrap();
+        assert_eq!(developer_model.provider, "gemini");
+        assert_eq!(
+            developer_model.metadata["google_auth_boundary"],
+            serde_json::json!("api_key")
+        );
+
+        let vertex_model = vertex_models
+            .iter()
+            .find(|model| model.id == "gemini-3.5-flash")
+            .unwrap();
+        assert_eq!(vertex_model.provider, "vertex_ai");
+        assert_eq!(
+            vertex_model.metadata["google_auth_boundary"],
+            serde_json::json!("bearer_token")
+        );
+        assert_eq!(
+            vertex_model.metadata["google_endpoint_family"],
+            serde_json::json!("aiplatform_publishers_google")
+        );
     }
 
     #[test]

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -25,7 +25,7 @@ use crate::core::types::{
 use super::client::GeminiClient;
 use super::config::GeminiConfig;
 use super::error::{GeminiErrorMapper, gemini_model_error, gemini_validation_error};
-use super::models::{ModelFeature, get_gemini_registry};
+use super::models::{GoogleGeminiApiSurface, ModelFeature, get_gemini_registry};
 use super::streaming::GeminiStream;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
@@ -49,11 +49,8 @@ impl GeminiProvider {
 
         // Get
         let registry = get_gemini_registry();
-        let supported_models = registry
-            .list_models()
-            .into_iter()
-            .map(|spec| spec.model_info.clone())
-            .collect();
+        let supported_models =
+            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::DeveloperApi);
 
         Ok(Self {
             client,

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -50,7 +50,7 @@ pub mod fal_ai;
 // fireworks: Tier 1 -> registry/catalog.rs
 // friendliai: Tier 1 -> registry/catalog.rs
 // galadriel: Tier 1 -> registry/catalog.rs
-#[cfg(feature = "providers-extended")]
+#[cfg(any(feature = "providers-extended", feature = "providers-extra"))]
 pub mod gemini;
 #[cfg(feature = "providers-extended")]
 pub mod github;

--- a/src/core/providers/vertex_ai/client.rs
+++ b/src/core/providers/vertex_ai/client.rs
@@ -18,7 +18,7 @@ use crate::core::{
         embedding::EmbeddingRequest,
         health::HealthStatus,
         image::ImageGenerationRequest,
-        model::{ModelInfo, ProviderCapability},
+        model::ModelInfo,
         responses::{ChatResponse, EmbeddingResponse, ImageGenerationResponse},
     },
 };
@@ -46,9 +46,39 @@ pub struct VertexAIProvider {
     config: Box<VertexAIProviderConfig>,
     auth: Arc<VertexAuth>,
     http_client: BaseHttpClient,
+    supported_models: Vec<ModelInfo>,
     // Cost calculation integrated internally
     gemini_transformer: GeminiTransformer,
     partner_transformer: PartnerModelTransformer,
+}
+
+fn vertex_gemini_models(include_experimental: bool) -> Vec<ModelInfo> {
+    let mut models = crate::core::providers::gemini::get_gemini_registry()
+        .list_model_infos_for_surface(
+            crate::core::providers::gemini::GoogleGeminiApiSurface::VertexAi {
+                include_experimental,
+            },
+        );
+
+    for model in &mut models {
+        match super::vertex_prices_per_1k(&model.id) {
+            Ok((input, output)) => {
+                model.input_cost_per_1k_tokens = input;
+                model.output_cost_per_1k_tokens = output;
+            }
+            Err(error) => {
+                tracing::error!(
+                    model = %model.id,
+                    %error,
+                    "Vertex AI model pricing is unavailable"
+                );
+                model.input_cost_per_1k_tokens = None;
+                model.output_cost_per_1k_tokens = None;
+            }
+        }
+    }
+
+    models
 }
 
 impl VertexAIProvider {
@@ -67,11 +97,13 @@ impl VertexAIProvider {
                 ..Default::default()
             },
         )?;
+        let supported_models = vertex_gemini_models(config.enable_experimental);
 
         Ok(Self {
             config: Box::new(config),
             auth,
             http_client,
+            supported_models,
             gemini_transformer: GeminiTransformer::new(),
             partner_transformer: PartnerModelTransformer::new(),
         })
@@ -284,64 +316,7 @@ impl LLMProvider for VertexAIProvider {
     }
 
     fn models(&self) -> &[ModelInfo] {
-        use std::sync::LazyLock;
-        static MODELS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
-            let prices = |model| {
-                super::vertex_prices_per_1k(model).unwrap_or_else(|error| {
-                    tracing::error!(model, %error, "Vertex AI model pricing is unavailable");
-                    (None, None)
-                })
-            };
-            let pro_prices = prices("gemini-1.5-pro");
-            let flash_prices = prices("gemini-1.5-flash");
-            vec![
-                ModelInfo {
-                    id: "gemini-1.5-pro".to_string(),
-                    name: "Gemini 1.5 Pro".to_string(),
-                    provider: "vertex_ai".to_string(),
-                    max_context_length: 2_097_152,
-                    max_output_length: Some(8192),
-                    supports_streaming: true,
-                    supports_tools: true,
-                    supports_multimodal: true,
-                    input_cost_per_1k_tokens: pro_prices.0,
-                    output_cost_per_1k_tokens: pro_prices.1,
-                    currency: "USD".to_string(),
-                    capabilities: vec![
-                        ProviderCapability::ChatCompletion,
-                        ProviderCapability::ChatCompletionStream,
-                        ProviderCapability::FunctionCalling,
-                        ProviderCapability::ToolCalling,
-                    ],
-                    created_at: None,
-                    updated_at: None,
-                    metadata: std::collections::HashMap::new(),
-                },
-                ModelInfo {
-                    id: "gemini-1.5-flash".to_string(),
-                    name: "Gemini 1.5 Flash".to_string(),
-                    provider: "vertex_ai".to_string(),
-                    max_context_length: 1_048_576,
-                    max_output_length: Some(8192),
-                    supports_streaming: true,
-                    supports_tools: true,
-                    supports_multimodal: true,
-                    input_cost_per_1k_tokens: flash_prices.0,
-                    output_cost_per_1k_tokens: flash_prices.1,
-                    currency: "USD".to_string(),
-                    capabilities: vec![
-                        ProviderCapability::ChatCompletion,
-                        ProviderCapability::ChatCompletionStream,
-                        ProviderCapability::FunctionCalling,
-                        ProviderCapability::ToolCalling,
-                    ],
-                    created_at: None,
-                    updated_at: None,
-                    metadata: std::collections::HashMap::new(),
-                },
-            ]
-        });
-        &MODELS
+        &self.supported_models
     }
 
     async fn chat_completion(

--- a/src/core/providers/vertex_ai/client.rs
+++ b/src/core/providers/vertex_ai/client.rs
@@ -18,7 +18,7 @@ use crate::core::{
         embedding::EmbeddingRequest,
         health::HealthStatus,
         image::ImageGenerationRequest,
-        model::{ModelInfo, ProviderCapability},
+        model::ModelInfo,
         responses::{ChatResponse, EmbeddingResponse, ImageGenerationResponse},
     },
 };
@@ -286,52 +286,9 @@ impl LLMProvider for VertexAIProvider {
     fn models(&self) -> &[ModelInfo] {
         use std::sync::LazyLock;
         static MODELS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
-            vec![
-                ModelInfo {
-                    id: "gemini-1.5-pro".to_string(),
-                    name: "Gemini 1.5 Pro".to_string(),
-                    provider: "vertex_ai".to_string(),
-                    max_context_length: 2_097_152,
-                    max_output_length: Some(8192),
-                    supports_streaming: true,
-                    supports_tools: true,
-                    supports_multimodal: true,
-                    input_cost_per_1k_tokens: Some(1.25),
-                    output_cost_per_1k_tokens: Some(3.75),
-                    currency: "USD".to_string(),
-                    capabilities: vec![
-                        ProviderCapability::ChatCompletion,
-                        ProviderCapability::ChatCompletionStream,
-                        ProviderCapability::FunctionCalling,
-                        ProviderCapability::ToolCalling,
-                    ],
-                    created_at: None,
-                    updated_at: None,
-                    metadata: std::collections::HashMap::new(),
-                },
-                ModelInfo {
-                    id: "gemini-1.5-flash".to_string(),
-                    name: "Gemini 1.5 Flash".to_string(),
-                    provider: "vertex_ai".to_string(),
-                    max_context_length: 1_048_576,
-                    max_output_length: Some(8192),
-                    supports_streaming: true,
-                    supports_tools: true,
-                    supports_multimodal: true,
-                    input_cost_per_1k_tokens: Some(0.0625),
-                    output_cost_per_1k_tokens: Some(0.25),
-                    currency: "USD".to_string(),
-                    capabilities: vec![
-                        ProviderCapability::ChatCompletion,
-                        ProviderCapability::ChatCompletionStream,
-                        ProviderCapability::FunctionCalling,
-                        ProviderCapability::ToolCalling,
-                    ],
-                    created_at: None,
-                    updated_at: None,
-                    metadata: std::collections::HashMap::new(),
-                },
-            ]
+            crate::core::providers::gemini::get_gemini_registry().list_model_infos_for_surface(
+                crate::core::providers::gemini::GoogleGeminiApiSurface::VertexAi,
+            )
         });
         &MODELS
     }
@@ -412,20 +369,19 @@ impl LLMProvider for VertexAIProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        // Basic cost calculation for Vertex AI models (per 1M tokens)
-        let cost = match model {
-            m if m.contains("gemini-pro") => {
-                (input_tokens as f64 * 0.0005 + output_tokens as f64 * 0.0015) / 1000.0
-            }
-            m if m.contains("gemini-1.5-pro") => {
-                (input_tokens as f64 * 0.00125 + output_tokens as f64 * 0.00375) / 1000.0
-            }
-            m if m.contains("gemini-1.5-flash") => {
-                (input_tokens as f64 * 0.000075 + output_tokens as f64 * 0.0003) / 1000.0
-            }
-            _ => 0.0, // Default cost for unknown models
-        };
-        Ok(cost)
+        let vertex_model = super::parse_vertex_model(model);
+        if let Some(catalog_model_id) = vertex_model.gemini_catalog_model_id()
+            && let Some(cost) =
+                crate::core::providers::gemini::models::CostCalculator::calculate_cost(
+                    catalog_model_id,
+                    input_tokens,
+                    output_tokens,
+                )
+        {
+            return Ok(cost);
+        }
+
+        Ok(0.0)
     }
 
     /// Model

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
+use crate::core::types::model::ProviderCapability;
+
+fn test_vertex_provider_config() -> VertexAIProviderConfig {
+    VertexAIProviderConfig {
+        project_id: "test-project".to_string(),
+        location: "us-central1".to_string(),
+        credentials: crate::core::providers::vertex_ai::VertexCredentials::AccessToken(
+            "test-token".to_string(),
+        ),
+        ..Default::default()
+    }
+}
 
 #[test]
 fn test_client_vertex_usage_parser_is_strict_and_endpoint_aware() {
@@ -318,6 +330,72 @@ fn test_model_info_structure() {
     assert_eq!(model_info.id, "gemini-1.5-pro");
     assert_eq!(model_info.max_context_length, 2_097_152);
     assert!(model_info.supports_tools);
+}
+
+#[tokio::test]
+async fn test_vertex_models_are_gemini_registry_surface_overlay() {
+    let provider = VertexAIProvider::new(test_vertex_provider_config())
+        .await
+        .unwrap();
+    let model_ids = provider
+        .models()
+        .iter()
+        .map(|model| model.id.clone())
+        .collect::<Vec<_>>();
+
+    let expected_ids = crate::core::providers::gemini::get_gemini_registry()
+        .list_model_infos_for_surface(
+            crate::core::providers::gemini::GoogleGeminiApiSurface::VertexAi,
+        )
+        .into_iter()
+        .map(|model| model.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(model_ids, expected_ids);
+    assert!(model_ids.iter().any(|id| id == "gemini-3.5-flash"));
+    assert!(!model_ids.iter().any(|id| id == "gemini-1.0-pro"));
+
+    let model = provider
+        .models()
+        .iter()
+        .find(|model| model.id == "gemini-3.5-flash")
+        .unwrap();
+    assert_eq!(model.provider, "vertex_ai");
+    assert_eq!(
+        model.metadata["google_auth_boundary"],
+        serde_json::json!("bearer_token")
+    );
+}
+
+#[tokio::test]
+async fn test_vertex_gemini_cost_uses_shared_catalog_pricing() {
+    let provider = VertexAIProvider::new(test_vertex_provider_config())
+        .await
+        .unwrap();
+
+    let cost = provider
+        .calculate_cost("gemini-3.5-flash", 1000, 500)
+        .await
+        .unwrap();
+    let expected = crate::core::providers::gemini::models::CostCalculator::calculate_cost(
+        "gemini-3.5-flash",
+        1000,
+        500,
+    )
+    .unwrap();
+    assert!((cost - expected).abs() < f64::EPSILON);
+
+    let alias_cost = provider
+        .calculate_cost("gemini-1.5-pro-002", 1000, 500)
+        .await
+        .unwrap();
+    let canonical_cost = crate::core::providers::gemini::models::CostCalculator::calculate_cost(
+        "gemini-1.5-pro",
+        1000,
+        500,
+    )
+    .unwrap();
+    assert!((alias_cost - canonical_cost).abs() < f64::EPSILON);
 }
 
 // ==================== Cost Calculation Tests ====================

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -1,5 +1,24 @@
 use super::*;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
+use crate::core::types::model::ProviderCapability;
+
+fn test_vertex_provider_config_with_experimental(
+    enable_experimental: bool,
+) -> VertexAIProviderConfig {
+    VertexAIProviderConfig {
+        project_id: "test-project".to_string(),
+        location: "us-central1".to_string(),
+        credentials: crate::core::providers::vertex_ai::VertexCredentials::AccessToken(
+            "test-token".to_string(),
+        ),
+        enable_experimental,
+        ..Default::default()
+    }
+}
+
+fn test_vertex_provider_config() -> VertexAIProviderConfig {
+    test_vertex_provider_config_with_experimental(false)
+}
 
 async fn pricing_test_provider() -> VertexAIProvider {
     VertexAIProvider::new(VertexAIProviderConfig {
@@ -27,6 +46,8 @@ async fn vertex_cost_uses_shared_per_token_pricing() {
     for (model, expected) in [
         ("gemini-2.0-flash", 0.0003),
         ("gemini-1.5-pro-002", 0.00875),
+        ("gemini-1.5-pro-vision", 0.00875),
+        ("gemini-pro-vision", 0.00875),
         ("gemini-1.5-flash-002", 0.000225),
         ("claude-3-opus@20240229", 0.0525),
         ("claude-opus-4-6@20260114", 0.0175),
@@ -394,6 +415,101 @@ fn test_model_info_structure() {
     assert!(model_info.supports_tools);
 }
 
+#[tokio::test]
+async fn test_vertex_models_are_gemini_registry_surface_overlay() {
+    let provider = VertexAIProvider::new(test_vertex_provider_config())
+        .await
+        .unwrap();
+    let model_ids = provider
+        .models()
+        .iter()
+        .map(|model| model.id.clone())
+        .collect::<Vec<_>>();
+
+    let expected_ids = crate::core::providers::gemini::get_gemini_registry()
+        .list_model_infos_for_surface(
+            crate::core::providers::gemini::GoogleGeminiApiSurface::VertexAi {
+                include_experimental: false,
+            },
+        )
+        .into_iter()
+        .map(|model| model.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(model_ids, expected_ids);
+    assert!(model_ids.iter().any(|id| id == "gemini-3.5-flash"));
+    assert!(!model_ids.iter().any(|id| id == "gemini-1.0-pro"));
+    assert!(!model_ids.iter().any(|id| id == "gemini-2.0-flash-exp"));
+    assert!(
+        !model_ids
+            .iter()
+            .any(|id| id == "gemini-2.0-flash-thinking-exp")
+    );
+
+    let model = provider
+        .models()
+        .iter()
+        .find(|model| model.id == "gemini-3.5-flash")
+        .unwrap();
+    assert_eq!(model.provider, "vertex_ai");
+    assert_eq!(
+        model.metadata["google_auth_boundary"],
+        serde_json::json!("bearer_token")
+    );
+
+    let pro = provider
+        .models()
+        .iter()
+        .find(|model| model.id == "gemini-1.5-pro")
+        .unwrap();
+    assert_eq!(pro.max_context_length, 2_097_152);
+    assert!((pro.input_cost_per_1k_tokens.unwrap() - 0.0035).abs() < 1e-12);
+    assert!((pro.output_cost_per_1k_tokens.unwrap() - 0.0105).abs() < 1e-12);
+
+    let flash = provider
+        .models()
+        .iter()
+        .find(|model| model.id == "gemini-1.5-flash")
+        .unwrap();
+    assert_eq!(flash.max_context_length, 1_048_576);
+
+    let flash_preview = provider
+        .models()
+        .iter()
+        .find(|model| model.id == "gemini-3-flash-preview")
+        .unwrap();
+    assert_eq!(flash_preview.max_context_length, 1_000_000);
+}
+
+#[tokio::test]
+async fn test_vertex_models_include_experimental_when_enabled() {
+    let provider = VertexAIProvider::new(test_vertex_provider_config_with_experimental(true))
+        .await
+        .unwrap();
+    let model_ids = provider
+        .models()
+        .iter()
+        .map(|model| model.id.clone())
+        .collect::<Vec<_>>();
+
+    let expected_ids = crate::core::providers::gemini::get_gemini_registry()
+        .list_model_infos_for_surface(
+            crate::core::providers::gemini::GoogleGeminiApiSurface::VertexAi {
+                include_experimental: true,
+            },
+        )
+        .into_iter()
+        .map(|model| model.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(model_ids, expected_ids);
+    assert!(model_ids.iter().any(|id| id == "gemini-2.0-flash-exp"));
+    assert!(
+        model_ids
+            .iter()
+            .any(|id| id == "gemini-2.0-flash-thinking-exp")
+    );
+}
 // ==================== URL Building Tests (logic only) ====================
 
 #[test]

--- a/src/core/providers/vertex_ai/mod.rs
+++ b/src/core/providers/vertex_ai/mod.rs
@@ -179,6 +179,9 @@ impl crate::core::traits::provider::ProviderConfig for VertexAIProviderConfig {
 /// Supported Vertex AI models
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VertexAIModel {
+    // Gemini 3.5 models (2026 - latest)
+    Gemini35Flash, // gemini-3.5-flash
+
     // Gemini 3.1 models (2026 - latest previews)
     Gemini31ProPreview, // gemini-3.1-pro-preview
     Gemini31Flash,      // gemini-3.1-flash
@@ -250,6 +253,9 @@ impl VertexAIModel {
     /// Get the model ID string for API calls
     pub fn model_id(&self) -> String {
         match self {
+            // Gemini 3.5 models
+            Self::Gemini35Flash => "gemini-3.5-flash".to_string(),
+
             // Gemini 3.1 models
             Self::Gemini31ProPreview => "gemini-3.1-pro-preview".to_string(),
             Self::Gemini31Flash => "gemini-3.1-flash".to_string(),
@@ -321,7 +327,8 @@ impl VertexAIModel {
     pub fn is_gemini(&self) -> bool {
         matches!(
             self,
-            Self::Gemini31ProPreview
+            Self::Gemini35Flash
+                | Self::Gemini31ProPreview
                 | Self::Gemini31Flash
                 | Self::Gemini31FlashLite
                 | Self::Gemini3Pro
@@ -378,7 +385,8 @@ impl VertexAIModel {
     pub fn supports_vision(&self) -> bool {
         matches!(
             self,
-            Self::Gemini31ProPreview
+            Self::Gemini35Flash
+                | Self::Gemini31ProPreview
                 | Self::Gemini31Flash
                 | Self::Gemini31FlashLite
                 | Self::Gemini3Pro
@@ -454,9 +462,36 @@ impl VertexAIModel {
         )
     }
 
+    /// Get the shared Gemini catalog ID for Gemini models routed through Vertex AI.
+    pub fn gemini_catalog_model_id(&self) -> Option<&'static str> {
+        match self {
+            Self::Gemini35Flash => Some("gemini-3.5-flash"),
+            Self::Gemini31ProPreview => Some("gemini-3.1-pro-preview"),
+            Self::Gemini31Flash => Some("gemini-3.1-flash"),
+            Self::Gemini31FlashLite => Some("gemini-3.1-flash-lite"),
+            Self::Gemini3Pro => Some("gemini-3-pro"),
+            Self::Gemini3ProDeepThink => Some("gemini-3-pro-deep-think"),
+            Self::Gemini3FlashPreview => Some("gemini-3-flash-preview"),
+            Self::Gemini3ProImage => Some("gemini-3-pro-image-preview"),
+            Self::Gemini25Pro => Some("gemini-2.5-pro"),
+            Self::Gemini25Flash => Some("gemini-2.5-flash"),
+            Self::Gemini25FlashLite => Some("gemini-2.5-flash-lite"),
+            Self::Gemini20FlashExp => Some("gemini-2.0-flash-exp"),
+            Self::Gemini20FlashThinking => Some("gemini-2.0-flash-thinking-exp"),
+            Self::GeminiPro => Some("gemini-1.5-pro"),
+            Self::GeminiProVision => Some("gemini-1.5-pro"),
+            Self::GeminiFlash => Some("gemini-1.5-flash"),
+            Self::GeminiFlash8B => Some("gemini-1.5-flash-8b"),
+            _ => None,
+        }
+    }
+
     /// Get maximum context window
     pub fn max_context_tokens(&self) -> usize {
         match self {
+            // Gemini 3.5 models
+            Self::Gemini35Flash => 1_048_576,
+
             // Gemini 3.1 models
             Self::Gemini31ProPreview | Self::Gemini31Flash | Self::Gemini31FlashLite => 1_048_576,
 
@@ -524,6 +559,11 @@ impl VertexAIModel {
 /// Parse model string to VertexAIModel enum
 pub fn parse_vertex_model(model: &str) -> VertexAIModel {
     let model_lower = model.to_lowercase();
+
+    // Gemini 3.5 models
+    if model_lower.contains("gemini-3.5-flash") {
+        return VertexAIModel::Gemini35Flash;
+    }
 
     // Gemini 3.1 models (check before Gemini 3.0 as more specific)
     if model_lower.contains("gemini-3.1-flash-lite") {

--- a/src/core/providers/vertex_ai/mod.rs
+++ b/src/core/providers/vertex_ai/mod.rs
@@ -136,6 +136,9 @@ impl crate::core::traits::provider::ProviderConfig for VertexAIProviderConfig {
 /// Supported Vertex AI models
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VertexAIModel {
+    // Gemini 3.5 models (2026 - latest)
+    Gemini35Flash, // gemini-3.5-flash
+
     // Gemini 3.1 models (2026 - latest previews)
     Gemini31ProPreview, // gemini-3.1-pro-preview
     Gemini31Flash,      // gemini-3.1-flash
@@ -207,6 +210,9 @@ impl VertexAIModel {
     /// Get the model ID string for API calls
     pub fn model_id(&self) -> String {
         match self {
+            // Gemini 3.5 models
+            Self::Gemini35Flash => "gemini-3.5-flash".to_string(),
+
             // Gemini 3.1 models
             Self::Gemini31ProPreview => "gemini-3.1-pro-preview".to_string(),
             Self::Gemini31Flash => "gemini-3.1-flash".to_string(),
@@ -278,7 +284,8 @@ impl VertexAIModel {
     pub fn is_gemini(&self) -> bool {
         matches!(
             self,
-            Self::Gemini31ProPreview
+            Self::Gemini35Flash
+                | Self::Gemini31ProPreview
                 | Self::Gemini31Flash
                 | Self::Gemini31FlashLite
                 | Self::Gemini3Pro
@@ -335,7 +342,8 @@ impl VertexAIModel {
     pub fn supports_vision(&self) -> bool {
         matches!(
             self,
-            Self::Gemini31ProPreview
+            Self::Gemini35Flash
+                | Self::Gemini31ProPreview
                 | Self::Gemini31Flash
                 | Self::Gemini31FlashLite
                 | Self::Gemini3Pro
@@ -411,9 +419,35 @@ impl VertexAIModel {
         )
     }
 
+    /// Get the shared Gemini catalog ID for Gemini models routed through Vertex AI.
+    pub fn gemini_catalog_model_id(&self) -> Option<&'static str> {
+        match self {
+            Self::Gemini35Flash => Some("gemini-3.5-flash"),
+            Self::Gemini31ProPreview => Some("gemini-3.1-pro-preview"),
+            Self::Gemini31Flash => Some("gemini-3.1-flash"),
+            Self::Gemini31FlashLite => Some("gemini-3.1-flash-lite"),
+            Self::Gemini3Pro => Some("gemini-3-pro"),
+            Self::Gemini3ProDeepThink => Some("gemini-3-pro-deep-think"),
+            Self::Gemini3FlashPreview => Some("gemini-3-flash-preview"),
+            Self::Gemini3ProImage => Some("gemini-3-pro-image-preview"),
+            Self::Gemini25Pro => Some("gemini-2.5-pro"),
+            Self::Gemini25Flash => Some("gemini-2.5-flash"),
+            Self::Gemini25FlashLite => Some("gemini-2.5-flash-lite"),
+            Self::Gemini20FlashExp => Some("gemini-2.0-flash-exp"),
+            Self::Gemini20FlashThinking => Some("gemini-2.0-flash-thinking-exp"),
+            Self::GeminiPro => Some("gemini-1.5-pro"),
+            Self::GeminiFlash => Some("gemini-1.5-flash"),
+            Self::GeminiFlash8B => Some("gemini-1.5-flash-8b"),
+            _ => None,
+        }
+    }
+
     /// Get maximum context window
     pub fn max_context_tokens(&self) -> usize {
         match self {
+            // Gemini 3.5 models
+            Self::Gemini35Flash => 1_048_576,
+
             // Gemini 3.1 models
             Self::Gemini31ProPreview | Self::Gemini31Flash | Self::Gemini31FlashLite => 1_048_576,
 
@@ -481,6 +515,11 @@ impl VertexAIModel {
 /// Parse model string to VertexAIModel enum
 pub fn parse_vertex_model(model: &str) -> VertexAIModel {
     let model_lower = model.to_lowercase();
+
+    // Gemini 3.5 models
+    if model_lower.contains("gemini-3.5-flash") {
+        return VertexAIModel::Gemini35Flash;
+    }
 
     // Gemini 3.1 models (check before Gemini 3.0 as more specific)
     if model_lower.contains("gemini-3.1-flash-lite") {

--- a/src/core/providers/vertex_ai/tests.rs
+++ b/src/core/providers/vertex_ai/tests.rs
@@ -87,6 +87,7 @@ fn test_vertex_ai_provider_config_max_retries() {
 
 #[test]
 fn test_vertex_ai_model_gemini_ids() {
+    assert_eq!(VertexAIModel::Gemini35Flash.model_id(), "gemini-3.5-flash");
     assert_eq!(
         VertexAIModel::Gemini31ProPreview.model_id(),
         "gemini-3.1-pro-preview"
@@ -178,7 +179,25 @@ fn test_vertex_ai_model_custom() {
 }
 
 #[test]
+fn test_vertex_ai_model_gemini_catalog_ids() {
+    assert_eq!(
+        VertexAIModel::Gemini35Flash.gemini_catalog_model_id(),
+        Some("gemini-3.5-flash")
+    );
+    assert_eq!(
+        VertexAIModel::GeminiPro.gemini_catalog_model_id(),
+        Some("gemini-1.5-pro")
+    );
+    assert_eq!(
+        VertexAIModel::Gemini20FlashThinking.gemini_catalog_model_id(),
+        Some("gemini-2.0-flash-thinking-exp")
+    );
+    assert_eq!(VertexAIModel::Claude3Opus.gemini_catalog_model_id(), None);
+}
+
+#[test]
 fn test_vertex_ai_model_is_gemini() {
+    assert!(VertexAIModel::Gemini35Flash.is_gemini());
     assert!(VertexAIModel::Gemini31ProPreview.is_gemini());
     assert!(VertexAIModel::Gemini3FlashPreview.is_gemini());
     assert!(VertexAIModel::Gemini25Pro.is_gemini());
@@ -212,6 +231,7 @@ fn test_vertex_ai_model_is_partner_model() {
 
 #[test]
 fn test_vertex_ai_model_supports_vision() {
+    assert!(VertexAIModel::Gemini35Flash.supports_vision());
     assert!(VertexAIModel::Gemini31ProPreview.supports_vision());
     assert!(VertexAIModel::Gemini3FlashPreview.supports_vision());
     assert!(VertexAIModel::Gemini25Pro.supports_vision());
@@ -269,6 +289,8 @@ fn test_vertex_ai_model_supports_thinking_mode() {
 
 #[test]
 fn test_vertex_ai_model_max_context_tokens() {
+    assert_eq!(VertexAIModel::Gemini35Flash.max_context_tokens(), 1_048_576);
+
     // Gemini 3
     assert_eq!(
         VertexAIModel::Gemini31ProPreview.max_context_tokens(),
@@ -310,6 +332,10 @@ fn test_vertex_ai_model_max_context_tokens() {
 
 #[test]
 fn test_parse_vertex_model_gemini_3() {
+    assert!(matches!(
+        parse_vertex_model("gemini-3.5-flash"),
+        VertexAIModel::Gemini35Flash
+    ));
     assert!(matches!(
         parse_vertex_model("gemini-3.1-pro-preview"),
         VertexAIModel::Gemini31ProPreview

--- a/src/core/providers/vertex_ai/tests.rs
+++ b/src/core/providers/vertex_ai/tests.rs
@@ -87,6 +87,7 @@ fn test_vertex_ai_provider_config_max_retries() {
 
 #[test]
 fn test_vertex_ai_model_gemini_ids() {
+    assert_eq!(VertexAIModel::Gemini35Flash.model_id(), "gemini-3.5-flash");
     assert_eq!(
         VertexAIModel::Gemini31ProPreview.model_id(),
         "gemini-3.1-pro-preview"
@@ -178,7 +179,29 @@ fn test_vertex_ai_model_custom() {
 }
 
 #[test]
+fn test_vertex_ai_model_gemini_catalog_ids() {
+    assert_eq!(
+        VertexAIModel::Gemini35Flash.gemini_catalog_model_id(),
+        Some("gemini-3.5-flash")
+    );
+    assert_eq!(
+        VertexAIModel::GeminiPro.gemini_catalog_model_id(),
+        Some("gemini-1.5-pro")
+    );
+    assert_eq!(
+        VertexAIModel::GeminiProVision.gemini_catalog_model_id(),
+        Some("gemini-1.5-pro")
+    );
+    assert_eq!(
+        VertexAIModel::Gemini20FlashThinking.gemini_catalog_model_id(),
+        Some("gemini-2.0-flash-thinking-exp")
+    );
+    assert_eq!(VertexAIModel::Claude3Opus.gemini_catalog_model_id(), None);
+}
+
+#[test]
 fn test_vertex_ai_model_is_gemini() {
+    assert!(VertexAIModel::Gemini35Flash.is_gemini());
     assert!(VertexAIModel::Gemini31ProPreview.is_gemini());
     assert!(VertexAIModel::Gemini3FlashPreview.is_gemini());
     assert!(VertexAIModel::Gemini25Pro.is_gemini());
@@ -212,6 +235,7 @@ fn test_vertex_ai_model_is_partner_model() {
 
 #[test]
 fn test_vertex_ai_model_supports_vision() {
+    assert!(VertexAIModel::Gemini35Flash.supports_vision());
     assert!(VertexAIModel::Gemini31ProPreview.supports_vision());
     assert!(VertexAIModel::Gemini3FlashPreview.supports_vision());
     assert!(VertexAIModel::Gemini25Pro.supports_vision());
@@ -269,6 +293,8 @@ fn test_vertex_ai_model_supports_thinking_mode() {
 
 #[test]
 fn test_vertex_ai_model_max_context_tokens() {
+    assert_eq!(VertexAIModel::Gemini35Flash.max_context_tokens(), 1_048_576);
+
     // Gemini 3
     assert_eq!(
         VertexAIModel::Gemini31ProPreview.max_context_tokens(),
@@ -310,6 +336,10 @@ fn test_vertex_ai_model_max_context_tokens() {
 
 #[test]
 fn test_parse_vertex_model_gemini_3() {
+    assert!(matches!(
+        parse_vertex_model("gemini-3.5-flash"),
+        VertexAIModel::Gemini35Flash
+    ));
     assert!(matches!(
         parse_vertex_model("gemini-3.1-pro-preview"),
         VertexAIModel::Gemini31ProPreview


### PR DESCRIPTION
## Summary
- add Gemini API surface overlays for Developer API vs Vertex AI, including auth/endpoint metadata, stable sorting, Vertex context-limit overlays, and experimental model filtering
- derive Vertex advertised Gemini models from the shared Gemini registry and overlay Vertex pricing metadata from the pricing service
- keep Vertex cost authority on the shared pricing service and map legacy Pro Vision aliases to the Vertex Pro pricing row

Closes #1112

## Validation
- `cargo fmt --check`
- `git diff --check origin/main`
- `cargo check --features providers-extra`
- `cargo clippy --features providers-extra,providers-extended --lib -- -D warnings`
- `cargo test --features providers-extra --lib test_google`
- `cargo test --features providers-extra --lib test_vertex_models`
- `cargo test --features providers-extra --lib vertex_cost_uses_shared_per_token_pricing`
- `cargo test --features providers-extra --lib test_vertex_ai_model_gemini_catalog_ids`
- `cargo test --features providers-extra --lib google_authority`
