### PR TITLE
feat(gemini): refresh Developer API model catalog

### DIFF
--- a/config/model_prices_extended.json
+++ b/config/model_prices_extended.json
@@ -6,9 +6,9 @@
     "source_commit": "0ade44f4da6171e7222c8e4273c3703a6258f972",
     "generated_by": "scripts/sync_litellm_pricing.py",
     "upstream_model_count": 2917,
-    "compatibility_overlay_count": 166,
+    "compatibility_overlay_count": 168,
     "compatibility_overlay_override_count": 54,
-    "compatibility_overlay_add_count": 112,
+    "compatibility_overlay_add_count": 114,
     "compatibility_overlay_keys": [
       "MiniMax-M2",
       "MiniMax-M2.1",
@@ -66,6 +66,8 @@
       "gemini-3.1-flash-lite",
       "gemini-3.1-pro-preview",
       "gemini-3.5-flash",
+      "gemini-3.5-flash-lite",
+      "gemini-3.6-flash",
       "gemini-pro",
       "gemini-pro-vision",
       "gemini/gemini-2.5-flash",
@@ -177,7 +179,7 @@
       "yi-large",
       "yi-medium"
     ],
-    "total_model_count": 3029
+    "total_model_count": 3031
   },
   "sample_spec": {
     "code_interpreter_cost_per_session": 0.0,
@@ -18338,6 +18340,34 @@
     "supports_vision": true,
     "supports_streaming": true,
     "supports_system_message": true
+  },
+  "gemini-3.5-flash-lite": {
+    "max_tokens": 65536,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-07,
+    "output_cost_per_token": 2.5e-06,
+    "litellm_provider": "gemini",
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_vision": true,
+    "supports_streaming": true,
+    "supports_system_message": true,
+    "source": "https://ai.google.dev/gemini-api/docs/pricing"
+  },
+  "gemini-3.6-flash": {
+    "max_tokens": 65536,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-06,
+    "output_cost_per_token": 7.5e-06,
+    "litellm_provider": "gemini",
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_vision": true,
+    "supports_streaming": true,
+    "supports_system_message": true,
+    "source": "https://ai.google.dev/gemini-api/docs/pricing"
   },
   "gemini/gemini-2.5-pro-preview-tts": {
     "cache_read_input_token_cost": 1.25e-07,

--- a/src/core/providers/gemini/client.rs
+++ b/src/core/providers/gemini/client.rs
@@ -32,6 +32,7 @@ use super::config::GeminiConfig;
 use super::error::{
     GeminiErrorMapper, gemini_multimodal_error, gemini_network_error, gemini_parse_error,
 };
+use super::models::{has_trailing_assistant_prefill, uses_fixed_sampling_contract};
 use super::streaming::GeminiUsagePolicy;
 
 /// Gemini API client
@@ -255,6 +256,14 @@ impl GeminiClient {
 
     /// Request
     pub fn transform_chat_request(&self, request: &ChatRequest) -> Result<Value, ProviderError> {
+        if uses_fixed_sampling_contract(&request.model) && has_trailing_assistant_prefill(request) {
+            return Err(
+                crate::core::providers::gemini::error::gemini_validation_error(format!(
+                    "Model {} does not accept a trailing non-empty assistant message",
+                    request.model
+                )),
+            );
+        }
         let mut contents = Vec::new();
         let mut tool_planner = GoogleToolPlanner::new("gemini");
 
@@ -302,12 +311,13 @@ impl GeminiClient {
             generation_config["maxOutputTokens"] = json!(max_tokens);
         }
 
-        if let Some(temperature) = request.temperature {
-            generation_config["temperature"] = json!(temperature);
-        }
-
-        if let Some(top_p) = request.top_p {
-            generation_config["topP"] = json!(top_p);
+        if !uses_fixed_sampling_contract(&request.model) {
+            if let Some(temperature) = request.temperature {
+                generation_config["temperature"] = json!(temperature);
+            }
+            if let Some(top_p) = request.top_p {
+                generation_config["topP"] = json!(top_p);
+            }
         }
 
         if let Some(stop) = &request.stop {

--- a/src/core/providers/gemini/client_tests.rs
+++ b/src/core/providers/gemini/client_tests.rs
@@ -191,6 +191,35 @@ fn test_gemini_request_rejects_unknown_tool_result_id() {
 }
 
 #[test]
+fn july_2026_request_body_omits_sampling_parameters() {
+    let client = GeminiClient::new(GeminiConfig::new_google_ai("test-key")).unwrap();
+    let mut request = ChatRequest {
+        model: "gemini-3.6-flash".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Hello".to_string())),
+            ..Default::default()
+        }],
+        temperature: Some(0.7),
+        top_p: Some(0.9),
+        max_tokens: Some(16),
+        ..Default::default()
+    };
+
+    let body = client.transform_chat_request(&request).unwrap();
+    assert_eq!(body["generationConfig"]["maxOutputTokens"], 16);
+    assert!(body["generationConfig"].get("temperature").is_none());
+    assert!(body["generationConfig"].get("topP").is_none());
+
+    request.messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(MessageContent::Text("prefill".to_string())),
+        ..Default::default()
+    });
+    assert!(client.transform_chat_request(&request).is_err());
+}
+
+#[test]
 fn test_gemini_finish_reason_tool_calls() {
     let config = GeminiConfig::new_google_ai("test-key");
     let client = GeminiClient::new(config).unwrap();

--- a/src/core/providers/gemini/mod.rs
+++ b/src/core/providers/gemini/mod.rs
@@ -105,15 +105,17 @@ pub fn create_gemini_provider_from_env() -> Result<GeminiProvider, error::Gemini
 /// Get supported models
 pub fn supported_models() -> Vec<String> {
     get_gemini_registry()
-        .list_models()
+        .list_model_infos_for_surface(GoogleGeminiApiSurface::DeveloperApi)
         .into_iter()
-        .map(|spec| spec.model_info.id.clone())
+        .map(|model| model.id)
         .collect()
 }
 
 /// Check if model is supported
 pub fn is_model_supported(model_id: &str) -> bool {
-    get_gemini_registry().get_model_spec(model_id).is_some()
+    get_gemini_registry()
+        .get_model_spec(model_id)
+        .is_some_and(|spec| GoogleGeminiApiSurface::DeveloperApi.includes(spec))
 }
 
 /// Get model pricing
@@ -144,6 +146,11 @@ mod pricing_tests {
             get_model_pricing("gemini-2.5-flash").expect("catalogued model should be priced");
         assert!((input - 0.30).abs() < 1e-12);
         assert!((output - 2.50).abs() < 1e-12);
+        assert_eq!(get_model_pricing("gemini-3.6-flash").unwrap(), (1.5, 7.5));
+        assert_eq!(
+            get_model_pricing("gemini-3.5-flash-lite").unwrap(),
+            (0.3, 2.5)
+        );
         assert!(matches!(
             get_model_pricing("gemini-1.5-flash"),
             Err(ProviderError::ModelNotFound { .. })

--- a/src/core/providers/gemini/models/catalog/gemini35.rs
+++ b/src/core/providers/gemini/models/catalog/gemini35.rs
@@ -6,6 +6,54 @@ use crate::core::types::model::ModelInfo;
 
 pub(super) fn register(registry: &mut GeminiModelRegistry) {
     registry.register_model(
+        "gemini-3.5-flash-lite",
+        ModelSpec {
+            model_info: ModelInfo {
+                id: "gemini-3.5-flash-lite".to_string(),
+                name: "Gemini 3.5 Flash-Lite".to_string(),
+                provider: "gemini".to_string(),
+                max_context_length: 1_048_576,
+                max_output_length: Some(65_536),
+                supports_streaming: true,
+                supports_tools: true,
+                supports_multimodal: true,
+                input_cost_per_1k_tokens: Some(0.0003),
+                output_cost_per_1k_tokens: Some(0.0025),
+                currency: "USD".to_string(),
+                capabilities: super::advanced_text_capabilities(),
+                created_at: None,
+                updated_at: None,
+                metadata: std::collections::HashMap::new(),
+            },
+            family: GeminiModelFamily::Gemini35FlashLite,
+            features: vec![
+                ModelFeature::MultimodalSupport,
+                ModelFeature::ToolCalling,
+                ModelFeature::FunctionCalling,
+                ModelFeature::StreamingSupport,
+                ModelFeature::ContextCaching,
+                ModelFeature::SystemInstructions,
+                ModelFeature::BatchProcessing,
+                ModelFeature::JsonMode,
+                ModelFeature::CodeExecution,
+                ModelFeature::SearchGrounding,
+                ModelFeature::VideoUnderstanding,
+                ModelFeature::AudioUnderstanding,
+            ],
+            pricing: pricing_per_million(0.3, 2.5, None, None, None, None),
+            limits: ModelLimits {
+                max_context_length: 1_048_576,
+                max_output_tokens: 65_536,
+                max_images: None,
+                max_video_seconds: None,
+                max_audio_seconds: None,
+                rpm_limit: None,
+                tpm_limit: None,
+            },
+        },
+    );
+
+    registry.register_model(
         "gemini-3.5-flash",
         ModelSpec {
             model_info: ModelInfo {

--- a/src/core/providers/gemini/models/catalog/gemini36.rs
+++ b/src/core/providers/gemini/models/catalog/gemini36.rs
@@ -1,0 +1,58 @@
+use super::{
+    super::{
+        GeminiModelFamily, GeminiModelRegistry, ModelFeature, ModelLimits, ModelSpec,
+        pricing_per_million,
+    },
+    advanced_text_capabilities,
+};
+use crate::core::types::model::ModelInfo;
+
+pub(super) fn register(registry: &mut GeminiModelRegistry) {
+    registry.register_model(
+        "gemini-3.6-flash",
+        ModelSpec {
+            model_info: ModelInfo {
+                id: "gemini-3.6-flash".to_string(),
+                name: "Gemini 3.6 Flash".to_string(),
+                provider: "gemini".to_string(),
+                max_context_length: 1_048_576,
+                max_output_length: Some(65_536),
+                supports_streaming: true,
+                supports_tools: true,
+                supports_multimodal: true,
+                input_cost_per_1k_tokens: Some(0.0015),
+                output_cost_per_1k_tokens: Some(0.0075),
+                currency: "USD".to_string(),
+                capabilities: advanced_text_capabilities(),
+                created_at: None,
+                updated_at: None,
+                metadata: std::collections::HashMap::new(),
+            },
+            family: GeminiModelFamily::Gemini36Flash,
+            features: vec![
+                ModelFeature::MultimodalSupport,
+                ModelFeature::ToolCalling,
+                ModelFeature::FunctionCalling,
+                ModelFeature::StreamingSupport,
+                ModelFeature::ContextCaching,
+                ModelFeature::SystemInstructions,
+                ModelFeature::BatchProcessing,
+                ModelFeature::JsonMode,
+                ModelFeature::CodeExecution,
+                ModelFeature::SearchGrounding,
+                ModelFeature::VideoUnderstanding,
+                ModelFeature::AudioUnderstanding,
+            ],
+            pricing: pricing_per_million(1.5, 7.5, None, None, None, None),
+            limits: ModelLimits {
+                max_context_length: 1_048_576,
+                max_output_tokens: 65_536,
+                max_images: None,
+                max_video_seconds: None,
+                max_audio_seconds: None,
+                rpm_limit: None,
+                tpm_limit: None,
+            },
+        },
+    );
+}

--- a/src/core/providers/gemini/models/catalog/mod.rs
+++ b/src/core/providers/gemini/models/catalog/mod.rs
@@ -2,6 +2,7 @@ mod gemini25;
 mod gemini3;
 mod gemini31;
 mod gemini35;
+mod gemini36;
 mod legacy;
 
 use super::GeminiModelRegistry;
@@ -29,6 +30,7 @@ pub(super) fn function_batch_capabilities() -> Vec<ProviderCapability> {
 }
 
 pub(super) fn register_all(registry: &mut GeminiModelRegistry) {
+    gemini36::register(registry);
     gemini35::register(registry);
     gemini31::register(registry);
     gemini3::register(registry);

--- a/src/core/providers/gemini/models/contract.rs
+++ b/src/core/providers/gemini/models/contract.rs
@@ -1,0 +1,75 @@
+use super::{GeminiModelFamily, get_gemini_registry};
+use crate::core::types::{
+    chat::{ChatMessage, ChatRequest},
+    content::ContentPart,
+    message::{MessageContent, MessageRole},
+};
+
+/// Whether Google requires the July 2026 fixed-sampling request contract.
+pub(crate) fn uses_fixed_sampling_contract(model_id: &str) -> bool {
+    matches!(
+        get_gemini_registry().get_model_family(model_id),
+        Some(GeminiModelFamily::Gemini36Flash | GeminiModelFamily::Gemini35FlashLite)
+    )
+}
+
+pub(crate) fn has_trailing_assistant_prefill(request: &ChatRequest) -> bool {
+    request
+        .messages
+        .iter()
+        .rev()
+        .filter(|message| !matches!(message.role, MessageRole::System | MessageRole::Developer))
+        .find(|message| message_has_payload(message))
+        .is_some_and(|message| message.role == MessageRole::Assistant)
+}
+
+fn message_has_payload(message: &ChatMessage) -> bool {
+    let has_content = match message.content.as_ref() {
+        Some(MessageContent::Text(text)) => !text.trim().is_empty(),
+        Some(MessageContent::Parts(parts)) => parts.iter().any(|part| match part {
+            ContentPart::Text { text } => !text.trim().is_empty(),
+            _ => true,
+        }),
+        None => false,
+    };
+    has_content
+        || message.audio.is_some()
+        || message.thinking.is_some()
+        || message.function_call.is_some()
+        || message
+            .tool_calls
+            .as_ref()
+            .is_some_and(|calls| !calls.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_sampling_contract_is_limited_to_july_2026_models() {
+        assert!(uses_fixed_sampling_contract("gemini-3.6-flash"));
+        assert!(uses_fixed_sampling_contract("gemini-3.5-flash-lite"));
+        assert!(!uses_fixed_sampling_contract("gemini-3.5-flash"));
+    }
+
+    #[test]
+    fn system_instruction_after_assistant_does_not_hide_prefill() {
+        let request = ChatRequest {
+            messages: vec![
+                ChatMessage {
+                    role: MessageRole::Assistant,
+                    content: Some(MessageContent::Text("prefill".to_string())),
+                    ..Default::default()
+                },
+                ChatMessage {
+                    role: MessageRole::System,
+                    content: Some(MessageContent::Text("instruction".to_string())),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(has_trailing_assistant_prefill(&request));
+    }
+}

--- a/src/core/providers/gemini/models/mod.rs
+++ b/src/core/providers/gemini/models/mod.rs
@@ -6,8 +6,10 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 
 mod catalog;
+mod contract;
 mod surface;
 
+pub(crate) use contract::{has_trailing_assistant_prefill, uses_fixed_sampling_contract};
 pub use surface::GoogleGeminiApiSurface;
 
 pub use crate::core::cost::types::ModelPricing;
@@ -44,42 +46,36 @@ pub enum ModelFeature {
     RealtimeStreaming,
 }
 
-/// Model family classification
 #[derive(Debug, Clone, PartialEq)]
 pub enum GeminiModelFamily {
+    Gemini36Flash,
     /// Gemini 3.5 series (2026 - Latest)
     Gemini35Flash,
+    Gemini35FlashLite,
 
-    /// Gemini 3.1 series (2026)
     Gemini31ProPreview,
     Gemini31Flash,
     Gemini31FlashLite,
 
-    /// Gemini 3 series (2025-2026)
     Gemini3Pro,
     Gemini3ProDeepThink,
     Gemini3Flash,
     Gemini3ProImage,
 
-    /// Gemini 2.5 series (2025)
     Gemini25Pro,
     Gemini25Flash,
     Gemini25FlashLite,
 
-    /// Gemini 2.0 series
     Gemini20Flash,
     Gemini20FlashThinking,
 
-    /// Gemini 1.5 series
     Gemini15Pro,
     Gemini15Flash,
     Gemini15Flash8B,
 
-    /// Gemini 1.0 series
     Gemini10Pro,
     Gemini10ProVision,
 
-    /// Experimental models
     GeminiExperimental,
 }
 
@@ -150,9 +146,8 @@ pub struct GeminiModelRegistry {
 
 impl GeminiModelRegistry {
     /// Expected number of Gemini models for capacity hint
-    const EXPECTED_MODEL_COUNT: usize = 17;
+    const EXPECTED_MODEL_COUNT: usize = 19;
 
-    /// Create
     pub fn new() -> Self {
         let mut registry = Self {
             models: HashMap::with_capacity(Self::EXPECTED_MODEL_COUNT),
@@ -161,7 +156,6 @@ impl GeminiModelRegistry {
         registry
     }
 
-    /// Initialize all Gemini models
     fn initialize_models(&mut self) {
         catalog::register_all(self);
     }
@@ -171,12 +165,10 @@ impl GeminiModelRegistry {
         self.models.insert(id.to_string(), spec);
     }
 
-    /// Model
     pub fn get_model_spec(&self, model_id: &str) -> Option<&ModelSpec> {
         self.models.get(model_id)
     }
 
-    /// Model
     pub fn list_models(&self) -> Vec<&ModelSpec> {
         self.models.values().collect()
     }
@@ -225,8 +217,11 @@ impl GeminiModelRegistry {
     pub fn from_model_name(model_name: &str) -> Option<GeminiModelFamily> {
         let model_lower = model_name.to_lowercase();
 
-        // Gemini 3.5 series
-        if model_lower.contains("gemini-3.5-flash") {
+        if model_lower.contains("gemini-3.6-flash") {
+            Some(GeminiModelFamily::Gemini36Flash)
+        } else if model_lower.contains("gemini-3.5-flash-lite") {
+            Some(GeminiModelFamily::Gemini35FlashLite)
+        } else if model_lower.contains("gemini-3.5-flash") {
             Some(GeminiModelFamily::Gemini35Flash)
         }
         // Gemini 3.1 series (check before 3.0 as more specific)

--- a/src/core/providers/gemini/models/surface.rs
+++ b/src/core/providers/gemini/models/surface.rs
@@ -1,5 +1,69 @@
 use super::{GeminiModelFamily, ModelInfo, ModelSpec};
 
+const OFFICIAL_LIFECYCLE_SOURCE: &str = "https://ai.google.dev/gemini-api/docs/deprecations";
+
+#[derive(Debug, Clone, Copy)]
+struct DeveloperModelLifecycle {
+    id: &'static str,
+    release_date: &'static str,
+    shutdown_date: Option<&'static str>,
+}
+
+const DEVELOPER_CHAT_MODELS: [DeveloperModelLifecycle; 9] = [
+    DeveloperModelLifecycle {
+        id: "gemini-3.6-flash",
+        release_date: "2026-07-21",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-3.5-flash-lite",
+        release_date: "2026-07-21",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-3.5-flash",
+        release_date: "2026-05-19",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-3.1-pro-preview",
+        release_date: "2026-02-19",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-3.1-flash-lite",
+        release_date: "2026-05-07",
+        shutdown_date: Some("2027-05-07"),
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-3-flash-preview",
+        release_date: "2025-12-17",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-2.5-pro",
+        release_date: "2025-06-17",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-2.5-flash",
+        release_date: "2025-06-17",
+        shutdown_date: None,
+    },
+    DeveloperModelLifecycle {
+        id: "gemini-2.5-flash-lite",
+        release_date: "2025-07-22",
+        shutdown_date: None,
+    },
+];
+
+fn developer_lifecycle(model_id: &str) -> Option<DeveloperModelLifecycle> {
+    DEVELOPER_CHAT_MODELS
+        .iter()
+        .copied()
+        .find(|model| model.id == model_id)
+}
+
 /// Google Gemini API surface for provider-specific catalog overlays.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GoogleGeminiApiSurface {
@@ -42,11 +106,13 @@ impl GoogleGeminiApiSurface {
 
     pub(crate) fn includes(self, spec: &ModelSpec) -> bool {
         match self {
-            Self::DeveloperApi => true,
+            Self::DeveloperApi => developer_lifecycle(&spec.model_info.id).is_some(),
             Self::VertexAi => {
                 !matches!(
                     spec.family,
-                    GeminiModelFamily::Gemini10Pro
+                    GeminiModelFamily::Gemini36Flash
+                        | GeminiModelFamily::Gemini35FlashLite
+                        | GeminiModelFamily::Gemini10Pro
                         | GeminiModelFamily::Gemini10ProVision
                         | GeminiModelFamily::GeminiExperimental
                         | GeminiModelFamily::Gemini20FlashThinking
@@ -54,7 +120,10 @@ impl GoogleGeminiApiSurface {
             }
             Self::VertexAiExperimental => !matches!(
                 spec.family,
-                GeminiModelFamily::Gemini10Pro | GeminiModelFamily::Gemini10ProVision
+                GeminiModelFamily::Gemini36Flash
+                    | GeminiModelFamily::Gemini35FlashLite
+                    | GeminiModelFamily::Gemini10Pro
+                    | GeminiModelFamily::Gemini10ProVision
             ),
         }
     }
@@ -78,6 +147,22 @@ impl GoogleGeminiApiSurface {
             "google_model_source_provider".to_string(),
             serde_json::json!("gemini"),
         );
+        if let Some(lifecycle) = developer_lifecycle(&spec.model_info.id) {
+            model_info.metadata.insert(
+                "google_lifecycle_source".to_string(),
+                serde_json::json!(OFFICIAL_LIFECYCLE_SOURCE),
+            );
+            model_info.metadata.insert(
+                "google_release_date".to_string(),
+                serde_json::json!(lifecycle.release_date),
+            );
+            if let Some(shutdown_date) = lifecycle.shutdown_date {
+                model_info.metadata.insert(
+                    "google_shutdown_date".to_string(),
+                    serde_json::json!(shutdown_date),
+                );
+            }
+        }
         model_info
     }
 }
@@ -97,17 +182,37 @@ mod tests {
         let experimental_vertex_models =
             registry.list_model_infos_for_surface(GoogleGeminiApiSurface::VertexAiExperimental);
 
-        assert_eq!(developer_models.len(), registry.list_models().len());
-        assert!(
-            developer_models
-                .iter()
-                .any(|model| model.id == "gemini-1.0-pro")
-        );
+        assert_eq!(developer_models.len(), DEVELOPER_CHAT_MODELS.len());
+        let developer_ids = developer_models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>();
+        let mut expected_ids = DEVELOPER_CHAT_MODELS
+            .iter()
+            .map(|model| model.id)
+            .collect::<Vec<_>>();
+        expected_ids.sort_unstable();
+        assert_eq!(developer_ids, expected_ids);
+        assert!(!developer_ids.contains(&"gemini-1.0-pro"));
+        assert!(!developer_ids.contains(&"gemini-3.1-flash"));
         assert!(
             vertex_models
                 .iter()
                 .any(|model| model.id == "gemini-3.5-flash")
         );
+        for developer_only_id in ["gemini-3.6-flash", "gemini-3.5-flash-lite"] {
+            assert!(developer_ids.contains(&developer_only_id));
+            assert!(
+                !vertex_models
+                    .iter()
+                    .any(|model| model.id == developer_only_id)
+            );
+            assert!(
+                !experimental_vertex_models
+                    .iter()
+                    .any(|model| model.id == developer_only_id)
+            );
+        }
         assert!(
             !vertex_models
                 .iter()
@@ -144,6 +249,10 @@ mod tests {
         assert_eq!(
             developer_model.metadata["google_auth_boundary"],
             serde_json::json!("api_key")
+        );
+        assert_eq!(
+            developer_model.metadata["google_lifecycle_source"],
+            serde_json::json!(OFFICIAL_LIFECYCLE_SOURCE)
         );
 
         let vertex_model = vertex_models

--- a/src/core/providers/gemini/provider.rs
+++ b/src/core/providers/gemini/provider.rs
@@ -26,7 +26,10 @@ use crate::core::types::{
 use super::client::GeminiClient;
 use super::config::GeminiConfig;
 use super::error::{GeminiErrorMapper, gemini_model_error, gemini_validation_error};
-use super::models::{GoogleGeminiApiSurface, ModelFeature, get_gemini_registry};
+use super::models::{
+    GoogleGeminiApiSurface, ModelFeature, get_gemini_registry, has_trailing_assistant_prefill,
+    uses_fixed_sampling_contract,
+};
 use super::streaming::GeminiStream;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
@@ -34,6 +37,7 @@ use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 #[derive(Debug)]
 pub struct GeminiProvider {
     client: GeminiClient,
+    surface: GoogleGeminiApiSurface,
     supported_models: Vec<ModelInfo>,
 }
 
@@ -50,11 +54,16 @@ impl GeminiProvider {
 
         // Get
         let registry = get_gemini_registry();
-        let supported_models =
-            registry.list_model_infos_for_surface(GoogleGeminiApiSurface::DeveloperApi);
+        let surface = if config.use_vertex_ai {
+            GoogleGeminiApiSurface::VertexAi
+        } else {
+            GoogleGeminiApiSurface::DeveloperApi
+        };
+        let supported_models = registry.list_model_infos_for_surface(surface);
 
         Ok(Self {
             client,
+            surface,
             supported_models,
         })
     }
@@ -74,6 +83,7 @@ impl GeminiProvider {
 
         let model_spec = registry
             .get_model_spec(&request.model)
+            .filter(|spec| self.surface.includes(spec))
             .ok_or_else(|| gemini_model_error(format!("Unsupported model: {}", request.model)))?;
 
         // Common validation: empty messages + max_tokens
@@ -83,20 +93,26 @@ impl GeminiProvider {
             model_spec.limits.max_output_tokens,
         )?;
 
-        // Check temperature range
-        if let Some(temperature) = request.temperature
-            && !(0.0..=2.0).contains(&temperature)
-        {
-            return Err(gemini_validation_error(
-                "temperature must be between 0.0 and 2.0",
-            ));
-        }
-
-        // Check top_p range
-        if let Some(top_p) = request.top_p
-            && !(0.0..=1.0).contains(&top_p)
-        {
-            return Err(gemini_validation_error("top_p must be between 0.0 and 1.0"));
+        if uses_fixed_sampling_contract(&request.model) {
+            if has_trailing_assistant_prefill(request) {
+                return Err(gemini_validation_error(format!(
+                    "Model {} does not accept a trailing non-empty assistant message",
+                    request.model
+                )));
+            }
+        } else {
+            if let Some(temperature) = request.temperature
+                && !(0.0..=2.0).contains(&temperature)
+            {
+                return Err(gemini_validation_error(
+                    "temperature must be between 0.0 and 2.0",
+                ));
+            }
+            if let Some(top_p) = request.top_p
+                && !(0.0..=1.0).contains(&top_p)
+            {
+                return Err(gemini_validation_error("top_p must be between 0.0 and 1.0"));
+            }
         }
 
         // Check tool calling support
@@ -143,7 +159,9 @@ impl LLMProvider for GeminiProvider {
     }
 
     fn supports_model(&self, model: &str) -> bool {
-        get_gemini_registry().get_model_spec(model).is_some()
+        get_gemini_registry()
+            .get_model_spec(model)
+            .is_some_and(|spec| self.surface.includes(spec))
     }
 
     fn supports_tools(&self) -> bool {
@@ -166,7 +184,10 @@ impl LLMProvider for GeminiProvider {
         true // Gemini supports vision understanding
     }
 
-    fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
+    fn get_supported_openai_params(&self, model: &str) -> &'static [&'static str] {
+        if uses_fixed_sampling_contract(model) {
+            return &["max_tokens", "stop", "stream", "tools", "tool_choice"];
+        }
         &[
             "temperature",
             "max_tokens",
@@ -181,11 +202,16 @@ impl LLMProvider for GeminiProvider {
     async fn map_openai_params(
         &self,
         params: HashMap<String, Value>,
-        _model: &str,
+        model: &str,
     ) -> Result<HashMap<String, Value>, ProviderError> {
         let mut mapped = HashMap::new();
 
         for (key, value) in params {
+            if uses_fixed_sampling_contract(model)
+                && matches!(key.as_str(), "temperature" | "top_p" | "top_k")
+            {
+                continue;
+            }
             match key.as_str() {
                 // Directly mapped parameters
                 "temperature" | "top_p" | "stop" | "stream" => {
@@ -458,7 +484,7 @@ mod native_tests {
         config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
         let provider = GeminiProvider::new(config).unwrap();
         let request = ChatRequest {
-            model: "gemini-1.5-flash".to_string(),
+            model: "gemini-2.5-flash".to_string(),
             messages: vec![ChatMessage {
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("hello".to_string())),

--- a/src/core/providers/gemini/provider_tests.rs
+++ b/src/core/providers/gemini/provider_tests.rs
@@ -90,17 +90,29 @@ fn test_model_support() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    assert!(provider.supports_model("gemini-1.0-pro"));
-    assert!(provider.supports_model("gemini-1.5-flash"));
+    assert!(provider.supports_model("gemini-3.6-flash"));
+    assert!(provider.supports_model("gemini-3.5-flash-lite"));
+    assert!(provider.supports_model("gemini-2.5-flash"));
+    assert!(!provider.supports_model("gemini-1.0-pro"));
+    assert!(!provider.supports_model("gemini-3.1-flash"));
     assert!(!provider.supports_model("gpt-4"));
 }
 
 #[test]
-fn test_model_support_gemini_1_0_pro() {
+fn vertex_provider_does_not_assume_developer_only_models() {
+    let provider = GeminiProvider::new(GeminiConfig::new_vertex_ai("project", "location")).unwrap();
+
+    assert!(!provider.supports_model("gemini-3.6-flash"));
+    assert!(!provider.supports_model("gemini-3.5-flash-lite"));
+    assert!(provider.supports_model("gemini-3.5-flash"));
+}
+
+#[test]
+fn test_retired_gemini_1_0_pro_is_not_published() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    assert!(provider.supports_model("gemini-1.0-pro"));
+    assert!(!provider.supports_model("gemini-1.0-pro"));
 }
 
 #[test]
@@ -130,7 +142,7 @@ fn test_request_validation_empty_messages() {
     let provider = GeminiProvider::new(config).unwrap();
 
     let empty_request = ChatRequest {
-        model: "gemini-1.0-pro".to_string(),
+        model: "gemini-2.5-flash".to_string(),
         messages: vec![],
         ..Default::default()
     };
@@ -143,7 +155,7 @@ fn test_request_validation_invalid_temperature_high() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.temperature = Some(3.0); // Out of range
 
     assert!(provider.validate_request(&request).is_err());
@@ -154,7 +166,7 @@ fn test_request_validation_invalid_temperature_negative() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.temperature = Some(-0.5);
 
     assert!(provider.validate_request(&request).is_err());
@@ -165,7 +177,7 @@ fn test_request_validation_valid_temperature() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.temperature = Some(1.0);
 
     assert!(provider.validate_request(&request).is_ok());
@@ -176,7 +188,7 @@ fn test_request_validation_temperature_edge_low() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.temperature = Some(0.0);
 
     assert!(provider.validate_request(&request).is_ok());
@@ -187,7 +199,7 @@ fn test_request_validation_temperature_edge_high() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.temperature = Some(2.0);
 
     assert!(provider.validate_request(&request).is_ok());
@@ -198,7 +210,7 @@ fn test_request_validation_invalid_top_p_high() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.top_p = Some(1.5);
 
     assert!(provider.validate_request(&request).is_err());
@@ -209,7 +221,7 @@ fn test_request_validation_invalid_top_p_negative() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.top_p = Some(-0.1);
 
     assert!(provider.validate_request(&request).is_err());
@@ -220,7 +232,7 @@ fn test_request_validation_valid_top_p() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let mut request = create_valid_request("gemini-1.0-pro");
+    let mut request = create_valid_request("gemini-2.5-flash");
     request.top_p = Some(0.9);
 
     assert!(provider.validate_request(&request).is_ok());
@@ -235,6 +247,27 @@ fn test_request_validation_unsupported_model() {
     assert!(provider.validate_request(&request).is_err());
 }
 
+#[test]
+fn july_2026_models_reject_non_empty_assistant_prefill() {
+    let provider = GeminiProvider::new(GeminiConfig::new_google_ai(
+        "test-api-key-12345678901234567890",
+    ))
+    .unwrap();
+
+    for model in ["gemini-3.6-flash", "gemini-3.5-flash-lite"] {
+        let mut request = create_valid_request(model);
+        request.messages.push(ChatMessage {
+            role: MessageRole::Assistant,
+            content: Some(MessageContent::Text("prefill".to_string())),
+            ..Default::default()
+        });
+        assert!(provider.validate_request(&request).is_err(), "{model}");
+
+        request.messages.last_mut().unwrap().content = Some(MessageContent::Text("  ".to_string()));
+        assert!(provider.validate_request(&request).is_ok(), "{model}");
+    }
+}
+
 // ==================== Supported Params Tests ====================
 
 #[test]
@@ -242,7 +275,7 @@ fn test_supported_openai_params() {
     let config = GeminiConfig::new_google_ai("test-api-key-12345678901234567890");
     let provider = GeminiProvider::new(config).unwrap();
 
-    let params = provider.get_supported_openai_params("gemini-1.0-pro");
+    let params = provider.get_supported_openai_params("gemini-2.5-flash");
     assert!(params.contains(&"temperature"));
     assert!(params.contains(&"max_tokens"));
     assert!(params.contains(&"top_p"));
@@ -250,6 +283,45 @@ fn test_supported_openai_params() {
     assert!(params.contains(&"stream"));
     assert!(params.contains(&"tools"));
     assert!(params.contains(&"tool_choice"));
+}
+
+#[test]
+fn july_2026_models_do_not_advertise_sampling_parameters() {
+    let provider = GeminiProvider::new(GeminiConfig::new_google_ai(
+        "test-api-key-12345678901234567890",
+    ))
+    .unwrap();
+
+    for model in ["gemini-3.6-flash", "gemini-3.5-flash-lite"] {
+        let params = provider.get_supported_openai_params(model);
+        assert!(!params.contains(&"temperature"), "{model}");
+        assert!(!params.contains(&"top_p"), "{model}");
+        assert!(!params.contains(&"top_k"), "{model}");
+        assert!(params.contains(&"max_tokens"), "{model}");
+    }
+}
+
+#[tokio::test]
+async fn july_2026_models_drop_sampling_parameters() {
+    let provider = GeminiProvider::new(GeminiConfig::new_google_ai(
+        "test-api-key-12345678901234567890",
+    ))
+    .unwrap();
+    let params = HashMap::from([
+        ("temperature".to_string(), serde_json::json!(0.7)),
+        ("top_p".to_string(), serde_json::json!(0.9)),
+        ("top_k".to_string(), serde_json::json!(20)),
+        ("max_tokens".to_string(), serde_json::json!(16)),
+    ]);
+
+    let mapped = provider
+        .map_openai_params(params, "gemini-3.6-flash")
+        .await
+        .unwrap();
+    assert!(!mapped.contains_key("temperature"));
+    assert!(!mapped.contains_key("top_p"));
+    assert!(!mapped.contains_key("top_k"));
+    assert_eq!(mapped["max_output_tokens"], serde_json::json!(16));
 }
 
 #[tokio::test]
@@ -261,7 +333,7 @@ async fn test_map_openai_params_max_tokens() {
     params.insert("max_tokens".to_string(), serde_json::json!(100));
 
     let mapped = provider
-        .map_openai_params(params, "gemini-1.0-pro")
+        .map_openai_params(params, "gemini-2.5-flash")
         .await
         .unwrap();
     assert!(mapped.contains_key("max_output_tokens"));
@@ -277,7 +349,7 @@ async fn test_map_openai_params_temperature() {
     params.insert("temperature".to_string(), serde_json::json!(0.7));
 
     let mapped = provider
-        .map_openai_params(params, "gemini-1.0-pro")
+        .map_openai_params(params, "gemini-2.5-flash")
         .await
         .unwrap();
     assert!(mapped.contains_key("temperature"));
@@ -293,7 +365,7 @@ async fn test_map_openai_params_unsupported_ignored() {
     params.insert("presence_penalty".to_string(), serde_json::json!(0.5));
 
     let mapped = provider
-        .map_openai_params(params, "gemini-1.0-pro")
+        .map_openai_params(params, "gemini-2.5-flash")
         .await
         .unwrap();
     assert!(!mapped.contains_key("frequency_penalty"));
@@ -310,7 +382,7 @@ async fn test_map_openai_params_tools() {
     params.insert("tool_choice".to_string(), serde_json::json!("auto"));
 
     let mapped = provider
-        .map_openai_params(params, "gemini-1.0-pro")
+        .map_openai_params(params, "gemini-2.5-flash")
         .await
         .unwrap();
     assert!(mapped.contains_key("tools"));

--- a/src/core/providers/shared.rs
+++ b/src/core/providers/shared.rs
@@ -22,7 +22,9 @@ pub const GEMINI_31_CONTEXT_WINDOW: u32 = 1_048_576;
 pub fn gemini_context_window(model_name: &str) -> Option<u32> {
     let model_lower = model_name.to_ascii_lowercase();
 
-    if model_lower.contains("gemini-3.5-flash")
+    if model_lower.contains("gemini-3.6-flash")
+        || model_lower.contains("gemini-3.5-flash-lite")
+        || model_lower.contains("gemini-3.5-flash")
         || model_lower.contains("gemini-3.1-flash-lite")
         || model_lower.contains("gemini-3.1-flash")
         || model_lower.contains("gemini-3.1-pro")

--- a/src/utils/ai/models/utils.rs
+++ b/src/utils/ai/models/utils.rs
@@ -426,7 +426,9 @@ impl ModelUtils {
             "claude-3",
             "claude-2",
             "gemini",
+            "gemini-3.6-flash",
             "gemini-3.5-flash",
+            "gemini-3.5-flash-lite",
             "gemini-3.1-pro-preview",
             "gemini-3-flash-preview",
             "gemini-3.1-flash-lite",
@@ -544,6 +546,8 @@ impl ModelUtils {
                 "claude-instant".to_string(),
             ],
             "google" => vec![
+                "gemini-3.6-flash".to_string(),
+                "gemini-3.5-flash-lite".to_string(),
                 "gemini-3.5-flash".to_string(),
                 "gemini-3.1-flash-lite".to_string(),
                 "gemini-pro".to_string(),

--- a/tests/common/providers.rs
+++ b/tests/common/providers.rs
@@ -141,7 +141,7 @@ pub fn test_models() -> std::collections::HashMap<&'static str, &'static str> {
     models.insert("openai", "gpt-3.5-turbo");
     models.insert("anthropic", "claude-3-haiku-20240307");
     models.insert("groq", "llama-3.1-8b-instant");
-    models.insert("gemini", "gemini-1.5-flash");
+    models.insert("gemini", "gemini-2.5-flash");
     models.insert("mistral", "mistral-small-latest");
     models.insert("deepseek", "deepseek-v4-flash");
     models.insert("xiaomi_mimo", "mimo-v2.5");

--- a/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
+++ b/tests/integration/completions_route_tests/tests/streaming_and_budget_tests.rs
@@ -43,7 +43,7 @@ async fn gemini_invalid_terminal_usage_is_not_serialized_or_settled_as_valid() {
         "gemini",
         "test-key-12345678901234567890",
         &format!("http://{address}"),
-        vec!["gemini-1.5-flash".to_string()],
+        vec!["gemini-2.5-flash".to_string()],
     )];
     let gateway = GatewayHttpServer::new(&config)
         .await
@@ -56,7 +56,7 @@ async fn gemini_invalid_terminal_usage_is_not_serialized_or_settled_as_valid() {
         ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
     );
     state.budget_limits.models.set_model_limit(
-        "gemini-1.5-flash",
+        "gemini-2.5-flash",
         ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
     );
     let budget_limits = state.budget_limits.clone();
@@ -71,7 +71,7 @@ async fn gemini_invalid_terminal_usage_is_not_serialized_or_settled_as_valid() {
         test::TestRequest::post()
             .uri("/v1/completions")
             .set_json(json!({
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.5-flash",
                 "prompt": "hello",
                 "stream": true,
                 "max_tokens": 8,
@@ -162,7 +162,7 @@ async fn gemini_invalid_terminal_usage_is_not_serialized_by_chat_or_settled_as_v
         "gemini",
         "test-key-12345678901234567890",
         &format!("http://{address}"),
-        vec!["gemini-1.5-flash".to_string()],
+        vec!["gemini-2.5-flash".to_string()],
     )];
     let gateway = GatewayHttpServer::new(&config)
         .await
@@ -175,7 +175,7 @@ async fn gemini_invalid_terminal_usage_is_not_serialized_by_chat_or_settled_as_v
         ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
     );
     state.budget_limits.models.set_model_limit(
-        "gemini-1.5-flash",
+        "gemini-2.5-flash",
         ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
     );
     let budget_limits = state.budget_limits.clone();
@@ -190,7 +190,7 @@ async fn gemini_invalid_terminal_usage_is_not_serialized_by_chat_or_settled_as_v
         test::TestRequest::post()
             .uri("/v1/chat/completions")
             .set_json(json!({
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.5-flash",
                 "messages": [{"role": "user", "content": "hello"}],
                 "stream": true,
                 "max_tokens": 8,

--- a/tests/live_gemini_catalog.rs
+++ b/tests/live_gemini_catalog.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "providers-extended")]
+
+use std::collections::HashSet;
+
+use serde::Deserialize;
+use serde_json::json;
+
+const LIVE_OPT_IN: &str = "LITELLM_RS_LIVE_GEMINI_CATALOG";
+const MODELS_URL: &str = "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000";
+
+#[derive(Deserialize)]
+struct ModelList {
+    models: Vec<RemoteModel>,
+}
+
+#[derive(Deserialize)]
+struct RemoteModel {
+    name: String,
+    #[serde(rename = "supportedGenerationMethods", default)]
+    supported_generation_methods: Vec<String>,
+}
+
+fn failure_class(status: reqwest::StatusCode) -> &'static str {
+    match status.as_u16() {
+        401 | 403 => "auth",
+        404 => "not_found",
+        429 => "quota",
+        _ => "protocol",
+    }
+}
+
+#[tokio::test]
+async fn live_developer_catalog_matches_list_models_and_accepts_minimal_calls() {
+    if std::env::var(LIVE_OPT_IN).as_deref() != Ok("1") {
+        return;
+    }
+    let api_key = std::env::var("GEMINI_API_KEY")
+        .or_else(|_| std::env::var("GOOGLE_API_KEY"))
+        .unwrap_or_else(|_| panic!("{LIVE_OPT_IN}=1 requires GEMINI_API_KEY or GOOGLE_API_KEY"));
+    let client = reqwest::Client::new();
+    let list_response = client
+        .get(MODELS_URL)
+        .header("x-goog-api-key", &api_key)
+        .send()
+        .await
+        .unwrap_or_else(|_| panic!("Gemini list-models failed: network"));
+    assert!(
+        list_response.status().is_success(),
+        "Gemini list-models failed: {}",
+        failure_class(list_response.status())
+    );
+    let remote: ModelList = list_response
+        .json()
+        .await
+        .unwrap_or_else(|_| panic!("Gemini list-models failed: protocol"));
+    let callable = remote
+        .models
+        .into_iter()
+        .filter(|model| {
+            model
+                .supported_generation_methods
+                .iter()
+                .any(|method| method == "generateContent")
+        })
+        .filter_map(|model| model.name.strip_prefix("models/").map(str::to_string))
+        .collect::<HashSet<_>>();
+
+    let static_models = litellm_rs::core::providers::gemini::supported_models();
+    for model in &static_models {
+        assert!(
+            callable.contains(model),
+            "Gemini catalog mismatch: {model} not_found"
+        );
+    }
+
+    for model in static_models {
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+        );
+        let response = client
+            .post(url)
+            .header("x-goog-api-key", &api_key)
+            .json(&json!({
+                "contents": [{"role": "user", "parts": [{"text": "Reply OK"}]}],
+                "generationConfig": {"maxOutputTokens": 1}
+            }))
+            .send()
+            .await
+            .unwrap_or_else(|_| panic!("Gemini minimal call failed for {model}: network"));
+        assert!(
+            response.status().is_success(),
+            "Gemini minimal call failed for {model}: {}",
+            failure_class(response.status())
+        );
+    }
+}

--- a/tests/responses_routes.rs
+++ b/tests/responses_routes.rs
@@ -452,7 +452,7 @@ mod tests {
             "gemini",
             "test-key-12345678901234567890",
             &format!("http://{address}"),
-            vec!["gemini-1.5-flash".to_string()],
+            vec!["gemini-2.5-flash".to_string()],
         )];
         let gateway = GatewayHttpServer::new(&config)
             .await
@@ -466,7 +466,7 @@ mod tests {
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
         state.budget_limits.models.set_model_limit(
-            "gemini-1.5-flash",
+            "gemini-2.5-flash",
             ModelLimitConfig::new(100.0, ResetPeriod::Monthly),
         );
         let budget_limits = state.budget_limits.clone();
@@ -481,7 +481,7 @@ mod tests {
             test::TestRequest::post()
                 .uri("/v1/responses")
                 .set_json(json!({
-                    "model": "gemini-1.5-flash",
+                    "model": "gemini-2.5-flash",
                     "input": "hello",
                     "stream": true
                 }))


### PR DESCRIPTION
Closes #1108

## Summary
- add Gemini 3.6 Flash and Gemini 3.5 Flash-Lite limits and pricing
- publish only lifecycle-evidenced Developer API chat IDs while keeping Vertex surfaces separate
- omit removed sampling parameters and reject trailing assistant prefill before network calls
- add an explicit opt-in live catalog/list-models/minimal-call smoke test with redacted failure classes

## Verification
- cargo fmt --check
- cargo check --features providers-extended
- cargo clippy --features providers-extended --all-targets -- -D warnings
- cargo test --features providers-extended
- cargo test --features providers-extended --test live_gemini_catalog (self-skips without opt-in)

## Review note
- Local Codex CLI review was attempted, but the configured account is usage-limited until Aug 16; no review result was produced.