### PR TITLE
fix(keys): require authentication and ownership on /v1/keys/verify

### DIFF
--- a/src/core/keys/manager.rs
+++ b/src/core/keys/manager.rs
@@ -94,6 +94,11 @@ impl KeyManager {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_recorded_key_usage(&self, key_id: Uuid) -> bool {
+        self.last_used_cache.contains_key(&key_id)
+    }
+
     /// Generate a new API key
     ///
     /// Returns a tuple of (key_id, raw_key). The raw_key should be shown to the user
@@ -147,6 +152,19 @@ impl KeyManager {
     ///
     /// Returns verification result with key info if valid.
     pub async fn validate_key(&self, raw_key: &str) -> Result<VerifyKeyResult> {
+        let result = self.validate_key_without_usage_update(raw_key).await?;
+        self.record_validated_key_usage(&result);
+        Ok(result)
+    }
+
+    /// Validate a raw API key without recording it as used.
+    ///
+    /// Authorization-sensitive callers must use this method and call
+    /// [`Self::record_validated_key_usage`] only after access is granted.
+    pub(crate) async fn validate_key_without_usage_update(
+        &self,
+        raw_key: &str,
+    ) -> Result<VerifyKeyResult> {
         debug!("Validating API key");
 
         // Hash the provided key
@@ -187,8 +205,24 @@ impl KeyManager {
             });
         }
 
-        // Update last used (throttled to once per 5 minutes per key)
-        let key_id = key.id;
+        debug!("API key validated successfully");
+        Ok(VerifyKeyResult {
+            valid: true,
+            key: Some(KeyInfo::from(&key)),
+            invalid_reason: None,
+        })
+    }
+
+    /// Record usage for a successfully validated key, throttled to once per
+    /// five minutes per key.
+    pub(crate) fn record_validated_key_usage(&self, result: &VerifyKeyResult) {
+        if !result.valid {
+            return;
+        }
+        let Some(key_id) = result.key.as_ref().map(|key| key.id) else {
+            return;
+        };
+
         let now = Instant::now();
         self.prune_last_used_cache(now);
         let should_update = match self.last_used_cache.get(&key_id) {
@@ -205,13 +239,6 @@ impl KeyManager {
                 }
             });
         }
-
-        debug!("API key validated successfully");
-        Ok(VerifyKeyResult {
-            valid: true,
-            key: Some(KeyInfo::from(&key)),
-            invalid_reason: None,
-        })
     }
 
     /// Revoke an API key

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -67,6 +67,16 @@ pub(super) fn check_auth_result_ownership(
     }
 }
 
