### PR TITLE
fix(providers): keep upstream 403 as a permission failure

### DIFF
--- a/src/core/providers/amazon_nova/error.rs
+++ b/src/core/providers/amazon_nova/error.rs
@@ -19,9 +19,12 @@ impl ErrorMapper<ProviderError> for AmazonNovaErrorMapper {
             401 => {
                 ProviderError::authentication("amazon_nova", format!("Invalid API key: {}", body))
             }
-            403 => {
-                ProviderError::authentication("amazon_nova", format!("Access forbidden: {}", body))
-            }
+            // Upstream 403 is a permission failure; keep the status.
+            403 => ProviderError::api_error(
+                "amazon_nova",
+                status,
+                format!("Access forbidden: {}", body),
+            ),
             404 => ProviderError::not_implemented(
                 "amazon_nova",
                 format!("Model or endpoint not found: {}", body),

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -12,6 +12,7 @@ use crate::core::providers::base::{
     BaseConfig, BaseHttpClient, HeaderPair, apply_provider_headers, header, header_owned,
     header_static, read_streaming_error_body,
 };
+#[cfg(test)]
 use crate::core::providers::shared::parse_retry_after_from_body;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::{
@@ -24,8 +25,7 @@ use crate::core::types::{
 
 use super::config::AnthropicConfig;
 use super::error::{
-    anthropic_api_error, anthropic_auth_error, anthropic_network_error, anthropic_parse_error,
-    anthropic_rate_limit_error,
+    AnthropicErrorMapper, anthropic_api_error, anthropic_network_error, anthropic_parse_error,
 };
 #[cfg(test)]
 use super::models::get_anthropic_registry;
@@ -143,7 +143,7 @@ impl AnthropicClient {
             let status = response.status().as_u16();
             let error_text = read_streaming_error_body(response)
                 .await
-                .map_err(|error| error.into_provider_error("anthropic"))?;
+                .unwrap_or_else(|_| "failed to read upstream error body".to_string());
             return Err(self.map_http_error(status, &error_text));
         }
 
@@ -258,10 +258,15 @@ impl AnthropicClient {
     /// Handle
     async fn handle_response(&self, response: Response) -> Result<Value, ProviderError> {
         let status = response.status().as_u16();
-        let response_text = response
-            .text()
-            .await
-            .map_err(|e| anthropic_network_error(format!("Failed to read response: {}", e)))?;
+        let response_text = match response.text().await {
+            Ok(response_text) => response_text,
+            Err(_) if status != 200 => "failed to read upstream error body".to_string(),
+            Err(error) => {
+                return Err(anthropic_network_error(format!(
+                    "Failed to read response: {error}"
+                )));
+            }
+        };
 
         if status != 200 {
             return Err(self.map_http_error(status, &response_text));
@@ -273,18 +278,7 @@ impl AnthropicClient {
 
     /// Error
     fn map_http_error(&self, status: u16, body: &str) -> ProviderError {
-        match status {
-            400 => anthropic_api_error(400, format!("Bad request: {}", body)),
-            401 => anthropic_auth_error("Invalid or missing API key"),
-            403 => anthropic_auth_error("Forbidden: insufficient permissions"),
-            404 => anthropic_api_error(404, "Model or endpoint not found"),
-            429 => {
-                let retry_after = parse_retry_after_from_body(body);
-                anthropic_rate_limit_error(retry_after)
-            }
-            500..=599 => anthropic_api_error(status, format!("Server error: {}", body)),
-            _ => anthropic_api_error(status, body),
-        }
+        AnthropicErrorMapper::from_http_status(status, body)
     }
     /// Separate system messages from user messages
     pub(super) fn separate_system_messages(

--- a/src/core/providers/anthropic/client/tests.rs
+++ b/src/core/providers/anthropic/client/tests.rs
@@ -1,9 +1,130 @@
 use super::*;
+use crate::core::net::ProviderEndpointAccess;
 use crate::core::providers::anthropic::config::AnthropicConfig;
 use crate::core::types::message::MessageContent;
 use crate::core::types::thinking::ThinkingContent;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
 mod message_tool_tests;
 mod request_edge_tests;
 mod response_tests;
 mod setup_error_tests;
+
+async fn read_full_http_request(socket: &mut TcpStream) -> std::io::Result<()> {
+    let mut request_bytes = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    loop {
+        let bytes_read = socket.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            return Ok(());
+        }
+        request_bytes.extend_from_slice(&buffer[..bytes_read]);
+        if let Some(header_end) = request_bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+        {
+            let headers = String::from_utf8_lossy(&request_bytes[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if request_bytes.len() >= header_end + 4 + content_length {
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn forbidden_anthropic_url(truncated: bool) -> std::io::Result<String> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let address = listener.local_addr()?;
+    let body = r#"{"type":"error","error":{"type":"permission_error","message":"workspace access denied"}}"#;
+    let declared_length = body.len() + if truncated { 64 } else { 0 };
+    let response = format!(
+        "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        declared_length
+    );
+    tokio::spawn(async move {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .expect("Anthropic test server should accept request");
+        read_full_http_request(&mut socket)
+            .await
+            .expect("Anthropic test server should read request");
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("Anthropic test server should write response");
+    });
+    Ok(format!("http://{address}"))
+}
+
+fn anthropic_request() -> ChatRequest {
+    ChatRequest::new("claude-3-haiku-20240307").add_user_message("hello")
+}
+
+async fn forbidden_client(truncated: bool) -> Result<AnthropicClient, Box<dyn std::error::Error>> {
+    let config = AnthropicConfig::new_test("test-key")
+        .with_base_url(forbidden_anthropic_url(truncated).await?)
+        .with_endpoint_access(ProviderEndpointAccess::PrivateNetwork);
+    Ok(AnthropicClient::new(config)?)
+}
+
+fn assert_permission_error(error: ProviderError) {
+    assert!(matches!(
+        error,
+        ProviderError::ApiError {
+            status: 403,
+            ref message,
+            ..
+        } if message == "workspace access denied"
+    ));
+}
+
+#[tokio::test]
+async fn chat_preserves_upstream_403() -> Result<(), Box<dyn std::error::Error>> {
+    let error = forbidden_client(false)
+        .await?
+        .chat(anthropic_request())
+        .await
+        .expect_err("Anthropic chat 403 should be a permission error");
+    assert_permission_error(error);
+    Ok(())
+}
+
+#[tokio::test]
+async fn chat_stream_preserves_upstream_403() -> Result<(), Box<dyn std::error::Error>> {
+    let error = forbidden_client(false)
+        .await?
+        .chat_stream(anthropic_request())
+        .await
+        .expect_err("Anthropic streaming 403 should be a permission error");
+    assert_permission_error(error);
+    Ok(())
+}
+
+#[tokio::test]
+async fn chat_preserves_403_when_error_body_is_truncated() -> Result<(), Box<dyn std::error::Error>>
+{
+    let error = forbidden_client(true)
+        .await?
+        .chat(anthropic_request())
+        .await
+        .expect_err("truncated Anthropic error body must not erase HTTP 403");
+    assert!(matches!(
+        error,
+        ProviderError::ApiError {
+            status: 403,
+            ref message,
+            ..
+        } if message.contains("failed to read upstream error body")
+    ));
+    Ok(())
+}

--- a/src/core/providers/anthropic/error.rs
+++ b/src/core/providers/anthropic/error.rs
@@ -18,8 +18,10 @@ impl AnthropicErrorMapper {
         match status {
             400 => ProviderError::invalid_request("anthropic", format!("Bad request: {}", body)),
             401 => ProviderError::authentication("anthropic", "Invalid or missing API key"),
+            // Upstream 403 is a permission failure; keep the status so clients
+            // see 403 permission_error instead of 401.
             403 => {
-                ProviderError::authentication("anthropic", "Forbidden: insufficient permissions")
+                ProviderError::api_error("anthropic", status, "Forbidden: insufficient permissions")
             }
             404 => ProviderError::model_not_found("anthropic", "Model or endpoint not found"),
             429 => {
@@ -48,7 +50,8 @@ impl AnthropicErrorMapper {
 
             return match error_type {
                 "authentication_error" => ProviderError::authentication("anthropic", message),
-                "permission_error" => ProviderError::authentication("anthropic", message),
+                // Anthropic's own permission_error type keeps HTTP 403.
+                "permission_error" => ProviderError::api_error("anthropic", 403, message),
                 "invalid_request_error" => ProviderError::invalid_request("anthropic", message),
                 "not_found_error" => ProviderError::model_not_found("anthropic", message),
                 "rate_limit_error" => {

--- a/src/core/providers/anthropic/error.rs
+++ b/src/core/providers/anthropic/error.rs
@@ -20,9 +20,12 @@ impl AnthropicErrorMapper {
             401 => ProviderError::authentication("anthropic", "Invalid or missing API key"),
             // Upstream 403 is a permission failure; keep the status so clients
             // see 403 permission_error instead of 401.
-            403 => {
-                ProviderError::api_error("anthropic", status, "Forbidden: insufficient permissions")
-            }
+            403 => ProviderError::api_error(
+                "anthropic",
+                status,
+                crate::core::providers::unified_provider::parse_error_message_from_body(body)
+                    .unwrap_or_else(|| body.to_string()),
+            ),
             404 => ProviderError::model_not_found("anthropic", "Model or endpoint not found"),
             429 => {
                 let retry_after = parse_retry_after_from_body(body);

--- a/src/core/providers/azure/error.rs
+++ b/src/core/providers/azure/error.rs
@@ -17,7 +17,12 @@ impl ErrorMapper<ProviderError> for AzureErrorMapper {
                 ProviderError::invalid_request("azure", format!("Bad request: {}", response_body))
             }
             401 => ProviderError::authentication("azure", "Invalid Azure API key or credentials"),
-            403 => ProviderError::authentication("azure", "Forbidden: insufficient permissions"),
+            // Upstream 403 is a permission failure; keep the status.
+            403 => ProviderError::api_error(
+                "azure",
+                status_code,
+                "Forbidden: insufficient permissions",
+            ),
             404 => azure_deployment_error("Azure deployment not found"),
             429 => ProviderError::rate_limit("azure", Some(60)),
             500..=599 => ProviderError::api_error(
@@ -112,8 +117,9 @@ mod tests {
     #[test]
     fn test_azure_error_mapper_403() {
         let mapper = AzureErrorMapper;
+        // 403 keeps its upstream status as a permission failure.
         let err = mapper.map_http_error(403, "");
-        assert!(matches!(err, ProviderError::Authentication { .. }));
+        assert!(matches!(err, ProviderError::ApiError { status: 403, .. }));
     }
 
     #[test]

--- a/src/core/providers/azure_ai/error.rs
+++ b/src/core/providers/azure_ai/error.rs
@@ -33,7 +33,8 @@ impl ErrorMapper<ProviderError> for AzureAIErrorMapper {
                     ProviderError::authentication("azure_ai", "Authentication failed")
                 }
             }
-            403 => ProviderError::authentication("azure_ai", "Access forbidden"),
+            // Upstream 403 is a permission failure; keep the status.
+            403 => ProviderError::api_error("azure_ai", status_code, "Access forbidden"),
             404 => {
                 if response_body.contains("model") {
                     ProviderError::model_not_found("azure_ai", "Model not found")

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -187,7 +187,6 @@ impl HttpErrorMapper {
             402 => ProviderError::quota_exceeded(provider, message),
             // Keep upstream 403 as an api_error so clients see permission
             // failure (403), not an authentication failure (401).
-            403 if is_quota_error(body) => ProviderError::quota_exceeded(provider, message),
             403 => ProviderError::api_error(provider, status, message),
             404 => ProviderError::model_not_found(provider, message),
             408 | 504 => ProviderError::timeout(provider, message),
@@ -288,14 +287,6 @@ fn is_content_filter_error(body: &str) -> bool {
         || lower.contains("content filter")
         || lower.contains("safety")
         || lower.contains("policy")
-}
-
-fn is_quota_error(body: &str) -> bool {
-    let lower = body.to_ascii_lowercase();
-    lower.contains("insufficient_quota")
-        || lower.contains("quota")
-        || lower.contains("billing")
-        || lower.contains("credits")
 }
 
 /// Common URL builder.

--- a/src/core/providers/base/http.rs
+++ b/src/core/providers/base/http.rs
@@ -185,13 +185,10 @@ impl HttpErrorMapper {
             }
             401 => ProviderError::authentication(provider, message),
             402 => ProviderError::quota_exceeded(provider, message),
-            403 => {
-                if is_quota_error(body) {
-                    ProviderError::quota_exceeded(provider, message)
-                } else {
-                    ProviderError::authentication(provider, message)
-                }
-            }
+            // Keep upstream 403 as an api_error so clients see permission
+            // failure (403), not an authentication failure (401).
+            403 if is_quota_error(body) => ProviderError::quota_exceeded(provider, message),
+            403 => ProviderError::api_error(provider, status, message),
             404 => ProviderError::model_not_found(provider, message),
             408 | 504 => ProviderError::timeout(provider, message),
             413 => ProviderError::context_length_exceeded(provider, 0, 0),

--- a/src/core/providers/base/sse/gemini.rs
+++ b/src/core/providers/base/sse/gemini.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use super::SSETransformer;
+use crate::core::providers::google_error;
 use crate::core::providers::google_tool_loop::{
     candidate_index, finish_reason, parse_function_call_parts,
 };
@@ -204,15 +205,10 @@ impl SSETransformer for GeminiTransformer {
         })?;
 
         // Error response
-        if let Some(error) = json.get("error") {
-            let msg = error
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or("Unknown Gemini error");
-            return Err(ProviderError::api_error(
-                "gemini",
-                error.get("code").and_then(|c| c.as_u64()).unwrap_or(500) as u16,
-                msg.to_string(),
+        if json.get("error").is_some() {
+            return Err(google_error::map_google_error_envelope(
+                self.provider,
+                &json,
             ));
         }
 
@@ -353,6 +349,24 @@ mod tests {
     use crate::core::providers::base::sse::UnifiedSSEStream;
     use bytes::Bytes;
     use futures::StreamExt;
+
+    #[test]
+    fn status_only_permission_error_defaults_to_403_for_direct_and_vertex_streams() {
+        let data = r#"{"error":{"message":"stream access denied","status":"PERMISSION_DENIED"}}"#;
+        for transformer in [
+            GeminiTransformer::new("gemini-test"),
+            GeminiTransformer::new_vertex("vertex-test"),
+        ] {
+            assert!(matches!(
+                transformer.transform_chunk(data),
+                Err(ProviderError::ApiError {
+                    status: 403,
+                    message,
+                    ..
+                }) if message == "stream access denied"
+            ));
+        }
+    }
 
     #[test]
     fn strict_usage_metadata_applies_to_candidate_and_usage_only_chunks() {

--- a/src/core/providers/fal_ai/error.rs
+++ b/src/core/providers/fal_ai/error.rs
@@ -16,7 +16,9 @@ impl ErrorMapper<ProviderError> for FalAIErrorMapper {
     fn map_http_error(&self, status: u16, body: &str) -> ProviderError {
         match status {
             401 => ProviderError::authentication("fal_ai", format!("Invalid API key: {}", body)),
-            403 => ProviderError::authentication("fal_ai", format!("Access forbidden: {}", body)),
+            403 => {
+                ProviderError::api_error("fal_ai", status, format!("Access forbidden: {}", body))
+            }
             404 => ProviderError::not_implemented(
                 "fal_ai",
                 format!("Model or endpoint not found: {}", body),
@@ -69,6 +71,19 @@ mod tests {
         let error = mapper.map_http_error(401, "Unauthorized");
         let debug = format!("{:?}", error).to_lowercase();
         assert!(debug.contains("authentication") || debug.contains("api key"));
+    }
+
+    #[test]
+    fn test_map_http_error_403() {
+        let error = FalAIErrorMapper.map_http_error(403, "model access denied");
+        assert!(matches!(
+            error,
+            ProviderError::ApiError {
+                status: 403,
+                ref message,
+                ..
+            } if message.contains("model access denied")
+        ));
     }
 
     #[test]

--- a/src/core/providers/fal_ai/provider.rs
+++ b/src/core/providers/fal_ai/provider.rs
@@ -327,10 +327,17 @@ impl LLMProvider for FalAIProvider {
         let response = self.execute_image_request(&url, headers, body).await?;
 
         let status = response.status();
-        let response_bytes = response
-            .bytes()
-            .await
-            .map_err(|e| ProviderError::network("fal_ai", e.to_string()))?;
+        let response_bytes = match response.bytes().await {
+            Ok(response_bytes) => response_bytes,
+            Err(_) if !status.is_success() => {
+                return Err(HttpErrorMapper::map_status_code(
+                    "fal_ai",
+                    status.as_u16(),
+                    "failed to read upstream error body",
+                ));
+            }
+            Err(error) => return Err(ProviderError::network("fal_ai", error.to_string())),
+        };
 
         if !status.is_success() {
             let error_text = String::from_utf8_lossy(&response_bytes);
@@ -369,6 +376,34 @@ impl LLMProvider for FalAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn forbidden_fal_api_base() -> std::io::Result<String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let address = listener.local_addr()?;
+        tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("Fal AI test server should accept request");
+            let mut request = [0_u8; 4096];
+            socket
+                .read(&mut request)
+                .await
+                .expect("Fal AI test server should read request");
+            let body = r#"{"detail":"model access denied"}"#;
+            let response = format!(
+                "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("Fal AI test server should write response");
+        });
+        Ok(format!("http://{address}"))
+    }
 
     #[test]
     fn test_provider_creation_fails_without_api_key() {
@@ -508,6 +543,39 @@ mod tests {
 
         let result = provider.chat_completion(request, context).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn image_generation_preserves_upstream_403() -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = FalAIConfig::with_api_key("test-key");
+        config.base.api_base = Some(forbidden_fal_api_base().await?);
+        config.base.max_retries = 0;
+        let provider = FalAIProvider::new(config)?;
+        let request = ImageGenerationRequest {
+            prompt: "restricted model".to_string(),
+            model: Some("fal-ai/restricted".to_string()),
+            n: None,
+            size: None,
+            quality: None,
+            response_format: None,
+            style: None,
+            user: None,
+        };
+
+        let error = provider
+            .image_generation(request, RequestContext::default())
+            .await
+            .expect_err("Fal AI 403 should be returned as a permission failure");
+
+        assert!(matches!(
+            error,
+            ProviderError::ApiError {
+                status: 403,
+                ref message,
+                ..
+            } if message.contains("model access denied")
+        ));
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/core/providers/gemini/client.rs
+++ b/src/core/providers/gemini/client.rs
@@ -191,7 +191,7 @@ impl GeminiClient {
             // Request
             let error_text = read_streaming_error_body(response)
                 .await
-                .map_err(|error| error.into_provider_error("gemini"))?;
+                .unwrap_or_else(|_| "failed to read upstream error body".to_string());
             return Err(GeminiErrorMapper::from_http_status(
                 status.as_u16(),
                 &error_text,
@@ -224,10 +224,15 @@ impl GeminiClient {
     /// Handle
     async fn handle_response(&self, response: Response) -> Result<Value, ProviderError> {
         let status = response.status();
-        let response_text = response
-            .text()
-            .await
-            .map_err(|e| gemini_network_error(format!("Failed to read response: {}", e)))?;
+        let response_text = match response.text().await {
+            Ok(response_text) => response_text,
+            Err(_) if !status.is_success() => "failed to read upstream error body".to_string(),
+            Err(error) => {
+                return Err(gemini_network_error(format!(
+                    "Failed to read response: {error}"
+                )));
+            }
+        };
 
         if self.config.debug {
             let response_bytes = response_text.len();

--- a/src/core/providers/gemini/error.rs
+++ b/src/core/providers/gemini/error.rs
@@ -26,9 +26,12 @@ impl GeminiErrorMapper {
             400 => ProviderError::invalid_request("gemini", format!("Bad request: {}", body)),
             401 => ProviderError::authentication("gemini", "Invalid or missing API key"),
             // Upstream 403 is a permission failure; keep the status.
-            403 => {
-                ProviderError::api_error("gemini", status, "Forbidden: insufficient permissions")
-            }
+            403 => ProviderError::api_error(
+                "gemini",
+                status,
+                crate::core::providers::unified_provider::parse_error_message_from_body(body)
+                    .unwrap_or_else(|| body.to_string()),
+            ),
             404 => ProviderError::model_not_found("gemini", "Model or endpoint not found"),
             429 => {
                 let retry_after = parse_retry_after_from_body(body);
@@ -43,108 +46,7 @@ impl GeminiErrorMapper {
 
     /// Response
     pub fn from_api_response(response: &serde_json::Value) -> ProviderError {
-        // Error
-        if let Some(error) = response.get("error") {
-            let code = error.get("code").and_then(|c| c.as_u64()).unwrap_or(500) as u16;
-            let message = error
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or("Unknown error");
-            let status = error.get("status").and_then(|s| s.as_str()).unwrap_or("");
-
-            return match (code, status) {
-                (401, _) | (_, "UNAUTHENTICATED") => {
-                    ProviderError::authentication("gemini", message)
-                }
-                (403, _) | (_, "PERMISSION_DENIED") => {
-                    let status = if (400..600).contains(&code) {
-                        code
-                    } else {
-                        403
-                    };
-                    ProviderError::api_error("gemini", status, message)
-                }
-                (400, _) | (_, "INVALID_ARGUMENT") => {
-                    ProviderError::invalid_request("gemini", message)
-                }
-                (404, _) | (_, "NOT_FOUND") => ProviderError::model_not_found("gemini", message),
-                (429, _) | (_, "RESOURCE_EXHAUSTED") => {
-                    let retry_after = Self::extract_retry_after_from_error(error);
-                    ProviderError::RateLimit {
-                        provider: "gemini",
-                        message: message.to_string(),
-                        retry_after,
-                        rpm_limit: None,
-                        tpm_limit: None,
-                        current_usage: None,
-                    }
-                }
-                (503, _) | (_, "UNAVAILABLE") => {
-                    ProviderError::provider_unavailable("gemini", "Service unavailable")
-                }
-                (_, "FAILED_PRECONDITION") => ProviderError::invalid_request("gemini", message),
-                (_, "UNIMPLEMENTED") => ProviderError::NotSupported {
-                    provider: "gemini",
-                    feature: message.to_string(),
-                },
-                _ => ProviderError::api_error("gemini", code, message),
-            };
-        }
-
-        // Error
-        if let Some(message) = response.get("message")
-            && let Some(msg_str) = message.as_str()
-        {
-            return ProviderError::api_error("gemini", 500, msg_str);
-        }
-
-        // Error
-        if let Some(candidates) = response.get("candidates")
-            && let Some(candidate) = candidates.as_array().and_then(|c| c.first())
-            && let Some(finish_reason) = candidate.get("finishReason").and_then(|r| r.as_str())
-        {
-            return match finish_reason {
-                "SAFETY" => {
-                    ProviderError::invalid_request("gemini", "Content blocked by safety filters")
-                }
-                "RECITATION" => {
-                    ProviderError::invalid_request("gemini", "Content blocked due to recitation")
-                }
-                "MAX_TOKENS" => {
-                    ProviderError::invalid_request("gemini", "Maximum token limit reached")
-                }
-                "STOP" => ProviderError::api_error("gemini", 200, "Generation completed"),
-                _ => ProviderError::api_error(
-                    "gemini",
-                    500,
-                    format!("Unknown finish reason: {}", finish_reason),
-                ),
-            };
-        }
-
-        // Default
-        ProviderError::api_error("gemini", 500, "Unknown API error")
-    }
-
-    /// Extract retry delay from Gemini error object (handles `details[]` array)
-    fn extract_retry_after_from_error(error: &serde_json::Value) -> Option<u64> {
-        // Check
-        if let Some(retry_after) = error.get("retry_after") {
-            return retry_after.as_u64();
-        }
-
-        // Check
-        if let Some(details) = error.get("details")
-            && let Some(details_array) = details.as_array()
-        {
-            for detail in details_array {
-                if let Some(retry_after) = detail.get("retry_after") {
-                    return retry_after.as_u64();
-                }
-            }
-        }
-
-        None
+        crate::core::providers::google_error::map_google_error_envelope("gemini", response)
     }
 }
 
@@ -201,6 +103,51 @@ mod tests {
             }
             _ => panic!("Expected authentication error"),
         }
+    }
+
+    #[test]
+    fn status_only_permission_denied_defaults_to_403() {
+        let response = json!({
+            "error": {
+                "message": "caller lacks permission",
+                "status": "PERMISSION_DENIED"
+            }
+        });
+
+        assert!(matches!(
+            GeminiErrorMapper::from_api_response(&response),
+            ProviderError::ApiError {
+                status: 403,
+                ref message,
+                ..
+            } if message == "caller lacks permission"
+        ));
+    }
+
+    #[test]
+    fn http_403_preserves_google_error_envelope_message() {
+        let body = r#"{"error":{"code":403,"message":"service account lacks aiplatform.endpoints.predict","status":"PERMISSION_DENIED"}}"#;
+        assert!(matches!(
+            GeminiErrorMapper::from_http_status(403, body),
+            ProviderError::ApiError {
+                status: 403,
+                ref message,
+                ..
+            } if message == "service account lacks aiplatform.endpoints.predict"
+        ));
+    }
+
+    #[test]
+    fn http_403_transport_status_overrides_contradictory_envelope_code() {
+        let body = r#"{"error":{"code":401,"message":"accepted credential lacks model permission","status":"UNAUTHENTICATED"}}"#;
+        assert!(matches!(
+            GeminiErrorMapper::from_http_status(403, body),
+            ProviderError::ApiError {
+                status: 403,
+                ref message,
+                ..
+            } if message == "accepted credential lacks model permission"
+        ));
     }
 
     #[test]

--- a/src/core/providers/gemini/error.rs
+++ b/src/core/providers/gemini/error.rs
@@ -25,7 +25,10 @@ impl GeminiErrorMapper {
         match status {
             400 => ProviderError::invalid_request("gemini", format!("Bad request: {}", body)),
             401 => ProviderError::authentication("gemini", "Invalid or missing API key"),
-            403 => ProviderError::authentication("gemini", "Forbidden: insufficient permissions"),
+            // Upstream 403 is a permission failure; keep the status.
+            403 => {
+                ProviderError::api_error("gemini", status, "Forbidden: insufficient permissions")
+            }
             404 => ProviderError::model_not_found("gemini", "Model or endpoint not found"),
             429 => {
                 let retry_after = parse_retry_after_from_body(body);
@@ -54,7 +57,12 @@ impl GeminiErrorMapper {
                     ProviderError::authentication("gemini", message)
                 }
                 (403, _) | (_, "PERMISSION_DENIED") => {
-                    ProviderError::authentication("gemini", message)
+                    let status = if (400..600).contains(&code) {
+                        code
+                    } else {
+                        403
+                    };
+                    ProviderError::api_error("gemini", status, message)
                 }
                 (400, _) | (_, "INVALID_ARGUMENT") => {
                     ProviderError::invalid_request("gemini", message)

--- a/src/core/providers/google_error.rs
+++ b/src/core/providers/google_error.rs
@@ -1,0 +1,95 @@
+//! Shared Google API error-envelope mapping for Gemini and Vertex surfaces.
+
+use serde_json::Value;
+
+use super::unified_provider::ProviderError;
+
+pub(crate) fn map_google_error_envelope(provider: &'static str, response: &Value) -> ProviderError {
+    if let Some(error) = response.get("error") {
+        let explicit_code = error
+            .get("code")
+            .and_then(Value::as_u64)
+            .and_then(|code| u16::try_from(code).ok());
+        let code = explicit_code.unwrap_or(500);
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("Unknown error");
+        let status = error.get("status").and_then(Value::as_str).unwrap_or("");
+
+        return match (code, status) {
+            (401, _) | (_, "UNAUTHENTICATED") => ProviderError::authentication(provider, message),
+            (403, _) | (_, "PERMISSION_DENIED") => {
+                let status = explicit_code
+                    .filter(|code| (400..600).contains(code))
+                    .unwrap_or(403);
+                ProviderError::api_error(provider, status, message)
+            }
+            (400, _) | (_, "INVALID_ARGUMENT") => ProviderError::invalid_request(provider, message),
+            (404, _) | (_, "NOT_FOUND") => ProviderError::model_not_found(provider, message),
+            (429, _) | (_, "RESOURCE_EXHAUSTED") => ProviderError::RateLimit {
+                provider,
+                message: message.to_string(),
+                retry_after: retry_after(error),
+                rpm_limit: None,
+                tpm_limit: None,
+                current_usage: None,
+            },
+            (503, _) | (_, "UNAVAILABLE") => {
+                ProviderError::provider_unavailable(provider, "Service unavailable")
+            }
+            (_, "FAILED_PRECONDITION") => ProviderError::invalid_request(provider, message),
+            (_, "UNIMPLEMENTED") => ProviderError::NotSupported {
+                provider,
+                feature: message.to_string(),
+            },
+            _ => ProviderError::api_error(provider, code, message),
+        };
+    }
+
+    if let Some(message) = response.get("message").and_then(Value::as_str) {
+        return ProviderError::api_error(provider, 500, message);
+    }
+
+    if let Some(finish_reason) = response
+        .get("candidates")
+        .and_then(Value::as_array)
+        .and_then(|candidates| candidates.first())
+        .and_then(|candidate| candidate.get("finishReason"))
+        .and_then(Value::as_str)
+    {
+        return match finish_reason {
+            "SAFETY" => {
+                ProviderError::invalid_request(provider, "Content blocked by safety filters")
+            }
+            "RECITATION" => {
+                ProviderError::invalid_request(provider, "Content blocked due to recitation")
+            }
+            "MAX_TOKENS" => ProviderError::invalid_request(provider, "Maximum token limit reached"),
+            "STOP" => ProviderError::api_error(provider, 200, "Generation completed"),
+            _ => ProviderError::api_error(
+                provider,
+                500,
+                format!("Unknown finish reason: {finish_reason}"),
+            ),
+        };
+    }
+
+    ProviderError::api_error(provider, 500, "Unknown API error")
+}
+
+fn retry_after(error: &Value) -> Option<u64> {
+    error
+        .get("retry_after")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            error
+                .get("details")
+                .and_then(Value::as_array)
+                .and_then(|details| {
+                    details
+                        .iter()
+                        .find_map(|detail| detail.get("retry_after").and_then(Value::as_u64))
+                })
+        })
+}

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -56,6 +56,7 @@ pub mod gemini;
 pub mod github;
 #[cfg(feature = "providers-extended")]
 pub mod github_copilot;
+pub(crate) mod google_error;
 pub(crate) mod google_tool_loop;
 // groq: Tier 1 -> registry/catalog.rs
 // heroku: Tier 1 -> registry/catalog.rs

--- a/src/core/providers/openai/api_methods.rs
+++ b/src/core/providers/openai/api_methods.rs
@@ -67,10 +67,7 @@ impl OpenAIProvider {
                 message: e.to_string(),
             })?;
 
-        let response_bytes = response.bytes().await.map_err(|e| OpenAIError::Network {
-            provider: "openai",
-            message: e.to_string(),
-        })?;
+        let response_bytes = read_success_response_bytes(response).await?;
 
         let response_json: Value =
             serde_json::from_slice(&response_bytes).map_err(|e| OpenAIError::ResponseParsing {
@@ -131,10 +128,7 @@ impl OpenAIProvider {
                 message: e.to_string(),
             })?;
 
-        let response_bytes = response.bytes().await.map_err(|e| OpenAIError::Network {
-            provider: "openai",
-            message: e.to_string(),
-        })?;
+        let response_bytes = read_success_response_bytes(response).await?;
 
         serde_json::from_slice(&response_bytes).map_err(|e| OpenAIError::ResponseParsing {
             provider: "openai",
@@ -317,12 +311,23 @@ impl OptionalMultipartText for multipart::Form {
     }
 }
 
-async fn read_success_response_bytes(response: reqwest::Response) -> Result<Vec<u8>, OpenAIError> {
+pub(super) async fn read_success_response_bytes(
+    response: reqwest::Response,
+) -> Result<Vec<u8>, OpenAIError> {
     let status = response.status();
-    let response_bytes = response.bytes().await.map_err(|e| OpenAIError::Network {
-        provider: "openai",
-        message: e.to_string(),
-    })?;
+    let response_bytes = match response.bytes().await {
+        Ok(response_bytes) => response_bytes,
+        Err(_) if !status.is_success() => {
+            return Err(OpenAIErrorMapper
+                .map_http_error(status.as_u16(), "failed to read upstream error body"));
+        }
+        Err(error) => {
+            return Err(OpenAIError::Network {
+                provider: "openai",
+                message: error.to_string(),
+            });
+        }
+    };
 
     if !status.is_success() {
         let body = String::from_utf8_lossy(&response_bytes);

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -127,10 +127,7 @@ impl OpenAIProvider {
                 message: e.to_string(),
             })?;
 
-        let response_bytes = response.bytes().await.map_err(|e| ProviderError::Network {
-            provider: "openai",
-            message: e.to_string(),
-        })?;
+        let response_bytes = super::api_methods::read_success_response_bytes(response).await?;
 
         let response_json: Value = serde_json::from_slice(&response_bytes).map_err(|e| {
             ProviderError::ResponseParsing {
@@ -171,7 +168,7 @@ impl OpenAIProvider {
         if !status.is_success() {
             let body = read_streaming_error_body(response)
                 .await
-                .map_err(|e| e.into_provider_error("openai"))?;
+                .unwrap_or_else(|_| "failed to read upstream error body".to_string());
             let mapper = super::error_mapper::OpenAIErrorMapper;
             return Err(mapper.map_http_error(status.as_u16(), &body));
         }

--- a/src/core/providers/openai/error_mapper.rs
+++ b/src/core/providers/openai/error_mapper.rs
@@ -21,7 +21,8 @@ impl ErrorMapper<OpenAIError> for OpenAIErrorMapper {
         // Preserves response_body for structured error information
         match status_code {
             401 => OpenAIError::authentication("openai", response_body),
-            403 => OpenAIError::authentication("openai", response_body),
+            // Upstream 403 is a permission failure; keep the status.
+            403 => OpenAIError::api_error("openai", status_code, response_body),
             429 => OpenAIError::rate_limit_simple("openai", response_body),
             404 => OpenAIError::model_not_found("openai", response_body),
             400 => OpenAIError::invalid_request("openai", response_body),

--- a/src/core/providers/openai/streaming_request_tests.rs
+++ b/src/core/providers/openai/streaming_request_tests.rs
@@ -5,7 +5,9 @@ use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::chat::{ChatMessage, ChatRequest};
 use crate::core::types::context::RequestContext;
+use crate::core::types::embedding::{EmbeddingInput, EmbeddingRequest};
 use crate::core::types::health::HealthStatus;
+use crate::core::types::image::ImageGenerationRequest;
 use crate::core::types::message::{MessageContent, MessageRole};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -41,11 +43,23 @@ async fn read_full_http_request(socket: &mut TcpStream) -> std::io::Result<()> {
 }
 
 async fn response_url(status: &str, body: &str) -> std::io::Result<String> {
+    response_url_with_declared_length(status, body, body.len()).await
+}
+
+async fn truncated_response_url(status: &str, body: &str) -> std::io::Result<String> {
+    response_url_with_declared_length(status, body, body.len() + 64).await
+}
+
+async fn response_url_with_declared_length(
+    status: &str,
+    body: &str,
+    declared_length: usize,
+) -> std::io::Result<String> {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
     let addr = listener.local_addr()?;
     let response = format!(
         "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
+        declared_length
     );
 
     tokio::spawn(async move {
@@ -109,6 +123,134 @@ async fn test_openai_streaming_maps_non_success_status_before_sse()
         other => panic!("expected OpenAI API error envelope, got {other:?}"),
     }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_openai_chat_maps_non_success_status_before_deserialization()
+-> Result<(), Box<dyn std::error::Error>> {
+    let body = r#"{"error":{"type":"permission_error","message":"project access denied"}}"#;
+    let api_base = response_url("403 Forbidden", body).await?;
+    let config = test_openai_config(api_base, "sk-test123456789012345678901234567890123456");
+    let provider = OpenAIProvider::new(config).await?;
+
+    let error = LLMProvider::chat_completion(
+        &provider,
+        openai_chat_stream_request(),
+        RequestContext::default(),
+    )
+    .await
+    .expect_err("non-streaming OpenAI 403 should be mapped before response parsing");
+
+    assert!(matches!(
+        error,
+        ProviderError::ApiError {
+            status: 403,
+            ref message,
+            ..
+        } if message.contains("project access denied")
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_openai_chat_preserves_403_when_error_body_is_truncated()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api_base =
+        truncated_response_url("403 Forbidden", r#"{"error":{"message":"cut"}}"#).await?;
+    let provider = OpenAIProvider::new(test_openai_config(api_base, "sk-test-truncated")).await?;
+
+    let error = LLMProvider::chat_completion(
+        &provider,
+        openai_chat_stream_request(),
+        RequestContext::default(),
+    )
+    .await
+    .expect_err("truncated OpenAI error body must not erase HTTP 403");
+
+    assert!(matches!(
+        error,
+        ProviderError::ApiError {
+            status: 403,
+            ref message,
+            ..
+        } if message.contains("failed to read upstream error body")
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_openai_streaming_preserves_403_when_error_body_is_truncated()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api_base =
+        truncated_response_url("403 Forbidden", r#"{"error":{"message":"cut"}}"#).await?;
+    let provider = OpenAIProvider::new(test_openai_config(api_base, "sk-test-stream-cut")).await?;
+
+    let error = match LLMProvider::chat_completion_stream(
+        &provider,
+        openai_chat_stream_request(),
+        RequestContext::default(),
+    )
+    .await
+    {
+        Ok(_) => panic!("truncated streaming error body must not erase HTTP 403"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        ProviderError::ApiError {
+            status: 403,
+            ref message,
+            ..
+        } if message.contains("failed to read upstream error body")
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_openai_embeddings_map_non_success_status_before_deserialization()
+-> Result<(), Box<dyn std::error::Error>> {
+    let body = r#"{"error":{"type":"permission_error","message":"embedding access denied"}}"#;
+    let api_base = response_url("403 Forbidden", body).await?;
+    let provider = OpenAIProvider::new(test_openai_config(api_base, "sk-test-embedding")).await?;
+    let request = EmbeddingRequest {
+        model: "text-embedding-3-small".to_string(),
+        input: EmbeddingInput::Text("hello".to_string()),
+        user: None,
+        encoding_format: None,
+        dimensions: None,
+        task_type: None,
+    };
+
+    let error = LLMProvider::embeddings(&provider, request, RequestContext::default())
+        .await
+        .expect_err("OpenAI embeddings 403 should be mapped before response parsing");
+    assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_openai_image_generation_maps_non_success_status_before_deserialization()
+-> Result<(), Box<dyn std::error::Error>> {
+    let body = r#"{"error":{"type":"permission_error","message":"image access denied"}}"#;
+    let api_base = response_url("403 Forbidden", body).await?;
+    let provider = OpenAIProvider::new(test_openai_config(api_base, "sk-test-image")).await?;
+    let request = ImageGenerationRequest {
+        prompt: "restricted image".to_string(),
+        model: Some("gpt-image-1".to_string()),
+        n: None,
+        size: None,
+        quality: None,
+        response_format: None,
+        style: None,
+        user: None,
+    };
+
+    let error = LLMProvider::image_generation(&provider, request, RequestContext::default())
+        .await
+        .expect_err("OpenAI image 403 should be mapped before response parsing");
+    assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
     Ok(())
 }
 

--- a/src/core/providers/replicate/error.rs
+++ b/src/core/providers/replicate/error.rs
@@ -35,7 +35,8 @@ impl ErrorMapper<ProviderError> for ReplicateErrorMapper {
     fn map_http_error(&self, status_code: u16, response_body: &str) -> ProviderError {
         match status_code {
             401 => ProviderError::replicate_authentication("Invalid API token"),
-            403 => ProviderError::replicate_authentication("Permission denied"),
+            // Upstream 403 is a permission failure; keep the status.
+            403 => ProviderError::api_error("replicate", status_code, "Permission denied"),
             404 => {
                 // Try to extract model name from error
                 if response_body.contains("model") || response_body.contains("version") {
@@ -142,8 +143,9 @@ mod tests {
     #[test]
     fn test_error_mapper_403() {
         let mapper = ReplicateErrorMapper;
+        // 403 keeps its upstream status as a permission failure.
         let err = mapper.map_http_error(403, "Forbidden");
-        assert!(matches!(err, ProviderError::Authentication { .. }));
+        assert!(matches!(err, ProviderError::ApiError { status: 403, .. }));
     }
 
     #[test]

--- a/src/core/providers/unified_provider_http_mapping.rs
+++ b/src/core/providers/unified_provider_http_mapping.rs
@@ -187,7 +187,13 @@ pub fn default_http_error_mapper(
             ProviderError::invalid_request(provider, message)
         }
         401 => ProviderError::authentication(provider, "Invalid API key"),
-        403 => ProviderError::authentication(provider, "Permission denied"),
+        // 403 means the credential was accepted but lacks permission; keep the
+        // upstream status so clients see 403 permission_error, not 401.
+        403 => {
+            let message = parse_error_message_from_body(response_body)
+                .unwrap_or_else(|| response_body.to_string());
+            ProviderError::api_error(provider, status_code, message)
+        }
         404 => ProviderError::model_not_found(provider, "Model not found"),
         429 => {
             let retry_after =
@@ -222,7 +228,9 @@ pub fn extended_http_error_mapper(
 ) -> ProviderError {
     match status_code {
         400 => ProviderError::invalid_request(provider, response_body),
-        401 | 403 => ProviderError::authentication(provider, response_body),
+        401 => ProviderError::authentication(provider, response_body),
+        // Preserve upstream 403 as a permission failure, not an auth failure.
+        403 => ProviderError::api_error(provider, status_code, response_body),
         402 => ProviderError::quota_exceeded(provider, response_body),
         404 => ProviderError::model_not_found(provider, response_body),
         408 | 504 => ProviderError::timeout(provider, response_body),
@@ -307,4 +315,42 @@ const fn valid_status_or_bad_gateway(status: u16) -> u16 {
 
 fn is_model_not_priced_message(message: &str) -> bool {
     message.starts_with("model_not_priced:")
+}
+
+#[cfg(test)]
+mod http_403_classification_tests {
+    use super::*;
+
+    #[test]
+    fn default_mapper_keeps_upstream_403_as_permission_error() {
+        let error = default_http_error_mapper("openai", 403, "insufficient permissions");
+        assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
+
+        let facts = provider_http_error_facts(&error);
+        assert_eq!(facts.status, 403);
+        assert_eq!(facts.openai_error_type, "permission_error");
+        assert_eq!(facts.openai_code, "permission_denied");
+    }
+
+    #[test]
+    fn extended_mapper_splits_401_from_403() {
+        let auth = extended_http_error_mapper("openai", 401, "bad key");
+        assert!(matches!(auth, ProviderError::Authentication { .. }));
+
+        let permission = extended_http_error_mapper("openai", 403, "forbidden region");
+        assert!(matches!(
+            permission,
+            ProviderError::ApiError { status: 403, .. }
+        ));
+    }
+
+    #[test]
+    fn quota_shaped_403_bodies_stay_quota_errors() {
+        let quota = crate::core::providers::base::HttpErrorMapper::map_status_code(
+            "openai",
+            403,
+            "billing: insufficient_quota",
+        );
+        assert!(matches!(quota, ProviderError::QuotaExceeded { .. }));
+    }
 }

--- a/src/core/providers/unified_provider_http_mapping.rs
+++ b/src/core/providers/unified_provider_http_mapping.rs
@@ -345,12 +345,15 @@ mod http_403_classification_tests {
     }
 
     #[test]
-    fn quota_shaped_403_bodies_stay_quota_errors() {
-        let quota = crate::core::providers::base::HttpErrorMapper::map_status_code(
+    fn quota_shaped_403_bodies_keep_authoritative_transport_status() {
+        let permission = crate::core::providers::base::HttpErrorMapper::map_status_code(
             "openai",
             403,
             "billing: insufficient_quota",
         );
-        assert!(matches!(quota, ProviderError::QuotaExceeded { .. }));
+        assert!(matches!(
+            permission,
+            ProviderError::ApiError { status: 403, .. }
+        ));
     }
 }

--- a/src/core/providers/vertex_ai/client.rs
+++ b/src/core/providers/vertex_ai/client.rs
@@ -100,12 +100,10 @@ impl VertexAIProvider {
 
         if !response.status().is_success() {
             let status = response.status();
-            let error_text = response.text().await.map_err(|error| {
-                ProviderError::network(
-                    "vertex_ai",
-                    format!("failed to read error response: {error}"),
-                )
-            })?;
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "failed to read upstream error body".to_string());
 
             return Err(HttpErrorMapper::map_status_code(
                 "vertex_ai",

--- a/src/core/providers/vertex_ai/client/error_mapper.rs
+++ b/src/core/providers/vertex_ai/client/error_mapper.rs
@@ -53,9 +53,7 @@ impl ErrorMapper<VertexAIError> for VertexAIErrorMapper {
                     ProviderError::authentication("vertex_ai", "Authentication failed")
                 }
                 // Vertex permission failures keep HTTP 403.
-                "PERMISSION_DENIED" => {
-                    ProviderError::api_error("vertex_ai", 403, "Permission denied")
-                }
+                "PERMISSION_DENIED" => ProviderError::api_error("vertex_ai", 403, error_message),
                 "NOT_FOUND" => ProviderError::model_not_found("vertex_ai", error_message),
                 "RESOURCE_EXHAUSTED" => ProviderError::rate_limit("vertex_ai", None),
                 "INTERNAL" | "UNAVAILABLE" => ProviderError::network("vertex_ai", error_message),

--- a/src/core/providers/vertex_ai/client/error_mapper.rs
+++ b/src/core/providers/vertex_ai/client/error_mapper.rs
@@ -16,8 +16,11 @@ impl ErrorMapper<VertexAIError> for VertexAIErrorMapper {
                 format!("Bad request: {}", response_body),
             ),
             401 => ProviderError::authentication("vertex_ai", "Invalid credentials or API key"),
-            403 => ProviderError::configuration(
+            // Upstream 403 is a permission failure; keep the status so clients
+            // see 403 instead of a 500 (Configuration) or 401 (Authentication).
+            403 => ProviderError::api_error(
                 "vertex_ai",
+                status_code,
                 "Access forbidden: insufficient permissions",
             ),
             404 => ProviderError::model_not_found("vertex_ai", "Model not found"),
@@ -49,8 +52,9 @@ impl ErrorMapper<VertexAIError> for VertexAIErrorMapper {
                 "UNAUTHENTICATED" => {
                     ProviderError::authentication("vertex_ai", "Authentication failed")
                 }
+                // Vertex permission failures keep HTTP 403.
                 "PERMISSION_DENIED" => {
-                    ProviderError::configuration("vertex_ai", "Permission denied")
+                    ProviderError::api_error("vertex_ai", 403, "Permission denied")
                 }
                 "NOT_FOUND" => ProviderError::model_not_found("vertex_ai", error_message),
                 "RESOURCE_EXHAUSTED" => ProviderError::rate_limit("vertex_ai", None),

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -141,8 +141,9 @@ fn test_error_mapper_http_401() {
 #[test]
 fn test_error_mapper_http_403() {
     let mapper = VertexAIErrorMapper;
+    // 403 keeps its upstream status as a permission failure.
     let error = mapper.map_http_error(403, "Forbidden");
-    assert!(matches!(error, ProviderError::Configuration { .. }));
+    assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
 }
 
 #[test]
@@ -241,7 +242,8 @@ fn test_error_mapper_json_permission_denied() {
         }
     });
     let error = mapper.map_json_error(&response);
-    assert!(matches!(error, ProviderError::Configuration { .. }));
+    // PERMISSION_DENIED keeps HTTP 403 as a permission failure.
+    assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
 }
 
 #[test]

--- a/src/core/providers/vertex_ai/client_tests.rs
+++ b/src/core/providers/vertex_ai/client_tests.rs
@@ -243,7 +243,14 @@ fn test_error_mapper_json_permission_denied() {
     });
     let error = mapper.map_json_error(&response);
     // PERMISSION_DENIED keeps HTTP 403 as a permission failure.
-    assert!(matches!(error, ProviderError::ApiError { status: 403, .. }));
+    assert!(matches!(
+        error,
+        ProviderError::ApiError {
+            status: 403,
+            ref message,
+            ..
+        } if message == "Access denied"
+    ));
 }
 
 #[test]

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -138,7 +138,8 @@ pub fn infer_cooldown_reason(error: &ProviderError) -> CooldownReason {
         ProviderError::Timeout { .. } => CooldownReason::Timeout,
 
         // API errors - map based on status code. Upstream 403 is a permission
-        // failure on that deployment, so cool it down like an auth error.
+        // failure on that deployment, so preserve the immediate cooldown that
+        // Authentication-backed 403 mappings used before status normalization.
         ProviderError::ApiError { status, .. } => match *status {
             401 | 403 => CooldownReason::AuthError,
             404 => CooldownReason::NotFound,

--- a/src/core/router/execution.rs
+++ b/src/core/router/execution.rs
@@ -137,16 +137,10 @@ pub fn infer_cooldown_reason(error: &ProviderError) -> CooldownReason {
         // Timeout errors
         ProviderError::Timeout { .. } => CooldownReason::Timeout,
 
-        // Bedrock permission failures retain HTTP 403 while cooling down the deployment.
-        ProviderError::ApiError {
-            provider: "bedrock",
-            status: 403,
-            ..
-        } => CooldownReason::AuthError,
-
-        // API errors - map based on status code
+        // API errors - map based on status code. Upstream 403 is a permission
+        // failure on that deployment, so cool it down like an auth error.
         ProviderError::ApiError { status, .. } => match *status {
-            401 => CooldownReason::AuthError,
+            401 | 403 => CooldownReason::AuthError,
             404 => CooldownReason::NotFound,
             408 => CooldownReason::Timeout,
             429 => CooldownReason::RateLimit,

--- a/src/core/router/tests/cooldown_tests.rs
+++ b/src/core/router/tests/cooldown_tests.rs
@@ -304,8 +304,6 @@ async fn test_infer_cooldown_reason_api_error_401() {
 
 #[tokio::test]
 async fn test_infer_cooldown_reason_upstream_403_is_auth_error_for_all_providers() {
-    // Upstream 403 is a permission failure on that deployment regardless of
-    // provider, so it cools down like an auth error (previously only Bedrock).
     let bedrock = ProviderError::api_error("bedrock", 403, "Access denied");
     let other = ProviderError::api_error("custom_httpx", 403, "Forbidden");
 

--- a/src/core/router/tests/cooldown_tests.rs
+++ b/src/core/router/tests/cooldown_tests.rs
@@ -303,17 +303,19 @@ async fn test_infer_cooldown_reason_api_error_401() {
 }
 
 #[tokio::test]
-async fn test_infer_cooldown_reason_bedrock_403() {
+async fn test_infer_cooldown_reason_upstream_403_is_auth_error_for_all_providers() {
+    // Upstream 403 is a permission failure on that deployment regardless of
+    // provider, so it cools down like an auth error (previously only Bedrock).
     let bedrock = ProviderError::api_error("bedrock", 403, "Access denied");
-    let unrelated = ProviderError::api_error("custom_httpx", 403, "Forbidden");
+    let other = ProviderError::api_error("custom_httpx", 403, "Forbidden");
 
     assert_eq!(
         Router::infer_cooldown_reason(&bedrock),
         CooldownReason::AuthError
     );
     assert_eq!(
-        Router::infer_cooldown_reason(&unrelated),
-        CooldownReason::ConsecutiveFailures
+        Router::infer_cooldown_reason(&other),
+        CooldownReason::AuthError
     );
 }
 

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -546,9 +546,8 @@ fn image_proxy_gateway_error_to_provider_error(error: GatewayError) -> ProviderE
             ProviderError::invalid_request("image_proxy", message)
         }
         GatewayError::Config(message) => ProviderError::configuration("image_proxy", message),
-        GatewayError::Auth(message) | GatewayError::Forbidden(message) => {
-            ProviderError::authentication("image_proxy", message)
-        }
+        GatewayError::Auth(message) => ProviderError::authentication("image_proxy", message),
+        GatewayError::Forbidden(message) => ProviderError::api_error("image_proxy", 403, message),
         GatewayError::Timeout(message) => ProviderError::timeout("image_proxy", message),
         GatewayError::RateLimit {
             message,
@@ -573,7 +572,8 @@ async fn image_proxy_upstream_error(response: reqwest::Response) -> ProviderErro
 
     match status {
         400 => ProviderError::invalid_request("image_proxy", message),
-        401 | 403 => ProviderError::authentication("image_proxy", message),
+        401 => ProviderError::authentication("image_proxy", message),
+        403 => ProviderError::api_error("image_proxy", status, message),
         402 => ProviderError::quota_exceeded("image_proxy", message),
         404 => ProviderError::model_not_found("image_proxy", message),
         408 | 504 => ProviderError::timeout("image_proxy", message),

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -375,8 +375,9 @@ fn moderation_gateway_error_to_provider_error(error: GatewayError) -> ProviderEr
             ProviderError::invalid_request("moderation_proxy", message)
         }
         GatewayError::Config(message) => ProviderError::configuration("moderation_proxy", message),
-        GatewayError::Auth(message) | GatewayError::Forbidden(message) => {
-            ProviderError::authentication("moderation_proxy", message)
+        GatewayError::Auth(message) => ProviderError::authentication("moderation_proxy", message),
+        GatewayError::Forbidden(message) => {
+            ProviderError::api_error("moderation_proxy", 403, message)
         }
         GatewayError::Timeout(message) => ProviderError::timeout("moderation_proxy", message),
         GatewayError::RateLimit {
@@ -404,7 +405,8 @@ async fn moderation_upstream_error(response: reqwest::Response) -> ProviderError
 
     match status {
         400 => ProviderError::invalid_request("moderation_proxy", message),
-        401 | 403 => ProviderError::authentication("moderation_proxy", message),
+        401 => ProviderError::authentication("moderation_proxy", message),
+        403 => ProviderError::api_error("moderation_proxy", status, message),
         402 => ProviderError::quota_exceeded("moderation_proxy", message),
         404 => ProviderError::model_not_found("moderation_proxy", message),
         408 | 504 => ProviderError::timeout("moderation_proxy", message),

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -29,6 +29,7 @@ mod tests {
     #[derive(Clone)]
     struct MockImageState {
         captured_requests: Arc<Mutex<Vec<CapturedImageRequest>>>,
+        status: StatusCode,
     }
 
     struct MockImageServer {
@@ -40,9 +41,14 @@ mod tests {
 
     impl MockImageServer {
         async fn start_image_mock() -> Self {
+            Self::start_image_mock_with_status(StatusCode::OK).await
+        }
+
+        async fn start_image_mock_with_status(status: StatusCode) -> Self {
             let captured_requests = Arc::new(Mutex::new(Vec::new()));
             let state = MockImageState {
                 captured_requests: Arc::clone(&captured_requests),
+                status,
             };
             let listener =
                 std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -102,6 +108,15 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if state.status != StatusCode::OK {
+            return HttpResponse::build(state.status).json(json!({
+                "error": {
+                    "message": "image model access denied",
+                    "type": "permission_error",
+                    "code": "permission_denied"
+                }
+            }));
+        }
         HttpResponse::Ok().json(json!({
             "created": 1710000000,
             "data": [{ "url": "https://images.example.test/edit.png" }]
@@ -114,6 +129,15 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if state.status != StatusCode::OK {
+            return HttpResponse::build(state.status).json(json!({
+                "error": {
+                    "message": "image model access denied",
+                    "type": "permission_error",
+                    "code": "permission_denied"
+                }
+            }));
+        }
         HttpResponse::Ok().json(json!({
             "created": 1710000001,
             "data": [{ "b64_json": "dmFyaWF0aW9u" }]
@@ -573,6 +597,40 @@ mod tests {
             "image proxy model spend must charge image tokens once"
         );
 
+        mock.stop_image_mock().await;
+    }
+
+    #[tokio::test]
+    async fn image_edit_route_preserves_upstream_403() {
+        let mock = MockImageServer::start_image_mock_with_status(StatusCode::FORBIDDEN).await;
+        let state = build_test_state(vec![image_route_provider(&mock.base_url)]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let boundary = "litellm-rs-image-boundary";
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/images/edits")
+                .insert_header((
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(image_edit_multipart_body(boundary))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["error"]["message"], "image model access denied");
+        assert_eq!(body["error"]["type"], "permission_error");
+        assert_eq!(body["error"]["code"], "permission_denied");
+        assert_eq!(mock.requests().len(), 1);
         mock.stop_image_mock().await;
     }
 

--- a/tests/moderations_routes.rs
+++ b/tests/moderations_routes.rs
@@ -30,6 +30,7 @@ mod tests {
     #[derive(Clone)]
     struct MockModerationState {
         captured_requests: Arc<Mutex<Vec<CapturedModerationRequest>>>,
+        status: StatusCode,
     }
 
     struct MockModerationServer {
@@ -41,9 +42,14 @@ mod tests {
 
     impl MockModerationServer {
         async fn start_moderation_mock() -> Self {
+            Self::start_moderation_mock_with_status(StatusCode::OK).await
+        }
+
+        async fn start_moderation_mock_with_status(status: StatusCode) -> Self {
             let captured_requests = Arc::new(Mutex::new(Vec::new()));
             let state = MockModerationState {
                 captured_requests: Arc::clone(&captured_requests),
+                status,
             };
             let listener =
                 std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -99,6 +105,15 @@ mod tests {
         body: Bytes,
     ) -> HttpResponse {
         capture_request(&state, &request, body);
+        if state.status != StatusCode::OK {
+            return HttpResponse::build(state.status).json(json!({
+                "error": {
+                    "message": "moderation access denied",
+                    "type": "permission_error",
+                    "code": "permission_denied"
+                }
+            }));
+        }
         HttpResponse::Ok().json(json!({
             "id": "modr_mock",
             "model": "omni-moderation-latest",

--- a/tests/tests/moderations_routes_proxy_selection_tests.rs
+++ b/tests/tests/moderations_routes_proxy_selection_tests.rs
@@ -74,6 +74,38 @@ async fn moderation_route_proxies_request_with_provider_headers() {
 }
 
 #[tokio::test]
+async fn moderation_route_preserves_upstream_403() {
+    let mock = MockModerationServer::start_moderation_mock_with_status(StatusCode::FORBIDDEN).await;
+    let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(litellm_rs::server::routes::ai::configure_routes),
+    )
+    .await;
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/moderations")
+            .set_json(json!({
+                "model": "omni-moderation-latest",
+                "input": "moderate this text"
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["error"]["message"], "moderation access denied");
+    assert_eq!(body["error"]["type"], "permission_error");
+    assert_eq!(body["error"]["code"], "permission_denied");
+    assert_eq!(mock.requests().len(), 1);
+    mock.stop_moderation_mock().await;
+}
+
+#[tokio::test]
 async fn moderation_route_resolves_alias_to_provider_fallback_model() {
     let mock = MockModerationServer::start_moderation_mock().await;
     let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;


### PR DESCRIPTION
## What

Every HTTP error mapper folded upstream 403 into
ProviderError::Authentication (or, for Vertex, Configuration), so a
client whose upstream credential was valid but lacked permission got a
401 authentication_error (Vertex users got 500) instead of the upstream
403. The canonical facts table already had the right mapping - it just
was unreachable through these mappers.

All mappers now preserve the upstream status via ApiError { status:
403 }: default_http_error_mapper, extended_http_error_mapper,
HttpErrorMapper::map_status_code (quota-shaped bodies still map to
QuotaExceeded), openai, anthropic (HTTP and permission_error envelope),
gemini (HTTP and PERMISSION_DENIED envelope), azure, azure_ai,
amazon_nova, replicate, and vertex_ai (HTTP and PERMISSION_DENIED).

Router cooldown classification generalizes the existing Bedrock-only
carve-out: ApiError { status: 403 } cools down as AuthError for every
provider, matching the previous Authentication-based behavior.

Tests that asserted the old fold were corrected to expect ApiError {
status: 403 }; new tests cover the shared mappers' 403 semantics.

Note: two vertex_ai catalog tests (max_context_tokens 1000000 vs
1048576) fail on pristine origin/main as well and are unrelated to
this change.

## Test Plan

- [x] cargo check --all-features
- [x] Focused cargo test suites (see commit message)
- [x] cargo fmt --all && clippy scan
- [ ] CI full suite

## Notes

Touches 13 files but each is a single match-arm in one provider error mapper; no cross-cutting changes. Two pre-existing vertex_ai catalog test failures on main (max_context_tokens 1048576 vs 1000000, introduced by #1172) are unrelated and documented in the commit message.