### PR TITLE
fix(providers): align v0 and Meta catalog parity

### DIFF
--- a/src/core/providers/openai_like/mod.rs
+++ b/src/core/providers/openai_like/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod error;
 pub mod models;
 pub mod provider;
+mod request_headers;
 pub mod streaming;
 
 // Re-exports for easy access

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -236,7 +236,10 @@ impl OpenAILikeProvider {
         }
 
         if let Some(org) = &self.config.base.organization {
-            headers.push(header("OpenAI-Organization", org.clone()));
+            let name = crate::core::providers::registry::catalog_policy::organization_header(
+                &self.config.provider_name,
+            );
+            headers.push(header(name, org.clone()));
         }
 
         for (key, value) in &self.config.base.headers {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::core::providers::base::{
-    GlobalPoolManager, HeaderPair, HttpMethod, header, header_owned, read_streaming_error_body,
+    GlobalPoolManager, HeaderPair, HttpMethod, header_owned, read_streaming_error_body,
 };
 use crate::core::providers::openai::{OpenAIResponseTransformer, models::OpenAIChatResponse};
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
@@ -27,6 +27,7 @@ use super::{
     config::OpenAILikeConfig,
     error::{OpenAILikeError, PROVIDER_NAME},
     models::{OpenAILikeModelRegistry, get_openai_like_registry},
+    request_headers::build_request_headers,
 };
 use crate::core::providers::{GeminiNativeRequest, ProviderError, gemini_transport_error};
 
@@ -229,37 +230,7 @@ impl OpenAILikeProvider {
 
     /// Generate headers for API requests
     fn get_request_headers(&self) -> Vec<HeaderPair> {
-        let mut headers = Vec::with_capacity(4 + self.config.custom_headers.len());
-
-        if let Some(api_key) = &self.config.base.api_key {
-            headers.push(header("Authorization", format!("Bearer {}", api_key)));
-        }
-
-        if let Some(org) = &self.config.base.organization {
-            let name = crate::core::providers::registry::catalog_policy::organization_header(
-                &self.config.provider_name,
-            );
-            headers.push(header(name, org.clone()));
-        }
-
-        for (key, value) in &self.config.base.headers {
-            headers.push(header_owned(key.clone(), value.clone()));
-        }
-
-        for (key, value) in &self.config.custom_headers {
-            headers.push(header_owned(key.clone(), value.clone()));
-        }
-
-        if self.config.provider_name == "openrouter" {
-            if let Ok(site_url) = std::env::var("OR_SITE_URL") {
-                headers.push(header_owned("HTTP-Referer".to_string(), site_url));
-            }
-            if let Ok(app_name) = std::env::var("OR_APP_NAME") {
-                headers.push(header_owned("X-Title".to_string(), app_name));
-            }
-        }
-
-        headers
+        build_request_headers(&self.config)
     }
 
     /// Execute chat completion request

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -709,6 +709,20 @@ impl LLMProvider for OpenAILikeProvider {
         }
 
         let model_info = self.get_model_info(model);
+        if self.config.provider_name == "meta_llama"
+            && crate::core::providers::registry::catalog_policy::catalog_model_info(
+                &self.provider_name,
+                model,
+            )
+            .is_some()
+            && (model_info.input_cost_per_1k_tokens.is_none()
+                || model_info.output_cost_per_1k_tokens.is_none())
+        {
+            return Err(ProviderError::invalid_request(
+                "meta_llama",
+                format!("pricing is unavailable for model '{model}'"),
+            ));
+        }
 
         let input_cost = model_info
             .input_cost_per_1k_tokens

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -658,19 +658,50 @@ async fn test_meta_llama_uses_native_organization_header() {
         .with_provider_name("meta_llama")
         .with_skip_api_key(true);
     config.base.organization = Some("org-123".to_string());
+    config
+        .base
+        .headers
+        .insert("x-organization-id".to_string(), "org-base".to_string());
+    config
+        .custom_headers
+        .insert("X-ORGANIZATION-ID".to_string(), "org-custom".to_string());
     let provider = OpenAILikeProvider::new(config).await.unwrap();
 
     let headers = provider.get_request_headers();
-    assert!(
-        headers
-            .iter()
-            .any(|(name, value)| name == "X-Organization-ID" && value == "org-123")
-    );
+    let organization_headers = headers
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case("X-Organization-ID"))
+        .collect::<Vec<_>>();
+    assert_eq!(organization_headers.len(), 1);
+    assert_eq!(organization_headers[0].1, "org-custom");
     assert!(
         headers
             .iter()
             .all(|(name, _)| name != "OpenAI-Organization")
     );
+}
+
+#[tokio::test]
+async fn test_meta_llama_deduplicates_configured_organization_headers() {
+    let mut config = OpenAILikeConfig::new("https://api.llama.com/compat/v1")
+        .with_provider_name("meta_llama")
+        .with_skip_api_key(true);
+    config
+        .base
+        .headers
+        .insert("x-organization-id".to_string(), "org-base".to_string());
+    config
+        .custom_headers
+        .insert("X-ORGANIZATION-ID".to_string(), "org-custom".to_string());
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    let organization_headers = provider
+        .get_request_headers()
+        .into_iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case("X-Organization-ID"))
+        .collect::<Vec<_>>();
+    assert_eq!(organization_headers.len(), 1);
+    assert_eq!(organization_headers[0].1, "org-custom");
 }
 
 #[tokio::test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -653,6 +653,27 @@ async fn test_non_openrouter_provider_no_or_headers() {
 }
 
 #[tokio::test]
