### PR TITLE
fix(rate-limit): stop trusting the attacker-controlled XFF prefix

### DIFF
--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -432,7 +432,8 @@ fn parse_peer_ip(peer: &str) -> String {
 ///
 /// Priority:
 /// 1. Authenticated API key ID / user ID from `RequestContext`, when present
-/// 2. `X-Forwarded-For` first address — only when peer IP is in `trusted_proxies`
+/// 2. `X-Forwarded-For` rightmost non-trusted address — only when peer IP is
+///    in `trusted_proxies` (leftmost entries are attacker-controlled)
 /// 3. Direct peer address from connection info
 fn extract_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> String {
     if let Some(identity) = authenticated_client_key(req) {
@@ -470,16 +471,36 @@ fn network_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> Strin
     let peer = conn.peer_addr().unwrap_or("unknown");
     let peer_ip = parse_peer_ip(peer);
 
+    // Only honor X-Forwarded-For when the direct peer is a trusted proxy.
     if trusted_proxies.iter().any(|p| p == &peer_ip)
-        && let Some(forwarded) = req.headers().get("X-Forwarded-For")
-        && let Ok(val) = forwarded.to_str()
-        && let first = val.split(',').next().unwrap_or("").trim()
-        && !first.is_empty()
+        && let Some(client_ip) = req
+            .headers()
+            .get("X-Forwarded-For")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|val| last_untrusted_xff_ip(val, trusted_proxies))
     {
-        return format!("ip:{}", first);
+        return format!("ip:{}", client_ip);
     }
 
     format!("ip:{}", peer_ip)
+}
+
+/// Pick the client IP from an `X-Forwarded-For` header by walking from the
+/// right and skipping entries that match `trusted_proxies`.
+///
+/// Everything left of the rightmost non-trusted entry is attacker-controlled:
+/// a client can seed `X-Forwarded-For` with arbitrary addresses before the
+/// request reaches the trusted proxy. Using the leftmost entry therefore lets
+/// clients rotate identities to dodge per-IP limits.
+fn last_untrusted_xff_ip(val: &str, trusted_proxies: &[String]) -> Option<String> {
+    let mut fallback = None;
+    for entry in val.rsplit(',').map(str::trim).filter(|e| !e.is_empty()) {
+        fallback.get_or_insert(entry);
+        if !trusted_proxies.iter().any(|p| p == entry) {
+            return Some(entry.to_string());
+        }
+    }
+    fallback.map(str::to_string)
 }
 
 impl<S, B> Service<ServiceRequest> for RateLimitMiddlewareService<S>

--- a/src/server/middleware/rate_limit.rs
+++ b/src/server/middleware/rate_limit.rs
@@ -8,14 +8,14 @@ use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::body::EitherBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
-use actix_web::http::StatusCode;
+use actix_web::http::{StatusCode, header::HeaderMap};
 use actix_web::web;
 use actix_web::{HttpMessage, HttpResponse, ResponseError};
 use dashmap::DashMap;
 use futures::future::{Ready, ready};
 use std::fmt;
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -419,13 +419,24 @@ pub struct RateLimitMiddlewareService<S> {
     fallback_store: Arc<DashMap<String, KeyTracker>>,
 }
 
-/// Extract the IP address (without port) from a peer address string.
+/// Parse an IP address, optionally accompanied by a port.
 ///
-/// Handles IPv4 (`1.2.3.4:5678` → `1.2.3.4`) and IPv6 (`[::1]:5678` → `::1`).
-fn parse_peer_ip(peer: &str) -> String {
-    peer.parse::<SocketAddr>()
-        .map(|addr| addr.ip().to_string())
-        .unwrap_or_else(|_| peer.to_string())
+/// Handles bare IPv4/IPv6 addresses and socket addresses such as
+/// `1.2.3.4:5678` and `[::1]:5678`.
+fn parse_ip(value: &str) -> Option<IpAddr> {
+    let value = value.trim();
+    value
+        .parse::<IpAddr>()
+        .ok()
+        .or_else(|| value.parse::<SocketAddr>().ok().map(|addr| addr.ip()))
+        .map(|ip| ip.to_canonical())
+}
+
+fn is_trusted_proxy(ip: IpAddr, trusted_proxies: &[String]) -> bool {
+    trusted_proxies
+        .iter()
+        .filter_map(|proxy| parse_ip(proxy))
+        .any(|proxy| proxy == ip)
 }
 
 /// Extract a client identifier from the request.
@@ -467,17 +478,15 @@ fn client_key_from_context(context: &RequestContext) -> Option<String> {
 }
 
 fn network_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> String {
-    let conn = req.connection_info();
-    let peer = conn.peer_addr().unwrap_or("unknown");
-    let peer_ip = parse_peer_ip(peer);
+    let Some(peer_ip) = req.peer_addr().map(|addr| addr.ip().to_canonical()) else {
+        // Without a transport peer there is no trusted hop from which a
+        // forwarded header could have arrived.
+        return "ip:unknown".to_string();
+    };
 
     // Only honor X-Forwarded-For when the direct peer is a trusted proxy.
-    if trusted_proxies.iter().any(|p| p == &peer_ip)
-        && let Some(client_ip) = req
-            .headers()
-            .get("X-Forwarded-For")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|val| last_untrusted_xff_ip(val, trusted_proxies))
+    if is_trusted_proxy(peer_ip, trusted_proxies)
+        && let Some(client_ip) = last_untrusted_xff_ip(req.headers(), trusted_proxies)
     {
         return format!("ip:{}", client_ip);
     }
@@ -485,22 +494,28 @@ fn network_client_key(req: &ServiceRequest, trusted_proxies: &[String]) -> Strin
     format!("ip:{}", peer_ip)
 }
 
-/// Pick the client IP from an `X-Forwarded-For` header by walking from the
-/// right and skipping entries that match `trusted_proxies`.
+/// Pick the client IP from all `X-Forwarded-For` fields by walking from the
+/// last field's last hop toward the first and skipping trusted proxies.
 ///
 /// Everything left of the rightmost non-trusted entry is attacker-controlled:
 /// a client can seed `X-Forwarded-For` with arbitrary addresses before the
 /// request reaches the trusted proxy. Using the leftmost entry therefore lets
-/// clients rotate identities to dodge per-IP limits.
-fn last_untrusted_xff_ip(val: &str, trusted_proxies: &[String]) -> Option<String> {
+/// clients rotate identities to dodge per-IP limits. A malformed entry in the
+/// trusted suffix rejects the header so parsing cannot continue into the
+/// attacker-controlled prefix.
+fn last_untrusted_xff_ip(headers: &HeaderMap, trusted_proxies: &[String]) -> Option<IpAddr> {
     let mut fallback = None;
-    for entry in val.rsplit(',').map(str::trim).filter(|e| !e.is_empty()) {
-        fallback.get_or_insert(entry);
-        if !trusted_proxies.iter().any(|p| p == entry) {
-            return Some(entry.to_string());
+    for field in headers.get_all("X-Forwarded-For").rev() {
+        for entry in field.as_bytes().rsplit(|byte| *byte == b',') {
+            let entry = std::str::from_utf8(entry).ok()?;
+            let ip = parse_ip(entry)?;
+            fallback.get_or_insert(ip);
+            if !is_trusted_proxy(ip, trusted_proxies) {
+                return Some(ip);
+            }
         }
     }
-    fallback.map(str::to_string)
+    fallback
 }
 
 impl<S, B> Service<ServiceRequest> for RateLimitMiddlewareService<S>

--- a/src/server/middleware/rate_limit_tests.rs
+++ b/src/server/middleware/rate_limit_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use actix_web::http::header::{HeaderName, HeaderValue};
 use actix_web::test::TestRequest;
 use uuid::Uuid;
 
@@ -9,42 +10,57 @@ fn require_recorded_at(value: Option<Instant>) -> Instant {
     }
 }
 
-#[test]
-fn test_parse_peer_ip_ipv4_with_port() {
-    assert_eq!(parse_peer_ip("127.0.0.1:1234"), "127.0.0.1");
+fn parse_single_xff(value: &str, trusted_proxies: &[String]) -> Option<IpAddr> {
+    let req = TestRequest::default()
+        .insert_header(("X-Forwarded-For", value))
+        .to_srv_request();
+    last_untrusted_xff_ip(req.headers(), trusted_proxies)
 }
 
 #[test]
-fn test_parse_peer_ip_ipv4_no_port() {
-    assert_eq!(parse_peer_ip("10.0.0.1"), "10.0.0.1");
+fn test_parse_ip_ipv4_with_port() {
+    assert_eq!(parse_ip("127.0.0.1:1234"), "127.0.0.1".parse().ok());
 }
 
 #[test]
-fn test_parse_peer_ip_ipv6_with_port() {
-    assert_eq!(parse_peer_ip("[::1]:8080"), "::1");
+fn test_parse_ip_ipv4_no_port() {
+    assert_eq!(parse_ip("10.0.0.1"), "10.0.0.1".parse().ok());
 }
 
 #[test]
-fn test_parse_peer_ip_unknown_falls_back() {
-    assert_eq!(parse_peer_ip("unknown"), "unknown");
+fn test_parse_ip_ipv6_with_port() {
+    assert_eq!(parse_ip("[::1]:8080"), "::1".parse().ok());
+}
+
+#[test]
+fn test_parse_ip_rejects_unknown() {
+    assert_eq!(parse_ip("unknown"), None);
+}
+
+#[test]
+fn test_parse_ip_canonicalizes_ipv4_mapped_ipv6() {
+    assert_eq!(
+        parse_ip("::ffff:192.0.2.1"),
+        Some("192.0.2.1".parse().unwrap())
+    );
 }
 
 #[test]
 fn test_trusted_proxy_match() {
     let proxies = ["10.0.0.1".to_string()];
-    assert!(proxies.iter().any(|p| p == "10.0.0.1"));
+    assert!(is_trusted_proxy("10.0.0.1".parse().unwrap(), &proxies));
 }
 
 #[test]
 fn test_trusted_proxy_no_match() {
     let proxies = ["10.0.0.1".to_string()];
-    assert!(!proxies.iter().any(|p| p == "10.0.0.2"));
+    assert!(!is_trusted_proxy("10.0.0.2".parse().unwrap(), &proxies));
 }
 
 #[test]
 fn test_trusted_proxy_empty_list() {
     let proxies: Vec<String> = vec![];
-    assert!(!proxies.iter().any(|p| p == "127.0.0.1"));
+    assert!(!is_trusted_proxy("127.0.0.1".parse().unwrap(), &proxies));
 }
 
 #[test]
@@ -106,6 +122,162 @@ fn test_extract_client_key_sees_through_enumerated_proxy_chain() {
         .to_srv_request();
 
     let key = extract_client_key(&req, &["10.0.0.1".to_string(), "10.0.0.2".to_string()]);
+
+    assert_eq!(key, "ip:198.51.100.7");
+}
+
+#[test]
+fn test_extract_client_key_normalizes_ipv4_ports_and_whitespace() {
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "198.51.100.7:4242 , 10.0.0.2:8080"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1:9000".to_string(), "10.0.0.2".to_string()]);
+
+    assert_eq!(key, "ip:198.51.100.7");
+}
+
+#[test]
+fn test_extract_client_key_normalizes_bracketed_ipv6_ports() {
+    let req = TestRequest::default()
+        .peer_addr("[2001:db8::1]:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "[2001:db8::7]:4242, [2001:db8::2]:8080"))
+        .to_srv_request();
+
+    let key = extract_client_key(
+        &req,
+        &[
+            "[2001:0DB8:0:0:0:0:0:1]:9000".to_string(),
+            "2001:0DB8:0:0:0:0:0:2".to_string(),
+        ],
+    );
+
+    assert_eq!(key, "ip:2001:db8::7");
+}
+
+#[test]
+fn test_extract_client_key_rejects_malformed_forwarded_chain() {
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "198.51.100.7, malformed, 10.0.0.2"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string(), "10.0.0.2".to_string()]);
+
+    assert_eq!(key, "ip:10.0.0.1");
+}
+
+#[test]
+fn test_extract_client_key_ignores_forwarded_header_from_untrusted_peer() {
+    let req = TestRequest::default()
+        .peer_addr("203.0.113.10:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "198.51.100.7"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
+
+    assert_eq!(key, "ip:203.0.113.10");
+}
+
+#[test]
+fn test_extract_client_key_ignores_forwarded_header_for_malformed_proxy_config() {
+    let req = TestRequest::default()
+        .peer_addr("203.0.113.10:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "198.51.100.7"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["203.0.113.10/24".to_string()]);
+
+    assert_eq!(key, "ip:203.0.113.10");
+}
+
+#[test]
+fn test_extract_client_key_without_peer_ignores_forwarded_header() {
+    let req = TestRequest::default()
+        .insert_header(("X-Forwarded-For", "198.51.100.7"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["198.51.100.1".to_string()]);
+
+    assert_eq!(key, "ip:unknown");
+}
+
+#[test]
+fn test_extract_client_key_walks_repeated_forwarded_fields_in_global_reverse_order() {
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "192.0.2.66"))
+        .append_header(("X-Forwarded-For", "198.51.100.7, 10.0.0.2"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string(), "10.0.0.2".to_string()]);
+
+    assert_eq!(key, "ip:198.51.100.7");
+}
+
+#[test]
+fn test_extract_client_key_rejects_non_utf8_forwarded_field() {
+    let non_utf8 = HeaderValue::from_bytes(&[0xff]).unwrap();
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "192.0.2.66"))
+        .append_header((HeaderName::from_static("x-forwarded-for"), non_utf8))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
+
+    assert_eq!(key, "ip:10.0.0.1");
+}
+
+#[test]
+fn test_extract_client_key_ignores_non_utf8_prefix_after_selecting_client() {
+    let mut forwarded = vec![0xff, b',', b' '];
+    forwarded.extend_from_slice(b"198.51.100.7");
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header((
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_bytes(&forwarded).unwrap(),
+        ))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
+
+    assert_eq!(key, "ip:198.51.100.7");
+}
+
+#[test]
+fn test_extract_client_key_rejects_non_utf8_suffix_before_client_boundary() {
+    let mut forwarded = b"198.51.100.7, ".to_vec();
+    forwarded.push(0xff);
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header((
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_bytes(&forwarded).unwrap(),
+        ))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
+
+    assert_eq!(key, "ip:10.0.0.1");
+}
+
+#[test]
+fn test_extract_client_key_canonicalizes_ipv4_mapped_ipv6_everywhere() {
+    let req = TestRequest::default()
+        .peer_addr("[::ffff:10.0.0.1]:1000".parse().unwrap())
+        .insert_header((
+            "X-Forwarded-For",
+            "[::ffff:198.51.100.7]:4242, ::ffff:10.0.0.2",
+        ))
+        .to_srv_request();
+
+    let key = extract_client_key(
+        &req,
+        &["10.0.0.1".to_string(), "[::ffff:10.0.0.2]:9000".to_string()],
+    );
 
     assert_eq!(key, "ip:198.51.100.7");
 }
@@ -255,34 +427,34 @@ fn test_last_untrusted_xff_ip_ignores_attacker_seeded_prefix() {
     // Client seeds "1.2.3.4"; the trusted proxy appends the client's real
     // address. The seeded entry must be ignored (old code picked it).
     let trusted = vec!["10.0.0.1".to_string()];
-    let got = last_untrusted_xff_ip("1.2.3.4, 203.0.113.50", &trusted);
-    assert_eq!(got.as_deref(), Some("203.0.113.50"));
+    let got = parse_single_xff("1.2.3.4, 203.0.113.50", &trusted);
+    assert_eq!(got, Some("203.0.113.50".parse().unwrap()));
 }
 
 #[test]
 fn test_last_untrusted_xff_ip_walks_past_trusted_chain() {
     let trusted = vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()];
-    let got = last_untrusted_xff_ip("9.9.9.9, 1.2.3.4, 10.0.0.2, 10.0.0.1", &trusted);
-    assert_eq!(got.as_deref(), Some("1.2.3.4"));
+    let got = parse_single_xff("9.9.9.9, 1.2.3.4, 10.0.0.2, 10.0.0.1", &trusted);
+    assert_eq!(got, Some("1.2.3.4".parse().unwrap()));
 }
 
 #[test]
 fn test_last_untrusted_xff_ip_all_trusted_falls_back_to_rightmost() {
     let trusted = vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()];
-    let got = last_untrusted_xff_ip("10.0.0.2, 10.0.0.1", &trusted);
-    assert_eq!(got.as_deref(), Some("10.0.0.1"));
+    let got = parse_single_xff("10.0.0.2, 10.0.0.1", &trusted);
+    assert_eq!(got, Some("10.0.0.1".parse().unwrap()));
 }
 
 #[test]
 fn test_last_untrusted_xff_ip_single_entry() {
     let trusted = vec![];
-    let got = last_untrusted_xff_ip("203.0.113.7", &trusted);
-    assert_eq!(got.as_deref(), Some("203.0.113.7"));
+    let got = parse_single_xff("203.0.113.7", &trusted);
+    assert_eq!(got, Some("203.0.113.7".parse().unwrap()));
 }
 
 #[test]
-fn test_last_untrusted_xff_ip_ignores_empty_entries() {
+fn test_last_untrusted_xff_ip_rejects_empty_entries_in_trusted_suffix() {
     let trusted = vec!["10.0.0.1".to_string()];
-    let got = last_untrusted_xff_ip("  ,  , 10.0.0.1", &trusted);
-    assert_eq!(got.as_deref(), Some("10.0.0.1"));
+    let got = parse_single_xff("  ,  , 10.0.0.1", &trusted);
+    assert_eq!(got, None);
 }

--- a/src/server/middleware/rate_limit_tests.rs
+++ b/src/server/middleware/rate_limit_tests.rs
@@ -84,13 +84,28 @@ fn test_extract_client_key_ignores_rotating_api_key_headers() {
 }
 
 #[test]
-fn test_extract_client_key_uses_trusted_forwarded_ip() {
+fn test_extract_client_key_uses_rightmost_untrusted_forwarded_ip() {
+    // Only enumerated proxies are skipped when walking X-Forwarded-For from
+    // the right. 10.0.0.2 is not listed, so its own address is used instead
+    // of the attacker-controllable leftmost entry.
     let req = TestRequest::default()
         .peer_addr("10.0.0.1:1000".parse().unwrap())
         .insert_header(("X-Forwarded-For", "198.51.100.7, 10.0.0.2"))
         .to_srv_request();
 
     let key = extract_client_key(&req, &["10.0.0.1".to_string()]);
+
+    assert_eq!(key, "ip:10.0.0.2");
+}
+
+#[test]
+fn test_extract_client_key_sees_through_enumerated_proxy_chain() {
+    let req = TestRequest::default()
+        .peer_addr("10.0.0.1:1000".parse().unwrap())
+        .insert_header(("X-Forwarded-For", "198.51.100.7, 10.0.0.2"))
+        .to_srv_request();
+
+    let key = extract_client_key(&req, &["10.0.0.1".to_string(), "10.0.0.2".to_string()]);
 
     assert_eq!(key, "ip:198.51.100.7");
 }
@@ -233,4 +248,41 @@ fn test_enforce_fallback_capacity_evicts_oldest_when_all_fresh() {
     assert!(store.len() <= MAX_FALLBACK_ENTRIES);
     assert!(!store.contains_key("k-0"));
     assert!(store.contains_key(&format!("k-{}", MAX_FALLBACK_ENTRIES + 4)));
+}
+
+#[test]
+fn test_last_untrusted_xff_ip_ignores_attacker_seeded_prefix() {
+    // Client seeds "1.2.3.4"; the trusted proxy appends the client's real
+    // address. The seeded entry must be ignored (old code picked it).
+    let trusted = vec!["10.0.0.1".to_string()];
+    let got = last_untrusted_xff_ip("1.2.3.4, 203.0.113.50", &trusted);
+    assert_eq!(got.as_deref(), Some("203.0.113.50"));
+}
+
+#[test]
+fn test_last_untrusted_xff_ip_walks_past_trusted_chain() {
+    let trusted = vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()];
+    let got = last_untrusted_xff_ip("9.9.9.9, 1.2.3.4, 10.0.0.2, 10.0.0.1", &trusted);
+    assert_eq!(got.as_deref(), Some("1.2.3.4"));
+}
+
+#[test]
+fn test_last_untrusted_xff_ip_all_trusted_falls_back_to_rightmost() {
+    let trusted = vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()];
+    let got = last_untrusted_xff_ip("10.0.0.2, 10.0.0.1", &trusted);
+    assert_eq!(got.as_deref(), Some("10.0.0.1"));
+}
+
+#[test]
+fn test_last_untrusted_xff_ip_single_entry() {
+    let trusted = vec![];
+    let got = last_untrusted_xff_ip("203.0.113.7", &trusted);
+    assert_eq!(got.as_deref(), Some("203.0.113.7"));
+}
+
+#[test]
+fn test_last_untrusted_xff_ip_ignores_empty_entries() {
+    let trusted = vec!["10.0.0.1".to_string()];
+    let got = last_untrusted_xff_ip("  ,  , 10.0.0.1", &trusted);
+    assert_eq!(got.as_deref(), Some("10.0.0.1"));
 }


### PR DESCRIPTION
## What

network_client_key took the FIRST X-Forwarded-For entry whenever the
direct peer was a trusted proxy. Clients can seed that leftmost entry
with arbitrary addresses, so every request could present a fresh
identity and bypass per-IP rate limits entirely.

Walk the header from the right instead and use the rightmost entry that
is not itself in trusted_proxies (falling back to the rightmost entry
when all are trusted). Entries right of a trusted hop are appended by
proxies we control, so they cannot be forged by the client. Operators
must enumerate their full internal proxy chain in server.trusted_proxies
to see through it — matching standard real-ip handling.

The legacy test asserting leftmost extraction was updated: its
expectation encoded exactly the bypass this fix removes.

## Test Plan

- [x] cargo check --all-features
- [x] Focused cargo test suites (see commit message)
- [x] cargo fmt --all && clippy scan
- [ ] CI full suite