### PR TITLE
feat(pricing): add DeepSeek V4 peak windows

### DIFF
--- a/config/model_prices_extended.json
+++ b/config/model_prices_extended.json
@@ -11325,6 +11325,14 @@
     "input_cost_per_token": 2.2e-07,
     "output_cost_per_token": 6.6e-07,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "litellm_provider": "deepseek",
     "mode": "chat",
     "supports_function_calling": true,
@@ -11343,6 +11351,14 @@
     "input_cost_per_token": 2.2e-07,
     "output_cost_per_token": 6.6e-07,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "litellm_provider": "deepseek",
     "mode": "chat",
     "supports_function_calling": true,
@@ -13842,6 +13858,14 @@
   "deepseek/deepseek-chat": {
     "cache_creation_input_token_cost": 0.0,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "input_cost_per_token": 2.2e-07,
     "input_cost_per_token_cache_hit": 7e-09,
     "litellm_provider": "deepseek",
@@ -13895,6 +13919,14 @@
   },
   "deepseek/deepseek-reasoner": {
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "input_cost_per_token": 2.2e-07,
     "input_cost_per_token_cache_hit": 7e-09,
     "litellm_provider": "deepseek",
@@ -42753,6 +42785,14 @@
     "input_cost_per_token": 2.2e-07,
     "output_cost_per_token": 6.6e-07,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "litellm_provider": "deepseek",
     "mode": "chat",
     "supports_function_calling": true,
@@ -42770,6 +42810,14 @@
     "input_cost_per_token": 2.2e-07,
     "output_cost_per_token": 6.6e-07,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "litellm_provider": "deepseek",
     "mode": "chat",
     "supported_endpoints": [
@@ -42799,6 +42847,14 @@
     "input_cost_per_token": 6.6e-07,
     "output_cost_per_token": 1.98e-06,
     "cache_read_input_token_cost": 2.2e-08,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 1.32e-06, "output_cost_per_token": 3.96e-06, "cache_read_input_token_cost": 4.4e-08}
+    },
     "litellm_provider": "deepseek",
     "mode": "chat",
     "supports_function_calling": true,
@@ -42812,6 +42868,14 @@
   "deepseek/deepseek-v4-flash": {
     "cache_creation_input_token_cost": 0.0,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "input_cost_per_token": 2.2e-07,
     "input_cost_per_token_cache_hit": 7e-09,
     "litellm_provider": "deepseek",
@@ -42838,6 +42902,14 @@
   "deepseek/deepseek-v4-flash-vision-exp": {
     "cache_creation_input_token_cost": 0.0,
     "cache_read_input_token_cost": 7e-09,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 4.4e-07, "output_cost_per_token": 1.32e-06, "cache_read_input_token_cost": 1.4e-08}
+    },
     "input_cost_per_token": 2.2e-07,
     "input_cost_per_token_cache_hit": 7e-09,
     "litellm_provider": "deepseek",