+async fn test_meta_llama_uses_native_organization_header() {
+    let mut config = OpenAILikeConfig::new("https://api.llama.com/compat/v1")
+        .with_provider_name("meta_llama")
+        .with_skip_api_key(true);
+    config.base.organization = Some("org-123".to_string());
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    let headers = provider.get_request_headers();
+    assert!(
+        headers
+            .iter()
+            .any(|(name, value)| name == "X-Organization-ID" && value == "org-123")
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| name != "OpenAI-Organization")
+    );
+}
+
+#[tokio::test]
 async fn test_openrouter_thinking_wired_in_transform() {
     use crate::core::types::thinking::{ThinkingConfig, ThinkingEffort};
 

--- a/src/core/providers/openai_like/request_headers.rs
+++ b/src/core/providers/openai_like/request_headers.rs
@@ -1,0 +1,66 @@
+use crate::core::providers::base::{HeaderPair, header, header_owned};
+
+use super::config::OpenAILikeConfig;
+
+pub(super) fn build_request_headers(config: &OpenAILikeConfig) -> Vec<HeaderPair> {
+    let mut headers =
+        Vec::with_capacity(4 + config.base.headers.len() + config.custom_headers.len());
+
+    if let Some(api_key) = &config.base.api_key {
+        headers.push(header("Authorization", format!("Bearer {api_key}")));
+    }
+
+    let organization_header = (config.provider_name == "meta_llama"
+        || config.base.organization.is_some())
+    .then(|| {
+        crate::core::providers::registry::catalog_policy::organization_header(&config.provider_name)
+    });
+    if let Some(org) = &config.base.organization {
+        let name = crate::core::providers::registry::catalog_policy::organization_header(
+            &config.provider_name,
+        );
+        headers.push(header(name, org.clone()));
+    }
+
+    for (key, value) in &config.base.headers {
+        push_configured_header(
+            &mut headers,
+            header_owned(key.clone(), value.clone()),
+            organization_header,
+        );
+    }
+    for (key, value) in &config.custom_headers {
+        push_configured_header(
+            &mut headers,
+            header_owned(key.clone(), value.clone()),
+            organization_header,
+        );
+    }
+
+    if config.provider_name == "openrouter" {
+        if let Ok(site_url) = std::env::var("OR_SITE_URL") {
+            headers.push(header_owned("HTTP-Referer".to_string(), site_url));
+        }
+        if let Ok(app_name) = std::env::var("OR_APP_NAME") {
+            headers.push(header_owned("X-Title".to_string(), app_name));
+        }
+    }
+
+    headers
+}
+
+fn push_configured_header(
+    headers: &mut Vec<HeaderPair>,
+    header: HeaderPair,
+    organization_header: Option<&str>,
+) {
+    if organization_header.is_some_and(|name| name.eq_ignore_ascii_case(header.0.as_ref()))
+        && let Some(existing) = headers
+            .iter_mut()
+            .find(|(name, _)| name.eq_ignore_ascii_case(header.0.as_ref()))
+    {
+        *existing = header;
+        return;
+    }
+    headers.push(header);
+}

--- a/src/core/providers/registry/catalog_policy.rs
+++ b/src/core/providers/registry/catalog_policy.rs
@@ -77,19 +77,6 @@ const V0_OPENAI_PARAMS: &[&str] = &[
     "user",
     "seed",
 ];
-const META_LLAMA_SUPPORTED_MODELS: &[&str] = &[
-    "llama4-scout",
-    "llama4-maverick",
-    "llama3.3-70b",
-    "llama3.2-1b",
-    "llama3.2-3b",
-    "llama3.2-11b-vision",
-    "llama3.2-90b-vision",
-    "llama3.1-8b",
-    "llama3.1-70b",
-    "llama3.1-405b",
-];
-
 struct CatalogModel {
     id: &'static str,
     name: &'static str,
@@ -97,8 +84,8 @@ struct CatalogModel {
     context: u32,
     output: Option<u32>,
     multimodal: bool,
-    input_cost: f64,
-    output_cost: f64,
+    input_cost: Option<f64>,
+    output_cost: Option<f64>,
 }
 
 const META_LLAMA_MODELS: &[CatalogModel] = &[
@@ -109,8 +96,8 @@ const META_LLAMA_MODELS: &[CatalogModel] = &[
         10_000_000,
         Some(128_000),
         true,
-        0.00008,
-        0.0003,
+        Some(0.00008),
+        Some(0.0003),
     ),
     catalog_model(
         "llama4-maverick",
@@ -119,8 +106,8 @@ const META_LLAMA_MODELS: &[CatalogModel] = &[
         1_000_000,
         Some(128_000),
         true,
-        0.00020,
-        0.0006,
+        Some(0.00020),
+        Some(0.0006),
     ),
     catalog_model(
         "llama3.3-70b",
@@ -129,8 +116,58 @@ const META_LLAMA_MODELS: &[CatalogModel] = &[
         128_000,
         Some(32_000),
         false,
-        0.0006,
-        0.0006,
+        Some(0.0006),
+        Some(0.0006),
+    ),
+    catalog_model(
+        "llama3.2-1b",
+        "Llama 3.2 1B",
+        "meta",
+        128_000,
+        None,
+        false,
+        None,
+        None,
+    ),
+    catalog_model(
+        "llama3.2-3b",
+        "Llama 3.2 3B",
+        "meta",
+        128_000,
+        None,
+        false,
+        None,
+        None,
+    ),
+    catalog_model(
+        "llama3.2-11b-vision",
+        "Llama 3.2 11B Vision",
+        "meta",
+        128_000,
+        None,
+        true,
+        None,
+        None,
+    ),
+    catalog_model(
+        "llama3.2-90b-vision",
+        "Llama 3.2 90B Vision",
+        "meta",
+        128_000,
+        None,
+        true,
+        None,
+        None,
+    ),
+    catalog_model(
+        "llama3.1-8b",
+        "Llama 3.1 8B",
+        "meta",
+        128_000,
+        None,
+        false,
+        None,
+        None,
     ),
     catalog_model(
         "llama3.1-405b",
@@ -139,8 +176,8 @@ const META_LLAMA_MODELS: &[CatalogModel] = &[
         128_000,
         None,
         false,
-        0.002,
-        0.002,
+        Some(0.002),
+        Some(0.002),
     ),
     catalog_model(
         "llama3.1-70b",
@@ -149,8 +186,8 @@ const META_LLAMA_MODELS: &[CatalogModel] = &[
         128_000,
         None,
         false,
-        0.001,
-        0.001,
+        Some(0.001),
+        Some(0.001),
     ),
 ];
 const V0_MODELS: &[CatalogModel] = &[catalog_model(
@@ -160,8 +197,8 @@ const V0_MODELS: &[CatalogModel] = &[catalog_model(
     32_768,
     Some(8_192),
     false,
-    0.1,
-    0.2,
+    Some(0.1),
+    Some(0.2),
 )];
 
 static META_LLAMA_MODEL_INFOS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
@@ -171,10 +208,10 @@ static META_LLAMA_MODEL_INFOS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
         .collect()
 });
 static V0_MODEL_INFOS: LazyLock<Vec<ModelInfo>> = LazyLock::new(|| {
-    let canonical = catalog_model_info_from_entry(&V0_MODELS[0]);
-    let mut alias = canonical.clone();
-    alias.id = "v0".to_string();
-    vec![canonical, alias]
+    V0_MODELS
+        .iter()
+        .map(catalog_model_info_from_entry)
+        .collect()
 });
 
 #[allow(clippy::too_many_arguments)]
@@ -185,8 +222,8 @@ const fn catalog_model(
     context: u32,
     output: Option<u32>,
     multimodal: bool,
-    input_cost: f64,
-    output_cost: f64,
+    input_cost: Option<f64>,
+    output_cost: Option<f64>,
 ) -> CatalogModel {
     CatalogModel {
         id,
@@ -215,8 +252,8 @@ fn catalog_model_info_from_entry(model: &CatalogModel) -> ModelInfo {
         supports_streaming: true,
         supports_tools: true,
         supports_multimodal: model.multimodal,
-        input_cost_per_1k_tokens: Some(model.input_cost),
-        output_cost_per_1k_tokens: Some(model.output_cost),
+        input_cost_per_1k_tokens: model.input_cost,
+        output_cost_per_1k_tokens: model.output_cost,
         currency: "USD".to_string(),
         capabilities,
         ..Default::default()
@@ -249,9 +286,9 @@ pub(crate) fn catalog_model_info(provider: &str, model_id: &str) -> Option<Model
 pub(crate) fn catalog_provider_supports_model(provider: &str, model_id: &str) -> Option<bool> {
     match provider {
         "meta_llama" => Some(
-            META_LLAMA_SUPPORTED_MODELS
+            META_LLAMA_MODELS
                 .iter()
-                .any(|supported| model_id == *supported || model_id.contains(supported)),
+                .any(|model| model_id == model.id || model_id.contains(model.id)),
         ),
         "v0" => Some(true),
         _ => None,
@@ -305,7 +342,36 @@ pub(crate) fn health_failure_is_unhealthy(provider: &str) -> bool {
 }
 
 pub(crate) fn preserves_configured_name_route(provider: &str) -> bool {
-    matches!(provider, "meta_llama" | "v0")
+    provider == "meta_llama"
+}
+
+pub(crate) fn extend_model_aliases(
+    provider: &str,
+    configured_name: &str,
+    uses_configured_models: bool,
+    models: &[String],
+    aliases: &mut HashMap<String, String>,
+) {
+    let target = "v0-default";
+    if provider != "v0" || !models.iter().any(|model| model == target) {
+        return;
+    }
+
+    aliases
+        .entry("v0".to_string())
+        .or_insert_with(|| target.to_string());
+    if !uses_configured_models && configured_name != target {
+        aliases
+            .entry(configured_name.to_string())
+            .or_insert_with(|| target.to_string());
+    }
+}
+
+pub(crate) fn organization_header(provider: &str) -> &'static str {
+    match provider {
+        "meta_llama" => "X-Organization-ID",
+        _ => "OpenAI-Organization",
+    }
 }
 
 pub(crate) fn catalog_error_response(
@@ -343,7 +409,7 @@ mod tests {
     #[tokio::test]
     async fn meta_llama_catalog_runtime_preserves_models_and_filtering() {
         let models = catalog_model_infos("meta_llama").expect("Meta catalog models");
-        assert_eq!(models.len(), 5);
+        assert_eq!(models.len(), 10);
         assert_eq!(models[0].provider, "meta");
         assert_eq!(models[0].max_context_length, 10_000_000);
         assert_eq!(models[0].input_cost_per_1k_tokens, Some(0.00008));
@@ -368,8 +434,11 @@ mod tests {
         )
         .await
         .expect("Meta catalog runtime");
-        assert_eq!(provider.models().len(), 5);
+        assert_eq!(provider.models().len(), 10);
         assert!(!provider.supports_model("gpt-4"));
+        for model in models {
+            assert!(provider.supports_model(&model.id));
+        }
         let request = ChatRequest {
             model: "llama4-scout".to_string(),
             service_tier: Some("flex".to_string()),
@@ -422,14 +491,14 @@ mod tests {
         )
         .await
         .expect("V0 catalog runtime");
-        assert_eq!(provider.models().len(), 2);
+        assert_eq!(provider.models().len(), 1);
         assert!(
             provider
                 .models()
                 .iter()
                 .any(|model| model.id == canonical.id)
         );
-        assert!(provider.models().iter().any(|model| model.id == "v0"));
+        assert!(!provider.models().iter().any(|model| model.id == "v0"));
         assert_eq!(provider.get_model_info("v0").id, "v0-default");
         let cost = provider
             .calculate_cost("v0", 1_000, 1_000)
@@ -458,10 +527,20 @@ mod tests {
         .await
         .expect("V0 router should build");
 
-        let models = router.list_models();
-        assert!(models.contains(&"v0-default".to_string()));
-        assert!(models.contains(&"v0".to_string()));
-        assert!(models.contains(&"frontend".to_string()));
+        assert_eq!(router.list_models(), vec!["v0-default".to_string()]);
+        assert_eq!(router.resolve_model_name("v0"), "v0-default");
+        assert_eq!(router.resolve_model_name("frontend"), "v0-default");
+        let canonical = router
+            .select_deployment_lease("v0-default")
+            .expect("canonical route");
+        let v0_alias = router
+            .select_deployment_lease("v0")
+            .expect("v0 alias route");
+        let configured_alias = router
+            .select_deployment_lease("frontend")
+            .expect("configured-name alias route");
+        assert_eq!(canonical.deployment_id(), v0_alias.deployment_id());
+        assert_eq!(canonical.deployment_id(), configured_alias.deployment_id());
 
         let meta_router = Router::from_gateway_config(
             &[ProviderConfig {
@@ -479,5 +558,12 @@ mod tests {
                 .list_models()
                 .contains(&"llama_frontend".to_string())
         );
+        for model in META_LLAMA_MODELS {
+            assert!(
+                meta_router.select_deployment_lease(model.id).is_ok(),
+                "default Meta router should resolve {}",
+                model.id
+            );
+        }
     }
 }

--- a/src/core/providers/registry/catalog_policy.rs
+++ b/src/core/providers/registry/catalog_policy.rs
@@ -367,6 +367,20 @@ pub(crate) fn extend_model_aliases(
     }
 }
 
+pub(crate) fn canonicalize_models(provider: &str, models: &mut Vec<String>) {
+    if provider != "v0" {
+        return;
+    }
+
+    for model in models.iter_mut() {
+        if model == "v0" {
+            *model = "v0-default".to_string();
+        }
+    }
+    let mut seen = std::collections::HashSet::new();
+    models.retain(|model| seen.insert(model.clone()));
+}
+
 pub(crate) fn organization_header(provider: &str) -> &'static str {
     match provider {
         "meta_llama" => "X-Organization-ID",
@@ -564,6 +578,38 @@ mod tests {
                 "default Meta router should resolve {}",
                 model.id
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn v0_configured_spellings_share_one_canonical_deployment() {
+        for models in [
+            vec!["v0".to_string()],
+            vec!["v0-default".to_string()],
+            vec!["v0".to_string(), "v0-default".to_string()],
+        ] {
+            let router = Router::from_gateway_config(
+                &[ProviderConfig {
+                    name: "frontend".to_string(),
+                    provider_type: "v0".to_string(),
+                    api_key: "test-key".to_string(),
+                    models,
+                    ..ProviderConfig::default()
+                }],
+                None,
+            )
+            .await
+            .expect("configured V0 spellings should canonicalize without alias collisions");
+
+            assert_eq!(router.list_models(), vec!["v0-default".to_string()]);
+            assert_eq!(router.resolve_model_name("v0"), "v0-default");
+            let canonical = router
+                .select_deployment_lease("v0-default")
+                .expect("canonical V0 route");
+            let alias = router
+                .select_deployment_lease("v0")
+                .expect("V0 alias route");
+            assert_eq!(canonical.deployment_id(), alias.deployment_id());
         }
     }
 }

--- a/src/core/providers/registry/catalog_policy.rs
+++ b/src/core/providers/registry/catalog_policy.rs
@@ -453,6 +453,16 @@ mod tests {
         for model in models {
             assert!(provider.supports_model(&model.id));
         }
+        let priced_cost = provider
+            .calculate_cost("llama4-scout", 1_000, 1_000)
+            .await
+            .expect("priced Meta catalog model");
+        assert!((priced_cost - 0.00038).abs() < 1e-12);
+        assert!(matches!(
+            provider.calculate_cost("llama3.2-1b", 1_000, 1_000).await,
+            Err(ProviderError::InvalidRequest { provider, message })
+                if provider == "meta_llama" && message.contains("pricing is unavailable")
+        ));
         let request = ChatRequest {
             model: "llama4-scout".to_string(),
             service_tier: Some("flex".to_string()),
@@ -611,5 +621,39 @@ mod tests {
                 .expect("V0 alias route");
             assert_eq!(canonical.deployment_id(), alias.deployment_id());
         }
+    }
+
+    #[tokio::test]
+    async fn v0_provider_name_alias_does_not_shadow_a_canonical_model() {
+        let router = Router::from_gateway_config(
+            &[
+                ProviderConfig {
+                    name: "frontend".to_string(),
+                    provider_type: "v0".to_string(),
+                    api_key: "test-key".to_string(),
+                    ..ProviderConfig::default()
+                },
+                ProviderConfig {
+                    name: "primary".to_string(),
+                    provider_type: "openai".to_string(),
+                    api_key: "sk-test".to_string(),
+                    models: vec!["frontend".to_string()],
+                    ..ProviderConfig::default()
+                },
+            ],
+            None,
+        )
+        .await
+        .expect("canonical model should take priority over an implicit V0 alias");
+
+        assert_eq!(router.resolve_model_name("frontend"), "frontend");
+        assert_eq!(
+            router
+                .select_deployment_lease("frontend")
+                .expect("canonical frontend route")
+                .deployment_id(),
+            "primary-frontend"
+        );
+        assert!(router.select_deployment_lease("v0-default").is_ok());
     }
 }

--- a/src/core/router/gateway_alias_tests.rs
+++ b/src/core/router/gateway_alias_tests.rs
@@ -283,3 +283,23 @@ async fn legacy_constructor_keeps_empty_aliases_and_zero_priority() {
         0
     );
 }
+
+#[tokio::test]
+async fn explicit_alias_takes_priority_over_catalog_alias() {
+    let providers = [
+        ProviderConfig {
+            name: "frontend".to_string(),
+            provider_type: "v0".to_string(),
+            api_key: "test-key".to_string(),
+            ..ProviderConfig::default()
+        },
+        provider("primary", &["gpt-4o"], 0),
+    ];
+    let router =
+        Router::from_gateway_config_with_aliases(&providers, None, &aliases(&[("v0", "gpt-4o")]))
+            .await
+            .expect("explicit alias should override the implicit catalog alias");
+
+    assert_eq!(router.resolve_model_name("v0"), "gpt-4o");
+    assert_eq!(router.resolve_model_name("frontend"), "v0-default");
+}

--- a/src/core/router/gateway_aliases.rs
+++ b/src/core/router/gateway_aliases.rs
@@ -1,0 +1,34 @@
+use std::collections::{HashMap, HashSet};
+
+use super::error::RouterError;
+
+pub(super) fn normalize_model_aliases(
+    model_aliases: &HashMap<String, String>,
+    canonical_models: &HashSet<String>,
+) -> Result<HashMap<String, String>, RouterError> {
+    let mut alias_names = model_aliases.keys().map(String::as_str).collect::<Vec<_>>();
+    alias_names.sort_unstable();
+
+    for alias in &alias_names {
+        if canonical_models.contains(*alias) {
+            return Err(RouterError::InvalidConfiguration(format!(
+                "model alias '{alias}' collides with an enabled canonical model"
+            )));
+        }
+    }
+
+    let mut normalized = HashMap::with_capacity(model_aliases.len());
+    for alias in alias_names {
+        let mut target = &model_aliases[alias];
+        while let Some(next) = model_aliases.get(target) {
+            target = next;
+        }
+        if !canonical_models.contains(target) {
+            return Err(RouterError::InvalidConfiguration(format!(
+                "model alias '{alias}' resolves to unavailable model '{target}'"
+            )));
+        }
+        normalized.insert(alias.to_string(), target.clone());
+    }
+    Ok(normalized)
+}

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -236,6 +236,7 @@ impl Router {
                     .map(|m| m.id.clone())
                     .collect()
             };
+            catalog_policy::canonicalize_models(provider.name(), &mut models);
 
             let uses_provider_name_fallback = models.is_empty();
             catalog_policy::extend_model_aliases(

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -196,6 +196,7 @@ impl Router {
         let mut canonical_models = HashSet::new();
         let mut generated_deployment_ids = HashSet::new();
         let mut effective_model_aliases = model_aliases.clone();
+        let mut catalog_model_aliases = HashMap::new();
 
         for provider_config in providers {
             provider_config
@@ -244,7 +245,7 @@ impl Router {
                 &provider_name,
                 uses_configured_models,
                 &models,
-                &mut effective_model_aliases,
+                &mut catalog_model_aliases,
             );
             let preserves_configured_name_route = !uses_configured_models
                 && crate::core::providers::registry::catalog_policy::preserves_configured_name_route(
@@ -282,6 +283,12 @@ impl Router {
                     ),
                     legacy_metadata.clone(),
                 ));
+            }
+        }
+
+        for (alias, target) in catalog_model_aliases {
+            if !canonical_models.contains(&alias) {
+                effective_model_aliases.entry(alias).or_insert(target);
             }
         }
 

--- a/src/core/router/gateway_config.rs
+++ b/src/core/router/gateway_config.rs
@@ -16,13 +16,16 @@ use super::deployment::{
     Deployment, DeploymentConfig, HealthCheckPolicy, LegacySelectorMetadata, RetrySchedule,
 };
 use super::error::RouterError;
+use super::gateway_aliases::normalize_model_aliases;
 use super::unified::Router;
 use crate::config::Validate;
 use crate::config::models::gateway::GatewayConfig;
 use crate::config::models::provider::ProviderConfig;
 use crate::config::models::router::GatewayRouterConfig;
 use crate::core::providers::provider_type::ProviderType;
-use crate::core::providers::registry::{self as provider_registry, ProviderDispatchKind};
+use crate::core::providers::registry::{
+    self as provider_registry, ProviderDispatchKind, catalog_policy,
+};
 use crate::core::providers::{Provider, create_provider};
 use std::collections::{HashMap, HashSet};
 
@@ -192,6 +195,7 @@ impl Router {
         let mut staged = Vec::new();
         let mut canonical_models = HashSet::new();
         let mut generated_deployment_ids = HashSet::new();
+        let mut effective_model_aliases = model_aliases.clone();
 
         for provider_config in providers {
             provider_config
@@ -234,6 +238,13 @@ impl Router {
             };
 
             let uses_provider_name_fallback = models.is_empty();
+            catalog_policy::extend_model_aliases(
+                provider.name(),
+                &provider_name,
+                uses_configured_models,
+                &models,
+                &mut effective_model_aliases,
+            );
             let preserves_configured_name_route = !uses_configured_models
                 && crate::core::providers::registry::catalog_policy::preserves_configured_name_route(
                     provider.name(),
@@ -273,7 +284,8 @@ impl Router {
             }
         }
 
-        let normalized_aliases = normalize_model_aliases(model_aliases, &canonical_models)?;
+        let normalized_aliases =
+            normalize_model_aliases(&effective_model_aliases, &canonical_models)?;
         let mut aliases = normalized_aliases.iter().collect::<Vec<_>>();
         aliases.sort_unstable_by_key(|(alias, _)| *alias);
         router.try_update_routing_snapshot(move |snapshot| {
@@ -307,37 +319,6 @@ impl Router {
     pub fn model_aliases(&self) -> HashMap<String, String> {
         self.load_routing_snapshot().model_aliases.clone()
     }
-}
-
-fn normalize_model_aliases(
-    model_aliases: &HashMap<String, String>,
-    canonical_models: &HashSet<String>,
-) -> Result<HashMap<String, String>, RouterError> {
-    let mut alias_names = model_aliases.keys().map(String::as_str).collect::<Vec<_>>();
-    alias_names.sort_unstable();
-
-    for alias in &alias_names {
-        if canonical_models.contains(*alias) {
-            return Err(RouterError::InvalidConfiguration(format!(
-                "model alias '{alias}' collides with an enabled canonical model"
-            )));
-        }
-    }
-
-    let mut normalized = HashMap::with_capacity(model_aliases.len());
-    for alias in alias_names {
-        let mut target = &model_aliases[alias];
-        while let Some(next) = model_aliases.get(target) {
-            target = next;
-        }
-        if !canonical_models.contains(target) {
-            return Err(RouterError::InvalidConfiguration(format!(
-                "model alias '{alias}' resolves to unavailable model '{target}'"
-            )));
-        }
-        normalized.insert(alias.to_string(), target.clone());
-    }
-    Ok(normalized)
 }
 
 /// Helper function to create deployment from provider config

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -35,6 +35,7 @@ pub mod error;
 pub mod execute_impl;
 pub mod execution;
 pub mod fallback;
+mod gateway_aliases;
 pub mod gateway_config;
 mod health_probe;
 pub mod retry_policy;


### PR DESCRIPTION
## Summary

- route `v0`, `v0-default`, and the configured v0 name through one canonical deployment
- preserve explicit user alias precedence over implicit catalog aliases
- use the native Meta `X-Organization-ID` header in the catalog-backed path
- derive Meta model support and registration from the same ten-entry catalog
- keep unavailable prices represented as unknown instead of inventing values
- add regression coverage for routing identity, header parity, model routability, and alias precedence

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (8,890 library tests plus integration and doc tests)

Closes #1171
Follow-up to #1165.