### PR TITLE
fix(pricing): prefer provider-exact model keys

### DIFF
--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -333,7 +333,7 @@ fn resolve_model_info_for_provider(
         .iter()
         .filter(|(candidate, _)| candidate.eq_ignore_ascii_case(&provider_exact_model))
         .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
-        .min_by(|(left, _), (right, _)| left.cmp(right))
+        .min_by_key(|(candidate, _)| *candidate)
     {
         return Some((candidate.clone(), info.clone()));
     }
@@ -357,7 +357,7 @@ fn resolve_model_info_for_provider(
         .iter()
         .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
         .filter(|(candidate, _)| is_shared_model_match(&candidate.to_lowercase(), &requested))
-        .max_by(|(left, _), (right, _)| left.len().cmp(&right.len()).then_with(|| right.cmp(left)))
+        .max_by_key(|(candidate, _)| (candidate.len(), std::cmp::Reverse(*candidate)))
         .map(|(candidate, info)| (candidate.clone(), info.clone()))
         .or_else(|| provider_catalog_model_info(&normalized_provider, model))
 }

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -329,6 +329,14 @@ fn resolve_model_info_for_provider(
     {
         return Some((provider_exact_model, info.clone()));
     }
+    if let Some((candidate, info)) = models
+        .iter()
+        .filter(|(candidate, _)| candidate.eq_ignore_ascii_case(&provider_exact_model))
+        .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
+        .min_by(|(left, _), (right, _)| left.cmp(right))
+    {
+        return Some((candidate.clone(), info.clone()));
+    }
 
     if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
         for candidate in

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -322,6 +322,14 @@ fn resolve_model_info_for_provider(
         return Some((normalized_model.to_string(), info.clone()));
     }
 
+    let provider_exact_model = format!("{normalized_provider}/{normalized_model}");
+    if let Some(info) = models
+        .get(&provider_exact_model)
+        .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+    {
+        return Some((provider_exact_model, info.clone()));
+    }
+
     if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
         for candidate in
             super::google::exact_pricing_candidates(&normalized_provider, model, normalized_model)
@@ -341,7 +349,7 @@ fn resolve_model_info_for_provider(
         .iter()
         .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
         .filter(|(candidate, _)| is_shared_model_match(&candidate.to_lowercase(), &requested))
-        .max_by_key(|(candidate, _)| candidate.len())
+        .max_by(|(left, _), (right, _)| left.len().cmp(&right.len()).then_with(|| right.cmp(left)))
         .map(|(candidate, info)| (candidate.clone(), info.clone()))
         .or_else(|| provider_catalog_model_info(&normalized_provider, model))
 }

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -21,7 +21,7 @@ impl PricingService {
         let models = service.load_from_embedded_default()?;
         {
             let mut data = service.pricing_data.write();
-            data.models = models;
+            data.replace_models(models);
             data.last_updated = SystemTime::now();
         }
         Ok(service)
@@ -50,7 +50,7 @@ impl PricingService {
         model: &str,
     ) -> Option<(String, LiteLLMModelInfo)> {
         let data = self.pricing_data.read();
-        resolve_model_info_for_provider(&data.models, provider, model)
+        resolve_model_info_for_provider(&data, provider, model)
     }
 
     /// Calculate a completion cost from already-loaded pricing data.
@@ -276,10 +276,11 @@ impl PricingService {
 }
 
 fn resolve_model_info_for_provider(
-    models: &HashMap<String, LiteLLMModelInfo>,
+    data: &super::types::PricingData,
     provider: &str,
     model: &str,
 ) -> Option<(String, LiteLLMModelInfo)> {
+    let models = &data.models;
     let normalized_provider = crate::core::pricing::normalize_pricing_provider(provider);
     if normalized_provider == "amazon_nova" {
         return amazon_nova_pricing_model_info(model);
@@ -290,8 +291,8 @@ fn resolve_model_info_for_provider(
         let prefixed_provider = crate::core::pricing::normalize_pricing_provider(prefixed_provider);
         if prefixed_provider != "openai_like"
             && let Some(resolved) =
-                resolve_model_info_for_provider(models, &prefixed_provider, stripped_model)
-                    .or_else(|| resolve_model_info_for_provider(models, &prefixed_provider, model))
+                resolve_model_info_for_provider(data, &prefixed_provider, stripped_model)
+                    .or_else(|| resolve_model_info_for_provider(data, &prefixed_provider, model))
         {
             return Some(resolved);
         }
@@ -312,47 +313,51 @@ fn resolve_model_info_for_provider(
     {
         return Some((model.to_string(), info.clone()));
     }
+    if let Some((candidate, info)) = data
+        .get_model_case_insensitive(model)
+        .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
+    {
+        return Some((candidate.to_string(), info.clone()));
+    }
 
     let normalized_model = crate::core::pricing::normalize_model_key(model);
-    if normalized_model != model
-        && let Some(info) = models
-            .get(normalized_model)
-            .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-    {
-        return Some((normalized_model.to_string(), info.clone()));
-    }
-
-    let provider_exact_model = format!("{normalized_provider}/{normalized_model}");
-    if let Some(info) = models
-        .get(&provider_exact_model)
-        .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-    {
-        return Some((provider_exact_model, info.clone()));
-    }
-    if let Some((candidate, info)) = models
-        .iter()
-        .filter(|(candidate, _)| candidate.eq_ignore_ascii_case(&provider_exact_model))
-        .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
-        .min_by_key(|(candidate, _)| *candidate)
-    {
-        return Some((candidate.clone(), info.clone()));
-    }
-
     if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
         for candidate in
             super::google::exact_pricing_candidates(&normalized_provider, model, normalized_model)
         {
-            if let Some(info) = models
-                .get(&candidate)
-                .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+            if let Some((canonical, info)) =
+                data.get_model_case_insensitive(&candidate)
+                    .filter(|(_, info)| {
+                        provider_name_matches(&info.litellm_provider, &provider_aliases)
+                    })
             {
-                return Some((candidate, info.clone()));
+                return Some((canonical.to_string(), info.clone()));
             }
         }
         return None;
     }
 
-    let requested = normalized_model.to_lowercase();
+    if let Some(plain_model) = provider_exact_plain_model(model, &provider_aliases) {
+        if plain_model != model
+            && let Some((canonical, info)) =
+                data.get_model_case_insensitive(plain_model)
+                    .filter(|(_, info)| {
+                        provider_name_matches(&info.litellm_provider, &provider_aliases)
+                    })
+        {
+            return Some((canonical.to_string(), info.clone()));
+        }
+
+        let provider_exact_model = format!("{normalized_provider}/{plain_model}");
+        if let Some((canonical, info)) = data
+            .get_model_case_insensitive(&provider_exact_model)
+            .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
+        {
+            return Some((canonical.to_string(), info.clone()));
+        }
+    }
+
+    let requested = model.to_lowercase();
     models
         .iter()
         .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
@@ -562,6 +567,16 @@ fn provider_prefixed_model(model: &str) -> Option<(&str, &str)> {
         return None;
     }
     Some((provider, stripped_model))
+}
+
+fn provider_exact_plain_model<'a>(model: &'a str, provider_aliases: &[String]) -> Option<&'a str> {
+    let Some((prefix, stripped_model)) = provider_prefixed_model(model) else {
+        return Some(model);
+    };
+    if stripped_model.contains('/') || !provider_name_matches(prefix, provider_aliases) {
+        return None;
+    }
+    Some(stripped_model)
 }
 
 fn is_xiaomi_mimo_model(model: &str) -> bool {

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -201,6 +201,24 @@ fn provider_aware_authority_resolves_amazon_nova_short_alias() {
 }
 
 #[test]
+fn provider_aware_authority_resolves_mixed_case_provider_exact_key() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    let Some((resolved, _)) = service.get_model_info_for_provider("azure", "GPT-5.5") else {
+        panic!("mixed-case Azure model should resolve");
+    };
+
+    assert_eq!(resolved, "azure/gpt-5.5");
+
+    let Some((resolved, _)) = service.get_model_info_for_provider("azure_ai", "phi-4") else {
+        panic!("lowercase Azure AI model should resolve to its mixed-case catalog key");
+    };
+
+    assert_eq!(resolved, "azure_ai/Phi-4");
+}
+
+#[test]
 fn provider_aware_authority_preserves_core_pricing_tiers() {
     let service = match PricingService::with_embedded_default() {
         Ok(service) => service,
@@ -225,17 +243,14 @@ fn provider_aware_authority_preserves_core_pricing_tiers() {
 
 #[test]
 fn provider_aware_authority_breaks_equal_length_fuzzy_ties_deterministically() {
-    let service = PricingService::new(None);
-    service.add_custom_model(
-        "region-b/model-2026".to_string(),
-        test_model_info("synthetic"),
-    );
-    service.add_custom_model(
-        "region-a/model-2026".to_string(),
-        test_model_info("synthetic"),
-    );
-
-    for _ in 0..8 {
+    for candidates in [
+        ["region-b/model-2026", "region-a/model-2026"],
+        ["region-a/model-2026", "region-b/model-2026"],
+    ] {
+        let service = PricingService::new(None);
+        for candidate in candidates {
+            service.add_custom_model(candidate.to_string(), test_model_info("synthetic"));
+        }
         let Some((resolved, _)) = service.get_model_info_for_provider("synthetic", "model") else {
             panic!("synthetic fuzzy model should resolve");
         };

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -201,6 +201,78 @@ fn provider_aware_authority_resolves_amazon_nova_short_alias() {
 }
 
 #[test]
+fn provider_aware_authority_preserves_non_provider_qualifiers() {
+    let service = PricingService::new(None);
+    for model in [
+        "synthetic/model",
+        "region-a/model-2026",
+        "region-b/model-2026",
+        "deployment-x/model-2026",
+    ] {
+        service.add_custom_model(model.to_string(), test_model_info("synthetic"));
+    }
+
+    for (requested, expected) in [
+        ("region-a/model", "region-a/model-2026"),
+        ("region-b/model", "region-b/model-2026"),
+        ("deployment-x/model", "deployment-x/model-2026"),
+    ] {
+        let Some((resolved, _)) = service.get_model_info_for_provider("synthetic", requested)
+        else {
+            panic!("qualified synthetic model should resolve: {requested}");
+        };
+        assert_eq!(resolved, expected);
+    }
+}
+
+#[test]
+fn provider_exact_eligibility_rejects_nested_catalog_qualifiers() {
+    let azure_aliases = pricing_provider_aliases("azure", "gpt-5.1");
+    assert_eq!(
+        provider_exact_plain_model("azure/gpt-5.1", &azure_aliases),
+        Some("gpt-5.1")
+    );
+    assert_eq!(
+        provider_exact_plain_model("azure/us/gpt-5.1", &azure_aliases),
+        None
+    );
+    assert_eq!(
+        provider_exact_plain_model("azure/eu/gpt-5.1", &azure_aliases),
+        None
+    );
+
+    let vertex_aliases = pricing_provider_aliases("vertex_ai", "gemini-1.5-pro");
+    assert_eq!(
+        provider_exact_plain_model(
+            "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas",
+            &vertex_aliases,
+        ),
+        None
+    );
+}
+
+#[test]
+fn provider_aware_authority_preserves_nested_catalog_qualifiers() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    for (provider, requested, expected) in [
+        ("azure", "AZURE/US/GPT-5.1", "azure/us/gpt-5.1"),
+        ("azure", "AZURE/EU/GPT-5.1", "azure/eu/gpt-5.1"),
+        (
+            "vertex_ai",
+            "VERTEX_AI/META/LLAMA-4-SCOUT-17B-16E-INSTRUCT-MAAS",
+            "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas",
+        ),
+    ] {
+        let Some((resolved, _)) = service.get_model_info_for_provider(provider, requested) else {
+            panic!("qualified catalog model should resolve: {requested}");
+        };
+        assert_eq!(resolved, expected);
+    }
+}
+
+#[test]
 fn provider_aware_authority_resolves_mixed_case_provider_exact_key() {
     let service = PricingService::with_embedded_default()
         .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -173,7 +173,7 @@ fn provider_aware_authority_resolves_xai_openai_like_prefix() {
         Err(error) => panic!("xAI OpenAI-like prefixed model should resolve: {error}"),
     };
 
-    assert_eq!(cost.model, "xai/grok-4.3-latest");
+    assert_eq!(cost.model, "xai/grok-4.3");
     assert_eq!(cost.provider, "openai_like");
     assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
 }
@@ -216,11 +216,31 @@ fn provider_aware_authority_preserves_core_pricing_tiers() {
         Err(error) => panic!("Azure tiered fallback pricing should resolve: {error}"),
     };
 
-    assert_eq!(cost.model, "azure/gpt-5.5-2026-04-23");
+    assert_eq!(cost.model, "azure/gpt-5.5");
     assert_eq!(cost.provider, "azure");
     assert!((cost.input_cost - 3.0).abs() < 1e-12);
     assert!((cost.output_cost - 0.045).abs() < 1e-12);
     assert!((cost.total_cost - 3.045).abs() < 1e-12);
+}
+
+#[test]
+fn provider_aware_authority_breaks_equal_length_fuzzy_ties_deterministically() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "region-b/model-2026".to_string(),
+        test_model_info("synthetic"),
+    );
+    service.add_custom_model(
+        "region-a/model-2026".to_string(),
+        test_model_info("synthetic"),
+    );
+
+    for _ in 0..8 {
+        let Some((resolved, _)) = service.get_model_info_for_provider("synthetic", "model") else {
+            panic!("synthetic fuzzy model should resolve");
+        };
+        assert_eq!(resolved, "region-a/model-2026");
+    }
 }
 
 #[test]

--- a/src/core/pricing_service/cache.rs
+++ b/src/core/pricing_service/cache.rs
@@ -68,8 +68,7 @@ impl PricingService {
         // Update in-memory data and timestamp in single lock
         {
             let mut pricing_data = self.pricing_data.write();
-            pricing_data.models.clear();
-            pricing_data.models.extend(data);
+            pricing_data.replace_models(data);
             pricing_data.last_updated = SystemTime::now();
         }
 
@@ -116,5 +115,28 @@ mod tests {
             super::super::REMOTE_LITELLM_PRICING_SOURCE
         );
         assert!(!service.should_fallback_to_embedded_on_remote_error());
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_preserves_models_and_canonical_index() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let missing_source = temp_dir.path().join("missing-pricing.json");
+        let service = PricingService::new(Some(missing_source.to_string_lossy().into_owned()));
+        let model_info = serde_json::from_str(r#"{"litellm_provider":"synthetic","mode":"chat"}"#)
+            .expect("test model should deserialize");
+        service.add_custom_model("synthetic/Mixed-Model".to_string(), model_info);
+
+        let error = service
+            .force_refresh()
+            .await
+            .expect_err("missing pricing source must return an error");
+
+        assert!(matches!(error, GatewayError::Io(_)));
+        assert_eq!(
+            service
+                .get_model_info_for_provider("synthetic", "MIXED-MODEL")
+                .map(|(model, _)| model),
+            Some("synthetic/Mixed-Model".to_string())
+        );
     }
 }

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -70,6 +70,45 @@ pub struct PricingService {
     pub(super) event_sender: broadcast::Sender<PricingUpdateEvent>,
 }
 
+impl PricingData {
+    pub(super) fn replace_models(&mut self, models: HashMap<String, LiteLLMModelInfo>) {
+        let mut canonical_model_keys = HashMap::with_capacity(models.len());
+        for model in models.keys() {
+            index_canonical_model_key(&mut canonical_model_keys, model);
+        }
+        self.models = models;
+        self.canonical_model_keys = canonical_model_keys;
+    }
+
+    pub(super) fn insert_model(&mut self, model: String, model_info: LiteLLMModelInfo) {
+        index_canonical_model_key(&mut self.canonical_model_keys, &model);
+        self.models.insert(model, model_info);
+    }
+
+    pub(super) fn get_model_case_insensitive(
+        &self,
+        model: &str,
+    ) -> Option<(&str, &LiteLLMModelInfo)> {
+        let lowercase = model.to_ascii_lowercase();
+        let canonical = self.canonical_model_keys.get(&lowercase)?;
+        self.models
+            .get_key_value(canonical)
+            .map(|(model, info)| (model.as_str(), info))
+    }
+}
+
+fn index_canonical_model_key(index: &mut HashMap<String, String>, model: &str) {
+    index
+        .entry(model.to_ascii_lowercase())
+        .and_modify(|canonical| {
+            if model < canonical.as_str() {
+                canonical.clear();
+                canonical.push_str(model);
+            }
+        })
+        .or_insert_with(|| model.to_string());
+}
+
 impl PricingService {
     /// Create a new pricing service
     pub fn new(pricing_url: Option<String>) -> Self {
@@ -77,10 +116,7 @@ impl PricingService {
         let use_embedded_fallback_on_remote_error = false;
 
         let service = Self {
-            pricing_data: Arc::new(RwLock::new(PricingData {
-                models: HashMap::new(),
-                last_updated: SystemTime::UNIX_EPOCH,
-            })),
+            pricing_data: Arc::new(RwLock::new(PricingData::default())),
             http_client: default_outbound_client().clone(),
             pricing_url: pricing_url.unwrap_or_default(),
             use_embedded_fallback_on_remote_error,
@@ -236,7 +272,7 @@ impl PricingService {
     pub fn add_custom_model(&self, model: String, model_info: LiteLLMModelInfo) {
         {
             let mut data = self.pricing_data.write();
-            data.models.insert(model.clone(), model_info.clone());
+            data.insert_model(model.clone(), model_info.clone());
         }
 
         // Send update event
@@ -378,7 +414,40 @@ mod tests {
         let service = PricingService::new(None);
         let data = service.pricing_data.read();
         assert!(data.models.is_empty());
+        assert!(data.canonical_model_keys.is_empty());
         assert_eq!(data.last_updated, SystemTime::UNIX_EPOCH);
+    }
+
+    #[test]
+    fn canonical_model_index_uses_lexical_key_for_case_only_collisions() {
+        for order in [
+            ["synthetic/phi-4", "synthetic/Phi-4"],
+            ["synthetic/Phi-4", "synthetic/phi-4"],
+        ] {
+            let mut inserted = PricingData::default();
+            for model in order {
+                inserted.insert_model(model.to_string(), create_test_model_info("synthetic"));
+            }
+            assert_eq!(
+                inserted
+                    .get_model_case_insensitive("SYNTHETIC/PHI-4")
+                    .map(|(model, _)| model),
+                Some("synthetic/Phi-4")
+            );
+
+            let models = order
+                .into_iter()
+                .map(|model| (model.to_string(), create_test_model_info("synthetic")))
+                .collect();
+            let mut replaced = PricingData::default();
+            replaced.replace_models(models);
+            assert_eq!(
+                replaced
+                    .get_model_case_insensitive("SYNTHETIC/PHI-4")
+                    .map(|(model, _)| model),
+                Some("synthetic/Phi-4")
+            );
+        }
     }
 
     // ==================== Model Info Tests ====================

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -10,6 +10,8 @@ use std::time::SystemTime;
 pub(super) struct PricingData {
     /// Model pricing data (model_name -> LiteLLMModelInfo)
     pub models: HashMap<String, LiteLLMModelInfo>,
+    /// Case-insensitive model key lookup (lowercase -> canonical model name).
+    pub canonical_model_keys: HashMap<String, String>,
     /// Last update time
     pub last_updated: SystemTime,
 }
@@ -18,6 +20,7 @@ impl Default for PricingData {
     fn default() -> Self {
         Self {
             models: HashMap::new(),
+            canonical_model_keys: HashMap::new(),
             last_updated: SystemTime::UNIX_EPOCH,
         }
     }
@@ -460,10 +463,9 @@ mod tests {
             },
         );
 
-        let data = PricingData {
-            models,
-            last_updated: SystemTime::now(),
-        };
+        let mut data = PricingData::default();
+        data.replace_models(models);
+        data.last_updated = SystemTime::now();
 
         assert_eq!(data.models.len(), 1);
         assert!(data.models.contains_key("gpt-4"));

--- a/src/server/routes/pricing.rs
+++ b/src/server/routes/pricing.rs
@@ -315,7 +315,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body: Value = test::read_body_json(response).await;
-        assert_eq!(body["model"], "xai/grok-4.3-latest");
+        assert_eq!(body["model"], "xai/grok-4.3");
         assert_eq!(body["provider"], "xai");
         let total_cost = match body["total_cost"].as_f64() {
             Some(total_cost) => total_cost,
@@ -347,7 +347,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body: Value = test::read_body_json(response).await;
-        assert_eq!(body["model"], "azure/gpt-5.5-2026-04-23");
+        assert_eq!(body["model"], "azure/gpt-5.5");
         assert_eq!(body["provider"], "azure");
         let total_cost = match body["total_cost"].as_f64() {
             Some(total_cost) => total_cost,


### PR DESCRIPTION
## What

- resolve an exact `<provider>/<model>` catalog key before regional or versioned fuzzy aliases
- keep provider-alias validation on exact prefixed rows
- make equal-length fuzzy fallback deterministic by choosing the lexicographically smallest key
- update authority and pricing-route contract tests; the two `src/server/routes/pricing.rs` changes are test-only expectations for Azure and xAI resolved-model keys

## Why

The provider-aware resolver skipped an existing provider-prefixed exact key after its unprefixed checks. A generic Azure request could therefore inherit a regional price uplift, and equal-length candidates depended on `HashMap` iteration order. This PR is a prerequisite for the runtime pricing catalog refresh in #1201.

Fixes #1203

## Test Plan

- [x] `cargo test core::pricing_service::authority`
- [x] `cargo test calculate_cost_route_applies_provider_aware_tiered_pricing`
- [x] `cargo test calculate_cost_route_resolves_xai_openai_like_prefix`
- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`

## Notes

This change was prepared with AI-assisted development and manually scoped and verified.