### PR TITLE
feat(providers): wire native Ollama factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Wired the `ollama` selector to its native chat, streaming, embeddings, tools, and health runtime behind `providers-extended`, with policy-bound public/private endpoint handling for #837.
 - Wired `guardrails` into canonical chat request/response execution with default-on prompt-injection protection and an explicit `guardrails.enabled: false` opt-out.
 - Added gateway `ip_access` configuration and registered its middleware ahead of authentication, handlers, and provider execution; default empty rules remain allow-all.
 - Wired `enterprise.audit_logging` into request audit middleware with structured JSON stderr/file output, and aligned the observability facade with configured Langfuse/OpenTelemetry/Datadog lifecycle callbacks.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ into the enum, dispatch, registry metadata, and factory.
 | `azure` | passthrough / passthrough | `providers-extra` / `providers-extra` | – / – / ✅ | passthrough / passthrough | SDK exposes Azure embeddings; SDK chat is not implemented. |
 | `azure_ai` | passthrough / passthrough | `providers-extra` / `providers-extra` | – / – / – | `providers-extra` / `providers-extra` | `completion()` supports `azure_ai/` and `azure-ai/` routes when the native feature is enabled. |
 | `bedrock` | ✅ / ✅ | ✅ / – | – / – / – | – / – | SDK Bedrock and public `completion()` routing are not implemented. |
-| `mistral`, `cloudflare`, `cohere`, `vertex_ai`, `gemini`, `fal_ai`, `replicate` | provider-specific | provider-specific | – / – / – | – / – | See `support_matrix.rs` for feature-gated HTTP support. |
+| `mistral`, `cloudflare`, `cohere`, `vertex_ai`, `gemini`, `fal_ai`, `replicate`, `ollama` | provider-specific | provider-specific | – / – / – | – / – | See `support_matrix.rs` for feature-gated HTTP support. Ollama retains its existing SDK stream-only path. |
 | `google` / SDK `Google` | – / – | – / – | – / – / – | – / – | Google/Gemini SDK chat is intentionally unsupported until a real adapter exists. |
 | Default catalog dynamic routes: `openrouter`, `deepseek`, `moonshot`, `minimax`, `zhipu`, `zai`, `together_ai`, `fireworks_ai`, `aiml`, `groq`, `xiaomi_mimo`, `xai` | passthrough / passthrough | – / – | – / – / – | ✅ / ✅ | OpenAI-compatible routes wired into default `completion()` routing. |
 | Other Tier 1 catalog providers | passthrough / passthrough | – / – | – / – / – | – / – | HTTP gateway chat/stream only unless routed through explicit OpenAI-compatible config. |
