### PR TITLE
feat(responses): add Codex tool protocol compatibility

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ A high-performance AI Gateway written in Rust that provides unified access to 10
 ### Implementation Guides
 - [Getting Started](./guides/getting-started.md) - Quick start guide and basic usage
 - [Configuration](./guides/configuration.md) - Configuration management and environment setup
+- [Codex](./guides/codex.md) - Use Codex with the Responses API compatibility layer
 - [Deployment](./guides/deployment.md) - Production deployment strategies
 - [Testing](./guides/testing.md) - Testing strategies and best practices
 

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -1,0 +1,77 @@
+# Codex through LiteLLM-RS
+
+LiteLLM-RS exposes the Responses API endpoint Codex expects at
+`POST /v1/responses`. The gateway translates portable function calls and Codex
+custom/freeform tools to each provider's normal tool-calling protocol while
+preserving response item and call IDs across turns.
+
+## Start the gateway
+
+Configure at least one tool-capable model in `config/gateway.yaml`, then start
+the server:
+
+```bash
+cargo run --bin gateway
+```
+
+The development example listens on `http://127.0.0.1:8080`. Production
+deployments should enable authentication and provide the API key through an
+environment variable.
+
+## Configure Codex
+
+Add a provider to the user-level `~/.codex/config.toml`. This is a manual step;
+LiteLLM-RS never edits Codex configuration.
+
+```toml
+model = "your-gateway-model"
+model_provider = "litellm_rs"
+
+[model_providers.litellm_rs]
+name = "LiteLLM-RS"
+base_url = "http://127.0.0.1:8080/v1"
+env_key = "LITELLM_RS_API_KEY"
+wire_api = "responses"
+```
+
+Set `LITELLM_RS_API_KEY` in the environment that launches Codex. Do not put the
+key directly in `config.toml`.
+
+## Smoke test
+
+First verify the gateway independently of Codex:
+
+```bash
+curl --fail-with-body http://127.0.0.1:8080/v1/responses \
+  -H "Authorization: Bearer ${LITELLM_RS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"your-gateway-model","input":"Reply with OK","store":false}'
+```
+
+Then run Codex with the configured provider:
+
+```bash
+codex exec "Reply with OK"
+```
+
+## Compatibility contract
+
+| Codex feature | Gateway behavior |
+| --- | --- |
+| Messages and text | Forwarded through the selected provider |
+| Function calls and outputs | Converted to provider tool calls with `call_id` preserved |
+| Custom/freeform tools | Reversibly wrapped as a string-valued `input` function argument |
+| OpenAI-compatible, Anthropic, Gemini | Supported when the configured model advertises tool calling |
+| Streaming | Emits output-item added/delta/done events and one terminal response event |
+| Stored multi-turn responses | Replays prior function/custom calls before correlating tool outputs |
+
+Tier 2 Codex extensions are deliberately fail-closed: namespaces, tool search,
+additional tools, local shell calls, compaction items, hosted web search, MCP,
+and computer use return `unsupported_codex_feature` before an upstream request.
+The gateway does not execute tools; Codex remains responsible for running them
+and sending their outputs on the next turn.
+
+`strict=true` and deferred function loading are also rejected because the
+current chat-tool representation cannot preserve those semantics. Use a model
+and provider with ordinary function/tool-calling support for this compatibility
+path.

--- a/src/core/models/openai/responses_api.rs
+++ b/src/core/models/openai/responses_api.rs
@@ -528,15 +528,30 @@ pub enum ResponseStreamEvent {
     #[serde(rename = "response.function_call_arguments.delta")]
     ResponseFunctionCallArgumentsDelta {
         output_index: u32,
-        call_id: String,
+        item_id: String,
         delta: String,
     },
     /// Function-call arguments finished
     #[serde(rename = "response.function_call_arguments.done")]
     ResponseFunctionCallArgumentsDone {
         output_index: u32,
-        call_id: String,
+        item_id: String,
+        name: String,
         arguments: String,
+    },
+    /// Incremental custom-tool input.
+    #[serde(rename = "response.custom_tool_call_input.delta")]
+    ResponseCustomToolCallInputDelta {
+        output_index: u32,
+        item_id: String,
+        delta: String,
+    },
+    /// Custom-tool input finished.
+    #[serde(rename = "response.custom_tool_call_input.done")]
+    ResponseCustomToolCallInputDone {
+        output_index: u32,
+        item_id: String,
+        input: String,
     },
     /// Incremental reasoning-summary delta (o-series / Anthropic
     /// extended thinking / DeepSeek R1 / Gemini thinking).

--- a/src/core/types/codex.rs
+++ b/src/core/types/codex.rs
@@ -242,3 +242,360 @@ pub mod wire {
         serde_json::from_value(Value::Object(payload))
     }
 }
