### PR TITLE
fix(ollama): close native runtime correctness gaps

### DIFF
--- a/src/core/providers/ollama/embedding.rs
+++ b/src/core/providers/ollama/embedding.rs
@@ -1,0 +1,107 @@
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::responses::{EmbeddingData, EmbeddingResponse, Usage};
+
+pub(super) fn parse_embedding_response(
+    response: &serde_json::Value,
+    expected_embedding_count: usize,
+    model: &str,
+) -> Result<EmbeddingResponse, ProviderError> {
+    let embeddings = response
+        .get("embeddings")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            ProviderError::response_parsing("ollama", "Missing embeddings in response")
+        })?;
+
+    if embeddings.len() != expected_embedding_count {
+        return Err(ProviderError::response_parsing(
+            "ollama",
+            format!(
+                "Ollama returned {} embeddings for {expected_embedding_count} inputs",
+                embeddings.len()
+            ),
+        ));
+    }
+
+    let mut expected_dimension = None;
+    let mut data = Vec::with_capacity(embeddings.len());
+    for (i, emb) in embeddings.iter().enumerate() {
+        let values = emb.as_array().ok_or_else(|| {
+            ProviderError::response_parsing(
+                "ollama",
+                format!("Ollama embedding at index {i} is not an array"),
+            )
+        })?;
+        if values.is_empty() {
+            return Err(ProviderError::response_parsing(
+                "ollama",
+                format!("Ollama embedding at index {i} is empty"),
+            ));
+        }
+        if expected_dimension.is_some_and(|dimension| dimension != values.len()) {
+            return Err(ProviderError::response_parsing(
+                "ollama",
+                format!("Ollama embedding at index {i} has an inconsistent dimension"),
+            ));
+        }
+        expected_dimension.get_or_insert(values.len());
+        let embedding = values
+            .iter()
+            .enumerate()
+            .map(|(coordinate, value)| {
+                value
+                    .as_f64()
+                    .filter(|value| value.is_finite() && (*value as f32).is_finite())
+                    .map(|value| value as f32)
+                    .ok_or_else(|| {
+                        ProviderError::response_parsing(
+                            "ollama",
+                            format!(
+                                "Ollama embedding at index {i} has an invalid coordinate at {coordinate}"
+                            ),
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let index = u32::try_from(i).map_err(|_| {
+            ProviderError::response_parsing(
+                "ollama",
+                "Ollama embedding response contains too many rows",
+            )
+        })?;
+
+        data.push(EmbeddingData {
+            object: "embedding".to_string(),
+            embedding,
+            index,
+        });
+    }
+
+    let prompt_tokens = match response.get("prompt_eval_count") {
+        None => 0,
+        Some(count) => count
+            .as_u64()
+            .and_then(|count| u32::try_from(count).ok())
+            .ok_or_else(|| {
+                ProviderError::response_parsing(
+                    "ollama",
+                    "Ollama embedding response has an invalid prompt_eval_count",
+                )
+            })?,
+    };
+
+    Ok(EmbeddingResponse {
+        object: "list".to_string(),
+        data,
+        model: format!("ollama/{model}"),
+        usage: Some(Usage {
+            prompt_tokens,
+            completion_tokens: 0,
+            total_tokens: prompt_tokens,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+            thinking_usage: None,
+        }),
+        embeddings: None,
+    })
+}

--- a/src/core/providers/ollama/error.rs
+++ b/src/core/providers/ollama/error.rs
@@ -85,7 +85,15 @@ pub(super) fn response_format_value(
             let schema = match schema.as_object() {
                 Some(wrapper)
                     if wrapper.get("name").is_some_and(|name| name.is_string())
-                        && wrapper.contains_key("schema")
+                        && wrapper
+                            .get("schema")
+                            .is_some_and(|schema| schema.is_object())
+                        && wrapper
+                            .get("description")
+                            .is_none_or(serde_json::Value::is_string)
+                        && wrapper
+                            .get("strict")
+                            .is_none_or(serde_json::Value::is_boolean)
                         && wrapper.keys().all(|key| {
                             matches!(key.as_str(), "name" | "description" | "strict" | "schema")
                         }) =>

--- a/src/core/providers/ollama/error.rs
+++ b/src/core/providers/ollama/error.rs
@@ -82,11 +82,30 @@ pub(super) fn response_format_value(
                     "json_schema response format needs a schema",
                 )
             })?;
-            let schema = schema
-                .as_object()
-                .filter(|wrapper| wrapper.contains_key("name") || wrapper.contains_key("strict"))
-                .and_then(|wrapper| wrapper.get("schema"))
-                .unwrap_or(schema);
+            let schema = match schema.as_object() {
+                Some(wrapper)
+                    if wrapper.get("name").is_some_and(|name| name.is_string())
+                        && wrapper.contains_key("schema")
+                        && wrapper.keys().all(|key| {
+                            matches!(key.as_str(), "name" | "description" | "strict" | "schema")
+                        }) =>
+                {
+                    &wrapper["schema"]
+                }
+                Some(_) => schema,
+                None => {
+                    return Err(ProviderError::invalid_request(
+                        "ollama",
+                        "json_schema response format must be a JSON object",
+                    ));
+                }
+            };
+            if !schema.is_object() {
+                return Err(ProviderError::invalid_request(
+                    "ollama",
+                    "json_schema response format inner schema must be a JSON object",
+                ));
+            }
             Ok(Some(schema.clone()))
         }
         other => Err(ProviderError::invalid_request(

--- a/src/core/providers/ollama/mod.rs
+++ b/src/core/providers/ollama/mod.rs
@@ -18,9 +18,11 @@
 
 // Core modules
 mod config;
+mod embedding;
 mod error;
 mod model_info;
 mod provider;
+mod request_options;
 #[cfg(test)]
 mod runtime_tests;
 mod streaming;

--- a/src/core/providers/ollama/model_info.rs
+++ b/src/core/providers/ollama/model_info.rs
@@ -130,6 +130,14 @@ impl OllamaModelInfo {
 
 impl From<OllamaModelInfo> for ModelInfo {
     fn from(model: OllamaModelInfo) -> Self {
+        let mut capabilities = vec![
+            ProviderCapability::ChatCompletion,
+            ProviderCapability::ChatCompletionStream,
+            ProviderCapability::Embeddings,
+        ];
+        if model.supports_tools {
+            capabilities.push(ProviderCapability::ToolCalling);
+        }
         Self {
             id: model.name,
             name: model.display_name,
@@ -142,11 +150,7 @@ impl From<OllamaModelInfo> for ModelInfo {
             input_cost_per_1k_tokens: Some(0.0),
             output_cost_per_1k_tokens: Some(0.0),
             currency: "USD".to_string(),
-            capabilities: vec![
-                ProviderCapability::ChatCompletion,
-                ProviderCapability::ChatCompletionStream,
-                ProviderCapability::Embeddings,
-            ],
+            capabilities,
             created_at: None,
             updated_at: None,
             metadata: HashMap::new(),
@@ -329,6 +333,25 @@ mod tests {
         assert!(info.supports_tools);
         assert!(!info.supports_multimodal);
         assert_eq!(info.parameter_size, Some("8B".to_string()));
+
+        let model: ModelInfo = info.into();
+        assert!(model.supports_tools);
+        assert!(
+            model
+                .capabilities
+                .contains(&ProviderCapability::ToolCalling)
+        );
+    }
+
+    #[test]
+    fn model_without_tools_does_not_advertise_tool_calling() {
+        let model: ModelInfo = get_model_info("gemma:7b").into();
+        assert!(!model.supports_tools);
+        assert!(
+            !model
+                .capabilities
+                .contains(&ProviderCapability::ToolCalling)
+        );
     }
 
     #[test]

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -9,11 +9,13 @@ use std::sync::Arc;
 use tracing::debug;
 
 use super::config::OllamaConfig;
+use super::embedding::parse_embedding_response;
 use super::error::{
     inline_image_data, parse_http_json_response, parse_tool_arguments, response_format_value,
     should_send_tools,
 };
 use super::model_info::{OllamaModelInfo, OllamaShowResponse, OllamaTagsResponse, get_model_info};
+use super::request_options::merge_request_options;
 use super::streaming::OllamaStream;
 use crate::core::providers::base::{
     BaseConfig, GlobalPoolManager, HttpErrorMapper, HttpMethod, header,
@@ -35,9 +37,7 @@ use crate::core::types::{
     message::MessageRole,
     model::ModelInfo,
     model::ProviderCapability,
-    responses::{
-        ChatChoice, ChatChunk, ChatResponse, EmbeddingData, EmbeddingResponse, FinishReason, Usage,
-    },
+    responses::{ChatChoice, ChatChunk, ChatResponse, EmbeddingResponse, FinishReason, Usage},
     tools::FunctionCall,
     tools::ToolCall,
 };
@@ -59,78 +59,6 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    const REQUEST_INTEGER_OPTIONS: [&'static str; 2] = ["num_ctx", "num_predict"];
-    const REQUEST_FLOAT_OPTIONS: [&'static str; 1] = ["repeat_penalty"];
-
-    fn merge_request_options(
-        &self,
-        options: &mut serde_json::Map<String, serde_json::Value>,
-        request: &ChatRequest,
-    ) -> Result<(), ProviderError> {
-        for name in Self::REQUEST_INTEGER_OPTIONS {
-            let Some(value) = request.extra_params.get(name) else {
-                continue;
-            };
-            let integer = value
-                .as_i64()
-                .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
-                .or_else(|| {
-                    value.as_f64().and_then(|value| {
-                        (value.is_finite()
-                            && value.fract() == 0.0
-                            && value >= i64::MIN as f64
-                            && value <= i64::MAX as f64)
-                            .then_some(value as i64)
-                    })
-                });
-            let valid = match (name, integer) {
-                ("num_ctx", Some(value)) => value > 0 && u32::try_from(value).is_ok(),
-                (_, Some(_)) => true,
-                (_, None) => false,
-            };
-            if !valid {
-                return Err(ProviderError::invalid_request(
-                    "ollama",
-                    format!("native Ollama option {name} must be a valid integer"),
-                ));
-            }
-            let integer = integer.expect("validated integer option");
-            if name == "num_ctx"
-                && self
-                    .config
-                    .num_ctx
-                    .is_some_and(|configured_max| integer as u64 > u64::from(configured_max))
-            {
-                return Err(ProviderError::invalid_request(
-                    "ollama",
-                    format!(
-                        "native Ollama option num_ctx exceeds the configured maximum of {}",
-                        self.config.num_ctx.expect("checked configured num_ctx")
-                    ),
-                ));
-            }
-            options.insert(name.to_string(), serde_json::json!(integer));
-        }
-
-        for name in Self::REQUEST_FLOAT_OPTIONS {
-            let Some(value) = request.extra_params.get(name) else {
-                continue;
-            };
-            let valid = value
-                .as_f64()
-                .is_some_and(|value| value.is_finite() && (value as f32).is_finite());
-            if !valid {
-                return Err(ProviderError::invalid_request(
-                    "ollama",
-                    format!("native Ollama option {name} must be a finite number"),
-                ));
-            }
-            options.insert(name.to_string(), value.clone());
-        }
-
-        Ok(())
-    }
-
     /// Create a new Ollama provider instance
     pub async fn new(config: OllamaConfig) -> Result<Self, ProviderError> {
         // Validate configuration
@@ -389,7 +317,7 @@ impl OllamaProvider {
         // Add options from request parameters
         let mut options = self.config.build_options();
         if let serde_json::Value::Object(ref mut opts) = options {
-            self.merge_request_options(opts, request)?;
+            merge_request_options(&self.config, opts, request)?;
             if let Some(temp) = request.temperature {
                 opts.insert("temperature".to_string(), serde_json::json!(temp));
             }
@@ -743,97 +671,7 @@ impl LLMProvider for OllamaProvider {
             .execute_request(&url, HttpMethod::POST, Some(body))
             .await?;
 
-        // Parse Ollama embeddings response
-        // Ollama returns: { "embeddings": [[...], [...]] }
-        let embeddings = response
-            .get("embeddings")
-            .and_then(|e| e.as_array())
-            .ok_or_else(|| {
-                ProviderError::response_parsing("ollama", "Missing embeddings in response")
-            })?;
-
-        if embeddings.len() != expected_embedding_count {
-            return Err(ProviderError::response_parsing(
-                "ollama",
-                format!(
-                    "Ollama returned {} embeddings for {expected_embedding_count} inputs",
-                    embeddings.len()
-                ),
-            ));
-        }
-
-        let mut expected_dimension = None;
-        let data: Vec<EmbeddingData> = embeddings
-            .iter()
-            .enumerate()
-            .map(|(i, emb)| -> Result<EmbeddingData, ProviderError> {
-                let values = emb
-                    .as_array()
-                    .ok_or_else(|| {
-                        ProviderError::response_parsing(
-                            "ollama",
-                            format!("Ollama embedding at index {i} is not an array"),
-                        )
-                    })?;
-                if values.is_empty() {
-                    return Err(ProviderError::response_parsing(
-                        "ollama",
-                        format!("Ollama embedding at index {i} is empty"),
-                    ));
-                }
-                if expected_dimension.is_some_and(|dimension| dimension != values.len()) {
-                    return Err(ProviderError::response_parsing(
-                        "ollama",
-                        format!("Ollama embedding at index {i} has an inconsistent dimension"),
-                    ));
-                }
-                expected_dimension.get_or_insert(values.len());
-                let embedding = values
-                    .iter()
-                    .enumerate()
-                    .map(|(coordinate, value)| {
-                        value
-                            .as_f64()
-                            .filter(|value| value.is_finite() && (*value as f32).is_finite())
-                            .map(|value| value as f32)
-                            .ok_or_else(|| {
-                                ProviderError::response_parsing(
-                                    "ollama",
-                                    format!(
-                                        "Ollama embedding at index {i} has an invalid coordinate at {coordinate}"
-                                    ),
-                                )
-                            })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(EmbeddingData {
-                    object: "embedding".to_string(),
-                    embedding,
-                    index: i as u32,
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let prompt_tokens = response
-            .get("prompt_eval_count")
-            .and_then(serde_json::Value::as_u64)
-            .map(|count| u32::try_from(count).unwrap_or(u32::MAX))
-            .unwrap_or(0);
-
-        Ok(EmbeddingResponse {
-            object: "list".to_string(),
-            data,
-            model: format!("ollama/{}", model),
-            usage: Some(Usage {
-                prompt_tokens,
-                completion_tokens: 0,
-                total_tokens: prompt_tokens,
-                prompt_tokens_details: None,
-                completion_tokens_details: None,
-                thinking_usage: None,
-            }),
-            embeddings: None,
-        })
+        parse_embedding_response(&response, expected_embedding_count, model)
     }
 
     async fn health_check(&self) -> HealthStatus {

--- a/src/core/providers/ollama/provider.rs
+++ b/src/core/providers/ollama/provider.rs
@@ -59,6 +59,78 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
+    const REQUEST_INTEGER_OPTIONS: [&'static str; 2] = ["num_ctx", "num_predict"];
+    const REQUEST_FLOAT_OPTIONS: [&'static str; 1] = ["repeat_penalty"];
+
+    fn merge_request_options(
+        &self,
+        options: &mut serde_json::Map<String, serde_json::Value>,
+        request: &ChatRequest,
+    ) -> Result<(), ProviderError> {
+        for name in Self::REQUEST_INTEGER_OPTIONS {
+            let Some(value) = request.extra_params.get(name) else {
+                continue;
+            };
+            let integer = value
+                .as_i64()
+                .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+                .or_else(|| {
+                    value.as_f64().and_then(|value| {
+                        (value.is_finite()
+                            && value.fract() == 0.0
+                            && value >= i64::MIN as f64
+                            && value <= i64::MAX as f64)
+                            .then_some(value as i64)
+                    })
+                });
+            let valid = match (name, integer) {
+                ("num_ctx", Some(value)) => value > 0 && u32::try_from(value).is_ok(),
+                (_, Some(_)) => true,
+                (_, None) => false,
+            };
+            if !valid {
+                return Err(ProviderError::invalid_request(
+                    "ollama",
+                    format!("native Ollama option {name} must be a valid integer"),
+                ));
+            }
+            let integer = integer.expect("validated integer option");
+            if name == "num_ctx"
+                && self
+                    .config
+                    .num_ctx
+                    .is_some_and(|configured_max| integer as u64 > u64::from(configured_max))
+            {
+                return Err(ProviderError::invalid_request(
+                    "ollama",
+                    format!(
+                        "native Ollama option num_ctx exceeds the configured maximum of {}",
+                        self.config.num_ctx.expect("checked configured num_ctx")
+                    ),
+                ));
+            }
+            options.insert(name.to_string(), serde_json::json!(integer));
+        }
+
+        for name in Self::REQUEST_FLOAT_OPTIONS {
+            let Some(value) = request.extra_params.get(name) else {
+                continue;
+            };
+            let valid = value
+                .as_f64()
+                .is_some_and(|value| value.is_finite() && (value as f32).is_finite());
+            if !valid {
+                return Err(ProviderError::invalid_request(
+                    "ollama",
+                    format!("native Ollama option {name} must be a finite number"),
+                ));
+            }
+            options.insert(name.to_string(), value.clone());
+        }
+
+        Ok(())
+    }
+
     /// Create a new Ollama provider instance
     pub async fn new(config: OllamaConfig) -> Result<Self, ProviderError> {
         // Validate configuration
@@ -317,6 +389,7 @@ impl OllamaProvider {
         // Add options from request parameters
         let mut options = self.config.build_options();
         if let serde_json::Value::Object(ref mut opts) = options {
+            self.merge_request_options(opts, request)?;
             if let Some(temp) = request.temperature {
                 opts.insert("temperature".to_string(), serde_json::json!(temp));
             }
@@ -530,9 +603,6 @@ impl LLMProvider for OllamaProvider {
             "num_ctx",
             "num_predict",
             "repeat_penalty",
-            "mirostat",
-            "mirostat_eta",
-            "mirostat_tau",
         ]
     }
 
@@ -661,6 +731,7 @@ impl LLMProvider for OllamaProvider {
             crate::core::types::embedding::EmbeddingInput::Text(text) => vec![text],
             crate::core::types::embedding::EmbeddingInput::Array(texts) => texts,
         };
+        let expected_embedding_count = input.len();
 
         let body = serde_json::json!({
             "model": model,
@@ -678,33 +749,71 @@ impl LLMProvider for OllamaProvider {
             .get("embeddings")
             .and_then(|e| e.as_array())
             .ok_or_else(|| {
-                ProviderError::api_error(
-                    "ollama",
-                    500,
-                    "Missing embeddings in response".to_string(),
-                )
+                ProviderError::response_parsing("ollama", "Missing embeddings in response")
             })?;
 
+        if embeddings.len() != expected_embedding_count {
+            return Err(ProviderError::response_parsing(
+                "ollama",
+                format!(
+                    "Ollama returned {} embeddings for {expected_embedding_count} inputs",
+                    embeddings.len()
+                ),
+            ));
+        }
+
+        let mut expected_dimension = None;
         let data: Vec<EmbeddingData> = embeddings
             .iter()
             .enumerate()
-            .map(|(i, emb)| {
-                let embedding: Vec<f32> = emb
+            .map(|(i, emb)| -> Result<EmbeddingData, ProviderError> {
+                let values = emb
                     .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_f64().map(|f| f as f32))
-                            .collect()
+                    .ok_or_else(|| {
+                        ProviderError::response_parsing(
+                            "ollama",
+                            format!("Ollama embedding at index {i} is not an array"),
+                        )
+                    })?;
+                if values.is_empty() {
+                    return Err(ProviderError::response_parsing(
+                        "ollama",
+                        format!("Ollama embedding at index {i} is empty"),
+                    ));
+                }
+                if expected_dimension.is_some_and(|dimension| dimension != values.len()) {
+                    return Err(ProviderError::response_parsing(
+                        "ollama",
+                        format!("Ollama embedding at index {i} has an inconsistent dimension"),
+                    ));
+                }
+                expected_dimension.get_or_insert(values.len());
+                let embedding = values
+                    .iter()
+                    .enumerate()
+                    .map(|(coordinate, value)| {
+                        value
+                            .as_f64()
+                            .filter(|value| value.is_finite() && (*value as f32).is_finite())
+                            .map(|value| value as f32)
+                            .ok_or_else(|| {
+                                ProviderError::response_parsing(
+                                    "ollama",
+                                    format!(
+                                        "Ollama embedding at index {i} has an invalid coordinate at {coordinate}"
+                                    ),
+                                )
+                            })
                     })
-                    .unwrap_or_default();
+                    .collect::<Result<Vec<_>, _>>()?;
 
-                EmbeddingData {
+                Ok(EmbeddingData {
                     object: "embedding".to_string(),
                     embedding,
                     index: i as u32,
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
         let prompt_tokens = response
             .get("prompt_eval_count")
             .and_then(serde_json::Value::as_u64)

--- a/src/core/providers/ollama/request_options.rs
+++ b/src/core/providers/ollama/request_options.rs
@@ -1,0 +1,87 @@
+use super::config::OllamaConfig;
+use crate::core::providers::unified_provider::ProviderError;
+use crate::core::types::chat::ChatRequest;
+
+const INTEGER_OPTIONS: [&str; 2] = ["num_ctx", "num_predict"];
+const FLOAT_OPTIONS: [&str; 1] = ["repeat_penalty"];
+const I64_MIN_AS_F64: f64 = -9_223_372_036_854_775_808.0;
+const I64_MAX_EXCLUSIVE_AS_F64: f64 = 9_223_372_036_854_775_808.0;
+
+pub(super) fn merge_request_options(
+    config: &OllamaConfig,
+    options: &mut serde_json::Map<String, serde_json::Value>,
+    request: &ChatRequest,
+) -> Result<(), ProviderError> {
+    for name in INTEGER_OPTIONS {
+        if name == "num_predict"
+            && request
+                .max_completion_tokens
+                .or(request.max_tokens)
+                .is_some()
+        {
+            continue;
+        }
+        let Some(value) = request.extra_params.get(name) else {
+            continue;
+        };
+        let integer = value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+            .or_else(|| {
+                value
+                    .is_f64()
+                    .then(|| value.as_f64())
+                    .flatten()
+                    .and_then(|value| {
+                        (value.is_finite()
+                            && value.fract() == 0.0
+                            && (I64_MIN_AS_F64..I64_MAX_EXCLUSIVE_AS_F64).contains(&value))
+                        .then_some(value as i64)
+                    })
+            });
+        let valid = match (name, integer) {
+            ("num_ctx", Some(value)) => value > 0 && u32::try_from(value).is_ok(),
+            (_, Some(_)) => true,
+            (_, None) => false,
+        };
+        if !valid {
+            return Err(ProviderError::invalid_request(
+                "ollama",
+                format!("native Ollama option {name} must be a valid integer"),
+            ));
+        }
+        let integer = integer.expect("validated integer option");
+        if name == "num_ctx"
+            && config
+                .num_ctx
+                .is_some_and(|configured_max| integer as u64 > u64::from(configured_max))
+        {
+            return Err(ProviderError::invalid_request(
+                "ollama",
+                format!(
+                    "native Ollama option num_ctx exceeds the configured maximum of {}",
+                    config.num_ctx.expect("checked configured num_ctx")
+                ),
+            ));
+        }
+        options.insert(name.to_string(), serde_json::json!(integer));
+    }
+
+    for name in FLOAT_OPTIONS {
+        let Some(value) = request.extra_params.get(name) else {
+            continue;
+        };
+        let valid = value
+            .as_f64()
+            .is_some_and(|value| value.is_finite() && (value as f32).is_finite());
+        if !valid {
+            return Err(ProviderError::invalid_request(
+                "ollama",
+                format!("native Ollama option {name} must be a finite number"),
+            ));
+        }
+        options.insert(name.to_string(), value.clone());
+    }
+
+    Ok(())
+}

--- a/src/core/providers/ollama/runtime_tests.rs
+++ b/src/core/providers/ollama/runtime_tests.rs
@@ -1,3 +1,4 @@
+use super::streaming::OllamaStream;
 use super::{OllamaConfig, OllamaProvider};
 use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::unified_provider::ProviderError;
@@ -7,11 +8,13 @@ use crate::core::types::content::{ContentPart, ImageUrl};
 use crate::core::types::context::RequestContext;
 use crate::core::types::embedding::{EmbeddingInput, EmbeddingRequest};
 use crate::core::types::message::{MessageContent, MessageRole};
-use crate::core::types::responses::FinishReason;
+use crate::core::types::responses::{EmbeddingResponse, FinishReason};
 use crate::core::types::tools::{
     FunctionCall, FunctionChoice, FunctionDefinition, ResponseFormat, Tool, ToolCall, ToolChoice,
     ToolType,
 };
+use bytes::Bytes;
+use futures::StreamExt as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -132,6 +135,109 @@ async fn transform_request_preserves_generation_and_tool_selection_contract() {
         .await
         .expect_err("native Ollama cannot force a specific tool");
     assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+}
+
+#[tokio::test]
+async fn transform_request_preserves_raw_schema_annotation_keywords() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let request = ChatRequest {
+        model: "ollama/llama3:8b".to_string(),
+        response_format: Some(ResponseFormat {
+            format_type: "json_schema".to_string(),
+            json_schema: Some(serde_json::json!({
+                "name": "answer",
+                "strict": true,
+                "schema": {"custom": "annotation"},
+                "type": "object"
+            })),
+            response_type: None,
+        }),
+        ..Default::default()
+    };
+
+    let body = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect("raw JSON Schema annotation keywords must not imply an OpenAI envelope");
+    assert_eq!(body["format"]["name"], "answer");
+    assert_eq!(body["format"]["strict"], true);
+    assert_eq!(body["format"]["schema"]["custom"], "annotation");
+}
+
+#[tokio::test]
+async fn transform_request_forwards_validated_request_options_with_typed_precedence() {
+    let provider = OllamaProvider::new(OllamaConfig {
+        num_ctx: Some(8_192),
+        repeat_penalty: Some(1.1),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+    let request = ChatRequest {
+        model: "ollama/llama3:8b".to_string(),
+        max_completion_tokens: Some(32),
+        extra_params: std::collections::HashMap::from([
+            ("num_ctx".to_string(), serde_json::json!(8_192.0)),
+            ("num_predict".to_string(), serde_json::json!(64.0)),
+            ("repeat_penalty".to_string(), serde_json::json!(1.25)),
+        ]),
+        ..Default::default()
+    };
+
+    let body = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect("valid request-scoped options should transform");
+
+    assert_eq!(body["options"]["num_ctx"], 8_192);
+    assert_eq!(body["options"]["num_predict"], 32);
+    assert_eq!(body["options"]["repeat_penalty"], 1.25);
+}
+
+#[tokio::test]
+async fn transform_request_enforces_configured_num_ctx_ceiling() {
+    let provider = OllamaProvider::new(OllamaConfig {
+        num_ctx: Some(2_048),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+    let request = ChatRequest {
+        model: "ollama/llama3:8b".to_string(),
+        extra_params: std::collections::HashMap::from([(
+            "num_ctx".to_string(),
+            serde_json::json!(4_096),
+        )]),
+        ..Default::default()
+    };
+
+    let error = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect_err("request num_ctx must not exceed the operator ceiling");
+    assert!(matches!(error, ProviderError::InvalidRequest { .. }));
+}
+
+#[tokio::test]
+async fn transform_request_rejects_invalid_request_scoped_option_types() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let invalid = [
+        ("num_ctx", serde_json::json!(-1)),
+        ("num_predict", serde_json::json!(1.5)),
+        ("repeat_penalty", serde_json::json!("high")),
+    ];
+
+    for (name, value) in invalid {
+        let request = ChatRequest {
+            model: "ollama/llama3:8b".to_string(),
+            extra_params: std::collections::HashMap::from([(name.to_string(), value)]),
+            ..Default::default()
+        };
+        let error = LLMProvider::transform_request(&provider, request, RequestContext::default())
+            .await
+            .expect_err("invalid advertised option must fail visibly");
+        assert!(
+            matches!(error, ProviderError::InvalidRequest { .. }),
+            "unexpected error for {name}: {error}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -257,6 +363,102 @@ async fn non_streaming_maps_upstream_error_status() -> Result<(), Box<dyn std::e
     Ok(())
 }
 
+fn stream_from_records(
+    records: Vec<Bytes>,
+) -> OllamaStream<impl futures::Stream<Item = Result<Bytes, reqwest::Error>>> {
+    OllamaStream::new(futures::stream::iter(
+        records.into_iter().map(Ok::<_, reqwest::Error>),
+    ))
+}
+
+#[tokio::test]
+async fn stream_preserves_tool_indices_and_non_stop_terminal_reason() {
+    let records = [
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"function\":{\"index\":2,\"name\":\"first\",\"arguments\":{}}}]},\"done\":false}\n",
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"function\":{\"name\":\"second\",\"arguments\":{}}}]},\"done\":false}\n",
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\"done_reason\":\"length\"}",
+    ];
+    let mut stream = stream_from_records(
+        records
+            .map(|record| Bytes::from_static(record.as_bytes()))
+            .to_vec(),
+    );
+
+    let first = stream.next().await.unwrap().unwrap();
+    let second = stream.next().await.unwrap().unwrap();
+    let last = stream.next().await.unwrap().unwrap();
+    let first_call = &first.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+    let second_call = &second.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+    assert_eq!(first_call.index, 2);
+    assert_eq!(second_call.index, 3);
+    assert_ne!(first_call.id, second_call.id);
+    assert_eq!(last.choices[0].finish_reason, Some(FinishReason::Length));
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn premature_eof_and_missing_model_fail_terminally() {
+    for bytes in [
+        Bytes::new(),
+        Bytes::from_static(
+            b"{\"message\":{\"role\":\"assistant\",\"content\":\"complete\"},\"done\":true}",
+        ),
+    ] {
+        let mut stream = stream_from_records(vec![bytes]);
+        assert!(stream.next().await.unwrap().is_err());
+        assert!(stream.next().await.is_none());
+    }
+
+    let mut partial = stream_from_records(vec![Bytes::from_static(
+        b"{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"content\":\"partial\"},\"done\":false}\n",
+    )]);
+    assert_eq!(
+        partial.next().await.unwrap().unwrap().choices[0]
+            .delta
+            .content
+            .as_deref(),
+        Some("partial")
+    );
+    assert!(partial.next().await.unwrap().is_err());
+    assert!(partial.next().await.is_none());
+}
+
+#[tokio::test]
+async fn stream_errors_preserve_status_redact_and_are_fused() {
+    let records = concat!(
+        "{\"error\":\"Authorization: Bearer sk-secret123 model missing\",\"status\":404}\n",
+        "{\"model\":\"llama3:8b\",\"done\":true}\n"
+    );
+    let mut stream = stream_from_records(vec![Bytes::from_static(records.as_bytes())]);
+    let error = stream.next().await.unwrap().unwrap_err();
+    assert!(matches!(error, ProviderError::ModelNotFound { .. }));
+    assert!(!error.to_string().contains("sk-secret123"));
+    assert!(error.to_string().contains("[REDACTED]"));
+    assert!(stream.next().await.is_none());
+
+    for status in ["\"bad\"", "700", "-1"] {
+        let record = format!("{{\"error\":\"runner failed\",\"status\":{status}}}\n");
+        let mut stream = stream_from_records(vec![Bytes::from(record)]);
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Err(ProviderError::ApiError { status: 500, .. })
+        ));
+        assert!(stream.next().await.is_none());
+    }
+}
+
+#[tokio::test]
+async fn stream_rejects_usage_overflow() {
+    let mut stream = stream_from_records(vec![Bytes::from_static(
+        b"{\"model\":\"llama3:8b\",\"done\":true,\"prompt_eval_count\":4294967295,\"eval_count\":1}",
+    )]);
+    assert!(matches!(
+        stream.next().await.unwrap(),
+        Err(ProviderError::ResponseParsing { .. })
+    ));
+    assert!(stream.next().await.is_none());
+}
+
 #[tokio::test]
 async fn embeddings_preserve_prompt_token_usage() -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
@@ -304,4 +506,121 @@ async fn embeddings_preserve_prompt_token_usage() -> Result<(), Box<dyn std::err
     assert_eq!(usage.prompt_tokens, 7);
     assert_eq!(usage.total_tokens, 7);
     Ok(())
+}
+
+async fn embeddings_from_fixture(
+    body: &str,
+    input: EmbeddingInput,
+) -> Result<EmbeddingResponse, ProviderError> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("fixture listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("fixture listener should have an address");
+    let body = body.to_string();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .expect("fixture server accepts request");
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        loop {
+            let read = socket
+                .read(&mut buffer)
+                .await
+                .expect("fixture server reads request");
+            assert!(read > 0, "fixture request ended before its complete body");
+            request.extend_from_slice(&buffer[..read]);
+            let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") else {
+                continue;
+            };
+            let headers = std::str::from_utf8(&request[..header_end])
+                .expect("fixture request headers are UTF-8");
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .expect("fixture request has Content-Length");
+            if request.len() >= header_end + 4 + content_length {
+                let request_body: serde_json::Value = serde_json::from_slice(
+                    &request[header_end + 4..header_end + 4 + content_length],
+                )
+                .expect("fixture request body is JSON");
+                assert_eq!(request_body["model"], "nomic-embed-text");
+                assert!(request_body["input"].is_array());
+                break;
+            }
+        }
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("fixture server writes response");
+    });
+
+    let provider = OllamaProvider::new(OllamaConfig {
+        api_base: Some(format!("http://{address}")),
+        endpoint_access: ProviderEndpointAccess::PrivateNetwork,
+        ..Default::default()
+    })
+    .await
+    .expect("fixture provider should build");
+    let result = LLMProvider::embeddings(
+        &provider,
+        EmbeddingRequest {
+            model: "ollama/nomic-embed-text".to_string(),
+            input,
+            user: None,
+            encoding_format: None,
+            dimensions: None,
+            task_type: None,
+        },
+        RequestContext::default(),
+    )
+    .await;
+    server.await.expect("fixture server task should finish");
+    result
+}
+
+#[tokio::test]
+async fn embeddings_reject_malformed_vectors_and_count_mismatches() {
+    let malformed = [
+        (
+            r#"{"embeddings":[42]}"#,
+            EmbeddingInput::Text("a".to_string()),
+        ),
+        (
+            r#"{"embeddings":[[0.1,"bad"]]}"#,
+            EmbeddingInput::Text("a".to_string()),
+        ),
+        (
+            r#"{"embeddings":[[1e39]]}"#,
+            EmbeddingInput::Text("a".to_string()),
+        ),
+        (
+            r#"{"embeddings":[[0.1],[0.2,0.3]]}"#,
+            EmbeddingInput::Array(vec!["a".to_string(), "b".to_string()]),
+        ),
+        (
+            r#"{"embeddings":[[0.1,0.2]]}"#,
+            EmbeddingInput::Array(vec!["a".to_string(), "b".to_string()]),
+        ),
+    ];
+
+    for (body, input) in malformed {
+        let error = embeddings_from_fixture(body, input)
+            .await
+            .expect_err("malformed embedding response must fail visibly");
+        assert!(matches!(error, ProviderError::ResponseParsing { .. }));
+        assert!(!error.is_retryable());
+    }
 }

--- a/src/core/providers/ollama/runtime_tests.rs
+++ b/src/core/providers/ollama/runtime_tests.rs
@@ -443,6 +443,12 @@ async fn stream_reuses_tool_identity_across_repeated_and_fragmented_chunks() {
     let terminal_call = &terminal.choices[0].delta.tool_calls.as_ref().unwrap()[0];
     assert_eq!(first_call.index, terminal_call.index);
     assert_eq!(first_call.id, terminal_call.id);
+    assert!(
+        terminal_call
+            .function
+            .as_ref()
+            .is_some_and(|function| function.arguments.is_none())
+    );
     assert_eq!(
         terminal.choices[0].finish_reason,
         Some(FinishReason::ToolCalls)

--- a/src/core/providers/ollama/runtime_tests.rs
+++ b/src/core/providers/ollama/runtime_tests.rs
@@ -140,7 +140,7 @@ async fn transform_request_preserves_generation_and_tool_selection_contract() {
 #[tokio::test]
 async fn transform_request_preserves_raw_schema_annotation_keywords() {
     let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
-    let request = ChatRequest {
+    let mut request = ChatRequest {
         model: "ollama/llama3:8b".to_string(),
         response_format: Some(ResponseFormat {
             format_type: "json_schema".to_string(),
@@ -155,12 +155,24 @@ async fn transform_request_preserves_raw_schema_annotation_keywords() {
         ..Default::default()
     };
 
-    let body = LLMProvider::transform_request(&provider, request, RequestContext::default())
-        .await
-        .expect("raw JSON Schema annotation keywords must not imply an OpenAI envelope");
+    let body =
+        LLMProvider::transform_request(&provider, request.clone(), RequestContext::default())
+            .await
+            .expect("raw JSON Schema annotation keywords must not imply an OpenAI envelope");
     assert_eq!(body["format"]["name"], "answer");
     assert_eq!(body["format"]["strict"], true);
     assert_eq!(body["format"]["schema"]["custom"], "annotation");
+
+    let raw_schema = serde_json::json!({
+        "name": "answer",
+        "strict": "custom annotation",
+        "schema": "custom annotation"
+    });
+    request.response_format.as_mut().unwrap().json_schema = Some(raw_schema.clone());
+    let body = LLMProvider::transform_request(&provider, request, RequestContext::default())
+        .await
+        .expect("invalid envelope metadata types must remain valid raw schema annotations");
+    assert_eq!(body["format"], raw_schema);
 }
 
 #[tokio::test]
@@ -177,7 +189,7 @@ async fn transform_request_forwards_validated_request_options_with_typed_precede
         max_completion_tokens: Some(32),
         extra_params: std::collections::HashMap::from([
             ("num_ctx".to_string(), serde_json::json!(8_192.0)),
-            ("num_predict".to_string(), serde_json::json!(64.0)),
+            ("num_predict".to_string(), serde_json::json!("shadowed")),
             ("repeat_penalty".to_string(), serde_json::json!(1.25)),
         ]),
         ..Default::default()
@@ -221,6 +233,10 @@ async fn transform_request_rejects_invalid_request_scoped_option_types() {
     let invalid = [
         ("num_ctx", serde_json::json!(-1)),
         ("num_predict", serde_json::json!(1.5)),
+        (
+            "num_predict",
+            serde_json::json!(9_223_372_036_854_775_808.0),
+        ),
         ("repeat_penalty", serde_json::json!("high")),
     ];
 
@@ -237,6 +253,19 @@ async fn transform_request_rejects_invalid_request_scoped_option_types() {
             matches!(error, ProviderError::InvalidRequest { .. }),
             "unexpected error for {name}: {error}"
         );
+    }
+}
+
+#[tokio::test]
+async fn supported_request_options_match_the_runtime_surface() {
+    let provider = OllamaProvider::new(OllamaConfig::default()).await.unwrap();
+    let params = provider.get_supported_openai_params("llama3:8b");
+
+    for supported in ["num_ctx", "num_predict", "repeat_penalty"] {
+        assert!(params.contains(&supported));
+    }
+    for unsupported in ["mirostat", "mirostat_eta", "mirostat_tau"] {
+        assert!(!params.contains(&unsupported));
     }
 }
 
@@ -397,6 +426,64 @@ async fn stream_preserves_tool_indices_and_non_stop_terminal_reason() {
 }
 
 #[tokio::test]
+async fn stream_reuses_tool_identity_across_repeated_and_fragmented_chunks() {
+    let records = [
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"function\":{\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}}}]},\"done\":false}\n",
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"function\":{\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}}}]},\"done\":true,\"done_reason\":\"stop\"}",
+    ];
+    let mut stream = stream_from_records(
+        records
+            .map(|record| Bytes::from_static(record.as_bytes()))
+            .to_vec(),
+    );
+
+    let first = stream.next().await.unwrap().unwrap();
+    let terminal = stream.next().await.unwrap().unwrap();
+    let first_call = &first.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+    let terminal_call = &terminal.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+    assert_eq!(first_call.index, terminal_call.index);
+    assert_eq!(first_call.id, terminal_call.id);
+    assert_eq!(
+        terminal.choices[0].finish_reason,
+        Some(FinishReason::ToolCalls)
+    );
+    assert!(stream.next().await.is_none());
+
+    let records = [
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"upstream-call\",\"function\":{\"index\":5,\"name\":\"weather\",\"arguments\":\"{\\\"city\\\":\"}}]},\"done\":false}\n",
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"upstream-call\",\"function\":{\"name\":\"weather\",\"arguments\":\"\\\"Paris\\\"}\"}}]},\"done\":true,\"done_reason\":\"stop\"}",
+    ];
+    let mut stream = stream_from_records(
+        records
+            .map(|record| Bytes::from_static(record.as_bytes()))
+            .to_vec(),
+    );
+    let first = stream.next().await.unwrap().unwrap();
+    let terminal = stream.next().await.unwrap().unwrap();
+    for chunk in [&first, &terminal] {
+        let call = &chunk.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(call.index, 5);
+        assert_eq!(call.id.as_deref(), Some("upstream-call"));
+    }
+
+    let records = [
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"first\",\"function\":{\"name\":\"lookup\",\"arguments\":{}}},{\"id\":\"second\",\"function\":{\"name\":\"lookup\",\"arguments\":{}}}]},\"done\":false}\n",
+        "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"second\",\"function\":{\"name\":\"lookup\",\"arguments\":{}}},{\"id\":\"first\",\"function\":{\"name\":\"lookup\",\"arguments\":{}}}]},\"done\":true,\"done_reason\":\"stop\"}",
+    ];
+    let mut stream = stream_from_records(
+        records
+            .map(|record| Bytes::from_static(record.as_bytes()))
+            .to_vec(),
+    );
+    let first = stream.next().await.unwrap().unwrap();
+    let terminal = stream.next().await.unwrap().unwrap();
+    let first_calls = first.choices[0].delta.tool_calls.as_ref().unwrap();
+    let terminal_calls = terminal.choices[0].delta.tool_calls.as_ref().unwrap();
+    assert_eq!(first_calls[0].index, terminal_calls[1].index);
+    assert_eq!(first_calls[1].index, terminal_calls[0].index);
+}
+
+#[tokio::test]
 async fn premature_eof_and_missing_model_fail_terminally() {
     for bytes in [
         Bytes::new(),
@@ -410,7 +497,7 @@ async fn premature_eof_and_missing_model_fail_terminally() {
     }
 
     let mut partial = stream_from_records(vec![Bytes::from_static(
-        b"{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"content\":\"partial\"},\"done\":false}\n",
+        b"{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",\"content\":\"partial\"},\"done\":false}",
     )]);
     assert_eq!(
         partial.next().await.unwrap().unwrap().choices[0]
@@ -613,6 +700,18 @@ async fn embeddings_reject_malformed_vectors_and_count_mismatches() {
         (
             r#"{"embeddings":[[0.1,0.2]]}"#,
             EmbeddingInput::Array(vec!["a".to_string(), "b".to_string()]),
+        ),
+        (
+            r#"{"embeddings":[[0.1]],"prompt_eval_count":-1}"#,
+            EmbeddingInput::Text("a".to_string()),
+        ),
+        (
+            r#"{"embeddings":[[0.1]],"prompt_eval_count":"many"}"#,
+            EmbeddingInput::Text("a".to_string()),
+        ),
+        (
+            r#"{"embeddings":[[0.1]],"prompt_eval_count":4294967296}"#,
+            EmbeddingInput::Text("a".to_string()),
         ),
     ];
 

--- a/src/core/providers/ollama/streaming.rs
+++ b/src/core/providers/ollama/streaming.rs
@@ -101,6 +101,7 @@ pub struct OllamaStream<S> {
     next_tool_index: u32,
     tool_calls: HashMap<u32, (String, String)>,
     tool_call_indices_by_id: HashMap<String, u32>,
+    tool_call_arguments: HashMap<u32, serde_json::Value>,
     implicit_tool_indices: Vec<u32>,
     pending_error: Option<ProviderError>,
     finished: bool,
@@ -119,6 +120,7 @@ where
             next_tool_index: 0,
             tool_calls: HashMap::new(),
             tool_call_indices_by_id: HashMap::new(),
+            tool_call_arguments: HashMap::new(),
             implicit_tool_indices: Vec::new(),
             pending_error: None,
             finished: false,
@@ -278,13 +280,45 @@ where
                     {
                         *mapped_index = index;
                     }
+                    let arguments = match self.tool_call_arguments.get(&index) {
+                        None if tc.function.arguments.is_null() => None,
+                        None => {
+                            self.tool_call_arguments
+                                .insert(index, tc.function.arguments.clone());
+                            Some(tc.function.arguments.to_string())
+                        }
+                        Some(previous)
+                            if !tc.function.arguments.is_string()
+                                && previous == &tc.function.arguments =>
+                        {
+                            None
+                        }
+                        Some(previous)
+                            if !tc.function.arguments.is_string()
+                                && !tc.function.arguments.is_null()
+                                && !previous.is_string() =>
+                        {
+                            return Err(ProviderError::response_parsing(
+                                "ollama",
+                                format!(
+                                    "Ollama tool call index {index} changed complete arguments within the stream"
+                                ),
+                            ));
+                        }
+                        Some(_) if tc.function.arguments.is_null() => None,
+                        Some(_) => {
+                            self.tool_call_arguments
+                                .insert(index, tc.function.arguments.clone());
+                            Some(tc.function.arguments.to_string())
+                        }
+                    };
                     converted.push(crate::core::types::responses::ToolCallDelta {
                         index,
                         id: Some(id),
                         tool_type: Some("function".to_string()),
                         function: Some(crate::core::types::responses::FunctionCallDelta {
                             name: Some(tc.function.name.clone()),
-                            arguments: Some(tc.function.arguments.to_string()),
+                            arguments,
                         }),
                     });
                 }

--- a/src/core/providers/ollama/streaming.rs
+++ b/src/core/providers/ollama/streaming.rs
@@ -12,6 +12,7 @@ use crate::core::types::responses::ChatResponse;
 use crate::core::types::responses::{ChatChunk, ChatDelta, ChatStreamChoice, FinishReason, Usage};
 use bytes::Bytes;
 use futures::Stream;
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -98,6 +99,10 @@ pub struct OllamaStream<S> {
     chunk_id: String,
     saw_tool_calls: bool,
     next_tool_index: u32,
+    tool_calls: HashMap<u32, (String, String)>,
+    tool_call_indices_by_id: HashMap<String, u32>,
+    implicit_tool_indices: Vec<u32>,
+    pending_error: Option<ProviderError>,
     finished: bool,
 }
 
@@ -112,6 +117,10 @@ where
             chunk_id: format!("ollama-{}", uuid::Uuid::new_v4()),
             saw_tool_calls: false,
             next_tool_index: 0,
+            tool_calls: HashMap::new(),
+            tool_call_indices_by_id: HashMap::new(),
+            implicit_tool_indices: Vec::new(),
+            pending_error: None,
             finished: false,
         }
     }
@@ -190,29 +199,88 @@ where
             // Convert tool calls if present
             if let Some(tool_calls) = &message.tool_calls {
                 let mut converted = Vec::with_capacity(tool_calls.len());
-                for tc in tool_calls {
-                    let index = tc.function.index.unwrap_or(self.next_tool_index);
-                    if index < self.next_tool_index {
+                for (position, tc) in tool_calls.iter().enumerate() {
+                    let index = match tc.function.index {
+                        Some(index) => index,
+                        None => {
+                            tc.id
+                                .as_ref()
+                                .and_then(|id| self.tool_call_indices_by_id.get(id).copied())
+                                .or_else(|| {
+                                    self.implicit_tool_indices.get(position).copied().filter(
+                                        |index| {
+                                            self.tool_calls
+                                                .get(index)
+                                                .is_some_and(|(name, _)| name == &tc.function.name)
+                                        },
+                                    )
+                                })
+                                .unwrap_or(self.next_tool_index)
+                        }
+                    };
+                    if tc.id.as_ref().is_some_and(|id| {
+                        self.tool_call_indices_by_id
+                            .get(id)
+                            .is_some_and(|mapped_index| *mapped_index != index)
+                    }) {
+                        return Err(ProviderError::response_parsing(
+                            "ollama",
+                            "Ollama tool call ID changed index within the stream",
+                        ));
+                    }
+                    if index < self.next_tool_index && !self.tool_calls.contains_key(&index) {
                         return Err(ProviderError::response_parsing(
                             "ollama",
                             format!(
-                                "Ollama tool call index {index} duplicates or precedes the next expected index {}",
+                                "Ollama tool call index {index} precedes the next expected index {}",
                                 self.next_tool_index
                             ),
                         ));
                     }
-                    self.next_tool_index = index.checked_add(1).ok_or_else(|| {
-                        ProviderError::response_parsing(
-                            "ollama",
-                            "Ollama tool call index exceeds the supported range",
-                        )
-                    })?;
+                    let id = match self.tool_calls.get(&index) {
+                        Some((name, id)) => {
+                            if name != &tc.function.name
+                                || tc.id.as_ref().is_some_and(|upstream_id| upstream_id != id)
+                            {
+                                return Err(ProviderError::response_parsing(
+                                    "ollama",
+                                    format!(
+                                        "Ollama tool call index {index} changed identity within the stream"
+                                    ),
+                                ));
+                            }
+                            id.clone()
+                        }
+                        None => {
+                            let next_index = index.checked_add(1).ok_or_else(|| {
+                                ProviderError::response_parsing(
+                                    "ollama",
+                                    "Ollama tool call index exceeds the supported range",
+                                )
+                            })?;
+                            self.next_tool_index = self.next_tool_index.max(next_index);
+                            let id = tc
+                                .id
+                                .clone()
+                                .unwrap_or_else(|| format!("call_{}_{index}", self.chunk_id));
+                            self.tool_calls
+                                .insert(index, (tc.function.name.clone(), id.clone()));
+                            if let Some(upstream_id) = &tc.id {
+                                self.tool_call_indices_by_id
+                                    .insert(upstream_id.clone(), index);
+                            }
+                            id
+                        }
+                    };
+                    if position == self.implicit_tool_indices.len() {
+                        self.implicit_tool_indices.push(index);
+                    } else if let Some(mapped_index) = self.implicit_tool_indices.get_mut(position)
+                    {
+                        *mapped_index = index;
+                    }
                     converted.push(crate::core::types::responses::ToolCallDelta {
                         index,
-                        id: tc
-                            .id
-                            .clone()
-                            .or_else(|| Some(format!("call_{}_{index}", self.chunk_id))),
+                        id: Some(id),
                         tool_type: Some("function".to_string()),
                         function: Some(crate::core::types::responses::FunctionCallDelta {
                             name: Some(tc.function.name.clone()),
@@ -301,6 +369,10 @@ where
         if self.finished {
             return Poll::Ready(None);
         }
+        if let Some(error) = self.pending_error.take() {
+            self.finished = true;
+            return Poll::Ready(Some(Err(error)));
+        }
 
         loop {
             // Check if we have a complete line in the buffer
@@ -360,6 +432,14 @@ where
                                     self.finished = true;
                                     return Poll::Ready(Some(Ok(chunk)));
                                 }
+                                self.pending_error = Some(ProviderError::streaming_error(
+                                    "ollama",
+                                    "chat",
+                                    None,
+                                    None,
+                                    "Ollama stream ended before a done record",
+                                ));
+                                return Poll::Ready(Some(Ok(chunk)));
                             }
                             Ok(None) => {}
                             Err(e) => {

--- a/src/core/providers/ollama/streaming.rs
+++ b/src/core/providers/ollama/streaming.rs
@@ -3,6 +3,7 @@
 //! Handles Ollama's streaming response format (NDJSON - newline-delimited JSON).
 //! Ollama uses a different format than OpenAI's SSE, so we need a custom parser.
 
+use crate::core::providers::base::HttpErrorMapper;
 use crate::core::providers::shared::MessageTransformer;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::message::MessageRole;
@@ -18,7 +19,8 @@ use std::task::{Context, Poll};
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct OllamaStreamChunk {
     /// Model name
-    pub model: String,
+    #[serde(default)]
+    pub model: Option<String>,
 
     /// Message content
     #[serde(default)]
@@ -43,6 +45,10 @@ pub struct OllamaStreamChunk {
     /// Error message (if any)
     #[serde(default)]
     pub error: Option<String>,
+
+    /// HTTP status associated with an error record
+    #[serde(default)]
+    pub status: Option<serde_json::Value>,
 }
 
 /// Ollama message in streaming response
@@ -76,6 +82,9 @@ pub struct OllamaToolCall {
 /// Ollama tool function format
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct OllamaToolFunction {
+    #[serde(default)]
+    pub index: Option<u32>,
+
     pub name: String,
 
     #[serde(default)]
@@ -87,6 +96,8 @@ pub struct OllamaStream<S> {
     inner: S,
     buffer: Vec<u8>,
     chunk_id: String,
+    saw_tool_calls: bool,
+    next_tool_index: u32,
     finished: bool,
 }
 
@@ -99,12 +110,14 @@ where
             inner: stream,
             buffer: Vec::new(),
             chunk_id: format!("ollama-{}", uuid::Uuid::new_v4()),
+            saw_tool_calls: false,
+            next_tool_index: 0,
             finished: false,
         }
     }
 
     /// Parse a single line as an Ollama chunk
-    fn parse_line(&self, line: &str) -> Result<Option<ChatChunk>, ProviderError> {
+    fn parse_line(&mut self, line: &str) -> Result<Option<ChatChunk>, ProviderError> {
         let line = line.trim();
         if line.is_empty() {
             return Ok(None);
@@ -115,8 +128,15 @@ where
         })?;
 
         // Check for error
-        if let Some(error) = chunk.error {
-            return Err(ProviderError::api_error("ollama", 500, error));
+        if let Some(error) = chunk.error.as_deref() {
+            let status = chunk
+                .status
+                .as_ref()
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|status| u16::try_from(status).ok())
+                .filter(|status| (100..=599).contains(status))
+                .unwrap_or(500);
+            return Err(HttpErrorMapper::map_status_code("ollama", status, error).redacted());
         }
 
         // Convert to ChatChunk
@@ -124,7 +144,7 @@ where
         Ok(Some(chat_chunk))
     }
 
-    fn parse_bytes(&self, line: &[u8]) -> Result<Option<ChatChunk>, ProviderError> {
+    fn parse_bytes(&mut self, line: &[u8]) -> Result<Option<ChatChunk>, ProviderError> {
         let line = std::str::from_utf8(line).map_err(|error| {
             ProviderError::streaming_error("ollama", "chat", None, None, error.to_string())
         })?;
@@ -132,7 +152,17 @@ where
     }
 
     /// Convert Ollama chunk to standard ChatChunk
-    fn convert_chunk(&self, chunk: OllamaStreamChunk) -> Result<ChatChunk, ProviderError> {
+    fn convert_chunk(&mut self, chunk: OllamaStreamChunk) -> Result<ChatChunk, ProviderError> {
+        let model = chunk
+            .model
+            .as_deref()
+            .filter(|model| !model.trim().is_empty())
+            .ok_or_else(|| {
+                ProviderError::response_parsing(
+                    "ollama",
+                    "Ollama streaming success record is missing a model",
+                )
+            })?;
         let mut delta = ChatDelta::default();
 
         // Extract message content
@@ -159,22 +189,37 @@ where
 
             // Convert tool calls if present
             if let Some(tool_calls) = &message.tool_calls {
-                let converted: Vec<_> = tool_calls
-                    .iter()
-                    .enumerate()
-                    .map(|(i, tc)| crate::core::types::responses::ToolCallDelta {
-                        index: i as u32,
+                let mut converted = Vec::with_capacity(tool_calls.len());
+                for tc in tool_calls {
+                    let index = tc.function.index.unwrap_or(self.next_tool_index);
+                    if index < self.next_tool_index {
+                        return Err(ProviderError::response_parsing(
+                            "ollama",
+                            format!(
+                                "Ollama tool call index {index} duplicates or precedes the next expected index {}",
+                                self.next_tool_index
+                            ),
+                        ));
+                    }
+                    self.next_tool_index = index.checked_add(1).ok_or_else(|| {
+                        ProviderError::response_parsing(
+                            "ollama",
+                            "Ollama tool call index exceeds the supported range",
+                        )
+                    })?;
+                    converted.push(crate::core::types::responses::ToolCallDelta {
+                        index,
                         id: tc
                             .id
                             .clone()
-                            .or_else(|| Some(format!("call_{}_{i}", self.chunk_id))),
+                            .or_else(|| Some(format!("call_{}_{index}", self.chunk_id))),
                         tool_type: Some("function".to_string()),
                         function: Some(crate::core::types::responses::FunctionCallDelta {
                             name: Some(tc.function.name.clone()),
                             arguments: Some(tc.function.arguments.to_string()),
                         }),
-                    })
-                    .collect();
+                    });
+                }
 
                 if !converted.is_empty() {
                     delta.tool_calls = Some(converted);
@@ -182,33 +227,45 @@ where
             }
         }
 
+        if delta
+            .tool_calls
+            .as_ref()
+            .is_some_and(|calls| !calls.is_empty())
+        {
+            self.saw_tool_calls = true;
+        }
+
         // Determine finish reason
         let finish_reason = if chunk.done {
-            Some(
-                if delta
-                    .tool_calls
-                    .as_ref()
-                    .is_some_and(|calls| !calls.is_empty())
-                {
-                    FinishReason::ToolCalls
-                } else {
-                    chunk
-                        .done_reason
-                        .as_deref()
-                        .and_then(MessageTransformer::parse_finish_reason)
-                        .unwrap_or(FinishReason::Stop)
-                },
-            )
+            let upstream_reason = chunk
+                .done_reason
+                .as_deref()
+                .and_then(MessageTransformer::parse_finish_reason);
+            Some(match upstream_reason {
+                None | Some(FinishReason::Stop) if self.saw_tool_calls => FinishReason::ToolCalls,
+                Some(reason) => reason,
+                None => FinishReason::Stop,
+            })
         } else {
             None
         };
 
         // Build usage info (only on final chunk)
         let usage = if chunk.done {
+            let prompt_tokens = chunk.prompt_eval_count.unwrap_or(0);
+            let completion_tokens = chunk.eval_count.unwrap_or(0);
+            let total_tokens = prompt_tokens
+                .checked_add(completion_tokens)
+                .ok_or_else(|| {
+                    ProviderError::response_parsing(
+                        "ollama",
+                        "Ollama streaming token usage overflow",
+                    )
+                })?;
             Some(Usage {
-                prompt_tokens: chunk.prompt_eval_count.unwrap_or(0),
-                completion_tokens: chunk.eval_count.unwrap_or(0),
-                total_tokens: chunk.prompt_eval_count.unwrap_or(0) + chunk.eval_count.unwrap_or(0),
+                prompt_tokens,
+                completion_tokens,
+                total_tokens,
                 prompt_tokens_details: None,
                 completion_tokens_details: None,
                 thinking_usage: None,
@@ -221,7 +278,7 @@ where
             id: self.chunk_id.clone(),
             object: "chat.completion.chunk".to_string(),
             created: chrono::Utc::now().timestamp(),
-            model: format!("ollama/{}", chunk.model),
+            model: format!("ollama/{model}"),
             system_fingerprint: None,
             choices: vec![ChatStreamChoice {
                 index: 0,
@@ -264,7 +321,11 @@ where
                         return Poll::Ready(Some(Ok(chunk)));
                     }
                     Ok(None) => continue, // Empty line, try next
-                    Err(e) => return Poll::Ready(Some(Err(e))),
+                    Err(e) => {
+                        self.finished = true;
+                        self.buffer.clear();
+                        return Poll::Ready(Some(Err(e)));
+                    }
                 }
             }
 
@@ -275,6 +336,8 @@ where
                     // Continue loop to check for complete lines
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    self.finished = true;
+                    self.buffer.clear();
                     return Poll::Ready(Some(Err(ProviderError::streaming_error(
                         "ollama",
                         "chat",
@@ -289,18 +352,30 @@ where
                         let line = std::mem::take(&mut self.buffer);
                         match self.parse_bytes(&line) {
                             Ok(Some(chunk)) => {
-                                self.finished = true;
-                                return Poll::Ready(Some(Ok(chunk)));
+                                if chunk
+                                    .choices
+                                    .first()
+                                    .is_some_and(|choice| choice.finish_reason.is_some())
+                                {
+                                    self.finished = true;
+                                    return Poll::Ready(Some(Ok(chunk)));
+                                }
                             }
-                            Ok(None) => {
+                            Ok(None) => {}
+                            Err(e) => {
                                 self.finished = true;
-                                return Poll::Ready(None);
+                                return Poll::Ready(Some(Err(e)));
                             }
-                            Err(e) => return Poll::Ready(Some(Err(e))),
                         }
                     }
                     self.finished = true;
-                    return Poll::Ready(None);
+                    return Poll::Ready(Some(Err(ProviderError::streaming_error(
+                        "ollama",
+                        "chat",
+                        None,
+                        None,
+                        "Ollama stream ended before a done record",
+                    ))));
                 }
                 Poll::Pending => return Poll::Pending,
             }
@@ -405,7 +480,7 @@ mod tests {
         }"#;
 
         let chunk: OllamaStreamChunk = serde_json::from_str(json).unwrap();
-        assert_eq!(chunk.model, "llama3:8b");
+        assert_eq!(chunk.model.as_deref(), Some("llama3:8b"));
         assert!(!chunk.done);
         assert!(chunk.message.is_some());
         assert_eq!(chunk.message.unwrap().content, Some("Hello".to_string()));
@@ -514,7 +589,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streamed_tool_ids_are_stable_and_override_stop_reason() {
+    async fn streamed_tool_calls_before_terminal_chunk_override_stop_reason() {
         let first = concat!(
             "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",",
             "\"tool_calls\":[{\"function\":{\"name\":\"weather\",\"arguments\":{}}}]},",
@@ -522,7 +597,7 @@ mod tests {
         );
         let last = concat!(
             "{\"model\":\"llama3:8b\",\"message\":{\"role\":\"assistant\",",
-            "\"tool_calls\":[{\"function\":{\"name\":\"weather\",\"arguments\":{}}}]},",
+            "\"content\":\"\"},",
             "\"done\":true,\"done_reason\":\"stop\"}\n"
         );
         let chunks = vec![
@@ -536,12 +611,25 @@ mod tests {
         let first_id = first.choices[0].delta.tool_calls.as_ref().unwrap()[0]
             .id
             .as_deref();
-        let last_id = last.choices[0].delta.tool_calls.as_ref().unwrap()[0]
-            .id
-            .as_deref();
-        assert_eq!(first_id, last_id);
         assert!(first_id.is_some_and(|id| id.starts_with("call_ollama-")));
+        assert!(last.choices[0].delta.tool_calls.is_none());
         assert_eq!(last.choices[0].finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    #[tokio::test]
+    async fn error_only_stream_chunk_preserves_upstream_message() {
+        let chunks = vec![Ok::<Bytes, reqwest::Error>(Bytes::from_static(
+            b"{\"error\":\"runner crashed\"}\n",
+        ))];
+        let mut stream = OllamaStream::new(futures::stream::iter(chunks));
+
+        let error = stream
+            .next()
+            .await
+            .expect("error record should emit one result")
+            .expect_err("error record should fail the stream");
+
+        assert!(error.to_string().contains("runner crashed"));
     }
 
     #[test]

--- a/src/core/providers/ollama/tests.rs
+++ b/src/core/providers/ollama/tests.rs
@@ -478,7 +478,9 @@ async fn test_provider_supported_params() {
     assert!(params.contains(&"stop"));
     assert!(params.contains(&"tools"));
     assert!(params.contains(&"num_ctx"));
-    assert!(params.contains(&"mirostat"));
+    assert!(params.contains(&"num_predict"));
+    assert!(params.contains(&"repeat_penalty"));
+    assert!(!params.contains(&"mirostat"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1169

## Summary
- make native Ollama NDJSON streams fail closed on premature EOF/protocol errors, preserve tool indices and non-stop finish reasons, map status codes, and redact upstream error text
- distinguish raw JSON Schemas from structurally complete OpenAI envelopes and forward only current upstream request options with an operator `num_ctx` ceiling
- reject malformed embedding matrices as non-retryable response-parsing failures and align model tool capability metadata
- keep unsupported current-upstream `mirostat*` options out of the newly advertised request surface

## Verification
- `cargo test --lib --features providers-extended ollama` (59 passed)
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (8,888 lib tests plus integration and doc tests passed; existing deprecation fixture warnings only)

## Review
- first review findings were triaged by introduction/scope/source evidence and all in-scope blockers were addressed
- current Ollama protocol facts were cross-checked against upstream `api/types.go` and `openai/openai.go`
- no unresolved in-scope correctness or security blocker remains in the updated diff

## Scope
This is a focused correctness follow-up to #1164. It adds no unsupported provider surface and does not merge the PR.