### PR TITLE
fix(security): upgrade jsonwebtoken to patched 10.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -3116,17 +3117,20 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -4384,7 +4388,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4548,7 +4552,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5871,6 +5875,12 @@ checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6724,6 +6734,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ vaultrs = { version = "0.7", optional = true }
 
 
 # Authentication and security
-jsonwebtoken = { version = "10.3", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 argon2 = { version = "0.5", optional = true }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ vaultrs = { version = "0.7", optional = true }
 
 
 # Authentication and security
-jsonwebtoken = "9.3"
+jsonwebtoken = { version = "10.3", features = ["aws_lc_rs"] }
 argon2 = { version = "0.5", optional = true }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 sha2 = "0.10"


### PR DESCRIPTION
Closes #1166

## Summary
- upgrade jsonwebtoken from 9.3 to the patched 10.x line (resolved to 10.4.0)
- explicitly select the required aws_lc_rs crypto backend
- refresh Cargo.lock without unrelated package upgrades

## Verification
- cargo fmt --check
- cargo check --locked
- cargo check --all-features --locked
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked
- cargo test --locked jwt (89 passed)
- cargo test --locked --test lib auth_middleware (24 passed)
- cargo audit (GHSA-h395-gr6q-cpjc no longer reported; three pre-existing allowed transitive warnings remain)
- independent Codex review: no actionable P0-P3 findings