@@ -208,6 +208,7 @@ into the enum, dispatch, registry metadata, and factory.
 | Amazon Nova (`amazon_nova`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | fal.ai (`fal_ai`) | native factory (`providers-extended`) | – | – | – | ✅ | – | Uses native Fal AI image-generation endpoints; chat and streaming are explicitly unsupported. |
 | Replicate (`replicate`) | native factory (`providers-extended`) | ✅ | ✅ | – | ✅ | – | Uses native Replicate prediction lifecycle handling for chat, streaming, and image generation; explicitly unsupported without `providers-extended`. |
+| Ollama (`ollama`) | native factory (`providers-extended`) | ✅ | ✅ | ✅ | – | – | Uses native `/api/chat` NDJSON streaming, `/api/embed`, and model tags/show endpoints. Localhost defaults to private-network endpoint policy; explicit endpoints keep their configured policy. |
 | GitHub Models (`github`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | GitHub Copilot (`github_copilot`) | native factory (`providers-extended`) | ✅ | ✅ | – | – | – | Uses native GitHub Copilot auth and model access when `providers-extended` is enabled; otherwise explicitly unsupported. |
 | Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | – | – | – | For self-hosted / unlisted chat-completions endpoints. |
@@ -228,7 +229,7 @@ All entries below route through `OpenAILikeProvider`. Chat and streaming work fo
 
 The following modules exist under `src/core/providers/` (gated on `providers-extra` or `providers-extended`) but are **not wired into the unified `Provider` enum or the factory** today. They compile but cannot be selected through `create_provider`/`from_config_async`. Treat them as experimental scaffolding subject to change:
 
-`custom_api`, `ollama`
+`custom_api`
 
 For self-hosted or unlisted OpenAI-compatible endpoints, prefer the generic `openai_compatible` provider type instead.
 

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -155,9 +155,7 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
         let api_key_key = provider_env_name(&name, "API_KEY");
         let provider_type = required_env(&type_key)?;
         let selector = provider_type.to_lowercase();
-        let skip_api_key = crate::core::providers::registry::get_definition(&selector)
-            .map(|def| def.skip_api_key)
-            .unwrap_or(false);
+        let skip_api_key = crate::core::providers::registry::selector_skips_api_key(&selector);
         let api_key = if skip_api_key {
             env_var(&api_key_key).unwrap_or_default()
         } else {

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -25,7 +25,7 @@ const TEST_ENV_KEYS: [&str; 24] = [
     "LITELLM_PROVIDER_OPENAI_MODELS",
     "LITELLM_PROVIDER_OPENAI_TAGS",
     "LITELLM_PROVIDER_OPENAI_MAX_RETRIES",
-    "LITELLM_PROVIDER_VLLM_TYPE",
+    "LITELLM_PROVIDER_OLLAMA_TYPE",
 ];
 
 fn clear_test_env() {
@@ -165,8 +165,8 @@ fn test_gateway_config_from_env_allows_local_provider_without_api_key() {
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "true");
         env::set_var(ENV_JWT_SECRET, "StrongJwtSecretWithMixedCaseAndNumbers1234");
-        env::set_var(ENV_PROVIDERS, "vllm");
-        env::set_var("LITELLM_PROVIDER_VLLM_TYPE", "vllm");
+        env::set_var(ENV_PROVIDERS, "ollama");
+        env::set_var("LITELLM_PROVIDER_OLLAMA_TYPE", "ollama");
     }
 
     let config = match GatewayConfig::from_env() {
@@ -174,7 +174,7 @@ fn test_gateway_config_from_env_allows_local_provider_without_api_key() {
         Err(error) => panic!("expected GatewayConfig::from_env() to succeed: {}", error),
     };
     assert_eq!(config.providers.len(), 1);
-    assert_eq!(config.providers[0].provider_type, "vllm");
+    assert_eq!(config.providers[0].provider_type, "ollama");
     assert_eq!(config.providers[0].api_key, "");
 
     clear_test_env();

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -262,15 +262,7 @@ impl Validate for ProviderConfig {
         .map_err(|message| format!("Provider {} {message}", self.name))?;
 
         let requires_api_key =
-            crate::core::providers::registry::get_definition(&provider_selector.to_lowercase())
-                .map(|def| !def.skip_api_key)
-                .unwrap_or_else(|| {
-                    provider_selector
-                        .parse::<crate::core::providers::ProviderType>()
-                        .map_or(true, |provider_type| {
-                            !matches!(provider_type, crate::core::providers::ProviderType::Ollama)
-                        })
-                });
+            !crate::core::providers::registry::selector_skips_api_key(provider_selector);
 
         if requires_api_key && self.api_key.is_empty() {
             return Err(format!("Provider {} API key cannot be empty", self.name));

--- a/src/config/validation/config_validators.rs
+++ b/src/config/validation/config_validators.rs
@@ -264,7 +264,13 @@ impl Validate for ProviderConfig {
         let requires_api_key =
             crate::core::providers::registry::get_definition(&provider_selector.to_lowercase())
                 .map(|def| !def.skip_api_key)
-                .unwrap_or(true);
+                .unwrap_or_else(|| {
+                    provider_selector
+                        .parse::<crate::core::providers::ProviderType>()
+                        .map_or(true, |provider_type| {
+                            !matches!(provider_type, crate::core::providers::ProviderType::Ollama)
+                        })
+                });
 
         if requires_api_key && self.api_key.is_empty() {
             return Err(format!("Provider {} API key cannot be empty", self.name));
@@ -601,6 +607,25 @@ mod endpoint_access_tests {
                 .unwrap_err()
                 .contains("top-level")
         );
+    }
+
+    #[cfg(feature = "providers-extended")]
+    #[test]
+    fn keyless_ollama_startup_validation_preserves_endpoint_policy() {
+        let mut config = public_provider();
+        config.name = "local-ollama".to_string();
+        config.provider_type = "ollama".to_string();
+        config.api_key.clear();
+        config.base_url = None;
+        assert!(Validate::validate(&config).is_ok());
+
+        config.base_url = Some("http://127.0.0.1:11434".to_string());
+        let error = Validate::validate(&config)
+            .expect_err("explicit public-only loopback must remain fail-closed");
+        assert!(error.contains("private or reserved"), "{error}");
+
+        config.endpoint_access = ProviderEndpointAccess::PrivateNetwork;
+        assert!(Validate::validate(&config).is_ok());
     }
 
     #[test]

--- a/src/core/providers/base/http/source_boundary_tests.rs
+++ b/src/core/providers/base/http/source_boundary_tests.rs
@@ -60,9 +60,6 @@ const BOUNDARY_EXCEPTIONS: &[BoundaryException] = &[
     exception!("src/core/providers/meta_llama/common_utils.rs", "unwired lifecycle stub; Gateway uses the policy-wired catalog route", [
             "<module>: raw HTTP path crate::utils::net::http::create_custom_client", "<module>: raw HTTP path reqwest::Client",
     ]),
-    exception!("src/core/providers/ollama/provider.rs", "unwired lifecycle stub; Gateway uses the policy-wired catalog route", [
-            "chat_completion_stream: raw HTTP path crate::core::http::outbound::streaming_outbound_client", "chat_completion_stream: raw HTTP path crate::core::providers::base::connection_pool::send_streaming_request", "new: legacy GlobalPoolManager::new() constructor",
-    ]),
     exception!("src/core/providers/replicate/provider.rs", "native runtime is restricted by the factory to the fixed Replicate API endpoint", [
             "<module>: raw HTTP path crate::core::providers::base::apply_headers", "build_request: raw HTTP client accessor .client()", "build_request: raw HTTP client accessor .client()", "build_request: raw HTTP client accessor .client()", "build_request: raw HTTP client accessor .client()", "chat_completion_stream: raw HTTP path crate::core::http::outbound::streaming_outbound_client", "chat_completion_stream: raw HTTP path crate::core::providers::base::connection_pool::send_streaming_request_with_timeout", "new: legacy GlobalPoolManager::new() constructor",
     ]),

--- a/src/core/providers/factory/endpoint_policy.rs
+++ b/src/core/providers/factory/endpoint_policy.rs
@@ -7,7 +7,7 @@ pub(super) fn provider_type_supports(provider_type: &ProviderType) -> bool {
     use ProviderType::*;
     match provider_type {
         OpenAI | OpenAICompatible | Anthropic | Mistral | Cohere | Azure | AzureAI | Bedrock
-        | VertexAI | Gemini => true,
+        | VertexAI | Gemini | Ollama => true,
         Cloudflare | FalAI | Replicate | GitHubCopilot => false,
         _ => provider_registry::catalog_definition_for_provider_type(provider_type).is_some(),
     }
@@ -21,12 +21,11 @@ pub(crate) fn selector_supports_endpoint_access(selector: &str) -> bool {
 }
 
 pub(crate) fn selector_allows_implicit_private(selector: &str) -> bool {
-    selector
-        .parse::<ProviderType>()
-        .is_ok_and(|provider_type| matches!(provider_type, ProviderType::Bedrock))
-        || catalog_definition_for_supported_selector(selector)
-            .and_then(|definition| url::Url::parse(definition.base_url).ok())
-            .is_some_and(|url| url.host_str() == Some("localhost"))
+    selector.parse::<ProviderType>().is_ok_and(|provider_type| {
+        matches!(provider_type, ProviderType::Bedrock | ProviderType::Ollama)
+    }) || catalog_definition_for_supported_selector(selector)
+        .and_then(|definition| url::Url::parse(definition.base_url).ok())
+        .is_some_and(|url| url.host_str() == Some("localhost"))
 }
 
 const STANDARD_ENDPOINT_KEYS: &[&str] = &["base_url", "api_base"];

--- a/src/core/providers/factory/factory_creation_tests.rs
+++ b/src/core/providers/factory/factory_creation_tests.rs
@@ -1,0 +1,44 @@
+use super::create_provider;
+#[cfg(feature = "providers-extended")]
+use crate::core::providers::Provider;
+use crate::core::providers::ProviderError;
+
+#[tokio::test]
+async fn reports_unknown_custom_provider() {
+    let config = crate::config::models::provider::ProviderConfig {
+        name: "my-custom-provider".to_string(),
+        provider_type: "".to_string(),
+        api_key: "test-key".to_string(),
+        ..Default::default()
+    };
+
+    let error = create_provider(config)
+        .await
+        .expect_err("Expected unknown custom provider to fail");
+    // Unknown provider strings produce InvalidRequest at selector parsing time.
+    assert!(
+        matches!(error, ProviderError::InvalidRequest { .. }),
+        "Expected InvalidRequest error, got {error}"
+    );
+    assert!(
+        error.to_string().contains("my-custom-provider"),
+        "Expected custom provider name in error, got {error}"
+    );
+}
+
+#[cfg(feature = "providers-extended")]
+#[tokio::test]
+async fn creates_native_ollama_from_gateway_config() {
+    let config = crate::config::models::provider::ProviderConfig {
+        name: "local-ollama".to_string(),
+        provider_type: "ollama".to_string(),
+        base_url: Some("http://127.0.0.1:11434".to_string()),
+        endpoint_access: crate::core::net::ProviderEndpointAccess::PrivateNetwork,
+        ..Default::default()
+    };
+
+    let provider = create_provider(config)
+        .await
+        .unwrap_or_else(|error| panic!("gateway config should create native Ollama: {error}"));
+    assert!(matches!(provider, Provider::Ollama(_)));
+}

--- a/src/core/providers/factory/factory_creation_tests.rs
+++ b/src/core/providers/factory/factory_creation_tests.rs
@@ -34,6 +34,7 @@ async fn creates_native_ollama_from_gateway_config() {
         provider_type: "ollama".to_string(),
         base_url: Some("http://127.0.0.1:11434".to_string()),
         endpoint_access: crate::core::net::ProviderEndpointAccess::PrivateNetwork,
+        models: vec!["llama3:8b".to_string()],
         ..Default::default()
     };
 

--- a/src/core/providers/factory/mod.rs
+++ b/src/core/providers/factory/mod.rs
@@ -15,6 +15,8 @@ mod cohere_builder;
 #[cfg(test)]
 mod endpoint_access_tests;
 mod endpoint_policy;
+#[cfg(test)]
+mod factory_creation_tests;
 #[cfg(feature = "providers-extended")]
 mod fal_ai_builder;
 #[cfg(feature = "providers-extended")]
@@ -784,31 +786,5 @@ mod tests {
                 provider_type
             );
         }
-    }
-
-    #[tokio::test]
-    async fn test_create_provider_reports_unknown_custom_provider() {
-        let config = crate::config::models::provider::ProviderConfig {
-            name: "my-custom-provider".to_string(),
-            provider_type: "".to_string(),
-            api_key: "test-key".to_string(),
-            ..Default::default()
-        };
-
-        let err = create_provider(config)
-            .await
-            .expect_err("Expected unknown custom provider to fail");
-        // Unknown provider strings now produce InvalidRequest (via ConfigError::InvalidValue)
-        // instead of NotImplemented, so callers get a clear parse-time error.
-        assert!(
-            matches!(err, ProviderError::InvalidRequest { .. }),
-            "Expected InvalidRequest error, got {}",
-            err
-        );
-        assert!(
-            err.to_string().contains("my-custom-provider"),
-            "Expected custom provider name in error, got {}",
-            err
-        );
     }
 }

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -59,10 +59,11 @@ fn build_ollama_config_from_factory(
     let object = normalized
         .as_object_mut()
         .ok_or_else(|| ProviderError::configuration("ollama", "configuration must be an object"))?;
-    if !object.contains_key("api_base")
-        && let Some(base_url) = base_url
-    {
-        object.insert("api_base".to_string(), base_url.into());
+    if let Some(endpoint) = api_base.or(base_url) {
+        object.insert(
+            "api_base".to_string(),
+            endpoint.trim_end_matches('/').into(),
+        );
     }
     object.remove("base_url");
     let ollama_config: ollama::OllamaConfig = serde_json::from_value(normalized)
@@ -255,7 +256,11 @@ impl Provider {
                 #[cfg(feature = "providers-extended")]
                 {
                     let ollama_config = build_ollama_config_from_factory(&config)?;
-                    let provider = ollama::OllamaProvider::new(ollama_config).await?;
+                    let discover_models = ollama_config.models.is_empty();
+                    let mut provider = ollama::OllamaProvider::new(ollama_config).await?;
+                    if discover_models {
+                        provider.refresh_models().await?;
+                    }
                     Ok(Provider::Ollama(provider))
                 }
                 #[cfg(not(feature = "providers-extended"))]

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -407,6 +407,7 @@ mod tests {
                 "use_streaming": true
             }),
             ProviderType::Ollama => serde_json::json!({
+                "models": ["llama3:8b"],
                 "timeout": 30,
                 "max_retries": 2
             }),

--- a/src/core/providers/factory/registry.rs
+++ b/src/core/providers/factory/registry.rs
@@ -12,7 +12,9 @@ use crate::core::providers::{
 #[cfg(feature = "providers-extra")]
 use crate::core::providers::{azure, azure_ai, vertex_ai};
 #[cfg(feature = "providers-extended")]
-use crate::core::providers::{cohere, fal_ai, gemini, github_copilot, replicate};
+use crate::core::providers::{cohere, fal_ai, gemini, github_copilot, ollama, replicate};
+#[cfg(feature = "providers-extended")]
+use crate::core::traits::provider::ProviderConfig as _;
 
 #[cfg(feature = "providers-extended")]
 use super::builder::build_github_copilot_config_from_factory;
@@ -39,6 +41,37 @@ use super::fal_ai_builder::build_fal_ai_config_from_factory;
 use super::gemini_builder::build_gemini_config_from_factory;
 #[cfg(feature = "providers-extended")]
 use super::replicate_builder::build_replicate_config_from_factory;
+
+#[cfg(feature = "providers-extended")]
+fn build_ollama_config_from_factory(
+    config: &serde_json::Value,
+) -> Result<ollama::OllamaConfig, ProviderError> {
+    let base_url = config_str(config, "base_url");
+    let api_base = config_str(config, "api_base");
+    if matches!((base_url, api_base), (Some(base_url), Some(api_base)) if base_url.trim_end_matches('/') != api_base.trim_end_matches('/'))
+    {
+        return Err(ProviderError::configuration(
+            "ollama",
+            "base_url and api_base must not configure different endpoints",
+        ));
+    }
+    let mut normalized = config.clone();
+    let object = normalized
+        .as_object_mut()
+        .ok_or_else(|| ProviderError::configuration("ollama", "configuration must be an object"))?;
+    if !object.contains_key("api_base")
+        && let Some(base_url) = base_url
+    {
+        object.insert("api_base".to_string(), base_url.into());
+    }
+    object.remove("base_url");
+    let ollama_config: ollama::OllamaConfig = serde_json::from_value(normalized)
+        .map_err(|error| ProviderError::configuration("ollama", error.to_string()))?;
+    ollama_config
+        .validate()
+        .map_err(|error| ProviderError::configuration("ollama", error))?;
+    Ok(ollama_config)
+}
 
 impl Provider {
     /// Create provider from configuration asynchronously
@@ -218,6 +251,21 @@ impl Provider {
                     ))
                 }
             }
+            ProviderType::Ollama => {
+                #[cfg(feature = "providers-extended")]
+                {
+                    let ollama_config = build_ollama_config_from_factory(&config)?;
+                    let provider = ollama::OllamaProvider::new(ollama_config).await?;
+                    Ok(Provider::Ollama(provider))
+                }
+                #[cfg(not(feature = "providers-extended"))]
+                {
+                    Err(ProviderError::not_implemented(
+                        "ollama",
+                        "Ollama native dispatch requires the providers-extended feature",
+                    ))
+                }
+            }
             ProviderType::GitHubCopilot => {
                 #[cfg(feature = "providers-extended")]
                 {
@@ -276,10 +324,6 @@ mod tests {
     #[cfg(feature = "providers-extended")]
     use crate::core::providers::{fal_ai::FalAIConfig, replicate::ReplicateConfig};
     use provider_registry::{ProviderDispatchKind, provider_type_registry};
-
-    fn supported_factory_provider_types() -> Vec<ProviderType> {
-        Provider::factory_supported_provider_types().to_vec()
-    }
 
     fn minimal_dispatch_config() -> serde_json::Value {
         serde_json::json!({
@@ -357,6 +401,10 @@ mod tests {
                 "polling_retries": 3,
                 "use_streaming": true
             }),
+            ProviderType::Ollama => serde_json::json!({
+                "timeout": 30,
+                "max_retries": 2
+            }),
             _ => minimal_dispatch_config(),
         }
     }
@@ -398,6 +446,8 @@ mod tests {
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::Replicate, Provider::Replicate(_)) => {}
                     #[cfg(feature = "providers-extended")]
+                    (ProviderType::Ollama, Provider::Ollama(_)) => {}
+                    #[cfg(feature = "providers-extended")]
                     (ProviderType::Gemini, Provider::Gemini(_)) => {}
                     #[cfg(feature = "providers-extended")]
                     (ProviderType::GitHubCopilot, Provider::GitHubCopilot(_)) => {}
@@ -422,51 +472,6 @@ mod tests {
             if entry.dispatch_kind == ProviderDispatchKind::CatalogOpenAiLike {
                 assert_eq!(provider.name(), entry.canonical_name);
             }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_from_config_async_supported_variants_do_not_fallthrough_to_not_implemented() {
-        for provider_type in supported_factory_provider_types() {
-            let result =
-                Provider::from_config_async(provider_type.clone(), serde_json::json!({})).await;
-            // Success is fine (e.g. local catalog providers with skip_api_key);
-            // a real config error is also fine. Only NotImplemented is wrong.
-            if let Err(err) = result {
-                assert!(
-                    !matches!(err, ProviderError::NotImplemented { .. }),
-                    "{:?} unexpectedly fell through to NotImplemented: {}",
-                    provider_type,
-                    err
-                );
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_from_config_async_unsupported_variants_return_not_implemented() {
-        let supported = supported_factory_provider_types();
-
-        for provider_type in crate::core::providers::provider_type::all_non_custom_provider_types()
-        {
-            if supported.contains(&provider_type) {
-                continue;
-            }
-
-            let err = Provider::from_config_async(provider_type.clone(), serde_json::json!({}))
-                .await
-                .expect_err("Expected unsupported provider to fail");
-            assert!(
-                matches!(err, ProviderError::NotImplemented { .. }),
-                "Expected NotImplemented for {:?}, got {}",
-                provider_type,
-                err
-            );
-            assert_eq!(
-                err.provider(),
-                provider_type.to_string(),
-                "NotImplemented provider name should identify the requested provider"
-            );
         }
     }
 
@@ -757,36 +762,12 @@ mod tests {
             "error should identify static api_key rejection: {err}"
         );
     }
-
-    #[tokio::test]
-    async fn issue_606_catalogified_candidates_use_catalog_runtime_path() {
-        for provider_type in [
-            ProviderType::MetaLlama,
-            ProviderType::V0,
-            ProviderType::AmazonNova,
-            ProviderType::GitHub,
-            ProviderType::Custom("together".to_string()),
-        ] {
-            let expected_capabilities =
-                provider_registry::catalog_definition_for_provider_type(&provider_type)
-                    .expect("catalogified provider should have a definition")
-                    .capabilities;
-            let provider = Provider::from_config_async(
-                provider_type.clone(),
-                serde_json::json!({
-                    "api_key": "sk-test-key",
-                    "headers": {"x-test-header": "test-value"},
-                    "custom_headers": {"x-custom-header": "custom-value"},
-                    "timeout": 42,
-                    "max_retries": 4
-                }),
-            )
-            .await
-            .unwrap_or_else(|err| panic!("{provider_type:?} should be creatable: {err}"));
-
-            assert!(matches!(provider, Provider::OpenAILike(_)));
-            assert_eq!(provider.name(), provider_type.to_string());
-            assert_eq!(provider.capabilities(), expected_capabilities);
-        }
-    }
 }
+
+#[cfg(test)]
+#[path = "registry_catalog_tests.rs"]
+mod catalog_tests;
+
+#[cfg(test)]
+#[path = "registry_support_tests.rs"]
+mod support_tests;

--- a/src/core/providers/factory/registry_catalog_tests.rs
+++ b/src/core/providers/factory/registry_catalog_tests.rs
@@ -1,0 +1,33 @@
+use crate::core::providers::{Provider, ProviderType, registry as provider_registry};
+
+#[tokio::test]
+async fn issue_606_catalogified_candidates_use_catalog_runtime_path() {
+    for provider_type in [
+        ProviderType::MetaLlama,
+        ProviderType::V0,
+        ProviderType::AmazonNova,
+        ProviderType::GitHub,
+        ProviderType::Custom("together".to_string()),
+    ] {
+        let expected_capabilities =
+            provider_registry::catalog_definition_for_provider_type(&provider_type)
+                .expect("catalogified provider should have a definition")
+                .capabilities;
+        let provider = Provider::from_config_async(
+            provider_type.clone(),
+            serde_json::json!({
+                "api_key": "sk-test-key",
+                "headers": {"x-test-header": "test-value"},
+                "custom_headers": {"x-custom-header": "custom-value"},
+                "timeout": 42,
+                "max_retries": 4
+            }),
+        )
+        .await
+        .unwrap_or_else(|err| panic!("{provider_type:?} should be creatable: {err}"));
+
+        assert!(matches!(provider, Provider::OpenAILike(_)));
+        assert_eq!(provider.name(), provider_type.to_string());
+        assert_eq!(provider.capabilities(), expected_capabilities);
+    }
+}

--- a/src/core/providers/factory/registry_support_tests.rs
+++ b/src/core/providers/factory/registry_support_tests.rs
@@ -1,5 +1,9 @@
 use crate::core::providers::provider_type::{ProviderType, all_non_custom_provider_types};
 use crate::core::providers::{Provider, ProviderError};
+#[cfg(feature = "providers-extended")]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "providers-extended")]
+use tokio::net::TcpListener;
 
 #[tokio::test]
 async fn supported_variants_do_not_fallthrough_to_not_implemented() {
@@ -48,7 +52,8 @@ async fn ollama_factory_creates_policy_wired_native_provider() {
         ProviderType::Ollama,
         serde_json::json!({
             "base_url": "http://127.0.0.1:11434",
-            "endpoint_access": "private_network"
+            "endpoint_access": "private_network",
+            "models": ["llama3:8b"]
         }),
     )
     .await
@@ -63,6 +68,47 @@ async fn ollama_factory_creates_policy_wired_native_provider() {
         capabilities.contains(&crate::core::types::model::ProviderCapability::ChatCompletionStream)
     );
     assert!(capabilities.contains(&crate::core::types::model::ProviderCapability::Embeddings));
+}
+
+#[cfg(feature = "providers-extended")]
+#[tokio::test]
+async fn ollama_factory_discovers_models_and_normalizes_trailing_slash() {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("test listener binds");
+    let address = listener.local_addr().expect("test listener has address");
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("factory requests tags");
+        let mut request = [0_u8; 4096];
+        let read = socket
+            .read(&mut request)
+            .await
+            .expect("request is readable");
+        let body = r#"{"models":[{"name":"llama3:8b"}]}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("tags response is writable");
+        String::from_utf8_lossy(&request[..read]).into_owned()
+    });
+
+    let provider = Provider::from_config_async(
+        ProviderType::Ollama,
+        serde_json::json!({
+            "api_base": format!("http://{address}/"),
+            "endpoint_access": "private_network"
+        }),
+    )
+    .await
+    .expect("Ollama factory should discover models");
+
+    assert_eq!(provider.list_models()[0].id, "llama3:8b");
+    let request = server.await.expect("test server completes");
+    assert!(request.starts_with("GET /api/tags "), "{request}");
 }
 
 #[cfg(feature = "providers-extended")]

--- a/src/core/providers/factory/registry_support_tests.rs
+++ b/src/core/providers/factory/registry_support_tests.rs
@@ -1,0 +1,113 @@
+use crate::core::providers::provider_type::{ProviderType, all_non_custom_provider_types};
+use crate::core::providers::{Provider, ProviderError};
+
+#[tokio::test]
+async fn supported_variants_do_not_fallthrough_to_not_implemented() {
+    for provider_type in Provider::factory_supported_provider_types() {
+        let result =
+            Provider::from_config_async(provider_type.clone(), serde_json::json!({})).await;
+        // Success is fine (e.g. local catalog providers with skip_api_key);
+        // a real config error is also fine. Only NotImplemented is wrong.
+        if let Err(error) = result {
+            assert!(
+                !matches!(error, ProviderError::NotImplemented { .. }),
+                "{provider_type:?} unexpectedly fell through to NotImplemented: {error}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn unsupported_variants_return_not_implemented() {
+    let supported = Provider::factory_supported_provider_types();
+
+    for provider_type in all_non_custom_provider_types() {
+        if supported.contains(&provider_type) {
+            continue;
+        }
+
+        let error = Provider::from_config_async(provider_type.clone(), serde_json::json!({}))
+            .await
+            .expect_err("Expected unsupported provider to fail");
+        assert!(
+            matches!(error, ProviderError::NotImplemented { .. }),
+            "Expected NotImplemented for {provider_type:?}, got {error}"
+        );
+        assert_eq!(
+            error.provider(),
+            provider_type.to_string(),
+            "NotImplemented provider name should identify the requested provider"
+        );
+    }
+}
+
+#[cfg(feature = "providers-extended")]
+#[tokio::test]
+async fn ollama_factory_creates_policy_wired_native_provider() {
+    let provider = Provider::from_config_async(
+        ProviderType::Ollama,
+        serde_json::json!({
+            "base_url": "http://127.0.0.1:11434",
+            "endpoint_access": "private_network"
+        }),
+    )
+    .await
+    .unwrap_or_else(|error| panic!("ollama should create a native provider: {error}"));
+
+    assert!(matches!(provider, Provider::Ollama(_)));
+    assert_eq!(provider.name(), "ollama");
+    assert_eq!(provider.provider_type(), ProviderType::Ollama);
+    let capabilities = provider.capabilities();
+    assert!(capabilities.contains(&crate::core::types::model::ProviderCapability::ChatCompletion));
+    assert!(
+        capabilities.contains(&crate::core::types::model::ProviderCapability::ChatCompletionStream)
+    );
+    assert!(capabilities.contains(&crate::core::types::model::ProviderCapability::Embeddings));
+}
+
+#[cfg(feature = "providers-extended")]
+#[tokio::test]
+async fn ollama_factory_rejects_explicit_public_loopback() {
+    let error = Provider::from_config_async(
+        ProviderType::Ollama,
+        serde_json::json!({
+            "api_base": "http://127.0.0.1:11434",
+            "endpoint_access": "public_only"
+        }),
+    )
+    .await
+    .expect_err("public-only Ollama must reject an explicit loopback endpoint");
+
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+    assert!(error.to_string().contains("private or reserved"));
+}
+
+#[cfg(feature = "providers-extended")]
+#[tokio::test]
+async fn ollama_factory_rejects_conflicting_endpoint_aliases() {
+    let error = Provider::from_config_async(
+        ProviderType::Ollama,
+        serde_json::json!({
+            "base_url": "https://example.com",
+            "api_base": "http://127.0.0.1:11434",
+            "endpoint_access": "public_only"
+        }),
+    )
+    .await
+    .expect_err("conflicting Ollama endpoint aliases must fail closed");
+
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+    assert!(error.to_string().contains("different endpoints"));
+}
+
+#[cfg(not(feature = "providers-extended"))]
+#[tokio::test]
+async fn ollama_factory_requires_providers_extended() {
+    let error = Provider::from_config_async(ProviderType::Ollama, serde_json::json!({}))
+        .await
+        .expect_err("ollama should require providers-extended");
+
+    assert!(matches!(error, ProviderError::NotImplemented { .. }));
+    assert_eq!(error.provider(), "ollama");
+    assert!(error.to_string().contains("providers-extended"));
+}

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -289,6 +289,8 @@ macro_rules! dispatch_provider {
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => p.$method($($arg),*),
             #[cfg(feature = "providers-extended")]
+            Provider::Ollama(p) => p.$method($($arg),*),
+            #[cfg(feature = "providers-extended")]
             Provider::FalAI(p) => p.$method($($arg),*),
             Provider::Mistral(p) => p.$method($($arg),*),
             Provider::Cloudflare(p) => p.$method($($arg),*),
@@ -315,6 +317,8 @@ macro_rules! dispatch_provider {
             Provider::Gemini(p) => LLMProvider::$method(p.as_ref(), $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
+            #[cfg(feature = "providers-extended")]
+            Provider::Ollama(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             #[cfg(feature = "providers-extended")]
             Provider::FalAI(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*).await.map_err(ProviderError::from),
@@ -343,6 +347,8 @@ macro_rules! dispatch_provider {
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p, $($arg),*),
             #[cfg(feature = "providers-extended")]
+            Provider::Ollama(p) => LLMProvider::$method(p, $($arg),*),
+            #[cfg(feature = "providers-extended")]
             Provider::FalAI(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Mistral(p) => LLMProvider::$method(p, $($arg),*),
             Provider::Cloudflare(p) => LLMProvider::$method(p, $($arg),*),
@@ -369,6 +375,8 @@ macro_rules! dispatch_provider {
             Provider::Gemini(p) => LLMProvider::$method(p.as_ref()).await,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(p) => LLMProvider::$method(p).await,
+            #[cfg(feature = "providers-extended")]
+            Provider::Ollama(p) => LLMProvider::$method(p).await,
             #[cfg(feature = "providers-extended")]
             Provider::FalAI(p) => LLMProvider::$method(p).await,
             Provider::Mistral(p) => LLMProvider::$method(p).await,
@@ -427,6 +435,8 @@ pub enum Provider {
     #[cfg(feature = "providers-extended")]
     GitHubCopilot(github_copilot::GitHubCopilotProvider),
     #[cfg(feature = "providers-extended")]
+    Ollama(ollama::OllamaProvider),
+    #[cfg(feature = "providers-extended")]
     FalAI(fal_ai::FalAIProvider),
     Mistral(mistral::MistralProvider),
     Cloudflare(cloudflare::CloudflareProvider),
@@ -474,6 +484,8 @@ impl Provider {
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => "github_copilot",
             #[cfg(feature = "providers-extended")]
+            Provider::Ollama(_) => "ollama",
+            #[cfg(feature = "providers-extended")]
             Provider::FalAI(_) => "fal_ai",
             Provider::Mistral(_) => "mistral",
             Provider::Cloudflare(_) => "cloudflare",
@@ -504,6 +516,8 @@ impl Provider {
             Provider::Gemini(_) => ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             Provider::GitHubCopilot(_) => ProviderType::GitHubCopilot,
+            #[cfg(feature = "providers-extended")]
+            Provider::Ollama(_) => ProviderType::Ollama,
             #[cfg(feature = "providers-extended")]
             Provider::FalAI(_) => ProviderType::FalAI,
             Provider::Mistral(_) => ProviderType::Mistral,
@@ -646,156 +660,6 @@ impl Provider {
     }
 }
 
-// ==================== Unit Tests ====================
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_provider_enum_is_send_sync() {
-        assert!(matches!(ProviderType::from("openai"), ProviderType::OpenAI));
-    }
-
-    #[tokio::test]
-    async fn test_provider_capabilities_embeddings_error_names_real_provider() {
-        let provider = Provider::Anthropic(
-            anthropic::AnthropicProvider::new(anthropic::AnthropicConfig::new_test("test-key"))
-                .unwrap(),
-        );
-
-        assert!(!provider.supports_capability(&ProviderCapability::Embeddings));
-
-        let err = provider
-            .create_embeddings(
-                crate::core::types::embedding::EmbeddingRequest {
-                    model: "claude-3-opus-20240229".to_string(),
-                    input: crate::core::types::embedding::EmbeddingInput::Text("hello".to_string()),
-                    user: None,
-                    encoding_format: None,
-                    dimensions: None,
-                    task_type: None,
-                },
-                crate::core::types::context::RequestContext::default(),
-            )
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                err,
-                ProviderError::NotSupported {
-                    provider: "anthropic",
-                    ..
-                }
-            ),
-            "expected provider-specific NotSupported, got {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_provider_enum_calculate_cost_delegates_mistral_aliases() {
-        let Ok(mistral_provider) = mistral::MistralProvider::new(mistral::MistralConfig {
-            api_key: "sk-test".to_string(),
-            ..mistral::MistralConfig::default()
-        })
-        .await
-        else {
-            panic!("Mistral provider should initialize with a test API key");
-        };
-        let provider = Provider::Mistral(mistral_provider);
-
-        let Ok(alias_cost) = provider
-            .calculate_cost("magistral-medium-1-2", 1000, 500)
-            .await
-        else {
-            panic!("Mistral alias cost should calculate");
-        };
-        let Ok(canonical_cost) = provider
-            .calculate_cost("magistral-medium-2509", 1000, 500)
-            .await
-        else {
-            panic!("Mistral canonical cost should calculate");
-        };
-        let Ok(devstral_alias_cost) = provider.calculate_cost("devstral-2-2512", 1000, 500).await
-        else {
-            panic!("Devstral alias cost should calculate");
-        };
-
-        assert!((alias_cost - canonical_cost).abs() < 1e-12);
-        assert!((alias_cost - 0.0045).abs() < 1e-12);
-        assert!((devstral_alias_cost - 0.0014).abs() < 1e-12);
-    }
-
-    #[tokio::test]
-    async fn test_provider_enum_calculate_cost_strips_openai_prefix() {
-        let mut config = openai::OpenAIConfig::default();
-        config.base.api_key = Some("sk-test123456789012345678901234567890123456".to_string());
-        let Ok(openai_provider) = openai::OpenAIProvider::new(config).await else {
-            panic!("OpenAI provider should initialize with a test API key");
-        };
-        let provider = Provider::OpenAI(openai_provider);
-
-        let Ok(cost) = provider
-            .calculate_cost("openai/gpt-5.5-pro", 1000, 500)
-            .await
-        else {
-            panic!("prefixed OpenAI cost should calculate");
-        };
-
-        assert!((cost - 0.12).abs() < 1e-12);
-    }
-
-    #[tokio::test]
-    async fn test_provider_capabilities_image_error_names_real_provider() {
-        let provider = Provider::Anthropic(
-            anthropic::AnthropicProvider::new(anthropic::AnthropicConfig::new_test("test-key"))
-                .unwrap(),
-        );
-
-        assert!(!provider.supports_capability(&ProviderCapability::ImageGeneration));
-
-        let err = provider
-            .create_images(
-                crate::core::types::image::ImageGenerationRequest {
-                    prompt: "a small test image".to_string(),
-                    model: Some("claude-3-opus-20240229".to_string()),
-                    n: None,
-                    size: None,
-                    quality: None,
-                    response_format: None,
-                    style: None,
-                    user: None,
-                },
-                crate::core::types::context::RequestContext::default(),
-            )
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                err,
-                ProviderError::NotSupported {
-                    provider: "anthropic",
-                    ..
-                }
-            ),
-            "expected provider-specific NotSupported, got {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_provider_supports_capability_for_optional_provider() {
-        let mut config = openai::OpenAIConfig::default();
-        config.base.api_key = Some("sk-test123456789012345678901234567890123456".to_string());
-        let Ok(openai_provider) = openai::OpenAIProvider::new(config).await else {
-            panic!("OpenAI provider should initialize with a test API key");
-        };
-        let provider = Provider::OpenAI(openai_provider);
-
-        assert!(provider.supports_capability(&ProviderCapability::ChatCompletion));
-        assert!(provider.supports_capability(&ProviderCapability::ChatCompletionStream));
-        assert!(provider.supports_capability(&ProviderCapability::Embeddings));
-        assert!(provider.supports_capability(&ProviderCapability::TextToSpeech));
-    }
-}
+#[path = "provider_tests.rs"]
+mod tests;

--- a/src/core/providers/ollama/config.rs
+++ b/src/core/providers/ollama/config.rs
@@ -113,6 +113,9 @@ impl ProviderConfig for OllamaConfig {
         if self.timeout == 0 {
             return Err("Timeout must be greater than 0".to_string());
         }
+        if self.template.is_some() {
+            return Err("Native Ollama chat does not support template overrides".to_string());
+        }
 
         // Validate mirostat value if set
         if let Some(mirostat) = self.mirostat

--- a/src/core/providers/ollama/config.rs
+++ b/src/core/providers/ollama/config.rs
@@ -20,6 +20,10 @@ pub struct OllamaConfig {
     #[serde(default)]
     pub endpoint_access: ProviderEndpointAccess,
 
+    /// Models explicitly assigned to this provider. Empty means discover via `/api/tags`.
+    #[serde(default)]
+    pub models: Vec<String>,
+
     /// Request timeout in seconds
     #[serde(default = "default_timeout")]
     pub timeout: u64,
@@ -79,6 +83,7 @@ impl Default for OllamaConfig {
             api_key: None,
             api_base: None,
             endpoint_access: ProviderEndpointAccess::PublicOnly,
+            models: Vec::new(),
             timeout: default_timeout(),
             max_retries: default_max_retries(),
             debug: false,

--- a/src/core/providers/ollama/config.rs
+++ b/src/core/providers/ollama/config.rs
@@ -2,8 +2,10 @@
 //!
 //! Configuration for Ollama API access including connection settings and model options.
 
+use crate::core::net::ProviderEndpointAccess;
 use crate::core::traits::provider::ProviderConfig;
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 
 /// Ollama provider configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +15,10 @@ pub struct OllamaConfig {
 
     /// API base URL (default: <http://localhost:11434>)
     pub api_base: Option<String>,
+
+    /// Network scope allowed for the configured Ollama endpoint.
+    #[serde(default)]
+    pub endpoint_access: ProviderEndpointAccess,
 
     /// Request timeout in seconds
     #[serde(default = "default_timeout")]
@@ -72,6 +78,7 @@ impl Default for OllamaConfig {
         Self {
             api_key: None,
             api_base: None,
+            endpoint_access: ProviderEndpointAccess::PublicOnly,
             timeout: default_timeout(),
             max_retries: default_max_retries(),
             debug: false,
@@ -120,6 +127,10 @@ impl ProviderConfig for OllamaConfig {
         self.api_base.as_deref()
     }
 
+    fn endpoint_access(&self) -> ProviderEndpointAccess {
+        self.endpoint_access
+    }
+
     fn timeout(&self) -> std::time::Duration {
         std::time::Duration::from_secs(self.timeout)
     }
@@ -130,6 +141,23 @@ impl ProviderConfig for OllamaConfig {
 }
 
 impl OllamaConfig {
+    pub(crate) fn resolved_endpoint_access(&self, api_base: &str) -> ProviderEndpointAccess {
+        if self.api_base.is_none()
+            && self.endpoint_access == ProviderEndpointAccess::PublicOnly
+            && url::Url::parse(api_base)
+                .ok()
+                .and_then(|url| url.host_str().map(str::to_owned))
+                .is_some_and(|host| {
+                    host.eq_ignore_ascii_case("localhost")
+                        || host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+                })
+        {
+            ProviderEndpointAccess::PrivateNetwork
+        } else {
+            self.endpoint_access
+        }
+    }
+
     /// Get API key with environment variable fallback
     pub fn get_api_key(&self) -> Option<String> {
         self.api_key

--- a/src/core/providers/ollama/error.rs
+++ b/src/core/providers/ollama/error.rs
@@ -2,6 +2,7 @@
 
 use crate::core::providers::base::HttpErrorMapper;
 pub use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::tools::{ResponseFormat, ToolChoice};
 
 /// Ollama error type (alias to unified ProviderError)
 pub type OllamaError = ProviderError;
@@ -36,4 +37,35 @@ pub(super) fn parse_tool_arguments(raw: &str) -> Result<serde_json::Value, Provi
         ));
     }
     Ok(arguments)
+}
+
+pub(super) fn should_send_tools(tool_choice: Option<&ToolChoice>) -> Result<bool, ProviderError> {
+    match tool_choice {
+        None => Ok(true),
+        Some(ToolChoice::String(choice)) if choice == "auto" => Ok(true),
+        Some(ToolChoice::String(choice)) if choice == "none" => Ok(false),
+        Some(_) => Err(ProviderError::invalid_request(
+            "ollama",
+            "native Ollama supports only tool_choice auto or none",
+        )),
+    }
+}
+
+pub(super) fn response_format_value(
+    format: Option<&ResponseFormat>,
+) -> Result<Option<serde_json::Value>, ProviderError> {
+    let Some(format) = format else {
+        return Ok(None);
+    };
+    match format.format_type.as_str() {
+        "text" => Ok(None),
+        "json_object" => Ok(Some(serde_json::Value::String("json".to_string()))),
+        "json_schema" => format.json_schema.clone().map(Some).ok_or_else(|| {
+            ProviderError::invalid_request("ollama", "json_schema response format needs a schema")
+        }),
+        other => Err(ProviderError::invalid_request(
+            "ollama",
+            format!("unsupported response format: {other}"),
+        )),
+    }
 }

--- a/src/core/providers/ollama/error.rs
+++ b/src/core/providers/ollama/error.rs
@@ -1,6 +1,39 @@
 //! Error types for Ollama provider.
 
+use crate::core::providers::base::HttpErrorMapper;
 pub use crate::core::providers::unified_provider::ProviderError;
 
 /// Ollama error type (alias to unified ProviderError)
 pub type OllamaError = ProviderError;
+
+pub(super) fn parse_http_json_response(
+    status: u16,
+    body: &[u8],
+) -> Result<serde_json::Value, ProviderError> {
+    if !(200..300).contains(&status) {
+        return Err(HttpErrorMapper::map_status_code(
+            "ollama",
+            status,
+            &String::from_utf8_lossy(body),
+        ));
+    }
+    serde_json::from_slice(body).map_err(|error| {
+        ProviderError::api_error("ollama", 500, format!("Failed to parse response: {error}"))
+    })
+}
+
+pub(super) fn parse_tool_arguments(raw: &str) -> Result<serde_json::Value, ProviderError> {
+    let arguments: serde_json::Value = serde_json::from_str(raw).map_err(|error| {
+        ProviderError::invalid_request(
+            "ollama",
+            format!("tool call arguments must be valid JSON: {error}"),
+        )
+    })?;
+    if !arguments.is_object() {
+        return Err(ProviderError::invalid_request(
+            "ollama",
+            "tool call arguments must be a JSON object",
+        ));
+    }
+    Ok(arguments)
+}

--- a/src/core/providers/ollama/error.rs
+++ b/src/core/providers/ollama/error.rs
@@ -39,6 +39,21 @@ pub(super) fn parse_tool_arguments(raw: &str) -> Result<serde_json::Value, Provi
     Ok(arguments)
 }
 
+pub(super) fn inline_image_data(url: &str) -> Result<String, ProviderError> {
+    url.strip_prefix("data:")
+        .and_then(|data| {
+            let (metadata, payload) = data.split_once(',')?;
+            metadata.ends_with(";base64").then_some(payload.to_string())
+        })
+        .filter(|payload| !payload.is_empty())
+        .ok_or_else(|| {
+            ProviderError::invalid_request(
+                "ollama",
+                "native Ollama image URLs must be non-empty base64 data URLs",
+            )
+        })
+}
+
 pub(super) fn should_send_tools(tool_choice: Option<&ToolChoice>) -> Result<bool, ProviderError> {
     match tool_choice {
         None => Ok(true),
@@ -60,9 +75,20 @@ pub(super) fn response_format_value(
     match format.format_type.as_str() {
         "text" => Ok(None),
         "json_object" => Ok(Some(serde_json::Value::String("json".to_string()))),
-        "json_schema" => format.json_schema.clone().map(Some).ok_or_else(|| {
-            ProviderError::invalid_request("ollama", "json_schema response format needs a schema")
-        }),
+        "json_schema" => {
+            let schema = format.json_schema.as_ref().ok_or_else(|| {
+                ProviderError::invalid_request(
+                    "ollama",
+                    "json_schema response format needs a schema",
+                )
+            })?;
+            let schema = schema
+                .as_object()
+                .filter(|wrapper| wrapper.contains_key("name") || wrapper.contains_key("strict"))
+                .and_then(|wrapper| wrapper.get("schema"))
+                .unwrap_or(schema);
+            Ok(Some(schema.clone()))
+        }
         other => Err(ProviderError::invalid_request(
             "ollama",
             format!("unsupported response format: {other}"),

--- a/src/core/providers/ollama/mod.rs
+++ b/src/core/providers/ollama/mod.rs
@@ -21,6 +21,8 @@ mod config;
 mod error;
 mod model_info;
 mod provider;
+#[cfg(test)]
+mod runtime_tests;
 mod streaming;
 
 // Re-export main types for external use

--- a/src/core/providers/ollama/model_info.rs
+++ b/src/core/providers/ollama/model_info.rs
@@ -4,7 +4,9 @@
 //! Unlike cloud providers, Ollama models are locally managed and can be
 //! dynamically discovered via the API.
 
+use crate::core::types::model::{ModelInfo, ProviderCapability};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Ollama model information
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,6 +125,32 @@ impl OllamaModelInfo {
         self.max_context_length = infer_context_length(&name_lower);
 
         self
+    }
+}
+
+impl From<OllamaModelInfo> for ModelInfo {
+    fn from(model: OllamaModelInfo) -> Self {
+        Self {
+            id: model.name,
+            name: model.display_name,
+            provider: "ollama".to_string(),
+            max_context_length: model.max_context_length.unwrap_or(4096),
+            max_output_length: None,
+            supports_streaming: true,
+            supports_tools: model.supports_tools,
+            supports_multimodal: model.supports_multimodal,
+            input_cost_per_1k_tokens: Some(0.0),
+            output_cost_per_1k_tokens: Some(0.0),
+            currency: "USD".to_string(),
+            capabilities: vec![
+                ProviderCapability::ChatCompletion,
+                ProviderCapability::ChatCompletionStream,
+                ProviderCapability::Embeddings,
+            ],
+            created_at: None,
+            updated_at: None,
+            metadata: HashMap::new(),
+        }
     }
 }
 

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -10,7 +10,8 @@ use tracing::debug;
 
 use super::config::OllamaConfig;
 use super::error::{
-    parse_http_json_response, parse_tool_arguments, response_format_value, should_send_tools,
+    inline_image_data, parse_http_json_response, parse_tool_arguments, response_format_value,
+    should_send_tools,
 };
 use super::model_info::{OllamaModelInfo, OllamaShowResponse, OllamaTagsResponse, get_model_info};
 use super::streaming::OllamaStream;
@@ -193,9 +194,30 @@ impl OllamaProvider {
         request: &ChatRequest,
         stream: bool,
     ) -> Result<serde_json::Value, ProviderError> {
-        let mut messages = Vec::new();
+        if request.n.is_some_and(|n| n != 1) {
+            return Err(ProviderError::invalid_request(
+                "ollama",
+                "native Ollama supports exactly one choice",
+            ));
+        }
+        let tool_names: HashMap<&str, &str> = request
+            .messages
+            .iter()
+            .filter_map(|message| message.tool_calls.as_ref())
+            .flatten()
+            .map(|call| (call.id.as_str(), call.function.name.as_str()))
+            .collect();
+        let mut messages = self
+            .config
+            .system
+            .as_ref()
+            .map(|system| vec![serde_json::json!({"role": "system", "content": system})])
+            .unwrap_or_default();
 
         for msg in &request.messages {
+            if self.config.system.is_some() && msg.role == MessageRole::System {
+                continue;
+            }
             let role = match &msg.role {
                 MessageRole::System | MessageRole::Developer => "system",
                 MessageRole::User => "user",
@@ -224,18 +246,7 @@ impl OllamaProvider {
                                 text_parts.push(text.clone());
                             }
                             crate::core::types::content::ContentPart::ImageUrl { image_url } => {
-                                // Extract base64 image data from data URL or URL
-                                let url = &image_url.url;
-                                if url.starts_with("data:") {
-                                    // Extract base64 data
-                                    if let Some(comma_pos) = url.find(',') {
-                                        let base64_data = &url[comma_pos + 1..];
-                                        images.push(base64_data.to_string());
-                                    }
-                                } else {
-                                    // Regular URL - Ollama expects base64, so this might not work
-                                    images.push(url.clone());
-                                }
+                                images.push(inline_image_data(&image_url.url)?);
                             }
                             crate::core::types::content::ContentPart::Image { source, .. } => {
                                 // Base64 encoded image
@@ -263,6 +274,7 @@ impl OllamaProvider {
                     .map(|tc| {
                         let arguments = parse_tool_arguments(&tc.function.arguments)?;
                         Ok(serde_json::json!({
+                            "id": tc.id,
                             "function": {
                                 "name": tc.function.name,
                                 "arguments": arguments
@@ -273,11 +285,23 @@ impl OllamaProvider {
                 message["tool_calls"] = serde_json::json!(ollama_tool_calls);
             }
 
-            // Handle tool call id for tool messages
-            if msg.role == MessageRole::Tool
-                && let Some(name) = &msg.name
-            {
-                message["name"] = serde_json::json!(name);
+            if msg.role == MessageRole::Tool {
+                if let Some(id) = msg.tool_call_id.as_deref() {
+                    message["tool_call_id"] = serde_json::json!(id);
+                    let name = msg
+                        .name
+                        .as_deref()
+                        .or_else(|| tool_names.get(id).copied())
+                        .ok_or_else(|| {
+                            ProviderError::invalid_request(
+                                "ollama",
+                                format!("tool result references unknown call ID: {id}"),
+                            )
+                        })?;
+                    message["tool_name"] = serde_json::json!(name);
+                } else if let Some(name) = &msg.name {
+                    message["tool_name"] = serde_json::json!(name);
+                }
             }
 
             messages.push(message);
@@ -681,15 +705,20 @@ impl LLMProvider for OllamaProvider {
                 }
             })
             .collect();
+        let prompt_tokens = response
+            .get("prompt_eval_count")
+            .and_then(serde_json::Value::as_u64)
+            .map(|count| u32::try_from(count).unwrap_or(u32::MAX))
+            .unwrap_or(0);
 
         Ok(EmbeddingResponse {
             object: "list".to_string(),
             data,
             model: format!("ollama/{}", model),
             usage: Some(Usage {
-                prompt_tokens: 0, // Ollama doesn't report token usage for embeddings
+                prompt_tokens,
                 completion_tokens: 0,
-                total_tokens: 0,
+                total_tokens: prompt_tokens,
                 prompt_tokens_details: None,
                 completion_tokens_details: None,
                 thinking_usage: None,

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -9,12 +9,15 @@ use std::sync::Arc;
 use tracing::debug;
 
 use super::config::OllamaConfig;
-use super::error::{parse_http_json_response, parse_tool_arguments};
+use super::error::{
+    parse_http_json_response, parse_tool_arguments, response_format_value, should_send_tools,
+};
 use super::model_info::{OllamaModelInfo, OllamaShowResponse, OllamaTagsResponse, get_model_info};
 use super::streaming::OllamaStream;
 use crate::core::providers::base::{
     BaseConfig, GlobalPoolManager, HttpErrorMapper, HttpMethod, header,
 };
+use crate::core::providers::shared::MessageTransformer;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 use crate::core::traits::error_mapper::types::GenericErrorMapper;
@@ -84,8 +87,11 @@ impl OllamaProvider {
             })?,
         );
 
-        // Initialize with empty models (will be populated on first list_models call)
-        let models = Vec::new();
+        let models = config
+            .models
+            .iter()
+            .map(|model| get_model_info(model).into())
+            .collect();
 
         Ok(Self {
             config,
@@ -293,7 +299,7 @@ impl OllamaProvider {
             if let Some(top_p) = request.top_p {
                 opts.insert("top_p".to_string(), serde_json::json!(top_p));
             }
-            if let Some(max_tokens) = request.max_tokens {
+            if let Some(max_tokens) = request.max_completion_tokens.or(request.max_tokens) {
                 opts.insert("num_predict".to_string(), serde_json::json!(max_tokens));
             }
             if let Some(stop) = &request.stop {
@@ -318,7 +324,9 @@ impl OllamaProvider {
         body["options"] = options;
 
         // Add tools if present
-        if let Some(tools) = &request.tools {
+        if should_send_tools(request.tool_choice.as_ref())?
+            && let Some(tools) = &request.tools
+        {
             let ollama_tools: Vec<_> = tools
                 .iter()
                 .map(|t| {
@@ -336,10 +344,8 @@ impl OllamaProvider {
         }
 
         // Add response format if set
-        if let Some(format) = &request.response_format
-            && format.format_type == "json_object"
-        {
-            body["format"] = serde_json::json!("json");
+        if let Some(format) = response_format_value(request.response_format.as_ref())? {
+            body["format"] = format;
         }
 
         // Add keep_alive if set in config
@@ -403,17 +409,14 @@ impl OllamaProvider {
         };
 
         // Determine finish reason
-        let done_reason_str = response
-            .get("done_reason")
-            .and_then(|r| r.as_str())
-            .unwrap_or("stop");
-        let finish_reason = match done_reason_str {
-            "stop" => FinishReason::Stop,
-            "length" => FinishReason::Length,
-            "tool_calls" => FinishReason::ToolCalls,
-            "content_filter" => FinishReason::ContentFilter,
-            "function_call" => FinishReason::FunctionCall,
-            _ => FinishReason::Stop,
+        let finish_reason = if tool_calls.is_some() {
+            FinishReason::ToolCalls
+        } else {
+            response
+                .get("done_reason")
+                .and_then(|reason| reason.as_str())
+                .and_then(MessageTransformer::parse_finish_reason)
+                .unwrap_or(FinishReason::Stop)
         };
 
         // Build usage info
@@ -754,30 +757,7 @@ impl OllamaProvider {
     pub async fn refresh_models(&mut self) -> Result<(), ProviderError> {
         let ollama_models = self.list_models().await?;
 
-        self.models = ollama_models
-            .into_iter()
-            .map(|m| ModelInfo {
-                id: m.name.clone(),
-                name: m.display_name.clone(),
-                provider: "ollama".to_string(),
-                max_context_length: m.max_context_length.unwrap_or(4096),
-                max_output_length: None,
-                supports_streaming: true,
-                supports_tools: m.supports_tools,
-                supports_multimodal: m.supports_multimodal,
-                input_cost_per_1k_tokens: Some(0.0), // Ollama is free
-                output_cost_per_1k_tokens: Some(0.0), // Ollama is free
-                currency: "USD".to_string(),
-                capabilities: vec![
-                    ProviderCapability::ChatCompletion,
-                    ProviderCapability::ChatCompletionStream,
-                    ProviderCapability::Embeddings,
-                ],
-                created_at: None,
-                updated_at: None,
-                metadata: HashMap::new(),
-            })
-            .collect();
+        self.models = ollama_models.into_iter().map(Into::into).collect();
 
         Ok(())
     }

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -11,7 +11,9 @@ use tracing::debug;
 use super::config::OllamaConfig;
 use super::model_info::{OllamaModelInfo, OllamaShowResponse, OllamaTagsResponse, get_model_info};
 use super::streaming::OllamaStream;
-use crate::core::providers::base::{GlobalPoolManager, HttpErrorMapper, HttpMethod, header};
+use crate::core::providers::base::{
+    BaseConfig, GlobalPoolManager, HttpErrorMapper, HttpMethod, header,
+};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 use crate::core::traits::error_mapper::types::GenericErrorMapper;
@@ -59,10 +61,27 @@ impl OllamaProvider {
             .validate()
             .map_err(|e| ProviderError::configuration("ollama", e))?;
 
-        // Create pool manager
-        let pool_manager = Arc::new(GlobalPoolManager::new().map_err(|e| {
-            ProviderError::configuration("ollama", format!("Failed to create pool manager: {}", e))
-        })?);
+        let api_base = config.get_api_base();
+        let endpoint_access = config.resolved_endpoint_access(&api_base);
+        let pool_manager = Arc::new(
+            GlobalPoolManager::new_for_provider(
+                "ollama",
+                BaseConfig {
+                    api_key: config.get_api_key(),
+                    api_base: Some(api_base),
+                    endpoint_access,
+                    timeout: config.timeout,
+                    max_retries: config.max_retries,
+                    ..Default::default()
+                },
+            )
+            .map_err(|e| {
+                ProviderError::configuration(
+                    "ollama",
+                    format!("Failed to create pool manager: {}", e),
+                )
+            })?,
+        );
 
         // Initialize with empty models (will be populated on first list_models call)
         let models = Vec::new();
@@ -559,37 +578,29 @@ impl LLMProvider for OllamaProvider {
 
         let request_body = self.build_chat_request(&request, true)?;
 
-        // Use reqwest directly for streaming
         let url = self.config.get_chat_endpoint();
-        let mut req = crate::core::http::outbound::streaming_outbound_client()
-            .clone()
-            .post(&url);
-
-        // Add auth header if API key is set
+        let mut headers = vec![header("Content-Type", "application/json".to_string())];
         if let Some(api_key) = self.config.get_api_key() {
-            req = req.header("Authorization", format!("Bearer {}", api_key));
+            headers.push(header("Authorization", format!("Bearer {}", api_key)));
         }
-
-        let response = crate::core::providers::base::connection_pool::send_streaming_request(
-            req.header("Content-Type", "application/json")
-                .json(&request_body),
-            "ollama",
-        )
-        .await
-        .map_err(|error| {
-            let error_msg = error.to_string();
-            if error_msg.contains("Connection refused") || error_msg.contains("connect error") {
-                ProviderError::network(
-                    "ollama",
-                    format!(
-                        "Failed to connect to Ollama server at {}. Is Ollama running?",
-                        self.config.get_api_base()
-                    ),
-                )
-            } else {
-                error
-            }
-        })?;
+        let response = self
+            .pool_manager
+            .execute_streaming_request(&url, headers, request_body, "ollama")
+            .await
+            .map_err(|error| {
+                let error_msg = error.to_string();
+                if error_msg.contains("Connection refused") || error_msg.contains("connect error") {
+                    ProviderError::network(
+                        "ollama",
+                        format!(
+                            "Failed to connect to Ollama server at {}. Is Ollama running?",
+                            self.config.get_api_base()
+                        ),
+                    )
+                } else {
+                    error
+                }
+            })?;
 
         // Check status
         if !response.status().is_success() {

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use tracing::debug;
 
 use super::config::OllamaConfig;
+use super::error::{parse_http_json_response, parse_tool_arguments};
 use super::model_info::{OllamaModelInfo, OllamaShowResponse, OllamaTagsResponse, get_model_info};
 use super::streaming::OllamaStream;
 use crate::core::providers::base::{
@@ -146,14 +147,12 @@ impl OllamaProvider {
                 }
             })?;
 
+        let status = response.status().as_u16();
         let response_bytes = response
             .bytes()
             .await
             .map_err(|e| ProviderError::network("ollama", e.to_string()))?;
-
-        serde_json::from_slice(&response_bytes).map_err(|e| {
-            ProviderError::api_error("ollama", 500, format!("Failed to parse response: {}", e))
-        })
+        parse_http_json_response(status, &response_bytes)
     }
 
     /// List available models from Ollama server
@@ -253,17 +252,18 @@ impl OllamaProvider {
 
             // Handle tool calls for assistant messages
             if let Some(tool_calls) = &msg.tool_calls {
-                let ollama_tool_calls: Vec<_> = tool_calls
+                let ollama_tool_calls = tool_calls
                     .iter()
                     .map(|tc| {
-                        serde_json::json!({
+                        let arguments = parse_tool_arguments(&tc.function.arguments)?;
+                        Ok(serde_json::json!({
                             "function": {
                                 "name": tc.function.name,
-                                "arguments": tc.function.arguments
+                                "arguments": arguments
                             }
-                        })
+                        }))
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, ProviderError>>()?;
                 message["tool_calls"] = serde_json::json!(ollama_tool_calls);
             }
 

--- a/src/core/providers/ollama/runtime_tests.rs
+++ b/src/core/providers/ollama/runtime_tests.rs
@@ -1,0 +1,83 @@
+use super::{OllamaConfig, OllamaProvider};
+use crate::core::net::ProviderEndpointAccess;
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::chat::{ChatMessage, ChatRequest};
+use crate::core::types::context::RequestContext;
+use crate::core::types::message::{MessageContent, MessageRole};
+use crate::core::types::tools::{FunctionCall, ToolCall};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn transform_request_emits_tool_arguments_as_json_object() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let request = ChatRequest {
+        model: "ollama/llama3:8b".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::Assistant,
+            content: Some(MessageContent::Text(String::new())),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_123".to_string(),
+                tool_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "get_weather".to_string(),
+                    arguments: r#"{"location":"NYC"}"#.to_string(),
+                },
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let body = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect("valid tool arguments should transform");
+    assert_eq!(
+        body["messages"][0]["tool_calls"][0]["function"]["arguments"],
+        serde_json::json!({"location": "NYC"})
+    );
+}
+
+#[tokio::test]
+async fn non_streaming_maps_upstream_error_status() -> Result<(), Box<dyn std::error::Error>> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let address = listener.local_addr()?;
+    tokio::spawn(async move {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .expect("test server accepts request");
+        let mut buffer = [0_u8; 4096];
+        let _ = socket
+            .read(&mut buffer)
+            .await
+            .expect("test server reads request");
+        let body = r#"{"error":"model not found"}"#;
+        let response = format!(
+            "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("test server writes response");
+    });
+
+    let provider = OllamaProvider::new(OllamaConfig {
+        api_base: Some(format!("http://{address}")),
+        endpoint_access: ProviderEndpointAccess::PrivateNetwork,
+        ..Default::default()
+    })
+    .await?;
+    let error = LLMProvider::chat_completion(
+        &provider,
+        ChatRequest::new("ollama/missing").add_user_message("hello"),
+        RequestContext::default(),
+    )
+    .await
+    .expect_err("404 response must map before JSON success parsing");
+
+    assert!(matches!(error, ProviderError::ModelNotFound { .. }));
+    Ok(())
+}

--- a/src/core/providers/ollama/runtime_tests.rs
+++ b/src/core/providers/ollama/runtime_tests.rs
@@ -3,7 +3,9 @@ use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::chat::{ChatMessage, ChatRequest};
+use crate::core::types::content::{ContentPart, ImageUrl};
 use crate::core::types::context::RequestContext;
+use crate::core::types::embedding::{EmbeddingInput, EmbeddingRequest};
 use crate::core::types::message::{MessageContent, MessageRole};
 use crate::core::types::responses::FinishReason;
 use crate::core::types::tools::{
@@ -18,19 +20,27 @@ async fn transform_request_emits_tool_arguments_as_json_object() {
     let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
     let request = ChatRequest {
         model: "ollama/llama3:8b".to_string(),
-        messages: vec![ChatMessage {
-            role: MessageRole::Assistant,
-            content: Some(MessageContent::Text(String::new())),
-            tool_calls: Some(vec![ToolCall {
-                id: "call_123".to_string(),
-                tool_type: "function".to_string(),
-                function: FunctionCall {
-                    name: "get_weather".to_string(),
-                    arguments: r#"{"location":"NYC"}"#.to_string(),
-                },
-            }]),
-            ..Default::default()
-        }],
+        messages: vec![
+            ChatMessage {
+                role: MessageRole::Assistant,
+                content: Some(MessageContent::Text(String::new())),
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_123".to_string(),
+                    tool_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: "get_weather".to_string(),
+                        arguments: r#"{"location":"NYC"}"#.to_string(),
+                    },
+                }]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: MessageRole::Tool,
+                content: Some(MessageContent::Text("sunny".to_string())),
+                tool_call_id: Some("call_123".to_string()),
+                ..Default::default()
+            },
+        ],
         ..Default::default()
     };
 
@@ -41,6 +51,9 @@ async fn transform_request_emits_tool_arguments_as_json_object() {
         body["messages"][0]["tool_calls"][0]["function"]["arguments"],
         serde_json::json!({"location": "NYC"})
     );
+    assert_eq!(body["messages"][0]["tool_calls"][0]["id"], "call_123");
+    assert_eq!(body["messages"][1]["tool_call_id"], "call_123");
+    assert_eq!(body["messages"][1]["tool_name"], "get_weather");
 }
 
 fn weather_tool() -> Tool {
@@ -83,12 +96,31 @@ async fn transform_request_preserves_generation_and_tool_selection_contract() {
     assert_eq!(body["options"]["num_predict"], 20);
     assert_eq!(body["format"], schema);
 
+    request.response_format.as_mut().unwrap().json_schema = Some(serde_json::json!({
+        "name": "answer",
+        "strict": true,
+        "schema": schema
+    }));
+    let body =
+        LLMProvider::transform_request(&provider, request.clone(), RequestContext::default())
+            .await
+            .expect("standard JSON schema envelope should transform");
+    assert_eq!(body["format"]["type"], "object");
+
     request.tool_choice = Some(ToolChoice::String("auto".to_string()));
     let body =
         LLMProvider::transform_request(&provider, request.clone(), RequestContext::default())
             .await
             .expect("automatic tool selection should transform");
     assert_eq!(body["tools"].as_array().map(Vec::len), Some(1));
+
+    request.n = Some(2);
+    let error =
+        LLMProvider::transform_request(&provider, request.clone(), RequestContext::default())
+            .await
+            .expect_err("native Ollama cannot return multiple choices");
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+    request.n = None;
 
     request.tool_choice = Some(ToolChoice::Specific {
         choice_type: "function".to_string(),
@@ -99,6 +131,55 @@ async fn transform_request_preserves_generation_and_tool_selection_contract() {
     let error = LLMProvider::transform_request(&provider, request, RequestContext::default())
         .await
         .expect_err("native Ollama cannot force a specific tool");
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+}
+
+#[tokio::test]
+async fn configured_system_overrides_request_system_and_template_is_rejected() {
+    let provider = OllamaProvider::new(OllamaConfig {
+        system: Some("configured system".to_string()),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+    let request = ChatRequest::new("ollama/llama3:8b")
+        .add_system_message("request system")
+        .add_user_message("hello");
+    let body = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .unwrap();
+    assert_eq!(body["messages"].as_array().map(Vec::len), Some(2));
+    assert_eq!(body["messages"][0]["content"], "configured system");
+
+    let error = OllamaProvider::new(OllamaConfig {
+        template: Some("{{ .Prompt }}".to_string()),
+        ..Default::default()
+    })
+    .await
+    .expect_err("unsupported template override must fail configuration");
+    assert!(matches!(error, ProviderError::Configuration { .. }));
+}
+
+#[tokio::test]
+async fn transform_request_rejects_remote_image_urls() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let request = ChatRequest {
+        model: "ollama/llava".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Parts(vec![ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "https://example.test/image.png".to_string(),
+                    detail: None,
+                },
+            }])),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let error = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect_err("native Ollama requires inline base64 images");
     assert!(matches!(error, ProviderError::InvalidRequest { .. }));
 }
 
@@ -173,5 +254,54 @@ async fn non_streaming_maps_upstream_error_status() -> Result<(), Box<dyn std::e
     .expect_err("404 response must map before JSON success parsing");
 
     assert!(matches!(error, ProviderError::ModelNotFound { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn embeddings_preserve_prompt_token_usage() -> Result<(), Box<dyn std::error::Error>> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let address = listener.local_addr()?;
+    tokio::spawn(async move {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .expect("test server accepts request");
+        let mut buffer = [0_u8; 4096];
+        socket
+            .read(&mut buffer)
+            .await
+            .expect("test server reads request");
+        let body = r#"{"embeddings":[[0.1,0.2]],"prompt_eval_count":7}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("test server writes response");
+    });
+    let provider = OllamaProvider::new(OllamaConfig {
+        api_base: Some(format!("http://{address}")),
+        endpoint_access: ProviderEndpointAccess::PrivateNetwork,
+        ..Default::default()
+    })
+    .await?;
+    let response = LLMProvider::embeddings(
+        &provider,
+        EmbeddingRequest {
+            model: "ollama/nomic-embed-text".to_string(),
+            input: EmbeddingInput::Text("hello".to_string()),
+            user: None,
+            encoding_format: None,
+            dimensions: None,
+            task_type: None,
+        },
+        RequestContext::default(),
+    )
+    .await?;
+    let usage = response.usage.expect("embedding usage should be present");
+    assert_eq!(usage.prompt_tokens, 7);
+    assert_eq!(usage.total_tokens, 7);
     Ok(())
 }

--- a/src/core/providers/ollama/runtime_tests.rs
+++ b/src/core/providers/ollama/runtime_tests.rs
@@ -5,7 +5,11 @@ use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::chat::{ChatMessage, ChatRequest};
 use crate::core::types::context::RequestContext;
 use crate::core::types::message::{MessageContent, MessageRole};
-use crate::core::types::tools::{FunctionCall, ToolCall};
+use crate::core::types::responses::FinishReason;
+use crate::core::types::tools::{
+    FunctionCall, FunctionChoice, FunctionDefinition, ResponseFormat, Tool, ToolCall, ToolChoice,
+    ToolType,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -36,6 +40,96 @@ async fn transform_request_emits_tool_arguments_as_json_object() {
     assert_eq!(
         body["messages"][0]["tool_calls"][0]["function"]["arguments"],
         serde_json::json!({"location": "NYC"})
+    );
+}
+
+fn weather_tool() -> Tool {
+    Tool {
+        tool_type: ToolType::Function,
+        function: FunctionDefinition {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({"type": "object"})),
+        },
+    }
+}
+
+#[tokio::test]
+async fn transform_request_preserves_generation_and_tool_selection_contract() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {"answer": {"type": "string"}}
+    });
+    let mut request = ChatRequest {
+        model: "ollama/llama3:8b".to_string(),
+        tools: Some(vec![weather_tool()]),
+        tool_choice: Some(ToolChoice::String("none".to_string())),
+        max_tokens: Some(10),
+        max_completion_tokens: Some(20),
+        response_format: Some(ResponseFormat {
+            format_type: "json_schema".to_string(),
+            json_schema: Some(schema.clone()),
+            response_type: None,
+        }),
+        ..Default::default()
+    };
+
+    let body =
+        LLMProvider::transform_request(&provider, request.clone(), RequestContext::default())
+            .await
+            .expect("supported generation controls should transform");
+    assert!(body.get("tools").is_none());
+    assert_eq!(body["options"]["num_predict"], 20);
+    assert_eq!(body["format"], schema);
+
+    request.tool_choice = Some(ToolChoice::String("auto".to_string()));
+    let body =
+        LLMProvider::transform_request(&provider, request.clone(), RequestContext::default())
+            .await
+            .expect("automatic tool selection should transform");
+    assert_eq!(body["tools"].as_array().map(Vec::len), Some(1));
+
+    request.tool_choice = Some(ToolChoice::Specific {
+        choice_type: "function".to_string(),
+        function: Some(FunctionChoice {
+            name: "get_weather".to_string(),
+        }),
+    });
+    let error = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect_err("native Ollama cannot force a specific tool");
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+}
+
+#[tokio::test]
+async fn non_streaming_tool_calls_override_stop_finish_reason() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let raw = serde_json::to_vec(&serde_json::json!({
+        "model": "llama3:8b",
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "function": {"name": "get_weather", "arguments": {"city": "Paris"}}
+            }]
+        },
+        "done": true,
+        "done_reason": "stop"
+    }))
+    .unwrap();
+
+    let response = LLMProvider::transform_response(&provider, &raw, "llama3:8b", "request-1")
+        .await
+        .expect("tool response should parse");
+    assert_eq!(
+        response.choices[0].finish_reason,
+        Some(FinishReason::ToolCalls)
+    );
+    assert!(
+        response.choices[0].message.tool_calls.as_ref().unwrap()[0]
+            .id
+            .starts_with("call_")
     );
 }
 

--- a/src/core/providers/ollama/streaming.rs
+++ b/src/core/providers/ollama/streaming.rs
@@ -84,7 +84,7 @@ pub struct OllamaToolFunction {
 /// Ollama stream wrapper that handles NDJSON parsing
 pub struct OllamaStream<S> {
     inner: S,
-    buffer: String,
+    buffer: Vec<u8>,
     chunk_id: String,
     finished: bool,
 }
@@ -96,7 +96,7 @@ where
     pub fn new(stream: S) -> Self {
         Self {
             inner: stream,
-            buffer: String::new(),
+            buffer: Vec::new(),
             chunk_id: format!("ollama-{}", uuid::Uuid::new_v4()),
             finished: false,
         }
@@ -121,6 +121,13 @@ where
         // Convert to ChatChunk
         let chat_chunk = self.convert_chunk(chunk)?;
         Ok(Some(chat_chunk))
+    }
+
+    fn parse_bytes(&self, line: &[u8]) -> Result<Option<ChatChunk>, ProviderError> {
+        let line = std::str::from_utf8(line).map_err(|error| {
+            ProviderError::streaming_error("ollama", "chat", None, None, error.to_string())
+        })?;
+        self.parse_line(line)
     }
 
     /// Convert Ollama chunk to standard ChatChunk
@@ -230,11 +237,11 @@ where
 
         loop {
             // Check if we have a complete line in the buffer
-            if let Some(newline_pos) = self.buffer.find('\n') {
-                let line = self.buffer[..newline_pos].to_string();
-                self.buffer = self.buffer[newline_pos + 1..].to_string();
+            if let Some(newline_pos) = self.buffer.iter().position(|byte| *byte == b'\n') {
+                let mut line = self.buffer.drain(..=newline_pos).collect::<Vec<_>>();
+                line.pop();
 
-                match self.parse_line(&line) {
+                match self.parse_bytes(&line) {
                     Ok(Some(chunk)) => {
                         // Check if this is the final chunk
                         if chunk
@@ -254,8 +261,7 @@ where
             // Need more data from the underlying stream
             match Pin::new(&mut self.inner).poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
-                    let text = String::from_utf8_lossy(&bytes);
-                    self.buffer.push_str(&text);
+                    self.buffer.extend_from_slice(&bytes);
                     // Continue loop to check for complete lines
                 }
                 Poll::Ready(Some(Err(e))) => {
@@ -271,7 +277,7 @@ where
                     // Stream ended, process any remaining data
                     if !self.buffer.is_empty() {
                         let line = std::mem::take(&mut self.buffer);
-                        match self.parse_line(&line) {
+                        match self.parse_bytes(&line) {
                             Ok(Some(chunk)) => {
                                 self.finished = true;
                                 return Poll::Ready(Some(Ok(chunk)));
@@ -374,6 +380,7 @@ fn response_to_chunks(response: ChatResponse) -> Vec<ChatChunk> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt as _;
 
     #[test]
     fn test_ollama_stream_chunk_deserialization() {
@@ -473,6 +480,27 @@ mod tests {
 
         let chunk: OllamaStreamChunk = serde_json::from_str(json).unwrap();
         assert_eq!(chunk.error, Some("model not found".to_string()));
+    }
+
+    #[tokio::test]
+    async fn stream_preserves_utf8_split_across_transport_chunks() {
+        let json = concat!(
+            "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",",
+            "\"content\":\"你好\"},\"done\":true,\"done_reason\":\"stop\"}\n"
+        );
+        let split = json.find('你').expect("fixture contains multibyte content") + 1;
+        let chunks = vec![
+            Ok::<Bytes, reqwest::Error>(Bytes::copy_from_slice(&json.as_bytes()[..split])),
+            Ok(Bytes::copy_from_slice(&json.as_bytes()[split..])),
+        ];
+        let mut stream = OllamaStream::new(futures::stream::iter(chunks));
+
+        let chunk = stream
+            .next()
+            .await
+            .expect("stream should emit a chunk")
+            .expect("split UTF-8 should remain valid");
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("你好"));
     }
 
     #[test]

--- a/src/core/providers/ollama/streaming.rs
+++ b/src/core/providers/ollama/streaming.rs
@@ -3,11 +3,12 @@
 //! Handles Ollama's streaming response format (NDJSON - newline-delimited JSON).
 //! Ollama uses a different format than OpenAI's SSE, so we need a custom parser.
 
+use crate::core::providers::shared::MessageTransformer;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::message::MessageRole;
 #[cfg(test)]
 use crate::core::types::responses::ChatResponse;
-use crate::core::types::responses::{ChatChunk, ChatDelta, ChatStreamChoice, Usage};
+use crate::core::types::responses::{ChatChunk, ChatDelta, ChatStreamChoice, FinishReason, Usage};
 use bytes::Bytes;
 use futures::Stream;
 use std::pin::Pin;
@@ -163,7 +164,10 @@ where
                     .enumerate()
                     .map(|(i, tc)| crate::core::types::responses::ToolCallDelta {
                         index: i as u32,
-                        id: tc.id.clone(),
+                        id: tc
+                            .id
+                            .clone()
+                            .or_else(|| Some(format!("call_{}_{i}", self.chunk_id))),
                         tool_type: Some("function".to_string()),
                         function: Some(crate::core::types::responses::FunctionCallDelta {
                             name: Some(tc.function.name.clone()),
@@ -180,15 +184,21 @@ where
 
         // Determine finish reason
         let finish_reason = if chunk.done {
-            let reason_str = chunk.done_reason.as_deref().unwrap_or("stop");
-            Some(match reason_str {
-                "stop" => crate::core::types::responses::FinishReason::Stop,
-                "length" => crate::core::types::responses::FinishReason::Length,
-                "tool_calls" => crate::core::types::responses::FinishReason::ToolCalls,
-                "content_filter" => crate::core::types::responses::FinishReason::ContentFilter,
-                "function_call" => crate::core::types::responses::FinishReason::FunctionCall,
-                _ => crate::core::types::responses::FinishReason::Stop,
-            })
+            Some(
+                if delta
+                    .tool_calls
+                    .as_ref()
+                    .is_some_and(|calls| !calls.is_empty())
+                {
+                    FinishReason::ToolCalls
+                } else {
+                    chunk
+                        .done_reason
+                        .as_deref()
+                        .and_then(MessageTransformer::parse_finish_reason)
+                        .unwrap_or(FinishReason::Stop)
+                },
+            )
         } else {
             None
         };
@@ -501,6 +511,37 @@ mod tests {
             .expect("stream should emit a chunk")
             .expect("split UTF-8 should remain valid");
         assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("你好"));
+    }
+
+    #[tokio::test]
+    async fn streamed_tool_ids_are_stable_and_override_stop_reason() {
+        let first = concat!(
+            "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",",
+            "\"tool_calls\":[{\"function\":{\"name\":\"weather\",\"arguments\":{}}}]},",
+            "\"done\":false}\n"
+        );
+        let last = concat!(
+            "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",",
+            "\"tool_calls\":[{\"function\":{\"name\":\"weather\",\"arguments\":{}}}]},",
+            "\"done\":true,\"done_reason\":\"stop\"}\n"
+        );
+        let chunks = vec![
+            Ok::<Bytes, reqwest::Error>(Bytes::from_static(first.as_bytes())),
+            Ok(Bytes::from_static(last.as_bytes())),
+        ];
+        let mut stream = OllamaStream::new(futures::stream::iter(chunks));
+
+        let first = stream.next().await.unwrap().unwrap();
+        let last = stream.next().await.unwrap().unwrap();
+        let first_id = first.choices[0].delta.tool_calls.as_ref().unwrap()[0]
+            .id
+            .as_deref();
+        let last_id = last.choices[0].delta.tool_calls.as_ref().unwrap()[0]
+            .id
+            .as_deref();
+        assert_eq!(first_id, last_id);
+        assert!(first_id.is_some_and(|id| id.starts_with("call_ollama-")));
+        assert_eq!(last.choices[0].finish_reason, Some(FinishReason::ToolCalls));
     }
 
     #[test]

--- a/src/core/providers/provider_tests.rs
+++ b/src/core/providers/provider_tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+#[test]
+fn test_provider_enum_is_send_sync() {
+    assert!(matches!(ProviderType::from("openai"), ProviderType::OpenAI));
+}
+
+#[tokio::test]
+async fn test_provider_capabilities_embeddings_error_names_real_provider() {
+    let provider = Provider::Anthropic(
+        anthropic::AnthropicProvider::new(anthropic::AnthropicConfig::new_test("test-key"))
+            .unwrap(),
+    );
+
+    assert!(!provider.supports_capability(&ProviderCapability::Embeddings));
+
+    let err = provider
+        .create_embeddings(
+            crate::core::types::embedding::EmbeddingRequest {
+                model: "claude-3-opus-20240229".to_string(),
+                input: crate::core::types::embedding::EmbeddingInput::Text("hello".to_string()),
+                user: None,
+                encoding_format: None,
+                dimensions: None,
+                task_type: None,
+            },
+            crate::core::types::context::RequestContext::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            ProviderError::NotSupported {
+                provider: "anthropic",
+                ..
+            }
+        ),
+        "expected provider-specific NotSupported, got {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_provider_enum_calculate_cost_delegates_mistral_aliases() {
+    let Ok(mistral_provider) = mistral::MistralProvider::new(mistral::MistralConfig {
+        api_key: "sk-test".to_string(),
+        ..mistral::MistralConfig::default()
+    })
+    .await
+    else {
+        panic!("Mistral provider should initialize with a test API key");
+    };
+    let provider = Provider::Mistral(mistral_provider);
+
+    let Ok(alias_cost) = provider
+        .calculate_cost("magistral-medium-1-2", 1000, 500)
+        .await
+    else {
+        panic!("Mistral alias cost should calculate");
+    };
+    let Ok(canonical_cost) = provider
+        .calculate_cost("magistral-medium-2509", 1000, 500)
+        .await
+    else {
+        panic!("Mistral canonical cost should calculate");
+    };
+    let Ok(devstral_alias_cost) = provider.calculate_cost("devstral-2-2512", 1000, 500).await
+    else {
+        panic!("Devstral alias cost should calculate");
+    };
+
+    assert!((alias_cost - canonical_cost).abs() < 1e-12);
+    assert!((alias_cost - 0.0045).abs() < 1e-12);
+    assert!((devstral_alias_cost - 0.0014).abs() < 1e-12);
+}
+
+#[tokio::test]
+async fn test_provider_enum_calculate_cost_strips_openai_prefix() {
+    let mut config = openai::OpenAIConfig::default();
+    config.base.api_key = Some("sk-test123456789012345678901234567890123456".to_string());
+    let Ok(openai_provider) = openai::OpenAIProvider::new(config).await else {
+        panic!("OpenAI provider should initialize with a test API key");
+    };
+    let provider = Provider::OpenAI(openai_provider);
+
+    let Ok(cost) = provider
+        .calculate_cost("openai/gpt-5.5-pro", 1000, 500)
+        .await
+    else {
+        panic!("prefixed OpenAI cost should calculate");
+    };
+
+    assert!((cost - 0.12).abs() < 1e-12);
+}
+
+#[tokio::test]
+async fn test_provider_capabilities_image_error_names_real_provider() {
+    let provider = Provider::Anthropic(
+        anthropic::AnthropicProvider::new(anthropic::AnthropicConfig::new_test("test-key"))
+            .unwrap(),
+    );
+
+    assert!(!provider.supports_capability(&ProviderCapability::ImageGeneration));
+
+    let err = provider
+        .create_images(
+            crate::core::types::image::ImageGenerationRequest {
+                prompt: "a small test image".to_string(),
+                model: Some("claude-3-opus-20240229".to_string()),
+                n: None,
+                size: None,
+                quality: None,
+                response_format: None,
+                style: None,
+                user: None,
+            },
+            crate::core::types::context::RequestContext::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            ProviderError::NotSupported {
+                provider: "anthropic",
+                ..
+            }
+        ),
+        "expected provider-specific NotSupported, got {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_provider_supports_capability_for_optional_provider() {
+    let mut config = openai::OpenAIConfig::default();
+    config.base.api_key = Some("sk-test123456789012345678901234567890123456".to_string());
+    let Ok(openai_provider) = openai::OpenAIProvider::new(config).await else {
+        panic!("OpenAI provider should initialize with a test API key");
+    };
+    let provider = Provider::OpenAI(openai_provider);
+
+    assert!(provider.supports_capability(&ProviderCapability::ChatCompletion));
+    assert!(provider.supports_capability(&ProviderCapability::ChatCompletionStream));
+    assert!(provider.supports_capability(&ProviderCapability::Embeddings));
+    assert!(provider.supports_capability(&ProviderCapability::TextToSpeech));
+}

--- a/src/core/providers/provider_type.rs
+++ b/src/core/providers/provider_type.rs
@@ -15,6 +15,7 @@ pub enum ProviderType {
     DeepInfra,
     V0,
     MetaLlama,
+    Ollama,
     Mistral,
     Moonshot,
     Minimax,
@@ -104,6 +105,7 @@ pub fn all_non_custom_provider_types() -> Vec<ProviderType> {
         ProviderType::DeepInfra,
         ProviderType::V0,
         ProviderType::MetaLlama,
+        ProviderType::Ollama,
         ProviderType::Mistral,
         ProviderType::Moonshot,
         ProviderType::Minimax,
@@ -200,6 +202,11 @@ mod tests {
     }
 
     #[test]
+    fn test_provider_type_from_str_ollama() {
+        assert_eq!(ProviderType::from("ollama"), ProviderType::Ollama);
+    }
+
+    #[test]
     fn test_provider_type_from_str_mistral() {
         assert_eq!(ProviderType::from("mistral"), ProviderType::Mistral);
         assert_eq!(ProviderType::from("mistralai"), ProviderType::Mistral);
@@ -258,6 +265,7 @@ mod tests {
         assert_eq!(format!("{}", ProviderType::DeepInfra), "deepinfra");
         assert_eq!(format!("{}", ProviderType::V0), "v0");
         assert_eq!(format!("{}", ProviderType::MetaLlama), "meta_llama");
+        assert_eq!(format!("{}", ProviderType::Ollama), "ollama");
         assert_eq!(format!("{}", ProviderType::Mistral), "mistral");
         assert_eq!(format!("{}", ProviderType::Moonshot), "moonshot");
         assert_eq!(format!("{}", ProviderType::Groq), "groq");

--- a/src/core/providers/registry/lifecycle.rs
+++ b/src/core/providers/registry/lifecycle.rs
@@ -89,9 +89,9 @@ pub static PROVIDER_MODULE_LIFECYCLE: &[ProviderModuleLifecycleEntry] = &[
         "native Meta Llama module retained; ProviderType::MetaLlama currently uses a generic OpenAI-compatible adapter",
     ),
     wire("mistral", "native Provider enum variant"),
-    stub(
+    providers_extended_wire(
         "ollama",
-        "specialized provider module; not wired through the LLM factory yet",
+        "ProviderType::Ollama dispatches to the native Ollama protocol when providers-extended is enabled",
     ),
     wire("openai", "native Provider enum variant"),
     wire("openai_like", "shared OpenAI-compatible runtime provider"),
@@ -130,11 +130,6 @@ pub static PROVIDER_ORPHAN_BASELINE: &[ProviderOrphanBaselineEntry] = &[
         "meta_llama",
         "demote-to-catalog",
         "catalog-backed duplicate with native provider retained until demote tranche",
-    ),
-    baseline(
-        "ollama",
-        "demote-to-catalog",
-        "local OpenAI-compatible candidate",
     ),
     baseline(
         "v0",

--- a/src/core/providers/registry/lifecycle_tests.rs
+++ b/src/core/providers/registry/lifecycle_tests.rs
@@ -103,6 +103,7 @@ fn disabled_feature_gated_runtime_module_names() -> BTreeSet<&'static str> {
         ProviderType::FalAI,
         ProviderType::Gemini,
         ProviderType::GitHubCopilot,
+        ProviderType::Ollama,
         ProviderType::Replicate,
     ] {
         insert_disabled_feature_gated_module(
@@ -236,6 +237,7 @@ fn lifecycle_classifies_phase0_key_provider_modules() {
         ("fal_ai", cfg!(feature = "providers-extended")),
         ("replicate", cfg!(feature = "providers-extended")),
         ("gemini", cfg!(feature = "providers-extended")),
+        ("ollama", cfg!(feature = "providers-extended")),
     ] {
         let expected = if feature_enabled {
             ProviderModuleLifecycle::Wire

--- a/src/core/providers/registry/mod.rs
+++ b/src/core/providers/registry/mod.rs
@@ -46,3 +46,14 @@ pub fn catalog_definition_for_provider_type(
             .and_then(|entry| get_definition(entry.canonical_name)),
     }
 }
+
+/// Whether a provider selector can authenticate without an API key.
+pub fn selector_skips_api_key(selector: &str) -> bool {
+    let selector = selector.trim().to_ascii_lowercase();
+    get_definition(&selector).is_some_and(|definition| definition.skip_api_key)
+        || selector
+            .parse::<super::provider_type::ProviderType>()
+            .is_ok_and(|provider_type| {
+                matches!(provider_type, super::provider_type::ProviderType::Ollama)
+            })
+}

--- a/src/core/providers/registry/readme_tests.rs
+++ b/src/core/providers/registry/readme_tests.rs
@@ -160,6 +160,10 @@ fn expected_readme_tier2_row(entry: &ProviderRegistryEntry) -> Option<ExpectedRe
             "native factory (`providers-extended`)",
             ["✅", "✅", "–", "✅", "–"],
         )),
+        ProviderType::Ollama => Some(expected(
+            "native factory (`providers-extended`)",
+            ["✅", "✅", "✅", "–", "–"],
+        )),
         ProviderType::MetaLlama
         | ProviderType::V0
         | ProviderType::AmazonNova

--- a/src/core/providers/registry/support_matrix.rs
+++ b/src/core/providers/registry/support_matrix.rs
@@ -185,8 +185,8 @@ pub static PROVIDER_SURFACE_MATRIX: &[ProviderSurfaceSupport] = &[
     ),
     row(
         "ollama",
-        [U, U, U, U, U, S, U, U, U],
-        "SDK streaming reuses the OpenAI-compatible stream parser; chat is not implemented.",
+        [EXTENDED, EXTENDED, EXTENDED, U, U, S, U, U, U],
+        "Native HTTP chat, NDJSON streaming, and embeddings require providers-extended; SDK streaming keeps its existing OpenAI-compatible parser.",
     ),
     row(
         "openrouter",

--- a/src/core/providers/registry/types.rs
+++ b/src/core/providers/registry/types.rs
@@ -145,6 +145,13 @@ pub static PROVIDER_TYPE_REGISTRY: &[ProviderRegistryEntry] = &[
         true,
     ),
     entry(
+        ProviderType::Ollama,
+        "ollama",
+        &[],
+        providers_extended_native_dispatch_kind(),
+        false,
+    ),
+    entry(
         ProviderType::Mistral,
         "mistral",
         &["mistralai"],
@@ -490,6 +497,8 @@ mod tests {
             ProviderType::Gemini,
             #[cfg(feature = "providers-extended")]
             ProviderType::GitHubCopilot,
+            #[cfg(feature = "providers-extended")]
+            ProviderType::Ollama,
         ])
         .collect::<HashSet<_>>();
 
@@ -508,6 +517,10 @@ mod tests {
         );
         assert_eq!(
             dispatch_kind_for(&ProviderType::Gemini),
+            providers_extended_native_dispatch_kind()
+        );
+        assert_eq!(
+            dispatch_kind_for(&ProviderType::Ollama),
             providers_extended_native_dispatch_kind()
         );
         assert_eq!(


### PR DESCRIPTION
Refs #837

## Summary
- add Ollama to the canonical provider registry and unified native dispatch behind providers-extended
- construct ordinary and streaming Ollama requests through the policy-bound pool, including localhost/private-network handling and conflicting endpoint alias rejection
- update lifecycle/support/README matrices and split oversized inline test modules without changing their assertions

## Verification
- cargo fmt --check
- cargo check --all-features
- cargo clippy --all-features --lib -- -D warnings
- cargo clippy --all-targets -- -D warnings
- cargo test (passes: 8,884 lib tests plus integration and doc tests)
- focused Ollama/factory/registry/source-boundary tests with providers-extended enabled
- feature-disabled Ollama factory test with --no-default-features --features tracing --lib

## Existing all-features baseline
- cargo test --all-features reached 10,662 passing tests and 2 unrelated existing Vertex/Gemini context-window assertion failures (1,000,000 vs 1,048,576)
- this branch has no diff under src/core/providers/vertex_ai or src/core/providers/gemini

This is the Ollama wired-native tranche only; it does not close the broader provider lifecycle issue.