+/// Whether a caller may see the metadata returned by `/v1/keys/verify` for a
+/// valid key. Presenting the key's own secret is always sufficient; anything
+/// else falls back to standard ownership rules.
+pub(super) fn verify_key_access_allowed(auth: &AuthResult, key_info: &KeyInfo) -> bool {
+    if auth.context.api_key_id() == Some(key_info.id) {
+        return true;
+    }
+    check_auth_result_ownership(auth, key_info.user_id, key_info.team_id)
+}
+
 pub(super) fn is_auth_enabled(state: &web::Data<AppState>) -> bool {
     let cfg = state.config.load();
     cfg.auth().enable_jwt || cfg.auth().enable_api_key

--- a/src/server/routes/keys/access.rs
+++ b/src/server/routes/keys/access.rs
@@ -1,12 +1,14 @@
 use super::types::{CreateKeyRequest, KeyErrorResponse, UpdateKeyRequest};
 use crate::auth::{AUTHENTICATION_SERVICE_UNAVAILABLE_MESSAGE, AuthMethod, AuthResult};
 use crate::core::keys::{KeyInfo, KeyPermissions, KeyRateLimits, KeyStatus};
+use crate::core::models::ApiKey;
 use crate::core::models::user::types::{User, UserRole};
-use crate::core::types::context::RequestContext;
+use crate::core::types::context::{RequestContext, SharedRequestContext};
 use crate::server::middleware::extract_auth_method_with_api_key_header;
 use crate::server::routes::ApiResponse;
+use crate::server::routes::ai::check_permission;
 use crate::server::state::AppState;
-use actix_web::{HttpRequest, HttpResponse, web};
+use actix_web::{HttpMessage, HttpRequest, HttpResponse, web};
 use tracing::error;
 use uuid::Uuid;
 
@@ -74,7 +76,63 @@ pub(super) fn verify_key_access_allowed(auth: &AuthResult, key_info: &KeyInfo) -
     if auth.context.api_key_id() == Some(key_info.id) {
         return true;
     }
-    check_auth_result_ownership(auth, key_info.user_id, key_info.team_id)
+    verify_unknown_key_access_allowed(auth)
+        || verify_key_owned_by_caller(auth, key_info.user_id, key_info.team_id)
+}
+
+fn verify_key_owned_by_caller(
+    auth: &AuthResult,
+    key_user_id: Option<Uuid>,
+    key_team_id: Option<Uuid>,
+) -> bool {
+    if auth.api_key.is_some() {
+        let caller_team = auth.context.team_id();
+        if caller_team.is_some() && caller_team == key_team_id {
+            return true;
+        }
+    }
+
+    let Some(user) = auth.user.as_ref() else {
+        let caller_team = auth.context.team_id();
+        return caller_team.is_some() && caller_team == key_team_id;
+    };
+    if key_user_id == Some(user.id()) {
+        return true;
+    }
+    user.has_role(&UserRole::Manager)
+        && key_team_id.is_some_and(|team_id| user.team_ids.contains(&team_id))
+}
+
+/// Whether a caller may probe a key whose ownership cannot be established.
+/// This is deliberately limited to the repository's existing read-management
+/// operation so missing keys do not become an existence oracle.
+pub(super) fn verify_unknown_key_access_allowed(auth: &AuthResult) -> bool {
+    check_permission(auth.user.as_ref(), auth.api_key.as_ref(), "keys.list_all")
+}
+
+/// Reconstruct the authentication result already established by
+/// `AuthMiddleware`. Missing principals or context fail closed.
+pub(super) fn auth_result_from_request_extensions(req: &HttpRequest) -> Option<AuthResult> {
+    let extensions = req.extensions();
+    let user = extensions.get::<User>().cloned();
+    let api_key = extensions.get::<ApiKey>().cloned();
+    if user.is_none() && api_key.is_none() {
+        return None;
+    }
+
+    let context = extensions
+        .get::<SharedRequestContext>()
+        .map(|context| context.as_ref().clone())
+        .or_else(|| extensions.get::<RequestContext>().cloned())?;
+
+    Some(AuthResult {
+        success: true,
+        user,
+        api_key,
+        session: None,
+        error: None,
+        context,
+    })
 }
 
 pub(super) fn is_auth_enabled(state: &web::Data<AppState>) -> bool {

--- a/src/server/routes/keys/handlers.rs
+++ b/src/server/routes/keys/handlers.rs
@@ -709,7 +709,10 @@ pub async fn verify_key(
 
     let key_manager = get_key_manager(&state);
 
-    match key_manager.validate_key(&request.key).await {
+    match key_manager
+        .validate_key_without_usage_update(&request.key)
+        .await
+    {
         Ok(result) => {
             // Ownership check (skipped when auth is disabled): metadata for a
             // valid key may only be seen by the key's own caller, its owner,
@@ -729,6 +732,7 @@ pub async fn verify_key(
                         .json(ApiResponse::<()>::error(error_response.error)));
                 }
             }
+            key_manager.record_validated_key_usage(&result);
             let response = VerifyKeyResponse { result };
             Ok(HttpResponse::Ok().json(ApiResponse::success(response)))
         }

--- a/src/server/routes/keys/handlers.rs
+++ b/src/server/routes/keys/handlers.rs
@@ -4,7 +4,7 @@ use super::access::{
     authenticate_request, check_auth_result_ownership, check_ownership, filter_and_paginate_keys,
     invalidate_api_key_auth_cache, is_auth_enabled, resolve_create_key_scope,
     validate_create_key_rate_limits, validate_update_key_permissions,
-    validate_update_key_rate_limits,
+    validate_update_key_rate_limits, verify_key_access_allowed,
 };
 use super::types::{
     CreateKeyRequest, CreateKeyResponse, KeyErrorResponse, KeyResponse, KeyUsageResponse,
@@ -684,15 +684,50 @@ pub async fn get_key_usage(
 
 /// POST /v1/keys/verify - Verify an API key
 pub async fn verify_key(
+    req: HttpRequest,
     state: web::Data<AppState>,
     request: web::Json<VerifyKeyRequest>,
 ) -> ActixResult<HttpResponse> {
     info!("Verifying API key");
 
+    // Authenticate the caller first so verify cannot be used as an
+    // unauthenticated oracle for arbitrary key metadata.
+    let auth_opt = if is_auth_enabled(&state) {
+        match authenticate_request(&req, &state).await {
+            Err(resp) => return Ok(resp),
+            Ok(None) => {
+                let error_response =
+                    KeyErrorResponse::unauthorized("Authentication required to verify a key");
+                return Ok(HttpResponse::Unauthorized()
+                    .json(ApiResponse::<()>::error(error_response.error)));
+            }
+            Ok(auth) => auth,
+        }
+    } else {
+        None
+    };
+
     let key_manager = get_key_manager(&state);
 
     match key_manager.validate_key(&request.key).await {
         Ok(result) => {
+            // Ownership check (skipped when auth is disabled): metadata for a
+            // valid key may only be seen by the key's own caller, its owner,
+            // or management access. Verifying your own key by presenting its
+            // secret is always allowed.
+            if let (Some(auth), Some(key_info)) = (auth_opt.as_ref(), result.key.as_ref())
+                && !verify_key_access_allowed(auth, key_info)
+            {
+                warn!(
+                    "Caller attempted to verify a foreign key owned by user={:?} team={:?}",
+                    key_info.user_id, key_info.team_id
+                );
+                let error_response =
+                    KeyErrorResponse::forbidden("Not authorized to verify this key");
+                return Ok(
+                    HttpResponse::Forbidden().json(ApiResponse::<()>::error(error_response.error))
+                );
+            }
             let response = VerifyKeyResponse { result };
             Ok(HttpResponse::Ok().json(ApiResponse::success(response)))
         }

--- a/src/server/routes/keys/handlers.rs
+++ b/src/server/routes/keys/handlers.rs
@@ -1,10 +1,10 @@
 //! HTTP request handlers for API key management
 
 use super::access::{
-    authenticate_request, check_auth_result_ownership, check_ownership, filter_and_paginate_keys,
-    invalidate_api_key_auth_cache, is_auth_enabled, resolve_create_key_scope,
-    validate_create_key_rate_limits, validate_update_key_permissions,
-    validate_update_key_rate_limits, verify_key_access_allowed,
+    auth_result_from_request_extensions, authenticate_request, check_auth_result_ownership,
+    check_ownership, filter_and_paginate_keys, invalidate_api_key_auth_cache, is_auth_enabled,
+    resolve_create_key_scope, validate_create_key_rate_limits, validate_update_key_permissions,
+    validate_update_key_rate_limits, verify_key_access_allowed, verify_unknown_key_access_allowed,
 };
 use super::types::{
     CreateKeyRequest, CreateKeyResponse, KeyErrorResponse, KeyResponse, KeyUsageResponse,
@@ -690,18 +690,18 @@ pub async fn verify_key(
 ) -> ActixResult<HttpResponse> {
     info!("Verifying API key");
 
-    // Authenticate the caller first so verify cannot be used as an
-    // unauthenticated oracle for arbitrary key metadata.
+    // AuthMiddleware has already authenticated this non-public route and
+    // attached the principal. Reuse that result rather than repeating the
+    // authoritative database lookup and last-used update.
     let auth_opt = if is_auth_enabled(&state) {
-        match authenticate_request(&req, &state).await {
-            Err(resp) => return Ok(resp),
-            Ok(None) => {
+        match auth_result_from_request_extensions(&req) {
+            Some(auth) => Some(auth),
+            None => {
                 let error_response =
                     KeyErrorResponse::unauthorized("Authentication required to verify a key");
                 return Ok(HttpResponse::Unauthorized()
                     .json(ApiResponse::<()>::error(error_response.error)));
             }
-            Ok(auth) => auth,
         }
     } else {
         None
@@ -715,18 +715,19 @@ pub async fn verify_key(
             // valid key may only be seen by the key's own caller, its owner,
             // or management access. Verifying your own key by presenting its
             // secret is always allowed.
-            if let (Some(auth), Some(key_info)) = (auth_opt.as_ref(), result.key.as_ref())
-                && !verify_key_access_allowed(auth, key_info)
-            {
-                warn!(
-                    "Caller attempted to verify a foreign key owned by user={:?} team={:?}",
-                    key_info.user_id, key_info.team_id
-                );
-                let error_response =
-                    KeyErrorResponse::forbidden("Not authorized to verify this key");
-                return Ok(
-                    HttpResponse::Forbidden().json(ApiResponse::<()>::error(error_response.error))
-                );
+            if let Some(auth) = auth_opt.as_ref() {
+                let allowed = result
+                    .key
+                    .as_ref()
+                    .map(|key_info| verify_key_access_allowed(auth, key_info))
+                    .unwrap_or_else(|| verify_unknown_key_access_allowed(auth));
+                if !allowed {
+                    warn!("Caller attempted to verify a key without authorization");
+                    let error_response =
+                        KeyErrorResponse::forbidden("Not authorized to verify this key");
+                    return Ok(HttpResponse::Forbidden()
+                        .json(ApiResponse::<()>::error(error_response.error)));
+                }
             }
             let response = VerifyKeyResponse { result };
             Ok(HttpResponse::Ok().json(ApiResponse::success(response)))

--- a/src/server/routes/keys/handlers_tests.rs
+++ b/src/server/routes/keys/handlers_tests.rs
@@ -446,3 +446,62 @@ fn test_filter_and_paginate_keys_applies_limit_without_status_filter() {
         vec![second, third]
     );
 }
+
+#[test]
+fn test_verify_key_access_allows_presenting_own_key_secret() {
+    let key_id = Uuid::new_v4();
+    let key_info = make_key_info(key_id, KeyStatus::Active);
+    let mut context = RequestContext::new();
+    context.set_api_key_id(key_id);
+    let auth = AuthResult {
+        success: true,
+        user: None,
+        api_key: None,
+        session: None,
+        error: None,
+        context,
+    };
+
+    assert!(verify_key_access_allowed(&auth, &key_info));
+}
+
+#[test]
+fn test_verify_key_access_rejects_api_key_caller_for_foreign_key() {
+    let auth = make_team_auth(Uuid::new_v4());
+    let mut key_info = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    key_info.user_id = Some(Uuid::new_v4());
+
+    assert!(!verify_key_access_allowed(&auth, &key_info));
+}
+
+#[test]
+fn test_verify_key_access_allows_api_key_caller_in_same_team() {
+    let team_id = Uuid::new_v4();
+    let auth = make_team_auth(team_id);
+    let mut key_info = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    key_info.team_id = Some(team_id);
+
+    assert!(verify_key_access_allowed(&auth, &key_info));
+}
+
+#[test]
+fn test_verify_key_access_rejects_unrelated_authenticated_user() {
+    let auth = make_user_auth(make_user(UserRole::User, vec![]));
+    let mut key_info = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    key_info.user_id = Some(Uuid::new_v4());
+
+    assert!(!verify_key_access_allowed(&auth, &key_info));
+}
+
+#[test]
+fn test_verify_key_access_allows_owner_and_admin() {
+    let owner = make_user(UserRole::User, vec![]);
+    let mut owned = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    owned.user_id = Some(owner.id());
+    assert!(verify_key_access_allowed(&make_user_auth(owner), &owned));
+
+    let admin = make_user_auth(make_user(UserRole::Admin, vec![]));
+    let mut foreign = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    foreign.user_id = Some(Uuid::new_v4());
+    assert!(verify_key_access_allowed(&admin, &foreign));
+}

--- a/src/server/routes/keys/handlers_tests.rs
+++ b/src/server/routes/keys/handlers_tests.rs
@@ -683,7 +683,7 @@ fn test_auth_result_reuses_middleware_extensions() {
 #[actix_web::test]
 async fn verify_handler_reuses_middleware_auth_without_reauthenticating() {
     let state = auth_enabled_test_state().await;
-    let (_, raw_key) = state
+    let (key_id, raw_key) = state
         .key_manager
         .generate_key(CreateKeyConfig {
             name: "target".to_string(),
@@ -693,17 +693,25 @@ async fn verify_handler_reuses_middleware_auth_without_reauthenticating() {
         .expect("target key should be generated");
     let request = request_with_auth_extensions(&make_user_auth(make_user(UserRole::Admin, vec![])));
 
-    let response = verify_key(request, state, web::Json(VerifyKeyRequest { key: raw_key }))
-        .await
-        .expect("verification handler should respond");
+    let response = verify_key(
+        request,
+        state.clone(),
+        web::Json(VerifyKeyRequest { key: raw_key }),
+    )
+    .await
+    .expect("verification handler should respond");
 
     assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        state.key_manager.has_recorded_key_usage(key_id),
+        "allowed verification should schedule a last_used update"
+    );
 }
 
 #[actix_web::test]
 async fn verify_handler_hides_foreign_key_existence() {
     let state = auth_enabled_test_state().await;
-    let (_, active_raw_key) = state
+    let (active_id, active_raw_key) = state
         .key_manager
         .generate_key(CreateKeyConfig {
             name: "active foreign target".to_string(),
@@ -775,4 +783,9 @@ async fn verify_handler_hides_foreign_key_existence() {
             expected_body = Some(body);
         }
     }
+
+    assert!(
+        !state.key_manager.has_recorded_key_usage(active_id),
+        "unauthorized verification must not schedule a last_used update"
+    );
 }

--- a/src/server/routes/keys/handlers_tests.rs
+++ b/src/server/routes/keys/handlers_tests.rs
@@ -1,13 +1,16 @@
 use super::super::access::{
-    check_ownership, filter_and_paginate_keys, resolve_create_key_scope,
-    validate_update_key_permissions,
+    auth_result_from_request_extensions, check_auth_result_ownership, check_ownership,
+    filter_and_paginate_keys, resolve_create_key_scope, validate_update_key_permissions,
 };
 use super::*;
 use crate::auth::AuthResult;
 use crate::core::keys::{KeyInfo, KeyPermissions, KeyRateLimits, KeyUsageStats};
 use crate::core::models::user::types::{User, UserRole};
-use crate::core::types::context::RequestContext;
+use crate::core::models::{ApiKey, Metadata, UsageStats};
+use crate::core::types::context::{RequestContext, SharedRequestContext};
+use actix_web::{HttpMessage, body::to_bytes, http::StatusCode, test as actix_test, web};
 use chrono::Utc;
+use std::sync::Arc;
 
 #[test]
 fn test_create_key_config_from_request() {
@@ -86,6 +89,54 @@ fn make_team_auth(team_id: Uuid) -> AuthResult {
         error: None,
         context,
     }
+}
+
+fn make_api_key(id: Uuid, user_id: Option<Uuid>, team_id: Option<Uuid>) -> ApiKey {
+    ApiKey {
+        metadata: Metadata {
+            id,
+            ..Metadata::new()
+        },
+        name: "caller-key".to_string(),
+        key_hash: "hash".to_string(),
+        key_prefix: "gw-caller".to_string(),
+        user_id,
+        team_id,
+        permissions: Vec::new(),
+        rate_limits: None,
+        expires_at: None,
+        is_active: true,
+        last_used_at: None,
+        usage_stats: UsageStats::default(),
+    }
+}
+
+async fn auth_enabled_test_state() -> web::Data<AppState> {
+    let mut config = crate::config::Config::default();
+    config.gateway.auth.enable_jwt = true;
+    config.gateway.auth.enable_api_key = true;
+    config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+    let server = crate::server::http::HttpServer::new(&config)
+        .await
+        .expect("key-route test server should initialize");
+    web::Data::new(server.state().clone())
+}
+
+fn request_with_auth_extensions(auth: &AuthResult) -> HttpRequest {
+    let request = actix_test::TestRequest::default().to_http_request();
+    request
+        .extensions_mut()
+        .insert::<SharedRequestContext>(Arc::new(auth.context.clone()));
+    if let Some(user) = auth.user.clone() {
+        request.extensions_mut().insert::<User>(user);
+    }
+    if let Some(api_key) = auth.api_key.clone() {
+        request.extensions_mut().insert::<ApiKey>(api_key);
+    }
+    request
 }
 
 fn create_request_with_permissions(permissions: Option<KeyPermissions>) -> CreateKeyRequest {
@@ -485,12 +536,21 @@ fn test_verify_key_access_allows_api_key_caller_in_same_team() {
 }
 
 #[test]
-fn test_verify_key_access_rejects_unrelated_authenticated_user() {
+fn test_verify_key_access_rejects_foreign_keys_for_every_status_like_unknown_key() {
     let auth = make_user_auth(make_user(UserRole::User, vec![]));
-    let mut key_info = make_key_info(Uuid::new_v4(), KeyStatus::Active);
-    key_info.user_id = Some(Uuid::new_v4());
+    let unknown_allowed = verify_unknown_key_access_allowed(&auth);
 
-    assert!(!verify_key_access_allowed(&auth, &key_info));
+    assert!(!unknown_allowed);
+    for status in [KeyStatus::Active, KeyStatus::Revoked, KeyStatus::Expired] {
+        let mut key_info = make_key_info(Uuid::new_v4(), status);
+        key_info.user_id = Some(Uuid::new_v4());
+
+        assert_eq!(
+            verify_key_access_allowed(&auth, &key_info),
+            unknown_allowed,
+            "foreign {status} key must authorize identically to a missing key"
+        );
+    }
 }
 
 #[test]
@@ -504,4 +564,215 @@ fn test_verify_key_access_allows_owner_and_admin() {
     let mut foreign = make_key_info(Uuid::new_v4(), KeyStatus::Active);
     foreign.user_id = Some(Uuid::new_v4());
     assert!(verify_key_access_allowed(&admin, &foreign));
+}
+
+#[test]
+fn test_verify_key_access_honors_existing_management_permissions() {
+    let target = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+
+    for permission in ["*", "system.admin", "keys.list_all"] {
+        let caller_id = Uuid::new_v4();
+        let mut caller_key = make_api_key(caller_id, None, None);
+        caller_key.permissions = vec![permission.to_string()];
+        let mut context = RequestContext::new();
+        context.set_api_key_id(caller_id);
+        let auth = AuthResult {
+            success: true,
+            user: None,
+            api_key: Some(caller_key),
+            session: None,
+            error: None,
+            context,
+        };
+
+        assert!(
+            verify_key_access_allowed(&auth, &target),
+            "permission {permission} should grant foreign-key verification"
+        );
+        assert!(
+            verify_unknown_key_access_allowed(&auth),
+            "permission {permission} should grant missing-key verification"
+        );
+    }
+}
+
+#[test]
+fn test_verify_limited_admin_api_key_cannot_probe_foreign_or_unknown_keys() {
+    let admin = make_user(UserRole::Admin, vec![]);
+    let caller_id = Uuid::new_v4();
+    let mut caller_key = make_api_key(caller_id, Some(admin.id()), None);
+    caller_key.permissions = vec!["api.chat".to_string()];
+    let mut context = RequestContext::new();
+    context.set_api_key_id(caller_id);
+    let auth = AuthResult {
+        success: true,
+        user: Some(admin),
+        api_key: Some(caller_key),
+        session: None,
+        error: None,
+        context,
+    };
+    let mut foreign = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    foreign.user_id = Some(Uuid::new_v4());
+
+    assert!(!verify_key_access_allowed(&auth, &foreign));
+    assert!(!verify_unknown_key_access_allowed(&auth));
+}
+
+#[test]
+fn test_verify_key_access_preserves_api_key_team_when_user_is_loaded() {
+    let team_id = Uuid::new_v4();
+    let user = make_user(UserRole::User, vec![]);
+    let caller_id = Uuid::new_v4();
+    let caller_key = make_api_key(caller_id, Some(user.id()), Some(team_id));
+    let mut context = RequestContext::new();
+    context.set_api_key_id(caller_id);
+    context.set_team_id(team_id);
+    let auth = AuthResult {
+        success: true,
+        user: Some(user),
+        api_key: Some(caller_key),
+        session: None,
+        error: None,
+        context,
+    };
+    let mut target = make_key_info(Uuid::new_v4(), KeyStatus::Active);
+    target.team_id = Some(team_id);
+
+    assert!(verify_key_access_allowed(&auth, &target));
+    assert!(
+        !check_auth_result_ownership(&auth, target.user_id, target.team_id),
+        "general key routes must retain user-first ownership semantics"
+    );
+}
+
+#[test]
+fn test_auth_result_reuses_middleware_extensions() {
+    let team_id = Uuid::new_v4();
+    let user = make_user(UserRole::User, vec![]);
+    let caller_id = Uuid::new_v4();
+    let caller_key = make_api_key(caller_id, Some(user.id()), Some(team_id));
+    let mut context = RequestContext::new();
+    context.set_api_key_id(caller_id);
+    context.set_team_id(team_id);
+    let expected = AuthResult {
+        success: true,
+        user: Some(user),
+        api_key: Some(caller_key),
+        session: None,
+        error: None,
+        context,
+    };
+    let request = request_with_auth_extensions(&expected);
+
+    let actual = auth_result_from_request_extensions(&request)
+        .expect("middleware extensions should reconstruct authentication");
+
+    assert_eq!(
+        actual.user.as_ref().map(User::id),
+        expected.user.as_ref().map(User::id)
+    );
+    assert_eq!(
+        actual.api_key.as_ref().map(|key| key.metadata.id),
+        expected.api_key.as_ref().map(|key| key.metadata.id)
+    );
+    assert_eq!(actual.context.api_key_id(), Some(caller_id));
+    assert_eq!(actual.context.team_id(), Some(team_id));
+}
+
+#[actix_web::test]
+async fn verify_handler_reuses_middleware_auth_without_reauthenticating() {
+    let state = auth_enabled_test_state().await;
+    let (_, raw_key) = state
+        .key_manager
+        .generate_key(CreateKeyConfig {
+            name: "target".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("target key should be generated");
+    let request = request_with_auth_extensions(&make_user_auth(make_user(UserRole::Admin, vec![])));
+
+    let response = verify_key(request, state, web::Json(VerifyKeyRequest { key: raw_key }))
+        .await
+        .expect("verification handler should respond");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[actix_web::test]
+async fn verify_handler_hides_foreign_key_existence() {
+    let state = auth_enabled_test_state().await;
+    let (_, active_raw_key) = state
+        .key_manager
+        .generate_key(CreateKeyConfig {
+            name: "active foreign target".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("active foreign target should be generated");
+    let (revoked_id, revoked_raw_key) = state
+        .key_manager
+        .generate_key(CreateKeyConfig {
+            name: "revoked foreign target".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("revoked foreign target should be generated");
+    state
+        .key_manager
+        .revoke_key(revoked_id)
+        .await
+        .expect("foreign target should be revoked");
+    let (expired_id, expired_raw_key) = state
+        .key_manager
+        .generate_key(CreateKeyConfig {
+            name: "expired foreign target".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("expired foreign target should be generated");
+    state
+        .key_manager
+        .update_key(
+            expired_id,
+            UpdateKeyConfig {
+                expires_at: Some(Some(Utc::now() - chrono::Duration::hours(1))),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("foreign target should be expired");
+    let caller = make_user_auth(make_user(UserRole::User, vec![]));
+    let targets = [
+        ("active", active_raw_key),
+        ("revoked", revoked_raw_key),
+        ("expired", expired_raw_key),
+        ("missing", "gw-nonexistent-key-material".to_string()),
+    ];
+    let mut expected_body = None;
+
+    for (kind, key) in targets {
+        let response = verify_key(
+            request_with_auth_extensions(&caller),
+            state.clone(),
+            web::Json(VerifyKeyRequest { key }),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{kind} target verification should respond: {error}"));
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{kind} target must be hidden"
+        );
+        let body = to_bytes(response.into_body())
+            .await
+            .unwrap_or_else(|error| panic!("{kind} target response body should render: {error}"));
+
+        if let Some(expected) = expected_body.as_ref() {
+            assert_eq!(&body, expected, "{kind} target response body must match");
+        } else {
+            expected_body = Some(body);
+        }
+    }
 }


### PR DESCRIPTION
## What

/v1/keys/verify previously accepted any request body without checking
who was calling: with auth enabled it returned full KeyInfo metadata
(owner, team, budget, rate limits) for any valid key to unauthenticated
callers, turning the endpoint into a free metadata oracle.

The handler now:
- authenticates the caller first (401 when auth is enabled and no
  credentials are presented);
- gates the returned metadata behind verify_key_access_allowed:
  presenting the key's own secret is always sufficient, otherwise the
  standard ownership rules apply (owner, admin, same-team manager or
  same-team API key) with 403 otherwise.

The access decision lives in access.rs as a unit-tested helper; new
tests cover own-key presentation, foreign-key rejection for API-key
and user callers, same-team allowance, and owner/admin allowance.

## Test Plan

- [x] cargo check --all-features
- [x] Focused cargo test suites (see commit message)
- [x] cargo fmt --all && clippy scan
- [ ] CI full suite