### PR TITLE
feat(pricing): add DeepSeek V4 vision model

### DIFF
--- a/config/model_prices_extended.json
+++ b/config/model_prices_extended.json
@@ -42764,7 +42764,7 @@
     "source": "https://api-docs.deepseek.com/quick_start/pricing/"
   },
   "deepseek-v4-flash-vision-exp": {
-    "max_tokens": 393216,
+    "max_tokens": 1048576,
     "max_input_tokens": 1048576,
     "max_output_tokens": 393216,
     "input_cost_per_token": 2.2e-07,
@@ -42843,7 +42843,7 @@
     "litellm_provider": "deepseek",
     "max_input_tokens": 1048576,
     "max_output_tokens": 393216,
-    "max_tokens": 393216,
+    "max_tokens": 1048576,
     "mode": "chat",
     "output_cost_per_token": 6.6e-07,
     "pricing_status": "official_off_peak_rate_checked_2026_08_24",

--- a/config/model_prices_extended.json
+++ b/config/model_prices_extended.json
@@ -6,9 +6,9 @@
     "source_commit": "0ade44f4da6171e7222c8e4273c3703a6258f972",
     "generated_by": "scripts/sync_litellm_pricing.py",
     "upstream_model_count": 2917,
-    "compatibility_overlay_count": 172,
+    "compatibility_overlay_count": 174,
     "compatibility_overlay_override_count": 58,
-    "compatibility_overlay_add_count": 114,
+    "compatibility_overlay_add_count": 116,
     "compatibility_overlay_keys": [
       "MiniMax-M2",
       "MiniMax-M2.1",
@@ -48,10 +48,12 @@
       "deepseek-coder",
       "deepseek-reasoner",
       "deepseek-v4-flash",
+      "deepseek-v4-flash-vision-exp",
       "deepseek-v4-pro",
       "deepseek/deepseek-chat",
       "deepseek/deepseek-reasoner",
       "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-flash-vision-exp",
       "deepseek/deepseek-v4-pro",
       "devstral-2-2512",
       "devstral-2512",
@@ -183,7 +185,7 @@
       "yi-large",
       "yi-medium"
     ],
-    "total_model_count": 3031
+    "total_model_count": 3033
   },
   "sample_spec": {
     "code_interpreter_cost_per_session": 0.0,
@@ -42761,6 +42763,35 @@
     "pricing_status": "official_off_peak_rate_checked_2026_08_24",
     "source": "https://api-docs.deepseek.com/quick_start/pricing/"
   },
