### PR TITLE
fix(router): roll per-minute counters lazily to keep window semantics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,8 +88,6 @@ Real benchmark results from our unified router (run with `cargo bench`):
 | Router Creation | **39.4 ns** | Create empty router instance |
 | Add Deployment | **1.04 µs** | Insert single deployment |
 | Alias Resolution | **31.9 ns** | Model name alias lookup |
-| Record Success | **47.3 ns** | Atomic counter update (lock-free) |
-| Record Failure | **65.5 ns** | Atomic failure counter update |
 
 ### Routing Strategy Performance (10 deployments)
 
@@ -110,7 +108,7 @@ Real benchmark results from our unified router (run with `cargo bench`):
 | 50 | 3.2 µs | ~312K ops/s |
 | 100 | 6.3 µs | ~159K ops/s |
 
-### Concurrent Performance (lock-free operations)
+### Concurrent Performance (historical benchmark)
 
 | Concurrent Tasks | Time | Throughput |
 |------------------|------|------------|
@@ -121,9 +119,8 @@ Real benchmark results from our unified router (run with `cargo bench`):
 
 ### Key Performance Characteristics
 
-- **Lock-free design**: Uses `DashMap` and atomic operations for zero-lock concurrent access
+- **Low-contention design**: Uses `DashMap`, atomics, and a per-deployment rollover gate
 - **Static dispatch**: Provider enum avoids vtable overhead
-- **Nanosecond-level atomic ops**: Record success/failure in ~50ns
 - **Linear scaling**: Concurrent throughput scales with task count
 - **Sub-microsecond routing**: Most strategies complete under 2µs
 

--- a/docs/comparison/07-routing.md
+++ b/docs/comparison/07-routing.md
@@ -19,7 +19,7 @@ This document provides an in-depth analysis of the routing strategies between th
 
 | Aspect | Python LiteLLM | Rust LiteLLM-RS |
 |--------|---------------|-----------------|
-| **Architecture** | Plugin-based with external caching (Redis) | Lock-free atomic operations, in-memory |
+| **Architecture** | Plugin-based with external caching (Redis) | Atomic counters with synchronized rollover, in-memory |
 | **Strategy Count** | 6 strategies + custom | 7 strategies built-in |
 | **Concurrency Model** | asyncio + external state | DashMap + Atomic operations |
 | **State Management** | Distributed (Redis/DualCache) | Local (Atomic counters) |
