### PR TITLE
fix(config): reject unimplemented redis cluster mode at startup

### DIFF
--- a/src/auth/api_key/tests.rs
+++ b/src/auth/api_key/tests.rs
@@ -678,6 +678,7 @@ async fn live_redis_pool() -> Option<(RedisPool, String)> {
         max_connections: 2,
         connection_timeout: 1,
         cluster: false,
+        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -715,6 +716,7 @@ fn restricted_redis_config(redis_url: &str, username: &str, password: &str) -> R
         max_connections: 2,
         connection_timeout: 1,
         cluster: false,
+        cluster_configured: false,
         allow_degraded: false,
     }
 }

--- a/src/auth/api_key/tests.rs
+++ b/src/auth/api_key/tests.rs
@@ -678,7 +678,6 @@ async fn live_redis_pool() -> Option<(RedisPool, String)> {
         max_connections: 2,
         connection_timeout: 1,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -716,7 +715,6 @@ fn restricted_redis_config(redis_url: &str, username: &str, password: &str) -> R
         max_connections: 2,
         connection_timeout: 1,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,7 @@ use crate::config::models::server::ServerConfig;
 use crate::config::models::storage::StorageConfig;
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use regex::Regex;
+use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::path::Path;
 use tracing::{debug, info};
@@ -156,9 +157,66 @@ pub struct Config {
     pub gateway: GatewayConfig,
 }
 
+/// A configuration value plus presence metadata for layered merges.
+///
+/// Runtime configuration structs remain source-compatible and contain only
+/// their established public fields. This overlay carries the otherwise-lost
+/// distinction between an omitted boolean and an explicit `false`.
+#[derive(Debug, Clone)]
+pub struct ConfigOverlay {
+    config: Config,
+    redis_cluster: Option<bool>,
+}
+
+impl ConfigOverlay {
+    /// Create a programmatic overlay from an existing configuration.
+    pub fn from_config(config: Config) -> Self {
+        let redis_cluster = config.gateway.storage.redis.cluster.then_some(true);
+        Self {
+            config,
+            redis_cluster,
+        }
+    }
+
+    /// Explicitly override Redis cluster mode in this overlay.
+    pub fn with_redis_cluster(mut self, cluster: bool) -> Self {
+        self.config.gateway.storage.redis.cluster = cluster;
+        self.redis_cluster = Some(cluster);
+        self
+    }
+
+    /// Discard overlay metadata and return the runtime configuration.
+    pub fn into_config(self) -> Config {
+        self.config
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct GatewayConfigPresence {
+    #[serde(default)]
+    storage: StorageConfigPresence,
+}
+
+#[derive(Default, Deserialize)]
+struct StorageConfigPresence {
+    #[serde(default)]
+    redis: RedisConfigPresence,
+}
+
+#[derive(Default, Deserialize)]
+struct RedisConfigPresence {
+    #[serde(default)]
+    cluster: Option<bool>,
+}
+
 impl Config {
     /// Load configuration from file
     pub async fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Ok(Self::overlay_from_file(path).await?.into_config())
+    }
+
+    /// Load a presence-aware configuration overlay from a file.
+    pub async fn overlay_from_file<P: AsRef<Path>>(path: P) -> Result<ConfigOverlay> {
         let path = path.as_ref();
         info!("Loading configuration from: {:?}", path);
 
@@ -170,6 +228,8 @@ impl Config {
 
         let gateway: GatewayConfig = serde_yml::from_str(&content)
             .map_err(|e| GatewayError::Config(format!("Failed to parse config: {}", e)))?;
+        let presence: GatewayConfigPresence = serde_yml::from_str(&content)
+            .map_err(|e| GatewayError::Config(format!("Failed to parse config: {}", e)))?;
 
         let config = Self { gateway };
 
@@ -177,18 +237,29 @@ impl Config {
         config.validate()?;
 
         debug!("Configuration loaded successfully");
-        Ok(config)
+        Ok(ConfigOverlay {
+            config,
+            redis_cluster: presence.storage.redis.cluster,
+        })
     }
 
     /// Load configuration from environment variables
     pub fn from_env() -> Result<Self> {
+        Ok(Self::overlay_from_env()?.into_config())
+    }
+
+    /// Load a presence-aware configuration overlay from environment variables.
+    pub fn overlay_from_env() -> Result<ConfigOverlay> {
         info!("Loading configuration from environment variables");
 
-        let gateway = GatewayConfig::from_env()?;
+        let (gateway, redis_cluster) = GatewayConfig::from_env_with_redis_cluster_presence()?;
         let config = Self { gateway };
 
         config.validate()?;
-        Ok(config)
+        Ok(ConfigOverlay {
+            config,
+            redis_cluster,
+        })
     }
 
     /// Get server configuration
@@ -236,9 +307,20 @@ impl Config {
         Ok(())
     }
 
-    /// Merge with another configuration (other takes precedence)
+    /// Merge another materialized configuration using legacy default-aware semantics.
+    ///
+    /// Use [`Self::merge_overlay`] when an explicit value equal to its default
+    /// (for example `storage.redis.cluster=false`) must take precedence.
     pub fn merge(mut self, other: Self) -> Self {
         self.gateway = self.gateway.merge(other.gateway);
+        self
+    }
+
+    /// Merge a presence-aware overlay, with explicit default values winning.
+    pub fn merge_overlay(mut self, overlay: ConfigOverlay) -> Self {
+        self.gateway = self
+            .gateway
+            .merge_with_redis_cluster_override(overlay.config.gateway, overlay.redis_cluster);
         self
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,8 +310,8 @@ impl Config {
 
     /// Merge another materialized configuration using legacy default-aware semantics.
     ///
-    /// Use [`Self::merge_overlay`] when an explicit value equal to its default
-    /// (for example `storage.redis.cluster=false`) must take precedence.
+    /// Use [`Self::merge_overlay`] when an explicit
+    /// `storage.redis.cluster=false` must take precedence.
     pub fn merge(mut self, other: Self) -> Self {
         self.gateway = self.gateway.merge(other.gateway);
         self

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -168,6 +168,7 @@ pub struct Config {
 pub struct ConfigOverlay {
     config: Config,
     redis_cluster: Option<bool>,
+    env_auth: Option<(Option<bool>, Option<bool>)>,
 }
 
 impl ConfigOverlay {
@@ -177,6 +178,7 @@ impl ConfigOverlay {
         Self {
             config,
             redis_cluster,
+            env_auth: None,
         }
     }
 
@@ -241,6 +243,7 @@ impl Config {
         Ok(ConfigOverlay {
             config,
             redis_cluster: presence.storage.redis.cluster,
+            env_auth: None,
         })
     }
 
@@ -255,12 +258,14 @@ impl Config {
     pub fn overlay_from_env() -> Result<ConfigOverlay> {
         info!("Loading configuration from environment variables");
 
-        let (gateway, redis_cluster) = GatewayConfig::from_env_with_redis_cluster_presence()?;
+        let layer = GatewayConfig::from_env_with_redis_cluster_presence()?;
+        let gateway = layer.gateway;
         let config = Self { gateway };
 
         Ok(ConfigOverlay {
             config,
-            redis_cluster,
+            redis_cluster: layer.redis_cluster,
+            env_auth: Some((layer.enable_jwt, layer.enable_api_key)),
         })
     }
 
@@ -322,9 +327,17 @@ impl Config {
     ///
     /// The merged configuration must be validated before runtime use.
     pub fn merge_overlay(mut self, overlay: ConfigOverlay) -> Self {
-        self.gateway = self
-            .gateway
-            .merge_with_redis_cluster_override(overlay.config.gateway, overlay.redis_cluster);
+        self.gateway = match overlay.env_auth {
+            Some((jwt, api_key)) => self.gateway.merge_env_overlay(
+                overlay.config.gateway,
+                overlay.redis_cluster,
+                jwt,
+                api_key,
+            ),
+            None => self
+                .gateway
+                .merge_with_redis_cluster_override(overlay.config.gateway, overlay.redis_cluster),
+        };
         self
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -161,7 +161,8 @@ pub struct Config {
 ///
 /// Runtime configuration structs remain source-compatible and contain only
 /// their established public fields. This overlay carries the otherwise-lost
-/// distinction between an omitted boolean and an explicit `false`.
+/// distinction between an omitted `storage.redis.cluster` value and an
+/// explicit `false`.
 #[derive(Debug, Clone)]
 pub struct ConfigOverlay {
     config: Config,
@@ -316,7 +317,7 @@ impl Config {
         self
     }
 
-    /// Merge a presence-aware overlay, with explicit default values winning.
+    /// Merge an overlay while preserving explicit `storage.redis.cluster` values.
     pub fn merge_overlay(mut self, overlay: ConfigOverlay) -> Self {
         self.gateway = self
             .gateway

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -168,7 +168,7 @@ pub struct Config {
 pub struct ConfigOverlay {
     config: Config,
     redis_cluster: Option<bool>,
-    env_auth: Option<(Option<bool>, Option<bool>)>,
+    env_presence: Option<models::gateway::env_config::GatewayEnvPresence>,
 }
 
 impl ConfigOverlay {
@@ -178,7 +178,7 @@ impl ConfigOverlay {
         Self {
             config,
             redis_cluster,
-            env_auth: None,
+            env_presence: None,
         }
     }
 
@@ -243,7 +243,7 @@ impl Config {
         Ok(ConfigOverlay {
             config,
             redis_cluster: presence.storage.redis.cluster,
-            env_auth: None,
+            env_presence: None,
         })
     }
 
@@ -265,7 +265,7 @@ impl Config {
         Ok(ConfigOverlay {
             config,
             redis_cluster: layer.redis_cluster,
-            env_auth: Some((layer.enable_jwt, layer.enable_api_key)),
+            env_presence: Some(layer.presence),
         })
     }
 
@@ -327,12 +327,11 @@ impl Config {
     ///
     /// The merged configuration must be validated before runtime use.
     pub fn merge_overlay(mut self, overlay: ConfigOverlay) -> Self {
-        self.gateway = match overlay.env_auth {
-            Some((jwt, api_key)) => self.gateway.merge_env_overlay(
+        self.gateway = match overlay.env_presence {
+            Some(presence) => self.gateway.merge_env_overlay(
                 overlay.config.gateway,
                 overlay.redis_cluster,
-                jwt,
-                api_key,
+                &presence,
             ),
             None => self
                 .gateway

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -162,7 +162,8 @@ pub struct Config {
 /// Runtime configuration structs remain source-compatible and contain only
 /// their established public fields. This overlay carries the otherwise-lost
 /// distinction between an omitted `storage.redis.cluster` value and an
-/// explicit `false`.
+/// explicit `false`. It is an intermediate layer and is not finally validated
+/// until callers merge it into a runtime [`Config`] and validate that result.
 #[derive(Debug, Clone)]
 pub struct ConfigOverlay {
     config: Config,
@@ -186,7 +187,7 @@ impl ConfigOverlay {
         self
     }
 
-    /// Discard overlay metadata and return the runtime configuration.
+    /// Discard overlay metadata without performing final configuration validation.
     pub fn into_config(self) -> Config {
         self.config
     }
@@ -213,10 +214,13 @@ struct RedisConfigPresence {
 impl Config {
     /// Load configuration from file
     pub async fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
-        Ok(Self::overlay_from_file(path).await?.into_config())
+        let config = Self::overlay_from_file(path).await?.into_config();
+        config.validate()?;
+        debug!("Configuration loaded successfully");
+        Ok(config)
     }
 
-    /// Load a presence-aware configuration overlay from a file.
+    /// Parse a presence-aware, not-yet-finally-validated overlay from a file.
     pub async fn overlay_from_file<P: AsRef<Path>>(path: P) -> Result<ConfigOverlay> {
         let path = path.as_ref();
         info!("Loading configuration from: {:?}", path);
@@ -234,10 +238,6 @@ impl Config {
 
         let config = Self { gateway };
 
-        // Configuration
-        config.validate()?;
-
-        debug!("Configuration loaded successfully");
         Ok(ConfigOverlay {
             config,
             redis_cluster: presence.storage.redis.cluster,
@@ -246,17 +246,18 @@ impl Config {
 
     /// Load configuration from environment variables
     pub fn from_env() -> Result<Self> {
-        Ok(Self::overlay_from_env()?.into_config())
+        let config = Self::overlay_from_env()?.into_config();
+        config.validate()?;
+        Ok(config)
     }
 
-    /// Load a presence-aware configuration overlay from environment variables.
+    /// Parse a presence-aware, not-yet-finally-validated environment overlay.
     pub fn overlay_from_env() -> Result<ConfigOverlay> {
         info!("Loading configuration from environment variables");
 
         let (gateway, redis_cluster) = GatewayConfig::from_env_with_redis_cluster_presence()?;
         let config = Self { gateway };
 
-        config.validate()?;
         Ok(ConfigOverlay {
             config,
             redis_cluster,
@@ -318,6 +319,8 @@ impl Config {
     }
 
     /// Merge an overlay while preserving explicit `storage.redis.cluster` values.
+    ///
+    /// The merged configuration must be validated before runtime use.
     pub fn merge_overlay(mut self, overlay: ConfigOverlay) -> Self {
         self.gateway = self
             .gateway

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -359,25 +359,6 @@ impl GatewayConfig {
         self
     }
 
-    pub(crate) fn merge_env_overlay(
-        self,
-        other: Self,
-        redis_cluster: Option<bool>,
-        enable_jwt: Option<bool>,
-        enable_api_key: Option<bool>,
-    ) -> Self {
-        let jwt = enable_jwt.unwrap_or(self.auth.enable_jwt);
-        let api_key = enable_api_key.unwrap_or(self.auth.enable_api_key);
-        let guardrails = self.guardrails.clone();
-        let ip_access = self.ip_access.clone();
-        let mut merged = self.merge_with_redis_cluster_override(other, redis_cluster);
-        merged.auth.enable_jwt = jwt;
-        merged.auth.enable_api_key = api_key;
-        merged.guardrails = guardrails;
-        merged.ip_access = ip_access;
-        merged
-    }
-
     /// Validate the configuration
     pub fn validate(&self) -> Result<(), String> {
         crate::config::validation::Validate::validate(self)?;

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -525,6 +525,11 @@ impl Default for GatewayConfig {
 
 impl GatewayConfig {
     pub fn from_env() -> crate::utils::error::gateway_error::Result<Self> {
+        Self::from_env_with_redis_cluster_presence().map(|(config, _)| config)
+    }
+
+    pub(crate) fn from_env_with_redis_cluster_presence()
+    -> crate::utils::error::gateway_error::Result<(Self, Option<bool>)> {
         let mut config = Self::default();
 
         if let Some(host) = env_var(ENV_HOST) {
@@ -572,9 +577,9 @@ impl GatewayConfig {
         if let Some(connection_timeout) = parse_env::<u64>(ENV_REDIS_CONNECTION_TIMEOUT)? {
             config.storage.redis.connection_timeout = connection_timeout;
         }
-        if let Some(cluster) = parse_env_bool(ENV_REDIS_CLUSTER)? {
+        let redis_cluster = parse_env_bool(ENV_REDIS_CLUSTER)?;
+        if let Some(cluster) = redis_cluster {
             config.storage.redis.cluster = cluster;
-            config.storage.redis.cluster_configured = true;
         }
 
         if let Some(enable_jwt) = parse_env_bool(ENV_ENABLE_JWT)? {
@@ -627,13 +632,21 @@ impl GatewayConfig {
             config.enterprise.enabled = enabled;
         }
 
-        Ok(config)
+        Ok((config, redis_cluster))
     }
 }
 
 impl GatewayConfig {
     /// Merge two configurations, with other taking precedence
-    pub fn merge(mut self, other: Self) -> Self {
+    pub fn merge(self, other: Self) -> Self {
+        self.merge_with_redis_cluster_override(other, None)
+    }
+
+    pub(crate) fn merge_with_redis_cluster_override(
+        mut self,
+        other: Self,
+        redis_cluster: Option<bool>,
+    ) -> Self {
         self.server = self.server.merge(other.server);
 
         // Merge providers (other takes precedence for same names)
@@ -650,7 +663,9 @@ impl GatewayConfig {
         self.providers = provider_map.into_values().collect();
         self.model_aliases.extend(other.model_aliases);
         self.router = self.router.merge(other.router);
-        self.storage = self.storage.merge(other.storage);
+        self.storage = self
+            .storage
+            .merge_with_redis_cluster_override(other.storage, redis_cluster);
         self.auth = self.auth.merge(other.auth);
         self.monitoring = self.monitoring.merge(other.monitoring);
         self.cache = self.cache.merge(other.cache);

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -14,227 +14,21 @@ use super::server::ServerConfig;
 use super::storage::StorageConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+#[cfg(test)]
 use std::env;
 use std::str::FromStr;
 
-use crate::core::net::ProviderEndpointAccess;
 use crate::core::{guardrails::GuardrailConfig, ip_access::IpAccessConfig};
 
-const ENV_HOST: &str = "LITELLM_HOST";
-const ENV_PORT: &str = "LITELLM_PORT";
-const ENV_WORKERS: &str = "LITELLM_WORKERS";
-const ENV_TIMEOUT: &str = "LITELLM_TIMEOUT";
-const ENV_DATABASE_URL: &str = "LITELLM_DATABASE_URL";
-const ENV_DATABASE_MAX_CONNECTIONS: &str = "LITELLM_DATABASE_MAX_CONNECTIONS";
-const ENV_DATABASE_CONNECTION_TIMEOUT: &str = "LITELLM_DATABASE_CONNECTION_TIMEOUT";
-const ENV_DATABASE_SSL: &str = "LITELLM_DATABASE_SSL";
-const ENV_DATABASE_ENABLED: &str = "LITELLM_DATABASE_ENABLED";
-const ENV_DATABASE_AUTO_MIGRATE: &str = "LITELLM_DATABASE_AUTO_MIGRATE";
-const ENV_REDIS_URL: &str = "LITELLM_REDIS_URL";
-const ENV_REDIS_ENABLED: &str = "LITELLM_REDIS_ENABLED";
-const ENV_REDIS_MAX_CONNECTIONS: &str = "LITELLM_REDIS_MAX_CONNECTIONS";
-const ENV_REDIS_CONNECTION_TIMEOUT: &str = "LITELLM_REDIS_CONNECTION_TIMEOUT";
-const ENV_REDIS_CLUSTER: &str = "LITELLM_REDIS_CLUSTER";
-const ENV_ENABLE_JWT: &str = "LITELLM_ENABLE_JWT";
-const ENV_ENABLE_API_KEY: &str = "LITELLM_ENABLE_API_KEY";
-const ENV_JWT_SECRET: &str = "LITELLM_JWT_SECRET";
-const ENV_JWT_EXPIRATION: &str = "LITELLM_JWT_EXPIRATION";
-const ENV_API_KEY_HEADER: &str = "LITELLM_API_KEY_HEADER";
-const ENV_PROVIDERS: &str = "LITELLM_PROVIDERS";
-const ENV_PRICING_SOURCE: &str = "LITELLM_PRICING_SOURCE";
-const ENV_UNPRICED_MODEL_POLICY: &str = "LITELLM_UNPRICED_MODEL_POLICY";
-const ENV_UNPRICED_FALLBACK_COST_PER_1K_TOKENS: &str =
-    "LITELLM_UNPRICED_FALLBACK_COST_PER_1K_TOKENS";
-const ENV_CACHE_ENABLED: &str = "LITELLM_CACHE_ENABLED";
-const ENV_RATE_LIMIT_ENABLED: &str = "LITELLM_RATE_LIMIT_ENABLED";
-const ENV_ENTERPRISE_ENABLED: &str = "LITELLM_ENTERPRISE_ENABLED";
 const DEFAULT_PRICING_SOURCE: &str = crate::core::pricing_service::DEFAULT_PRICING_SOURCE;
+
+#[path = "gateway_env.rs"]
+pub(crate) mod env_config;
+#[cfg(test)]
+use env_config::*;
 
 #[cfg(test)]
 pub(crate) static GATEWAY_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-fn env_var(key: &str) -> Option<String> {
-    env::var(key)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn parse_env<T>(key: &str) -> crate::utils::error::gateway_error::Result<Option<T>>
-where
-    T: std::str::FromStr,
-    T::Err: std::fmt::Display,
-{
-    let Some(raw) = env_var(key) else {
-        return Ok(None);
-    };
-
-    raw.parse::<T>().map(Some).map_err(|error| {
-        crate::utils::error::gateway_error::GatewayError::Config(format!(
-            "Invalid value for {}: {}",
-            key, error
-        ))
-    })
-}
-
-fn parse_env_bool(key: &str) -> crate::utils::error::gateway_error::Result<Option<bool>> {
-    let Some(raw) = env_var(key) else {
-        return Ok(None);
-    };
-
-    let value = match raw.to_ascii_lowercase().as_str() {
-        "true" | "1" | "yes" | "on" => true,
-        "false" | "0" | "no" | "off" => false,
-        _ => {
-            return Err(crate::utils::error::gateway_error::GatewayError::Config(
-                format!("Invalid boolean value for {}: {}", key, raw),
-            ));
-        }
-    };
-    Ok(Some(value))
-}
-
-fn parse_env_list(key: &str) -> Option<Vec<String>> {
-    env_var(key).map(|raw| {
-        raw.split(',')
-            .map(str::trim)
-            .filter(|segment| !segment.is_empty())
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-    })
-}
-
-fn required_env(key: &str) -> crate::utils::error::gateway_error::Result<String> {
-    env_var(key).ok_or_else(|| {
-        crate::utils::error::gateway_error::GatewayError::Config(format!(
-            "Missing required env var: {}",
-            key
-        ))
-    })
-}
-
-fn provider_env_key(provider_name: &str) -> String {
-    provider_name
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_uppercase()
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
-fn provider_env_name(provider_name: &str, field: &str) -> String {
-    format!(
-        "LITELLM_PROVIDER_{}_{}",
-        provider_env_key(provider_name),
-        field
-    )
-}
-
-fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<ProviderConfig>> {
-    let provider_names = parse_env_list(ENV_PROVIDERS).ok_or_else(|| {
-        crate::utils::error::gateway_error::GatewayError::Config(format!(
-            "{} must be set with at least one provider name",
-            ENV_PROVIDERS
-        ))
-    })?;
-
-    if provider_names.is_empty() {
-        return Err(crate::utils::error::gateway_error::GatewayError::Config(
-            format!("{} must contain at least one provider name", ENV_PROVIDERS),
-        ));
-    }
-
-    let mut providers = Vec::with_capacity(provider_names.len());
-
-    for name in provider_names {
-        let type_key = provider_env_name(&name, "TYPE");
-        let api_key_key = provider_env_name(&name, "API_KEY");
-        let provider_type = required_env(&type_key)?;
-        let selector = provider_type.to_lowercase();
-        let skip_api_key = crate::core::providers::registry::selector_skips_api_key(&selector);
-        let api_key = if skip_api_key {
-            env_var(&api_key_key).unwrap_or_default()
-        } else {
-            required_env(&api_key_key)?
-        };
-
-        let mut provider = ProviderConfig {
-            name: name.clone(),
-            provider_type,
-            api_key,
-            ..ProviderConfig::default()
-        };
-
-        if let Some(base_url) = env_var(&provider_env_name(&name, "BASE_URL")) {
-            provider.base_url = Some(base_url);
-        }
-        let endpoint_access_key = provider_env_name(&name, "ENDPOINT_ACCESS");
-        match env::var(&endpoint_access_key) {
-            Ok(raw) => {
-                provider.endpoint_access =
-                    raw.parse::<ProviderEndpointAccess>().map_err(|error| {
-                        crate::utils::error::gateway_error::GatewayError::Config(format!(
-                            "Invalid value for {endpoint_access_key}: {error}"
-                        ))
-                    })?;
-            }
-            Err(env::VarError::NotPresent) => {}
-            Err(error) => {
-                return Err(crate::utils::error::gateway_error::GatewayError::Config(
-                    format!("Invalid value for {endpoint_access_key}: {error}"),
-                ));
-            }
-        }
-        if let Some(api_version) = env_var(&provider_env_name(&name, "API_VERSION")) {
-            provider.api_version = Some(api_version);
-        }
-        if let Some(organization) = env_var(&provider_env_name(&name, "ORGANIZATION")) {
-            provider.organization = Some(organization);
-        }
-        if let Some(project) = env_var(&provider_env_name(&name, "PROJECT")) {
-            provider.project = Some(project);
-        }
-
-        if let Some(weight) = parse_env::<f32>(&provider_env_name(&name, "WEIGHT"))? {
-            provider.weight = weight;
-        }
-        if let Some(rpm) = parse_env::<u32>(&provider_env_name(&name, "RPM"))? {
-            provider.rpm = rpm;
-        }
-        if let Some(tpm) = parse_env::<u32>(&provider_env_name(&name, "TPM"))? {
-            provider.tpm = tpm;
-        }
-        if let Some(max_concurrent_requests) =
-            parse_env::<u32>(&provider_env_name(&name, "MAX_CONCURRENT_REQUESTS"))?
-        {
-            provider.max_concurrent_requests = max_concurrent_requests;
-        }
-        if let Some(timeout) = parse_env::<u64>(&provider_env_name(&name, "TIMEOUT"))? {
-            provider.timeout = timeout;
-        }
-        if let Some(max_retries) = parse_env::<u32>(&provider_env_name(&name, "MAX_RETRIES"))? {
-            provider.max_retries = max_retries;
-        }
-
-        if let Some(enabled) = parse_env_bool(&provider_env_name(&name, "ENABLED"))? {
-            provider.enabled = enabled;
-        }
-        if let Some(models) = parse_env_list(&provider_env_name(&name, "MODELS")) {
-            provider.models = models;
-        }
-        if let Some(tags) = parse_env_list(&provider_env_name(&name, "TAGS")) {
-            provider.tags = tags;
-        }
-
-        providers.push(provider);
-    }
-
-    Ok(providers)
-}
 
 /// Request-time behavior when provider/model pricing is unavailable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -524,119 +318,6 @@ impl Default for GatewayConfig {
 }
 
 impl GatewayConfig {
-    pub fn from_env() -> crate::utils::error::gateway_error::Result<Self> {
-        Self::from_env_with_redis_cluster_presence().map(|(config, _)| config)
-    }
-
-    pub(crate) fn from_env_with_redis_cluster_presence()
-    -> crate::utils::error::gateway_error::Result<(Self, Option<bool>)> {
-        let mut config = Self::default();
-
-        if let Some(host) = env_var(ENV_HOST) {
-            config.server.host = host;
-        }
-        if let Some(port) = parse_env::<u16>(ENV_PORT)? {
-            config.server.port = port;
-        }
-        if let Some(workers) = parse_env::<usize>(ENV_WORKERS)? {
-            config.server.workers = Some(workers);
-        }
-        if let Some(timeout) = parse_env::<u64>(ENV_TIMEOUT)? {
-            config.server.timeout = timeout;
-        }
-
-        if let Some(database_url) = env_var(ENV_DATABASE_URL) {
-            config.storage.database.url = database_url;
-        }
-        if let Some(max_connections) = parse_env::<u32>(ENV_DATABASE_MAX_CONNECTIONS)? {
-            config.storage.database.max_connections = max_connections;
-        }
-        if let Some(connection_timeout) = parse_env::<u64>(ENV_DATABASE_CONNECTION_TIMEOUT)? {
-            config.storage.database.connection_timeout = connection_timeout;
-        }
-        if let Some(ssl) = parse_env_bool(ENV_DATABASE_SSL)? {
-            config.storage.database.ssl = ssl;
-        }
-        if let Some(enabled) = parse_env_bool(ENV_DATABASE_ENABLED)? {
-            config.storage.database.enabled = enabled;
-        }
-        if let Some(auto_migrate) = parse_env_bool(ENV_DATABASE_AUTO_MIGRATE)? {
-            config.storage.database.auto_migrate = auto_migrate;
-            config.storage.database.auto_migrate_configured = true;
-        }
-
-        if let Some(redis_url) = env_var(ENV_REDIS_URL) {
-            config.storage.redis.url = redis_url;
-        }
-        if let Some(enabled) = parse_env_bool(ENV_REDIS_ENABLED)? {
-            config.storage.redis.enabled = enabled;
-        }
-        if let Some(max_connections) = parse_env::<u32>(ENV_REDIS_MAX_CONNECTIONS)? {
-            config.storage.redis.max_connections = max_connections;
-        }
-        if let Some(connection_timeout) = parse_env::<u64>(ENV_REDIS_CONNECTION_TIMEOUT)? {
-            config.storage.redis.connection_timeout = connection_timeout;
-        }
-        let redis_cluster = parse_env_bool(ENV_REDIS_CLUSTER)?;
-        if let Some(cluster) = redis_cluster {
-            config.storage.redis.cluster = cluster;
-        }
-
-        if let Some(enable_jwt) = parse_env_bool(ENV_ENABLE_JWT)? {
-            config.auth.enable_jwt = enable_jwt;
-        }
-        if let Some(enable_api_key) = parse_env_bool(ENV_ENABLE_API_KEY)? {
-            config.auth.enable_api_key = enable_api_key;
-        }
-        if let Some(jwt_secret) = env_var(ENV_JWT_SECRET) {
-            config.auth.jwt_secret = jwt_secret;
-        } else if config.auth.enable_jwt {
-            return Err(crate::utils::error::gateway_error::GatewayError::Config(
-                format!(
-                    "{} is required when {} is enabled",
-                    ENV_JWT_SECRET, ENV_ENABLE_JWT
-                ),
-            ));
-        }
-        if let Some(jwt_expiration) = parse_env::<u64>(ENV_JWT_EXPIRATION)? {
-            config.auth.jwt_expiration = jwt_expiration;
-        }
-        if let Some(api_key_header) = env_var(ENV_API_KEY_HEADER) {
-            config.auth.api_key_header = api_key_header;
-        }
-
-        config.providers = load_providers_from_env()?;
-
-        if let Some(pricing_source) = env_var(ENV_PRICING_SOURCE) {
-            config.pricing.source = Some(pricing_source);
-            config.pricing.mark_source_explicit_for_merge();
-        }
-        if let Some(policy) = parse_env::<UnpricedModelPolicy>(ENV_UNPRICED_MODEL_POLICY)? {
-            config.pricing.unpriced_model_policy = policy;
-            config
-                .pricing
-                .mark_unpriced_model_policy_explicit_for_merge();
-        }
-        if let Some(cost) = parse_env::<f64>(ENV_UNPRICED_FALLBACK_COST_PER_1K_TOKENS)? {
-            config.pricing.unpriced_fallback_cost_per_1k_tokens = Some(cost);
-            config.pricing.mark_unpriced_fallback_explicit_for_merge();
-        }
-
-        if let Some(enabled) = parse_env_bool(ENV_CACHE_ENABLED)? {
-            config.cache.enabled = enabled;
-        }
-        if let Some(enabled) = parse_env_bool(ENV_RATE_LIMIT_ENABLED)? {
-            config.rate_limit.enabled = enabled;
-        }
-        if let Some(enabled) = parse_env_bool(ENV_ENTERPRISE_ENABLED)? {
-            config.enterprise.enabled = enabled;
-        }
-
-        Ok((config, redis_cluster))
-    }
-}
-
-impl GatewayConfig {
     /// Merge two configurations, with other taking precedence
     pub fn merge(self, other: Self) -> Self {
         self.merge_with_redis_cluster_override(other, None)
@@ -676,6 +357,25 @@ impl GatewayConfig {
         self.pricing = self.pricing.merge(other.pricing);
 
         self
+    }
+
+    pub(crate) fn merge_env_overlay(
+        self,
+        other: Self,
+        redis_cluster: Option<bool>,
+        enable_jwt: Option<bool>,
+        enable_api_key: Option<bool>,
+    ) -> Self {
+        let jwt = enable_jwt.unwrap_or(self.auth.enable_jwt);
+        let api_key = enable_api_key.unwrap_or(self.auth.enable_api_key);
+        let guardrails = self.guardrails.clone();
+        let ip_access = self.ip_access.clone();
+        let mut merged = self.merge_with_redis_cluster_override(other, redis_cluster);
+        merged.auth.enable_jwt = jwt;
+        merged.auth.enable_api_key = api_key;
+        merged.guardrails = guardrails;
+        merged.ip_access = ip_access;
+        merged
     }
 
     /// Validate the configuration

--- a/src/config/models/gateway.rs
+++ b/src/config/models/gateway.rs
@@ -574,6 +574,7 @@ impl GatewayConfig {
         }
         if let Some(cluster) = parse_env_bool(ENV_REDIS_CLUSTER)? {
             config.storage.redis.cluster = cluster;
+            config.storage.redis.cluster_configured = true;
         }
 
         if let Some(enable_jwt) = parse_env_bool(ENV_ENABLE_JWT)? {
@@ -744,46 +745,8 @@ impl GatewayConfig {
 }
 
 #[cfg(test)]
-mod endpoint_access_env_tests {
-    use super::*;
-
-    const ACCESS_KEY: &str = "LITELLM_PROVIDER_OPENAI_ENDPOINT_ACCESS";
-
-    fn clear_env() {
-        for key in [
-            ENV_ENABLE_JWT,
-            ENV_PROVIDERS,
-            "LITELLM_PROVIDER_OPENAI_TYPE",
-            "LITELLM_PROVIDER_OPENAI_API_KEY",
-            ACCESS_KEY,
-        ] {
-            unsafe { env::remove_var(key) };
-        }
-    }
-
-    #[test]
-    fn endpoint_access_env_preserves_presence_and_rejects_invalid_values() {
-        let _guard = GATEWAY_ENV_LOCK.blocking_lock();
-        clear_env();
-        unsafe {
-            env::set_var(ENV_ENABLE_JWT, "false");
-            env::set_var(ENV_PROVIDERS, "openai");
-            env::set_var("LITELLM_PROVIDER_OPENAI_TYPE", "openai");
-            env::set_var("LITELLM_PROVIDER_OPENAI_API_KEY", "sk-test");
-            env::set_var(ACCESS_KEY, "private_network");
-        }
-        let private = GatewayConfig::from_env().expect("private access env should parse");
-        assert_eq!(
-            private.providers[0].endpoint_access,
-            ProviderEndpointAccess::PrivateNetwork
-        );
-        for invalid in ["", "private"] {
-            unsafe { env::set_var(ACCESS_KEY, invalid) };
-            assert!(GatewayConfig::from_env().is_err());
-        }
-        clear_env();
-    }
-}
+#[path = "gateway_env_tests.rs"]
+mod env_tests;
 
 #[cfg(test)]
 #[path = "gateway_tests.rs"]

--- a/src/config/models/gateway_env.rs
+++ b/src/config/models/gateway_env.rs
@@ -1,0 +1,343 @@
+//! Environment parsing for gateway configuration and presence-aware overlays.
+
+use std::env;
+
+use super::*;
+use crate::core::net::ProviderEndpointAccess;
+
+pub(crate) struct GatewayEnvOverlay {
+    pub(crate) gateway: GatewayConfig,
+    pub(crate) redis_cluster: Option<bool>,
+    pub(crate) enable_jwt: Option<bool>,
+    pub(crate) enable_api_key: Option<bool>,
+}
+
+pub(super) const ENV_HOST: &str = "LITELLM_HOST";
+pub(super) const ENV_PORT: &str = "LITELLM_PORT";
+pub(super) const ENV_WORKERS: &str = "LITELLM_WORKERS";
+pub(super) const ENV_TIMEOUT: &str = "LITELLM_TIMEOUT";
+pub(super) const ENV_DATABASE_URL: &str = "LITELLM_DATABASE_URL";
+pub(super) const ENV_DATABASE_MAX_CONNECTIONS: &str = "LITELLM_DATABASE_MAX_CONNECTIONS";
+pub(super) const ENV_DATABASE_CONNECTION_TIMEOUT: &str = "LITELLM_DATABASE_CONNECTION_TIMEOUT";
+pub(super) const ENV_DATABASE_SSL: &str = "LITELLM_DATABASE_SSL";
+pub(super) const ENV_DATABASE_ENABLED: &str = "LITELLM_DATABASE_ENABLED";
+pub(super) const ENV_DATABASE_AUTO_MIGRATE: &str = "LITELLM_DATABASE_AUTO_MIGRATE";
+pub(super) const ENV_REDIS_URL: &str = "LITELLM_REDIS_URL";
+pub(super) const ENV_REDIS_ENABLED: &str = "LITELLM_REDIS_ENABLED";
+pub(super) const ENV_REDIS_MAX_CONNECTIONS: &str = "LITELLM_REDIS_MAX_CONNECTIONS";
+pub(super) const ENV_REDIS_CONNECTION_TIMEOUT: &str = "LITELLM_REDIS_CONNECTION_TIMEOUT";
+pub(super) const ENV_REDIS_CLUSTER: &str = "LITELLM_REDIS_CLUSTER";
+pub(super) const ENV_ENABLE_JWT: &str = "LITELLM_ENABLE_JWT";
+pub(super) const ENV_ENABLE_API_KEY: &str = "LITELLM_ENABLE_API_KEY";
+pub(super) const ENV_JWT_SECRET: &str = "LITELLM_JWT_SECRET";
+pub(super) const ENV_JWT_EXPIRATION: &str = "LITELLM_JWT_EXPIRATION";
+pub(super) const ENV_API_KEY_HEADER: &str = "LITELLM_API_KEY_HEADER";
+pub(super) const ENV_PROVIDERS: &str = "LITELLM_PROVIDERS";
+pub(super) const ENV_PRICING_SOURCE: &str = "LITELLM_PRICING_SOURCE";
+pub(super) const ENV_UNPRICED_MODEL_POLICY: &str = "LITELLM_UNPRICED_MODEL_POLICY";
+pub(super) const ENV_UNPRICED_FALLBACK_COST_PER_1K_TOKENS: &str =
+    "LITELLM_UNPRICED_FALLBACK_COST_PER_1K_TOKENS";
+pub(super) const ENV_CACHE_ENABLED: &str = "LITELLM_CACHE_ENABLED";
+pub(super) const ENV_RATE_LIMIT_ENABLED: &str = "LITELLM_RATE_LIMIT_ENABLED";
+pub(super) const ENV_ENTERPRISE_ENABLED: &str = "LITELLM_ENTERPRISE_ENABLED";
+
+fn env_var(key: &str) -> Option<String> {
+    env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_env<T>(key: &str) -> crate::utils::error::gateway_error::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    let Some(raw) = env_var(key) else {
+        return Ok(None);
+    };
+    raw.parse::<T>().map(Some).map_err(|error| {
+        crate::utils::error::gateway_error::GatewayError::Config(format!(
+            "Invalid value for {}: {}",
+            key, error
+        ))
+    })
+}
+
+fn parse_env_bool(key: &str) -> crate::utils::error::gateway_error::Result<Option<bool>> {
+    let Some(raw) = env_var(key) else {
+        return Ok(None);
+    };
+    let value = match raw.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => true,
+        "false" | "0" | "no" | "off" => false,
+        _ => {
+            return Err(crate::utils::error::gateway_error::GatewayError::Config(
+                format!("Invalid boolean value for {}: {}", key, raw),
+            ));
+        }
+    };
+    Ok(Some(value))
+}
+
+fn parse_env_list(key: &str) -> Option<Vec<String>> {
+    env_var(key).map(|raw| {
+        raw.split(',')
+            .map(str::trim)
+            .filter(|segment| !segment.is_empty())
+            .map(ToString::to_string)
+            .collect()
+    })
+}
+
+fn required_env(key: &str) -> crate::utils::error::gateway_error::Result<String> {
+    env_var(key).ok_or_else(|| {
+        crate::utils::error::gateway_error::GatewayError::Config(format!(
+            "Missing required env var: {}",
+            key
+        ))
+    })
+}
+
+fn provider_env_key(provider_name: &str) -> String {
+    provider_name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn provider_env_name(provider_name: &str, field: &str) -> String {
+    format!(
+        "LITELLM_PROVIDER_{}_{}",
+        provider_env_key(provider_name),
+        field
+    )
+}
+
+fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<ProviderConfig>> {
+    let Some(provider_names) = parse_env_list(ENV_PROVIDERS) else {
+        return Ok(Vec::new());
+    };
+    if provider_names.is_empty() {
+        return Err(crate::utils::error::gateway_error::GatewayError::Config(
+            format!("{} must contain at least one provider name", ENV_PROVIDERS),
+        ));
+    }
+
+    let mut providers = Vec::with_capacity(provider_names.len());
+    for name in provider_names {
+        let type_key = provider_env_name(&name, "TYPE");
+        let api_key_key = provider_env_name(&name, "API_KEY");
+        let provider_type = required_env(&type_key)?;
+        let selector = provider_type.to_lowercase();
+        let skip_api_key = crate::core::providers::registry::selector_skips_api_key(&selector);
+        let api_key = if skip_api_key {
+            env_var(&api_key_key).unwrap_or_default()
+        } else {
+            required_env(&api_key_key)?
+        };
+        let mut provider = ProviderConfig {
+            name: name.clone(),
+            provider_type,
+            api_key,
+            ..ProviderConfig::default()
+        };
+
+        if let Some(base_url) = env_var(&provider_env_name(&name, "BASE_URL")) {
+            provider.base_url = Some(base_url);
+        }
+        let endpoint_access_key = provider_env_name(&name, "ENDPOINT_ACCESS");
+        match env::var(&endpoint_access_key) {
+            Ok(raw) => {
+                provider.endpoint_access =
+                    raw.parse::<ProviderEndpointAccess>().map_err(|error| {
+                        crate::utils::error::gateway_error::GatewayError::Config(format!(
+                            "Invalid value for {endpoint_access_key}: {error}"
+                        ))
+                    })?;
+            }
+            Err(env::VarError::NotPresent) => {}
+            Err(error) => {
+                return Err(crate::utils::error::gateway_error::GatewayError::Config(
+                    format!("Invalid value for {endpoint_access_key}: {error}"),
+                ));
+            }
+        }
+        if let Some(value) = env_var(&provider_env_name(&name, "API_VERSION")) {
+            provider.api_version = Some(value);
+        }
+        if let Some(value) = env_var(&provider_env_name(&name, "ORGANIZATION")) {
+            provider.organization = Some(value);
+        }
+        if let Some(value) = env_var(&provider_env_name(&name, "PROJECT")) {
+            provider.project = Some(value);
+        }
+        if let Some(value) = parse_env::<f32>(&provider_env_name(&name, "WEIGHT"))? {
+            provider.weight = value;
+        }
+        if let Some(value) = parse_env::<u32>(&provider_env_name(&name, "RPM"))? {
+            provider.rpm = value;
+        }
+        if let Some(value) = parse_env::<u32>(&provider_env_name(&name, "TPM"))? {
+            provider.tpm = value;
+        }
+        if let Some(value) = parse_env::<u32>(&provider_env_name(&name, "MAX_CONCURRENT_REQUESTS"))?
+        {
+            provider.max_concurrent_requests = value;
+        }
+        if let Some(value) = parse_env::<u64>(&provider_env_name(&name, "TIMEOUT"))? {
+            provider.timeout = value;
+        }
+        if let Some(value) = parse_env::<u32>(&provider_env_name(&name, "MAX_RETRIES"))? {
+            provider.max_retries = value;
+        }
+        if let Some(value) = parse_env_bool(&provider_env_name(&name, "ENABLED"))? {
+            provider.enabled = value;
+        }
+        if let Some(value) = parse_env_list(&provider_env_name(&name, "MODELS")) {
+            provider.models = value;
+        }
+        if let Some(value) = parse_env_list(&provider_env_name(&name, "TAGS")) {
+            provider.tags = value;
+        }
+        providers.push(provider);
+    }
+    Ok(providers)
+}
+
+impl GatewayConfig {
+    pub fn from_env() -> crate::utils::error::gateway_error::Result<Self> {
+        Self::from_env_inner(true).map(|overlay| overlay.gateway)
+    }
+
+    pub(crate) fn from_env_with_redis_cluster_presence()
+    -> crate::utils::error::gateway_error::Result<GatewayEnvOverlay> {
+        Self::from_env_inner(false)
+    }
+
+    fn from_env_inner(
+        standalone: bool,
+    ) -> crate::utils::error::gateway_error::Result<GatewayEnvOverlay> {
+        let mut config = Self::default();
+        if let Some(value) = env_var(ENV_HOST) {
+            config.server.host = value;
+        }
+        if let Some(value) = parse_env::<u16>(ENV_PORT)? {
+            config.server.port = value;
+        }
+        if let Some(value) = parse_env::<usize>(ENV_WORKERS)? {
+            config.server.workers = Some(value);
+        }
+        if let Some(value) = parse_env::<u64>(ENV_TIMEOUT)? {
+            config.server.timeout = value;
+        }
+
+        if let Some(value) = env_var(ENV_DATABASE_URL) {
+            config.storage.database.url = value;
+        }
+        if let Some(value) = parse_env::<u32>(ENV_DATABASE_MAX_CONNECTIONS)? {
+            config.storage.database.max_connections = value;
+        }
+        if let Some(value) = parse_env::<u64>(ENV_DATABASE_CONNECTION_TIMEOUT)? {
+            config.storage.database.connection_timeout = value;
+        }
+        if let Some(value) = parse_env_bool(ENV_DATABASE_SSL)? {
+            config.storage.database.ssl = value;
+        }
+        if let Some(value) = parse_env_bool(ENV_DATABASE_ENABLED)? {
+            config.storage.database.enabled = value;
+        }
+        if let Some(value) = parse_env_bool(ENV_DATABASE_AUTO_MIGRATE)? {
+            config.storage.database.auto_migrate = value;
+            config.storage.database.auto_migrate_configured = true;
+        }
+
+        if let Some(value) = env_var(ENV_REDIS_URL) {
+            config.storage.redis.url = value;
+        }
+        if let Some(value) = parse_env_bool(ENV_REDIS_ENABLED)? {
+            config.storage.redis.enabled = value;
+        }
+        if let Some(value) = parse_env::<u32>(ENV_REDIS_MAX_CONNECTIONS)? {
+            config.storage.redis.max_connections = value;
+        }
+        if let Some(value) = parse_env::<u64>(ENV_REDIS_CONNECTION_TIMEOUT)? {
+            config.storage.redis.connection_timeout = value;
+        }
+        let redis_cluster = parse_env_bool(ENV_REDIS_CLUSTER)?;
+        if let Some(value) = redis_cluster {
+            config.storage.redis.cluster = value;
+        }
+
+        let enable_jwt = parse_env_bool(ENV_ENABLE_JWT)?;
+        if let Some(value) = enable_jwt {
+            config.auth.enable_jwt = value;
+        }
+        let enable_api_key = parse_env_bool(ENV_ENABLE_API_KEY)?;
+        if let Some(value) = enable_api_key {
+            config.auth.enable_api_key = value;
+        }
+        if let Some(value) = env_var(ENV_JWT_SECRET) {
+            config.auth.jwt_secret = value;
+        } else if standalone && config.auth.enable_jwt {
+            return Err(crate::utils::error::gateway_error::GatewayError::Config(
+                format!(
+                    "{} is required when {} is enabled",
+                    ENV_JWT_SECRET, ENV_ENABLE_JWT
+                ),
+            ));
+        }
+        if let Some(value) = parse_env::<u64>(ENV_JWT_EXPIRATION)? {
+            config.auth.jwt_expiration = value;
+        }
+        if let Some(value) = env_var(ENV_API_KEY_HEADER) {
+            config.auth.api_key_header = value;
+        }
+
+        config.providers = load_providers_from_env()?;
+        if standalone && config.providers.is_empty() {
+            return Err(crate::utils::error::gateway_error::GatewayError::Config(
+                format!(
+                    "{} must be set with at least one provider name",
+                    ENV_PROVIDERS
+                ),
+            ));
+        }
+
+        if let Some(value) = env_var(ENV_PRICING_SOURCE) {
+            config.pricing.source = Some(value);
+            config.pricing.mark_source_explicit_for_merge();
+        }
+        if let Some(value) = parse_env::<UnpricedModelPolicy>(ENV_UNPRICED_MODEL_POLICY)? {
+            config.pricing.unpriced_model_policy = value;
+            config
+                .pricing
+                .mark_unpriced_model_policy_explicit_for_merge();
+        }
+        if let Some(value) = parse_env::<f64>(ENV_UNPRICED_FALLBACK_COST_PER_1K_TOKENS)? {
+            config.pricing.unpriced_fallback_cost_per_1k_tokens = Some(value);
+            config.pricing.mark_unpriced_fallback_explicit_for_merge();
+        }
+        if let Some(value) = parse_env_bool(ENV_CACHE_ENABLED)? {
+            config.cache.enabled = value;
+        }
+        if let Some(value) = parse_env_bool(ENV_RATE_LIMIT_ENABLED)? {
+            config.rate_limit.enabled = value;
+        }
+        if let Some(value) = parse_env_bool(ENV_ENTERPRISE_ENABLED)? {
+            config.enterprise.enabled = value;
+        }
+        Ok(GatewayEnvOverlay {
+            gateway: config,
+            redis_cluster,
+            enable_jwt,
+            enable_api_key,
+        })
+    }
+}

--- a/src/config/models/gateway_env.rs
+++ b/src/config/models/gateway_env.rs
@@ -1,6 +1,6 @@
 //! Environment parsing for gateway configuration and presence-aware overlays.
 
-use std::env;
+use std::{collections::BTreeSet, env};
 
 use super::*;
 use crate::core::net::ProviderEndpointAccess;
@@ -8,9 +8,11 @@ use crate::core::net::ProviderEndpointAccess;
 pub(crate) struct GatewayEnvOverlay {
     pub(crate) gateway: GatewayConfig,
     pub(crate) redis_cluster: Option<bool>,
-    pub(crate) enable_jwt: Option<bool>,
-    pub(crate) enable_api_key: Option<bool>,
+    pub(crate) presence: GatewayEnvPresence,
 }
+
+#[derive(Debug, Clone)]
+pub(crate) struct GatewayEnvPresence(BTreeSet<String>);
 
 pub(super) const ENV_HOST: &str = "LITELLM_HOST";
 pub(super) const ENV_PORT: &str = "LITELLM_PORT";
@@ -41,11 +43,63 @@ pub(super) const ENV_CACHE_ENABLED: &str = "LITELLM_CACHE_ENABLED";
 pub(super) const ENV_RATE_LIMIT_ENABLED: &str = "LITELLM_RATE_LIMIT_ENABLED";
 pub(super) const ENV_ENTERPRISE_ENABLED: &str = "LITELLM_ENTERPRISE_ENABLED";
 
-fn env_var(key: &str) -> Option<String> {
-    env::var(key)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+const FIXED_ENV_KEYS: &[&str] = &[
+    ENV_HOST,
+    ENV_PORT,
+    ENV_WORKERS,
+    ENV_TIMEOUT,
+    ENV_DATABASE_URL,
+    ENV_DATABASE_MAX_CONNECTIONS,
+    ENV_DATABASE_CONNECTION_TIMEOUT,
+    ENV_DATABASE_SSL,
+    ENV_DATABASE_ENABLED,
+    ENV_DATABASE_AUTO_MIGRATE,
+    ENV_REDIS_URL,
+    ENV_REDIS_ENABLED,
+    ENV_REDIS_MAX_CONNECTIONS,
+    ENV_REDIS_CONNECTION_TIMEOUT,
+    ENV_REDIS_CLUSTER,
+    ENV_ENABLE_JWT,
+    ENV_ENABLE_API_KEY,
+    ENV_JWT_SECRET,
+    ENV_JWT_EXPIRATION,
+    ENV_API_KEY_HEADER,
+    ENV_PROVIDERS,
+    ENV_PRICING_SOURCE,
+    ENV_UNPRICED_MODEL_POLICY,
+    ENV_UNPRICED_FALLBACK_COST_PER_1K_TOKENS,
+    ENV_CACHE_ENABLED,
+    ENV_RATE_LIMIT_ENABLED,
+    ENV_ENTERPRISE_ENABLED,
+];
+
+const PROVIDER_ENV_FIELDS: &[&str] = &[
+    "TYPE",
+    "API_KEY",
+    "BASE_URL",
+    "ENDPOINT_ACCESS",
+    "API_VERSION",
+    "ORGANIZATION",
+    "PROJECT",
+    "WEIGHT",
+    "RPM",
+    "TPM",
+    "MAX_CONCURRENT_REQUESTS",
+    "TIMEOUT",
+    "MAX_RETRIES",
+    "ENABLED",
+    "MODELS",
+    "TAGS",
+];
+
+fn env_var(key: &str) -> crate::utils::error::gateway_error::Result<Option<String>> {
+    match env::var(key) {
+        Ok(value) => Ok(Some(value.trim().to_string())),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(crate::utils::error::gateway_error::GatewayError::Config(
+            format!("Invalid value for {}: {}", key, error),
+        )),
+    }
 }
 
 fn parse_env<T>(key: &str) -> crate::utils::error::gateway_error::Result<Option<T>>
@@ -53,7 +107,7 @@ where
     T: std::str::FromStr,
     T::Err: std::fmt::Display,
 {
-    let Some(raw) = env_var(key) else {
+    let Some(raw) = env_var(key)? else {
         return Ok(None);
     };
     raw.parse::<T>().map(Some).map_err(|error| {
@@ -65,7 +119,7 @@ where
 }
 
 fn parse_env_bool(key: &str) -> crate::utils::error::gateway_error::Result<Option<bool>> {
-    let Some(raw) = env_var(key) else {
+    let Some(raw) = env_var(key)? else {
         return Ok(None);
     };
     let value = match raw.to_ascii_lowercase().as_str() {
@@ -80,23 +134,27 @@ fn parse_env_bool(key: &str) -> crate::utils::error::gateway_error::Result<Optio
     Ok(Some(value))
 }
 
-fn parse_env_list(key: &str) -> Option<Vec<String>> {
-    env_var(key).map(|raw| {
-        raw.split(',')
-            .map(str::trim)
-            .filter(|segment| !segment.is_empty())
-            .map(ToString::to_string)
-            .collect()
+fn parse_env_list(key: &str) -> crate::utils::error::gateway_error::Result<Option<Vec<String>>> {
+    env_var(key).map(|value| {
+        value.map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|segment| !segment.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
     })
 }
 
 fn required_env(key: &str) -> crate::utils::error::gateway_error::Result<String> {
-    env_var(key).ok_or_else(|| {
-        crate::utils::error::gateway_error::GatewayError::Config(format!(
-            "Missing required env var: {}",
-            key
-        ))
-    })
+    env_var(key)?
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            crate::utils::error::gateway_error::GatewayError::Config(format!(
+                "Missing required env var: {}",
+                key
+            ))
+        })
 }
 
 fn provider_env_key(provider_name: &str) -> String {
@@ -120,8 +178,218 @@ fn provider_env_name(provider_name: &str, field: &str) -> String {
     )
 }
 
-fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<ProviderConfig>> {
-    let Some(provider_names) = parse_env_list(ENV_PROVIDERS) else {
+impl GatewayEnvPresence {
+    fn capture(providers: &[ProviderConfig]) -> Self {
+        let mut keys = FIXED_ENV_KEYS
+            .iter()
+            .filter(|key| env::var_os(key).is_some())
+            .map(|key| (*key).to_string())
+            .collect::<BTreeSet<_>>();
+        for provider in providers {
+            for field in PROVIDER_ENV_FIELDS {
+                let key = provider_env_name(&provider.name, field);
+                if env::var_os(&key).is_some() {
+                    keys.insert(key);
+                }
+            }
+        }
+        Self(keys)
+    }
+
+    pub(crate) fn contains(&self, key: &str) -> bool {
+        self.0.contains(key)
+    }
+
+    pub(crate) fn contains_provider_field(&self, provider: &str, field: &str) -> bool {
+        self.contains(&provider_env_name(provider, field))
+    }
+}
+
+fn merge_database_env(
+    base: &mut crate::config::models::storage::DatabaseConfig,
+    other: crate::config::models::storage::DatabaseConfig,
+    presence: &GatewayEnvPresence,
+) {
+    if presence.contains(ENV_DATABASE_URL) {
+        base.url = other.url;
+    }
+    if presence.contains(ENV_DATABASE_MAX_CONNECTIONS) {
+        base.max_connections = other.max_connections;
+    }
+    if presence.contains(ENV_DATABASE_CONNECTION_TIMEOUT) {
+        base.connection_timeout = other.connection_timeout;
+    }
+    if presence.contains(ENV_DATABASE_SSL) {
+        base.ssl = other.ssl;
+    }
+    if presence.contains(ENV_DATABASE_ENABLED) {
+        base.enabled = other.enabled;
+    }
+    if presence.contains(ENV_DATABASE_AUTO_MIGRATE) {
+        base.auto_migrate = other.auto_migrate;
+        base.auto_migrate_configured = true;
+    }
+}
+
+fn merge_redis_env(
+    base: &mut crate::config::models::storage::RedisConfig,
+    other: crate::config::models::storage::RedisConfig,
+    redis_cluster: Option<bool>,
+    presence: &GatewayEnvPresence,
+) {
+    if presence.contains(ENV_REDIS_URL) {
+        base.url = other.url;
+    }
+    if presence.contains(ENV_REDIS_ENABLED) {
+        base.enabled = other.enabled;
+    }
+    if presence.contains(ENV_REDIS_MAX_CONNECTIONS) {
+        base.max_connections = other.max_connections;
+    }
+    if presence.contains(ENV_REDIS_CONNECTION_TIMEOUT) {
+        base.connection_timeout = other.connection_timeout;
+    }
+    if let Some(cluster) = redis_cluster {
+        base.cluster = cluster;
+    }
+}
+
+fn merge_auth_env(base: &mut AuthConfig, other: AuthConfig, presence: &GatewayEnvPresence) {
+    if presence.contains(ENV_ENABLE_JWT) {
+        base.enable_jwt = other.enable_jwt;
+    }
+    if presence.contains(ENV_ENABLE_API_KEY) {
+        base.enable_api_key = other.enable_api_key;
+    }
+    if presence.contains(ENV_JWT_SECRET) {
+        base.jwt_secret = other.jwt_secret;
+    }
+    if presence.contains(ENV_JWT_EXPIRATION) {
+        base.jwt_expiration = other.jwt_expiration;
+    }
+    if presence.contains(ENV_API_KEY_HEADER) {
+        base.api_key_header = other.api_key_header;
+    }
+}
+
+fn merge_provider_env(
+    base: &mut Vec<ProviderConfig>,
+    providers: Vec<ProviderConfig>,
+    presence: &GatewayEnvPresence,
+) {
+    if !presence.contains(ENV_PROVIDERS) {
+        return;
+    }
+    for provider in providers {
+        match base.iter_mut().find(|item| item.name == provider.name) {
+            Some(existing) => merge_existing_provider_env(existing, provider, presence),
+            None => base.push(provider),
+        }
+    }
+}
+
+fn merge_existing_provider_env(
+    base: &mut ProviderConfig,
+    other: ProviderConfig,
+    presence: &GatewayEnvPresence,
+) {
+    let name = &other.name;
+    if presence.contains_provider_field(name, "TYPE") {
+        base.provider_type = other.provider_type;
+    }
+    if presence.contains_provider_field(name, "API_KEY") {
+        base.api_key = other.api_key;
+    }
+    if presence.contains_provider_field(name, "BASE_URL") {
+        base.base_url = other.base_url;
+    }
+    if presence.contains_provider_field(name, "ENDPOINT_ACCESS") {
+        base.endpoint_access = other.endpoint_access;
+    }
+    if presence.contains_provider_field(name, "API_VERSION") {
+        base.api_version = other.api_version;
+    }
+    if presence.contains_provider_field(name, "ORGANIZATION") {
+        base.organization = other.organization;
+    }
+    if presence.contains_provider_field(name, "PROJECT") {
+        base.project = other.project;
+    }
+    if presence.contains_provider_field(name, "WEIGHT") {
+        base.weight = other.weight;
+    }
+    if presence.contains_provider_field(name, "RPM") {
+        base.rpm = other.rpm;
+    }
+    if presence.contains_provider_field(name, "TPM") {
+        base.tpm = other.tpm;
+    }
+    if presence.contains_provider_field(name, "MAX_CONCURRENT_REQUESTS") {
+        base.max_concurrent_requests = other.max_concurrent_requests;
+    }
+    if presence.contains_provider_field(name, "TIMEOUT") {
+        base.timeout = other.timeout;
+    }
+    if presence.contains_provider_field(name, "MAX_RETRIES") {
+        base.max_retries = other.max_retries;
+    }
+    if presence.contains_provider_field(name, "ENABLED") {
+        base.enabled = other.enabled;
+    }
+    if presence.contains_provider_field(name, "MODELS") {
+        base.models = other.models;
+    }
+    if presence.contains_provider_field(name, "TAGS") {
+        base.tags = other.tags;
+    }
+}
+
+impl GatewayConfig {
+    pub(crate) fn merge_env_overlay(
+        mut self,
+        other: Self,
+        redis_cluster: Option<bool>,
+        presence: &GatewayEnvPresence,
+    ) -> Self {
+        if presence.contains(ENV_HOST) {
+            self.server.host = other.server.host;
+        }
+        if presence.contains(ENV_PORT) {
+            self.server.port = other.server.port;
+        }
+        if presence.contains(ENV_WORKERS) {
+            self.server.workers = other.server.workers;
+        }
+        if presence.contains(ENV_TIMEOUT) {
+            self.server.timeout = other.server.timeout;
+        }
+        merge_database_env(&mut self.storage.database, other.storage.database, presence);
+        merge_redis_env(
+            &mut self.storage.redis,
+            other.storage.redis,
+            redis_cluster,
+            presence,
+        );
+        merge_auth_env(&mut self.auth, other.auth, presence);
+        merge_provider_env(&mut self.providers, other.providers, presence);
+        self.pricing = self.pricing.merge(other.pricing);
+        if presence.contains(ENV_CACHE_ENABLED) {
+            self.cache.enabled = other.cache.enabled;
+        }
+        if presence.contains(ENV_RATE_LIMIT_ENABLED) {
+            self.rate_limit.enabled = other.rate_limit.enabled;
+        }
+        if presence.contains(ENV_ENTERPRISE_ENABLED) {
+            self.enterprise.enabled = other.enterprise.enabled;
+        }
+        self
+    }
+}
+
+fn load_providers_from_env(
+    standalone: bool,
+) -> crate::utils::error::gateway_error::Result<Vec<ProviderConfig>> {
+    let Some(provider_names) = parse_env_list(ENV_PROVIDERS)? else {
         return Ok(Vec::new());
     };
     if provider_names.is_empty() {
@@ -134,11 +402,15 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
     for name in provider_names {
         let type_key = provider_env_name(&name, "TYPE");
         let api_key_key = provider_env_name(&name, "API_KEY");
-        let provider_type = required_env(&type_key)?;
+        let provider_type = if standalone {
+            required_env(&type_key)?
+        } else {
+            env_var(&type_key)?.unwrap_or_default()
+        };
         let selector = provider_type.to_lowercase();
         let skip_api_key = crate::core::providers::registry::selector_skips_api_key(&selector);
-        let api_key = if skip_api_key {
-            env_var(&api_key_key).unwrap_or_default()
+        let api_key = if skip_api_key || !standalone {
+            env_var(&api_key_key)?.unwrap_or_default()
         } else {
             required_env(&api_key_key)?
         };
@@ -149,8 +421,8 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
             ..ProviderConfig::default()
         };
 
-        if let Some(base_url) = env_var(&provider_env_name(&name, "BASE_URL")) {
-            provider.base_url = Some(base_url);
+        if let Some(base_url) = env_var(&provider_env_name(&name, "BASE_URL"))? {
+            provider.base_url = (!base_url.is_empty()).then_some(base_url);
         }
         let endpoint_access_key = provider_env_name(&name, "ENDPOINT_ACCESS");
         match env::var(&endpoint_access_key) {
@@ -169,14 +441,14 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
                 ));
             }
         }
-        if let Some(value) = env_var(&provider_env_name(&name, "API_VERSION")) {
-            provider.api_version = Some(value);
+        if let Some(value) = env_var(&provider_env_name(&name, "API_VERSION"))? {
+            provider.api_version = (!value.is_empty()).then_some(value);
         }
-        if let Some(value) = env_var(&provider_env_name(&name, "ORGANIZATION")) {
-            provider.organization = Some(value);
+        if let Some(value) = env_var(&provider_env_name(&name, "ORGANIZATION"))? {
+            provider.organization = (!value.is_empty()).then_some(value);
         }
-        if let Some(value) = env_var(&provider_env_name(&name, "PROJECT")) {
-            provider.project = Some(value);
+        if let Some(value) = env_var(&provider_env_name(&name, "PROJECT"))? {
+            provider.project = (!value.is_empty()).then_some(value);
         }
         if let Some(value) = parse_env::<f32>(&provider_env_name(&name, "WEIGHT"))? {
             provider.weight = value;
@@ -200,10 +472,10 @@ fn load_providers_from_env() -> crate::utils::error::gateway_error::Result<Vec<P
         if let Some(value) = parse_env_bool(&provider_env_name(&name, "ENABLED"))? {
             provider.enabled = value;
         }
-        if let Some(value) = parse_env_list(&provider_env_name(&name, "MODELS")) {
+        if let Some(value) = parse_env_list(&provider_env_name(&name, "MODELS"))? {
             provider.models = value;
         }
-        if let Some(value) = parse_env_list(&provider_env_name(&name, "TAGS")) {
+        if let Some(value) = parse_env_list(&provider_env_name(&name, "TAGS"))? {
             provider.tags = value;
         }
         providers.push(provider);
@@ -225,7 +497,7 @@ impl GatewayConfig {
         standalone: bool,
     ) -> crate::utils::error::gateway_error::Result<GatewayEnvOverlay> {
         let mut config = Self::default();
-        if let Some(value) = env_var(ENV_HOST) {
+        if let Some(value) = env_var(ENV_HOST)? {
             config.server.host = value;
         }
         if let Some(value) = parse_env::<u16>(ENV_PORT)? {
@@ -238,7 +510,7 @@ impl GatewayConfig {
             config.server.timeout = value;
         }
 
-        if let Some(value) = env_var(ENV_DATABASE_URL) {
+        if let Some(value) = env_var(ENV_DATABASE_URL)? {
             config.storage.database.url = value;
         }
         if let Some(value) = parse_env::<u32>(ENV_DATABASE_MAX_CONNECTIONS)? {
@@ -258,7 +530,7 @@ impl GatewayConfig {
             config.storage.database.auto_migrate_configured = true;
         }
 
-        if let Some(value) = env_var(ENV_REDIS_URL) {
+        if let Some(value) = env_var(ENV_REDIS_URL)? {
             config.storage.redis.url = value;
         }
         if let Some(value) = parse_env_bool(ENV_REDIS_ENABLED)? {
@@ -283,9 +555,10 @@ impl GatewayConfig {
         if let Some(value) = enable_api_key {
             config.auth.enable_api_key = value;
         }
-        if let Some(value) = env_var(ENV_JWT_SECRET) {
+        if let Some(value) = env_var(ENV_JWT_SECRET)? {
             config.auth.jwt_secret = value;
-        } else if standalone && config.auth.enable_jwt {
+        }
+        if standalone && config.auth.enable_jwt && config.auth.jwt_secret.is_empty() {
             return Err(crate::utils::error::gateway_error::GatewayError::Config(
                 format!(
                     "{} is required when {} is enabled",
@@ -296,11 +569,11 @@ impl GatewayConfig {
         if let Some(value) = parse_env::<u64>(ENV_JWT_EXPIRATION)? {
             config.auth.jwt_expiration = value;
         }
-        if let Some(value) = env_var(ENV_API_KEY_HEADER) {
+        if let Some(value) = env_var(ENV_API_KEY_HEADER)? {
             config.auth.api_key_header = value;
         }
 
-        config.providers = load_providers_from_env()?;
+        config.providers = load_providers_from_env(standalone)?;
         if standalone && config.providers.is_empty() {
             return Err(crate::utils::error::gateway_error::GatewayError::Config(
                 format!(
@@ -310,8 +583,8 @@ impl GatewayConfig {
             ));
         }
 
-        if let Some(value) = env_var(ENV_PRICING_SOURCE) {
-            config.pricing.source = Some(value);
+        if let Some(value) = env_var(ENV_PRICING_SOURCE)? {
+            config.pricing.source = (!value.is_empty()).then_some(value);
             config.pricing.mark_source_explicit_for_merge();
         }
         if let Some(value) = parse_env::<UnpricedModelPolicy>(ENV_UNPRICED_MODEL_POLICY)? {
@@ -333,11 +606,11 @@ impl GatewayConfig {
         if let Some(value) = parse_env_bool(ENV_ENTERPRISE_ENABLED)? {
             config.enterprise.enabled = value;
         }
+        let presence = GatewayEnvPresence::capture(&config.providers);
         Ok(GatewayEnvOverlay {
             gateway: config,
             redis_cluster,
-            enable_jwt,
-            enable_api_key,
+            presence,
         })
     }
 }

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -6,6 +6,7 @@ fn clear_env() {
     for key in [
         ENV_ENABLE_JWT,
         ENV_PROVIDERS,
+        ENV_REDIS_ENABLED,
         ENV_REDIS_CLUSTER,
         "LITELLM_PROVIDER_OPENAI_TYPE",
         "LITELLM_PROVIDER_OPENAI_API_KEY",
@@ -60,5 +61,32 @@ fn redis_cluster_env_false_overrides_true_base() {
     let merged = base.merge_with_redis_cluster_override(overlay, redis_cluster);
 
     assert!(!merged.storage.redis.cluster);
+    clear_env();
+}
+
+#[test]
+fn config_environment_overlay_defers_final_cluster_validation() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    clear_env();
+    unsafe {
+        env::set_var(ENV_ENABLE_JWT, "false");
+        env::set_var(ENV_PROVIDERS, "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_TYPE", "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_API_KEY", "sk-test");
+        env::set_var(ENV_REDIS_ENABLED, "true");
+        env::set_var(ENV_REDIS_CLUSTER, "true");
+    }
+
+    assert!(crate::config::Config::from_env().is_err());
+    let layer = crate::config::Config::overlay_from_env()
+        .expect("environment overlay should parse before final validation")
+        .into_config();
+    assert!(
+        layer
+            .validate()
+            .expect_err("materialized cluster layer must remain invalid before merge")
+            .to_string()
+            .contains("storage.redis.cluster=false")
+    );
     clear_env();
 }

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+const ACCESS_KEY: &str = "LITELLM_PROVIDER_OPENAI_ENDPOINT_ACCESS";
+
+fn clear_env() {
+    for key in [
+        ENV_ENABLE_JWT,
+        ENV_PROVIDERS,
+        ENV_REDIS_CLUSTER,
+        "LITELLM_PROVIDER_OPENAI_TYPE",
+        "LITELLM_PROVIDER_OPENAI_API_KEY",
+        ACCESS_KEY,
+    ] {
+        unsafe { env::remove_var(key) };
+    }
+}
+
+#[test]
+fn endpoint_access_env_preserves_presence_and_rejects_invalid_values() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    clear_env();
+    unsafe {
+        env::set_var(ENV_ENABLE_JWT, "false");
+        env::set_var(ENV_PROVIDERS, "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_TYPE", "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_API_KEY", "sk-test");
+        env::set_var(ACCESS_KEY, "private_network");
+    }
+    let private = GatewayConfig::from_env().expect("private access env should parse");
+    assert_eq!(
+        private.providers[0].endpoint_access,
+        ProviderEndpointAccess::PrivateNetwork
+    );
+    for invalid in ["", "private"] {
+        unsafe { env::set_var(ACCESS_KEY, invalid) };
+        assert!(GatewayConfig::from_env().is_err());
+    }
+    clear_env();
+}
+
+#[test]
+fn redis_cluster_env_false_overrides_true_base() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    clear_env();
+    unsafe {
+        env::set_var(ENV_ENABLE_JWT, "false");
+        env::set_var(ENV_PROVIDERS, "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_TYPE", "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_API_KEY", "sk-test");
+        env::set_var(ENV_REDIS_CLUSTER, "false");
+    }
+
+    let overlay = GatewayConfig::from_env().expect("Redis cluster env should parse");
+    assert!(!overlay.storage.redis.cluster);
+    assert!(overlay.storage.redis.cluster_configured);
+
+    let mut base = GatewayConfig::default();
+    base.storage.redis.cluster = true;
+    let merged = base.merge(overlay);
+
+    assert!(!merged.storage.redis.cluster);
+    clear_env();
+}

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -50,13 +50,14 @@ fn redis_cluster_env_false_overrides_true_base() {
         env::set_var(ENV_REDIS_CLUSTER, "false");
     }
 
-    let overlay = GatewayConfig::from_env().expect("Redis cluster env should parse");
+    let (overlay, redis_cluster) = GatewayConfig::from_env_with_redis_cluster_presence()
+        .expect("Redis cluster env should parse");
     assert!(!overlay.storage.redis.cluster);
-    assert!(overlay.storage.redis.cluster_configured);
+    assert_eq!(redis_cluster, Some(false));
 
     let mut base = GatewayConfig::default();
     base.storage.redis.cluster = true;
-    let merged = base.merge(overlay);
+    let merged = base.merge_with_redis_cluster_override(overlay, redis_cluster);
 
     assert!(!merged.storage.redis.cluster);
     clear_env();

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -158,6 +158,10 @@ fn redis_only_env_overlay_merges_into_valid_base_without_standalone_auth_bypass(
         .allow_ip("127.0.0.1");
     base.gateway.storage.redis.enabled = true;
     base.gateway.storage.redis.cluster = true;
+    base.gateway.cache.enabled = true;
+    base.gateway.rate_limit.enabled = true;
+    base.gateway.enterprise.enabled = true;
+    base.gateway.router.strategy = crate::core::router::config::RoutingStrategy::LatencyBased;
 
     let overlay = crate::config::Config::overlay_from_env()
         .expect("Redis-only environment overlay should parse without standalone requirements");
@@ -170,11 +174,99 @@ fn redis_only_env_overlay_merges_into_valid_base_without_standalone_auth_bypass(
     assert!(!merged.gateway.auth.enable_api_key);
     assert!(merged.gateway.ip_access.enabled);
     assert_eq!(merged.gateway.ip_access.allowlist.len(), 1);
+    assert!(merged.gateway.cache.enabled);
+    assert!(merged.gateway.rate_limit.enabled);
+    assert!(merged.gateway.enterprise.enabled);
+    assert_eq!(
+        merged.gateway.router.strategy,
+        crate::core::router::config::RoutingStrategy::LatencyBased
+    );
 
     let gateway_error = GatewayConfig::from_env()
         .expect_err("standalone GatewayConfig environment loading must require providers");
     assert!(gateway_error.to_string().contains(ENV_PROVIDERS));
     assert!(crate::config::Config::from_env().is_err());
+}
+
+#[test]
+fn env_overlay_applies_only_present_fields_including_explicit_false() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    let _env = EnvGuard::cleared();
+    unsafe {
+        env::set_var(ENV_DATABASE_ENABLED, "false");
+        env::set_var(ENV_DATABASE_SSL, "false");
+        env::set_var(ENV_REDIS_ENABLED, "false");
+        env::set_var(ENV_CACHE_ENABLED, "false");
+        env::set_var(ENV_RATE_LIMIT_ENABLED, "false");
+        env::set_var(ENV_ENTERPRISE_ENABLED, "false");
+        env::set_var(ENV_ENABLE_API_KEY, "false");
+        env::set_var(ENV_PROVIDERS, "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_ENABLED", "false");
+        env::set_var("LITELLM_PROVIDER_OPENAI_TAGS", "");
+    }
+
+    let mut base = crate::config::Config::default();
+    base.gateway.storage.database.enabled = true;
+    base.gateway.storage.database.ssl = true;
+    base.gateway.storage.redis.enabled = true;
+    base.gateway.cache.enabled = true;
+    base.gateway.rate_limit.enabled = true;
+    base.gateway.enterprise.enabled = true;
+    base.gateway.auth.enable_api_key = true;
+    base.gateway.providers.push(ProviderConfig {
+        name: "openai".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "old-key".to_string(),
+        base_url: Some("https://example.test/v1".to_string()),
+        models: vec!["preserved-model".to_string()],
+        tags: vec!["clear-me".to_string()],
+        enabled: true,
+        ..ProviderConfig::default()
+    });
+
+    let overlay = crate::config::Config::overlay_from_env()
+        .expect("explicit false environment overlay should parse");
+    let merged = base.merge_overlay(overlay);
+
+    assert!(!merged.gateway.storage.database.enabled);
+    assert!(!merged.gateway.storage.database.ssl);
+    assert!(!merged.gateway.storage.redis.enabled);
+    assert!(!merged.gateway.cache.enabled);
+    assert!(!merged.gateway.rate_limit.enabled);
+    assert!(!merged.gateway.enterprise.enabled);
+    assert!(!merged.gateway.auth.enable_api_key);
+    assert_eq!(merged.gateway.providers[0].api_key, "old-key");
+    assert!(!merged.gateway.providers[0].enabled);
+    assert_eq!(
+        merged.gateway.providers[0].base_url.as_deref(),
+        Some("https://example.test/v1")
+    );
+    assert_eq!(merged.gateway.providers[0].models, ["preserved-model"]);
+    assert!(merged.gateway.providers[0].tags.is_empty());
+}
+
+#[test]
+fn empty_secret_is_present_and_cannot_preserve_a_valid_inherited_secret() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    let _env = EnvGuard::cleared();
+    unsafe { env::set_var(ENV_JWT_SECRET, "") };
+
+    let mut base = crate::config::Config::default();
+    base.gateway.providers.push(ProviderConfig {
+        name: "openai".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        ..ProviderConfig::default()
+    });
+    base.gateway.auth.enable_jwt = true;
+    base.gateway.auth.jwt_secret = "StrongJwtSecretWithMixedCaseAndNumbers1234!".to_string();
+
+    let overlay = crate::config::Config::overlay_from_env()
+        .expect("empty secret should parse as an explicit overlay value");
+    let merged = base.merge_overlay(overlay);
+    assert!(merged.gateway.auth.jwt_secret.is_empty());
+    assert!(merged.validate().is_err());
+    assert!(GatewayConfig::from_env().is_err());
 }
 
 #[test]

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -40,7 +40,7 @@ fn endpoint_access_env_preserves_presence_and_rejects_invalid_values() {
 }
 
 #[test]
-fn redis_cluster_env_false_overrides_true_base() {
+fn public_env_overlay_tracks_explicit_false_and_omission() {
     let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     clear_env();
     unsafe {
@@ -51,16 +51,29 @@ fn redis_cluster_env_false_overrides_true_base() {
         env::set_var(ENV_REDIS_CLUSTER, "false");
     }
 
-    let (overlay, redis_cluster) = GatewayConfig::from_env_with_redis_cluster_presence()
-        .expect("Redis cluster env should parse");
-    assert!(!overlay.storage.redis.cluster);
-    assert_eq!(redis_cluster, Some(false));
+    let mut base = crate::config::Config::default();
+    base.gateway.providers.push(ProviderConfig {
+        name: "openai".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        ..ProviderConfig::default()
+    });
+    base.gateway.storage.redis.enabled = true;
+    base.gateway.storage.redis.cluster = true;
 
-    let mut base = GatewayConfig::default();
-    base.storage.redis.cluster = true;
-    let merged = base.merge_with_redis_cluster_override(overlay, redis_cluster);
+    let explicit_false = crate::config::Config::overlay_from_env()
+        .expect("public Redis environment overlay should parse");
+    let merged = base.clone().merge_overlay(explicit_false);
+    merged
+        .validate()
+        .expect("explicit false must produce a valid merged configuration");
+    assert!(merged.gateway.storage.redis.enabled);
+    assert!(!merged.gateway.storage.redis.cluster);
 
-    assert!(!merged.storage.redis.cluster);
+    unsafe { env::remove_var(ENV_REDIS_CLUSTER) };
+    let omitted = crate::config::Config::overlay_from_env()
+        .expect("omitted Redis environment overlay should parse");
+    assert!(base.merge_overlay(omitted).gateway.storage.redis.cluster);
     clear_env();
 }
 

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -1,25 +1,86 @@
+use std::env;
+use std::ffi::OsString;
+
 use super::*;
+use crate::core::net::ProviderEndpointAccess;
 
 const ACCESS_KEY: &str = "LITELLM_PROVIDER_OPENAI_ENDPOINT_ACCESS";
+const TEST_ENV_KEYS: &[&str] = &[
+    ENV_HOST,
+    ENV_PORT,
+    ENV_WORKERS,
+    ENV_TIMEOUT,
+    ENV_DATABASE_URL,
+    ENV_DATABASE_MAX_CONNECTIONS,
+    ENV_DATABASE_CONNECTION_TIMEOUT,
+    ENV_DATABASE_SSL,
+    ENV_DATABASE_ENABLED,
+    ENV_DATABASE_AUTO_MIGRATE,
+    ENV_REDIS_URL,
+    ENV_REDIS_ENABLED,
+    ENV_REDIS_MAX_CONNECTIONS,
+    ENV_REDIS_CONNECTION_TIMEOUT,
+    ENV_REDIS_CLUSTER,
+    ENV_ENABLE_JWT,
+    ENV_ENABLE_API_KEY,
+    ENV_JWT_SECRET,
+    ENV_JWT_EXPIRATION,
+    ENV_API_KEY_HEADER,
+    ENV_PROVIDERS,
+    ENV_PRICING_SOURCE,
+    ENV_UNPRICED_MODEL_POLICY,
+    ENV_UNPRICED_FALLBACK_COST_PER_1K_TOKENS,
+    ENV_CACHE_ENABLED,
+    ENV_RATE_LIMIT_ENABLED,
+    ENV_ENTERPRISE_ENABLED,
+    "LITELLM_PROVIDER_OPENAI_TYPE",
+    "LITELLM_PROVIDER_OPENAI_API_KEY",
+    "LITELLM_PROVIDER_OPENAI_BASE_URL",
+    ACCESS_KEY,
+    "LITELLM_PROVIDER_OPENAI_API_VERSION",
+    "LITELLM_PROVIDER_OPENAI_ORGANIZATION",
+    "LITELLM_PROVIDER_OPENAI_PROJECT",
+    "LITELLM_PROVIDER_OPENAI_WEIGHT",
+    "LITELLM_PROVIDER_OPENAI_RPM",
+    "LITELLM_PROVIDER_OPENAI_TPM",
+    "LITELLM_PROVIDER_OPENAI_MAX_CONCURRENT_REQUESTS",
+    "LITELLM_PROVIDER_OPENAI_TIMEOUT",
+    "LITELLM_PROVIDER_OPENAI_MAX_RETRIES",
+    "LITELLM_PROVIDER_OPENAI_ENABLED",
+    "LITELLM_PROVIDER_OPENAI_MODELS",
+    "LITELLM_PROVIDER_OPENAI_TAGS",
+];
 
-fn clear_env() {
-    for key in [
-        ENV_ENABLE_JWT,
-        ENV_PROVIDERS,
-        ENV_REDIS_ENABLED,
-        ENV_REDIS_CLUSTER,
-        "LITELLM_PROVIDER_OPENAI_TYPE",
-        "LITELLM_PROVIDER_OPENAI_API_KEY",
-        ACCESS_KEY,
-    ] {
-        unsafe { env::remove_var(key) };
+struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+impl EnvGuard {
+    fn cleared() -> Self {
+        let saved = TEST_ENV_KEYS
+            .iter()
+            .map(|&key| (key, env::var_os(key)))
+            .collect();
+        for key in TEST_ENV_KEYS {
+            unsafe { env::remove_var(key) };
+        }
+        Self(saved)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.0 {
+            match value {
+                Some(value) => unsafe { env::set_var(key, value) },
+                None => unsafe { env::remove_var(key) },
+            }
+        }
     }
 }
 
 #[test]
 fn endpoint_access_env_preserves_presence_and_rejects_invalid_values() {
     let _guard = GATEWAY_ENV_LOCK.blocking_lock();
-    clear_env();
+    let _env = EnvGuard::cleared();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "false");
         env::set_var(ENV_PROVIDERS, "openai");
@@ -36,13 +97,12 @@ fn endpoint_access_env_preserves_presence_and_rejects_invalid_values() {
         unsafe { env::set_var(ACCESS_KEY, invalid) };
         assert!(GatewayConfig::from_env().is_err());
     }
-    clear_env();
 }
 
 #[test]
 fn public_env_overlay_tracks_explicit_false_and_omission() {
     let _guard = GATEWAY_ENV_LOCK.blocking_lock();
-    clear_env();
+    let _env = EnvGuard::cleared();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "false");
         env::set_var(ENV_PROVIDERS, "openai");
@@ -74,13 +134,80 @@ fn public_env_overlay_tracks_explicit_false_and_omission() {
     let omitted = crate::config::Config::overlay_from_env()
         .expect("omitted Redis environment overlay should parse");
     assert!(base.merge_overlay(omitted).gateway.storage.redis.cluster);
-    clear_env();
+}
+
+#[test]
+fn redis_only_env_overlay_merges_into_valid_base_without_standalone_auth_bypass() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    let _env = EnvGuard::cleared();
+    unsafe { env::set_var(ENV_REDIS_CLUSTER, "false") };
+
+    let mut base = crate::config::Config::default();
+    base.gateway.providers.push(ProviderConfig {
+        name: "openai".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        ..ProviderConfig::default()
+    });
+    base.gateway.auth.jwt_secret = "StrongJwtSecretWithMixedCaseAndNumbers1234!".to_string();
+    base.gateway.auth.enable_jwt = true;
+    base.gateway.auth.enable_api_key = false;
+    base.gateway.ip_access = IpAccessConfig::new()
+        .enable()
+        .with_mode(crate::core::ip_access::IpAccessMode::Allowlist)
+        .allow_ip("127.0.0.1");
+    base.gateway.storage.redis.enabled = true;
+    base.gateway.storage.redis.cluster = true;
+
+    let overlay = crate::config::Config::overlay_from_env()
+        .expect("Redis-only environment overlay should parse without standalone requirements");
+    let merged = base.merge_overlay(overlay);
+    merged
+        .validate()
+        .expect("valid base plus explicit cluster=false should validate");
+    assert!(!merged.gateway.storage.redis.cluster);
+    assert!(merged.gateway.auth.enable_jwt);
+    assert!(!merged.gateway.auth.enable_api_key);
+    assert!(merged.gateway.ip_access.enabled);
+    assert_eq!(merged.gateway.ip_access.allowlist.len(), 1);
+
+    let gateway_error = GatewayConfig::from_env()
+        .expect_err("standalone GatewayConfig environment loading must require providers");
+    assert!(gateway_error.to_string().contains(ENV_PROVIDERS));
+    assert!(crate::config::Config::from_env().is_err());
+}
+
+#[test]
+fn standalone_gateway_env_loader_preserves_jwt_requirement() {
+    let _guard = GATEWAY_ENV_LOCK.blocking_lock();
+    let _env = EnvGuard::cleared();
+    unsafe {
+        env::set_var(ENV_ENABLE_JWT, "true");
+        env::set_var(ENV_PROVIDERS, "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_TYPE", "openai");
+        env::set_var("LITELLM_PROVIDER_OPENAI_API_KEY", "sk-test");
+        env::set_var("LITELLM_PROVIDER_OPENAI_ENABLED", "invalid");
+    }
+
+    let error = GatewayConfig::from_env()
+        .expect_err("standalone GatewayConfig environment loading must require the JWT secret");
+    assert!(error.to_string().contains(ENV_JWT_SECRET));
+    assert!(crate::config::Config::from_env().is_err());
+
+    unsafe {
+        env::set_var(ENV_ENABLE_JWT, "false");
+        env::remove_var(ENV_PROVIDERS);
+        env::set_var(ENV_CACHE_ENABLED, "invalid");
+    }
+    let error = GatewayConfig::from_env()
+        .expect_err("standalone loading must require providers before later fields");
+    assert!(error.to_string().contains(ENV_PROVIDERS));
 }
 
 #[test]
 fn config_environment_overlay_defers_final_cluster_validation() {
     let _guard = GATEWAY_ENV_LOCK.blocking_lock();
-    clear_env();
+    let _env = EnvGuard::cleared();
     unsafe {
         env::set_var(ENV_ENABLE_JWT, "false");
         env::set_var(ENV_PROVIDERS, "openai");
@@ -101,5 +228,4 @@ fn config_environment_overlay_defers_final_cluster_validation() {
             .to_string()
             .contains("storage.redis.cluster=false")
     );
-    clear_env();
 }

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -317,10 +317,10 @@ fn test_gateway_config_validate_local_provider_without_api_key() {
     config.providers[0].api_key = "".to_string();
     assert!(config.validate().is_ok());
 }
-
 #[test]
 fn test_gateway_config_validate_empty_database_url() {
     let mut config = create_valid_config();
+    config.storage.database.enabled = true;
     config.storage.database.url = "".to_string();
     let result = config.validate();
     assert!(result.is_err());

--- a/src/config/models/gateway_tests.rs
+++ b/src/config/models/gateway_tests.rs
@@ -42,18 +42,22 @@ fn create_test_provider(name: &str) -> ProviderConfig {
         ..ProviderConfig::default()
     }
 }
-
 fn create_valid_config() -> GatewayConfig {
     let mut config = GatewayConfig {
         providers: vec![create_test_provider("test-provider")],
         ..Default::default()
     };
-    config.storage.database.enabled = true;
-    config.storage.database.url = "postgres://localhost/test".to_string();
+    #[cfg(feature = "sqlite")]
+    let (database_enabled, database_url) = (true, "sqlite::memory:");
+    #[cfg(all(not(feature = "sqlite"), feature = "postgres"))]
+    let (database_enabled, database_url) = (true, "postgres://localhost/test");
+    #[cfg(not(any(feature = "sqlite", feature = "postgres")))]
+    let (database_enabled, database_url) = (false, "");
+    config.storage.database.enabled = database_enabled;
+    config.storage.database.url = database_url.to_string();
     config.auth.jwt_secret = "StrongJwtSecretWithMixedCaseAndNumbers1234!".to_string();
     config
 }
-
 fn pricing_from_yaml(yaml: &str) -> GatewayPricingConfig {
     match serde_yml::from_str(yaml) {
         Ok(pricing) => pricing,

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -200,7 +200,8 @@ pub struct RedisConfig {
     /// Connection timeout in seconds
     #[serde(default = "default_connection_timeout")]
     pub connection_timeout: u64,
-    /// Enable cluster mode
+    /// Enable cluster mode. Not implemented: startup validation rejects
+    /// `cluster=true` instead of silently using a standalone connection.
     #[serde(default)]
     pub cluster: bool,
     /// When `enabled` is true and Redis init fails, allow the gateway to keep

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -1,9 +1,14 @@
 //! Storage configuration
 
+use super::default_connection_timeout;
+#[cfg(test)]
+use super::default_redis_max_connections;
 use super::file_storage::{FileStorageConfig, VectorDbConfig};
 use super::*;
-use super::{default_connection_timeout, default_redis_max_connections};
 use serde::{Deserialize, Serialize};
+
+mod redis_config;
+pub use redis_config::RedisConfig;
 
 /// Storage configuration
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -183,79 +188,6 @@ impl DatabaseConfig {
         }
         self
     }
-}
-
-/// Redis configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RedisConfig {
-    /// Redis URL
-    pub url: String,
-    /// Enable Redis (if false, use in-memory cache)
-    #[serde(default = "default_redis_enabled")]
-    pub enabled: bool,
-    /// Maximum connections
-    #[serde(default = "default_redis_max_connections")]
-    pub max_connections: u32,
-    /// Connection timeout in seconds
-    #[serde(default = "default_connection_timeout")]
-    pub connection_timeout: u64,
-    /// Enable cluster mode. Not implemented: startup validation rejects
-    /// `cluster=true` instead of silently using a standalone connection.
-    #[serde(default)]
-    pub cluster: bool,
-    /// When `enabled` is true and Redis init fails, allow the gateway to keep
-    /// running with an in-process/no-op fallback instead of failing startup.
-    ///
-    /// Defaults to `false` so an explicitly enabled-but-unreachable Redis is
-    /// surfaced at startup. Set to `true` only when running in environments
-    /// where caching is best-effort and silent degradation is acceptable.
-    #[serde(default)]
-    pub allow_degraded: bool,
-}
-
-impl Default for RedisConfig {
-    fn default() -> Self {
-        Self {
-            url: "redis://localhost:6379".to_string(),
-            enabled: default_redis_enabled(),
-            max_connections: default_redis_max_connections(),
-            connection_timeout: default_connection_timeout(),
-            cluster: false,
-            allow_degraded: false,
-        }
-    }
-}
-
-impl RedisConfig {
-    /// Merge Redis configurations
-    pub fn merge(mut self, other: Self) -> Self {
-        let default = Self::default();
-        if !other.url.is_empty() && other.url != default.url {
-            self.url = other.url;
-        }
-        if other.max_connections != default_redis_max_connections() {
-            self.max_connections = other.max_connections;
-        }
-        if other.connection_timeout != default_connection_timeout() {
-            self.connection_timeout = other.connection_timeout;
-        }
-        if other.cluster {
-            self.cluster = true;
-        }
-        // Redis defaults to enabled=false; propagate if other differs from default
-        if other.enabled != default_redis_enabled() {
-            self.enabled = other.enabled;
-        }
-        if other.allow_degraded {
-            self.allow_degraded = true;
-        }
-        self
-    }
-}
-
-fn default_redis_enabled() -> bool {
-    false
 }
 
 #[cfg(test)]
@@ -518,6 +450,7 @@ mod tests {
             max_connections: 200,
             connection_timeout: 60,
             cluster: true,
+            cluster_configured: false,
             allow_degraded: false,
         };
         assert!(config.cluster);
@@ -532,6 +465,7 @@ mod tests {
             max_connections: 50,
             connection_timeout: 15,
             cluster: false,
+            cluster_configured: false,
             allow_degraded: false,
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -556,6 +490,7 @@ mod tests {
             max_connections: 100,
             connection_timeout: 30,
             cluster: false,
+            cluster_configured: false,
             allow_degraded: false,
         };
         let merged = base.merge(other);
@@ -571,6 +506,7 @@ mod tests {
             max_connections: 100,
             connection_timeout: 30,
             cluster: true,
+            cluster_configured: false,
             allow_degraded: false,
         };
         let merged = base.merge(other);
@@ -586,6 +522,7 @@ mod tests {
             max_connections: default_redis_max_connections(),
             connection_timeout: default_connection_timeout(),
             cluster: false,
+            cluster_configured: false,
             allow_degraded: false,
         };
         let merged = base.merge(other);

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -28,9 +28,20 @@ pub struct StorageConfig {
 
 impl StorageConfig {
     /// Merge storage configurations
-    pub fn merge(mut self, other: Self) -> Self {
+    pub fn merge(self, other: Self) -> Self {
+        self.merge_with_redis_cluster_override(other, None)
+    }
+
+    /// Merge storage configurations with presence-aware Redis cluster semantics.
+    pub(crate) fn merge_with_redis_cluster_override(
+        mut self,
+        other: Self,
+        redis_cluster: Option<bool>,
+    ) -> Self {
         self.database = self.database.merge(other.database);
-        self.redis = self.redis.merge(other.redis);
+        self.redis = self
+            .redis
+            .merge_with_cluster_override(other.redis, redis_cluster);
         self.files = self.files.merge(other.files);
         if other.vector_db.is_some() {
             self.vector_db = other.vector_db;
@@ -450,7 +461,6 @@ mod tests {
             max_connections: 200,
             connection_timeout: 60,
             cluster: true,
-            cluster_configured: false,
             allow_degraded: false,
         };
         assert!(config.cluster);
@@ -465,7 +475,6 @@ mod tests {
             max_connections: 50,
             connection_timeout: 15,
             cluster: false,
-            cluster_configured: false,
             allow_degraded: false,
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -490,7 +499,6 @@ mod tests {
             max_connections: 100,
             connection_timeout: 30,
             cluster: false,
-            cluster_configured: false,
             allow_degraded: false,
         };
         let merged = base.merge(other);
@@ -506,7 +514,6 @@ mod tests {
             max_connections: 100,
             connection_timeout: 30,
             cluster: true,
-            cluster_configured: false,
             allow_degraded: false,
         };
         let merged = base.merge(other);
@@ -522,7 +529,6 @@ mod tests {
             max_connections: default_redis_max_connections(),
             connection_timeout: default_connection_timeout(),
             cluster: false,
-            cluster_configured: false,
             allow_degraded: false,
         };
         let merged = base.merge(other);

--- a/src/config/models/storage/redis_config.rs
+++ b/src/config/models/storage/redis_config.rs
@@ -1,0 +1,229 @@
+use super::super::{default_connection_timeout, default_redis_max_connections};
+use serde::{Deserialize, Serialize};
+
+/// Redis configuration.
+#[derive(Debug, Clone, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RedisConfig {
+    /// Redis URL.
+    pub url: String,
+    /// Enable Redis (if false, use in-memory cache).
+    #[serde(default = "default_redis_enabled")]
+    pub enabled: bool,
+    /// Maximum connections.
+    #[serde(default = "default_redis_max_connections")]
+    pub max_connections: u32,
+    /// Connection timeout in seconds.
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout: u64,
+    /// Enable cluster mode. Not implemented: startup validation rejects
+    /// `cluster=true` instead of silently using a standalone connection.
+    #[serde(default)]
+    pub cluster: bool,
+    /// Tracks whether `cluster` was present in deserialized config.
+    ///
+    /// This preserves merge semantics for layered configuration: an omitted
+    /// field must not be treated as an explicit `false` override.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub cluster_configured: bool,
+    /// When `enabled` is true and Redis init fails, allow the gateway to keep
+    /// running with an in-process/no-op fallback instead of failing startup.
+    ///
+    /// Defaults to `false` so an explicitly enabled-but-unreachable Redis is
+    /// surfaced at startup. Set to `true` only when running in environments
+    /// where caching is best-effort and silent degradation is acceptable.
+    #[serde(default)]
+    pub allow_degraded: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RedisConfigFields {
+    url: String,
+    #[serde(default = "default_redis_enabled")]
+    enabled: bool,
+    #[serde(default = "default_redis_max_connections")]
+    max_connections: u32,
+    #[serde(default = "default_connection_timeout")]
+    connection_timeout: u64,
+    #[serde(default, deserialize_with = "deserialize_cluster")]
+    cluster: Option<bool>,
+    #[serde(default)]
+    allow_degraded: bool,
+}
+
+impl<'de> Deserialize<'de> for RedisConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let fields = RedisConfigFields::deserialize(deserializer)?;
+        let cluster_configured = fields.cluster.is_some();
+
+        Ok(Self {
+            url: fields.url,
+            enabled: fields.enabled,
+            max_connections: fields.max_connections,
+            connection_timeout: fields.connection_timeout,
+            cluster: fields.cluster.unwrap_or(false),
+            cluster_configured,
+            allow_degraded: fields.allow_degraded,
+        })
+    }
+}
+
+fn deserialize_cluster<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    bool::deserialize(deserializer).map(Some)
+}
+
+fn default_redis_url() -> String {
+    "redis://localhost:6379".to_string()
+}
+
+fn default_redis_enabled() -> bool {
+    false
+}
+
+impl Default for RedisConfig {
+    fn default() -> Self {
+        Self {
+            url: default_redis_url(),
+            enabled: default_redis_enabled(),
+            max_connections: default_redis_max_connections(),
+            connection_timeout: default_connection_timeout(),
+            cluster: false,
+            cluster_configured: false,
+            allow_degraded: false,
+        }
+    }
+}
+
+impl RedisConfig {
+    /// Set cluster mode while preserving explicit presence for later merges.
+    pub fn with_cluster(mut self, cluster: bool) -> Self {
+        self.cluster = cluster;
+        self.cluster_configured = true;
+        self
+    }
+
+    /// Merge Redis configurations.
+    pub fn merge(mut self, other: Self) -> Self {
+        let default = Self::default();
+        if !other.url.is_empty() && other.url != default.url {
+            self.url = other.url;
+        }
+        if other.max_connections != default_redis_max_connections() {
+            self.max_connections = other.max_connections;
+        }
+        if other.connection_timeout != default_connection_timeout() {
+            self.connection_timeout = other.connection_timeout;
+        }
+        if other.cluster_configured || other.cluster {
+            self.cluster = other.cluster;
+            self.cluster_configured = other.cluster_configured;
+        }
+        // Redis defaults to enabled=false; propagate if other differs from default.
+        if other.enabled != default_redis_enabled() {
+            self.enabled = other.enabled;
+        }
+        if other.allow_degraded {
+            self.allow_degraded = true;
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RedisConfig;
+
+    fn from_yaml(fragment: &str) -> RedisConfig {
+        serde_yml::from_str(&format!("url: redis://localhost:6379\n{fragment}"))
+            .unwrap_or_else(|error| panic!("Redis YAML should parse: {error}"))
+    }
+
+    #[test]
+    fn yaml_tracks_cluster_presence() {
+        let omitted = from_yaml("");
+        let explicit_false = from_yaml("cluster: false");
+        let explicit_true = from_yaml("cluster: true");
+
+        assert!(!omitted.cluster_configured);
+        assert!(!explicit_false.cluster);
+        assert!(explicit_false.cluster_configured);
+        assert!(explicit_true.cluster);
+        assert!(explicit_true.cluster_configured);
+    }
+
+    #[test]
+    fn explicit_false_cluster_overlay_overrides_true_base() {
+        let base = from_yaml("cluster: true");
+        let overlay = from_yaml("cluster: false");
+
+        let merged = base.merge(overlay);
+
+        assert!(!merged.cluster);
+        assert!(merged.cluster_configured);
+    }
+
+    #[test]
+    fn omitted_cluster_overlay_preserves_true_base() {
+        let base = from_yaml("cluster: true");
+        let overlay = from_yaml("enabled: true");
+
+        let merged = base.merge(overlay);
+
+        assert!(merged.cluster);
+        assert!(merged.cluster_configured);
+    }
+
+    #[test]
+    fn programmatic_true_overlay_remains_compatible() {
+        let base = RedisConfig::default();
+        let overlay = RedisConfig {
+            cluster: true,
+            ..RedisConfig::default()
+        };
+
+        assert!(base.merge(overlay).cluster);
+    }
+
+    #[test]
+    fn programmatic_explicit_false_overlay_uses_presence_flag() {
+        let base = RedisConfig {
+            cluster: true,
+            ..RedisConfig::default()
+        };
+        let overlay = RedisConfig::default().with_cluster(false);
+
+        assert!(overlay.cluster_configured);
+        assert!(!base.merge(overlay).cluster);
+    }
+
+    #[test]
+    fn serialization_keeps_existing_cluster_shape() {
+        let value = serde_json::to_value(RedisConfig::default())
+            .unwrap_or_else(|error| panic!("Redis config should serialize: {error}"));
+
+        assert_eq!(value["cluster"], false);
+        assert!(value.get("cluster_configured").is_none());
+    }
+
+    #[test]
+    fn null_cluster_is_rejected() {
+        let result = serde_yml::from_str::<RedisConfig>("url: redis://localhost:6379\ncluster:");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_url_remains_rejected() {
+        let result = serde_yml::from_str::<RedisConfig>("cluster: false");
+
+        assert!(result.is_err());
+    }
+}

--- a/src/config/models/storage/redis_config.rs
+++ b/src/config/models/storage/redis_config.rs
@@ -2,7 +2,7 @@ use super::super::{default_connection_timeout, default_redis_max_connections};
 use serde::{Deserialize, Serialize};
 
 /// Redis configuration.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RedisConfig {
     /// Redis URL.
@@ -20,13 +20,6 @@ pub struct RedisConfig {
     /// `cluster=true` instead of silently using a standalone connection.
     #[serde(default)]
     pub cluster: bool,
-    /// Tracks whether `cluster` was present in deserialized config.
-    ///
-    /// This preserves merge semantics for layered configuration: an omitted
-    /// field must not be treated as an explicit `false` override.
-    #[doc(hidden)]
-    #[serde(skip)]
-    pub cluster_configured: bool,
     /// When `enabled` is true and Redis init fails, allow the gateway to keep
     /// running with an in-process/no-op fallback instead of failing startup.
     ///
@@ -35,49 +28,6 @@ pub struct RedisConfig {
     /// where caching is best-effort and silent degradation is acceptable.
     #[serde(default)]
     pub allow_degraded: bool,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RedisConfigFields {
-    url: String,
-    #[serde(default = "default_redis_enabled")]
-    enabled: bool,
-    #[serde(default = "default_redis_max_connections")]
-    max_connections: u32,
-    #[serde(default = "default_connection_timeout")]
-    connection_timeout: u64,
-    #[serde(default, deserialize_with = "deserialize_cluster")]
-    cluster: Option<bool>,
-    #[serde(default)]
-    allow_degraded: bool,
-}
-
-impl<'de> Deserialize<'de> for RedisConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let fields = RedisConfigFields::deserialize(deserializer)?;
-        let cluster_configured = fields.cluster.is_some();
-
-        Ok(Self {
-            url: fields.url,
-            enabled: fields.enabled,
-            max_connections: fields.max_connections,
-            connection_timeout: fields.connection_timeout,
-            cluster: fields.cluster.unwrap_or(false),
-            cluster_configured,
-            allow_degraded: fields.allow_degraded,
-        })
-    }
-}
-
-fn deserialize_cluster<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    bool::deserialize(deserializer).map(Some)
 }
 
 fn default_redis_url() -> String {
@@ -96,22 +46,33 @@ impl Default for RedisConfig {
             max_connections: default_redis_max_connections(),
             connection_timeout: default_connection_timeout(),
             cluster: false,
-            cluster_configured: false,
             allow_degraded: false,
         }
     }
 }
 
 impl RedisConfig {
-    /// Set cluster mode while preserving explicit presence for later merges.
-    pub fn with_cluster(mut self, cluster: bool) -> Self {
-        self.cluster = cluster;
-        self.cluster_configured = true;
-        self
+    /// Merge Redis configurations.
+    ///
+    /// For source compatibility, a programmatic `false` in `other` retains
+    /// the historical meaning of "not specified". Call
+    /// [`Self::merge_with_cluster_override`] when an explicit `false` must
+    /// clear an inherited `true` value.
+    pub fn merge(self, other: Self) -> Self {
+        self.merge_with_cluster_override(other, None)
     }
 
-    /// Merge Redis configurations.
-    pub fn merge(mut self, other: Self) -> Self {
+    /// Merge Redis configurations with presence-aware cluster semantics.
+    ///
+    /// `cluster_override` distinguishes an omitted value (`None`) from an
+    /// explicit `true` or `false`. Configuration overlay loaders use this
+    /// method so default-valued fields can override inherited settings without
+    /// adding state to the public [`RedisConfig`] struct.
+    pub fn merge_with_cluster_override(
+        mut self,
+        other: Self,
+        cluster_override: Option<bool>,
+    ) -> Self {
         let default = Self::default();
         if !other.url.is_empty() && other.url != default.url {
             self.url = other.url;
@@ -122,9 +83,8 @@ impl RedisConfig {
         if other.connection_timeout != default_connection_timeout() {
             self.connection_timeout = other.connection_timeout;
         }
-        if other.cluster_configured || other.cluster {
-            self.cluster = other.cluster;
-            self.cluster_configured = other.cluster_configured;
+        if let Some(cluster) = cluster_override.or(other.cluster.then_some(true)) {
+            self.cluster = cluster;
         }
         // Redis defaults to enabled=false; propagate if other differs from default.
         if other.enabled != default_redis_enabled() {
@@ -147,27 +107,24 @@ mod tests {
     }
 
     #[test]
-    fn yaml_tracks_cluster_presence() {
+    fn yaml_keeps_existing_cluster_wire_shape() {
         let omitted = from_yaml("");
         let explicit_false = from_yaml("cluster: false");
         let explicit_true = from_yaml("cluster: true");
 
-        assert!(!omitted.cluster_configured);
+        assert!(!omitted.cluster);
         assert!(!explicit_false.cluster);
-        assert!(explicit_false.cluster_configured);
         assert!(explicit_true.cluster);
-        assert!(explicit_true.cluster_configured);
     }
 
     #[test]
-    fn explicit_false_cluster_overlay_overrides_true_base() {
+    fn explicit_false_cluster_override_overrides_true_base() {
         let base = from_yaml("cluster: true");
         let overlay = from_yaml("cluster: false");
 
-        let merged = base.merge(overlay);
+        let merged = base.merge_with_cluster_override(overlay, Some(false));
 
         assert!(!merged.cluster);
-        assert!(merged.cluster_configured);
     }
 
     #[test]
@@ -178,7 +135,6 @@ mod tests {
         let merged = base.merge(overlay);
 
         assert!(merged.cluster);
-        assert!(merged.cluster_configured);
     }
 
     #[test]
@@ -193,15 +149,18 @@ mod tests {
     }
 
     #[test]
-    fn programmatic_explicit_false_overlay_uses_presence_flag() {
+    fn programmatic_explicit_false_overlay_uses_override_api() {
         let base = RedisConfig {
             cluster: true,
             ..RedisConfig::default()
         };
-        let overlay = RedisConfig::default().with_cluster(false);
+        let overlay = RedisConfig::default();
 
-        assert!(overlay.cluster_configured);
-        assert!(!base.merge(overlay).cluster);
+        assert!(
+            !base
+                .merge_with_cluster_override(overlay, Some(false))
+                .cluster
+        );
     }
 
     #[test]
@@ -210,7 +169,6 @@ mod tests {
             .unwrap_or_else(|error| panic!("Redis config should serialize: {error}"));
 
         assert_eq!(value["cluster"], false);
-        assert!(value.get("cluster_configured").is_none());
     }
 
     #[test]

--- a/src/config/models/storage/redis_config.rs
+++ b/src/config/models/storage/redis_config.rs
@@ -54,8 +54,8 @@ impl Default for RedisConfig {
 impl RedisConfig {
     /// Merge Redis configurations.
     ///
-    /// For source compatibility, a programmatic `false` in `other` retains
-    /// the historical meaning of "not specified". Call
+    /// For source compatibility, `cluster=false` in `other` retains the
+    /// historical meaning of "not specified". Call
     /// [`Self::merge_with_cluster_override`] when an explicit `false` must
     /// clear an inherited `true` value.
     pub fn merge(self, other: Self) -> Self {

--- a/src/config/models/storage/redis_config.rs
+++ b/src/config/models/storage/redis_config.rs
@@ -66,8 +66,8 @@ impl RedisConfig {
     ///
     /// `cluster_override` distinguishes an omitted value (`None`) from an
     /// explicit `true` or `false`. Configuration overlay loaders use this
-    /// method so default-valued fields can override inherited settings without
-    /// adding state to the public [`RedisConfig`] struct.
+    /// method so a default-valued cluster setting can override an inherited
+    /// value without adding state to the public [`RedisConfig`] struct.
     pub fn merge_with_cluster_override(
         mut self,
         other: Self,

--- a/src/config/validation/mod.rs
+++ b/src/config/validation/mod.rs
@@ -21,6 +21,8 @@ mod enterprise_validators;
 mod monitoring_validators;
 mod router_validators;
 mod ssrf;
+#[cfg(test)]
+mod storage_tests;
 mod storage_validators;
 #[cfg(test)]
 mod tests;

--- a/src/config/validation/storage_tests.rs
+++ b/src/config/validation/storage_tests.rs
@@ -1,0 +1,68 @@
+use super::trait_def::Validate;
+use crate::config::models::storage::{DatabaseConfig, RedisConfig};
+
+#[test]
+fn database_validation_skips_when_disabled() {
+    let config = DatabaseConfig {
+        enabled: false,
+        url: String::new(),
+        max_connections: 0,
+        connection_timeout: 0,
+        ssl: false,
+        auto_migrate: false,
+        auto_migrate_configured: false,
+        fallback_to_sqlite: false,
+        allow_degraded: false,
+    };
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[test]
+fn redis_validation_skips_when_disabled() {
+    let config = RedisConfig {
+        enabled: false,
+        url: String::new(),
+        max_connections: 0,
+        connection_timeout: 0,
+        cluster: false,
+        cluster_configured: false,
+        allow_degraded: false,
+    };
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[test]
+fn redis_validation_rejects_unimplemented_cluster_mode_with_actionable_remedy() {
+    let config = RedisConfig {
+        enabled: true,
+        url: "redis://localhost:6379".to_string(),
+        max_connections: 10,
+        connection_timeout: 5,
+        cluster: true,
+        cluster_configured: false,
+        allow_degraded: false,
+    };
+
+    let error = Validate::validate(&config).unwrap_err();
+
+    assert!(error.contains("cluster"), "got: {error}");
+    assert!(error.contains("not implemented"), "got: {error}");
+    assert!(
+        error.contains("storage.redis.cluster=false"),
+        "got: {error}"
+    );
+}
+
+#[test]
+fn redis_validation_accepts_standalone_when_enabled() {
+    let config = RedisConfig {
+        enabled: true,
+        url: "redis://localhost:6379".to_string(),
+        max_connections: 10,
+        connection_timeout: 5,
+        cluster: false,
+        cluster_configured: false,
+        allow_degraded: false,
+    };
+    assert!(Validate::validate(&config).is_ok());
+}

--- a/src/config/validation/storage_tests.rs
+++ b/src/config/validation/storage_tests.rs
@@ -25,7 +25,6 @@ fn redis_validation_skips_when_disabled() {
         max_connections: 0,
         connection_timeout: 0,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     };
     assert!(Validate::validate(&config).is_ok());
@@ -39,7 +38,6 @@ fn redis_validation_rejects_unimplemented_cluster_mode_with_actionable_remedy() 
         max_connections: 10,
         connection_timeout: 5,
         cluster: true,
-        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -61,7 +59,6 @@ fn redis_validation_accepts_standalone_when_enabled() {
         max_connections: 10,
         connection_timeout: 5,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     };
     assert!(Validate::validate(&config).is_ok());

--- a/src/config/validation/storage_tests.rs
+++ b/src/config/validation/storage_tests.rs
@@ -1,6 +1,9 @@
 use super::trait_def::Validate;
+#[cfg(all(feature = "storage", not(feature = "sqlite")))]
+use crate::config::models::storage::StorageConfig;
 use crate::config::models::storage::{DatabaseConfig, RedisConfig};
 
+#[cfg(any(not(feature = "storage"), feature = "sqlite"))]
 #[test]
 fn database_validation_skips_when_disabled() {
     let config = DatabaseConfig {
@@ -8,6 +11,120 @@ fn database_validation_skips_when_disabled() {
         url: String::new(),
         max_connections: 0,
         connection_timeout: 0,
+        ssl: false,
+        auto_migrate: false,
+        auto_migrate_configured: false,
+        fallback_to_sqlite: false,
+        allow_degraded: false,
+    };
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn database_validation_accepts_sqlite_when_feature_enabled() {
+    let config = DatabaseConfig {
+        enabled: true,
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        connection_timeout: 1,
+        ssl: false,
+        auto_migrate: true,
+        auto_migrate_configured: false,
+        fallback_to_sqlite: false,
+        allow_degraded: false,
+    };
+
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[cfg(not(feature = "sqlite"))]
+#[test]
+fn database_validation_rejects_sqlite_when_feature_disabled() {
+    let config = DatabaseConfig {
+        enabled: true,
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        connection_timeout: 1,
+        ssl: false,
+        auto_migrate: true,
+        auto_migrate_configured: false,
+        fallback_to_sqlite: false,
+        allow_degraded: false,
+    };
+
+    assert!(Validate::validate(&config).is_err());
+}
+
+#[cfg(not(feature = "postgres"))]
+#[test]
+fn database_validation_rejects_postgres_when_feature_disabled() {
+    let config = DatabaseConfig {
+        enabled: true,
+        url: "postgresql://localhost/litellm".to_string(),
+        max_connections: 1,
+        connection_timeout: 1,
+        ssl: false,
+        auto_migrate: false,
+        auto_migrate_configured: false,
+        fallback_to_sqlite: false,
+        allow_degraded: false,
+    };
+
+    let error = config.validate().unwrap_err();
+    assert!(error.contains("`postgres` feature"), "got: {error}");
+}
+
+#[cfg(all(feature = "storage", not(feature = "sqlite")))]
+#[test]
+fn database_validation_rejects_sqlite_dependent_runtime_modes() {
+    let disabled = DatabaseConfig::default();
+    let error = Validate::validate(&disabled).unwrap_err();
+    assert!(error.to_string().contains("enabled=false"), "got: {error}");
+    assert!(error.contains("`sqlite` feature"), "got: {error}");
+    let storage = StorageConfig {
+        database: disabled,
+        ..StorageConfig::default()
+    };
+    let error = Validate::validate(&storage).unwrap_err();
+    assert!(error.contains("enabled=false"), "got: {error}");
+    let mut config = crate::config::Config::default();
+    config
+        .gateway
+        .providers
+        .push(crate::config::models::provider::ProviderConfig {
+            name: "test-openai".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            ..Default::default()
+        });
+    let error = config.validate().unwrap_err();
+    assert!(error.to_string().contains("enabled=false"), "got: {error}");
+
+    let fallback = DatabaseConfig {
+        enabled: true,
+        url: "postgresql://localhost/litellm".to_string(),
+        max_connections: 1,
+        connection_timeout: 1,
+        ssl: false,
+        auto_migrate: false,
+        auto_migrate_configured: false,
+        fallback_to_sqlite: true,
+        allow_degraded: false,
+    };
+    let error = Validate::validate(&fallback).unwrap_err();
+    assert!(error.contains("fallback_to_sqlite=true"), "got: {error}");
+    assert!(error.contains("`sqlite` feature"), "got: {error}");
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn database_validation_accepts_postgres_when_feature_enabled() {
+    let config = DatabaseConfig {
+        enabled: true,
+        url: "postgresql://localhost/litellm".to_string(),
+        max_connections: 1,
+        connection_timeout: 1,
         ssl: false,
         auto_migrate: false,
         auto_migrate_configured: false,

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -12,9 +12,7 @@ impl Validate for StorageConfig {
     fn validate(&self) -> Result<(), String> {
         debug!("Validating storage configuration");
 
-        if self.database.enabled {
-            self.database.validate()?;
-        }
+        self.database.validate()?;
         if self.redis.enabled {
             self.redis.validate()?;
         }
@@ -68,6 +66,12 @@ impl Validate for FileStorageConfig {
 impl Validate for DatabaseConfig {
     fn validate(&self) -> Result<(), String> {
         if !self.enabled {
+            if cfg!(feature = "storage") && !cfg!(feature = "sqlite") {
+                return Err(
+                    "storage.database.enabled=false requires the `sqlite` feature because the runtime uses an in-memory SQLite backend"
+                        .to_string(),
+                );
+            }
             return Ok(());
         }
 
@@ -75,8 +79,23 @@ impl Validate for DatabaseConfig {
             return Err("Database URL cannot be empty".to_string());
         }
 
-        if !self.url.starts_with("postgresql://") && !self.url.starts_with("postgres://") {
-            return Err("Only PostgreSQL databases are supported".to_string());
+        if self.fallback_to_sqlite && !cfg!(feature = "sqlite") {
+            return Err(
+                "storage.database.fallback_to_sqlite=true requires the `sqlite` feature"
+                    .to_string(),
+            );
+        }
+
+        if self.url.starts_with("postgresql://") || self.url.starts_with("postgres://") {
+            if !cfg!(feature = "postgres") {
+                return Err("PostgreSQL database URLs require the `postgres` feature".to_string());
+            }
+        } else if self.url.starts_with("sqlite:") {
+            if !cfg!(feature = "sqlite") {
+                return Err("SQLite database URLs require the `sqlite` feature".to_string());
+            }
+        } else {
+            return Err("Database URL must use PostgreSQL or SQLite".to_string());
         }
 
         if self.max_connections == 0 {

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -106,7 +106,8 @@ impl Validate for RedisConfig {
                 "storage.redis.cluster=true is declared but not implemented yet. \
                  A standalone client against a cluster node only fails later \
                  with MOVED errors, so cluster mode is rejected at startup. \
-                 Point storage.redis.url at a standalone or primary endpoint."
+                 Set storage.redis.cluster=false and point storage.redis.url \
+                 at a standalone or primary endpoint."
                     .to_string(),
             );
         }

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -101,6 +101,16 @@ impl Validate for RedisConfig {
             return Ok(());
         }
 
+        if self.cluster {
+            return Err(
+                "storage.redis.cluster=true is declared but not implemented yet. \
+                 A standalone client against a cluster node only fails later \
+                 with MOVED errors, so cluster mode is rejected at startup. \
+                 Point storage.redis.url at a standalone or primary endpoint."
+                    .to_string(),
+            );
+        }
+
         if self.url.is_empty() {
             return Err("Redis URL cannot be empty".to_string());
         }

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -489,6 +489,34 @@ fn test_redis_validation_skips_when_disabled() {
 }
 
 #[test]
+fn test_redis_validation_rejects_unimplemented_cluster_mode() {
+    let config = RedisConfig {
+        enabled: true,
+        url: "redis://localhost:6379".to_string(),
+        max_connections: 10,
+        connection_timeout: 5,
+        cluster: true,
+        allow_degraded: false,
+    };
+    let error = Validate::validate(&config).unwrap_err();
+    assert!(error.contains("cluster"), "got: {error}");
+    assert!(error.contains("not implemented"), "got: {error}");
+}
+
+#[test]
+fn test_redis_validation_accepts_standalone_when_enabled() {
+    let config = RedisConfig {
+        enabled: true,
+        url: "redis://localhost:6379".to_string(),
+        max_connections: 10,
+        connection_timeout: 5,
+        cluster: false,
+        allow_degraded: false,
+    };
+    assert!(Validate::validate(&config).is_ok());
+}
+
+#[test]
 fn test_pricing_validation_defaults_to_reject_unpriced_models() {
     let config = GatewayPricingConfig::default();
 

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -12,7 +12,6 @@ use crate::config::models::gateway::{GatewayConfig, GatewayPricingConfig, Unpric
 use crate::config::models::provider::ProviderConfig;
 use crate::config::models::rate_limit::RateLimitConfig;
 use crate::config::models::server::ServerConfig;
-use crate::config::models::storage::{DatabaseConfig, RedisConfig};
 
 // ==================== Server Config Validation ====================
 
@@ -457,63 +456,6 @@ fn test_rate_limit_validation_rejects_zero_requests_per_minute_alias() {
     let error = Validate::validate(&config).unwrap_err();
     assert!(error.contains("Effective RPM"));
     assert!(error.contains("greater than 0"));
-}
-
-#[test]
-fn test_database_validation_skips_when_disabled() {
-    let config = DatabaseConfig {
-        enabled: false,
-        url: "".to_string(),
-        max_connections: 0,
-        connection_timeout: 0,
-        ssl: false,
-        auto_migrate: false,
-        auto_migrate_configured: false,
-        fallback_to_sqlite: false,
-        allow_degraded: false,
-    };
-    assert!(Validate::validate(&config).is_ok());
-}
-
-#[test]
-fn test_redis_validation_skips_when_disabled() {
-    let config = RedisConfig {
-        enabled: false,
-        url: "".to_string(),
-        max_connections: 0,
-        connection_timeout: 0,
-        cluster: false,
-        allow_degraded: false,
-    };
-    assert!(Validate::validate(&config).is_ok());
-}
-
-#[test]
-fn test_redis_validation_rejects_unimplemented_cluster_mode() {
-    let config = RedisConfig {
-        enabled: true,
-        url: "redis://localhost:6379".to_string(),
-        max_connections: 10,
-        connection_timeout: 5,
-        cluster: true,
-        allow_degraded: false,
-    };
-    let error = Validate::validate(&config).unwrap_err();
-    assert!(error.contains("cluster"), "got: {error}");
-    assert!(error.contains("not implemented"), "got: {error}");
-}
-
-#[test]
-fn test_redis_validation_accepts_standalone_when_enabled() {
-    let config = RedisConfig {
-        enabled: true,
-        url: "redis://localhost:6379".to_string(),
-        max_connections: 10,
-        connection_timeout: 5,
-        cluster: false,
-        allow_degraded: false,
-    };
-    assert!(Validate::validate(&config).is_ok());
 }
 
 #[test]

--- a/src/config/validation/tests.rs
+++ b/src/config/validation/tests.rs
@@ -364,8 +364,16 @@ fn test_gateway_validation_rejects_unwired_semantic_cache() {
         }],
         ..Default::default()
     };
-    config.storage.database.enabled = true;
-    config.storage.database.url = "postgres://localhost/test".to_string();
+    #[cfg(feature = "sqlite")]
+    {
+        config.storage.database.enabled = true;
+        config.storage.database.url = "sqlite::memory:".to_string();
+    }
+    #[cfg(all(not(feature = "sqlite"), feature = "postgres"))]
+    {
+        config.storage.database.enabled = true;
+        config.storage.database.url = "postgres://localhost/test".to_string();
+    }
     config.auth.jwt_secret = "StrongJwtSecretWithMixedCaseAndNumbers1234!".to_string();
     config.cache.semantic_cache = true;
 

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -46,6 +46,10 @@ pub struct HttpServer {
 impl HttpServer {
     /// Create a new HTTP server
     pub async fn new(config: &Config) -> Result<Self> {
+        config.gateway.storage.redis.validate().map_err(|error| {
+            GatewayError::Config(format!("Invalid Redis configuration: {error}"))
+        })?;
+
         info!("Creating HTTP server");
 
         crate::config::models::gateway::GatewayConfig::validate_model_alias_map(

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -49,25 +49,9 @@ impl HttpServer {
         config.gateway.storage.redis.validate().map_err(|error| {
             GatewayError::Config(format!("Invalid Redis configuration: {error}"))
         })?;
+        config.validate()?;
 
         info!("Creating HTTP server");
-
-        crate::config::models::gateway::GatewayConfig::validate_model_alias_map(
-            &config.gateway.model_aliases,
-        )
-        .map_err(|error| GatewayError::Config(format!("Invalid model aliases: {error}")))?;
-        Self::validate_cors_config(&config.gateway.server.cors)?;
-        config
-            .gateway
-            .cache
-            .validate()
-            .map_err(|e| GatewayError::Config(format!("Invalid cache configuration: {}", e)))?;
-        config
-            .gateway
-            .monitoring
-            .callbacks
-            .validate()
-            .map_err(|e| GatewayError::Config(format!("Invalid callback configuration: {}", e)))?;
         start_auth_rate_limiter_cleanup_task();
 
         let storage = crate::storage::StorageLayer::new(&config.gateway.storage).await?;
@@ -505,7 +489,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_rejects_invalid_cors_config_before_startup() {
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.server.cors.allowed_origins = vec!["*".to_string()];
         config.gateway.server.cors.allow_credentials = true;
 
@@ -516,7 +500,8 @@ mod tests {
 
         match error {
             GatewayError::Config(message) => {
-                assert!(message.contains("Invalid CORS configuration"));
+                assert!(message.contains("Gateway config error"));
+                assert!(message.contains("CORS"));
                 assert!(message.contains("credentials"));
             }
             other => panic!("expected config error, got: {other:?}"),
@@ -527,7 +512,7 @@ mod tests {
     /// the pricing source, which points at a non-existent file so the initial
     /// load fails deterministically.
     fn config_with_broken_pricing(allow_degraded: bool) -> Config {
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         // Disable enterprise/storage subsystems that would require real I/O.
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
@@ -561,7 +546,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_wires_enabled_cache_config() {
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = None;
@@ -577,7 +562,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_wires_configured_callback_backend() {
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         config.gateway.pricing.source = None;
@@ -606,7 +591,7 @@ mod tests {
     /// returns an empty snapshot set, exercising the "Ok(snapshots)" arm.
     #[tokio::test]
     async fn new_succeeds_with_in_memory_budgets_when_db_disabled() {
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
         // Disable pricing so we don't conflate with the broken-pricing tests.
@@ -632,7 +617,7 @@ mod tests {
             "reject_preflight",
         );
 
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
         config.gateway.auth.allow_anonymous = true;
@@ -681,7 +666,7 @@ mod tests {
         let _metrics_guard = MetricsMiddleware::test_lock().await;
         MetricsMiddleware::reset_for_tests();
 
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.auth.enable_jwt = true;
         config.gateway.auth.enable_api_key = true;
         config.gateway.auth.allow_anonymous = false;
@@ -722,13 +707,14 @@ mod tests {
     }
 
     include!("http_cors_tests.rs");
+    include!("http_validation_tests.rs");
 
     #[tokio::test]
     async fn app_factory_does_not_collect_http_metrics_when_metrics_disabled() {
         let _metrics_guard = MetricsMiddleware::test_lock().await;
         MetricsMiddleware::reset_for_tests();
 
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
         config.gateway.auth.allow_anonymous = true;
@@ -759,7 +745,7 @@ mod tests {
 
     #[tokio::test]
     async fn app_factory_mounts_explicit_cache_admin_surface() {
-        let mut config = Config::default();
+        let mut config = valid_http_test_config();
         config.gateway.auth.enable_jwt = false;
         config.gateway.auth.enable_api_key = false;
         config.gateway.auth.allow_anonymous = true;

--- a/src/server/http_cors_tests.rs
+++ b/src/server/http_cors_tests.rs
@@ -1,5 +1,5 @@
 fn cors_auth_test_config() -> Config {
-    let mut config = Config::default();
+    let mut config = valid_http_test_config();
     config.gateway.auth.enable_jwt = true;
     config.gateway.auth.enable_api_key = true;
     config.gateway.auth.allow_anonymous = false;

--- a/src/server/http_validation_tests.rs
+++ b/src/server/http_validation_tests.rs
@@ -1,0 +1,25 @@
+fn valid_http_test_config() -> Config {
+    let mut config = Config::default();
+    config.gateway.providers.push(
+        crate::config::models::provider::ProviderConfig {
+            name: "test-openai".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            ..Default::default()
+        },
+    );
+    config
+}
+
+#[tokio::test]
+async fn new_rejects_invalid_auth_before_runtime_initialization() {
+    let mut config = valid_http_test_config();
+    config.gateway.auth.enable_jwt = true;
+    config.gateway.auth.jwt_secret = "short".to_string();
+
+    let error = match HttpServer::new(&config).await {
+        Err(error) => error,
+        Ok(_) => panic!("invalid auth must fail before server initialization"),
+    };
+    assert!(error.to_string().contains("JWT secret"));
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,4 +18,19 @@ mod utils;
 pub use http::HttpServer;
 
 #[cfg(test)]
+pub(crate) fn valid_test_config() -> crate::config::Config {
+    let mut config = crate::config::Config::default();
+    config
+        .gateway
+        .providers
+        .push(crate::config::models::provider::ProviderConfig {
+            name: "test-openai".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            ..Default::default()
+        });
+    config
+}
+
+#[cfg(test)]
 mod tests;

--- a/src/server/routes/admin.rs
+++ b/src/server/routes/admin.rs
@@ -145,7 +145,7 @@ mod tests {
     use actix_web::{App, http::StatusCode, test};
 
     fn base_test_config(auth_enabled: bool) -> Config {
-        let mut config = Config::default();
+        let mut config = crate::server::valid_test_config();
         config.gateway.auth.enable_jwt = auth_enabled;
         config.gateway.auth.enable_api_key = auth_enabled;
         config.gateway.auth.allow_anonymous = !auth_enabled;

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -359,7 +359,6 @@ async fn engine_embeddings(
 
 #[cfg(test)]
 mod tests {
-    use crate::Config;
     use crate::core::types::context::RequestContext;
     use crate::server::HttpServer as GatewayHttpServer;
     use crate::server::middleware::RequestIdMiddleware;
@@ -368,7 +367,8 @@ mod tests {
     use serde_json::Value;
 
     async fn build_no_provider_state() -> crate::server::state::AppState {
-        let mut config = Config::default();
+        let mut config = crate::server::valid_test_config();
+        config.gateway.providers[0].enabled = false;
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
 

--- a/src/server/routes/ai/responses/codex_compat_tests.rs
+++ b/src/server/routes/ai/responses/codex_compat_tests.rs
@@ -82,7 +82,7 @@ fn codex_wire_distinguishes_tier_two_and_redacts_unknown_payload() {
 #[actix_web::test]
 async fn codex_wire_http_rejects_before_provider_dispatch() {
     let _guard = super::CODEX_DISPATCH_TEST_LOCK.lock().await;
-    let mut config = crate::config::Config::default();
+    let mut config = crate::server::valid_test_config();
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
     let server = crate::server::HttpServer::new(&config).await.unwrap();
@@ -144,7 +144,7 @@ async fn codex_wire_http_rejects_before_provider_dispatch() {
 #[actix_web::test]
 async fn codex_tier_one_reaches_provider_dispatch() {
     let _guard = super::CODEX_DISPATCH_TEST_LOCK.lock().await;
-    let mut config = crate::config::Config::default();
+    let mut config = crate::server::valid_test_config();
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
     let server = crate::server::HttpServer::new(&config).await.unwrap();

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -234,7 +234,7 @@ mod tests {
 
     #[actix_web::test]
     async fn direct_auth_distinguishes_invalid_credentials_from_storage_failure() {
-        let mut config = crate::config::Config::default();
+        let mut config = crate::server::valid_test_config();
         config.gateway.auth.enable_jwt = true;
         config.gateway.auth.enable_api_key = true;
         config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();

--- a/src/server/routes/pricing.rs
+++ b/src/server/routes/pricing.rs
@@ -214,7 +214,6 @@ pub fn configure_pricing_routes(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Config;
     use crate::core::pricing_service::LiteLLMModelInfo;
     use crate::server::HttpServer as GatewayHttpServer;
     use actix_web::http::StatusCode;
@@ -244,7 +243,7 @@ mod tests {
     }
 
     async fn build_pricing_route_state() -> AppState {
-        let mut config = Config::default();
+        let mut config = crate::server::valid_test_config();
         config.gateway.storage.database.enabled = false;
         config.gateway.storage.redis.enabled = false;
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -104,6 +104,28 @@ async fn test_server_builder_requires_config() {
 }
 
 #[tokio::test]
+async fn server_builder_rejects_redis_cluster_before_client_initialization() {
+    let mut config = crate::config::Config::default();
+    config.gateway.storage.redis.enabled = true;
+    config.gateway.storage.redis.cluster = true;
+
+    let error = match ServerBuilder::new().with_config(config).build().await {
+        Err(error) => error,
+        Ok(_) => panic!("server builder must reject unsupported Redis cluster mode"),
+    };
+
+    let message = error.to_string();
+    assert!(
+        message.contains("storage.redis.cluster=true"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("storage.redis.cluster=false"),
+        "got: {message}"
+    );
+}
+
+#[tokio::test]
 async fn explicit_config_path_missing_file_fails_without_env_fallback() {
     let temp_dir = match tempfile::tempdir() {
         Ok(temp_dir) => temp_dir,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -57,6 +57,20 @@ struct EnvGuard {
     saved: Vec<(&'static str, Option<String>)>,
 }
 
+fn valid_programmatic_config() -> crate::config::Config {
+    let mut config = crate::config::Config::default();
+    config
+        .gateway
+        .providers
+        .push(crate::config::models::provider::ProviderConfig {
+            name: "test-openai".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            ..Default::default()
+        });
+    config
+}
+
 impl EnvGuard {
     fn with_minimal_gateway_config() -> Self {
         let saved = GATEWAY_ENV_KEYS
@@ -123,6 +137,33 @@ async fn server_builder_rejects_redis_cluster_before_client_initialization() {
         message.contains("storage.redis.cluster=false"),
         "got: {message}"
     );
+}
+
+#[tokio::test]
+async fn server_builder_rejects_invalid_programmatic_config() {
+    let mut config = valid_programmatic_config();
+    config.gateway.auth.enable_jwt = true;
+    config.gateway.auth.jwt_secret = "short".to_string();
+
+    let error = match ServerBuilder::new().with_config(config).build().await {
+        Err(error) => error,
+        Ok(_) => panic!("builder must reject invalid auth before initialization"),
+    };
+    assert!(error.to_string().contains("JWT secret"));
+}
+
+#[cfg(feature = "gateway")]
+#[tokio::test]
+async fn gateway_rejects_invalid_programmatic_config() {
+    let mut config = valid_programmatic_config();
+    config.gateway.auth.enable_jwt = true;
+    config.gateway.auth.jwt_secret = "short".to_string();
+
+    let error = match crate::Gateway::new(config).await {
+        Err(error) => error,
+        Ok(_) => panic!("gateway must reject invalid auth before initialization"),
+    };
+    assert!(error.to_string().contains("JWT secret"));
 }
 
 #[tokio::test]
@@ -207,7 +248,7 @@ fn test_request_metrics_creation() {
 
 #[tokio::test]
 async fn enabled_audit_logging_is_constructed_in_gateway_state() {
-    let mut config = crate::config::Config::default();
+    let mut config = valid_programmatic_config();
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
     config.gateway.pricing.source = None;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -514,7 +514,6 @@ mod tests {
                 max_connections: 10,
                 connection_timeout: 5,
                 cluster: false,
-                cluster_configured: false,
                 allow_degraded: false,
             },
             files: FileStorageConfig::default(),
@@ -660,7 +659,6 @@ mod tests {
             max_connections: 1,
             connection_timeout: 1,
             cluster: false,
-            cluster_configured: false,
             allow_degraded,
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -74,6 +74,10 @@ impl StorageLayer {
     ///   the error is logged at `error!` level and the dependency status is
     ///   set to `Degraded` while the gateway keeps running.
     pub async fn new(config: &StorageConfig) -> Result<Self> {
+        crate::config::Validate::validate(&config.redis).map_err(|error| {
+            GatewayError::Config(format!("Invalid Redis configuration: {error}"))
+        })?;
+
         info!("Initializing storage layer");
 
         // Initialize database
@@ -510,6 +514,7 @@ mod tests {
                 max_connections: 10,
                 connection_timeout: 5,
                 cluster: false,
+                cluster_configured: false,
                 allow_degraded: false,
             },
             files: FileStorageConfig::default(),
@@ -655,6 +660,7 @@ mod tests {
             max_connections: 1,
             connection_timeout: 1,
             cluster: false,
+            cluster_configured: false,
             allow_degraded,
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -735,5 +735,6 @@ mod tests {
         assert_eq!(storage.redis_status, DependencyStatus::Disabled);
     }
 
+    #[cfg(feature = "sqlite")]
     include!("vector_startup_tests.rs");
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -77,6 +77,9 @@ impl StorageLayer {
         crate::config::Validate::validate(&config.redis).map_err(|error| {
             GatewayError::Config(format!("Invalid Redis configuration: {error}"))
         })?;
+        crate::config::Validate::validate(config).map_err(|error| {
+            GatewayError::Config(format!("Invalid storage configuration: {error}"))
+        })?;
 
         info!("Initializing storage layer");
 
@@ -732,64 +735,5 @@ mod tests {
         assert_eq!(storage.redis_status, DependencyStatus::Disabled);
     }
 
-    fn unreachable_vector_config(
-        allow_degraded: bool,
-    ) -> crate::config::models::file_storage::VectorDbConfig {
-        crate::config::models::file_storage::VectorDbConfig {
-            // Unsupported db_type forces VectorStoreBackend::new to return Err
-            // synchronously, which keeps the test fast and offline-friendly.
-            db_type: "weaviate".to_string(),
-            url: "http://127.0.0.1:1".to_string(),
-            api_key: "test".to_string(),
-            index_name: "test".to_string(),
-            allow_degraded,
-        }
-    }
-
-    #[tokio::test]
-    async fn vector_db_failing_without_allow_degraded_fails_startup() {
-        let config = StorageConfig {
-            database: sqlite_db_config(),
-            redis: RedisConfig::default(),
-            files: FileStorageConfig::default(),
-            vector_db: Some(unreachable_vector_config(false)),
-        };
-
-        let result = StorageLayer::new(&config).await;
-        assert!(
-            result.is_err(),
-            "configured vector DB that cannot init must fail startup when allow_degraded=false"
-        );
-    }
-
-    #[tokio::test]
-    async fn vector_db_failing_with_allow_degraded_continues_without_vector() {
-        let config = StorageConfig {
-            database: sqlite_db_config(),
-            redis: RedisConfig::default(),
-            files: FileStorageConfig::default(),
-            vector_db: Some(unreachable_vector_config(true)),
-        };
-
-        let storage = StorageLayer::new(&config)
-            .await
-            .expect("allow_degraded=true must allow startup without a vector backend");
-        assert!(storage.vector.is_none());
-        assert_eq!(storage.vector_status, DependencyStatus::Degraded);
-    }
-
-    #[tokio::test]
-    async fn vector_db_disabled_is_status_disabled() {
-        let config = StorageConfig {
-            database: sqlite_db_config(),
-            redis: RedisConfig::default(),
-            files: FileStorageConfig::default(),
-            vector_db: None,
-        };
-
-        let storage = StorageLayer::new(&config)
-            .await
-            .expect("storage layer must init without vector DB");
-        assert_eq!(storage.vector_status, DependencyStatus::Disabled);
-    }
+    include!("vector_startup_tests.rs");
 }

--- a/src/storage/redis/pool.rs
+++ b/src/storage/redis/pool.rs
@@ -94,7 +94,6 @@ impl RedisPool {
                 max_connections: 0,
                 connection_timeout: 0,
                 cluster: false,
-                cluster_configured: false,
                 allow_degraded: false,
             },
             noop_mode: true,

--- a/src/storage/redis/pool.rs
+++ b/src/storage/redis/pool.rs
@@ -34,6 +34,10 @@ pub struct RedisConnection {
 impl RedisPool {
     /// Create a new Redis pool
     pub async fn new(config: &RedisConfig) -> Result<Self> {
+        crate::config::Validate::validate(config).map_err(|error| {
+            GatewayError::Config(format!("Invalid Redis configuration: {error}"))
+        })?;
+
         if !config.enabled {
             info!("Redis disabled in config; using no-op Redis pool");
             return Ok(Self {
@@ -90,6 +94,7 @@ impl RedisPool {
                 max_connections: 0,
                 connection_timeout: 0,
                 cluster: false,
+                cluster_configured: false,
                 allow_degraded: false,
             },
             noop_mode: true,

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -323,7 +323,6 @@ mod tests {
             max_connections: 10,
             connection_timeout: 1,
             cluster: false,
-            cluster_configured: false,
             allow_degraded: false,
         };
 

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -323,6 +323,7 @@ mod tests {
             max_connections: 10,
             connection_timeout: 1,
             cluster: false,
+            cluster_configured: false,
             allow_degraded: false,
         };
 

--- a/src/storage/redis/tests.rs
+++ b/src/storage/redis/tests.rs
@@ -78,7 +78,6 @@ async fn test_redis_pool_creation_returns_error_for_unreachable_endpoint() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -94,7 +93,6 @@ async fn test_redis_pool_disabled_is_noop() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -112,7 +110,6 @@ async fn cluster_mode_is_rejected_before_standalone_connection_attempt() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: true,
-        cluster_configured: true,
         allow_degraded: true,
     };
 
@@ -165,7 +162,6 @@ async fn live_redis_pool() -> Option<RedisPool> {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
-        cluster_configured: false,
         allow_degraded: false,
     };
 

--- a/src/storage/redis/tests.rs
+++ b/src/storage/redis/tests.rs
@@ -1,7 +1,8 @@
 //! Redis module tests
 
 use super::pool::RedisPool;
-use crate::config::models::storage::RedisConfig;
+use crate::config::models::storage::{RedisConfig, StorageConfig};
+use crate::storage::StorageLayer;
 use crate::utils::error::gateway_error::GatewayError;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -77,6 +78,7 @@ async fn test_redis_pool_creation_returns_error_for_unreachable_endpoint() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
+        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -92,6 +94,7 @@ async fn test_redis_pool_disabled_is_noop() {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
+        cluster_configured: false,
         allow_degraded: false,
     };
 
@@ -99,6 +102,48 @@ async fn test_redis_pool_disabled_is_noop() {
         .await
         .expect("Disabled redis config should create no-op pool");
     assert!(pool.is_noop());
+}
+
+#[tokio::test]
+async fn cluster_mode_is_rejected_before_standalone_connection_attempt() {
+    let config = RedisConfig {
+        url: "redis://127.0.0.1:1".to_string(),
+        enabled: true,
+        max_connections: 10,
+        connection_timeout: 1,
+        cluster: true,
+        cluster_configured: true,
+        allow_degraded: true,
+    };
+
+    let error = RedisPool::new(&config)
+        .await
+        .expect_err("cluster mode must fail instead of degrading or connecting");
+    let message = error.to_string();
+
+    assert!(
+        message.contains("storage.redis.cluster=true"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("storage.redis.cluster=false"),
+        "got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn storage_rejects_cluster_mode_before_optional_dependency_initialization() {
+    let mut config = StorageConfig::default();
+    config.redis.enabled = true;
+    config.redis.cluster = true;
+    config.redis.allow_degraded = true;
+
+    let error = StorageLayer::new(&config)
+        .await
+        .expect_err("cluster mode must be rejected rather than degraded");
+
+    assert!(matches!(error, GatewayError::Config(_)));
+    assert!(error.to_string().contains("storage.redis.cluster=false"));
 }
 
 #[tokio::test]
@@ -120,6 +165,7 @@ async fn live_redis_pool() -> Option<RedisPool> {
         max_connections: 10,
         connection_timeout: 1,
         cluster: false,
+        cluster_configured: false,
         allow_degraded: false,
     };
 

--- a/src/storage/vector_startup_tests.rs
+++ b/src/storage/vector_startup_tests.rs
@@ -1,0 +1,100 @@
+fn vector_test_config(
+    db_type: &str,
+    url: String,
+    allow_degraded: bool,
+) -> crate::config::models::file_storage::VectorDbConfig {
+    crate::config::models::file_storage::VectorDbConfig {
+        db_type: db_type.to_string(),
+        url,
+        api_key: "test".to_string(),
+        index_name: "test".to_string(),
+        allow_degraded,
+    }
+}
+
+async fn failing_qdrant_config(
+    allow_degraded: bool,
+) -> (
+    crate::config::models::file_storage::VectorDbConfig,
+    tokio::task::JoinHandle<()>,
+) {
+    use tokio::io::AsyncWriteExt;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("mock Qdrant listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("mock Qdrant listener should have an address");
+    let task = tokio::spawn(async move {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .expect("mock Qdrant listener should accept one request");
+        socket
+            .write_all(
+                b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .expect("mock Qdrant response should be written");
+    });
+    (
+        vector_test_config("qdrant", format!("http://{address}"), allow_degraded),
+        task,
+    )
+}
+
+fn storage_with_vector(
+    vector_db: Option<crate::config::models::file_storage::VectorDbConfig>,
+) -> StorageConfig {
+    StorageConfig {
+        database: sqlite_db_config(),
+        redis: RedisConfig::default(),
+        files: FileStorageConfig::default(),
+        vector_db,
+    }
+}
+
+#[tokio::test]
+async fn vector_db_runtime_failure_without_allow_degraded_fails_startup() {
+    let (vector, server_task) = failing_qdrant_config(false).await;
+    let config = storage_with_vector(Some(vector));
+    let error = StorageLayer::new(&config)
+        .await
+        .expect_err("reachable validation followed by a failed Qdrant init must fail startup");
+    server_task.await.expect("mock Qdrant task should finish");
+    assert!(error.to_string().contains("503 Service Unavailable"));
+}
+
+#[tokio::test]
+async fn vector_db_runtime_failure_with_allow_degraded_continues_without_vector() {
+    let (vector, server_task) = failing_qdrant_config(true).await;
+    let config = storage_with_vector(Some(vector));
+    let storage = StorageLayer::new(&config)
+        .await
+        .expect("allow_degraded=true must tolerate a failed Qdrant init");
+    server_task.await.expect("mock Qdrant task should finish");
+    assert!(storage.vector.is_none());
+    assert_eq!(storage.vector_status, DependencyStatus::Degraded);
+}
+
+#[tokio::test]
+async fn invalid_vector_db_is_not_hidden_by_allow_degraded() {
+    let config = storage_with_vector(Some(vector_test_config(
+        "weaviate",
+        "http://127.0.0.1:1".to_string(),
+        true,
+    )));
+    let error = StorageLayer::new(&config)
+        .await
+        .expect_err("allow_degraded must not hide invalid vector configuration");
+    assert!(error.to_string().contains("not implemented yet"));
+}
+
+#[tokio::test]
+async fn vector_db_disabled_is_status_disabled() {
+    let storage = StorageLayer::new(&storage_with_vector(None))
+        .await
+        .expect("storage layer must init without vector DB");
+    assert_eq!(storage.vector_status, DependencyStatus::Disabled);
+}

--- a/src/storage/vector_startup_tests.rs
+++ b/src/storage/vector_startup_tests.rs
@@ -44,6 +44,18 @@ async fn failing_qdrant_config(
     )
 }
 
+async fn wait_for_mock_task(mut task: tokio::task::JoinHandle<()>) {
+    match tokio::time::timeout(std::time::Duration::from_secs(2), &mut task).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => panic!("mock Qdrant task failed: {error}"),
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            panic!("mock Qdrant task timed out");
+        }
+    }
+}
+
 fn storage_with_vector(
     vector_db: Option<crate::config::models::file_storage::VectorDbConfig>,
 ) -> StorageConfig {
@@ -62,7 +74,7 @@ async fn vector_db_runtime_failure_without_allow_degraded_fails_startup() {
     let error = StorageLayer::new(&config)
         .await
         .expect_err("reachable validation followed by a failed Qdrant init must fail startup");
-    server_task.await.expect("mock Qdrant task should finish");
+    wait_for_mock_task(server_task).await;
     assert!(error.to_string().contains("503 Service Unavailable"));
 }
 
@@ -73,7 +85,7 @@ async fn vector_db_runtime_failure_with_allow_degraded_continues_without_vector(
     let storage = StorageLayer::new(&config)
         .await
         .expect("allow_degraded=true must tolerate a failed Qdrant init");
-    server_task.await.expect("mock Qdrant task should finish");
+    wait_for_mock_task(server_task).await;
     assert!(storage.vector.is_none());
     assert_eq!(storage.vector_status, DependencyStatus::Degraded);
 }

--- a/tests/common/providers.rs
+++ b/tests/common/providers.rs
@@ -31,6 +31,15 @@ pub fn mock_provider_config(
 
 /// Preserve private test endpoints while staging PublicOnly request-time negative cases.
 pub fn route_policy_bootstrap_providers(providers: &[ProviderConfig]) -> Vec<ProviderConfig> {
+    if providers.is_empty() {
+        return vec![ProviderConfig {
+            name: "disabled-test-bootstrap".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            enabled: false,
+            ..ProviderConfig::default()
+        }];
+    }
     providers
         .iter()
         .cloned()

--- a/tests/files_routes.rs
+++ b/tests/files_routes.rs
@@ -3,6 +3,7 @@ mod tests {
     use actix_web::http::{StatusCode, header};
     use actix_web::{App, test, web};
     use litellm_rs::Config;
+    use litellm_rs::config::models::provider::ProviderConfig;
     use litellm_rs::core::models::user::types::{User, UserRole, UserStatus};
     use litellm_rs::core::models::{ApiKey, Metadata, UsageStats};
     use litellm_rs::server::http::HttpServer;
@@ -28,6 +29,13 @@ mod tests {
         config.gateway.storage.redis.enabled = false;
         config.gateway.storage.files.local_path = Some(local_path);
         config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.providers.push(ProviderConfig {
+            name: "disabled-test-bootstrap".to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            enabled: false,
+            ..ProviderConfig::default()
+        });
 
         let server = HttpServer::new(&config)
             .await

--- a/tests/integration/auth_middleware_tests_parts/disabled_auth.rs
+++ b/tests/integration/auth_middleware_tests_parts/disabled_auth.rs
@@ -1,8 +1,32 @@
 use super::*;
 
 #[tokio::test]
-async fn test_auth_middleware_fails_closed_when_disabled_without_anonymous_opt_in() {
-    let state = build_test_state(false, false).await;
+async fn server_rejects_disabled_auth_without_anonymous_opt_in() {
+    let mut config = Config::default();
+    config.gateway.auth.enable_jwt = false;
+    config.gateway.auth.enable_api_key = false;
+    config.gateway.auth.allow_anonymous = false;
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    add_disabled_bootstrap_provider(&mut config);
+
+    let error = match HttpServer::new(&config).await {
+        Err(error) => error,
+        Ok(_) => panic!("invalid auth configuration must fail before server initialization"),
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("Both JWT and API key authentication are disabled")
+    );
+}
+
+#[tokio::test]
+async fn auth_middleware_fails_closed_if_invalid_runtime_config_bypasses_validation() {
+    let state = build_test_state_with_rate_limit(false, false, true, None).await;
+    let mut runtime_config = state.config().as_ref().clone();
+    runtime_config.gateway.auth.allow_anonymous = false;
+    state.config.store(runtime_config);
     let hit_counter = Arc::new(AtomicUsize::new(0));
 
     let app = test::init_service(
@@ -13,7 +37,6 @@ async fn test_auth_middleware_fails_closed_when_disabled_without_anonymous_opt_i
             .route(AUTH_PROBE_PATH, web::get().to(auth_probe)),
     )
     .await;
-
     let response = test::call_service(
         &app,
         test::TestRequest::get().uri(AUTH_PROBE_PATH).to_request(),
@@ -23,8 +46,7 @@ async fn test_auth_middleware_fails_closed_when_disabled_without_anonymous_opt_i
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(hit_counter.load(Ordering::SeqCst), 0);
     let body = test::read_body(response).await;
-    let body = String::from_utf8_lossy(&body);
-    assert!(body.contains("Authentication is not configured"));
+    assert!(String::from_utf8_lossy(&body).contains("Authentication is not configured"));
 }
 
 #[tokio::test]

--- a/tests/integration/auth_middleware_tests_parts/mod.rs
+++ b/tests/integration/auth_middleware_tests_parts/mod.rs
@@ -1,6 +1,7 @@
 use actix_web::http::StatusCode;
 use actix_web::{App, HttpMessage, HttpRequest, HttpResponse, test, web};
 use litellm_rs::Config;
+use litellm_rs::config::models::provider::ProviderConfig;
 use litellm_rs::core::models::user::types::{User, UserRole, UserStatus};
 use litellm_rs::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
 use litellm_rs::core::types::context::{RequestContext, SharedRequestContext};
@@ -156,6 +157,7 @@ async fn build_test_state_with_rate_limit(
     config.gateway.storage.database.enabled = false;
     config.gateway.storage.redis.enabled = false;
     config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+    add_disabled_bootstrap_provider(&mut config);
     if let Some(default_rpm) = default_rpm {
         config.gateway.rate_limit.enabled = true;
         config.gateway.rate_limit.default_rpm = default_rpm;
@@ -188,6 +190,7 @@ async fn build_test_state_with_requests_per_minute_alias(
     config.gateway.rate_limit.enabled = true;
     config.gateway.rate_limit.default_rpm = default_rpm;
     config.gateway.rate_limit.requests_per_minute = Some(requests_per_minute);
+    add_disabled_bootstrap_provider(&mut config);
 
     let server = HttpServer::new(&config)
         .await
@@ -199,6 +202,16 @@ async fn build_test_state_with_requests_per_minute_alias(
         .await
         .expect("failed to run in-memory DB migrations for requests_per_minute test");
     state
+}
+
+fn add_disabled_bootstrap_provider(config: &mut Config) {
+    config.gateway.providers.push(ProviderConfig {
+        name: "disabled-test-bootstrap".to_string(),
+        provider_type: "openai".to_string(),
+        api_key: "sk-test".to_string(),
+        enabled: false,
+        ..ProviderConfig::default()
+    });
 }
 
 async fn build_test_state(enable_jwt: bool, enable_api_key: bool) -> AppState {

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -7,11 +7,13 @@
 #[cfg(test)]
 mod tests {
     use litellm_rs::Config;
+    use litellm_rs::config::ConfigOverlay;
     use litellm_rs::config::models::gateway::{GatewayConfig, UnpricedModelPolicy};
     use litellm_rs::config::models::provider::{
         ProviderConfig, ProviderHealthCheckConfig, RetryConfig,
     };
     use litellm_rs::config::models::server::{CorsConfig, ServerConfig, TlsConfig};
+    use litellm_rs::config::models::storage::RedisConfig;
     use std::path::Path;
 
     // ==================== GatewayConfig Validation ====================
@@ -485,13 +487,72 @@ mod tests {
         let base = Config::from_file(base_path)
             .await
             .expect("base config should load");
-        let overlay = Config::from_file(overlay_path)
+        let overlay = Config::overlay_from_file(overlay_path)
             .await
             .expect("overlay config should load");
-        let merged = base.merge(overlay);
+        let merged = base.merge_overlay(overlay);
 
         assert!(!merged.gateway.storage.redis.cluster);
-        assert!(merged.gateway.storage.redis.cluster_configured);
+    }
+
+    #[tokio::test]
+    async fn omitted_redis_cluster_file_overlay_preserves_true_base() {
+        let temp_dir = tempfile::tempdir().expect("temporary config directory should exist");
+        let overlay_path = temp_dir.path().join("overlay.yaml");
+        let mut base = Config {
+            gateway: create_valid_gateway_config(),
+        };
+        base.gateway.storage.redis.cluster = true;
+        let serialized = Config {
+            gateway: create_valid_gateway_config(),
+        }
+        .to_yaml()
+        .expect("overlay config should serialize");
+        let without_cluster = serialized
+            .lines()
+            .filter(|line| line.trim() != "cluster: false")
+            .collect::<Vec<_>>()
+            .join("\n");
+        tokio::fs::write(&overlay_path, without_cluster)
+            .await
+            .expect("overlay config should be written");
+
+        let overlay = Config::overlay_from_file(overlay_path)
+            .await
+            .expect("overlay config should load");
+        let merged = base.merge_overlay(overlay);
+
+        assert!(merged.gateway.storage.redis.cluster);
+    }
+
+    #[test]
+    fn programmatic_redis_cluster_false_overlay_overrides_true_base() {
+        let mut base = Config {
+            gateway: create_valid_gateway_config(),
+        };
+        base.gateway.storage.redis.cluster = true;
+        let overlay = ConfigOverlay::from_config(Config {
+            gateway: create_valid_gateway_config(),
+        })
+        .with_redis_cluster(false);
+
+        let merged = base.merge_overlay(overlay);
+
+        assert!(!merged.gateway.storage.redis.cluster);
+    }
+
+    #[test]
+    fn redis_config_exhaustive_literal_remains_source_compatible() {
+        let config = RedisConfig {
+            url: "redis://localhost:6379".to_string(),
+            enabled: false,
+            max_connections: 10,
+            connection_timeout: 5,
+            cluster: false,
+            allow_degraded: false,
+        };
+
+        assert!(!config.cluster);
     }
 
     // ==================== Default Config Tests ====================

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -517,6 +517,7 @@ mod tests {
         let mut base = Config {
             gateway: create_valid_gateway_config(),
         };
+        base.gateway.storage.redis.enabled = true;
         base.gateway.storage.redis.cluster = true;
         let serialized = Config {
             gateway: create_valid_gateway_config(),
@@ -545,6 +546,7 @@ mod tests {
         let mut base = Config {
             gateway: create_valid_gateway_config(),
         };
+        base.gateway.storage.redis.enabled = true;
         base.gateway.storage.redis.cluster = true;
         let overlay = ConfigOverlay::from_config(Config {
             gateway: create_valid_gateway_config(),
@@ -553,6 +555,10 @@ mod tests {
 
         let merged = base.merge_overlay(overlay);
 
+        merged
+            .validate()
+            .expect("programmatic explicit false must produce a valid merged configuration");
+        assert!(merged.gateway.storage.redis.enabled);
         assert!(!merged.gateway.storage.redis.cluster);
     }
 

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -455,6 +455,45 @@ mod tests {
         assert_eq!(provider.api_key, "new-api-key");
     }
 
+    #[tokio::test]
+    async fn redis_cluster_false_from_file_overrides_true_base() {
+        let temp_dir = tempfile::tempdir().expect("temporary config directory should exist");
+        let base_path = temp_dir.path().join("base.yaml");
+        let overlay_path = temp_dir.path().join("overlay.yaml");
+
+        let mut base = Config {
+            gateway: create_valid_gateway_config(),
+        };
+        base.gateway.storage.redis.cluster = true;
+        let overlay = Config {
+            gateway: create_valid_gateway_config(),
+        };
+
+        tokio::fs::write(
+            &base_path,
+            base.to_yaml().expect("base config should serialize"),
+        )
+        .await
+        .expect("base config should be written");
+        tokio::fs::write(
+            &overlay_path,
+            overlay.to_yaml().expect("overlay config should serialize"),
+        )
+        .await
+        .expect("overlay config should be written");
+
+        let base = Config::from_file(base_path)
+            .await
+            .expect("base config should load");
+        let overlay = Config::from_file(overlay_path)
+            .await
+            .expect("overlay config should load");
+        let merged = base.merge(overlay);
+
+        assert!(!merged.gateway.storage.redis.cluster);
+        assert!(merged.gateway.storage.redis.cluster_configured);
+    }
+
     // ==================== Default Config Tests ====================
 
     /// Test GatewayConfig default values

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -458,7 +458,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn redis_cluster_false_from_file_overrides_true_base() {
+    async fn enabled_redis_cluster_true_base_is_cleared_before_final_validation() {
         let temp_dir = tempfile::tempdir().expect("temporary config directory should exist");
         let base_path = temp_dir.path().join("base.yaml");
         let overlay_path = temp_dir.path().join("overlay.yaml");
@@ -466,6 +466,7 @@ mod tests {
         let mut base = Config {
             gateway: create_valid_gateway_config(),
         };
+        base.gateway.storage.redis.enabled = true;
         base.gateway.storage.redis.cluster = true;
         let overlay = Config {
             gateway: create_valid_gateway_config(),
@@ -484,14 +485,28 @@ mod tests {
         .await
         .expect("overlay config should be written");
 
-        let base = Config::from_file(base_path)
+        let standalone_error = Config::from_file(&base_path)
             .await
-            .expect("base config should load");
+            .expect_err("standalone cluster config must still fail final validation");
+        assert!(
+            standalone_error
+                .to_string()
+                .contains("storage.redis.cluster=false")
+        );
+
+        let base = Config::overlay_from_file(base_path)
+            .await
+            .expect("invalid intermediate base layer should parse")
+            .into_config();
         let overlay = Config::overlay_from_file(overlay_path)
             .await
             .expect("overlay config should load");
         let merged = base.merge_overlay(overlay);
 
+        merged
+            .validate()
+            .expect("merged cluster=false configuration should finally validate");
+        assert!(merged.gateway.storage.redis.enabled);
         assert!(!merged.gateway.storage.redis.cluster);
     }
 

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -20,19 +20,19 @@ mod tests {
         seaql_migrations,
     };
     use tempfile::TempDir;
-    #[cfg(feature = "postgres")]
+    #[cfg(all(feature = "postgres", feature = "sqlite"))]
     use tokio::sync::Mutex;
     use uuid::Uuid;
 
-    #[cfg(feature = "postgres")]
+    #[cfg(all(feature = "postgres", feature = "sqlite"))]
     static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
-    #[cfg(feature = "postgres")]
+    #[cfg(all(feature = "postgres", feature = "sqlite"))]
     struct EnvRestore {
         sqlite_path: Option<String>,
     }
 
-    #[cfg(feature = "postgres")]
+    #[cfg(all(feature = "postgres", feature = "sqlite"))]
     impl EnvRestore {
         fn capture() -> Self {
             Self {
@@ -41,7 +41,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "postgres")]
+    #[cfg(all(feature = "postgres", feature = "sqlite"))]
     impl Drop for EnvRestore {
         fn drop(&mut self) {
             unsafe {
@@ -324,7 +324,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "postgres")]
+    #[cfg(all(feature = "postgres", feature = "sqlite"))]
     #[tokio::test(flavor = "current_thread")]
     async fn test_storage_layer_sqlite_fallback_runs_startup_migrations() {
         let _guard = ENV_LOCK.lock().await;

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -20,15 +20,19 @@ mod tests {
         seaql_migrations,
     };
     use tempfile::TempDir;
+    #[cfg(feature = "postgres")]
     use tokio::sync::Mutex;
     use uuid::Uuid;
 
+    #[cfg(feature = "postgres")]
     static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
+    #[cfg(feature = "postgres")]
     struct EnvRestore {
         sqlite_path: Option<String>,
     }
 
+    #[cfg(feature = "postgres")]
     impl EnvRestore {
         fn capture() -> Self {
             Self {
@@ -37,6 +41,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "postgres")]
     impl Drop for EnvRestore {
         fn drop(&mut self) {
             unsafe {
@@ -319,6 +324,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "postgres")]
     #[tokio::test(flavor = "current_thread")]
     async fn test_storage_layer_sqlite_fallback_runs_startup_migrations() {
         let _guard = ENV_LOCK.lock().await;

--- a/tests/integration/http_routes_tests.rs
+++ b/tests/integration/http_routes_tests.rs
@@ -95,7 +95,16 @@ mod tests {
         CallbackRuntime::new(manager, 8).expect("embedding callback runtime")
     }
 
-    async fn build_state_with_config(config: Config) -> AppState {
+    async fn build_state_with_config(mut config: Config) -> AppState {
+        if config.gateway.providers.is_empty() {
+            config.gateway.providers.push(ProviderConfig {
+                name: "disabled-test-bootstrap".to_string(),
+                provider_type: "openai".to_string(),
+                api_key: "sk-test".to_string(),
+                enabled: false,
+                ..ProviderConfig::default()
+            });
+        }
         let server = match GatewayHttpServer::new(&config).await {
             Ok(server) => server,
             Err(err) => panic!("failed to build HTTP server for integration test: {err}"),

--- a/tests/tests/moderations_routes_proxy_selection_tests.rs
+++ b/tests/tests/moderations_routes_proxy_selection_tests.rs
@@ -144,11 +144,16 @@ async fn root_moderation_alias_proxies_request() {
 async fn moderation_route_uses_default_model_for_provider_selection_when_omitted() {
     let mock = MockModerationServer::start_moderation_mock().await;
     let state = build_test_app_state(vec![
-        moderation_provider_with_models(
+        named_moderation_provider(
+            "unrelated-provider",
             "http://127.0.0.1:9/v1",
             vec!["unrelated-moderation-model".to_string()],
         ),
-        moderation_provider_with_models(&mock.base_url, vec!["omni-moderation-latest".to_string()]),
+        named_moderation_provider(
+            "default-provider",
+            &mock.base_url,
+            vec!["omni-moderation-latest".to_string()],
+        ),
     ])
     .await;
     let app = test::init_service(


### PR DESCRIPTION
## What

storage.redis.cluster was parsed, merged, and env-overridable but never
read by the storage layer: a cluster URL got a standalone client that
only fails later at runtime with MOVED errors.

Fail closed instead: RedisConfig validation now rejects cluster=true
when redis is enabled (mirroring the vector-db validator pattern), and
the field doc says so. Validation runs after env overrides, so the
REDIS_CLUSTER env path is covered too.

## Test Plan

- [x] cargo check --all-features
- [x] Focused cargo test suites (see commit message)
- [x] cargo fmt --all && clippy scan
- [ ] CI full suite