@@ -42869,6 +42941,14 @@
   "deepseek/deepseek-v4-pro": {
     "cache_creation_input_token_cost": 0.0,
     "cache_read_input_token_cost": 2.2e-08,
+    "time_of_use_pricing": {
+      "timezone": "UTC",
+      "peak_windows": [
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+        {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+      ],
+      "peak_rates": {"input_cost_per_token": 1.32e-06, "output_cost_per_token": 3.96e-06, "cache_read_input_token_cost": 4.4e-08}
+    },
     "input_cost_per_token": 6.6e-07,
     "input_cost_per_token_cache_hit": 2.2e-08,
     "litellm_provider": "deepseek",

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -4,6 +4,7 @@
 //! This eliminates code duplication and ensures consistent behavior.
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::sync::LazyLock;
 
 use crate::core::cost::types::{
@@ -13,11 +14,18 @@ use crate::core::cost::utils::select_tiered_pricing;
 use crate::core::pricing_service::{PricingCostBreakdown, PricingService, PricingUsage};
 use crate::utils::error::gateway_error::GatewayError;
 
+mod catalog;
 pub(crate) mod pricing;
 
+use self::catalog::{
+    get_pricing_with_shared_source, get_pricing_with_shared_source_at, litellm_to_cost_pricing_at,
+};
+#[cfg(test)]
+use self::catalog::{get_shared_model_pricing, litellm_to_cost_pricing};
 use self::pricing::{
-    get_anthropic_pricing, get_azure_pricing, get_deepseek_pricing, get_minimax_pricing,
-    get_moonshot_pricing, get_openai_pricing, get_vertex_ai_pricing, get_zhipu_pricing,
+    get_anthropic_pricing, get_azure_pricing, get_deepseek_pricing, get_deepseek_pricing_at,
+    get_minimax_pricing, get_moonshot_pricing, get_openai_pricing, get_vertex_ai_pricing,
+    get_zhipu_pricing,
 };
 
 /// Unified Cost Calculator Trait
@@ -57,11 +65,22 @@ pub fn generic_cost_per_token(
     usage: &UsageTokens,
     provider: &str,
 ) -> Result<CostBreakdown, CostError> {
+    generic_cost_per_token_at(model, usage, provider, Utc::now())
+}
+
+/// Calculate cost using prices effective at a specific UTC instant.
+pub fn generic_cost_per_token_at(
+    model: &str,
+    usage: &UsageTokens,
+    provider: &str,
+    pricing_time: DateTime<Utc>,
+) -> Result<CostBreakdown, CostError> {
     let pricing_usage = pricing_usage_from_cost_usage(usage);
-    match default_pricing_authority().calculate_loaded_usage_cost_for_provider(
+    match default_pricing_authority().calculate_loaded_usage_cost_for_provider_at(
         provider,
         model,
         &pricing_usage,
+        pricing_time,
     ) {
         Ok(breakdown) => {
             return Ok(pricing_breakdown_to_cost_breakdown(
@@ -77,19 +96,28 @@ pub fn generic_cost_per_token(
         }
     }
 
-    let pricing = get_fallback_model_pricing(model, provider)?;
+    let pricing = get_fallback_model_pricing_at(model, provider, pricing_time)?;
     calculate_with_model_pricing(model, provider, usage, pricing)
 }
 
 /// Get model pricing information
 pub fn get_model_pricing(model: &str, provider: &str) -> Result<ModelPricing, CostError> {
+    get_model_pricing_at(model, provider, Utc::now())
+}
+
+/// Get model pricing effective at a specific UTC instant.
+pub fn get_model_pricing_at(
+    model: &str,
+    provider: &str,
+    pricing_time: DateTime<Utc>,
+) -> Result<ModelPricing, CostError> {
     if let Some((resolved_model, info)) =
         default_pricing_authority().get_model_info_for_provider(provider, model)
     {
-        return litellm_to_cost_pricing(&resolved_model, &info);
+        return litellm_to_cost_pricing_at(&resolved_model, &info, pricing_time);
     }
 
-    get_fallback_model_pricing(model, provider)
+    get_fallback_model_pricing_at(model, provider, pricing_time)
 }
 
 fn default_pricing_authority() -> &'static PricingService {
@@ -179,6 +207,36 @@ fn get_fallback_model_pricing(model: &str, provider: &str) -> Result<ModelPricin
             provider: provider.to_string(),
         }),
     }
+}
+
+fn get_fallback_model_pricing_at(
+    model: &str,
+    provider: &str,
+    pricing_time: DateTime<Utc>,
+) -> Result<ModelPricing, CostError> {
+    let normalized_provider = crate::core::pricing::normalize_pricing_provider(provider);
+    if normalized_provider == "deepseek" {
+        return get_pricing_with_shared_source_at(
+            model,
+            &["deepseek"],
+            |model| get_deepseek_pricing_at(model, pricing_time),
+            pricing_time,
+        );
+    }
+    if normalized_provider == "openai_like" {
+        if let Some((prefixed_provider, stripped_model)) = provider_prefixed_model(model) {
+            let prefixed_provider =
+                crate::core::pricing::normalize_pricing_provider(prefixed_provider);
+            if prefixed_provider != "openai_like" {
+                return get_model_pricing_at(stripped_model, &prefixed_provider, pricing_time);
+            }
+        }
+        return Err(CostError::ModelNotSupported {
+            model: model.to_string(),
+            provider: "openai_like".to_string(),
+        });
+    }
+    get_fallback_model_pricing(model, provider)
 }
 
 #[cfg(test)]
@@ -394,258 +452,6 @@ fn provider_prefixed_model(model: &str) -> Option<(&str, &str)> {
         return None;
     }
     Some((provider, stripped_model))
-}
-
-fn get_pricing_with_shared_source<F>(
-    model: &str,
-    provider_aliases: &[&str],
-    fallback: F,
-) -> Result<ModelPricing, CostError>
-where
-    F: FnOnce(&str) -> Result<ModelPricing, CostError>,
-{
-    // Some(..) means the shared catalog matched this model; an inner Err means
-    // it matched but carried no usable pricing — that must not fall through to
-    // hardcoded defaults, or an unpriced catalog entry would bill at $0.
-    if let Some(pricing) = get_shared_model_pricing(model, provider_aliases) {
-        return pricing;
-    }
-
-    fallback(model)
-}
-
-fn get_shared_model_pricing(
-    model: &str,
-    provider_aliases: &[&str],
-) -> Option<Result<ModelPricing, CostError>> {
-    let db = crate::core::pricing::get_pricing_db();
-
-    if let Some(info) = db.get_model_info(model)
-        && litellm_provider_matches(&info.litellm_provider, provider_aliases)
-    {
-        return Some(litellm_to_cost_pricing(model, info));
-    }
-
-    let normalized_model = crate::core::pricing::normalize_model_key(model);
-    if normalized_model != model
-        && let Some(info) = db.get_model_info(normalized_model)
-        && litellm_provider_matches(&info.litellm_provider, provider_aliases)
-    {
-        return Some(litellm_to_cost_pricing(normalized_model, info));
-    }
-
-    let model_lower = normalized_model.to_lowercase();
-    for provider in provider_aliases {
-        let mut candidates = db.get_provider_models(provider);
-        candidates.sort();
-
-        for model_id in candidates {
-            let model_id_lower = model_id.to_lowercase();
-            if is_shared_model_match(&model_id_lower, &model_lower)
-                && let Some(info) = db.get_model_info(&model_id)
-                && litellm_provider_matches(&info.litellm_provider, provider_aliases)
-            {
-                return Some(litellm_to_cost_pricing(&model_id, info));
-            }
-        }
-    }
-
-    None
-}
-
-fn is_shared_model_match(candidate: &str, requested: &str) -> bool {
-    fn model_id_matches(candidate: &str, requested: &str) -> bool {
-        if candidate == requested {
-            return true;
-        }
-
-        candidate
-            .strip_prefix(requested)
-            .and_then(|suffix| suffix.strip_prefix('-'))
-            .is_some_and(alias_suffix_matches)
-    }
-
-    if candidate == requested {
-        return true;
-    }
-
-    model_id_matches(candidate, requested)
-        || model_id_matches(requested, candidate)
-        || candidate
-            .rsplit_once('/')
-            .map(|(_, model_id)| {
-                model_id_matches(model_id, requested) || model_id_matches(requested, model_id)
-            })
-            .unwrap_or(false)
-}
-
-fn alias_suffix_matches(suffix: &str) -> bool {
-    if suffix == "latest" {
-        return true;
-    }
-
-    let digit_prefix_len = suffix.chars().take_while(|ch| ch.is_ascii_digit()).count();
-    digit_prefix_len >= 4
-        && suffix
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-}
-
-fn litellm_provider_matches(provider: &str, aliases: &[&str]) -> bool {
-    let provider = crate::core::pricing::normalize_pricing_provider(provider);
-    aliases
-        .iter()
-        .any(|alias| crate::core::pricing::normalize_pricing_provider(alias) == provider)
-}
-
-fn litellm_to_cost_pricing(
-    model: &str,
-    info: &crate::core::pricing::LiteLLMModelInfo,
-) -> Result<ModelPricing, CostError> {
-    use chrono::Utc;
-
-    // A catalog entry with neither token cost is unpriced data, not a free
-    // model: charging $0 would silently under-bill, so surface it instead.
-    if info.input_cost_per_token.is_none()
-        && info.output_cost_per_token.is_none()
-        && !has_non_token_pricing(info)
-    {
-        return Err(CostError::MissingPricing {
-            model: model.to_string(),
-        });
-    }
-    // Chat/completion requests consume both prompt and completion tokens; a
-    // single missing side would under-bill real completions, so fail closed.
-    if requires_bidirectional_token_pricing(info)
-        && (info.input_cost_per_token.is_none() || info.output_cost_per_token.is_none())
-    {
-        return Err(CostError::MissingPricing {
-            model: model.to_string(),
-        });
-    }
-    // Non-chat modes such as embeddings may only price one token direction.
-    // Keep allowing that shape, but flag the gap so catalog data can be fixed.
-    if info.input_cost_per_token.is_none() || info.output_cost_per_token.is_none() {
-        tracing::warn!(
-            "model '{}' is missing {} token cost; billing that side at $0",
-            model,
-            if info.input_cost_per_token.is_none() {
-                "input"
-            } else {
-                "output"
-            }
-        );
-    }
-
-    Ok(ModelPricing {
-        model: model.to_string(),
-        input_cost_per_1k_tokens: price_per_token_to_per_1k(
-            info.input_cost_per_token.unwrap_or(0.0),
-        ),
-        output_cost_per_1k_tokens: price_per_token_to_per_1k(
-            info.output_cost_per_token.unwrap_or(0.0),
-        ),
-        cache_read_input_token_cost: extra_token_cost_per_1k(info, "cache_read_input_token_cost"),
-        cache_creation_input_token_cost: extra_token_cost_per_1k(
-            info,
-            "cache_creation_input_token_cost",
-        ),
-        input_cost_per_audio_token: extra_f64(info, "input_cost_per_audio_token"),
-        output_cost_per_audio_token: extra_f64(info, "output_cost_per_audio_token"),
-        image_cost_per_token: image_cost_per_token(info),
-        reasoning_cost_per_token: extra_f64(info, "output_cost_per_reasoning_token"),
-        cost_per_second: info.cost_per_second,
-        video_cost_per_second: extra_f64(info, "video_cost_per_second"),
-        audio_cost_per_second: extra_f64(info, "audio_cost_per_second"),
-        cost_per_image: extra_cost_per_image(model, info)?,
-        tiered_pricing: extra_tiered_pricing_per_1k(info),
-        batch_discount: extra_f64(info, "batch_discount"),
-        currency: "USD".to_string(),
-        updated_at: Utc::now(),
-    })
-}
-
-fn requires_bidirectional_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {
-    matches!(info.mode.as_str(), "chat" | "completion")
-        || (info.mode.is_empty() && !has_non_token_pricing(info))
-}
-
-fn has_non_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {
-    info.cost_per_second.is_some()
-        || extra_f64(info, "video_cost_per_second").is_some()
-        || extra_f64(info, "audio_cost_per_second").is_some()
-        || image_cost_per_token(info).is_some()
-        || extra_f64(info, "output_cost_per_image").is_some()
-}
-
-fn extra_f64(info: &crate::core::pricing::LiteLLMModelInfo, key: &str) -> Option<f64> {
-    info.extra.get(key).and_then(serde_json::Value::as_f64)
-}
-
-fn extra_token_cost_per_1k(
-    info: &crate::core::pricing::LiteLLMModelInfo,
-    key: &str,
-) -> Option<f64> {
-    extra_f64(info, key).map(price_per_token_to_per_1k)
-}
-
-fn image_cost_per_token(info: &crate::core::pricing::LiteLLMModelInfo) -> Option<f64> {
-    extra_f64(info, "image_cost_per_token")
-        .or_else(|| extra_f64(info, "output_cost_per_image_token"))
-}
-
-fn extra_cost_per_image(
-    model: &str,
-    info: &crate::core::pricing::LiteLLMModelInfo,
-) -> Result<Option<std::collections::HashMap<String, f64>>, CostError> {
-    let Some(price) = extra_f64(info, "output_cost_per_image") else {
-        return Ok(None);
-    };
-    if !price.is_finite() || price < 0.0 {
-        return Err(CostError::InvalidUsage {
-            message: format!(
-                "Invalid image pricing for model {model}: output_cost_per_image ({price})"
-            ),
-        });
-    }
-    Ok(Some(std::collections::HashMap::from([(
-        "base".to_string(),
-        price,
-    )])))
-}
-
-fn extra_tiered_pricing_per_1k(
-    info: &crate::core::pricing::LiteLLMModelInfo,
-) -> Option<std::collections::HashMap<String, f64>> {
-    let tiered = info
-        .extra
-        .iter()
-        .filter_map(|(key, value)| {
-            let is_token_tier = key.starts_with("input_cost_per_token_above_")
-                || key.starts_with("output_cost_per_token_above_")
-                || key.starts_with("cache_creation_input_token_cost_above_")
-                || key.starts_with("cache_read_input_token_cost_above_");
-
-            if is_token_tier {
-                value
-                    .as_f64()
-                    .map(|cost_per_token| (key.clone(), price_per_token_to_per_1k(cost_per_token)))
-            } else {
-                None
-            }
-        })
-        .collect::<std::collections::HashMap<_, _>>();
-
-    if tiered.is_empty() {
-        None
-    } else {
-        Some(tiered)
-    }
-}
-
-fn price_per_token_to_per_1k(cost_per_token: f64) -> f64 {
-    let cost_per_1k = cost_per_token * 1000.0;
-    (cost_per_1k * 1_000_000_000_000.0).round() / 1_000_000_000_000.0
 }
 
 /// Calculate input cost

--- a/src/core/cost/calculator/catalog.rs
+++ b/src/core/cost/calculator/catalog.rs
@@ -1,0 +1,338 @@
+use crate::core::cost::types::{CostError, ModelPricing};
+use chrono::{DateTime, Utc};
+
+pub(super) fn get_pricing_with_shared_source<F>(
+    model: &str,
+    provider_aliases: &[&str],
+    fallback: F,
+) -> Result<ModelPricing, CostError>
+where
+    F: FnOnce(&str) -> Result<ModelPricing, CostError>,
+{
+    get_pricing_with_shared_source_at(model, provider_aliases, fallback, Utc::now())
+}
+
+pub(super) fn get_pricing_with_shared_source_at<F>(
+    model: &str,
+    provider_aliases: &[&str],
+    fallback: F,
+    pricing_time: DateTime<Utc>,
+) -> Result<ModelPricing, CostError>
+where
+    F: FnOnce(&str) -> Result<ModelPricing, CostError>,
+{
+    // Some(..) means the shared catalog matched this model; an inner Err means
+    // it matched but carried no usable pricing and must not bill at $0.
+    if let Some(pricing) = get_shared_model_pricing_at(model, provider_aliases, pricing_time) {
+        return pricing;
+    }
+    fallback(model)
+}
+
+#[cfg(test)]
+pub(super) fn get_shared_model_pricing(
+    model: &str,
+    provider_aliases: &[&str],
+) -> Option<Result<ModelPricing, CostError>> {
+    get_shared_model_pricing_at(model, provider_aliases, Utc::now())
+}
+
+fn get_shared_model_pricing_at(
+    model: &str,
+    provider_aliases: &[&str],
+    pricing_time: DateTime<Utc>,
+) -> Option<Result<ModelPricing, CostError>> {
+    let db = crate::core::pricing::get_pricing_db();
+
+    if let Some(info) = db.get_model_info(model)
+        && litellm_provider_matches(&info.litellm_provider, provider_aliases)
+    {
+        return Some(litellm_to_cost_pricing_at(model, info, pricing_time));
+    }
+
+    let normalized_model = crate::core::pricing::normalize_model_key(model);
+    if normalized_model != model
+        && let Some(info) = db.get_model_info(normalized_model)
+        && litellm_provider_matches(&info.litellm_provider, provider_aliases)
+    {
+        return Some(litellm_to_cost_pricing_at(
+            normalized_model,
+            info,
+            pricing_time,
+        ));
+    }
+
+    let model_lower = normalized_model.to_lowercase();
+    for provider in provider_aliases {
+        let mut candidates = db.get_provider_models(provider);
+        candidates.sort();
+
+        for model_id in candidates {
+            let model_id_lower = model_id.to_lowercase();
+            if is_shared_model_match(&model_id_lower, &model_lower)
+                && let Some(info) = db.get_model_info(&model_id)
+                && litellm_provider_matches(&info.litellm_provider, provider_aliases)
+            {
+                return Some(litellm_to_cost_pricing_at(&model_id, info, pricing_time));
+            }
+        }
+    }
+
+    None
+}
+
+fn is_shared_model_match(candidate: &str, requested: &str) -> bool {
+    fn model_id_matches(candidate: &str, requested: &str) -> bool {
+        if candidate == requested {
+            return true;
+        }
+
+        candidate
+            .strip_prefix(requested)
+            .and_then(|suffix| suffix.strip_prefix('-'))
+            .is_some_and(alias_suffix_matches)
+    }
+
+    candidate == requested
+        || model_id_matches(candidate, requested)
+        || model_id_matches(requested, candidate)
+        || candidate
+            .rsplit_once('/')
+            .map(|(_, model_id)| {
+                model_id_matches(model_id, requested) || model_id_matches(requested, model_id)
+            })
+            .unwrap_or(false)
+}
+
+fn alias_suffix_matches(suffix: &str) -> bool {
+    if suffix == "latest" {
+        return true;
+    }
+
+    let digit_prefix_len = suffix.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    digit_prefix_len >= 4
+        && suffix
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn litellm_provider_matches(provider: &str, aliases: &[&str]) -> bool {
+    let provider = crate::core::pricing::normalize_pricing_provider(provider);
+    aliases
+        .iter()
+        .any(|alias| crate::core::pricing::normalize_pricing_provider(alias) == provider)
+}
+
+#[cfg(test)]
+pub(super) fn litellm_to_cost_pricing(
+    model: &str,
+    info: &crate::core::pricing::LiteLLMModelInfo,
+) -> Result<ModelPricing, CostError> {
+    litellm_to_cost_pricing_at(model, info, Utc::now())
+}
+
+pub(super) fn litellm_to_cost_pricing_at(
+    model: &str,
+    info: &crate::core::pricing::LiteLLMModelInfo,
+    pricing_time: DateTime<Utc>,
+) -> Result<ModelPricing, CostError> {
+    if info.input_cost_per_token.is_none()
+        && info.output_cost_per_token.is_none()
+        && !has_non_token_pricing(info)
+    {
+        return Err(CostError::MissingPricing {
+            model: model.to_string(),
+        });
+    }
+    if requires_bidirectional_token_pricing(info)
+        && (info.input_cost_per_token.is_none() || info.output_cost_per_token.is_none())
+    {
+        return Err(CostError::MissingPricing {
+            model: model.to_string(),
+        });
+    }
+    if info.input_cost_per_token.is_none() || info.output_cost_per_token.is_none() {
+        tracing::warn!(
+            "model '{}' is missing {} token cost; billing that side at $0",
+            model,
+            if info.input_cost_per_token.is_none() {
+                "input"
+            } else {
+                "output"
+            }
+        );
+    }
+
+    let peak_rates = crate::core::pricing::time_of_use::peak_token_rates_at(info, pricing_time)
+        .map_err(|message| CostError::ConfigError {
+            message: format!("Invalid time-of-use pricing for model {model}: {message}"),
+        })?;
+    let input_cost_per_token = peak_rates
+        .map(|rates| rates.input_cost_per_token)
+        .or(info.input_cost_per_token)
+        .unwrap_or(0.0);
+    let output_cost_per_token = peak_rates
+        .map(|rates| rates.output_cost_per_token)
+        .or(info.output_cost_per_token)
+        .unwrap_or(0.0);
+    let cache_read_input_token_cost = peak_rates
+        .map(|rates| price_per_token_to_per_1k(rates.cache_read_input_token_cost))
+        .or_else(|| extra_token_cost_per_1k(info, "cache_read_input_token_cost"));
+
+    Ok(ModelPricing {
+        model: model.to_string(),
+        input_cost_per_1k_tokens: price_per_token_to_per_1k(input_cost_per_token),
+        output_cost_per_1k_tokens: price_per_token_to_per_1k(output_cost_per_token),
+        cache_read_input_token_cost,
+        cache_creation_input_token_cost: extra_token_cost_per_1k(
+            info,
+            "cache_creation_input_token_cost",
+        ),
+        input_cost_per_audio_token: extra_f64(info, "input_cost_per_audio_token"),
+        output_cost_per_audio_token: extra_f64(info, "output_cost_per_audio_token"),
+        image_cost_per_token: image_cost_per_token(info),
+        reasoning_cost_per_token: extra_f64(info, "output_cost_per_reasoning_token"),
+        cost_per_second: info.cost_per_second,
+        video_cost_per_second: extra_f64(info, "video_cost_per_second"),
+        audio_cost_per_second: extra_f64(info, "audio_cost_per_second"),
+        cost_per_image: extra_cost_per_image(model, info)?,
+        tiered_pricing: extra_tiered_pricing_per_1k(info),
+        batch_discount: extra_f64(info, "batch_discount"),
+        currency: "USD".to_string(),
+        updated_at: pricing_time,
+    })
+}
+
+fn requires_bidirectional_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {
+    matches!(info.mode.as_str(), "chat" | "completion")
+        || (info.mode.is_empty() && !has_non_token_pricing(info))
+}
+
+fn has_non_token_pricing(info: &crate::core::pricing::LiteLLMModelInfo) -> bool {
+    info.cost_per_second.is_some()
+        || extra_f64(info, "video_cost_per_second").is_some()
+        || extra_f64(info, "audio_cost_per_second").is_some()
+        || image_cost_per_token(info).is_some()
+        || extra_f64(info, "output_cost_per_image").is_some()
+}
+
+fn extra_f64(info: &crate::core::pricing::LiteLLMModelInfo, key: &str) -> Option<f64> {
+    info.extra.get(key).and_then(serde_json::Value::as_f64)
+}
+
+fn extra_token_cost_per_1k(
+    info: &crate::core::pricing::LiteLLMModelInfo,
+    key: &str,
+) -> Option<f64> {
+    extra_f64(info, key).map(price_per_token_to_per_1k)
+}
+
+fn image_cost_per_token(info: &crate::core::pricing::LiteLLMModelInfo) -> Option<f64> {
+    extra_f64(info, "image_cost_per_token")
+        .or_else(|| extra_f64(info, "output_cost_per_image_token"))
+}
+
+fn extra_cost_per_image(
+    model: &str,
+    info: &crate::core::pricing::LiteLLMModelInfo,
+) -> Result<Option<std::collections::HashMap<String, f64>>, CostError> {
+    let Some(price) = extra_f64(info, "output_cost_per_image") else {
+        return Ok(None);
+    };
+    if !price.is_finite() || price < 0.0 {
+        return Err(CostError::InvalidUsage {
+            message: format!(
+                "Invalid image pricing for model {model}: output_cost_per_image ({price})"
+            ),
+        });
+    }
+    Ok(Some(std::collections::HashMap::from([(
+        "base".to_string(),
+        price,
+    )])))
+}
+
+fn extra_tiered_pricing_per_1k(
+    info: &crate::core::pricing::LiteLLMModelInfo,
+) -> Option<std::collections::HashMap<String, f64>> {
+    let tiered = info
+        .extra
+        .iter()
+        .filter_map(|(key, value)| {
+            let is_token_tier = key.starts_with("input_cost_per_token_above_")
+                || key.starts_with("output_cost_per_token_above_")
+                || key.starts_with("cache_creation_input_token_cost_above_")
+                || key.starts_with("cache_read_input_token_cost_above_");
+
+            if is_token_tier {
+                value
+                    .as_f64()
+                    .map(|cost_per_token| (key.clone(), price_per_token_to_per_1k(cost_per_token)))
+            } else {
+                None
+            }
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+
+    if tiered.is_empty() {
+        None
+    } else {
+        Some(tiered)
+    }
+}
+
+fn price_per_token_to_per_1k(cost_per_token: f64) -> f64 {
+    let cost_per_1k = cost_per_token * 1000.0;
+    (cost_per_1k * 1_000_000_000_000.0).round() / 1_000_000_000_000.0
+}
+
+#[cfg(test)]
+mod time_of_use_tests {
+    use super::*;
+    use crate::core::cost::calculator::{generic_cost_per_token_at, get_model_pricing_at};
+    use crate::core::cost::types::UsageTokens;
+    use chrono::TimeZone;
+
+    #[test]
+    fn compatibility_apis_apply_deepseek_peak_rates() {
+        let mut usage = UsageTokens::new(1_000, 1_000);
+        usage.cached_tokens = Some(250);
+        let off_peak = Utc.with_ymd_and_hms(2026, 8, 29, 2, 0, 0).unwrap();
+        let peak = Utc.with_ymd_and_hms(2026, 8, 24, 2, 0, 0).unwrap();
+
+        for model in [
+            "deepseek-chat",
+            "deepseek-v4-flash-vision-exp",
+            "deepseek-v4-pro",
+            "deepseek/deepseek-reasoner",
+        ] {
+            let off_peak_cost =
+                generic_cost_per_token_at(model, &usage, "deepseek", off_peak).unwrap();
+            let peak_cost = generic_cost_per_token_at(model, &usage, "deepseek", peak).unwrap();
+            assert!(
+                (peak_cost.total_cost - off_peak_cost.total_cost * 2.0).abs() < 1e-12,
+                "{model} should use peak token and cache rates"
+            );
+
+            let off_peak_pricing = get_model_pricing_at(model, "deepseek", off_peak).unwrap();
+            let peak_pricing = get_model_pricing_at(model, "deepseek", peak).unwrap();
+            assert_eq!(
+                peak_pricing.input_cost_per_1k_tokens,
+                off_peak_pricing.input_cost_per_1k_tokens * 2.0
+            );
+            assert_eq!(
+                peak_pricing.cache_read_input_token_cost,
+                off_peak_pricing
+                    .cache_read_input_token_cost
+                    .map(|rate| rate * 2.0)
+            );
+        }
+
+        let prefixed_unlisted = "deepseek/deepseek-v4-flash-vision-exp-unlisted";
+        let off_peak_cost =
+            generic_cost_per_token_at(prefixed_unlisted, &usage, "openai_like", off_peak).unwrap();
+        let peak_cost =
+            generic_cost_per_token_at(prefixed_unlisted, &usage, "openai_like", peak).unwrap();
+        assert!((peak_cost.total_cost - off_peak_cost.total_cost * 2.0).abs() < 1e-12);
+    }
+}

--- a/src/core/cost/calculator/pricing.rs
+++ b/src/core/cost/calculator/pricing.rs
@@ -513,19 +513,28 @@ pub(super) fn get_vertex_ai_pricing(model: &str) -> Result<ModelPricing, CostErr
 }
 
 pub(super) fn get_deepseek_pricing(model: &str) -> Result<ModelPricing, CostError> {
-    use chrono::Utc;
+    get_deepseek_pricing_at(model, chrono::Utc::now())
+}
 
-    // DeepSeek publishes peak and off-peak V4 rates. This scalar compatibility
-    // surface uses the official off-peak card checked on 2026-08-24; peak-hour
-    // selection requires a separate time-of-use pricing model.
+pub(super) fn get_deepseek_pricing_at(
+    model: &str,
+    pricing_time: chrono::DateTime<chrono::Utc>,
+) -> Result<ModelPricing, CostError> {
+    let multiplier = if crate::core::pricing::time_of_use::is_deepseek_v4_peak_at(pricing_time) {
+        2.0
+    } else {
+        1.0
+    };
+
+    // DeepSeek's published V4 peak card is exactly twice its off-peak card.
     let pricing = match model.to_lowercase().as_str() {
         m if m.contains("deepseek-v4-pro") => ModelPricing {
             model: model.to_string(),
-            input_cost_per_1k_tokens: 0.00066,
-            output_cost_per_1k_tokens: 0.00198,
-            cache_read_input_token_cost: Some(0.000022),
+            input_cost_per_1k_tokens: 0.00066 * multiplier,
+            output_cost_per_1k_tokens: 0.00198 * multiplier,
+            cache_read_input_token_cost: Some(0.000022 * multiplier),
             currency: "USD".to_string(),
-            updated_at: Utc::now(),
+            updated_at: pricing_time,
             ..Default::default()
         },
         m if m.contains("deepseek-v4-flash")
@@ -534,11 +543,11 @@ pub(super) fn get_deepseek_pricing(model: &str) -> Result<ModelPricing, CostErro
         {
             ModelPricing {
                 model: model.to_string(),
-                input_cost_per_1k_tokens: 0.00022,
-                output_cost_per_1k_tokens: 0.00066,
-                cache_read_input_token_cost: Some(0.000007),
+                input_cost_per_1k_tokens: 0.00022 * multiplier,
+                output_cost_per_1k_tokens: 0.00066 * multiplier,
+                cache_read_input_token_cost: Some(0.000007 * multiplier),
                 currency: "USD".to_string(),
-                updated_at: Utc::now(),
+                updated_at: pricing_time,
                 ..Default::default()
             }
         }
@@ -634,4 +643,35 @@ pub(super) fn get_moonshot_pricing(model: &str) -> Result<ModelPricing, CostErro
     };
 
     Ok(pricing)
+}
+
+#[cfg(test)]
+mod deepseek_time_of_use_tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn hardcoded_fallback_uses_the_documented_utc_schedule() {
+        let off_peak = Utc.with_ymd_and_hms(2026, 8, 29, 2, 0, 0).unwrap();
+        let peak = Utc.with_ymd_and_hms(2026, 8, 24, 2, 0, 0).unwrap();
+
+        for model in ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat"] {
+            let off_peak_pricing = get_deepseek_pricing_at(model, off_peak).unwrap();
+            let peak_pricing = get_deepseek_pricing_at(model, peak).unwrap();
+            assert_eq!(
+                peak_pricing.input_cost_per_1k_tokens,
+                off_peak_pricing.input_cost_per_1k_tokens * 2.0
+            );
+            assert_eq!(
+                peak_pricing.output_cost_per_1k_tokens,
+                off_peak_pricing.output_cost_per_1k_tokens * 2.0
+            );
+            assert_eq!(
+                peak_pricing.cache_read_input_token_cost,
+                off_peak_pricing
+                    .cache_read_input_token_cost
+                    .map(|rate| rate * 2.0)
+            );
+        }
+    }
 }

--- a/src/core/cost/calculator/tests/pricing_lookup_tests.rs
+++ b/src/core/cost/calculator/tests/pricing_lookup_tests.rs
@@ -319,44 +319,50 @@ fn test_runtime_pricing_keeps_unprefixed_openai_like_models_strict() {
 
 #[test]
 fn test_get_deepseek_pricing() {
-    let Ok(flash) = get_model_pricing("deepseek-v4-flash", "deepseek") else {
+    use chrono::{TimeZone, Utc};
+    let off_peak = Utc.with_ymd_and_hms(2026, 8, 29, 2, 0, 0).unwrap();
+
+    let Ok(flash) = get_model_pricing_at("deepseek-v4-flash", "deepseek", off_peak) else {
         panic!("deepseek-v4-flash pricing should be available");
     };
     assert_cost_eq(flash.input_cost_per_1k_tokens, 0.00022);
     assert_cost_eq(flash.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(flash.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(pro) = get_model_pricing("deepseek-v4-pro", "deepseek") else {
+    let Ok(pro) = get_model_pricing_at("deepseek-v4-pro", "deepseek", off_peak) else {
         panic!("deepseek-v4-pro pricing should be available");
     };
     assert_cost_eq(pro.input_cost_per_1k_tokens, 0.00066);
     assert_cost_eq(pro.output_cost_per_1k_tokens, 0.00198);
     assert_eq!(pro.cache_read_input_token_cost, Some(0.000022));
 
-    let Ok(chat_alias) = get_model_pricing("deepseek-chat", "deepseek") else {
+    let Ok(chat_alias) = get_model_pricing_at("deepseek-chat", "deepseek", off_peak) else {
         panic!("deepseek-chat alias pricing should be available");
     };
     assert_cost_eq(chat_alias.input_cost_per_1k_tokens, 0.00022);
     assert_cost_eq(chat_alias.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(chat_alias.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(reasoner_alias) = get_model_pricing("deepseek-reasoner", "deepseek") else {
+    let Ok(reasoner_alias) = get_model_pricing_at("deepseek-reasoner", "deepseek", off_peak) else {
         panic!("deepseek-reasoner alias pricing should be available");
     };
     assert_cost_eq(reasoner_alias.input_cost_per_1k_tokens, 0.00022);
     assert_cost_eq(reasoner_alias.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(reasoner_alias.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(vision) = get_model_pricing("deepseek-v4-flash-vision-exp", "deepseek") else {
+    let Ok(vision) = get_model_pricing_at("deepseek-v4-flash-vision-exp", "deepseek", off_peak)
+    else {
         panic!("deepseek-v4-flash-vision-exp pricing should be available");
     };
     assert_cost_eq(vision.input_cost_per_1k_tokens, 0.00022);
     assert_cost_eq(vision.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(vision.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(prefixed_vision) =
-        get_model_pricing("deepseek/deepseek-v4-flash-vision-exp", "deepseek")
-    else {
+    let Ok(prefixed_vision) = get_model_pricing_at(
+        "deepseek/deepseek-v4-flash-vision-exp",
+        "deepseek",
+        off_peak,
+    ) else {
         panic!("prefixed deepseek-v4-flash-vision-exp pricing should be available");
     };
     assert_cost_eq(prefixed_vision.input_cost_per_1k_tokens, 0.00022);
@@ -366,21 +372,27 @@ fn test_get_deepseek_pricing() {
 
 #[test]
 fn test_deepseek_fallback_pricing() {
-    let Ok(flash) = super::super::pricing::get_deepseek_pricing("deepseek-v4-flash") else {
+    use chrono::{TimeZone, Utc};
+    let off_peak = Utc.with_ymd_and_hms(2026, 8, 29, 2, 0, 0).unwrap();
+
+    let Ok(flash) = super::super::pricing::get_deepseek_pricing_at("deepseek-v4-flash", off_peak)
+    else {
         panic!("deepseek-v4-flash fallback pricing should be available");
     };
     assert_cost_eq(flash.input_cost_per_1k_tokens, 0.00022);
     assert_cost_eq(flash.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(flash.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(pro) = super::super::pricing::get_deepseek_pricing("deepseek-v4-pro") else {
+    let Ok(pro) = super::super::pricing::get_deepseek_pricing_at("deepseek-v4-pro", off_peak)
+    else {
         panic!("deepseek-v4-pro fallback pricing should be available");
     };
     assert_cost_eq(pro.input_cost_per_1k_tokens, 0.00066);
     assert_cost_eq(pro.output_cost_per_1k_tokens, 0.00198);
     assert_eq!(pro.cache_read_input_token_cost, Some(0.000022));
 
-    let Ok(vision) = super::super::pricing::get_deepseek_pricing("deepseek-v4-flash-vision-exp")
+    let Ok(vision) =
+        super::super::pricing::get_deepseek_pricing_at("deepseek-v4-flash-vision-exp", off_peak)
     else {
         panic!("deepseek-v4-flash-vision-exp fallback pricing should be available");
     };
@@ -388,9 +400,11 @@ fn test_deepseek_fallback_pricing() {
     assert_cost_eq(vision.output_cost_per_1k_tokens, 0.00066);
     assert_eq!(vision.cache_read_input_token_cost, Some(0.000007));
 
-    let Ok(unlisted_vision_alias) =
-        get_model_pricing("deepseek-v4-flash-vision-exp-unlisted", "deepseek")
-    else {
+    let Ok(unlisted_vision_alias) = get_model_pricing_at(
+        "deepseek-v4-flash-vision-exp-unlisted",
+        "deepseek",
+        off_peak,
+    ) else {
         panic!("an unlisted DeepSeek V4 Flash alias should use fallback pricing");
     };
     assert_cost_eq(unlisted_vision_alias.input_cost_per_1k_tokens, 0.00022);

--- a/src/core/cost/mod.rs
+++ b/src/core/cost/mod.rs
@@ -19,7 +19,8 @@ pub mod utils;
     note = "use core::cost::calculator::* directly or PricingService for runtime pricing; removal is no earlier than 0.7.0"
 )]
 pub use calculator::{
-    CostCalculator, compare_model_costs, estimate_cost, generic_cost_per_token, get_model_pricing,
+    CostCalculator, compare_model_costs, estimate_cost, generic_cost_per_token,
+    generic_cost_per_token_at, get_model_pricing, get_model_pricing_at,
 };
 #[deprecated(
     note = "use core::pricing_service::CostResult; this legacy shape is retained only for compatibility and removal is no earlier than 0.7.0"

--- a/src/core/pricing.rs
+++ b/src/core/pricing.rs
@@ -1,11 +1,14 @@
 //! Shared pricing data types.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::LazyLock;
-use tracing::warn;
+use tracing::{error, warn};
+
+pub(crate) mod time_of_use;
 
 const EMBEDDED_MODEL_PRICES: &str = include_str!("../../config/model_prices_extended.json");
 
@@ -191,15 +194,20 @@ impl PricingDatabase {
 
     /// Calculate cost for a model and token usage.
     pub fn calculate(&self, model: &str, usage: &Usage) -> f64 {
+        self.calculate_at(model, usage, Utc::now())
+    }
+
+    /// Calculate cost for a model and token usage at a specific UTC instant.
+    pub fn calculate_at(&self, model: &str, usage: &Usage, at: DateTime<Utc>) -> f64 {
         if let Some(pricing) = self.models.get(model) {
-            return self.calculate_with_pricing(pricing, usage);
+            return self.calculate_with_pricing_at(pricing, usage, at);
         }
 
         let normalized_model = normalize_model_key(model);
         if normalized_model != model
             && let Some(pricing) = self.models.get(normalized_model)
         {
-            return self.calculate_with_pricing(pricing, usage);
+            return self.calculate_with_pricing_at(pricing, usage, at);
         }
 
         if let Some((_, pricing)) = self
@@ -208,7 +216,7 @@ impl PricingDatabase {
             .filter(|(key, _)| model_matches_key(normalized_model, key))
             .max_by_key(|(key, _)| key.len())
         {
-            return self.calculate_with_pricing(pricing, usage);
+            return self.calculate_with_pricing_at(pricing, usage, at);
         }
 
         0.0
@@ -219,10 +227,21 @@ impl PricingDatabase {
     /// Provider dispatch should use this method instead of `calculate` so a
     /// same-named model on another provider does not accidentally supply prices.
     pub fn calculate_for_provider(&self, provider: &str, model: &str, usage: &Usage) -> f64 {
+        self.calculate_for_provider_at(provider, model, usage, Utc::now())
+    }
+
+    /// Calculate cost for a provider/model pair at a specific UTC instant.
+    pub fn calculate_for_provider_at(
+        &self,
+        provider: &str,
+        model: &str,
+        usage: &Usage,
+        at: DateTime<Utc>,
+    ) -> f64 {
         if let Some(pricing) = self.models.get(model)
             && pricing_matches_provider(model, pricing, provider)
         {
-            return self.calculate_with_pricing(pricing, usage);
+            return self.calculate_with_pricing_at(pricing, usage, at);
         }
 
         let normalized_model = normalize_model_key(model);
@@ -230,7 +249,7 @@ impl PricingDatabase {
             && let Some(pricing) = self.models.get(normalized_model)
             && pricing_matches_provider(normalized_model, pricing, provider)
         {
-            return self.calculate_with_pricing(pricing, usage);
+            return self.calculate_with_pricing_at(pricing, usage, at);
         }
 
         if let Some((_, pricing)) = self
@@ -242,13 +261,18 @@ impl PricingDatabase {
             })
             .max_by_key(|(key, _)| key.len())
         {
-            return self.calculate_with_pricing(pricing, usage);
+            return self.calculate_with_pricing_at(pricing, usage, at);
         }
 
         0.0
     }
 
-    fn calculate_with_pricing(&self, pricing: &ModelPricing, usage: &Usage) -> f64 {
+    fn calculate_with_pricing_at(
+        &self,
+        pricing: &ModelPricing,
+        usage: &Usage,
+        at: DateTime<Utc>,
+    ) -> f64 {
         let mut cost = 0.0;
 
         if requires_bidirectional_database_token_pricing(pricing)
@@ -261,15 +285,35 @@ impl PricingDatabase {
             return 0.0;
         }
 
+        let peak_rates = match time_of_use::peak_token_rates_at(pricing, at) {
+            Ok(rates) => rates,
+            Err(message) => {
+                error!(
+                    provider = %pricing.litellm_provider,
+                    mode = %pricing.mode,
+                    error = %message,
+                    "invalid time-of-use pricing; refusing to calculate a partial cost"
+                );
+                return 0.0;
+            }
+        };
+        let base_input_cost = peak_rates
+            .map(|rates| rates.input_cost_per_token)
+            .or(pricing.input_cost_per_token)
+            .unwrap_or(0.0);
+        let base_output_cost = peak_rates
+            .map(|rates| rates.output_cost_per_token)
+            .or(pricing.output_cost_per_token)
+            .unwrap_or(0.0);
         let input_cost_per_token = tiered_cost_per_token(
             pricing,
-            pricing.input_cost_per_token.unwrap_or(0.0),
+            base_input_cost,
             "input_cost_per_token_above_",
             usage.prompt_tokens,
         );
         let output_cost_per_token = tiered_cost_per_token(
             pricing,
-            pricing.output_cost_per_token.unwrap_or(0.0),
+            base_output_cost,
             "output_cost_per_token_above_",
             usage.prompt_tokens,
         );
@@ -571,6 +615,21 @@ fn builtin_deepseek_v4_model(
         serde_json::Value::from(cache_read_input_token_cost),
     );
     model.extra.insert(
+        time_of_use::TIME_OF_USE_PRICING_KEY.to_string(),
+        serde_json::json!({
+            "timezone": "UTC",
+            "peak_windows": [
+                {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+                {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+            ],
+            "peak_rates": {
+                "input_cost_per_token": input_cost_per_token * 2.0,
+                "output_cost_per_token": output_cost_per_token * 2.0,
+                "cache_read_input_token_cost": cache_read_input_token_cost * 2.0
+            }
+        }),
+    );
+    model.extra.insert(
         "pricing_status".to_string(),
         serde_json::Value::from("official_off_peak_rate_checked_2026_08_24"),
     );
@@ -710,11 +769,19 @@ pub fn parse_litellm_pricing_json(
     content: &str,
 ) -> Result<HashMap<String, LiteLLMModelInfo>, serde_json::Error> {
     let all_data: HashMap<String, serde_json::Value> = serde_json::from_str(content)?;
-    all_data
+    let models: HashMap<String, LiteLLMModelInfo> = all_data
         .into_iter()
         .filter(|(key, _)| !is_litellm_pricing_metadata_key(key))
         .map(|(key, value)| serde_json::from_value(value).map(|pricing| (key, pricing)))
-        .collect()
+        .collect::<Result<_, _>>()?;
+    for (model, info) in &models {
+        time_of_use::validate_time_of_use_pricing(info).map_err(|message| {
+            <serde_json::Error as serde::de::Error>::custom(format!(
+                "invalid pricing for model {model}: {message}"
+            ))
+        })?;
+    }
+    Ok(models)
 }
 
 pub(crate) fn embedded_default_pricing_models() -> serde_json::Result<PricingModelMap> {

--- a/src/core/pricing/tests.rs
+++ b/src/core/pricing/tests.rs
@@ -74,6 +74,64 @@ fn parse_litellm_pricing_json_rejects_malformed_model_entries() {
 }
 
 #[test]
+fn parse_litellm_pricing_json_rejects_malformed_time_of_use_pricing() {
+    let cases = [
+        (
+            "timezone",
+            serde_json::json!({
+                "timezone": "Asia/Shanghai",
+                "peak_windows": [{"weekdays": [1], "start_hour": 1, "end_hour": 4}],
+                "peak_rates": {"input_cost_per_token": 1.0, "output_cost_per_token": 2.0, "cache_read_input_token_cost": 0.5}
+            }),
+        ),
+        (
+            "weekday",
+            serde_json::json!({
+                "timezone": "UTC",
+                "peak_windows": [{"weekdays": [0], "start_hour": 1, "end_hour": 4}],
+                "peak_rates": {"input_cost_per_token": 1.0, "output_cost_per_token": 2.0, "cache_read_input_token_cost": 0.5}
+            }),
+        ),
+        (
+            "window",
+            serde_json::json!({
+                "timezone": "UTC",
+                "peak_windows": [{"weekdays": [1], "start_hour": 4, "end_hour": 4}],
+                "peak_rates": {"input_cost_per_token": 1.0, "output_cost_per_token": 2.0, "cache_read_input_token_cost": 0.5}
+            }),
+        ),
+        (
+            "rate",
+            serde_json::json!({
+                "timezone": "UTC",
+                "peak_windows": [{"weekdays": [1], "start_hour": 1, "end_hour": 4}],
+                "peak_rates": {"input_cost_per_token": -1.0, "output_cost_per_token": 2.0, "cache_read_input_token_cost": 0.5}
+            }),
+        ),
+    ];
+
+    for (case, schedule) in cases {
+        let content = serde_json::json!({
+            "bad-time-priced-model": {
+                "input_cost_per_token": 0.000001,
+                "output_cost_per_token": 0.000002,
+                "litellm_provider": "test",
+                "mode": "chat",
+                "time_of_use_pricing": schedule
+            }
+        })
+        .to_string();
+        let error = parse_litellm_pricing_json(&content).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("bad-time-priced-model"),
+            "{case}: {message}"
+        );
+        assert!(message.contains("time_of_use_pricing"), "{case}: {message}");
+    }
+}
+
+#[test]
 fn parse_litellm_pricing_json_accepts_integral_float_token_limits_and_missing_mode() {
     let content = r#"{
             "float-token-model": {
@@ -716,6 +774,43 @@ fn test_default_source_loads_shared_pricing_file() {
 
     assert!(db.get_model_info("gpt-4o").is_some());
     assert!(db.calculate("gpt-4o", &Usage::new(1000, 500)) > 0.0);
+}
+
+#[test]
+fn deepseek_v4_catalog_rows_select_peak_rates_at_utc_boundaries() {
+    use chrono::{TimeZone, Utc};
+
+    let db = PricingDatabase::from_default_source().unwrap();
+    let usage = Usage::new(1_000, 1_000);
+    let off_peak = Utc.with_ymd_and_hms(2026, 8, 24, 4, 0, 0).unwrap();
+    let peak = Utc.with_ymd_and_hms(2026, 8, 24, 6, 0, 0).unwrap();
+    let models = [
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
+        "deepseek-v4-pro",
+        "deepseek/deepseek-chat",
+        "deepseek/deepseek-reasoner",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4-pro",
+    ];
+
+    for model in models {
+        let info = db.get_model_info(model).unwrap();
+        assert!(
+            info.extra
+                .contains_key(time_of_use::TIME_OF_USE_PRICING_KEY)
+        );
+        let off_peak_cost = db.calculate_for_provider_at("deepseek", model, &usage, off_peak);
+        let peak_cost = db.calculate_for_provider_at("deepseek", model, &usage, peak);
+        assert!(off_peak_cost > 0.0, "{model} should have an off-peak cost");
+        assert!(
+            (peak_cost - off_peak_cost * 2.0).abs() < 1e-12,
+            "{model} peak cost {peak_cost} should be twice off-peak {off_peak_cost}"
+        );
+    }
 }
 
 #[test]

--- a/src/core/pricing/time_of_use.rs
+++ b/src/core/pricing/time_of_use.rs
@@ -1,0 +1,285 @@
+use chrono::{DateTime, Datelike, Timelike, Utc};
+use serde::Deserialize;
+
+use super::LiteLLMModelInfo;
+
+pub(crate) const TIME_OF_USE_PRICING_KEY: &str = "time_of_use_pricing";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct TokenRates {
+    pub input_cost_per_token: f64,
+    pub output_cost_per_token: f64,
+    pub cache_read_input_token_cost: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TimeOfUsePricing {
+    timezone: String,
+    peak_windows: Vec<WeeklyPeakWindow>,
+    peak_rates: TokenRatesConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WeeklyPeakWindow {
+    weekdays: Vec<u8>,
+    start_hour: u8,
+    end_hour: u8,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TokenRatesConfig {
+    input_cost_per_token: f64,
+    output_cost_per_token: f64,
+    cache_read_input_token_cost: f64,
+}
+
+/// Return peak token rates when `at` falls inside a configured UTC window.
+///
+/// A missing `time_of_use_pricing` entry means the catalog's scalar rates
+/// apply. A present entry is validated completely so malformed schedules
+/// cannot silently fall back to a cheaper rate.
+pub(crate) fn peak_token_rates_at(
+    model_info: &LiteLLMModelInfo,
+    at: DateTime<Utc>,
+) -> Result<Option<TokenRates>, String> {
+    let Some(pricing) = parse_time_of_use_pricing(model_info)? else {
+        return Ok(None);
+    };
+
+    if pricing
+        .peak_windows
+        .iter()
+        .any(|window| window.contains(at))
+    {
+        Ok(Some(pricing.peak_rates.into()))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Validate an optional time-of-use declaration without selecting a rate.
+pub(crate) fn validate_time_of_use_pricing(model_info: &LiteLLMModelInfo) -> Result<(), String> {
+    parse_time_of_use_pricing(model_info).map(|_| ())
+}
+
+/// Return the highest configured rates for conservative budget reservation.
+pub(crate) fn configured_peak_token_rates(
+    model_info: &LiteLLMModelInfo,
+) -> Result<Option<TokenRates>, String> {
+    Ok(parse_time_of_use_pricing(model_info)?.map(|pricing| {
+        let mut rates: TokenRates = pricing.peak_rates.into();
+        let base_input = model_info.input_cost_per_token.unwrap_or(0.0);
+        let base_output = model_info.output_cost_per_token.unwrap_or(0.0);
+        let base_cache_read = model_info
+            .extra
+            .get("cache_read_input_token_cost")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(base_input);
+        rates.input_cost_per_token = rates.input_cost_per_token.max(base_input);
+        rates.output_cost_per_token = rates.output_cost_per_token.max(base_output);
+        rates.cache_read_input_token_cost = rates.cache_read_input_token_cost.max(base_cache_read);
+        rates
+    }))
+}
+
+fn parse_time_of_use_pricing(
+    model_info: &LiteLLMModelInfo,
+) -> Result<Option<TimeOfUsePricing>, String> {
+    let Some(value) = model_info.extra.get(TIME_OF_USE_PRICING_KEY) else {
+        return Ok(None);
+    };
+
+    let pricing: TimeOfUsePricing = serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid {TIME_OF_USE_PRICING_KEY}: {error}"))?;
+    pricing.validate()?;
+    Ok(Some(pricing))
+}
+
+/// DeepSeek V4's documented peak schedule, used only by the legacy fallback
+/// when no catalog row is available.
+pub(crate) fn is_deepseek_v4_peak_at(at: DateTime<Utc>) -> bool {
+    let weekday = at.weekday().number_from_monday();
+    let hour = at.hour();
+    weekday <= 5 && ((1..4).contains(&hour) || (6..10).contains(&hour))
+}
+
+impl TimeOfUsePricing {
+    fn validate(&self) -> Result<(), String> {
+        if self.timezone != "UTC" {
+            return Err(format!(
+                "{TIME_OF_USE_PRICING_KEY}.timezone must be UTC, got {:?}",
+                self.timezone
+            ));
+        }
+        if self.peak_windows.is_empty() {
+            return Err(format!(
+                "{TIME_OF_USE_PRICING_KEY}.peak_windows must not be empty"
+            ));
+        }
+        for (index, window) in self.peak_windows.iter().enumerate() {
+            window.validate(index)?;
+        }
+        self.peak_rates.validate()
+    }
+}
+
+impl WeeklyPeakWindow {
+    fn validate(&self, index: usize) -> Result<(), String> {
+        if self.weekdays.is_empty()
+            || self
+                .weekdays
+                .iter()
+                .any(|weekday| !(1..=7).contains(weekday))
+        {
+            return Err(format!(
+                "{TIME_OF_USE_PRICING_KEY}.peak_windows[{index}].weekdays must contain ISO weekdays 1 through 7"
+            ));
+        }
+        if self.start_hour >= self.end_hour || self.end_hour > 24 {
+            return Err(format!(
+                "{TIME_OF_USE_PRICING_KEY}.peak_windows[{index}] must satisfy start_hour < end_hour <= 24"
+            ));
+        }
+        Ok(())
+    }
+
+    fn contains(&self, at: DateTime<Utc>) -> bool {
+        let weekday = at.weekday().number_from_monday() as u8;
+        let hour = at.hour() as u8;
+        self.weekdays.contains(&weekday) && hour >= self.start_hour && hour < self.end_hour
+    }
+}
+
+impl TokenRatesConfig {
+    fn validate(&self) -> Result<(), String> {
+        for (name, rate) in [
+            ("input_cost_per_token", self.input_cost_per_token),
+            ("output_cost_per_token", self.output_cost_per_token),
+            (
+                "cache_read_input_token_cost",
+                self.cache_read_input_token_cost,
+            ),
+        ] {
+            if !rate.is_finite() || rate < 0.0 {
+                return Err(format!(
+                    "{TIME_OF_USE_PRICING_KEY}.peak_rates.{name} must be finite and non-negative"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl From<TokenRatesConfig> for TokenRates {
+    fn from(rates: TokenRatesConfig) -> Self {
+        Self {
+            input_cost_per_token: rates.input_cost_per_token,
+            output_cost_per_token: rates.output_cost_per_token,
+            cache_read_input_token_cost: rates.cache_read_input_token_cost,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::collections::HashMap;
+
+    fn model_info(schedule: serde_json::Value) -> LiteLLMModelInfo {
+        LiteLLMModelInfo {
+            max_tokens: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            input_cost_per_token: Some(1.0),
+            output_cost_per_token: Some(2.0),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: "test".to_string(),
+            mode: "chat".to_string(),
+            supports_function_calling: None,
+            supports_vision: None,
+            supports_streaming: None,
+            supports_parallel_function_calling: None,
+            supports_system_message: None,
+            extra: HashMap::from([(TIME_OF_USE_PRICING_KEY.to_string(), schedule)]),
+        }
+    }
+
+    fn deepseek_schedule() -> serde_json::Value {
+        serde_json::json!({
+            "timezone": "UTC",
+            "peak_windows": [
+                {"weekdays": [1, 2, 3, 4, 5], "start_hour": 1, "end_hour": 4},
+                {"weekdays": [1, 2, 3, 4, 5], "start_hour": 6, "end_hour": 10}
+            ],
+            "peak_rates": {
+                "input_cost_per_token": 3.0,
+                "output_cost_per_token": 4.0,
+                "cache_read_input_token_cost": 5.0
+            }
+        })
+    }
+
+    #[test]
+    fn selects_half_open_weekday_peak_windows() {
+        let info = model_info(deepseek_schedule());
+        for (hour, minute, is_peak) in [
+            (0, 59, false),
+            (1, 0, true),
+            (3, 59, true),
+            (4, 0, false),
+            (5, 59, false),
+            (6, 0, true),
+            (9, 59, true),
+            (10, 0, false),
+        ] {
+            let at = Utc.with_ymd_and_hms(2026, 8, 24, hour, minute, 0).unwrap();
+            assert_eq!(peak_token_rates_at(&info, at).unwrap().is_some(), is_peak);
+        }
+
+        let saturday = Utc.with_ymd_and_hms(2026, 8, 29, 2, 0, 0).unwrap();
+        assert!(peak_token_rates_at(&info, saturday).unwrap().is_none());
+    }
+
+    #[test]
+    fn rejects_a_malformed_declared_schedule() {
+        let info = model_info(serde_json::json!({
+            "timezone": "America/Los_Angeles",
+            "peak_windows": [
+                {"weekdays": [0], "start_hour": 4, "end_hour": 1}
+            ],
+            "peak_rates": {
+                "input_cost_per_token": -1.0,
+                "output_cost_per_token": 4.0,
+                "cache_read_input_token_cost": 5.0
+            }
+        }));
+        let at = Utc.with_ymd_and_hms(2026, 8, 24, 2, 0, 0).unwrap();
+        let error = peak_token_rates_at(&info, at).unwrap_err();
+        assert!(error.contains("timezone must be UTC"));
+    }
+
+    #[test]
+    fn maximum_rates_never_drop_below_scalar_rates() {
+        let info = model_info(serde_json::json!({
+            "timezone": "UTC",
+            "peak_windows": [
+                {"weekdays": [1], "start_hour": 1, "end_hour": 4}
+            ],
+            "peak_rates": {
+                "input_cost_per_token": 0.5,
+                "output_cost_per_token": 1.0,
+                "cache_read_input_token_cost": 0.25
+            }
+        }));
+        let rates = configured_peak_token_rates(&info).unwrap().unwrap();
+        assert_eq!(rates.input_cost_per_token, 1.0);
+        assert_eq!(rates.output_cost_per_token, 2.0);
+        assert_eq!(rates.cache_read_input_token_cost, 1.0);
+    }
+}

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -5,6 +5,7 @@ use super::types::{
     CostResult, CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingCostEstimate, PricingUsage,
 };
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 #[cfg(any(feature = "providers-extended", feature = "providers-extra"))]
 use std::sync::LazyLock;
@@ -67,6 +68,7 @@ impl PricingService {
         completion: Option<&str>,
         total_time_seconds: Option<f64>,
     ) -> Result<CostResult> {
+        let pricing_time = Utc::now();
         let (resolved_model, model_info) = self
             .get_model_info_for_provider(provider, model)
             .ok_or_else(|| model_not_found(provider, model))?;
@@ -96,11 +98,12 @@ impl PricingService {
             )
         } else {
             let usage = PricingUsage::new(input_tokens, output_tokens);
-            let breakdown = calculate_usage_cost_with_pricing(
+            let breakdown = super::usage_cost::calculate_usage_cost_with_pricing_at(
                 &model_info.litellm_provider,
                 &resolved_model,
                 &model_info,
                 &usage,
+                pricing_time,
             )?;
             Ok(CostResult {
                 input_cost: breakdown.input_cost,
@@ -123,11 +126,28 @@ impl PricingService {
         model: &str,
         usage: &PricingUsage,
     ) -> Result<PricingCostBreakdown> {
+        self.calculate_loaded_usage_cost_for_provider_at(provider, model, usage, Utc::now())
+    }
+
+    /// Calculate detailed token usage cost at a specific UTC instant.
+    pub fn calculate_loaded_usage_cost_for_provider_at(
+        &self,
+        provider: &str,
+        model: &str,
+        usage: &PricingUsage,
+        pricing_time: DateTime<Utc>,
+    ) -> Result<PricingCostBreakdown> {
         let (resolved_model, model_info) = self
             .get_model_info_for_provider(provider, model)
             .ok_or_else(|| model_not_found(provider, model))?;
 
-        calculate_usage_cost_with_pricing(provider, &resolved_model, &model_info, usage)
+        super::usage_cost::calculate_usage_cost_with_pricing_at(
+            provider,
+            &resolved_model,
+            &model_info,
+            usage,
+            pricing_time,
+        )
     }
 
     /// Calculate settlement cost for an already-successful request.
@@ -141,13 +161,20 @@ impl PricingService {
         model: &str,
         usage: &PricingUsage,
     ) -> Result<PricingCostBreakdown> {
-        match self.calculate_loaded_usage_cost_for_provider(provider, model, usage) {
+        let pricing_time = Utc::now();
+        match self.calculate_loaded_usage_cost_for_provider_at(provider, model, usage, pricing_time)
+        {
             Ok(breakdown) => Ok(breakdown),
             Err(error) => {
                 let Some(text_usage) = text_only_usage_for_modal_settlement(usage) else {
                     return Err(error);
                 };
-                match self.calculate_loaded_usage_cost_for_provider(provider, model, &text_usage) {
+                match self.calculate_loaded_usage_cost_for_provider_at(
+                    provider,
+                    model,
+                    &text_usage,
+                    pricing_time,
+                ) {
                     Ok(mut breakdown) => {
                         tracing::error!(
                             "modal cost calculation failed for '{provider}'/'{model}': {error}; \
@@ -186,11 +213,26 @@ impl PricingService {
         input_tokens: u32,
         max_output_tokens: Option<u32>,
     ) -> Result<PricingCostEstimate> {
+        let (resolved_model, model_info) = self
+            .get_model_info_for_provider(provider, model)
+            .ok_or_else(|| model_not_found(provider, model))?;
         let estimated_output_tokens = max_output_tokens.unwrap_or(100);
         let input_only = PricingUsage::new(input_tokens, 0);
         let full_usage = PricingUsage::new(input_tokens, estimated_output_tokens);
-        let input = self.dry_run_loaded_usage_cost_for_provider(provider, model, &input_only)?;
-        let full = self.dry_run_loaded_usage_cost_for_provider(provider, model, &full_usage)?;
+        // Reserve against the highest declared rate so a request crossing into
+        // a peak window cannot exceed its budget reservation at settlement.
+        let input = super::usage_cost::calculate_usage_cost_with_maximum_rates(
+            provider,
+            &resolved_model,
+            &model_info,
+            &input_only,
+        )?;
+        let full = super::usage_cost::calculate_usage_cost_with_maximum_rates(
+            provider,
+            &resolved_model,
+            &model_info,
+            &full_usage,
+        )?;
 
         Ok(PricingCostEstimate {
             min_cost: input.total_cost,
@@ -547,92 +589,6 @@ fn text_only_usage_for_modal_settlement(usage: &PricingUsage) -> Option<PricingU
     Some(text_usage)
 }
 
-fn calculate_usage_cost_with_pricing(
-    requested_provider: &str,
-    model: &str,
-    model_info: &LiteLLMModelInfo,
-    usage: &PricingUsage,
-) -> Result<PricingCostBreakdown> {
-    let (input_cost_per_token, output_cost_per_token) =
-        super::image_pricing::token_unit_prices(model, model_info, usage)?;
-
-    let input_cost_per_token = tiered_cost_per_token(
-        model_info,
-        input_cost_per_token,
-        "input_cost_per_token_above_",
-        usage.prompt_tokens,
-    );
-    let output_cost_per_token = tiered_cost_per_token(
-        model_info,
-        output_cost_per_token,
-        "output_cost_per_token_above_",
-        usage.prompt_tokens,
-    );
-    let cache_read_cost_per_token = tiered_cost_per_token(
-        model_info,
-        model_info
-            .extra
-            .get("cache_read_input_token_cost")
-            .and_then(serde_json::Value::as_f64)
-            .unwrap_or(input_cost_per_token),
-        "cache_read_input_token_cost_above_",
-        usage.prompt_tokens,
-    );
-    let cache_creation_cost_per_token = tiered_cost_per_token(
-        model_info,
-        model_info
-            .extra
-            .get("cache_creation_input_token_cost")
-            .and_then(serde_json::Value::as_f64)
-            .unwrap_or(input_cost_per_token),
-        "cache_creation_input_token_cost_above_",
-        usage.prompt_tokens,
-    );
-    let cache_creation_tokens = usage.cache_creation_token_count();
-    let cache_read_tokens = usage.cache_read_token_count();
-    let non_cached_tokens = usage.non_cached_prompt_tokens();
-    let input_cost = non_cached_tokens as f64 * input_cost_per_token;
-    let output_cost = usage.completion_tokens as f64 * output_cost_per_token;
-    let cache_cost = cache_creation_tokens as f64 * cache_creation_cost_per_token
-        + cache_read_tokens as f64 * cache_read_cost_per_token;
-    let audio_cost = priced_extra_units(
-        model_info,
-        model,
-        usage.audio_tokens,
-        &["input_cost_per_audio_token"],
-        "audio pricing",
-    )? + priced_extra_units(
-        model_info,
-        model,
-        usage.output_audio_tokens,
-        &["output_cost_per_audio_token"],
-        "output audio pricing",
-    )?;
-    let image_cost_per_token =
-        super::image_pricing::image_token_unit_price(model_info, usage).unwrap_or(0.0);
-    let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
-        + super::image_pricing::output_image_cost(model, model_info, usage)?;
-    let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64
-        * extra_f64(model_info, "output_cost_per_reasoning_token");
-    let total_cost =
-        input_cost + output_cost + cache_cost + audio_cost + image_cost + reasoning_cost;
-
-    Ok(PricingCostBreakdown {
-        total_cost,
-        input_cost,
-        output_cost,
-        cache_cost,
-        audio_cost,
-        image_cost,
-        reasoning_cost,
-        usage: usage.clone(),
-        currency: "USD".to_string(),
-        model: model.to_string(),
-        provider: requested_provider.to_string(),
-        cost_type: CostType::TokenBased,
-    })
-}
-
 fn model_not_found(provider: &str, model: &str) -> GatewayError {
     GatewayError::not_found(format!(
         "Model not found for provider {}: {}",
@@ -640,83 +596,8 @@ fn model_not_found(provider: &str, model: &str) -> GatewayError {
     ))
 }
 
-fn extra_f64(pricing: &LiteLLMModelInfo, key: &str) -> f64 {
-    pricing
-        .extra
-        .get(key)
-        .and_then(serde_json::Value::as_f64)
-        .unwrap_or(0.0)
-}
-
-fn priced_extra_units(
-    pricing: &LiteLLMModelInfo,
-    model: &str,
-    units: Option<u32>,
-    keys: &[&str],
-    pricing_type: &str,
-) -> Result<f64> {
-    let units = units.unwrap_or(0);
-    if units == 0 {
-        return Ok(0.0);
-    }
-
-    let (key, unit_price) = keys
-        .iter()
-        .find_map(|key| {
-            pricing
-                .extra
-                .get(*key)
-                .and_then(serde_json::Value::as_f64)
-                .map(|price| (*key, price))
-        })
-        .ok_or_else(|| {
-            GatewayError::Config(format!(
-                "Missing {pricing_type} for model {model}: {}",
-                keys.join(", ")
-            ))
-        })?;
-    if unit_price < 0.0 || unit_price.is_nan() {
-        return Err(GatewayError::Config(format!(
-            "Invalid {pricing_type} for model {model}: {key} ({unit_price})"
-        )));
-    }
-
-    Ok(units as f64 * unit_price)
-}
-
-fn tiered_cost_per_token(
-    pricing: &LiteLLMModelInfo,
-    base_cost: f64,
-    key_prefix: &str,
-    prompt_tokens: u32,
-) -> f64 {
-    pricing
-        .extra
-        .iter()
-        .filter_map(|(key, value)| {
-            if !key.starts_with(key_prefix) {
-                return None;
-            }
-            let threshold = extract_tier_threshold(key)?;
-            if prompt_tokens > threshold {
-                value.as_f64().map(|cost| (threshold, cost))
-            } else {
-                None
-            }
-        })
-        .max_by_key(|(threshold, _)| *threshold)
-        .map(|(_, cost)| cost)
-        .unwrap_or(base_cost)
-}
-
-fn extract_tier_threshold(key: &str) -> Option<u32> {
-    let threshold = key.split("_above_").nth(1)?.strip_suffix("_tokens")?;
-    if let Some(number) = threshold.strip_suffix('k') {
-        number.parse::<u32>().ok().map(|value| value * 1000)
-    } else {
-        threshold.parse::<u32>().ok()
-    }
-}
+#[cfg(test)]
+use super::usage_cost::extract_tier_threshold;
 
 #[cfg(test)]
 mod amazon_nova_catalog_authority_tests {

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -68,7 +68,32 @@ impl PricingService {
         completion: Option<&str>,
         total_time_seconds: Option<f64>,
     ) -> Result<CostResult> {
-        let pricing_time = Utc::now();
+        self.calculate_loaded_completion_cost_for_provider_at(
+            provider,
+            model,
+            input_tokens,
+            output_tokens,
+            prompt,
+            completion,
+            total_time_seconds,
+            Utc::now(),
+        )
+    }
+
+    /// Calculate a completion cost from already-loaded pricing data at a
+    /// specific UTC pricing instant.
+    #[allow(clippy::too_many_arguments)]
+    pub fn calculate_loaded_completion_cost_for_provider_at(
+        &self,
+        provider: &str,
+        model: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+        prompt: Option<&str>,
+        completion: Option<&str>,
+        total_time_seconds: Option<f64>,
+        pricing_time: DateTime<Utc>,
+    ) -> Result<CostResult> {
         let (resolved_model, model_info) = self
             .get_model_info_for_provider(provider, model)
             .ok_or_else(|| model_not_found(provider, model))?;

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -89,6 +89,36 @@ fn google_authority_uses_specialized_character_pricing() {
 }
 
 #[test]
+fn provider_aware_completion_cost_uses_supplied_pricing_time() {
+    use chrono::{TimeZone, Utc};
+
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+    let off_peak = Utc.with_ymd_and_hms(2026, 8, 24, 4, 0, 0).unwrap();
+    let peak = Utc.with_ymd_and_hms(2026, 8, 24, 6, 0, 0).unwrap();
+
+    let calculate_at = |pricing_time| {
+        service
+            .calculate_loaded_completion_cost_for_provider_at(
+                "deepseek",
+                "deepseek-v4-flash",
+                1_000,
+                1_000,
+                None,
+                None,
+                None,
+                pricing_time,
+            )
+            .unwrap_or_else(|error| panic!("loaded pricing should calculate cost: {error}"))
+    };
+
+    let off_peak_cost = calculate_at(off_peak);
+    let peak_cost = calculate_at(peak);
+
+    assert!((peak_cost.total_cost - off_peak_cost.total_cost * 2.0).abs() < 1e-12);
+}
+
+#[test]
 fn google_authority_is_case_insensitive_but_not_suffix_fuzzy() {
     let service = PricingService::with_embedded_default()
         .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));

--- a/src/core/pricing_service/completion.rs
+++ b/src/core/pricing_service/completion.rs
@@ -1,0 +1,156 @@
+//! Public completion-cost entry points.
+
+use super::service::{PricingService, require_pricing_field, require_total_time_seconds};
+use super::types::{CostResult, CostType, LiteLLMModelInfo, PricingUsage};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use chrono::{DateTime, Utc};
+use tracing::warn;
+
+impl PricingService {
+    /// Calculate completion cost using the prices effective at call start.
+    pub async fn calculate_completion_cost(
+        &self,
+        model: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+        prompt: Option<&str>,
+        completion: Option<&str>,
+        total_time_seconds: Option<f64>,
+    ) -> Result<CostResult> {
+        self.calculate_completion_cost_at(
+            model,
+            input_tokens,
+            output_tokens,
+            prompt,
+            completion,
+            total_time_seconds,
+            Utc::now(),
+        )
+        .await
+    }
+
+    /// Calculate completion cost at a specific UTC pricing instant.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn calculate_completion_cost_at(
+        &self,
+        model: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+        prompt: Option<&str>,
+        completion: Option<&str>,
+        total_time_seconds: Option<f64>,
+        pricing_time: DateTime<Utc>,
+    ) -> Result<CostResult> {
+        if self.needs_refresh()
+            && let Err(error) = self.refresh_pricing_data().await
+        {
+            warn!("Failed to refresh pricing data: {error}");
+        }
+
+        let model_info = self
+            .get_model_info(model)
+            .ok_or_else(|| GatewayError::not_found(format!("Model not found: {model}")))?;
+
+        if model_info.cost_per_second.is_some() {
+            let total_time_seconds = require_total_time_seconds(model, total_time_seconds)?;
+            return self.calculate_time_based_cost(model, &model_info, total_time_seconds);
+        }
+
+        match model_info.litellm_provider.as_str() {
+            "google" | "vertex_ai" => self.calculate_google_cost(
+                model,
+                &model_info,
+                input_tokens,
+                output_tokens,
+                prompt,
+                completion,
+            ),
+            _ => {
+                let usage = PricingUsage::new(input_tokens, output_tokens);
+                let breakdown = super::usage_cost::calculate_usage_cost_with_pricing_at(
+                    &model_info.litellm_provider,
+                    model,
+                    &model_info,
+                    &usage,
+                    pricing_time,
+                )?;
+                Ok(CostResult {
+                    input_cost: breakdown.input_cost,
+                    output_cost: breakdown.output_cost,
+                    total_cost: breakdown.total_cost,
+                    input_tokens,
+                    output_tokens,
+                    model: model.to_string(),
+                    provider: model_info.litellm_provider,
+                    cost_type: CostType::TokenBased,
+                })
+            }
+        }
+    }
+
+    /// Calculate scalar token-based cost for compatibility and Google fallback.
+    pub(super) fn calculate_token_based_cost(
+        &self,
+        model: &str,
+        model_info: &LiteLLMModelInfo,
+        input_tokens: u32,
+        output_tokens: u32,
+    ) -> Result<CostResult> {
+        let input_cost_per_token = require_pricing_field(
+            model_info.input_cost_per_token,
+            model,
+            "token pricing",
+            "input_cost_per_token",
+        )?;
+        let output_cost_per_token = require_pricing_field(
+            model_info.output_cost_per_token,
+            model,
+            "token pricing",
+            "output_cost_per_token",
+        )?;
+
+        let input_cost = input_tokens as f64 * input_cost_per_token;
+        let output_cost = output_tokens as f64 * output_cost_per_token;
+        Ok(CostResult {
+            input_cost,
+            output_cost,
+            total_cost: input_cost + output_cost,
+            input_tokens,
+            output_tokens,
+            model: model.to_string(),
+            provider: model_info.litellm_provider.clone(),
+            cost_type: CostType::TokenBased,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[tokio::test]
+    async fn public_completion_cost_applies_time_of_use_pricing() {
+        let service = PricingService::with_embedded_default().unwrap();
+        let off_peak = Utc.with_ymd_and_hms(2026, 8, 24, 4, 0, 0).unwrap();
+        let peak = Utc.with_ymd_and_hms(2026, 8, 24, 6, 0, 0).unwrap();
+        let off_peak_cost = service
+            .calculate_completion_cost_at(
+                "deepseek-v4-flash",
+                1_000,
+                1_000,
+                None,
+                None,
+                None,
+                off_peak,
+            )
+            .await
+            .unwrap();
+        let peak_cost = service
+            .calculate_completion_cost_at("deepseek-v4-flash", 1_000, 1_000, None, None, None, peak)
+            .await
+            .unwrap();
+
+        assert!((peak_cost.total_cost - off_peak_cost.total_cost * 2.0).abs() < 1e-12);
+    }
+}

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -5,12 +5,14 @@
 
 mod authority;
 mod cache;
+mod completion;
 mod events;
 mod google;
 mod image_pricing;
 mod loader;
 mod service;
 mod types;
+mod usage_cost;
 
 #[cfg(test)]
 mod tests;

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::broadcast;
-use tracing::{info, warn};
+use tracing::info;
 
 pub(super) fn require_pricing_field(
     value: Option<f64>,
@@ -102,94 +102,6 @@ impl PricingService {
     pub fn get_model_info(&self, model: &str) -> Option<LiteLLMModelInfo> {
         let data = self.pricing_data.read();
         data.models.get(model).cloned()
-    }
-
-    /// Calculate completion cost
-    pub async fn calculate_completion_cost(
-        &self,
-        model: &str,
-        input_tokens: u32,
-        output_tokens: u32,
-        prompt: Option<&str>,
-        completion: Option<&str>,
-        total_time_seconds: Option<f64>,
-    ) -> Result<CostResult> {
-        // Auto-refresh if needed
-        if self.needs_refresh()
-            && let Err(e) = self.refresh_pricing_data().await
-        {
-            warn!("Failed to refresh pricing data: {}", e);
-        }
-
-        let model_info = self
-            .get_model_info(model)
-            .ok_or_else(|| GatewayError::not_found(format!("Model not found: {}", model)))?;
-
-        if model_info.cost_per_second.is_some() {
-            let total_time_seconds = require_total_time_seconds(model, total_time_seconds)?;
-            return self.calculate_time_based_cost(model, &model_info, total_time_seconds);
-        }
-
-        match model_info.litellm_provider.as_str() {
-            "openai" | "azure" => {
-                self.calculate_token_based_cost(model, &model_info, input_tokens, output_tokens)
-            }
-            "anthropic" => {
-                self.calculate_token_based_cost(model, &model_info, input_tokens, output_tokens)
-            }
-            "google" | "vertex_ai" => self.calculate_google_cost(
-                model,
-                &model_info,
-                input_tokens,
-                output_tokens,
-                prompt,
-                completion,
-            ),
-            "zhipuai" | "glm" => {
-                self.calculate_token_based_cost(model, &model_info, input_tokens, output_tokens)
-            }
-            _ => {
-                // Default to token-based calculation
-                self.calculate_token_based_cost(model, &model_info, input_tokens, output_tokens)
-            }
-        }
-    }
-
-    /// Calculate token-based cost
-    pub(super) fn calculate_token_based_cost(
-        &self,
-        model: &str,
-        model_info: &LiteLLMModelInfo,
-        input_tokens: u32,
-        output_tokens: u32,
-    ) -> Result<CostResult> {
-        let input_cost_per_token = require_pricing_field(
-            model_info.input_cost_per_token,
-            model,
-            "token pricing",
-            "input_cost_per_token",
-        )?;
-        let output_cost_per_token = require_pricing_field(
-            model_info.output_cost_per_token,
-            model,
-            "token pricing",
-            "output_cost_per_token",
-        )?;
-
-        let input_cost = (input_tokens as f64) * input_cost_per_token;
-        let output_cost = (output_tokens as f64) * output_cost_per_token;
-        let total_cost = input_cost + output_cost;
-
-        Ok(CostResult {
-            input_cost,
-            output_cost,
-            total_cost,
-            input_tokens,
-            output_tokens,
-            model: model.to_string(),
-            provider: model_info.litellm_provider.clone(),
-            cost_type: CostType::TokenBased,
-        })
     }
 
     /// Calculate Google/Vertex AI cost (character or token based)

--- a/src/core/pricing_service/usage_cost.rs
+++ b/src/core/pricing_service/usage_cost.rs
@@ -1,0 +1,316 @@
+//! Pure token and modality usage-cost calculation for loaded catalog rows.
+
+use super::types::{CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingUsage};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use chrono::{DateTime, Utc};
+
+pub(super) fn calculate_usage_cost_with_pricing_at(
+    requested_provider: &str,
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+    pricing_time: DateTime<Utc>,
+) -> Result<PricingCostBreakdown> {
+    let peak_rates =
+        crate::core::pricing::time_of_use::peak_token_rates_at(model_info, pricing_time).map_err(
+            |message| {
+                GatewayError::Config(format!(
+                    "Invalid time-of-use pricing for model {model}: {message}"
+                ))
+            },
+        )?;
+    calculate_usage_cost_with_rates(requested_provider, model, model_info, usage, peak_rates)
+}
+
+pub(super) fn calculate_usage_cost_with_maximum_rates(
+    requested_provider: &str,
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+) -> Result<PricingCostBreakdown> {
+    let peak_rates = crate::core::pricing::time_of_use::configured_peak_token_rates(model_info)
+        .map_err(|message| {
+            GatewayError::Config(format!(
+                "Invalid time-of-use pricing for model {model}: {message}"
+            ))
+        })?;
+    calculate_usage_cost_with_rates(requested_provider, model, model_info, usage, peak_rates)
+}
+
+fn calculate_usage_cost_with_rates(
+    requested_provider: &str,
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+    peak_rates: Option<crate::core::pricing::time_of_use::TokenRates>,
+) -> Result<PricingCostBreakdown> {
+    let (mut input_cost_per_token, mut output_cost_per_token) =
+        super::image_pricing::token_unit_prices(model, model_info, usage)?;
+    if let Some(rates) = peak_rates {
+        input_cost_per_token = rates.input_cost_per_token;
+        output_cost_per_token = rates.output_cost_per_token;
+    }
+
+    let input_cost_per_token = tiered_cost_per_token(
+        model_info,
+        input_cost_per_token,
+        "input_cost_per_token_above_",
+        usage.prompt_tokens,
+    );
+    let output_cost_per_token = tiered_cost_per_token(
+        model_info,
+        output_cost_per_token,
+        "output_cost_per_token_above_",
+        usage.prompt_tokens,
+    );
+    let base_cache_read_cost = peak_rates
+        .map(|rates| rates.cache_read_input_token_cost)
+        .unwrap_or_else(|| {
+            model_info
+                .extra
+                .get("cache_read_input_token_cost")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(input_cost_per_token)
+        });
+    let cache_read_cost_per_token = tiered_cost_per_token(
+        model_info,
+        base_cache_read_cost,
+        "cache_read_input_token_cost_above_",
+        usage.prompt_tokens,
+    );
+    let cache_creation_cost_per_token = tiered_cost_per_token(
+        model_info,
+        model_info
+            .extra
+            .get("cache_creation_input_token_cost")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(input_cost_per_token),
+        "cache_creation_input_token_cost_above_",
+        usage.prompt_tokens,
+    );
+    let cache_creation_tokens = usage.cache_creation_token_count();
+    let cache_read_tokens = usage.cache_read_token_count();
+    let non_cached_tokens = usage.non_cached_prompt_tokens();
+    let input_cost = non_cached_tokens as f64 * input_cost_per_token;
+    let output_cost = usage.completion_tokens as f64 * output_cost_per_token;
+    let cache_cost = cache_creation_tokens as f64 * cache_creation_cost_per_token
+        + cache_read_tokens as f64 * cache_read_cost_per_token;
+    let audio_cost = priced_extra_units(
+        model_info,
+        model,
+        usage.audio_tokens,
+        &["input_cost_per_audio_token"],
+        "audio pricing",
+    )? + priced_extra_units(
+        model_info,
+        model,
+        usage.output_audio_tokens,
+        &["output_cost_per_audio_token"],
+        "output audio pricing",
+    )?;
+    let image_cost_per_token =
+        super::image_pricing::image_token_unit_price(model_info, usage).unwrap_or(0.0);
+    let image_cost = usage.image_tokens.unwrap_or(0) as f64 * image_cost_per_token
+        + super::image_pricing::output_image_cost(model, model_info, usage)?;
+    let reasoning_cost = usage.reasoning_tokens.unwrap_or(0) as f64
+        * extra_f64(model_info, "output_cost_per_reasoning_token");
+    let total_cost =
+        input_cost + output_cost + cache_cost + audio_cost + image_cost + reasoning_cost;
+
+    Ok(PricingCostBreakdown {
+        total_cost,
+        input_cost,
+        output_cost,
+        cache_cost,
+        audio_cost,
+        image_cost,
+        reasoning_cost,
+        usage: usage.clone(),
+        currency: "USD".to_string(),
+        model: model.to_string(),
+        provider: requested_provider.to_string(),
+        cost_type: CostType::TokenBased,
+    })
+}
+
+fn extra_f64(pricing: &LiteLLMModelInfo, key: &str) -> f64 {
+    pricing
+        .extra
+        .get(key)
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0)
+}
+
+fn priced_extra_units(
+    pricing: &LiteLLMModelInfo,
+    model: &str,
+    units: Option<u32>,
+    keys: &[&str],
+    pricing_type: &str,
+) -> Result<f64> {
+    let units = units.unwrap_or(0);
+    if units == 0 {
+        return Ok(0.0);
+    }
+
+    let (key, unit_price) = keys
+        .iter()
+        .find_map(|key| {
+            pricing
+                .extra
+                .get(*key)
+                .and_then(serde_json::Value::as_f64)
+                .map(|price| (*key, price))
+        })
+        .ok_or_else(|| {
+            GatewayError::Config(format!(
+                "Missing {pricing_type} for model {model}: {}",
+                keys.join(", ")
+            ))
+        })?;
+    if unit_price < 0.0 || unit_price.is_nan() {
+        return Err(GatewayError::Config(format!(
+            "Invalid {pricing_type} for model {model}: {key} ({unit_price})"
+        )));
+    }
+
+    Ok(units as f64 * unit_price)
+}
+
+fn tiered_cost_per_token(
+    pricing: &LiteLLMModelInfo,
+    base_cost: f64,
+    key_prefix: &str,
+    prompt_tokens: u32,
+) -> f64 {
+    pricing
+        .extra
+        .iter()
+        .filter_map(|(key, value)| {
+            if !key.starts_with(key_prefix) {
+                return None;
+            }
+            let threshold = extract_tier_threshold(key)?;
+            if prompt_tokens > threshold {
+                value.as_f64().map(|cost| (threshold, cost))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|(threshold, _)| *threshold)
+        .map(|(_, cost)| cost)
+        .unwrap_or(base_cost)
+}
+
+pub(super) fn extract_tier_threshold(key: &str) -> Option<u32> {
+    let threshold = key.split("_above_").nth(1)?.strip_suffix("_tokens")?;
+    if let Some(number) = threshold.strip_suffix('k') {
+        number.parse::<u32>().ok().map(|value| value * 1000)
+    } else {
+        threshold.parse::<u32>().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn authority_applies_deepseek_peak_rates_to_text_and_cache_usage() {
+        let service = super::super::PricingService::with_embedded_default().unwrap();
+        let mut usage = PricingUsage::new(1_000, 1_000);
+        usage.cached_tokens = Some(250);
+        let off_peak = Utc.with_ymd_and_hms(2026, 8, 24, 4, 0, 0).unwrap();
+        let peak = Utc.with_ymd_and_hms(2026, 8, 24, 6, 0, 0).unwrap();
+
+        for model in [
+            "deepseek-chat",
+            "deepseek-reasoner",
+            "deepseek-v4-flash",
+            "deepseek-v4-flash-vision-exp",
+            "deepseek-v4-pro",
+            "deepseek/deepseek-chat",
+            "deepseek/deepseek-reasoner",
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash-vision-exp",
+            "deepseek/deepseek-v4-pro",
+        ] {
+            let off_peak_cost = service
+                .calculate_loaded_usage_cost_for_provider_at("deepseek", model, &usage, off_peak)
+                .unwrap();
+            let peak_cost = service
+                .calculate_loaded_usage_cost_for_provider_at("deepseek", model, &usage, peak)
+                .unwrap();
+            for (off_peak_component, peak_component) in [
+                (off_peak_cost.input_cost, peak_cost.input_cost),
+                (off_peak_cost.output_cost, peak_cost.output_cost),
+                (off_peak_cost.cache_cost, peak_cost.cache_cost),
+                (off_peak_cost.total_cost, peak_cost.total_cost),
+            ] {
+                assert!(
+                    (peak_component - off_peak_component * 2.0).abs() < 1e-12,
+                    "{model} peak component {peak_component} should be twice {off_peak_component}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn authority_rejects_malformed_declared_time_of_use_pricing() {
+        let service = super::super::PricingService::with_embedded_default().unwrap();
+        let (_, mut info) = service
+            .get_model_info_for_provider("deepseek", "deepseek-v4-flash")
+            .unwrap();
+        info.extra.insert(
+            crate::core::pricing::time_of_use::TIME_OF_USE_PRICING_KEY.to_string(),
+            serde_json::json!({"timezone": "UTC"}),
+        );
+        let at = Utc.with_ymd_and_hms(2026, 8, 24, 2, 0, 0).unwrap();
+        let error = calculate_usage_cost_with_pricing_at(
+            "deepseek",
+            "deepseek-v4-flash",
+            &info,
+            &PricingUsage::new(1_000, 1_000),
+            at,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Invalid time-of-use pricing"));
+    }
+
+    #[test]
+    fn reservation_estimate_covers_a_request_that_crosses_into_peak() {
+        let service = super::super::PricingService::with_embedded_default().unwrap();
+        let usage = PricingUsage::new(1_000, 1_000);
+        let off_peak = Utc.with_ymd_and_hms(2026, 8, 24, 0, 59, 0).unwrap();
+        let peak = Utc.with_ymd_and_hms(2026, 8, 24, 1, 0, 0).unwrap();
+        let estimate = service
+            .estimate_loaded_completion_cost_for_provider(
+                "deepseek",
+                "deepseek-v4-flash",
+                1_000,
+                Some(1_000),
+            )
+            .unwrap();
+        let off_peak_cost = service
+            .calculate_loaded_usage_cost_for_provider_at(
+                "deepseek",
+                "deepseek-v4-flash",
+                &usage,
+                off_peak,
+            )
+            .unwrap();
+        let peak_cost = service
+            .calculate_loaded_usage_cost_for_provider_at(
+                "deepseek",
+                "deepseek-v4-flash",
+                &usage,
+                peak,
+            )
+            .unwrap();
+
+        assert!((estimate.max_cost - peak_cost.total_cost).abs() < 1e-12);
+        assert!(off_peak_cost.total_cost <= estimate.max_cost);
+        assert!(peak_cost.total_cost <= estimate.max_cost);
+    }
+}


### PR DESCRIPTION
## Summary

- add validated UTC time-of-use metadata for all 10 DeepSeek V4 models and aliases
- select official peak input, output, and cache-read rates across PricingService, PricingDatabase, public cost compatibility APIs, and legacy fallback pricing
- reserve against the component-wise highest declared rate so requests crossing a pricing boundary cannot exceed their reservation
- reject malformed time-of-use metadata during catalog loading and add deterministic boundary/weekday/cache/fallback tests

## Pricing schedule

Peak windows are Monday-Friday UTC `[01:00, 04:00)` and `[06:00, 10:00)`. Scalar catalog fields remain the official off-peak compatibility rates.

Source: https://api-docs.deepseek.com/quick_start/pricing/

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (8,906 library tests plus integration and doc tests passed)
- Codex read-only review: no actionable findings after fixes

## Stack

This PR is intentionally based on #1194 so each pricing repair remains reviewable as one issue/PR.

Closes #1195