@@ -629,7 +629,7 @@ impl Router {
 |--------|--------|------|
 | **Async Runtime** | asyncio | Tokio |
 | **State Storage** | Redis/DualCache | DashMap + Atomics |
-| **Lock Strategy** | Distributed locks | Lock-free |
+| **Lock Strategy** | Distributed locks | Low-contention per-deployment rollover gate |
 | **Memory Model** | GIL-protected | Atomic ordering |
 
 ### 7.2 State Tracking

--- a/docs/comparison/07-routing.md
+++ b/docs/comparison/07-routing.md
@@ -82,10 +82,10 @@ pub enum RoutingStrategy {
 ```
 
 **Key Characteristics**:
-- Lock-free atomic operations (`AtomicU64`, `AtomicU32`)
+- Atomic counters with synchronized per-minute rollover
 - State stored directly on `DeploymentState` struct
 - Uses `DashMap` for concurrent access
-- All state operations use `Ordering::Relaxed` for performance
+- Counter updates use `Ordering::Relaxed`; rollover publication uses acquire/release ordering
 
 ---
 
@@ -190,8 +190,8 @@ pub struct DeploymentState {
 }
 ```
 
-- Local atomic counters per deployment
-- Background task resets counters every minute
+- Local atomic counters per deployment with a shared rollover gate
+- Readers and writers lazily roll expired windows; a background reset is optional
 - No external dependencies for rate tracking
 
 ---

--- a/src/core/router/deployment.rs
+++ b/src/core/router/deployment.rs
@@ -187,8 +187,10 @@ impl Default for DeploymentConfig {
 ///
 /// ## State Reset
 ///
-/// TPM/RPM counters are reset every minute by a background task.
-/// The `minute_reset_at` timestamp tracks when the last reset occurred.
+/// Per-minute counters roll lazily: readers and writers call
+/// [`DeploymentStateInner::roll_minute_window`], which resets them once the
+/// window tracked by `minute_reset_at` has elapsed. No background task is
+/// required for correct per-minute semantics.
 #[derive(Debug, Clone)]
 pub struct DeploymentState {
     inner: Arc<DeploymentStateInner>,
@@ -295,6 +297,35 @@ impl DeploymentState {
 impl Default for DeploymentState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Length of the rolling per-minute window in seconds.
+const MINUTE_WINDOW_SECS: u64 = 60;
+
+impl DeploymentStateInner {
+    /// Lazily roll the per-minute window once it has elapsed.
+    ///
+    /// Production never starts a background reset task; instead, every reader
+    /// and writer of the per-minute counters calls this first so TPM/RPM
+    /// limits and cooldown windows keep their per-minute semantics over the
+    /// whole process lifetime. A single concurrent caller wins the CAS on
+    /// `minute_reset_at` and performs the reset.
+    pub(crate) fn roll_minute_window(&self) {
+        let now = current_timestamp();
+        let last = self.minute_reset_at.load(Ordering::Relaxed);
+        if now.saturating_sub(last) < MINUTE_WINDOW_SECS {
+            return;
+        }
+        if self
+            .minute_reset_at
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.tpm_current.store(0, Ordering::Relaxed);
+            self.rpm_current.store(0, Ordering::Relaxed);
+            self.fails_this_minute.store(0, Ordering::Relaxed);
+        }
     }
 }
 
@@ -676,6 +707,25 @@ mod tests {
     }
 
     #[test]
+    fn test_roll_minute_window_resets_after_elapsed_window() {
+        let state = DeploymentState::new();
+        state.tpm_current.store(1000, Ordering::Relaxed);
+        state.rpm_current.store(50, Ordering::Relaxed);
+        state.fails_this_minute.store(5, Ordering::Relaxed);
+
+        // Simulate a window that ended 61 seconds ago.
+        let stale = current_timestamp().saturating_sub(61);
+        state.minute_reset_at.store(stale, Ordering::Relaxed);
+
+        state.roll_minute_window();
+
+        assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
+        assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
+        assert_eq!(state.fails_this_minute.load(Ordering::Relaxed), 0);
+        assert!(state.minute_reset_at.load(Ordering::Relaxed) > stale);
+    }
+
+    #[test]
     fn test_deployment_state_health_status() {
         let state = DeploymentState::new();
         state
@@ -740,3 +790,7 @@ mod tests {
         assert!(ts2 >= ts1);
     }
 }
+
+#[cfg(test)]
+#[path = "deployment_window_tests.rs"]
+mod deployment_window_tests;

--- a/src/core/router/deployment.rs
+++ b/src/core/router/deployment.rs
@@ -3,26 +3,25 @@
 //! This module defines the fundamental building blocks for the LiteLLM Router:
 //! - `Deployment`: A concrete provider deployment with configuration and runtime state
 //! - `DeploymentConfig`: Configuration parameters (TPM/RPM limits, timeouts, weights)
-//! - `DeploymentState`: Lock-free runtime state using atomic operations
+//! - `DeploymentState`: Low-contention runtime state using atomic operations
 //! - `HealthStatus`: Health status enumeration for deployments
 //!
 //! ## Design Philosophy
 //!
-//! All state tracking uses atomic operations with `Relaxed` ordering for maximum performance.
-//! This is safe because:
-//! - State values are eventually consistent (exact precision not required for routing decisions)
-//! - No cross-field invariants need to be maintained atomically
-//! - Routing can tolerate slightly stale state for massive performance gains
+//! State tracking uses atomic operations for low-contention updates. Per-minute
+//! counter updates share a read lock, while the rare rollover takes its write
+//! lock so a reset cannot erase usage from the new window.
 //!
 //! ## Performance Characteristics
 //!
-//! - Lock-free: All state updates use atomics, zero contention
+//! - Low contention: ordinary per-minute updates proceed concurrently
 //! - Zero-copy: Deployments are accessed by reference, never cloned
 //! - Cache-friendly: Hot path fields grouped together
 
 use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::Provider;
 use crate::utils::auth::crypto::hmac::CredentialDigest;
+use parking_lot::RwLock;
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -182,18 +181,17 @@ impl Default for DeploymentConfig {
 
 /// Deployment runtime state
 ///
-/// All fields use atomics for lock-free updates with `Relaxed` ordering.
-/// This is safe because routing decisions can tolerate eventual consistency.
+/// Counters use relaxed atomics. Per-minute snapshots and updates additionally
+/// coordinate with rollover through a shared read/write gate.
 ///
 /// ## State Reset
 ///
-/// Per-minute counters roll lazily: readers and writers call
-/// [`DeploymentStateInner::roll_minute_window`], which resets them once the
-/// window tracked by `minute_reset_at` has elapsed. No background task is
-/// required for correct per-minute semantics.
+/// Per-minute counters roll lazily when readers or writers observe an elapsed
+/// window. No background task is required for correct per-minute semantics.
 #[derive(Debug, Clone)]
 pub struct DeploymentState {
     inner: Arc<DeploymentStateInner>,
+    minute_window_lock: Arc<RwLock<()>>,
 }
 
 impl Deref for DeploymentState {
@@ -274,18 +272,63 @@ impl DeploymentState {
                 consecutive_successes: AtomicU32::new(0),
                 minute_reset_at: AtomicU64::new(now),
             }),
+            minute_window_lock: Arc::new(RwLock::new(())),
         }
     }
 
-    /// Reset per-minute counters
+    /// Explicitly start a fresh per-minute counter window.
     ///
-    /// Should be called by a background task every minute.
+    /// Production correctness does not depend on calling this method because
+    /// counter readers and writers also roll elapsed windows lazily.
     pub fn reset_minute(&self) {
+        let _guard = self.minute_window_lock.write();
+        self.finish_minute_reset(current_timestamp());
+    }
+
+    pub(crate) fn roll_minute_window(&self, now: u64) {
+        self.with_current_minute(now, || ());
+    }
+
+    pub(crate) fn minute_counters(&self, now: u64) -> MinuteCounters {
+        self.roll_minute_window(now);
+        let _guard = self.minute_window_lock.read();
+        MinuteCounters {
+            tpm: self.tpm_current.load(Ordering::Relaxed),
+            rpm: self.rpm_current.load(Ordering::Relaxed),
+            failures: self.fails_this_minute.load(Ordering::Relaxed),
+        }
+    }
+
+    fn with_current_minute<T>(&self, now: u64, operation: impl FnOnce() -> T) -> T {
+        let guard = self.minute_window_lock.read();
+        let last = self.minute_reset_at.load(Ordering::Acquire);
+        if !minute_window_needs_roll(now, last) {
+            let result = operation();
+            drop(guard);
+            return result;
+        }
+        drop(guard);
+
+        let reset_guard = self.minute_window_lock.write();
+        // `now` may have been prefetched by a selector that stalled while
+        // another caller rolled the window. Re-read the wall clock on this
+        // rare slow path so an old observer cannot masquerade as rollback
+        // and erase fresh usage.
+        let reset_now = current_timestamp();
+        let last = self.minute_reset_at.load(Ordering::Acquire);
+        if minute_window_needs_roll(reset_now, last) {
+            self.finish_minute_reset(reset_now);
+        }
+        let result = operation();
+        drop(reset_guard);
+        result
+    }
+
+    fn finish_minute_reset(&self, now: u64) {
         self.tpm_current.store(0, Ordering::Relaxed);
         self.rpm_current.store(0, Ordering::Relaxed);
         self.fails_this_minute.store(0, Ordering::Relaxed);
-        self.minute_reset_at
-            .store(current_timestamp(), Ordering::Relaxed);
+        self.minute_reset_at.store(now, Ordering::Release);
     }
 
     /// Get current health status
@@ -300,33 +343,17 @@ impl Default for DeploymentState {
     }
 }
 
-/// Length of the rolling per-minute window in seconds.
 const MINUTE_WINDOW_SECS: u64 = 60;
 
-impl DeploymentStateInner {
-    /// Lazily roll the per-minute window once it has elapsed.
-    ///
-    /// Production never starts a background reset task; instead, every reader
-    /// and writer of the per-minute counters calls this first so TPM/RPM
-    /// limits and cooldown windows keep their per-minute semantics over the
-    /// whole process lifetime. A single concurrent caller wins the CAS on
-    /// `minute_reset_at` and performs the reset.
-    pub(crate) fn roll_minute_window(&self) {
-        let now = current_timestamp();
-        let last = self.minute_reset_at.load(Ordering::Relaxed);
-        if now.saturating_sub(last) < MINUTE_WINDOW_SECS {
-            return;
-        }
-        if self
-            .minute_reset_at
-            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
-            .is_ok()
-        {
-            self.tpm_current.store(0, Ordering::Relaxed);
-            self.rpm_current.store(0, Ordering::Relaxed);
-            self.fails_this_minute.store(0, Ordering::Relaxed);
-        }
-    }
+fn minute_window_needs_roll(now: u64, last: u64) -> bool {
+    now < last || now - last >= MINUTE_WINDOW_SECS
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MinuteCounters {
+    pub(crate) tpm: u64,
+    pub(crate) rpm: u64,
+    pub(crate) failures: u32,
 }
 
 /// Deployment - a concrete provider deployment
@@ -376,7 +403,7 @@ pub struct Deployment {
     /// Configuration
     pub config: DeploymentConfig,
 
-    /// Runtime state (lock-free)
+    /// Shared low-contention runtime state
     pub state: DeploymentState,
 
     /// Tags for filtering (e.g., ["production", "fast"])
@@ -467,14 +494,14 @@ impl Deployment {
     /// * `tokens` - Number of tokens consumed
     /// * `latency_us` - Request latency in microseconds
     pub fn record_success(&self, tokens: u64, latency_us: u64) {
-        // Update counters
+        let now = current_timestamp();
         self.state.total_requests.fetch_add(1, Ordering::Relaxed);
         self.state.success_requests.fetch_add(1, Ordering::Relaxed);
-        self.state.tpm_current.fetch_add(tokens, Ordering::Relaxed);
-        self.state.rpm_current.fetch_add(1, Ordering::Relaxed);
-        self.state
-            .last_request_at
-            .store(current_timestamp(), Ordering::Relaxed);
+        self.state.with_current_minute(now, || {
+            self.state.tpm_current.fetch_add(tokens, Ordering::Relaxed);
+            self.state.rpm_current.fetch_add(1, Ordering::Relaxed);
+        });
+        self.state.last_request_at.store(now, Ordering::Relaxed);
 
         // Update average latency using exponential moving average (alpha = 0.2)
         let current_avg = self.state.avg_latency_us.load(Ordering::Relaxed);
@@ -500,12 +527,22 @@ impl Deployment {
     /// Increments failure counters. The caller is responsible for deciding
     /// whether to enter cooldown based on failure rate.
     pub fn record_failure(&self) {
+        self.record_failure_with_minute_counters();
+    }
+
+    pub(crate) fn record_failure_with_minute_counters(&self) -> MinuteCounters {
+        let now = current_timestamp();
         self.state.total_requests.fetch_add(1, Ordering::Relaxed);
         self.state.fail_requests.fetch_add(1, Ordering::Relaxed);
-        self.state.fails_this_minute.fetch_add(1, Ordering::Relaxed);
-        self.state
-            .last_request_at
-            .store(current_timestamp(), Ordering::Relaxed);
+        let counters = self.state.with_current_minute(now, || {
+            self.state.fails_this_minute.fetch_add(1, Ordering::Relaxed);
+            MinuteCounters {
+                tpm: self.state.tpm_current.load(Ordering::Relaxed),
+                rpm: self.state.rpm_current.load(Ordering::Relaxed),
+                failures: self.state.fails_this_minute.load(Ordering::Relaxed),
+            }
+        });
+        self.state.last_request_at.store(now, Ordering::Relaxed);
 
         // Reset consecutive success counter on failure
         self.state.consecutive_successes.store(0, Ordering::Relaxed);
@@ -527,6 +564,7 @@ impl Deployment {
                 Err(observed) => current = observed,
             }
         }
+        counters
     }
 
     pub(crate) fn promote_to_healthy_if_degraded(&self) {
@@ -575,7 +613,7 @@ impl Deployment {
 /// Get current Unix timestamp in seconds
 ///
 /// Returns the number of seconds since UNIX_EPOCH.
-fn current_timestamp() -> u64 {
+pub(crate) fn current_timestamp() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_else(|_| std::time::Duration::from_secs(0))
@@ -583,214 +621,5 @@ fn current_timestamp() -> u64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::Ordering;
-
-    // ==================== HealthStatus Tests ====================
-
-    #[test]
-    fn test_health_status_from_u8_healthy() {
-        assert_eq!(HealthStatus::from(1), HealthStatus::Healthy);
-    }
-
-    #[test]
-    fn test_health_status_from_u8_degraded() {
-        assert_eq!(HealthStatus::from(2), HealthStatus::Degraded);
-    }
-
-    #[test]
-    fn test_health_status_from_u8_unhealthy() {
-        assert_eq!(HealthStatus::from(3), HealthStatus::Unhealthy);
-    }
-
-    #[test]
-    fn test_health_status_from_u8_cooldown() {
-        assert_eq!(HealthStatus::from(4), HealthStatus::Cooldown);
-    }
-
-    #[test]
-    fn test_health_status_from_u8_unknown() {
-        assert_eq!(HealthStatus::from(0), HealthStatus::Unknown);
-        assert_eq!(HealthStatus::from(255), HealthStatus::Unknown);
-    }
-
-    #[test]
-    fn test_health_status_to_u8() {
-        assert_eq!(u8::from(HealthStatus::Unknown), 0);
-        assert_eq!(u8::from(HealthStatus::Healthy), 1);
-        assert_eq!(u8::from(HealthStatus::Degraded), 2);
-        assert_eq!(u8::from(HealthStatus::Unhealthy), 3);
-        assert_eq!(u8::from(HealthStatus::Cooldown), 4);
-    }
-
-    #[test]
-    fn test_health_status_clone() {
-        let status = HealthStatus::Healthy;
-        let cloned = status;
-        assert_eq!(status, cloned);
-    }
-
-    // ==================== DeploymentConfig Tests ====================
-
-    #[test]
-    fn test_deployment_config_default() {
-        let config = DeploymentConfig::default();
-        assert!(config.tpm_limit.is_none());
-        assert!(config.rpm_limit.is_none());
-        assert!(config.max_parallel_requests.is_none());
-        assert_eq!(config.weight, 1);
-        assert_eq!(config.timeout_secs, 60);
-        assert_eq!(config.priority, 0);
-        assert!(config.health_check_policy.is_none());
-    }
-
-    #[test]
-    fn test_deployment_config_custom() {
-        let config = DeploymentConfig {
-            tpm_limit: Some(100_000),
-            rpm_limit: Some(500),
-            max_parallel_requests: Some(10),
-            weight: 2,
-            timeout_secs: 120,
-            priority: 1,
-            retry_schedule: None,
-            health_check_policy: None,
-        };
-        assert_eq!(config.tpm_limit, Some(100_000));
-        assert_eq!(config.rpm_limit, Some(500));
-        assert_eq!(config.max_parallel_requests, Some(10));
-        assert_eq!(config.weight, 2);
-    }
-
-    #[test]
-    fn test_deployment_config_clone() {
-        let config = DeploymentConfig {
-            tpm_limit: Some(50_000),
-            rpm_limit: Some(100),
-            ..DeploymentConfig::default()
-        };
-        let cloned = config.clone();
-        assert_eq!(config.tpm_limit, cloned.tpm_limit);
-        assert_eq!(config.rpm_limit, cloned.rpm_limit);
-    }
-
-    // ==================== DeploymentState Tests ====================
-
-    #[test]
-    fn test_deployment_state_new() {
-        let state = DeploymentState::new();
-        assert_eq!(state.health_status(), HealthStatus::Healthy);
-        assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
-        assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
-        assert_eq!(state.active_requests.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
-    fn test_deployment_state_default() {
-        let state = DeploymentState::default();
-        assert_eq!(state.health_status(), HealthStatus::Healthy);
-    }
-
-    #[test]
-    fn test_deployment_state_reset_minute() {
-        let state = DeploymentState::new();
-        state.tpm_current.store(1000, Ordering::Relaxed);
-        state.rpm_current.store(50, Ordering::Relaxed);
-        state.fails_this_minute.store(5, Ordering::Relaxed);
-
-        state.reset_minute();
-
-        assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
-        assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
-        assert_eq!(state.fails_this_minute.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
-    fn test_roll_minute_window_resets_after_elapsed_window() {
-        let state = DeploymentState::new();
-        state.tpm_current.store(1000, Ordering::Relaxed);
-        state.rpm_current.store(50, Ordering::Relaxed);
-        state.fails_this_minute.store(5, Ordering::Relaxed);
-
-        // Simulate a window that ended 61 seconds ago.
-        let stale = current_timestamp().saturating_sub(61);
-        state.minute_reset_at.store(stale, Ordering::Relaxed);
-
-        state.roll_minute_window();
-
-        assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
-        assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
-        assert_eq!(state.fails_this_minute.load(Ordering::Relaxed), 0);
-        assert!(state.minute_reset_at.load(Ordering::Relaxed) > stale);
-    }
-
-    #[test]
-    fn test_deployment_state_health_status() {
-        let state = DeploymentState::new();
-        state
-            .health
-            .store(HealthStatus::Degraded as u8, Ordering::Relaxed);
-        assert_eq!(state.health_status(), HealthStatus::Degraded);
-    }
-
-    #[test]
-    fn test_deployment_state_clone() {
-        let state = DeploymentState::new();
-        state.total_requests.store(100, Ordering::Relaxed);
-        state.success_requests.store(95, Ordering::Relaxed);
-
-        let cloned = state.clone();
-        assert_eq!(cloned.total_requests.load(Ordering::Relaxed), 100);
-        assert_eq!(cloned.success_requests.load(Ordering::Relaxed), 95);
-
-        cloned.total_requests.store(101, Ordering::Relaxed);
-        state.success_requests.store(96, Ordering::Relaxed);
-
-        assert_eq!(state.total_requests.load(Ordering::Relaxed), 101);
-        assert_eq!(cloned.success_requests.load(Ordering::Relaxed), 96);
-    }
-
-    #[tokio::test]
-    async fn test_deployment_clone_shares_runtime_state()
-    -> Result<(), crate::core::providers::unified_provider::ProviderError> {
-        let deployment = Deployment::new(
-            "test-1".to_string(),
-            Provider::OpenAI(
-                crate::core::providers::openai::OpenAIProvider::with_api_key(
-                    "sk-test-key-for-unit-testing-only",
-                )
-                .await?,
-            ),
-            "gpt-4-turbo".to_string(),
-            "gpt-4".to_string(),
-        );
-
-        let cloned = deployment.clone();
-        cloned.state.active_requests.store(7, Ordering::Relaxed);
-
-        assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 7);
-        Ok(())
-    }
-
-    // ==================== current_timestamp Tests ====================
-
-    #[test]
-    fn test_current_timestamp() {
-        let ts = current_timestamp();
-        assert!(ts > 0);
-        // Timestamp should be after year 2020
-        assert!(ts > 1577836800); // 2020-01-01
-    }
-
-    #[test]
-    fn test_current_timestamp_monotonic() {
-        let ts1 = current_timestamp();
-        let ts2 = current_timestamp();
-        assert!(ts2 >= ts1);
-    }
-}
-
-#[cfg(test)]
 #[path = "deployment_window_tests.rs"]
-mod deployment_window_tests;
+mod tests;

--- a/src/core/router/deployment_window_tests.rs
+++ b/src/core/router/deployment_window_tests.rs
@@ -1,13 +1,23 @@
-//! Complementary tests for lazy per-minute window rolling.
-//!
-//! The elapsed-window reset case lives in `deployment.rs` (`mod tests`).
-//! Production never starts a background reset task; readers and writers of
-//! the per-minute counters call [`super::DeploymentStateInner::roll_minute_window`]
-//! before touching them so TPM/RPM limits and cooldown windows keep their
-//! per-minute semantics over the process lifetime.
+//! Deployment and per-minute counter-window tests.
 
-use super::{DeploymentState, current_timestamp};
+use super::*;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Barrier};
+
+async fn create_test_deployment()
+-> Result<Deployment, crate::core::providers::unified_provider::ProviderError> {
+    Ok(Deployment::new(
+        "window-test".to_string(),
+        Provider::OpenAI(
+            crate::core::providers::openai::OpenAIProvider::with_api_key(
+                "sk-test-key-for-unit-testing-only",
+            )
+            .await?,
+        ),
+        "gpt-4-turbo".to_string(),
+        "gpt-4".to_string(),
+    ))
+}
 
 #[test]
 fn active_window_preserves_per_minute_counters() {
@@ -18,7 +28,7 @@ fn active_window_preserves_per_minute_counters() {
 
     // `DeploymentState::new` starts an active window; rolling must not
     // reset anything while it has not elapsed.
-    state.roll_minute_window();
+    state.roll_minute_window(current_timestamp());
 
     assert_eq!(state.tpm_current.load(Ordering::Relaxed), 1000);
     assert_eq!(state.rpm_current.load(Ordering::Relaxed), 50);
@@ -33,9 +43,333 @@ fn roll_is_idempotent_within_one_window() {
     let stale = current_timestamp().saturating_sub(61);
     state.minute_reset_at.store(stale, Ordering::Relaxed);
 
-    state.roll_minute_window();
-    state.roll_minute_window();
+    let now = current_timestamp();
+    state.roll_minute_window(now);
+    state.roll_minute_window(now);
 
     assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
     assert!(state.minute_reset_at.load(Ordering::Relaxed) >= stale + 60);
+}
+
+#[test]
+fn elapsed_window_resets_all_counters_before_publishing_timestamp() {
+    let state = DeploymentState::new();
+    let now = current_timestamp();
+    state.tpm_current.store(1000, Ordering::Relaxed);
+    state.rpm_current.store(50, Ordering::Relaxed);
+    state.fails_this_minute.store(5, Ordering::Relaxed);
+    state.minute_reset_at.store(now - 61, Ordering::Relaxed);
+
+    let counters = state.minute_counters(now);
+
+    assert_eq!(
+        counters,
+        MinuteCounters {
+            tpm: 0,
+            rpm: 0,
+            failures: 0
+        }
+    );
+    assert!(state.minute_reset_at.load(Ordering::Acquire) >= now);
+}
+
+#[test]
+fn stale_roll_observer_cannot_erase_new_window_updates() {
+    let state = DeploymentState::new();
+    let now = current_timestamp();
+    state.minute_reset_at.store(now - 61, Ordering::Relaxed);
+
+    state.roll_minute_window(now);
+    state.rpm_current.store(1, Ordering::Relaxed);
+    let published_at = state.minute_reset_at.load(Ordering::Acquire);
+    state.roll_minute_window(now - 61);
+
+    assert_eq!(state.rpm_current.load(Ordering::Relaxed), 1);
+    assert_eq!(state.minute_reset_at.load(Ordering::Acquire), published_at);
+}
+
+#[test]
+fn wall_clock_rollback_rebases_the_counter_window() {
+    let state = DeploymentState::new();
+    let now = current_timestamp();
+    state.rpm_current.store(10, Ordering::Relaxed);
+    state.minute_reset_at.store(now + 30, Ordering::Relaxed);
+
+    let counters = state.minute_counters(now);
+
+    assert_eq!(counters.rpm, 0);
+    let rebased_at = state.minute_reset_at.load(Ordering::Acquire);
+    assert!(rebased_at >= now);
+    assert!(rebased_at < now + 30);
+}
+
+#[tokio::test]
+async fn late_success_is_recorded_in_the_new_window()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let deployment = create_test_deployment().await?;
+    deployment.state.tpm_current.store(900, Ordering::Relaxed);
+    deployment.state.rpm_current.store(9, Ordering::Relaxed);
+    deployment
+        .state
+        .fails_this_minute
+        .store(3, Ordering::Relaxed);
+    deployment
+        .state
+        .minute_reset_at
+        .store(current_timestamp() - 61, Ordering::Relaxed);
+
+    deployment.record_success(25, 100);
+
+    assert_eq!(deployment.state.tpm_current.load(Ordering::Relaxed), 25);
+    assert_eq!(deployment.state.rpm_current.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        deployment.state.fails_this_minute.load(Ordering::Relaxed),
+        0
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn late_failure_is_recorded_in_the_new_window()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let deployment = create_test_deployment().await?;
+    deployment.state.tpm_current.store(900, Ordering::Relaxed);
+    deployment.state.rpm_current.store(9, Ordering::Relaxed);
+    deployment
+        .state
+        .fails_this_minute
+        .store(3, Ordering::Relaxed);
+    deployment
+        .state
+        .minute_reset_at
+        .store(current_timestamp() - 61, Ordering::Relaxed);
+
+    deployment.record_failure();
+
+    assert_eq!(deployment.state.tpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(deployment.state.rpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(
+        deployment.state.fails_this_minute.load(Ordering::Relaxed),
+        1
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_writers_cannot_be_erased_by_rollover()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    const WRITERS: usize = 32;
+    let deployment = Arc::new(create_test_deployment().await?);
+    deployment
+        .state
+        .minute_reset_at
+        .store(current_timestamp() - 61, Ordering::Relaxed);
+    let barrier = Arc::new(Barrier::new(WRITERS));
+    let mut handles = Vec::with_capacity(WRITERS);
+
+    for index in 0..WRITERS {
+        let deployment = deployment.clone();
+        let barrier = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            if index % 2 == 0 {
+                deployment.record_success(10, 100);
+            } else {
+                deployment.record_failure();
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("counter writer should not panic");
+    }
+
+    assert_eq!(deployment.state.tpm_current.load(Ordering::Relaxed), 160);
+    assert_eq!(deployment.state.rpm_current.load(Ordering::Relaxed), 16);
+    assert_eq!(
+        deployment.state.fails_this_minute.load(Ordering::Relaxed),
+        16
+    );
+    Ok(())
+}
+
+#[test]
+fn test_health_status_from_u8_healthy() {
+    assert_eq!(HealthStatus::from(1), HealthStatus::Healthy);
+}
+
+#[test]
+fn test_health_status_from_u8_degraded() {
+    assert_eq!(HealthStatus::from(2), HealthStatus::Degraded);
+}
+
+#[test]
+fn test_health_status_from_u8_unhealthy() {
+    assert_eq!(HealthStatus::from(3), HealthStatus::Unhealthy);
+}
+
+#[test]
+fn test_health_status_from_u8_cooldown() {
+    assert_eq!(HealthStatus::from(4), HealthStatus::Cooldown);
+}
+
+#[test]
+fn test_health_status_from_u8_unknown() {
+    assert_eq!(HealthStatus::from(0), HealthStatus::Unknown);
+    assert_eq!(HealthStatus::from(255), HealthStatus::Unknown);
+}
+
+#[test]
+fn test_health_status_to_u8() {
+    assert_eq!(u8::from(HealthStatus::Unknown), 0);
+    assert_eq!(u8::from(HealthStatus::Healthy), 1);
+    assert_eq!(u8::from(HealthStatus::Degraded), 2);
+    assert_eq!(u8::from(HealthStatus::Unhealthy), 3);
+    assert_eq!(u8::from(HealthStatus::Cooldown), 4);
+}
+
+#[test]
+fn test_health_status_clone() {
+    let status = HealthStatus::Healthy;
+    let cloned = status;
+    assert_eq!(status, cloned);
+}
+
+#[test]
+fn test_deployment_config_default() {
+    let config = DeploymentConfig::default();
+    assert!(config.tpm_limit.is_none());
+    assert!(config.rpm_limit.is_none());
+    assert!(config.max_parallel_requests.is_none());
+    assert_eq!(config.weight, 1);
+    assert_eq!(config.timeout_secs, 60);
+    assert_eq!(config.priority, 0);
+    assert!(config.health_check_policy.is_none());
+}
+
+#[test]
+fn test_deployment_config_custom() {
+    let config = DeploymentConfig {
+        tpm_limit: Some(100_000),
+        rpm_limit: Some(500),
+        max_parallel_requests: Some(10),
+        weight: 2,
+        timeout_secs: 120,
+        priority: 1,
+        retry_schedule: None,
+        health_check_policy: None,
+    };
+    assert_eq!(config.tpm_limit, Some(100_000));
+    assert_eq!(config.rpm_limit, Some(500));
+    assert_eq!(config.max_parallel_requests, Some(10));
+    assert_eq!(config.weight, 2);
+}
+
+#[test]
+fn test_deployment_config_clone() {
+    let config = DeploymentConfig {
+        tpm_limit: Some(50_000),
+        rpm_limit: Some(100),
+        ..DeploymentConfig::default()
+    };
+    let cloned = config.clone();
+    assert_eq!(config.tpm_limit, cloned.tpm_limit);
+    assert_eq!(config.rpm_limit, cloned.rpm_limit);
+}
+
+#[test]
+fn test_deployment_state_new() {
+    let state = DeploymentState::new();
+    assert_eq!(state.health_status(), HealthStatus::Healthy);
+    assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(state.active_requests.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn test_deployment_state_default() {
+    let state = DeploymentState::default();
+    assert_eq!(state.health_status(), HealthStatus::Healthy);
+}
+
+#[test]
+fn test_deployment_state_reset_minute() {
+    let state = DeploymentState::new();
+    state.tpm_current.store(1000, Ordering::Relaxed);
+    state.rpm_current.store(50, Ordering::Relaxed);
+    state.fails_this_minute.store(5, Ordering::Relaxed);
+
+    state.reset_minute();
+
+    assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(state.fails_this_minute.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn test_roll_minute_window_resets_after_elapsed_window() {
+    let state = DeploymentState::new();
+    state.tpm_current.store(1000, Ordering::Relaxed);
+    state.rpm_current.store(50, Ordering::Relaxed);
+    state.fails_this_minute.store(5, Ordering::Relaxed);
+
+    let stale = current_timestamp().saturating_sub(61);
+    state.minute_reset_at.store(stale, Ordering::Relaxed);
+
+    state.roll_minute_window(current_timestamp());
+
+    assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(state.rpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(state.fails_this_minute.load(Ordering::Relaxed), 0);
+    assert!(state.minute_reset_at.load(Ordering::Relaxed) > stale);
+}
+
+#[test]
+fn test_deployment_state_health_status() {
+    let state = DeploymentState::new();
+    state
+        .health
+        .store(HealthStatus::Degraded as u8, Ordering::Relaxed);
+    assert_eq!(state.health_status(), HealthStatus::Degraded);
+}
+
+#[test]
+fn test_deployment_state_clone() {
+    let state = DeploymentState::new();
+    state.total_requests.store(100, Ordering::Relaxed);
+    state.success_requests.store(95, Ordering::Relaxed);
+
+    let cloned = state.clone();
+    assert_eq!(cloned.total_requests.load(Ordering::Relaxed), 100);
+    assert_eq!(cloned.success_requests.load(Ordering::Relaxed), 95);
+
+    cloned.total_requests.store(101, Ordering::Relaxed);
+    state.success_requests.store(96, Ordering::Relaxed);
+
+    assert_eq!(state.total_requests.load(Ordering::Relaxed), 101);
+    assert_eq!(cloned.success_requests.load(Ordering::Relaxed), 96);
+}
+
+#[tokio::test]
+async fn test_deployment_clone_shares_runtime_state()
+-> Result<(), crate::core::providers::unified_provider::ProviderError> {
+    let deployment = create_test_deployment().await?;
+    let cloned = deployment.clone();
+    cloned.state.active_requests.store(7, Ordering::Relaxed);
+
+    assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 7);
+    Ok(())
+}
+
+#[test]
+fn test_current_timestamp() {
+    let ts = current_timestamp();
+    assert!(ts > 0);
+    assert!(ts > 1577836800);
+}
+
+#[test]
+fn test_current_timestamp_monotonic() {
+    let ts1 = current_timestamp();
+    let ts2 = current_timestamp();
+    assert!(ts2 >= ts1);
 }

--- a/src/core/router/deployment_window_tests.rs
+++ b/src/core/router/deployment_window_tests.rs
@@ -1,0 +1,41 @@
+//! Complementary tests for lazy per-minute window rolling.
+//!
+//! The elapsed-window reset case lives in `deployment.rs` (`mod tests`).
+//! Production never starts a background reset task; readers and writers of
+//! the per-minute counters call [`super::DeploymentStateInner::roll_minute_window`]
+//! before touching them so TPM/RPM limits and cooldown windows keep their
+//! per-minute semantics over the process lifetime.
+
+use super::{DeploymentState, current_timestamp};
+use std::sync::atomic::Ordering;
+
+#[test]
+fn active_window_preserves_per_minute_counters() {
+    let state = DeploymentState::new();
+    state.tpm_current.store(1000, Ordering::Relaxed);
+    state.rpm_current.store(50, Ordering::Relaxed);
+    state.fails_this_minute.store(5, Ordering::Relaxed);
+
+    // `DeploymentState::new` starts an active window; rolling must not
+    // reset anything while it has not elapsed.
+    state.roll_minute_window();
+
+    assert_eq!(state.tpm_current.load(Ordering::Relaxed), 1000);
+    assert_eq!(state.rpm_current.load(Ordering::Relaxed), 50);
+    assert_eq!(state.fails_this_minute.load(Ordering::Relaxed), 5);
+}
+
+#[test]
+fn roll_is_idempotent_within_one_window() {
+    let state = DeploymentState::new();
+    state.tpm_current.store(10, Ordering::Relaxed);
+
+    let stale = current_timestamp().saturating_sub(61);
+    state.minute_reset_at.store(stale, Ordering::Relaxed);
+
+    state.roll_minute_window();
+    state.roll_minute_window();
+
+    assert_eq!(state.tpm_current.load(Ordering::Relaxed), 0);
+    assert!(state.minute_reset_at.load(Ordering::Relaxed) >= stale + 60);
+}

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -317,6 +317,10 @@ impl Router {
                 continue;
             }
 
+            // Roll the per-minute window before reading windowed counters so
+            // stale usage from earlier minutes cannot exclude a healthy
+            // deployment.
+            deployment.state.roll_minute_window();
             let rpm_current = deployment.state.rpm_current.load(Relaxed);
             if let Some(limit) = deployment.config.rpm_limit
                 && rpm_current >= limit

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -4,7 +4,7 @@
 //! the best deployment for a given model.
 
 use super::config::RoutingStrategy;
-use super::deployment::{Deployment, DeploymentId};
+use super::deployment::{Deployment, DeploymentId, current_timestamp};
 use super::error::RouterError;
 use super::execution::router_error_to_provider_error;
 use super::strategy_impl::{self, RoutingContext};
@@ -253,6 +253,7 @@ impl Router {
         let mut existing_deployments = 0;
         let mut matching_deployments = 0;
         let mut routing_contexts = Vec::with_capacity(total_deployments);
+        let now = current_timestamp();
 
         for id in deployment_ids_ref.iter() {
             let Some(deployment) = snapshot.deployments.get(id.as_str()) else {
@@ -317,11 +318,8 @@ impl Router {
                 continue;
             }
 
-            // Roll the per-minute window before reading windowed counters so
-            // stale usage from earlier minutes cannot exclude a healthy
-            // deployment.
-            deployment.state.roll_minute_window();
-            let rpm_current = deployment.state.rpm_current.load(Relaxed);
+            let minute = deployment.state.minute_counters(now);
+            let rpm_current = minute.rpm;
             if let Some(limit) = deployment.config.rpm_limit
                 && rpm_current >= limit
             {
@@ -334,7 +332,7 @@ impl Router {
                 continue;
             }
 
-            let tpm_current = deployment.state.tpm_current.load(Relaxed);
+            let tpm_current = minute.tpm;
             if let Some(limit) = deployment.config.tpm_limit
                 && tpm_current >= limit
             {

--- a/src/core/router/strategy_impl.rs
+++ b/src/core/router/strategy_impl.rs
@@ -3,7 +3,7 @@
 //! This module contains the implementation of 7 routing strategies
 //! for selecting deployments.
 
-use super::deployment::{Deployment, DeploymentId};
+use super::deployment::{Deployment, DeploymentId, current_timestamp};
 use dashmap::DashMap;
 use rand::Rng;
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
@@ -32,18 +32,19 @@ pub fn build_routing_contexts<'id>(
     deployments: &DashMap<DeploymentId, Deployment>,
 ) -> Vec<RoutingContext<'id>> {
     let mut contexts = Vec::with_capacity(candidate_ids.len());
+    let now = current_timestamp();
 
     for id in candidate_ids {
         if let Some(deployment) = deployments.get(id.as_str()) {
-            deployment.state.roll_minute_window();
+            let minute = deployment.state.minute_counters(now);
             contexts.push(RoutingContext {
                 deployment_id: id,
                 weight: deployment.config.weight,
                 priority: deployment.config.priority,
                 active_requests: deployment.state.active_requests.load(Relaxed),
-                tpm_current: deployment.state.tpm_current.load(Relaxed),
+                tpm_current: minute.tpm,
                 tpm_limit: deployment.config.tpm_limit,
-                rpm_current: deployment.state.rpm_current.load(Relaxed),
+                rpm_current: minute.rpm,
                 rpm_limit: deployment.config.rpm_limit,
                 avg_latency_us: deployment.state.avg_latency_us.load(Relaxed),
             });

--- a/src/core/router/strategy_impl.rs
+++ b/src/core/router/strategy_impl.rs
@@ -35,6 +35,7 @@ pub fn build_routing_contexts<'id>(
 
     for id in candidate_ids {
         if let Some(deployment) = deployments.get(id.as_str()) {
+            deployment.state.roll_minute_window();
             contexts.push(RoutingContext {
                 deployment_id: id,
                 weight: deployment.config.weight,

--- a/src/core/router/tests/cooldown_tests.rs
+++ b/src/core/router/tests/cooldown_tests.rs
@@ -3,7 +3,7 @@
 use super::router_tests::create_test_deployment;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::router::config::RouterConfig;
-use crate::core::router::deployment::HealthStatus;
+use crate::core::router::deployment::{HealthStatus, current_timestamp};
 use crate::core::router::error::CooldownReason;
 use crate::core::router::unified::Router;
 use std::sync::Arc;
@@ -348,6 +348,62 @@ async fn test_minute_reset_task_integration() {
         assert_eq!(d.state.tpm_current.load(Ordering::Relaxed), 1000);
         assert_eq!(d.state.rpm_current.load(Ordering::Relaxed), 1);
     }
+
+    task.abort();
+}
+
+#[tokio::test]
+async fn test_minute_reset_task_preserves_fresh_window_usage() {
+    let router = Arc::new(Router::default());
+    let fresh = create_test_deployment("fresh", "gpt-4").await;
+    let expired = create_test_deployment("expired", "gpt-4").await;
+    expired.state.tpm_current.store(2000, Ordering::Relaxed);
+    expired.state.rpm_current.store(2, Ordering::Relaxed);
+    expired.state.fails_this_minute.store(2, Ordering::Relaxed);
+    expired
+        .state
+        .minute_reset_at
+        .store(current_timestamp().saturating_sub(61), Ordering::Relaxed);
+    router.add_deployment(fresh);
+    router.add_deployment(expired);
+
+    router.record_success("fresh", 1000, 50_000);
+    router.record_failure("fresh");
+
+    let task = router.clone().start_minute_reset_task();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let expired_rpm = router
+                .get_deployment("expired")
+                .expect("expired deployment should remain registered")
+                .state
+                .rpm_current
+                .load(Ordering::Relaxed);
+            if expired_rpm == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("minute reset task should roll the expired window");
+
+    if let Some(deployment) = router.get_deployment("fresh") {
+        assert_eq!(deployment.state.tpm_current.load(Ordering::Relaxed), 1000);
+        assert_eq!(deployment.state.rpm_current.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            deployment.state.fails_this_minute.load(Ordering::Relaxed),
+            1
+        );
+    } else {
+        panic!("fresh deployment should remain registered");
+    }
+
+    let expired = router
+        .get_deployment("expired")
+        .expect("expired deployment should remain registered");
+    assert_eq!(expired.state.tpm_current.load(Ordering::Relaxed), 0);
+    assert_eq!(expired.state.fails_this_minute.load(Ordering::Relaxed), 0);
 
     task.abort();
 }

--- a/src/core/router/tests/selection_tests.rs
+++ b/src/core/router/tests/selection_tests.rs
@@ -461,3 +461,40 @@ async fn test_latency_based_skips_rate_limited() {
     );
     router.release_deployment(&id);
 }
+
+#[tokio::test]
+async fn elapsed_minute_restores_standard_selection_eligibility() {
+    let router = Router::default();
+    let mut deployment = create_test_deployment("elapsed-standard", "gpt-4").await;
+    deployment.config.rpm_limit = Some(1);
+    deployment.config.tpm_limit = Some(10);
+    deployment.state.rpm_current.store(1, Relaxed);
+    deployment.state.tpm_current.store(10, Relaxed);
+    deployment.state.minute_reset_at.store(0, Relaxed);
+    router.add_deployment(deployment);
+
+    let id = router
+        .select_deployment("gpt-4")
+        .expect("expired usage must not permanently exclude a deployment");
+
+    assert_eq!(id, "elapsed-standard");
+    router.release_deployment(&id);
+}
+
+#[tokio::test]
+async fn elapsed_minute_restores_capability_selection_eligibility() {
+    let router = Router::default();
+    let mut deployment = create_test_deployment("elapsed-capability", "gpt-4").await;
+    deployment.config.rpm_limit = Some(1);
+    deployment.config.tpm_limit = Some(10);
+    deployment.state.rpm_current.store(1, Relaxed);
+    deployment.state.tpm_current.store(10, Relaxed);
+    deployment.state.minute_reset_at.store(0, Relaxed);
+    router.add_deployment(deployment);
+
+    let selected = router
+        .select_capability_deployment("gpt-4", &ProviderCapability::ChatCompletion)
+        .expect("capability selection must roll expired usage before filtering");
+
+    assert_eq!(selected.deployment_id, "elapsed-capability");
+}

--- a/src/core/router/tests/strategy_impl_tests/context_tests.rs
+++ b/src/core/router/tests/strategy_impl_tests/context_tests.rs
@@ -27,3 +27,19 @@ async fn test_build_routing_contexts_skips_missing_deployments() {
     assert_eq!(contexts[0].rpm_current, 12);
     assert_eq!(contexts[0].avg_latency_us, 55);
 }
+
+#[tokio::test]
+async fn test_build_routing_contexts_rolls_expired_usage() {
+    let deployments = DashMap::new();
+    let deployment = create_test_deployment("expired", DeploymentConfig::default()).await;
+    deployment.state.tpm_current.store(120, Relaxed);
+    deployment.state.rpm_current.store(12, Relaxed);
+    deployment.state.minute_reset_at.store(0, Relaxed);
+    deployments.insert("expired".to_string(), deployment);
+
+    let candidates = ["expired".to_string()];
+    let contexts = build_routing_contexts(&candidates, &deployments);
+
+    assert_eq!(contexts[0].tpm_current, 0);
+    assert_eq!(contexts[0].rpm_current, 0);
+}

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -4,7 +4,7 @@
 //! routing strategies, and intelligent request routing across multiple providers.
 
 use super::config::RouterConfig;
-use super::deployment::{Deployment, DeploymentId, LegacySelectorMetadata};
+use super::deployment::{Deployment, DeploymentId, LegacySelectorMetadata, current_timestamp};
 use super::error::CooldownReason;
 use super::execution::infer_cooldown_reason;
 use super::fallback::{FallbackConfig, FallbackType};
@@ -503,6 +503,7 @@ impl Router {
         let resolved_name = snapshot.resolve_model_name(model_name);
 
         let deployment_ids = snapshot.model_index.get(&resolved_name)?;
+        let now = current_timestamp();
 
         for id in deployment_ids.iter() {
             let Some(deployment) = snapshot.deployments.get(id.as_str()) else {
@@ -524,14 +525,15 @@ impl Router {
                 continue;
             }
 
-            let rpm_current = deployment.state.rpm_current.load(Relaxed);
+            let minute = deployment.state.minute_counters(now);
+            let rpm_current = minute.rpm;
             if let Some(limit) = deployment.config.rpm_limit
                 && rpm_current >= limit
             {
                 continue;
             }
 
-            let tpm_current = deployment.state.tpm_current.load(Relaxed);
+            let tpm_current = minute.tpm;
             if let Some(limit) = deployment.config.tpm_limit
                 && tpm_current >= limit
             {
@@ -622,10 +624,9 @@ impl Router {
     }
 
     pub(crate) fn record_failure_for_deployment(&self, deployment: &Deployment) {
-        deployment.record_failure();
-
-        let fails = deployment.state.fails_this_minute.load(Relaxed);
-        let successes_this_minute = deployment.state.rpm_current.load(Relaxed);
+        let minute = deployment.record_failure_with_minute_counters();
+        let fails = minute.failures;
+        let successes_this_minute = minute.rpm;
         let total_this_minute = successes_this_minute + fails as u64;
         if fails >= self.config.allowed_fails
             && total_this_minute >= self.config.min_requests as u64
@@ -655,7 +656,7 @@ impl Router {
         deployment: &Deployment,
         reason: CooldownReason,
     ) {
-        deployment.record_failure();
+        let minute = deployment.record_failure_with_minute_counters();
 
         let should_cooldown = match reason {
             CooldownReason::RateLimit
@@ -665,8 +666,8 @@ impl Router {
             | CooldownReason::Manual => true,
 
             CooldownReason::ConsecutiveFailures => {
-                let fails = deployment.state.fails_this_minute.load(Relaxed);
-                let successes_this_minute = deployment.state.rpm_current.load(Relaxed);
+                let fails = minute.failures;
+                let successes_this_minute = minute.rpm;
                 let total_this_minute = successes_this_minute + fails as u64;
                 fails >= self.config.allowed_fails
                     && total_this_minute >= self.config.min_requests as u64
@@ -760,7 +761,10 @@ impl Router {
         }
     }
 
-    /// Start background task to reset minute counters
+    /// Start optional maintenance that resets inactive minute counters.
+    ///
+    /// Request readers and writers roll elapsed windows themselves, so this
+    /// task is not required for correct rate-limit or circuit-breaker state.
     pub fn start_minute_reset_task(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60));

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -761,7 +761,7 @@ impl Router {
         }
     }
 
-    /// Start optional maintenance that periodically resets minute counters.
+    /// Start optional maintenance that periodically rolls expired minute windows.
     ///
     /// Request readers and writers roll elapsed windows themselves, so this
     /// task is not required for correct rate-limit or circuit-breaker state.
@@ -770,7 +770,11 @@ impl Router {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
             loop {
                 interval.tick().await;
-                self.reset_minute_counters();
+                let now = current_timestamp();
+                let snapshot = self.routing_snapshot.load();
+                for deployment in snapshot.deployments.values() {
+                    deployment.state.roll_minute_window(now);
+                }
             }
         })
     }

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -761,7 +761,7 @@ impl Router {
         }
     }
 
-    /// Start optional maintenance that resets inactive minute counters.
+    /// Start optional maintenance that periodically resets minute counters.
     ///
     /// Request readers and writers roll elapsed windows themselves, so this
     /// task is not required for correct rate-limit or circuit-breaker state.


### PR DESCRIPTION
## What

start_minute_reset_task was never started in production, so rpm_current /
tpm_current / fails_this_minute grew monotonically for the process
lifetime: deployments with tpm/rpm limits were permanently excluded from
selection once cumulative usage crossed the limit (eventual
NoAvailableDeployment), and the circuit breaker degenerated from a
per-minute window into lifetime statistics.

Instead of wiring a background task, readers and writers now call
roll_minute_window(), which resets the counters via a CAS on
minute_reset_at once the 60s window elapses. Covered by unit tests for
elapsed-window reset, active-window no-op, and idempotence.

## Test Plan

- [x] cargo check --all-features
- [x] Focused cargo test suites (see commit message)
- [x] cargo fmt --all && clippy scan
- [ ] CI full suite