+  "deepseek-v4-flash-vision-exp": {
+    "max_tokens": 393216,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 2.2e-07,
+    "output_cost_per_token": 6.6e-07,
+    "cache_read_input_token_cost": 7e-09,
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ],
+    "supports_assistant_prefill": true,
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_parallel_function_calling": true,
+    "supports_prompt_caching": true,
+    "supports_response_schema": true,
+    "supports_streaming": true,
+    "supports_system_message": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_reasoning": true,
+    "supports_vision": true,
+    "thinking_mode_default": "enabled",
+    "pricing_status": "official_off_peak_rate_checked_2026_08_24",
+    "source": "https://api-docs.deepseek.com/quick_start/pricing/"
+  },
   "deepseek-v4-pro": {
     "max_tokens": 1048576,
     "max_input_tokens": 1048576,
@@ -42803,6 +42834,37 @@
     "supports_system_messages": true,
     "supports_tool_choice": true,
     "supports_vision": false
+  },
+  "deepseek/deepseek-v4-flash-vision-exp": {
+    "cache_creation_input_token_cost": 0.0,
+    "cache_read_input_token_cost": 7e-09,
+    "input_cost_per_token": 2.2e-07,
+    "input_cost_per_token_cache_hit": 7e-09,
+    "litellm_provider": "deepseek",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 393216,
+    "max_tokens": 393216,
+    "mode": "chat",
+    "output_cost_per_token": 6.6e-07,
+    "pricing_status": "official_off_peak_rate_checked_2026_08_24",
+    "source": "https://api-docs.deepseek.com/quick_start/pricing/",
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ],
+    "supports_assistant_prefill": true,
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_parallel_function_calling": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_streaming": true,
+    "supports_system_message": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "thinking_mode_default": "enabled"
   },
   "deepseek/deepseek-v4-pro": {
     "cache_creation_input_token_cost": 0.0,

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -10,6 +10,7 @@ official DeepSeek API base is `https://api.deepseek.com`.
 | Model | Context | Max Output | Pricing per 1M tokens | Notes |
 |-------|---------|------------|------------------------|-------|
 | `deepseek-v4-flash` | 1M | 384K | Off-peak: $0.22 cache-miss input, $0.007 cache-hit input, $0.66 output | Fast V4 model; thinking is enabled by default and non-thinking mode is supported |
+| `deepseek-v4-flash-vision-exp` | 1M | 384K | Off-peak: $0.22 cache-miss input, $0.007 cache-hit input, $0.66 output | Experimental vision model; images are converted to input tokens and thinking is enabled by default |
 | `deepseek-v4-pro` | 1M | 384K | Off-peak: $0.66 cache-miss input, $0.022 cache-hit input, $1.98 output | Higher quality V4 model; thinking is enabled by default and non-thinking mode is supported |
 
 ### Legacy Aliases
@@ -32,16 +33,18 @@ Use the canonical `deepseek-v4-flash` or `deepseek-v4-pro` IDs for new code.
 
 ## Capabilities
 
-| Feature | `deepseek-v4-flash` | `deepseek-v4-pro` |
-|---------|---------------------|-------------------|
-| Chat completion | Yes | Yes |
-| Streaming | Yes | Yes |
-| Tool calls | Yes | Yes |
-| JSON output | Yes | Yes |
-| Chat prefix completion | Beta | Beta |
-| FIM completion | Non-thinking mode only | Non-thinking mode only |
-| Vision | No | No |
-| Embeddings | No | No |
+| Feature | `deepseek-v4-flash` | `deepseek-v4-pro` | `deepseek-v4-flash-vision-exp` |
+|---------|---------------------|-------------------|----------------------------------|
+| Chat completion | Yes | Yes | Yes |
+| Responses API | Yes | Yes | Yes |
+| Anthropic API | Yes | Yes | Yes |
+| Streaming | Yes | Yes | Yes |
+| Tool calls | Yes | Yes | Yes |
+| JSON output | Yes | Yes | Yes |
+| Chat prefix completion | Beta | Beta | Beta |
+| FIM completion | Non-thinking mode only | Non-thinking mode only | No |
+| Vision | No | No | Yes |
+| Embeddings | No | No | No |
 
 ## Setup
 
@@ -108,6 +111,7 @@ official pricing page on 2026-08-24.
 For current V4 pricing:
 
 - `deepseek-v4-flash`: off-peak $0.22 cache-miss input, $0.007 cache-hit input, $0.66 output per 1M tokens; peak $0.44, $0.014, and $1.32 respectively.
+- `deepseek-v4-flash-vision-exp`: uses the same rates as Flash; image tokens are billed as input tokens after dimension-based conversion.
 - `deepseek-v4-pro`: off-peak $0.66 cache-miss input, $0.022 cache-hit input, $1.98 output per 1M tokens; peak $1.32, $0.044, and $3.96 respectively.
 - `deepseek-chat` and `deepseek-reasoner` continue to use `deepseek-v4-flash` pricing as deprecated compatibility aliases.
 

--- a/src/core/cost/calculator/tests/pricing_lookup_tests.rs
+++ b/src/core/cost/calculator/tests/pricing_lookup_tests.rs
@@ -347,21 +347,17 @@ fn test_get_deepseek_pricing() {
     assert_cost_eq(reasoner_alias.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(reasoner_alias.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(vision) = get_model_pricing("deepseek-v4-flash-vision-exp", "deepseek") else {
-        panic!("deepseek-v4-flash-vision-exp pricing should be available");
-    };
-    assert_cost_eq(vision.input_cost_per_1k_tokens, 0.00022);
-    assert_cost_eq(vision.output_cost_per_1k_tokens, 0.00066);
-    assert_eq!(vision.cache_read_input_token_cost, Some(0.000007));
-
-    let Ok(prefixed_vision) =
-        get_model_pricing("deepseek/deepseek-v4-flash-vision-exp", "deepseek")
-    else {
-        panic!("prefixed deepseek-v4-flash-vision-exp pricing should be available");
-    };
-    assert_cost_eq(prefixed_vision.input_cost_per_1k_tokens, 0.00022);
-    assert_cost_eq(prefixed_vision.output_cost_per_1k_tokens, 0.00066);
-    assert_eq!(prefixed_vision.cache_read_input_token_cost, Some(0.000007));
+    for model in [
+        "deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4-flash-vision-exp",
+    ] {
+        let Ok(vision) = get_model_pricing(model, "deepseek") else {
+            panic!("deepseek vision model '{model}' pricing should be available");
+        };
+        assert_cost_eq(vision.input_cost_per_1k_tokens, 0.00022);
+        assert_cost_eq(vision.output_cost_per_1k_tokens, 0.00066);
+        assert_eq!(vision.cache_read_input_token_cost, Some(0.000007));
+    }
 }
 
 #[test]

--- a/src/core/cost/calculator/tests/pricing_lookup_tests.rs
+++ b/src/core/cost/calculator/tests/pricing_lookup_tests.rs
@@ -346,6 +346,22 @@ fn test_get_deepseek_pricing() {
     assert_cost_eq(reasoner_alias.input_cost_per_1k_tokens, 0.00022);
     assert_cost_eq(reasoner_alias.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(reasoner_alias.cache_read_input_token_cost, Some(0.000007));
+
+    let Ok(vision) = get_model_pricing("deepseek-v4-flash-vision-exp", "deepseek") else {
+        panic!("deepseek-v4-flash-vision-exp pricing should be available");
+    };
+    assert_cost_eq(vision.input_cost_per_1k_tokens, 0.00022);
+    assert_cost_eq(vision.output_cost_per_1k_tokens, 0.00066);
+    assert_eq!(vision.cache_read_input_token_cost, Some(0.000007));
+
+    let Ok(prefixed_vision) =
+        get_model_pricing("deepseek/deepseek-v4-flash-vision-exp", "deepseek")
+    else {
+        panic!("prefixed deepseek-v4-flash-vision-exp pricing should be available");
+    };
+    assert_cost_eq(prefixed_vision.input_cost_per_1k_tokens, 0.00022);
+    assert_cost_eq(prefixed_vision.output_cost_per_1k_tokens, 0.00066);
+    assert_eq!(prefixed_vision.cache_read_input_token_cost, Some(0.000007));
 }
 
 #[test]
@@ -363,6 +379,26 @@ fn test_deepseek_fallback_pricing() {
     assert_cost_eq(pro.input_cost_per_1k_tokens, 0.00066);
     assert_cost_eq(pro.output_cost_per_1k_tokens, 0.00198);
     assert_eq!(pro.cache_read_input_token_cost, Some(0.000022));
+
+    let Ok(vision) = super::super::pricing::get_deepseek_pricing("deepseek-v4-flash-vision-exp")
+    else {
+        panic!("deepseek-v4-flash-vision-exp fallback pricing should be available");
+    };
+    assert_cost_eq(vision.input_cost_per_1k_tokens, 0.00022);
+    assert_cost_eq(vision.output_cost_per_1k_tokens, 0.00066);
+    assert_eq!(vision.cache_read_input_token_cost, Some(0.000007));
+
+    let Ok(unlisted_vision_alias) =
+        get_model_pricing("deepseek-v4-flash-vision-exp-unlisted", "deepseek")
+    else {
+        panic!("an unlisted DeepSeek V4 Flash alias should use fallback pricing");
+    };
+    assert_cost_eq(unlisted_vision_alias.input_cost_per_1k_tokens, 0.00022);
+    assert_cost_eq(unlisted_vision_alias.output_cost_per_1k_tokens, 0.00066);
+    assert_eq!(
+        unlisted_vision_alias.cache_read_input_token_cost,
+        Some(0.000007)
+    );
 }
 
 #[test]

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -670,6 +670,11 @@ impl Default for PricingDatabase {
             builtin_deepseek_v4_model(0.00000066, 0.00000198, 0.000000022),
         );
 
+        let mut deepseek_vision = builtin_deepseek_v4_model(0.00000022, 0.00000066, 0.000000007);
+        deepseek_vision.max_tokens = Some(393_216);
+        deepseek_vision.supports_vision = Some(true);
+        models.insert("deepseek-v4-flash-vision-exp".to_string(), deepseek_vision);
+
         Self { models }
     }
 }

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -671,7 +671,6 @@ impl Default for PricingDatabase {
         );
 
         let mut deepseek_vision = builtin_deepseek_v4_model(0.00000022, 0.00000066, 0.000000007);
-        deepseek_vision.max_tokens = Some(393_216);
         deepseek_vision.supports_vision = Some(true);
         models.insert("deepseek-v4-flash-vision-exp".to_string(), deepseek_vision);
 

--- a/src/core/pricing/tests.rs
+++ b/src/core/pricing/tests.rs
@@ -322,6 +322,13 @@ fn deepseek_v4_pricing_surfaces_use_the_off_peak_card() {
         );
     }
 
+    let assert_vision_limits = |pricing: &LiteLLMModelInfo| {
+        assert_eq!(pricing.supports_vision, Some(true));
+        assert_eq!(pricing.max_tokens, Some(1_048_576));
+        assert_eq!(pricing.max_input_tokens, Some(1_048_576));
+        assert_eq!(pricing.max_output_tokens, Some(393_216));
+    };
+
     for model in [
         "deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-flash-vision-exp",
@@ -329,19 +336,13 @@ fn deepseek_v4_pricing_surfaces_use_the_off_peak_card() {
         let Some(pricing) = embedded.get(model) else {
             panic!("embedded pricing is missing {model}");
         };
-        assert_eq!(pricing.supports_vision, Some(true));
-        assert_eq!(pricing.max_tokens, Some(393_216));
-        assert_eq!(pricing.max_input_tokens, Some(1_048_576));
-        assert_eq!(pricing.max_output_tokens, Some(393_216));
+        assert_vision_limits(pricing);
     }
 
     let Some(builtin_vision) = builtin.get_model_info("deepseek-v4-flash-vision-exp") else {
         panic!("built-in pricing is missing deepseek-v4-flash-vision-exp");
     };
-    assert_eq!(builtin_vision.supports_vision, Some(true));
-    assert_eq!(builtin_vision.max_tokens, Some(393_216));
-    assert_eq!(builtin_vision.max_input_tokens, Some(1_048_576));
-    assert_eq!(builtin_vision.max_output_tokens, Some(393_216));
+    assert_vision_limits(builtin_vision);
 
     let Some(canonical_vision) = embedded.get("deepseek-v4-flash-vision-exp") else {
         panic!("embedded pricing is missing canonical vision metadata");

--- a/src/core/pricing/tests.rs
+++ b/src/core/pricing/tests.rs
@@ -259,6 +259,7 @@ fn deepseek_v4_pricing_surfaces_use_the_off_peak_card() {
     let builtin = PricingDatabase::default();
     for (model, expected) in [
         ("deepseek-v4-flash", FLASH_RATES),
+        ("deepseek-v4-flash-vision-exp", FLASH_RATES),
         ("deepseek-chat", FLASH_RATES),
         ("deepseek-reasoner", FLASH_RATES),
         ("deepseek-v4-pro", PRO_RATES),
@@ -291,6 +292,8 @@ fn deepseek_v4_pricing_surfaces_use_the_off_peak_card() {
     for (model, expected) in [
         ("deepseek-v4-flash", FLASH_RATES),
         ("deepseek/deepseek-v4-flash", FLASH_RATES),
+        ("deepseek-v4-flash-vision-exp", FLASH_RATES),
+        ("deepseek/deepseek-v4-flash-vision-exp", FLASH_RATES),
         ("deepseek-chat", FLASH_RATES),
         ("deepseek/deepseek-chat", FLASH_RATES),
         ("deepseek-reasoner", FLASH_RATES),
@@ -316,6 +319,52 @@ fn deepseek_v4_pricing_surfaces_use_the_off_peak_card() {
                 .get("pricing_status")
                 .and_then(serde_json::Value::as_str),
             Some(PRICING_STATUS)
+        );
+    }
+
+    for model in [
+        "deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4-flash-vision-exp",
+    ] {
+        let Some(pricing) = embedded.get(model) else {
+            panic!("embedded pricing is missing {model}");
+        };
+        assert_eq!(pricing.supports_vision, Some(true));
+        assert_eq!(pricing.max_tokens, Some(393_216));
+        assert_eq!(pricing.max_input_tokens, Some(1_048_576));
+        assert_eq!(pricing.max_output_tokens, Some(393_216));
+    }
+
+    let Some(builtin_vision) = builtin.get_model_info("deepseek-v4-flash-vision-exp") else {
+        panic!("built-in pricing is missing deepseek-v4-flash-vision-exp");
+    };
+    assert_eq!(builtin_vision.supports_vision, Some(true));
+    assert_eq!(builtin_vision.max_tokens, Some(393_216));
+    assert_eq!(builtin_vision.max_input_tokens, Some(1_048_576));
+    assert_eq!(builtin_vision.max_output_tokens, Some(393_216));
+
+    let Some(canonical_vision) = embedded.get("deepseek-v4-flash-vision-exp") else {
+        panic!("embedded pricing is missing canonical vision metadata");
+    };
+    let Some(prefixed_vision) = embedded.get("deepseek/deepseek-v4-flash-vision-exp") else {
+        panic!("embedded pricing is missing prefixed vision metadata");
+    };
+    assert_eq!(
+        canonical_vision.supports_streaming,
+        prefixed_vision.supports_streaming
+    );
+    for key in [
+        "supported_endpoints",
+        "supports_assistant_prefill",
+        "supports_native_streaming",
+        "supports_reasoning",
+        "supports_system_messages",
+        "thinking_mode_default",
+    ] {
+        assert_eq!(
+            canonical_vision.extra.get(key),
+            prefixed_vision.extra.get(key),
+            "vision catalog aliases disagree on {key}"
         );
     }
 }

--- a/src/core/providers/thinking/providers.rs
+++ b/src/core/providers/thinking/providers.rs
@@ -570,6 +570,9 @@ mod deepseek_v4_tests {
     #[test]
     fn supports_deepseek_v4_thinking_models() {
         assert!(deepseek_thinking::supports_thinking("deepseek-v4-flash"));
+        assert!(deepseek_thinking::supports_thinking(
+            "deepseek-v4-flash-vision-exp"
+        ));
         assert!(deepseek_thinking::supports_thinking("deepseek-v4-pro"));
 
         let caps = deepseek_thinking::capabilities("deepseek-v4-flash");


### PR DESCRIPTION
## What

- add bare and provider-prefixed catalog rows for deepseek-v4-flash-vision-exp
- record its official Flash-equivalent off-peak pricing, 1M input context, and 384K output limit
- expose vision, reasoning, streaming, tool, JSON, and Responses metadata consistently across aliases
- add built-in/fallback coverage and update DeepSeek provider documentation

## Why

DeepSeek lists this model in its official pricing and Chat Completions documentation, but the repository has no catalog row for it.

Fixes #1193

Official sources:
- https://api-docs.deepseek.com/quick_start/pricing/
- https://api-docs.deepseek.com/api/create-chat-completion/

## Stack

This PR is based on #1192 so it contains only the vision-model addition. After #1192 merges, this PR can be retargeted to main.

## Test Plan

- [x] cargo fmt --check
- [x] cargo check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test
- [x] cargo test --lib deepseek_v4_pricing_surfaces_use_the_off_peak_card
- [x] cargo test --lib test_get_deepseek_pricing
- [x] cargo test --lib test_deepseek_fallback_pricing
- [x] cargo test --lib supports_deepseek_v4_thinking_models
- [x] sync_litellm_pricing.py regenerated metadata and both new overlay rows identically