+
+/// SP1107-T2 builds the canonical model before SP1107-T3 wires it into routing.
+#[allow(dead_code)]
+pub(crate) mod domain {
+    use super::wire::{CODEX_PROTOCOL_BASELINE, CodexToolOutput, CodexToolOutputContent};
+    use crate::core::models::openai::responses_api::{
+        ResponseInput, ResponseInputContent, ResponseInputContentPart, ResponseInputItem,
+        ResponseInputMessage, ResponseTool, ResponsesApiRequest,
+    };
+    use std::collections::HashMap;
+    use thiserror::Error;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum CodexCallKind {
+        Function,
+        Custom,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum CodexCallState {
+        Declared,
+        OutputReceived,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct CodexCallRecord {
+        pub(crate) call_id: String,
+        pub(crate) kind: CodexCallKind,
+        pub(crate) name: String,
+        pub(crate) namespace: Option<String>,
+        pub(crate) state: CodexCallState,
+        pub(crate) declaration_index: usize,
+        pub(crate) output_index: Option<usize>,
+    }
+
+    #[derive(Debug, Clone, Default)]
+    pub(crate) struct CodexCallLedger {
+        pub(crate) calls: Vec<CodexCallRecord>,
+        call_indices: HashMap<String, usize>,
+    }
+
+    impl CodexCallLedger {
+        fn declare(
+            &mut self,
+            call_id: &str,
+            kind: CodexCallKind,
+            name: &str,
+            namespace: Option<&str>,
+            item_index: usize,
+        ) -> Result<(), CodexTurnError> {
+            validate_call_id(call_id, item_index)?;
+            if name.trim().is_empty() {
+                return Err(CodexTurnError::InvalidCallName { item_index });
+            }
+            if self.call_indices.contains_key(call_id) {
+                return Err(CodexTurnError::DuplicateCallId(item_index));
+            }
+
+            let call_index = self.calls.len();
+            self.calls.push(CodexCallRecord {
+                call_id: call_id.to_string(),
+                kind,
+                name: name.to_string(),
+                namespace: namespace.map(str::to_string),
+                state: CodexCallState::Declared,
+                declaration_index: item_index,
+                output_index: None,
+            });
+            self.call_indices.insert(call_id.to_string(), call_index);
+            Ok(())
+        }
+
+        fn receive_output(
+            &mut self,
+            call_id: &str,
+            kind: CodexCallKind,
+            name: Option<&str>,
+            item_index: usize,
+        ) -> Result<(), CodexTurnError> {
+            validate_call_id(call_id, item_index)?;
+            let Some(&call_index) = self.call_indices.get(call_id) else {
+                return Err(CodexTurnError::UnknownCallId(item_index));
+            };
+            let call = &mut self.calls[call_index];
+            if call.state == CodexCallState::OutputReceived {
+                return Err(CodexTurnError::DuplicateCallOutput(item_index));
+            }
+            if call.kind != kind {
+                return Err(CodexTurnError::CallKindMismatch(
+                    call.kind, kind, item_index,
+                ));
+            }
+            if name.is_some_and(|name| name.trim().is_empty() || name != call.name) {
+                return Err(CodexTurnError::InvalidCallName { item_index });
+            }
+            call.state = CodexCallState::OutputReceived;
+            call.output_index = Some(item_index);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub(crate) enum CodexTurnItem {
+        Text(String),
+        Item(ResponseInputItem),
+    }
+
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+    pub(crate) struct CodexExecutionRequirements {
+        pub(crate) streaming: bool,
+        pub(crate) function_tools: bool,
+        pub(crate) custom_tools: bool,
+        pub(crate) call_outputs: bool,
+    }
+
+    #[derive(Debug, Clone)]
+    pub(crate) struct CodexTurn {
+        pub(crate) protocol_version: &'static str,
+        pub(crate) items: Vec<CodexTurnItem>,
+        pub(crate) tools: Vec<ResponseTool>,
+        pub(crate) store: Option<bool>,
+        pub(crate) background: bool,
+        pub(crate) requirements: CodexExecutionRequirements,
+        pub(crate) ledger: CodexCallLedger,
+    }
+
+    impl TryFrom<&ResponsesApiRequest> for CodexTurn {
+        type Error = CodexTurnError;
+
+        fn try_from(request: &ResponsesApiRequest) -> Result<Self, Self::Error> {
+            if request.additional_tools.is_some() {
+                return Err(unsupported("additional_tools"));
+            }
+
+            let mut ledger = CodexCallLedger::default();
+            let mut requirements = CodexExecutionRequirements {
+                streaming: request.stream.unwrap_or(false),
+                ..Default::default()
+            };
+            let items = match &request.input {
+                ResponseInput::Text(text) => {
+                    if text.trim().is_empty() {
+                        return Err(CodexTurnError::EmptyInput);
+                    }
+                    vec![CodexTurnItem::Text(text.clone())]
+                }
+                ResponseInput::Items(items) => {
+                    if items.is_empty() {
+                        return Err(CodexTurnError::EmptyInput);
+                    }
+                    let mut turn_items = Vec::with_capacity(items.len());
+                    for (item_index, item) in items.iter().enumerate() {
+                        turn_items.push(normalize_item(
+                            item,
+                            item_index,
+                            &mut ledger,
+                            &mut requirements,
+                        )?);
+                    }
+                    turn_items
+                }
+            };
+
+            let tools = request.tools.clone().unwrap_or_default();
+            for (tool_index, tool) in tools.iter().enumerate() {
+                let (name, deferred, custom) = match tool {
+                    ResponseTool::Function(tool) => {
+                        (&tool.function.name, tool.function.defer_loading, false)
+                    }
+                    ResponseTool::CodexFunction(tool) => (&tool.name, tool.defer_loading, false),
+                    ResponseTool::Custom(tool) => (&tool.name, None, true),
+                    tool => return Err(unsupported(tool.feature_name())),
+                };
+                if name.trim().is_empty() {
+                    return Err(CodexTurnError::EmptyToolName { tool_index });
+                }
+                if deferred == Some(true) {
+                    return Err(unsupported("defer_loading"));
+                }
+                requirements.custom_tools |= custom;
+                requirements.function_tools |= !custom;
+            }
+
+            Ok(Self {
+                protocol_version: CODEX_PROTOCOL_BASELINE,
+                items,
+                tools,
+                store: request.store,
+                background: request.background.unwrap_or(false),
+                requirements,
+                ledger,
+            })
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Error)]
+    pub(crate) enum CodexTurnError {
+        #[error("Codex input must not be empty")]
+        EmptyInput,
+        #[error("Codex call_id must not be empty at item {item_index}")]
+        EmptyCallId { item_index: usize },
+        #[error("invalid Codex call name at item {item_index}")]
+        InvalidCallName { item_index: usize },
+        #[error("Codex tool name must not be empty at tool {tool_index}")]
+        EmptyToolName { tool_index: usize },
+        #[error("invalid Codex message role at item {item_index}")]
+        InvalidMessageRole { item_index: usize },
+        #[error("Codex call payload must not be empty at item {item_index}")]
+        EmptyCallPayload { item_index: usize },
+        #[error("Codex function arguments must be valid JSON at item {item_index}")]
+        InvalidFunctionArguments { item_index: usize },
+        #[error("duplicate Codex call_id at item {0}")]
+        DuplicateCallId(usize),
+        #[error("unknown Codex call_id at item {0}")]
+        UnknownCallId(usize),
+        #[error("duplicate Codex call output at item {0}")]
+        DuplicateCallOutput(usize),
+        #[error("Codex call kind mismatch at item {2}: expected {0:?}, got {1:?}")]
+        CallKindMismatch(CodexCallKind, CodexCallKind, usize),
+        #[error("unsupported Codex feature '{0}'")]
+        UnsupportedFeature(String),
+    }
+
+    fn normalize_item(
+        item: &ResponseInputItem,
+        item_index: usize,
+        ledger: &mut CodexCallLedger,
+        requirements: &mut CodexExecutionRequirements,
+    ) -> Result<CodexTurnItem, CodexTurnError> {
+        use CodexCallKind::{Custom, Function};
+        match item {
+            ResponseInputItem::Message(message) => validate_message(message, item_index)?,
+            ResponseInputItem::FunctionCall(call) => {
+                if serde_json::from_str::<serde_json::Value>(&call.arguments).is_err() {
+                    return Err(CodexTurnError::InvalidFunctionArguments { item_index });
+                }
+                ledger.declare(
+                    &call.call_id,
+                    Function,
+                    &call.name,
+                    call.namespace.as_deref(),
+                    item_index,
+                )?;
+                requirements.function_tools = true;
+            }
+            ResponseInputItem::FunctionCallOutput(output) => {
+                validate_tool_output(&output.output, item_index)?;
+                ledger.receive_output(&output.call_id, Function, None, item_index)?;
+                requirements.function_tools = true;
+                requirements.call_outputs = true;
+            }
+            ResponseInputItem::CustomToolCall(call) => {
+                if call.input.trim().is_empty() {
+                    return Err(CodexTurnError::EmptyCallPayload { item_index });
+                }
+                ledger.declare(
+                    &call.call_id,
+                    Custom,
+                    &call.name,
+                    call.namespace.as_deref(),
+                    item_index,
+                )?;
+                requirements.custom_tools = true;
+            }
+            ResponseInputItem::CustomToolCallOutput(output) => {
+                validate_tool_output(&output.output, item_index)?;
+                ledger.receive_output(
+                    &output.call_id,
+                    Custom,
+                    output.name.as_deref(),
+                    item_index,
+                )?;
+                requirements.custom_tools = true;
+                requirements.call_outputs = true;
+            }
+            item => {
+                return Err(unsupported(item.feature_name()));
+            }
+        }
+        Ok(CodexTurnItem::Item(item.clone()))
+    }
+
+    fn validate_call_id(call_id: &str, item_index: usize) -> Result<(), CodexTurnError> {
+        if call_id.trim().is_empty() {
+            return Err(CodexTurnError::EmptyCallId { item_index });
+        }
+        Ok(())
+    }
+
+    fn unsupported(feature: &str) -> CodexTurnError {
+        CodexTurnError::UnsupportedFeature(feature.into())
+    }
+
+    fn validate_message(
+        message: &ResponseInputMessage,
+        item_index: usize,
+    ) -> Result<(), CodexTurnError> {
+        if !matches!(
+            message.role.as_str(),
+            "user" | "assistant" | "system" | "developer"
+        ) {
+            return Err(CodexTurnError::InvalidMessageRole { item_index });
+        }
+        let empty = match &message.content {
+            ResponseInputContent::Text(text) => text.trim().is_empty(),
+            ResponseInputContent::Parts(parts) => {
+                if parts
+                    .iter()
+                    .any(|part| matches!(part, ResponseInputContentPart::InputAudio { .. }))
+                {
+                    return Err(unsupported("input_audio"));
+                }
+                parts.is_empty()
+                    || parts.iter().any(|part| match part {
+                        ResponseInputContentPart::InputText { text }
+                        | ResponseInputContentPart::OutputText { text } => text.trim().is_empty(),
+                        ResponseInputContentPart::InputImage { image_url, .. } => image_url
+                            .as_ref()
+                            .is_none_or(|image_url| image_url.trim().is_empty()),
+                        _ => false,
+                    })
+            }
+        };
+        if empty {
+            return Err(CodexTurnError::EmptyCallPayload { item_index });
+        }
+        Ok(())
+    }
+
+    fn validate_tool_output(
+        output: &CodexToolOutput,
+        item_index: usize,
+    ) -> Result<(), CodexTurnError> {
+        let empty = match output {
+            CodexToolOutput::Text(text) => text.trim().is_empty(),
+            CodexToolOutput::ContentItems(items) => {
+                items.is_empty()
+                    || items.iter().any(|item| match item {
+                        CodexToolOutputContent::InputText { text } => text.trim().is_empty(),
+                        CodexToolOutputContent::InputImage { image_url, .. } => {
+                            image_url.trim().is_empty()
+                        }
+                        CodexToolOutputContent::InputAudio { audio_url } => {
+                            audio_url.trim().is_empty()
+                        }
+                        CodexToolOutputContent::EncryptedContent { encrypted_content } => {
+                            encrypted_content.trim().is_empty()
+                        }
+                    })
+            }
+        };
+        if empty {
+            return Err(CodexTurnError::EmptyCallPayload { item_index });
+        }
+        Ok(())
+    }
+}

--- a/src/core/types/codex.rs
+++ b/src/core/types/codex.rs
@@ -243,10 +243,9 @@ pub mod wire {
     }
 }
 
-/// SP1107-T2 builds the canonical model before SP1107-T3 wires it into routing.
-#[allow(dead_code)]
+/// Canonical Codex turn used before provider-specific chat/tool conversion.
 pub(crate) mod domain {
-    use super::wire::{CODEX_PROTOCOL_BASELINE, CodexToolOutput, CodexToolOutputContent};
+    use super::wire::{CodexToolOutput, CodexToolOutputContent};
     use crate::core::models::openai::responses_api::{
         ResponseInput, ResponseInputContent, ResponseInputContentPart, ResponseInputItem,
         ResponseInputMessage, ResponseTool, ResponsesApiRequest,
@@ -349,23 +348,10 @@ pub(crate) mod domain {
         Item(ResponseInputItem),
     }
 
-    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-    pub(crate) struct CodexExecutionRequirements {
-        pub(crate) streaming: bool,
-        pub(crate) function_tools: bool,
-        pub(crate) custom_tools: bool,
-        pub(crate) call_outputs: bool,
-    }
-
     #[derive(Debug, Clone)]
     pub(crate) struct CodexTurn {
-        pub(crate) protocol_version: &'static str,
         pub(crate) items: Vec<CodexTurnItem>,
         pub(crate) tools: Vec<ResponseTool>,
-        pub(crate) store: Option<bool>,
-        pub(crate) background: bool,
-        pub(crate) requirements: CodexExecutionRequirements,
-        pub(crate) ledger: CodexCallLedger,
     }
 
     impl TryFrom<&ResponsesApiRequest> for CodexTurn {
@@ -377,10 +363,6 @@ pub(crate) mod domain {
             }
 
             let mut ledger = CodexCallLedger::default();
-            let mut requirements = CodexExecutionRequirements {
-                streaming: request.stream.unwrap_or(false),
-                ..Default::default()
-            };
             let items = match &request.input {
                 ResponseInput::Text(text) => {
                     if text.trim().is_empty() {
@@ -394,46 +376,52 @@ pub(crate) mod domain {
                     }
                     let mut turn_items = Vec::with_capacity(items.len());
                     for (item_index, item) in items.iter().enumerate() {
-                        turn_items.push(normalize_item(
-                            item,
-                            item_index,
-                            &mut ledger,
-                            &mut requirements,
-                        )?);
+                        turn_items.push(normalize_item(item, item_index, &mut ledger)?);
                     }
                     turn_items
                 }
             };
 
             let tools = request.tools.clone().unwrap_or_default();
+            let mut tool_names = std::collections::HashSet::new();
             for (tool_index, tool) in tools.iter().enumerate() {
-                let (name, deferred, custom) = match tool {
-                    ResponseTool::Function(tool) => {
-                        (&tool.function.name, tool.function.defer_loading, false)
+                let (name, deferred, strict) = match tool {
+                    ResponseTool::Function(tool) => (
+                        &tool.function.name,
+                        tool.function.defer_loading,
+                        tool.function.strict,
+                    ),
+                    ResponseTool::CodexFunction(tool) => {
+                        (&tool.name, tool.defer_loading, tool.strict)
                     }
-                    ResponseTool::CodexFunction(tool) => (&tool.name, tool.defer_loading, false),
-                    ResponseTool::Custom(tool) => (&tool.name, None, true),
+                    ResponseTool::Custom(tool) => {
+                        if tool
+                            .format
+                            .get("type")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(|format| format != "text")
+                        {
+                            return Err(unsupported("custom.format"));
+                        }
+                        (&tool.name, None, None)
+                    }
                     tool => return Err(unsupported(tool.feature_name())),
                 };
                 if name.trim().is_empty() {
                     return Err(CodexTurnError::EmptyToolName { tool_index });
                 }
+                if !tool_names.insert(name.as_str()) {
+                    return Err(CodexTurnError::DuplicateToolName { tool_index });
+                }
                 if deferred == Some(true) {
                     return Err(unsupported("defer_loading"));
                 }
-                requirements.custom_tools |= custom;
-                requirements.function_tools |= !custom;
+                if strict == Some(true) {
+                    return Err(unsupported("strict"));
+                }
             }
 
-            Ok(Self {
-                protocol_version: CODEX_PROTOCOL_BASELINE,
-                items,
-                tools,
-                store: request.store,
-                background: request.background.unwrap_or(false),
-                requirements,
-                ledger,
-            })
+            Ok(Self { items, tools })
         }
     }
 
@@ -447,6 +435,8 @@ pub(crate) mod domain {
         InvalidCallName { item_index: usize },
         #[error("Codex tool name must not be empty at tool {tool_index}")]
         EmptyToolName { tool_index: usize },
+        #[error("duplicate Codex tool name at tool {tool_index}")]
+        DuplicateToolName { tool_index: usize },
         #[error("invalid Codex message role at item {item_index}")]
         InvalidMessageRole { item_index: usize },
         #[error("Codex call payload must not be empty at item {item_index}")]
@@ -469,7 +459,6 @@ pub(crate) mod domain {
         item: &ResponseInputItem,
         item_index: usize,
         ledger: &mut CodexCallLedger,
-        requirements: &mut CodexExecutionRequirements,
     ) -> Result<CodexTurnItem, CodexTurnError> {
         use CodexCallKind::{Custom, Function};
         match item {
@@ -485,13 +474,10 @@ pub(crate) mod domain {
                     call.namespace.as_deref(),
                     item_index,
                 )?;
-                requirements.function_tools = true;
             }
             ResponseInputItem::FunctionCallOutput(output) => {
                 validate_tool_output(&output.output, item_index)?;
                 ledger.receive_output(&output.call_id, Function, None, item_index)?;
-                requirements.function_tools = true;
-                requirements.call_outputs = true;
             }
             ResponseInputItem::CustomToolCall(call) => {
                 if call.input.trim().is_empty() {
@@ -504,7 +490,6 @@ pub(crate) mod domain {
                     call.namespace.as_deref(),
                     item_index,
                 )?;
-                requirements.custom_tools = true;
             }
             ResponseInputItem::CustomToolCallOutput(output) => {
                 validate_tool_output(&output.output, item_index)?;
@@ -514,8 +499,6 @@ pub(crate) mod domain {
                     output.name.as_deref(),
                     item_index,
                 )?;
-                requirements.custom_tools = true;
-                requirements.call_outputs = true;
             }
             item => {
                 return Err(unsupported(item.feature_name()));

--- a/src/server/routes/ai/responses.rs
+++ b/src/server/routes/ai/responses.rs
@@ -12,6 +12,9 @@ use crate::core::models::openai::responses_api::{
     ResponseInputItem, ResponseOutputContent, ResponseOutputItem, ResponseOutputMessage,
     ResponseTool, ResponseUsage, ResponsesApiRequest, ResponsesApiResponse,
 };
+use crate::core::models::openai::tools::{Function, FunctionCall, Tool, ToolCall};
+use crate::core::types::codex::domain::{CodexTurn, CodexTurnError, CodexTurnItem};
+use crate::core::types::codex::wire::{CodexCustomToolCall, CodexToolOutput};
 use crate::core::types::responses::FinishReason;
 use crate::server::routes::ai::chat::handle_chat_completion_with_state;
 use crate::server::state::AppState;
@@ -28,6 +31,8 @@ pub use lifecycle::{cancel_response, delete_response, get_response, list_respons
 #[cfg(test)]
 static PROVIDER_DISPATCH_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static CODEX_DISPATCH_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// POST /v1/responses handler
 pub async fn create_response(
@@ -78,14 +83,17 @@ pub async fn create_response(
         Err(error) => return Ok(openai_errors::gateway_error_response(&error)),
     };
 
-    if let Some(feature) = unsupported_codex_feature(&request) {
-        return Ok(openai_errors::unsupported_codex_feature(
-            feature,
-            &request.model,
-        ));
-    }
-
-    let chat_request = match build_chat_request(&request) {
+    let turn = match CodexTurn::try_from(&request) {
+        Ok(turn) => turn,
+        Err(CodexTurnError::UnsupportedFeature(feature)) => {
+            return Ok(openai_errors::unsupported_codex_feature(
+                &feature,
+                &request.model,
+            ));
+        }
+        Err(error) => return Ok(openai_errors::validation_error(error.to_string())),
+    };
+    let chat_request = match build_chat_request_from_turn(&request, &turn) {
         Ok(r) => r,
         Err(e) => return Ok(openai_errors::validation_error(e)),
     };
@@ -154,8 +162,17 @@ async fn handle_sync_response(
 // ── Request conversion ────────────────────────────────────────────────────────
 
 /// Convert a `ResponsesApiRequest` to a `ChatCompletionRequest`.
+#[cfg(test)]
 pub(crate) fn build_chat_request(
     req: &ResponsesApiRequest,
+) -> Result<ChatCompletionRequest, String> {
+    let turn = CodexTurn::try_from(req).map_err(|error| error.to_string())?;
+    build_chat_request_from_turn(req, &turn)
+}
+
+fn build_chat_request_from_turn(
+    req: &ResponsesApiRequest,
+    turn: &CodexTurn,
 ) -> Result<ChatCompletionRequest, String> {
     let mut messages: Vec<ChatMessage> = Vec::new();
 
@@ -171,9 +188,9 @@ pub(crate) fn build_chat_request(
         });
     }
 
-    match &req.input {
-        ResponseInput::Text(text) => {
-            messages.push(ChatMessage {
+    for item in &turn.items {
+        let message = match item {
+            CodexTurnItem::Text(text) => ChatMessage {
                 role: MessageRole::User,
                 content: Some(MessageContent::Text(text.clone())),
                 name: None,
@@ -181,96 +198,82 @@ pub(crate) fn build_chat_request(
                 tool_calls: None,
                 tool_call_id: None,
                 audio: None,
-            });
-        }
-        ResponseInput::Items(items) => {
-            for item in items {
-                let ResponseInputItem::Message(msg) = item else {
-                    return Err(format!(
-                        "unsupported Codex feature: {}",
-                        item.feature_name()
-                    ));
-                };
-                let role = parse_role(&msg.role)?;
-                let content = match &msg.content {
-                    ResponseInputContent::Text(t) => MessageContent::Text(t.clone()),
-                    ResponseInputContent::Parts(parts) => {
-                        let mut content_parts: Vec<ContentPart> = Vec::new();
-                        for p in parts {
-                            match p {
-                                ResponseInputContentPart::InputText { text }
-                                | ResponseInputContentPart::OutputText { text } => {
-                                    content_parts.push(ContentPart::Text { text: text.clone() });
-                                }
-                                ResponseInputContentPart::InputImage { image_url, detail } => {
-                                    match image_url {
-                                        Some(url) => {
-                                            content_parts.push(ContentPart::ImageUrl {
-                                                image_url: ImageUrl {
-                                                    url: url.clone(),
-                                                    detail: detail.clone(),
-                                                },
-                                            });
-                                        }
-                                        None => {
-                                            return Err(
-                                                "input_image part is missing image_url".to_string()
-                                            );
-                                        }
-                                    }
-                                }
-                                ResponseInputContentPart::InputAudio { .. } => {
-                                    return Err(
-                                        "unsupported Codex feature: input_audio".to_string()
-                                    );
-                                }
-                            }
-                        }
-                        if content_parts.len() == 1 {
-                            if let ContentPart::Text { text } = &content_parts[0] {
-                                MessageContent::Text(text.clone())
-                            } else {
-                                MessageContent::Parts(content_parts)
-                            }
-                        } else {
-                            MessageContent::Parts(content_parts)
-                        }
-                    }
-                };
-                messages.push(ChatMessage {
-                    role,
-                    content: Some(content),
-                    name: None,
-                    function_call: None,
-                    tool_calls: None,
-                    tool_call_id: None,
-                    audio: None,
-                });
+            },
+            CodexTurnItem::Item(ResponseInputItem::Message(message)) => {
+                response_message_to_chat(message)?
             }
-        }
+            CodexTurnItem::Item(ResponseInputItem::FunctionCall(call)) => {
+                push_tool_call(
+                    &mut messages,
+                    &call.call_id,
+                    &call.name,
+                    call.arguments.clone(),
+                );
+                continue;
+            }
+            CodexTurnItem::Item(ResponseInputItem::CustomToolCall(call)) => {
+                push_tool_call(
+                    &mut messages,
+                    &call.call_id,
+                    &call.name,
+                    serde_json::json!({"input": call.input}).to_string(),
+                );
+                continue;
+            }
+            CodexTurnItem::Item(ResponseInputItem::FunctionCallOutput(output)) => {
+                tool_output_message(&output.call_id, tool_output_text(&output.output)?)
+            }
+            CodexTurnItem::Item(ResponseInputItem::CustomToolCallOutput(output)) => {
+                tool_output_message(&output.call_id, tool_output_text(&output.output)?)
+            }
+            CodexTurnItem::Item(item) => {
+                return Err(format!(
+                    "unsupported Codex feature: {}",
+                    item.feature_name()
+                ));
+            }
+        };
+        messages.push(message);
     }
 
     if messages.is_empty() {
         return Err("input must contain at least one message".to_string());
     }
 
-    let mut tools: Vec<crate::core::models::openai::tools::Tool> = Vec::new();
-    if let Some(req_tools) = &req.tools {
-        for t in req_tools {
-            let function = match t {
-                ResponseTool::Function(tool) => &tool.function,
-                ResponseTool::CodexFunction(tool) => tool,
-                _ => return Err(format!("unsupported Codex feature: {}", t.feature_name())),
-            };
-            tools.push(crate::core::models::openai::tools::Tool {
-                tool_type: "function".to_string(),
-                function: crate::core::models::openai::tools::Function {
-                    name: function.name.clone(),
-                    description: function.description.clone(),
-                    parameters: function.parameters.clone(),
-                },
-            });
-        }
+    let mut tools = Vec::new();
+    for tool in &turn.tools {
+        let function = match tool {
+            ResponseTool::Function(tool) => Function {
+                name: tool.function.name.clone(),
+                description: tool.function.description.clone(),
+                parameters: tool.function.parameters.clone(),
+            },
+            ResponseTool::CodexFunction(tool) => Function {
+                name: tool.name.clone(),
+                description: tool.description.clone(),
+                parameters: tool.parameters.clone(),
+            },
+            ResponseTool::Custom(tool) => Function {
+                name: tool.name.clone(),
+                description: Some(tool.description.clone()),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                    "required": ["input"],
+                    "additionalProperties": false
+                })),
+            },
+            tool => {
+                return Err(format!(
+                    "unsupported Codex feature: {}",
+                    tool.feature_name()
+                ));
+            }
+        };
+        tools.push(Tool {
+            tool_type: "function".to_string(),
+            function,
+        });
     }
 
     Ok(ChatCompletionRequest {
@@ -290,42 +293,99 @@ pub(crate) fn build_chat_request(
     })
 }
 
-fn unsupported_codex_feature(request: &ResponsesApiRequest) -> Option<&str> {
-    if request.additional_tools.is_some() {
-        return Some("additional_tools");
-    }
-    if let ResponseInput::Items(items) = &request.input {
-        for item in items {
-            match item {
-                ResponseInputItem::Message(message) => {
-                    if let ResponseInputContent::Parts(parts) = &message.content
-                        && parts
-                            .iter()
-                            .any(|part| matches!(part, ResponseInputContentPart::InputAudio { .. }))
-                    {
-                        return Some("input_audio");
+fn response_message_to_chat(
+    message: &crate::core::models::openai::responses_api::ResponseInputMessage,
+) -> Result<ChatMessage, String> {
+    let content = match &message.content {
+        ResponseInputContent::Text(text) => MessageContent::Text(text.clone()),
+        ResponseInputContent::Parts(parts) => {
+            let mut converted = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part {
+                    ResponseInputContentPart::InputText { text }
+                    | ResponseInputContentPart::OutputText { text } => {
+                        converted.push(ContentPart::Text { text: text.clone() });
+                    }
+                    ResponseInputContentPart::InputImage { image_url, detail } => {
+                        let url = image_url
+                            .as_ref()
+                            .ok_or_else(|| "input_image part is missing image_url".to_string())?;
+                        converted.push(ContentPart::ImageUrl {
+                            image_url: ImageUrl {
+                                url: url.clone(),
+                                detail: detail.clone(),
+                            },
+                        });
+                    }
+                    ResponseInputContentPart::InputAudio { .. } => {
+                        return Err("unsupported Codex feature: input_audio".to_string());
                     }
                 }
-                item => return Some(item.feature_name()),
+            }
+            match converted.as_slice() {
+                [ContentPart::Text { text }] => MessageContent::Text(text.clone()),
+                _ => MessageContent::Parts(converted),
             }
         }
-    }
-    request.tools.as_ref()?.iter().find_map(|tool| match tool {
-        ResponseTool::Function(tool) if tool.function.defer_loading == Some(true) => {
-            Some("defer_loading")
-        }
-        ResponseTool::CodexFunction(tool) if tool.defer_loading == Some(true) => {
-            Some("defer_loading")
-        }
-        ResponseTool::CodexFunction(tool) if tool.strict == Some(true) => Some("strict"),
-        ResponseTool::CodexFunction(tool)
-            if tool.description.is_none() || tool.parameters.is_none() || tool.strict.is_none() =>
-        {
-            Some("function_schema")
-        }
-        ResponseTool::Function(_) | ResponseTool::CodexFunction(_) => None,
-        tool => Some(tool.feature_name()),
+    };
+    Ok(ChatMessage {
+        role: parse_role(&message.role)?,
+        content: Some(content),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
     })
+}
+
+fn push_tool_call(messages: &mut Vec<ChatMessage>, call_id: &str, name: &str, arguments: String) {
+    let tool_call = ToolCall {
+        id: call_id.to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: name.to_string(),
+            arguments,
+        },
+    };
+    if let Some(message) = messages.last_mut()
+        && message.role == MessageRole::Assistant
+        && message.content.is_none()
+        && let Some(tool_calls) = message.tool_calls.as_mut()
+    {
+        tool_calls.push(tool_call);
+        return;
+    }
+    messages.push(ChatMessage {
+        role: MessageRole::Assistant,
+        content: None,
+        name: None,
+        function_call: None,
+        tool_calls: Some(vec![tool_call]),
+        tool_call_id: None,
+        audio: None,
+    });
+}
+
+fn tool_output_message(call_id: &str, output: String) -> ChatMessage {
+    ChatMessage {
+        role: MessageRole::Tool,
+        content: Some(MessageContent::Text(output)),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: Some(call_id.to_string()),
+        audio: None,
+    }
+}
+
+fn tool_output_text(output: &CodexToolOutput) -> Result<String, String> {
+    match output {
+        CodexToolOutput::Text(text) => Ok(text.clone()),
+        CodexToolOutput::ContentItems(items) => {
+            serde_json::to_string(items).map_err(|error| format!("invalid tool output: {error}"))
+        }
+    }
 }
 
 // ── Response conversion ───────────────────────────────────────────────────────
@@ -387,16 +447,28 @@ pub(crate) fn convert_to_responses_api(
                 }));
             }
 
-            // Tool calls → function call output items
+            // Tool calls → function or Codex custom-tool output items.
             if let Some(tool_calls) = choice.message.tool_calls {
                 for tc in tool_calls {
-                    items.push(ResponseOutputItem::FunctionCall(ResponseFunctionCall {
-                        id: format!("fc_{}", uuid_v4_hex()),
-                        name: tc.function.name.clone(),
-                        arguments: tc.function.arguments.clone(),
-                        status: finish_status.to_string(),
-                        call_id: Some(tc.id.clone()),
-                    }));
+                    if is_custom_tool(original, &tc.function.name) {
+                        items.push(ResponseOutputItem::CustomToolCall(CodexCustomToolCall {
+                            id: Some(format!("ct_{}", uuid_v4_hex())),
+                            call_id: tc.id.clone(),
+                            name: tc.function.name.clone(),
+                            namespace: None,
+                            input: custom_tool_input(&tc.function.arguments),
+                            status: Some(finish_status.to_string()),
+                            internal_chat_message_metadata_passthrough: None,
+                        }));
+                    } else {
+                        items.push(ResponseOutputItem::FunctionCall(ResponseFunctionCall {
+                            id: format!("fc_{}", uuid_v4_hex()),
+                            name: tc.function.name.clone(),
+                            arguments: tc.function.arguments.clone(),
+                            status: finish_status.to_string(),
+                            call_id: Some(tc.id.clone()),
+                        }));
+                    }
                 }
             }
 
@@ -442,6 +514,26 @@ pub(crate) fn convert_to_responses_api(
         previous_response_id: original.previous_response_id.clone(),
         metadata: original.metadata.clone(),
     }
+}
+
+pub(crate) fn is_custom_tool(original: &ResponsesApiRequest, name: &str) -> bool {
+    original.tools.as_ref().is_some_and(|tools| {
+        tools
+            .iter()
+            .any(|tool| matches!(tool, ResponseTool::Custom(tool) if tool.name == name))
+    })
+}
+
+pub(crate) fn custom_tool_input(arguments: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(arguments)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("input")
+                .and_then(|input| input.as_str())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| arguments.to_string())
 }
 
 /// Map a chat-completion `finish_reason` to a Responses API item/response status.

--- a/src/server/routes/ai/responses/codex_compat_tests.rs
+++ b/src/server/routes/ai/responses/codex_compat_tests.rs
@@ -1,9 +1,12 @@
 use crate::core::models::openai::responses_api::{
-    ResponseInputItem, ResponseTool, ResponsesApiRequest,
+    ResponseInputItem, ResponseOutputItem, ResponseTool, ResponsesApiRequest,
 };
-use crate::core::types::codex::domain::{
-    CodexCallKind, CodexCallState, CodexTurn, CodexTurnError, CodexTurnItem,
+use crate::core::models::openai::{
+    messages::{ChatMessage, MessageRole},
+    responses::{ChatChoice, ChatCompletionResponse},
+    tools::{FunctionCall, ToolCall},
 };
+use crate::core::types::codex::domain::{CodexCallKind, CodexTurn, CodexTurnError, CodexTurnItem};
 use crate::core::types::codex::wire::CODEX_PROTOCOL_BASELINE;
 use actix_web::{body::to_bytes, http::StatusCode, test as actix_test, web};
 use serde_json::{Value, json};
@@ -78,6 +81,7 @@ fn codex_wire_distinguishes_tier_two_and_redacts_unknown_payload() {
 }
 #[actix_web::test]
 async fn codex_wire_http_rejects_before_provider_dispatch() {
+    let _guard = super::CODEX_DISPATCH_TEST_LOCK.lock().await;
     let mut config = crate::config::Config::default();
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
@@ -85,7 +89,6 @@ async fn codex_wire_http_rejects_before_provider_dispatch() {
     let state = web::Data::new(server.state().clone());
     super::PROVIDER_DISPATCH_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
     let mut fixtures = vec![
-        json!({"model":"m","input":[{"type":"function_call","call_id":"c","name":"f","arguments":"{}"}]}),
         json!({"model":"m","input":[{"type":"future\nsecret=abcdefghijklmnop","secret":"drop"}]}),
         json!({"model":"m","input":"x","additional_tools":[{"type":"function","name":"f"}]}),
         json!({"model":"m","input":"x","additional_tools":[]}),
@@ -93,8 +96,6 @@ async fn codex_wire_http_rejects_before_provider_dispatch() {
     ];
     fixtures.extend(tier_two_items().map(|item| json!({"model":"m","input":[item]})));
     for tool in [
-        json!({"type":"custom","name":"shell","description":"d","format":{}}),
-        json!({"type":"function","name":"f"}),
         json!({"type":"function","name":"f","defer_loading":true}),
         json!({"type":"function","name":"f","strict":true}),
         json!({"type":"namespace"}),
@@ -140,20 +141,43 @@ async fn codex_wire_http_rejects_before_provider_dispatch() {
     );
 }
 
+#[actix_web::test]
+async fn codex_tier_one_reaches_provider_dispatch() {
+    let _guard = super::CODEX_DISPATCH_TEST_LOCK.lock().await;
+    let mut config = crate::config::Config::default();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    let server = crate::server::HttpServer::new(&config).await.unwrap();
+    let state = web::Data::new(server.state().clone());
+    super::PROVIDER_DISPATCH_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
+    let payload = codex_request(json!({
+        "model":"m",
+        "store":false,
+        "input":[{"type":"message","role":"user","content":"run"}],
+        "tools":[
+            {"type":"function","name":"lookup","parameters":{"type":"object"}},
+            {"type":"custom","name":"shell","description":"shell","format":{"type":"text"}}
+        ]
+    }));
+    let req = actix_test::TestRequest::post()
+        .insert_header(("x-codex-upstream-counter", "1"))
+        .to_http_request();
+    let _ = super::create_response(state, req, web::Json(payload))
+        .await
+        .unwrap();
+    assert_eq!(
+        super::PROVIDER_DISPATCH_COUNT.load(std::sync::atomic::Ordering::Relaxed),
+        1
+    );
+}
+
 #[test]
 fn codex_turn_preserves_order_and_correlates_mixed_calls() {
     let request = codex_request(serde_json::from_str(r#"{"model":"m","stream":true,"input":[{"type":"message","role":"user","content":"run both"},{"type":"function_call","call_id":"function-1","name":"lookup","arguments":"{}"},{"type":"custom_tool_call","call_id":"custom-1","name":"shell","namespace":"tools","input":"pwd"},{"type":"custom_tool_call_output","call_id":"custom-1","name":"shell","output":"/tmp"},{"type":"function_call_output","call_id":"function-1","output":"ok"}],"tools":[{"type":"function","name":"lookup","description":"lookup","parameters":{"type":"object"},"strict":false},{"type":"custom","name":"shell","description":"shell","format":{}}]}"#).unwrap());
 
     let turn = CodexTurn::try_from(&request).unwrap();
 
-    assert_eq!(turn.protocol_version, CODEX_PROTOCOL_BASELINE);
     assert_eq!(turn.tools.len(), 2);
-    assert_eq!(turn.store, None);
-    assert!(!turn.background);
-    assert!(turn.requirements.streaming);
-    assert!(turn.requirements.function_tools);
-    assert!(turn.requirements.custom_tools);
-    assert!(turn.requirements.call_outputs);
     assert!(matches!(
         turn.items[0],
         CodexTurnItem::Item(ResponseInputItem::Message(_))
@@ -175,25 +199,92 @@ fn codex_turn_preserves_order_and_correlates_mixed_calls() {
         CodexTurnItem::Item(ResponseInputItem::FunctionCallOutput(_))
     ));
 
-    let calls = &turn.ledger.calls;
-    assert_eq!(calls.len(), 2);
-    assert_eq!(calls[0].call_id, "function-1");
-    assert_eq!(calls[0].name, "lookup");
-    assert_eq!(calls[0].kind, CodexCallKind::Function);
-    assert_eq!(calls[0].state, CodexCallState::OutputReceived);
+    let chat = super::build_chat_request(&request).unwrap();
+    let encoded = serde_json::to_value(chat).unwrap();
+    assert_eq!(encoded["messages"][1]["tool_calls"][0]["id"], "function-1");
+    assert_eq!(encoded["messages"][1]["tool_calls"][1]["id"], "custom-1");
+    assert_eq!(encoded["messages"][2]["tool_call_id"], "custom-1");
+    assert_eq!(encoded["messages"][3]["tool_call_id"], "function-1");
+    assert_eq!(encoded["tools"][0]["function"]["name"], "lookup");
+    assert_eq!(encoded["tools"][1]["function"]["name"], "shell");
     assert_eq!(
-        (calls[0].declaration_index, calls[0].output_index),
-        (1, Some(4))
+        encoded["tools"][1]["function"]["parameters"]["required"][0],
+        "input"
     );
-    assert_eq!(calls[1].call_id, "custom-1");
-    assert_eq!(calls[1].name, "shell");
-    assert_eq!(calls[1].kind, CodexCallKind::Custom);
-    assert_eq!(calls[1].namespace.as_deref(), Some("tools"));
-    assert_eq!(calls[1].state, CodexCallState::OutputReceived);
-    assert_eq!(
-        (calls[1].declaration_index, calls[1].output_index),
-        (2, Some(3))
-    );
+}
+
+#[test]
+fn codex_non_streaming_reconstructs_custom_tool_output() {
+    let request = codex_request(json!({
+        "model":"m",
+        "input":"run",
+        "tools":[{"type":"custom","name":"shell","description":"shell","format":{"type":"text"}}]
+    }));
+    let chat = ChatCompletionResponse {
+        id: "chat_1".into(),
+        object: "chat.completion".into(),
+        created: 1,
+        model: "m".into(),
+        system_fingerprint: None,
+        choices: vec![ChatChoice {
+            index: 0,
+            message: ChatMessage {
+                role: MessageRole::Assistant,
+                content: None,
+                name: None,
+                function_call: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_1".into(),
+                    tool_type: "function".into(),
+                    function: FunctionCall {
+                        name: "shell".into(),
+                        arguments: r#"{"input":"pwd"}"#.into(),
+                    },
+                }]),
+                tool_call_id: None,
+                audio: None,
+            },
+            logprobs: None,
+            finish_reason: Some("tool_calls".into()),
+        }],
+        usage: None,
+    };
+
+    let response = super::convert_to_responses_api(chat, &request);
+    let ResponseOutputItem::CustomToolCall(call) = &response.output[0] else {
+        panic!("custom tool must remain custom in Responses output");
+    };
+    assert_eq!(call.call_id, "call_1");
+    assert_eq!(call.name, "shell");
+    assert_eq!(call.input, "pwd");
+    assert_eq!(call.status.as_deref(), Some("completed"));
+}
+
+#[test]
+fn portable_codex_turn_has_one_contract_for_supported_adapter_families() {
+    for model in [
+        "openai-compatible/test",
+        "anthropic/claude-test",
+        "gemini/gemini-test",
+    ] {
+        let request = codex_request(json!({
+            "model":model,
+            "input":[
+                {"type":"message","role":"user","content":"run"},
+                {"type":"custom_tool_call","call_id":"call_1","name":"shell","input":"pwd"},
+                {"type":"custom_tool_call_output","call_id":"call_1","name":"shell","output":"/tmp"}
+            ],
+            "tools":[{"type":"custom","name":"shell","description":"shell","format":{"type":"text"}}]
+        }));
+        let chat = super::build_chat_request(&request).unwrap();
+        assert_eq!(chat.model, model);
+        assert_eq!(
+            chat.messages[1].tool_calls.as_ref().unwrap()[0].id,
+            "call_1"
+        );
+        assert_eq!(chat.messages[2].tool_call_id.as_deref(), Some("call_1"));
+        assert_eq!(chat.tools.as_ref().unwrap()[0].function.name, "shell");
+    }
 }
 
 #[test]
@@ -203,14 +294,7 @@ fn codex_call_ledger_accepts_each_parallel_output_order() {
         r#"[{"type":"function_call","call_id":"function-1","name":"lookup","arguments":"{}"},{"type":"custom_tool_call","call_id":"custom-1","name":"shell","input":"pwd"},{"type":"custom_tool_call_output","call_id":"custom-1","name":"shell","output":"ok"},{"type":"function_call_output","call_id":"function-1","output":"ok"}]"#,
     ] {
         let turn = codex_turn_json(input).unwrap();
-        assert_eq!(turn.ledger.calls[0].call_id, "function-1");
-        assert_eq!(turn.ledger.calls[1].call_id, "custom-1");
-        assert!(
-            turn.ledger
-                .calls
-                .iter()
-                .all(|call| call.state == CodexCallState::OutputReceived)
-        );
+        assert_eq!(turn.items.len(), 4);
     }
 }
 
@@ -261,11 +345,13 @@ fn codex_turn_rejects_invalid_tool_definitions() {
         r#"{"model":"m","input":"x","tools":[{"type":"function","name":" ","parameters":{}}]}"#,
         r#"{"model":"m","input":"x","tools":[{"type":"custom","name":" ","description":"d","format":{}}]}"#,
         r#"{"model":"m","input":"x","tools":[{"type":"function","name":"lookup","defer_loading":true}]}"#,
+        r#"{"model":"m","input":"x","tools":[{"type":"custom","name":"shell","description":"d","format":{"type":"grammar","syntax":"regex","definition":".*"}}]}"#,
     ];
     let expected = [
         CodexTurnError::EmptyToolName { tool_index: 0 },
         CodexTurnError::EmptyToolName { tool_index: 0 },
         CodexTurnError::UnsupportedFeature("defer_loading".into()),
+        CodexTurnError::UnsupportedFeature("custom.format".into()),
     ];
     for (request, expected) in requests.into_iter().zip(expected) {
         let request = codex_request(serde_json::from_str(request).unwrap());

--- a/src/server/routes/ai/responses/codex_compat_tests.rs
+++ b/src/server/routes/ai/responses/codex_compat_tests.rs
@@ -1,11 +1,18 @@
 use crate::core::models::openai::responses_api::{
     ResponseInputItem, ResponseTool, ResponsesApiRequest,
 };
+use crate::core::types::codex::domain::{
+    CodexCallKind, CodexCallState, CodexTurn, CodexTurnError, CodexTurnItem,
+};
 use crate::core::types::codex::wire::CODEX_PROTOCOL_BASELINE;
 use actix_web::{body::to_bytes, http::StatusCode, test as actix_test, web};
 use serde_json::{Value, json};
 fn codex_request(value: Value) -> ResponsesApiRequest {
     serde_json::from_value(value).unwrap()
+}
+fn codex_turn_json(input: &str) -> Result<CodexTurn, CodexTurnError> {
+    let input: Value = serde_json::from_str(input).unwrap();
+    CodexTurn::try_from(&codex_request(json!({"model":"m","input":input})))
 }
 fn tier_two_items() -> [Value; 10] {
     serde_json::from_str(r#"[{"type":"additional_tools","role":"developer","tools":[]},{"type":"local_shell_call","call_id":"c1","status":"completed","action":{}},{"type":"mcp_tool_call_output","call_id":"c1","output":{"content":[]}},{"type":"tool_search_call","call_id":"c1","status":"completed","execution":"client","arguments":{}},{"type":"tool_search_output","call_id":"c1","status":"completed","execution":"client","tools":[]},{"type":"web_search_call","id":"i1","status":"completed"},{"type":"image_generation_call","id":"i1","status":"completed","result":"data"},{"type":"compaction","id":"i1","encrypted_content":"opaque"},{"type":"compaction_trigger"},{"type":"context_compaction","id":"i1","encrypted_content":"opaque"}]"#).unwrap()
@@ -131,4 +138,137 @@ async fn codex_wire_http_rejects_before_provider_dispatch() {
         super::PROVIDER_DISPATCH_COUNT.load(std::sync::atomic::Ordering::Relaxed),
         0
     );
+}
+
+#[test]
+fn codex_turn_preserves_order_and_correlates_mixed_calls() {
+    let request = codex_request(serde_json::from_str(r#"{"model":"m","stream":true,"input":[{"type":"message","role":"user","content":"run both"},{"type":"function_call","call_id":"function-1","name":"lookup","arguments":"{}"},{"type":"custom_tool_call","call_id":"custom-1","name":"shell","namespace":"tools","input":"pwd"},{"type":"custom_tool_call_output","call_id":"custom-1","name":"shell","output":"/tmp"},{"type":"function_call_output","call_id":"function-1","output":"ok"}],"tools":[{"type":"function","name":"lookup","description":"lookup","parameters":{"type":"object"},"strict":false},{"type":"custom","name":"shell","description":"shell","format":{}}]}"#).unwrap());
+
+    let turn = CodexTurn::try_from(&request).unwrap();
+
+    assert_eq!(turn.protocol_version, CODEX_PROTOCOL_BASELINE);
+    assert_eq!(turn.tools.len(), 2);
+    assert_eq!(turn.store, None);
+    assert!(!turn.background);
+    assert!(turn.requirements.streaming);
+    assert!(turn.requirements.function_tools);
+    assert!(turn.requirements.custom_tools);
+    assert!(turn.requirements.call_outputs);
+    assert!(matches!(
+        turn.items[0],
+        CodexTurnItem::Item(ResponseInputItem::Message(_))
+    ));
+    assert!(matches!(
+        turn.items[1],
+        CodexTurnItem::Item(ResponseInputItem::FunctionCall(_))
+    ));
+    assert!(matches!(
+        turn.items[2],
+        CodexTurnItem::Item(ResponseInputItem::CustomToolCall(_))
+    ));
+    assert!(matches!(
+        turn.items[3],
+        CodexTurnItem::Item(ResponseInputItem::CustomToolCallOutput(_))
+    ));
+    assert!(matches!(
+        turn.items[4],
+        CodexTurnItem::Item(ResponseInputItem::FunctionCallOutput(_))
+    ));
+
+    let calls = &turn.ledger.calls;
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].call_id, "function-1");
+    assert_eq!(calls[0].name, "lookup");
+    assert_eq!(calls[0].kind, CodexCallKind::Function);
+    assert_eq!(calls[0].state, CodexCallState::OutputReceived);
+    assert_eq!(
+        (calls[0].declaration_index, calls[0].output_index),
+        (1, Some(4))
+    );
+    assert_eq!(calls[1].call_id, "custom-1");
+    assert_eq!(calls[1].name, "shell");
+    assert_eq!(calls[1].kind, CodexCallKind::Custom);
+    assert_eq!(calls[1].namespace.as_deref(), Some("tools"));
+    assert_eq!(calls[1].state, CodexCallState::OutputReceived);
+    assert_eq!(
+        (calls[1].declaration_index, calls[1].output_index),
+        (2, Some(3))
+    );
+}
+
+#[test]
+fn codex_call_ledger_accepts_each_parallel_output_order() {
+    for input in [
+        r#"[{"type":"function_call","call_id":"function-1","name":"lookup","arguments":"{}"},{"type":"custom_tool_call","call_id":"custom-1","name":"shell","input":"pwd"},{"type":"function_call_output","call_id":"function-1","output":"ok"},{"type":"custom_tool_call_output","call_id":"custom-1","name":"shell","output":"ok"}]"#,
+        r#"[{"type":"function_call","call_id":"function-1","name":"lookup","arguments":"{}"},{"type":"custom_tool_call","call_id":"custom-1","name":"shell","input":"pwd"},{"type":"custom_tool_call_output","call_id":"custom-1","name":"shell","output":"ok"},{"type":"function_call_output","call_id":"function-1","output":"ok"}]"#,
+    ] {
+        let turn = codex_turn_json(input).unwrap();
+        assert_eq!(turn.ledger.calls[0].call_id, "function-1");
+        assert_eq!(turn.ledger.calls[1].call_id, "custom-1");
+        assert!(
+            turn.ledger
+                .calls
+                .iter()
+                .all(|call| call.state == CodexCallState::OutputReceived)
+        );
+    }
+}
+
+#[test]
+fn codex_call_ledger_rejects_invalid_input_without_leaking_identity() {
+    use CodexCallKind::{Custom, Function};
+    let secret = "abcdefghijklmnop";
+    let inputs = [
+        r#"[{"type":"function_call","call_id":"abcdefghijklmnop","name":"lookup","arguments":"{}"},{"type":"function_call","call_id":"abcdefghijklmnop","name":"lookup","arguments":"{}"}]"#,
+        r#"[{"type":"function_call_output","call_id":"c1","output":"ok"}]"#,
+        r#"[{"type":"function_call","call_id":"c1","name":"lookup","arguments":"{}"},{"type":"function_call_output","call_id":"c1","output":"ok"},{"type":"function_call_output","call_id":"c1","output":"again"}]"#,
+        r#"[{"type":"function_call","call_id":"c1","name":"lookup","arguments":"{}"},{"type":"custom_tool_call_output","call_id":"c1","name":"lookup","output":"ok"}]"#,
+        r#"[{"type":"function_call","call_id":" ","name":"lookup","arguments":"{}"}]"#,
+        r#"[{"type":"custom_tool_call","call_id":"c1","name":" ","input":"pwd"}]"#,
+        r#"[{"type":"custom_tool_call","call_id":"c1","name":"shell","input":"pwd"},{"type":"custom_tool_call_output","call_id":"c1","name":" ","output":"ok"}]"#,
+        r#"[{"type":"custom_tool_call","call_id":"c1","name":"shell","input":"pwd"},{"type":"custom_tool_call_output","call_id":"c1","name":"other","output":"ok"}]"#,
+        r#"[{"type":"function_call","call_id":"c1","name":"lookup","arguments":"not-json"}]"#,
+        r#"[{"type":"custom_tool_call","call_id":"c1","name":"shell","input":""}]"#,
+        r#"[{"type":"function_call","call_id":"c1","name":"lookup","arguments":"{}"},{"type":"function_call_output","call_id":"c1","output":""}]"#,
+        r#"[{"type":"message","role":"intruder","content":"x"}]"#,
+        r#"[{"type":"future_item","id":"i1","secret":"drop"}]"#,
+    ];
+    let expected = [
+        CodexTurnError::DuplicateCallId(1),
+        CodexTurnError::UnknownCallId(0),
+        CodexTurnError::DuplicateCallOutput(2),
+        CodexTurnError::CallKindMismatch(Function, Custom, 1),
+        CodexTurnError::EmptyCallId { item_index: 0 },
+        CodexTurnError::InvalidCallName { item_index: 0 },
+        CodexTurnError::InvalidCallName { item_index: 1 },
+        CodexTurnError::InvalidCallName { item_index: 1 },
+        CodexTurnError::InvalidFunctionArguments { item_index: 0 },
+        CodexTurnError::EmptyCallPayload { item_index: 0 },
+        CodexTurnError::EmptyCallPayload { item_index: 1 },
+        CodexTurnError::InvalidMessageRole { item_index: 0 },
+        CodexTurnError::UnsupportedFeature("future_item".into()),
+    ];
+    for (input, expected) in inputs.into_iter().zip(expected) {
+        let actual = codex_turn_json(input).unwrap_err();
+        assert_eq!(actual, expected);
+        assert!(!format!("{actual:?} {actual}").contains(secret));
+    }
+}
+
+#[test]
+fn codex_turn_rejects_invalid_tool_definitions() {
+    let requests = [
+        r#"{"model":"m","input":"x","tools":[{"type":"function","name":" ","parameters":{}}]}"#,
+        r#"{"model":"m","input":"x","tools":[{"type":"custom","name":" ","description":"d","format":{}}]}"#,
+        r#"{"model":"m","input":"x","tools":[{"type":"function","name":"lookup","defer_loading":true}]}"#,
+    ];
+    let expected = [
+        CodexTurnError::EmptyToolName { tool_index: 0 },
+        CodexTurnError::EmptyToolName { tool_index: 0 },
+        CodexTurnError::UnsupportedFeature("defer_loading".into()),
+    ];
+    for (request, expected) in requests.into_iter().zip(expected) {
+        let request = codex_request(serde_json::from_str(request).unwrap());
+        assert_eq!(CodexTurn::try_from(&request).unwrap_err(), expected);
+    }
 }

--- a/src/server/routes/ai/responses/lifecycle.rs
+++ b/src/server/routes/ai/responses/lifecycle.rs
@@ -3,6 +3,7 @@ use crate::core::models::openai::responses_api::{
     ResponseInput, ResponseInputContent, ResponseInputItem, ResponseInputMessage,
     ResponseOutputContent, ResponseOutputItem, ResponsesApiRequest, ResponsesApiResponse,
 };
+use crate::core::types::codex::wire::CodexFunctionCall;
 use crate::server::routes::ai::chat::handle_chat_completion_with_state;
 use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
@@ -507,21 +508,35 @@ fn stable_input_item_id(index: usize, item: &ResponseInputItem) -> String {
 fn output_items_as_input_context(output: &[ResponseOutputItem]) -> Vec<ResponseInputItem> {
     output
         .iter()
-        .filter_map(|item| {
-            let ResponseOutputItem::Message(message) = item else {
-                return None;
-            };
-            let text = output_text_content(&message.content);
-            if text.trim().is_empty() {
-                return None;
+        .filter_map(|item| match item {
+            ResponseOutputItem::Message(message) => {
+                let text = output_text_content(&message.content);
+                if text.trim().is_empty() {
+                    return None;
+                }
+                Some(ResponseInputItem::Message(ResponseInputMessage {
+                    id: Some(message.id.clone()),
+                    phase: None,
+                    internal_chat_message_metadata_passthrough: None,
+                    role: "assistant".to_string(),
+                    content: ResponseInputContent::Text(text),
+                }))
             }
-            Some(ResponseInputItem::Message(ResponseInputMessage {
-                id: Some(message.id.clone()),
-                phase: None,
-                internal_chat_message_metadata_passthrough: None,
-                role: "assistant".to_string(),
-                content: ResponseInputContent::Text(text),
-            }))
+            ResponseOutputItem::FunctionCall(call) => {
+                Some(ResponseInputItem::FunctionCall(CodexFunctionCall {
+                    id: Some(call.id.clone()),
+                    call_id: call.call_id.clone().unwrap_or_else(|| call.id.clone()),
+                    name: call.name.clone(),
+                    namespace: None,
+                    arguments: call.arguments.clone(),
+                    status: Some(call.status.clone()),
+                    internal_chat_message_metadata_passthrough: None,
+                }))
+            }
+            ResponseOutputItem::CustomToolCall(call) => {
+                Some(ResponseInputItem::CustomToolCall(call.clone()))
+            }
+            _ => None,
         })
         .collect()
 }

--- a/src/server/routes/ai/responses/lifecycle_tests.rs
+++ b/src/server/routes/ai/responses/lifecycle_tests.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::core::models::openai::responses_api::{
-    ResponseInputContent, ResponseInputItem, ResponseInputMessage, ResponseOutputMessage,
-    ResponsesApiRequest,
+    ResponseFunctionCall, ResponseInputContent, ResponseInputItem, ResponseInputMessage,
+    ResponseOutputMessage, ResponsesApiRequest,
+};
+use crate::core::types::codex::wire::{
+    CodexCustomToolCall, CodexFunctionCallOutput, CodexToolOutput,
 };
 use actix_web::{HttpMessage, body::to_bytes, http::StatusCode, test as actix_test};
 use serde_json::Value;
@@ -126,6 +129,66 @@ fn previous_context_prepends_prior_input_output_and_current_input() {
     let mut missing = req("follow up");
     missing.previous_response_id = Some(previous_id);
     assert!(resolve_previous_response_context(missing, &owner).is_err());
+}
+
+#[test]
+fn previous_context_preserves_codex_calls_for_correlated_outputs() {
+    let owner = Some(owner("codex-chain"));
+    let previous_id = format!("resp_test_{}", uuid_v4_hex());
+    let previous_req = req("run tools");
+    let mut previous_resp = resp(&previous_id, &previous_req, "");
+    previous_resp.output = vec![
+        ResponseOutputItem::FunctionCall(ResponseFunctionCall {
+            id: "fc_1".into(),
+            name: "lookup".into(),
+            arguments: "{}".into(),
+            status: "completed".into(),
+            call_id: Some("function-1".into()),
+        }),
+        ResponseOutputItem::CustomToolCall(CodexCustomToolCall {
+            id: Some("ct_1".into()),
+            call_id: "custom-1".into(),
+            name: "shell".into(),
+            namespace: None,
+            input: "pwd".into(),
+            status: Some("completed".into()),
+            internal_chat_message_metadata_passthrough: None,
+        }),
+    ];
+    store_response_if_requested(&previous_req, &previous_resp, owner.clone());
+
+    let mut follow_up = req("ignored");
+    follow_up.previous_response_id = Some(previous_id.clone());
+    follow_up.input = ResponseInput::Items(vec![
+        ResponseInputItem::FunctionCallOutput(CodexFunctionCallOutput {
+            id: None,
+            call_id: "function-1".into(),
+            output: CodexToolOutput::Text("found".into()),
+            internal_chat_message_metadata_passthrough: None,
+        }),
+        ResponseInputItem::CustomToolCallOutput(
+            crate::core::types::codex::wire::CodexCustomToolCallOutput {
+                id: None,
+                call_id: "custom-1".into(),
+                name: Some("shell".into()),
+                output: CodexToolOutput::Text("/tmp".into()),
+                internal_chat_message_metadata_passthrough: None,
+            },
+        ),
+    ]);
+    let resolved = resolve_previous_response_context(follow_up, &owner).unwrap();
+    assert!(crate::core::types::codex::domain::CodexTurn::try_from(&resolved).is_ok());
+    let ResponseInput::Items(items) = resolved.input else {
+        panic!("item input")
+    };
+    assert!(matches!(items[1], ResponseInputItem::FunctionCall(_)));
+    assert!(matches!(items[2], ResponseInputItem::CustomToolCall(_)));
+    assert!(matches!(items[3], ResponseInputItem::FunctionCallOutput(_)));
+    assert!(matches!(
+        items[4],
+        ResponseInputItem::CustomToolCallOutput(_)
+    ));
+    RESPONSE_STORE.remove(&previous_id);
 }
 
 #[test]

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -5,8 +5,8 @@
 
 use crate::core::models::openai::requests::{ChatCompletionRequest, StreamOptions};
 use crate::core::models::openai::responses_api::{
-    ResponseFunctionCall, ResponseOutputContent, ResponseOutputItem, ResponseOutputMessage,
-    ResponseStreamEvent, ResponsesApiRequest, ResponsesApiResponse,
+    ResponseOutputContent, ResponseOutputItem, ResponseOutputMessage, ResponseStreamEvent,
+    ResponsesApiRequest, ResponsesApiResponse,
 };
 use crate::core::providers::ProviderError;
 use crate::core::streaming::types::Event;
@@ -14,8 +14,8 @@ use crate::core::types::responses::Usage as ChatUsage;
 use crate::core::types::{context::SharedRequestContext, model::ProviderCapability};
 use crate::server::routes::ai::chat::build_core_chat_request;
 use crate::server::routes::ai::responses::{
-    ResponseOwner, current_unix_ts, finish_reason_enum_to_status, store_response_if_requested,
-    uuid_v4_hex,
+    ResponseOwner, current_unix_ts, custom_tool_input, finish_reason_enum_to_status,
+    is_custom_tool, store_response_if_requested, uuid_v4_hex,
 };
 use crate::server::state::AppState;
 use actix_web::http::header::{CACHE_CONTROL, CONTENT_TYPE};
@@ -520,7 +520,6 @@ pub(crate) async fn handle_streaming_response(
                                             std::collections::hash_map::Entry::Vacant(entry),
                                         ) = (&tc.id, tool_states.entry(idx))
                                         {
-                                            let item_id = format!("fc_{}", uuid_v4_hex());
                                             let out_idx = next_output_index;
                                             next_output_index += 1;
                                             let name = tc
@@ -529,21 +528,25 @@ pub(crate) async fn handle_streaming_response(
                                                 .and_then(|f| f.name.as_deref())
                                                 .unwrap_or("")
                                                 .to_string();
+                                            let custom = is_custom_tool(&original, &name);
+                                            let item_id = format!(
+                                                "{}_{}",
+                                                if custom { "ct" } else { "fc" },
+                                                uuid_v4_hex()
+                                            );
 
-                                            let fc_item = ResponseOutputItem::FunctionCall(
-                                                ResponseFunctionCall {
-                                                    id: item_id.clone(),
-                                                    name: name.clone(),
-                                                    arguments: String::new(),
-                                                    status: "in_progress".to_string(),
-                                                    call_id: Some(call_id.clone()),
-                                                },
+                                            let state = ToolCallAccum::new(
+                                                item_id,
+                                                call_id.clone(),
+                                                name,
+                                                out_idx,
+                                                custom,
                                             );
                                             if let Err(error) = emit(
                                                 &tx,
                                                 &ResponseStreamEvent::ResponseOutputItemAdded {
                                                     output_index: out_idx,
-                                                    item: fc_item,
+                                                    item: state.output_item("in_progress"),
                                                 },
                                             )
                                             .await
@@ -551,12 +554,7 @@ pub(crate) async fn handle_streaming_response(
                                                 return_after_emit_error!(error);
                                             }
 
-                                            entry.insert(ToolCallAccum::new(
-                                                item_id,
-                                                call_id.clone(),
-                                                name,
-                                                out_idx,
-                                            ));
+                                            entry.insert(state);
                                             tool_order.push(idx);
                                         }
 
@@ -568,22 +566,14 @@ pub(crate) async fn handle_streaming_response(
                                                 && state.name.is_empty()
                                             {
                                                 state.name.clone_from(n);
+                                                state.custom = is_custom_tool(&original, n);
                                             }
                                             if let Some(args) = &fn_delta.arguments
                                                 && !args.is_empty()
                                             {
                                                 state.arguments.push_str(args);
-                                                let (cid, oi) =
-                                                    (state.call_id.clone(), state.output_index);
-                                                if let Err(error) = emit(
-                                                    &tx,
-                                                    &ResponseStreamEvent::ResponseFunctionCallArgumentsDelta {
-                                                        output_index: oi,
-                                                        call_id: cid,
-                                                        delta: args.clone(),
-                                                    },
-                                                )
-                                                .await
+                                                if let Some(event) = state.delta_event(args.clone())
+                                                    && let Err(error) = emit(&tx, &event).await
                                                 {
                                                     return_after_emit_error!(error);
                                                 }
@@ -698,20 +688,13 @@ pub(crate) async fn handle_streaming_response(
 
                 for idx in &tool_order {
                     if let Some(state) = tool_states.get(idx) {
-                        if let Err(error) = emit(
-                            &tx,
-                            &ResponseStreamEvent::ResponseFunctionCallArgumentsDone {
-                                output_index: state.output_index,
-                                call_id: state.call_id.clone(),
-                                arguments: state.arguments.clone(),
-                            },
-                        )
-                        .await
-                        {
-                            return_after_emit_error!(error);
+                        for event in state.done_events() {
+                            if let Err(error) = emit(&tx, &event).await {
+                                return_after_emit_error!(error);
+                            }
                         }
 
-                        let fc_done = state.completed_item();
+                        let fc_done = state.output_item("completed");
                         if let Err(error) = emit(
                             &tx,
                             &ResponseStreamEvent::ResponseOutputItemDone {

--- a/src/server/routes/ai/responses_stream_state.rs
+++ b/src/server/routes/ai/responses_stream_state.rs
@@ -1,4 +1,7 @@
-use crate::core::models::openai::responses_api::{ResponseFunctionCall, ResponseOutputItem};
+use crate::core::models::openai::responses_api::{
+    ResponseFunctionCall, ResponseOutputItem, ResponseStreamEvent,
+};
+use crate::core::types::codex::wire::CodexCustomToolCall;
 use crate::core::types::responses::Usage as ChatUsage;
 
 pub(super) fn response_stream_total_tokens(
@@ -19,27 +22,82 @@ pub(super) struct ToolCallAccum {
     pub(super) name: String,
     pub(super) arguments: String,
     pub(super) output_index: u32,
+    pub(super) custom: bool,
 }
 
 impl ToolCallAccum {
-    pub(super) fn new(item_id: String, call_id: String, name: String, output_index: u32) -> Self {
+    pub(super) fn new(
+        item_id: String,
+        call_id: String,
+        name: String,
+        output_index: u32,
+        custom: bool,
+    ) -> Self {
         Self {
             item_id,
             call_id,
             name,
             arguments: String::new(),
             output_index,
+            custom,
         }
     }
 
-    pub(super) fn completed_item(&self) -> ResponseOutputItem {
+    pub(super) fn output_item(&self, status: &str) -> ResponseOutputItem {
+        if self.custom {
+            return ResponseOutputItem::CustomToolCall(CodexCustomToolCall {
+                id: Some(self.item_id.clone()),
+                call_id: self.call_id.clone(),
+                name: self.name.clone(),
+                namespace: None,
+                input: super::custom_tool_input(&self.arguments),
+                status: Some(status.to_string()),
+                internal_chat_message_metadata_passthrough: None,
+            });
+        }
         ResponseOutputItem::FunctionCall(ResponseFunctionCall {
             id: self.item_id.clone(),
             name: self.name.clone(),
-            arguments: self.arguments.clone(),
-            status: "completed".to_string(),
+            arguments: if status == "in_progress" {
+                String::new()
+            } else {
+                self.arguments.clone()
+            },
+            status: status.to_string(),
             call_id: Some(self.call_id.clone()),
         })
+    }
+
+    pub(super) fn delta_event(&self, delta: String) -> Option<ResponseStreamEvent> {
+        (!self.custom).then(|| ResponseStreamEvent::ResponseFunctionCallArgumentsDelta {
+            output_index: self.output_index,
+            item_id: self.item_id.clone(),
+            delta,
+        })
+    }
+
+    pub(super) fn done_events(&self) -> Vec<ResponseStreamEvent> {
+        if self.custom {
+            let input = super::custom_tool_input(&self.arguments);
+            return vec![
+                ResponseStreamEvent::ResponseCustomToolCallInputDelta {
+                    output_index: self.output_index,
+                    item_id: self.item_id.clone(),
+                    delta: input.clone(),
+                },
+                ResponseStreamEvent::ResponseCustomToolCallInputDone {
+                    output_index: self.output_index,
+                    item_id: self.item_id.clone(),
+                    input,
+                },
+            ];
+        }
+        vec![ResponseStreamEvent::ResponseFunctionCallArgumentsDone {
+            output_index: self.output_index,
+            item_id: self.item_id.clone(),
+            name: self.name.clone(),
+            arguments: self.arguments.clone(),
+        }]
     }
 }
 

--- a/src/server/routes/ai/responses_stream_tests.rs
+++ b/src/server/routes/ai/responses_stream_tests.rs
@@ -107,6 +107,48 @@ fn test_completed_response_output_contains_reasoning_item() {
 }
 
 #[test]
+fn codex_custom_tool_stream_events_are_ordered_and_lossless() {
+    let mut state = ToolCallAccum::new("ct_1".into(), "call_1".into(), "shell".into(), 2, true);
+    state.arguments = r#"{"input":"echo hello"}"#.into();
+    let added = serde_json::to_value(ResponseStreamEvent::ResponseOutputItemAdded {
+        output_index: 2,
+        item: state.output_item("in_progress"),
+    })
+    .unwrap();
+    let events = state
+        .done_events()
+        .into_iter()
+        .map(|event| serde_json::to_value(event).unwrap())
+        .collect::<Vec<_>>();
+    let done = serde_json::to_value(ResponseStreamEvent::ResponseOutputItemDone {
+        output_index: 2,
+        item: state.output_item("completed"),
+    })
+    .unwrap();
+
+    assert_eq!(added["item"]["type"], "custom_tool_call");
+    assert_eq!(events[0]["type"], "response.custom_tool_call_input.delta");
+    assert_eq!(events[0]["item_id"], "ct_1");
+    assert_eq!(events[0]["delta"], "echo hello");
+    assert_eq!(events[1]["type"], "response.custom_tool_call_input.done");
+    assert_eq!(events[1]["input"], "echo hello");
+    assert_eq!(done["item"]["call_id"], "call_1");
+    assert_eq!(done["item"]["input"], "echo hello");
+}
+
+#[test]
+fn function_call_stream_events_use_response_item_id() {
+    let mut state = ToolCallAccum::new("fc_1".into(), "call_1".into(), "lookup".into(), 0, false);
+    state.arguments = "{}".into();
+    let delta = serde_json::to_value(state.delta_event("{".into()).unwrap()).unwrap();
+    let done = serde_json::to_value(state.done_events().remove(0)).unwrap();
+    assert_eq!(delta["item_id"], "fc_1");
+    assert!(delta.get("call_id").is_none());
+    assert_eq!(done["item_id"], "fc_1");
+    assert_eq!(done["name"], "lookup");
+}
+
+#[test]
 fn test_response_usage_from_chat_usage_preserves_details() {
     let usage = ChatUsage {
         prompt_tokens: 100,


### PR DESCRIPTION
Closes #1107

## Summary
- accept and validate Codex message, function-call, function-output, custom-tool-call, and custom-tool-output items through a canonical turn/ledger
- map portable function and custom tools to provider chat tool protocols while preserving call IDs across stored multi-turn responses
- reconstruct function/custom Responses output for unary and ordered SSE paths; unsupported Tier 2 items fail closed before dispatch
- document manual Codex `wire_api = "responses"` setup without modifying user configuration

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --features providers-extended -- -D warnings`
- `cargo test codex_ --lib` (14 passed)
- `cargo test responses_stream::tests --lib` (10 passed)
- `cargo test` (9,228 lib tests plus integration/doc tests, 0 failed)

## Review
- manual frozen-diff review found and fixed parallel tool calls being emitted as separate assistant messages
- `codex review --uncommitted` was attempted, but the configured Codex account is usage-limited until 2026-08-16; no automated review result is claimed