### PR TITLE
refactor(pricing): add provider-scoped authority

### DIFF
--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -286,21 +286,26 @@ fn resolve_model_info_for_provider(
     if normalized_provider == "amazon_nova" {
         return amazon_nova_pricing_model_info(model);
     }
+
+    let provider_aliases = pricing_provider_aliases(provider, model);
+    let candidates = exact_pricing_candidates(&normalized_provider, model, &provider_aliases);
+    if let Some(resolved) = exact_provider_model(data, &provider_aliases, &candidates) {
+        return Some(resolved);
+    }
     if normalized_provider == "openai_like" {
         let parsed = ModelIdRef::parse(model);
         if let Some(prefix) = parsed.provider()
             && crate::core::providers::registry::selector_has_matrix_entry(prefix)
         {
-            let prefixed_provider = crate::core::pricing::normalize_pricing_provider(prefix);
+            let prefixed_provider = canonical_pricing_selector(prefix);
             if prefixed_provider != "openai_like" {
                 return resolve_model_info_for_provider(data, &prefixed_provider, parsed.model());
             }
         }
     }
-
-    let provider_aliases = pricing_provider_aliases(provider, model);
-    let candidates = exact_pricing_candidates(&normalized_provider, model, &provider_aliases);
-    if let Some(resolved) = exact_provider_model(data, &provider_aliases, &candidates) {
+    if let Some(alias) = super::google::explicit_pricing_alias(&normalized_provider, model)
+        && let Some(resolved) = exact_provider_model(data, &provider_aliases, &[alias.to_string()])
+    {
         return Some(resolved);
     }
     if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
@@ -325,10 +330,16 @@ fn exact_pricing_candidates(
         push_unique(&mut candidates, parsed.model());
         push_unique(&mut candidates, &format!("{provider}/{}", parsed.model()));
     }
-    if let Some(alias) = super::google::explicit_pricing_alias(provider, model) {
-        push_unique(&mut candidates, alias);
-    }
     candidates
+}
+
+fn canonical_pricing_selector(selector: &str) -> String {
+    let canonical = crate::core::providers::registry::canonical_selector(selector);
+    if canonical == "openai_compatible" {
+        "openai_like".to_string()
+    } else {
+        crate::core::pricing::normalize_pricing_provider(&canonical)
+    }
 }
 
 fn push_unique(candidates: &mut Vec<String>, candidate: &str) {

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -320,7 +320,7 @@ fn exact_pricing_candidates(
     push_unique(&mut candidates, &format!("{provider}/{}", parsed.raw()));
     if parsed.provider().is_some_and(|prefix| {
         let prefix = crate::core::pricing::normalize_pricing_provider(prefix);
-        provider_aliases.iter().any(|alias| alias == &prefix)
+        prefix == provider || provider_aliases.iter().any(|alias| alias == &prefix)
     }) {
         push_unique(&mut candidates, parsed.model());
         push_unique(&mut candidates, &format!("{provider}/{}", parsed.model()));

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -2,8 +2,10 @@
 
 use super::service::PricingService;
 use super::types::{
-    CostResult, CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingCostEstimate, PricingUsage,
+    CostResult, CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingCostEstimate, PricingData,
+    PricingUsage,
 };
+use crate::core::types::model_id::ModelIdRef;
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
@@ -19,10 +21,10 @@ impl PricingService {
     pub fn with_embedded_default() -> Result<Self> {
         let service = Self::new(Some(super::DEFAULT_PRICING_SOURCE.to_string()));
         let models = service.load_from_embedded_default()?;
+        let next = super::service::build_pricing_data(models, SystemTime::now());
         {
-            let mut data = service.pricing_data.write();
-            data.models = models;
-            data.last_updated = SystemTime::now();
+            let _write_guard = service.pricing_write_lock.lock();
+            service.pricing_data.store(std::sync::Arc::new(next));
         }
         Ok(service)
     }
@@ -49,8 +51,8 @@ impl PricingService {
         provider: &str,
         model: &str,
     ) -> Option<(String, LiteLLMModelInfo)> {
-        let data = self.pricing_data.read();
-        resolve_model_info_for_provider(&data.models, provider, model)
+        let data = self.pricing_data.load();
+        resolve_model_info_for_provider(&data, provider, model)
     }
 
     /// Calculate a completion cost from already-loaded pricing data.
@@ -276,7 +278,7 @@ impl PricingService {
 }
 
 fn resolve_model_info_for_provider(
-    models: &HashMap<String, LiteLLMModelInfo>,
+    data: &PricingData,
     provider: &str,
     model: &str,
 ) -> Option<(String, LiteLLMModelInfo)> {
@@ -284,66 +286,86 @@ fn resolve_model_info_for_provider(
     if normalized_provider == "amazon_nova" {
         return amazon_nova_pricing_model_info(model);
     }
-    if normalized_provider == "openai_like"
-        && let Some((prefixed_provider, stripped_model)) = provider_prefixed_model(model)
-    {
-        let prefixed_provider = crate::core::pricing::normalize_pricing_provider(prefixed_provider);
-        if prefixed_provider != "openai_like"
-            && let Some(resolved) =
-                resolve_model_info_for_provider(models, &prefixed_provider, stripped_model)
-                    .or_else(|| resolve_model_info_for_provider(models, &prefixed_provider, model))
+    if normalized_provider == "openai_like" {
+        let parsed = ModelIdRef::parse(model);
+        if let Some(prefix) = parsed.provider()
+            && crate::core::providers::registry::selector_has_matrix_entry(prefix)
         {
-            return Some(resolved);
+            let prefixed_provider = crate::core::pricing::normalize_pricing_provider(prefix);
+            if prefixed_provider != "openai_like" {
+                return resolve_model_info_for_provider(data, &prefixed_provider, parsed.model());
+            }
         }
     }
 
     let provider_aliases = pricing_provider_aliases(provider, model);
-    if let Some((prefixed_provider, _)) = provider_prefixed_model(model)
-        && crate::core::providers::registry::selector_has_matrix_entry(prefixed_provider)
-        && !super::google::is_vertex_publisher_prefix(&normalized_provider, prefixed_provider)
-        && !provider_name_matches(prefixed_provider, &provider_aliases)
-    {
+    let candidates = exact_pricing_candidates(&normalized_provider, model, &provider_aliases);
+    if let Some(resolved) = exact_provider_model(data, &provider_aliases, &candidates) {
+        return Some(resolved);
+    }
+    if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
         return None;
     }
+    provider_catalog_model_info(&normalized_provider, model)
+}
 
-    if let Some(info) = models
-        .get(model)
-        .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-    {
-        return Some((model.to_string(), info.clone()));
+fn exact_pricing_candidates(
+    provider: &str,
+    model: &str,
+    provider_aliases: &[String],
+) -> Vec<String> {
+    let parsed = ModelIdRef::parse(model);
+    let mut candidates = Vec::with_capacity(5);
+    push_unique(&mut candidates, parsed.raw());
+    push_unique(&mut candidates, &format!("{provider}/{}", parsed.raw()));
+    if parsed.provider().is_some_and(|prefix| {
+        let prefix = crate::core::pricing::normalize_pricing_provider(prefix);
+        provider_aliases.iter().any(|alias| alias == &prefix)
+    }) {
+        push_unique(&mut candidates, parsed.model());
+        push_unique(&mut candidates, &format!("{provider}/{}", parsed.model()));
     }
-
-    let normalized_model = crate::core::pricing::normalize_model_key(model);
-    if normalized_model != model
-        && let Some(info) = models
-            .get(normalized_model)
-            .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
-    {
-        return Some((normalized_model.to_string(), info.clone()));
+    if let Some(alias) = super::google::explicit_pricing_alias(provider, model) {
+        push_unique(&mut candidates, alias);
     }
+    candidates
+}
 
-    if matches!(normalized_provider.as_str(), "gemini" | "vertex_ai") {
-        for candidate in
-            super::google::exact_pricing_candidates(&normalized_provider, model, normalized_model)
+fn push_unique(candidates: &mut Vec<String>, candidate: &str) {
+    if !candidate.is_empty() && !candidates.iter().any(|existing| existing == candidate) {
+        candidates.push(candidate.to_string());
+    }
+}
+
+fn exact_provider_model(
+    data: &PricingData,
+    providers: &[String],
+    candidates: &[String],
+) -> Option<(String, LiteLLMModelInfo)> {
+    for candidate in candidates {
+        if let Some(info) = data
+            .models
+            .get(candidate)
+            .filter(|info| provider_name_matches(&info.litellm_provider, providers))
         {
-            if let Some(info) = models
-                .get(&candidate)
-                .filter(|info| provider_name_matches(&info.litellm_provider, &provider_aliases))
+            return Some((candidate.clone(), info.clone()));
+        }
+    }
+    for provider in providers {
+        let Some(index) = data.exact_by_provider.get(provider) else {
+            continue;
+        };
+        for candidate in candidates {
+            if let Some(canonical) = index
+                .get(&candidate.to_ascii_lowercase())
+                .and_then(|collisions| collisions.first())
+                && let Some(info) = data.models.get(canonical)
             {
-                return Some((candidate, info.clone()));
+                return Some((canonical.clone(), info.clone()));
             }
         }
-        return None;
     }
-
-    let requested = normalized_model.to_lowercase();
-    models
-        .iter()
-        .filter(|(_, info)| provider_name_matches(&info.litellm_provider, &provider_aliases))
-        .filter(|(candidate, _)| is_shared_model_match(&candidate.to_lowercase(), &requested))
-        .max_by_key(|(candidate, _)| candidate.len())
-        .map(|(candidate, info)| (candidate.clone(), info.clone()))
-        .or_else(|| provider_catalog_model_info(&normalized_provider, model))
+    None
 }
 
 fn provider_catalog_model_info(
@@ -351,15 +373,6 @@ fn provider_catalog_model_info(
     model: &str,
 ) -> Option<(String, LiteLLMModelInfo)> {
     match normalized_provider {
-        "azure" | "azure_ai" => crate::core::cost::calculator::pricing::get_azure_pricing(model)
-            .ok()
-            .map(|pricing| {
-                let resolved_model = pricing.model.clone();
-                (
-                    resolved_model,
-                    core_pricing_to_litellm_model_info(normalized_provider, pricing),
-                )
-            }),
         "bedrock" => crate::core::providers::bedrock::CostCalculator::get_core_model_pricing(model)
             .map(|pricing| {
                 let resolved_model = pricing.model.clone();
@@ -540,16 +553,16 @@ fn pricing_provider_aliases(provider: &str, model: &str) -> Vec<String> {
         })
 }
 
-fn provider_prefixed_model(model: &str) -> Option<(&str, &str)> {
-    let (provider, stripped_model) = model.split_once('/')?;
-    if provider.is_empty() || stripped_model.is_empty() {
-        return None;
-    }
-    Some((provider, stripped_model))
-}
-
 fn is_xiaomi_mimo_model(model: &str) -> bool {
-    crate::core::pricing::normalize_model_key(model).starts_with("mimo-")
+    let parsed = ModelIdRef::parse(model);
+    let local = if parsed.provider().is_some_and(|prefix| {
+        crate::core::pricing::normalize_pricing_provider(prefix) == "anthropic"
+    }) {
+        parsed.model()
+    } else {
+        parsed.raw()
+    };
+    local.to_ascii_lowercase().starts_with("mimo-")
 }
 
 fn provider_name_matches(provider: &str, aliases: &[String]) -> bool {
@@ -557,44 +570,6 @@ fn provider_name_matches(provider: &str, aliases: &[String]) -> bool {
     aliases
         .iter()
         .any(|alias| crate::core::pricing::normalize_pricing_provider(alias) == provider)
-}
-
-fn is_shared_model_match(candidate: &str, requested: &str) -> bool {
-    fn model_id_matches(candidate: &str, requested: &str) -> bool {
-        if candidate == requested {
-            return true;
-        }
-
-        candidate
-            .strip_prefix(requested)
-            .and_then(|suffix| suffix.strip_prefix('-'))
-            .is_some_and(alias_suffix_matches)
-    }
-
-    if candidate == requested {
-        return true;
-    }
-
-    model_id_matches(candidate, requested)
-        || model_id_matches(requested, candidate)
-        || candidate
-            .rsplit_once('/')
-            .map(|(_, model_id)| {
-                model_id_matches(model_id, requested) || model_id_matches(requested, model_id)
-            })
-            .unwrap_or(false)
-}
-
-fn alias_suffix_matches(suffix: &str) -> bool {
-    if suffix == "latest" {
-        return true;
-    }
-
-    let digit_prefix_len = suffix.chars().take_while(|ch| ch.is_ascii_digit()).count();
-    digit_prefix_len >= 4
-        && suffix
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
 }
 
 fn text_only_usage_for_modal_settlement(usage: &PricingUsage) -> Option<PricingUsage> {

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -69,6 +69,21 @@ fn provider_aware_authority_resolves_anthropic_mimo_alias() {
 }
 
 #[test]
+fn provider_aware_authority_strips_qualified_anthropic_mimo_prefix() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    let Some((resolved, info)) =
+        service.get_model_info_for_provider("anthropic", "anthropic/mimo-v2.5-pro")
+    else {
+        panic!("qualified Anthropic-compatible MiMo should resolve through Xiaomi pricing");
+    };
+
+    assert_eq!(resolved, "mimo-v2.5-pro");
+    assert_eq!(info.litellm_provider, "xiaomi_mimo");
+}
+
+#[test]
 fn google_authority_uses_specialized_character_pricing() {
     let service = PricingService::with_embedded_default()
         .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -173,7 +173,7 @@ fn provider_aware_authority_resolves_xai_openai_like_prefix() {
         Err(error) => panic!("xAI OpenAI-like prefixed model should resolve: {error}"),
     };
 
-    assert_eq!(cost.model, "xai/grok-4.3-latest");
+    assert_eq!(cost.model, "xai/grok-4.3");
     assert_eq!(cost.provider, "openai_like");
     assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
 }
@@ -216,7 +216,7 @@ fn provider_aware_authority_preserves_core_pricing_tiers() {
         Err(error) => panic!("Azure tiered fallback pricing should resolve: {error}"),
     };
 
-    assert_eq!(cost.model, "azure/gpt-5.5-2026-04-23");
+    assert_eq!(cost.model, "azure/gpt-5.5");
     assert_eq!(cost.provider, "azure");
     assert!((cost.input_cost - 3.0).abs() < 1e-12);
     assert!((cost.output_cost - 0.045).abs() < 1e-12);
@@ -256,4 +256,180 @@ fn provider_aware_authority_rejects_missing_token_pricing() {
     };
 
     assert!(error.to_string().contains("output_cost_per_token"));
+}
+
+#[test]
+fn provider_scoped_authority_preserves_native_slash_namespaces() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    for (provider, model, expected) in [
+        (
+            "together_ai",
+            "BAAI/bge-base-en-v1.5",
+            "together_ai/BAAI/bge-base-en-v1.5",
+        ),
+        (
+            "together_ai",
+            "openai/gpt-oss-120b",
+            "together_ai/openai/gpt-oss-120b",
+        ),
+        (
+            "anyscale",
+            "google/gemma-7b-it",
+            "anyscale/google/gemma-7b-it",
+        ),
+    ] {
+        let Some((resolved, info)) = service.get_model_info_for_provider(provider, model) else {
+            panic!("{provider}/{model} should retain its provider-native namespace");
+        };
+        assert_eq!(resolved, expected);
+        assert_eq!(
+            crate::core::pricing::normalize_pricing_provider(&info.litellm_provider),
+            provider
+        );
+    }
+}
+
+#[test]
+fn provider_scoped_authority_preserves_region_and_deployment_qualifiers() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    for (model, expected) in [
+        ("us/gpt-5.1", "azure/us/gpt-5.1"),
+        ("AZURE/EU/GPT-5.1", "azure/eu/gpt-5.1"),
+        ("gpt-5.1", "azure/gpt-5.1"),
+    ] {
+        let Some((resolved, _)) = service.get_model_info_for_provider("azure", model) else {
+            panic!("Azure pricing should resolve {model}");
+        };
+        assert_eq!(resolved, expected);
+    }
+
+    service.add_custom_model(
+        "azure/deployment-blue/gpt-5.1".to_string(),
+        test_model_info("azure"),
+    );
+    let Some((resolved, _)) =
+        service.get_model_info_for_provider("azure", "deployment-blue/gpt-5.1")
+    else {
+        panic!("deployment-qualified model should resolve without losing its qualifier");
+    };
+    assert_eq!(resolved, "azure/deployment-blue/gpt-5.1");
+
+    let Some((plain, _)) = service.get_model_info_for_provider("azure", "gpt-5.1") else {
+        panic!("plain Azure model should retain its generic exact row");
+    };
+    assert_eq!(plain, "azure/gpt-5.1");
+}
+
+#[test]
+fn provider_scoped_authority_resolves_vertex_publishers_but_not_unknown_suffixes() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    let Some((resolved, info)) =
+        service.get_model_info_for_provider("vertex_ai", "meta/llama-4-scout-17b-16e-instruct")
+    else {
+        panic!("Vertex publisher alias should resolve through its bounded explicit alias");
+    };
+    assert_eq!(
+        resolved,
+        "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas"
+    );
+    assert_eq!(info.litellm_provider, "vertex_ai-llama_models");
+    assert!(
+        service
+            .get_model_info_for_provider("vertex_ai", "gemini-1.5-pro-9999")
+            .is_none()
+    );
+}
+
+#[test]
+fn provider_scoped_casefold_keeps_cross_provider_collisions() {
+    let service = PricingService::new(None);
+    let mut gemini = test_model_info("gemini");
+    gemini.input_cost_per_token = Some(0.000_001);
+    let mut vertex = test_model_info("vertex_ai");
+    vertex.input_cost_per_token = Some(0.000_002);
+    service.add_custom_model("Model-X".to_string(), gemini);
+    service.add_custom_model("model-x".to_string(), vertex);
+
+    let (gemini_key, gemini_info) = service
+        .get_model_info_for_provider("gemini", "MODEL-X")
+        .expect("Gemini collision entry should remain scoped");
+    let (vertex_key, vertex_info) = service
+        .get_model_info_for_provider("vertex_ai", "MODEL-X")
+        .expect("Vertex collision entry should remain scoped");
+    assert_eq!(gemini_key, "Model-X");
+    assert_eq!(gemini_info.input_cost_per_token, Some(0.000_001));
+    assert_eq!(vertex_key, "model-x");
+    assert_eq!(vertex_info.input_cost_per_token, Some(0.000_002));
+}
+
+#[test]
+fn provider_scoped_casefold_is_lexical_regardless_of_insertion_order() {
+    fn build(reverse: bool) -> PricingService {
+        let service = PricingService::new(None);
+        let lower = ("model-x".to_string(), test_model_info("runtime_provider"));
+        let upper = ("Model-X".to_string(), test_model_info("runtime_provider"));
+        let entries = if reverse {
+            vec![upper, lower]
+        } else {
+            vec![lower, upper]
+        };
+        for (model, info) in entries {
+            service.add_custom_model(model, info);
+        }
+        service
+    }
+
+    for service in [build(false), build(true)] {
+        let (mixed, _) = service
+            .get_model_info_for_provider("runtime_provider", "MODEL-X")
+            .expect("mixed-case lookup should use deterministic canonical key");
+        assert_eq!(mixed, "Model-X");
+        assert_eq!(
+            service
+                .get_model_info_for_provider("runtime_provider", "model-x")
+                .expect("exact lowercase spelling should win")
+                .0,
+            "model-x"
+        );
+    }
+}
+
+#[test]
+fn provider_scoped_exact_rows_precede_old_fuzzy_aliases() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    assert_eq!(
+        service
+            .get_model_info_for_provider("openai_like", "xai/grok-4.3")
+            .expect("xAI exact row should resolve")
+            .0,
+        "xai/grok-4.3"
+    );
+    assert_eq!(
+        service
+            .get_model_info_for_provider("azure", "gpt-5.5")
+            .expect("Azure exact row should resolve")
+            .0,
+        "azure/gpt-5.5"
+    );
+
+    assert!(
+        service
+            .get_model_info_for_provider("anthropic", "mimo-v2.5-pro")
+            .is_some()
+    );
+    assert_eq!(
+        service
+            .get_model_info_for_provider("amazon_nova", "nova-2-lite")
+            .expect("Amazon Nova explicit catalog alias should remain supported")
+            .0,
+        "amazon.nova-2-lite-v1:0"
+    );
 }

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -151,6 +151,22 @@ fn google_authority_is_case_insensitive_but_not_suffix_fuzzy() {
 }
 
 #[test]
+fn provider_scoped_casefold_exact_precedes_google_explicit_alias() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+    let mut custom = test_model_info("vertex_ai");
+    custom.input_cost_per_token = Some(0.123);
+    service.add_custom_model("Gemini-1.5-Pro-001".to_string(), custom);
+
+    let (resolved, info) = service
+        .get_model_info_for_provider("vertex_ai", "GEMINI-1.5-PRO-001")
+        .expect("provider-scoped casefold exact row should resolve");
+
+    assert_eq!(resolved, "Gemini-1.5-Pro-001");
+    assert_eq!(info.input_cost_per_token, Some(0.123));
+}
+
+#[test]
 fn provider_aware_authority_resolves_loaded_openai_like_model_without_prefix() {
     let service = PricingService::new(None);
     service.add_custom_model(
@@ -191,6 +207,41 @@ fn provider_aware_authority_resolves_xai_openai_like_prefix() {
     assert_eq!(cost.model, "xai/grok-4.3");
     assert_eq!(cost.provider, "openai_like");
     assert!((cost.total_cost - 0.0025).abs() < f64::EPSILON);
+}
+
+#[test]
+fn openai_like_raw_exact_native_slash_precedes_selector_routing() {
+    let service = PricingService::new(None);
+    let mut custom = test_model_info("openai_like");
+    custom.input_cost_per_token = Some(0.456);
+    service.add_custom_model("xai/review-future".to_string(), custom);
+
+    let (resolved, info) = service
+        .get_model_info_for_provider("openai_like", "xai/review-future")
+        .expect("raw exact OpenAI-like slash row should resolve before xAI routing");
+
+    assert_eq!(resolved, "xai/review-future");
+    assert_eq!(info.input_cost_per_token, Some(0.456));
+}
+
+#[test]
+fn openai_like_selector_aliases_route_after_raw_exact_miss() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+
+    assert!(
+        service
+            .get_model_info_for_provider("openai_like", "google_vertex/gemini-1.5-pro")
+            .is_some()
+    );
+    assert!(
+        service
+            .get_model_info_for_provider(
+                "openai_like",
+                "aws_bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            )
+            .is_some()
+    );
 }
 
 #[cfg(feature = "providers-extended")]

--- a/src/core/pricing_service/cache.rs
+++ b/src/core/pricing_service/cache.rs
@@ -1,6 +1,7 @@
 //! Caching and refresh functionality for the pricing service
 
 use super::service::PricingService;
+use super::service::build_pricing_data;
 use super::types::{PricingEventType, PricingUpdateEvent};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::sync::Arc;
@@ -65,12 +66,11 @@ impl PricingService {
             self.load_from_file().await?
         };
 
-        // Update in-memory data and timestamp in single lock
+        let timestamp = SystemTime::now();
+        let next = Arc::new(build_pricing_data(data, timestamp));
         {
-            let mut pricing_data = self.pricing_data.write();
-            pricing_data.models.clear();
-            pricing_data.models.extend(data);
-            pricing_data.last_updated = SystemTime::now();
+            let _write_guard = self.pricing_write_lock.lock();
+            self.pricing_data.store(next);
         }
 
         // Send update event
@@ -78,7 +78,7 @@ impl PricingService {
             event_type: PricingEventType::DataRefreshed,
             model: "*".to_string(),
             provider: "*".to_string(),
-            timestamp: SystemTime::now(),
+            timestamp,
         });
 
         info!("Pricing data refreshed successfully");
@@ -87,7 +87,7 @@ impl PricingService {
 
     /// Check if pricing data needs refresh
     pub fn needs_refresh(&self) -> bool {
-        let data = self.pricing_data.read();
+        let data = self.pricing_data.load();
         SystemTime::now()
             .duration_since(data.last_updated)
             .map(|duration| duration > self.cache_ttl)

--- a/src/core/pricing_service/google.rs
+++ b/src/core/pricing_service/google.rs
@@ -20,14 +20,6 @@ pub(super) const VERTEX_PROVIDER_ALIASES: &[&str] = &[
     "vertex_ai-zai_models",
 ];
 
-pub(super) fn is_vertex_publisher_prefix(provider: &str, prefix: &str) -> bool {
-    provider == "vertex_ai"
-        && matches!(
-            prefix.to_ascii_lowercase().as_str(),
-            "ai21" | "meta" | "mistral"
-        )
-}
-
 pub(super) fn uses_google_completion_calculator(
     requested_provider: &str,
     catalog_provider: &str,
@@ -37,32 +29,19 @@ pub(super) fn uses_google_completion_calculator(
         || catalog_provider.starts_with("vertex_ai_")
 }
 
-pub(super) fn exact_pricing_candidates(
-    provider: &str,
-    model: &str,
-    normalized_model: &str,
-) -> Vec<String> {
-    let model = model.to_ascii_lowercase();
-    let normalized_model = normalized_model.to_ascii_lowercase();
-    let mut candidates = Vec::with_capacity(5);
-    for candidate in [
-        model.clone(),
-        normalized_model.clone(),
-        format!("{provider}/{model}"),
-        format!("{provider}/{normalized_model}"),
-    ] {
-        if !candidates.contains(&candidate) {
-            candidates.push(candidate);
-        }
+pub(super) fn explicit_pricing_alias(provider: &str, model: &str) -> Option<&'static str> {
+    if provider != "vertex_ai" {
+        return None;
     }
-
-    if provider == "vertex_ai"
-        && let Some(alias) = vertex_pricing_alias(&model)
-        && !candidates.iter().any(|candidate| candidate == alias)
-    {
-        candidates.push(alias.to_string());
-    }
-    candidates
+    let parsed = crate::core::types::model_id::ModelIdRef::parse(model);
+    let local = if parsed.provider().is_some_and(|prefix| {
+        crate::core::pricing::normalize_pricing_provider(prefix) == "vertex_ai"
+    }) {
+        parsed.model()
+    } else {
+        parsed.raw()
+    };
+    vertex_pricing_alias(&local.to_ascii_lowercase())
 }
 
 fn vertex_pricing_alias(model: &str) -> Option<&'static str> {

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -238,10 +238,11 @@ impl PricingService {
         let timestamp = SystemTime::now();
         {
             let _write_guard = self.pricing_write_lock.lock();
-            let mut models = self.pricing_data.load().models.clone();
+            let current = self.pricing_data.load_full();
+            let mut models = current.models.clone();
             models.insert(model.clone(), model_info.clone());
             self.pricing_data
-                .store(Arc::new(build_pricing_data(models, timestamp)));
+                .store(Arc::new(build_pricing_data(models, current.last_updated)));
         }
 
         // Send update event
@@ -409,6 +410,37 @@ mod tests {
         let data = service.pricing_data.load();
         assert!(data.models.is_empty());
         assert_eq!(data.last_updated, SystemTime::UNIX_EPOCH);
+    }
+
+    #[test]
+    fn add_custom_model_preserves_catalog_refresh_age() {
+        let service = PricingService::new(None);
+        let catalog_timestamp = SystemTime::UNIX_EPOCH + Duration::from_secs(60);
+        service.pricing_data.store(Arc::new(build_pricing_data(
+            HashMap::from([(
+                "catalog-model".to_string(),
+                create_test_model_info("catalog-provider"),
+            )]),
+            catalog_timestamp,
+        )));
+        assert!(service.needs_refresh());
+        let mut updates = service.subscribe_to_updates();
+
+        service.add_custom_model(
+            "custom-model".to_string(),
+            create_test_model_info("custom-provider"),
+        );
+
+        assert_eq!(service.pricing_data.load().last_updated, catalog_timestamp);
+        assert!(
+            service.needs_refresh(),
+            "custom insertion must not postpone a due catalog refresh"
+        );
+        let event = updates
+            .try_recv()
+            .expect("custom insertion should still publish an update event");
+        assert!(event.timestamp > catalog_timestamp);
+        assert_eq!(event.model, "custom-model");
     }
 
     // ==================== Model Info Tests ====================

--- a/src/core/pricing_service/service.rs
+++ b/src/core/pricing_service/service.rs
@@ -6,7 +6,8 @@ use super::types::{
 };
 use crate::core::http::outbound::default_outbound_client;
 use crate::utils::error::gateway_error::{GatewayError, Result};
-use parking_lot::RwLock;
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -56,8 +57,10 @@ pub(super) fn require_total_time_seconds(
 /// Pricing service using LiteLLM data format
 #[derive(Debug, Clone)]
 pub struct PricingService {
-    /// Consolidated pricing data - single lock for model data and timestamp
-    pub(super) pricing_data: Arc<RwLock<PricingData>>,
+    /// Immutable model/index/timestamp snapshot published atomically.
+    pub(super) pricing_data: Arc<ArcSwap<PricingData>>,
+    /// Serializes writers so insert and refresh cannot lose each other's update.
+    pub(super) pricing_write_lock: Arc<Mutex<()>>,
     /// HTTP client for fetching updates
     pub(super) http_client: reqwest::Client,
     /// Pricing data source URL
@@ -77,10 +80,8 @@ impl PricingService {
         let use_embedded_fallback_on_remote_error = false;
 
         let service = Self {
-            pricing_data: Arc::new(RwLock::new(PricingData {
-                models: HashMap::new(),
-                last_updated: SystemTime::UNIX_EPOCH,
-            })),
+            pricing_data: Arc::new(ArcSwap::from_pointee(PricingData::default())),
+            pricing_write_lock: Arc::new(Mutex::new(())),
             http_client: default_outbound_client().clone(),
             pricing_url: pricing_url.unwrap_or_default(),
             use_embedded_fallback_on_remote_error,
@@ -95,12 +96,12 @@ impl PricingService {
     pub(super) fn should_fallback_to_embedded_on_remote_error(&self) -> bool {
         self.use_embedded_fallback_on_remote_error
             && self.pricing_url == super::REMOTE_LITELLM_PRICING_SOURCE
-            && self.pricing_data.read().models.is_empty()
+            && self.pricing_data.load().models.is_empty()
     }
 
     /// Get model information
     pub fn get_model_info(&self, model: &str) -> Option<LiteLLMModelInfo> {
-        let data = self.pricing_data.read();
+        let data = self.pricing_data.load();
         data.models.get(model).cloned()
     }
 
@@ -210,7 +211,7 @@ impl PricingService {
 
     /// Get all available models for a provider
     pub fn get_models_by_provider(&self, provider: &str) -> Vec<String> {
-        let data = self.pricing_data.read();
+        let data = self.pricing_data.load();
         data.models
             .iter()
             .filter(|(_, info)| info.litellm_provider == provider)
@@ -220,7 +221,7 @@ impl PricingService {
 
     /// Get all available providers
     pub fn get_providers(&self) -> Vec<String> {
-        let data = self.pricing_data.read();
+        let data = self.pricing_data.load();
         let mut providers: Vec<String> = data
             .models
             .values()
@@ -234,9 +235,13 @@ impl PricingService {
 
     /// Add custom model pricing
     pub fn add_custom_model(&self, model: String, model_info: LiteLLMModelInfo) {
+        let timestamp = SystemTime::now();
         {
-            let mut data = self.pricing_data.write();
-            data.models.insert(model.clone(), model_info.clone());
+            let _write_guard = self.pricing_write_lock.lock();
+            let mut models = self.pricing_data.load().models.clone();
+            models.insert(model.clone(), model_info.clone());
+            self.pricing_data
+                .store(Arc::new(build_pricing_data(models, timestamp)));
         }
 
         // Send update event
@@ -244,13 +249,13 @@ impl PricingService {
             event_type: PricingEventType::ModelAdded,
             model,
             provider: model_info.litellm_provider,
-            timestamp: SystemTime::now(),
+            timestamp,
         });
     }
 
     /// Get pricing statistics
     pub fn get_statistics(&self) -> PricingStatistics {
-        let data = self.pricing_data.read();
+        let data = self.pricing_data.load();
         let total_models = data.models.len();
 
         let mut provider_stats = HashMap::new();
@@ -285,6 +290,31 @@ impl PricingService {
             cost_ranges,
             last_updated: data.last_updated,
         }
+    }
+}
+
+pub(super) fn build_pricing_data(
+    models: HashMap<String, LiteLLMModelInfo>,
+    last_updated: SystemTime,
+) -> PricingData {
+    let mut exact_by_provider: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
+    for (canonical, info) in &models {
+        let provider = crate::core::pricing::normalize_pricing_provider(&info.litellm_provider);
+        exact_by_provider
+            .entry(provider)
+            .or_default()
+            .entry(canonical.to_ascii_lowercase())
+            .or_default()
+            .push(canonical.clone());
+    }
+    for candidates in exact_by_provider.values_mut().flat_map(HashMap::values_mut) {
+        candidates.sort();
+        candidates.dedup();
+    }
+    PricingData {
+        models,
+        exact_by_provider,
+        last_updated,
     }
 }
 
@@ -376,7 +406,7 @@ mod tests {
     #[test]
     fn test_pricing_service_initial_state() {
         let service = PricingService::new(None);
-        let data = service.pricing_data.read();
+        let data = service.pricing_data.load();
         assert!(data.models.is_empty());
         assert_eq!(data.last_updated, SystemTime::UNIX_EPOCH);
     }

--- a/src/core/pricing_service/service_tests.rs
+++ b/src/core/pricing_service/service_tests.rs
@@ -313,7 +313,6 @@ async fn test_calculate_completion_cost_propagates_missing_token_pricing() {
     let mut model_info = create_test_model_info("openai");
     model_info.output_cost_per_token = None;
     service.add_custom_model("gpt-public-missing-price".to_string(), model_info);
-    service.pricing_data.write().last_updated = SystemTime::now();
 
     let result = service
         .calculate_completion_cost("gpt-public-missing-price", 1000, 500, None, None, None)
@@ -332,7 +331,6 @@ async fn test_calculate_completion_cost_requires_time_for_time_based_pricing() {
     let service = PricingService::new(None);
     let model_info = create_time_based_model_info("replicate");
     service.add_custom_model("replicate/timed".to_string(), model_info);
-    service.pricing_data.write().last_updated = SystemTime::now();
 
     let result = service
         .calculate_completion_cost("replicate/timed", 0, 0, None, None, None)
@@ -427,7 +425,6 @@ async fn pricing_review_rejects_negative_total_time_seconds() {
         "replicate/negative-duration".to_string(),
         create_time_based_model_info("replicate"),
     );
-    service.pricing_data.write().last_updated = SystemTime::now();
 
     let result = service
         .calculate_completion_cost("replicate/negative-duration", 0, 0, None, None, Some(-1.0))
@@ -448,7 +445,6 @@ async fn pricing_review_rejects_nan_total_time_seconds() {
         "replicate/nan-duration".to_string(),
         create_time_based_model_info("replicate"),
     );
-    service.pricing_data.write().last_updated = SystemTime::now();
 
     let result = service
         .calculate_completion_cost("replicate/nan-duration", 0, 0, None, None, Some(f64::NAN))
@@ -469,7 +465,6 @@ async fn pricing_review_uses_token_pricing_for_token_priced_together_ai_model() 
         "together/token-priced".to_string(),
         create_test_model_info("together_ai"),
     );
-    service.pricing_data.write().last_updated = SystemTime::now();
 
     let result = service
         .calculate_completion_cost("together/token-priced", 1000, 500, None, None, None)
@@ -492,7 +487,6 @@ async fn pricing_review_uses_token_pricing_for_token_priced_baseten_model() {
         "baseten/token-priced".to_string(),
         create_test_model_info("baseten"),
     );
-    service.pricing_data.write().last_updated = SystemTime::now();
 
     let result = service
         .calculate_completion_cost("baseten/token-priced", 2000, 750, None, None, None)
@@ -523,4 +517,72 @@ fn test_pricing_service_clone() {
     // Adding to original should be visible in clone (same Arc)
     service.add_custom_model("gpt-3.5".to_string(), create_test_model_info("openai"));
     assert!(cloned.get_model_info("gpt-3.5").is_some());
+}
+
+#[test]
+fn custom_model_overwrite_moves_provider_index_atomically() {
+    let service = PricingService::new(None);
+    service.add_custom_model(
+        "shared-model".to_string(),
+        create_test_model_info("provider_one"),
+    );
+    assert!(
+        service
+            .get_model_info_for_provider("provider_one", "shared-model")
+            .is_some()
+    );
+
+    service.add_custom_model(
+        "shared-model".to_string(),
+        create_test_model_info("provider_two"),
+    );
+
+    assert!(
+        service
+            .get_model_info_for_provider("provider_one", "shared-model")
+            .is_none(),
+        "overwriting a key must remove its old provider ownership"
+    );
+    assert!(
+        service
+            .get_model_info_for_provider("provider_two", "shared-model")
+            .is_some(),
+        "overwriting a key must publish its new provider ownership"
+    );
+}
+
+#[tokio::test]
+async fn failed_refresh_preserves_models_indexes_and_timestamp() {
+    let path = std::env::temp_dir().join(format!(
+        "litellm-pricing-invalid-{}-{}.json",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    std::fs::write(&path, "{ invalid json")
+        .unwrap_or_else(|error| panic!("invalid pricing fixture should write: {error}"));
+
+    let service = PricingService::new(Some(path.to_string_lossy().into_owned()));
+    service.add_custom_model(
+        "stable-model".to_string(),
+        create_test_model_info("stable_provider"),
+    );
+    let before = service.get_statistics().last_updated;
+
+    let error = service
+        .refresh_pricing_data()
+        .await
+        .expect_err("invalid refresh must fail explicitly");
+    assert!(error.to_string().contains("Failed to parse pricing JSON"));
+    assert_eq!(service.get_statistics().last_updated, before);
+    assert!(
+        service
+            .get_model_info_for_provider("stable_provider", "stable-model")
+            .is_some(),
+        "failed refresh must preserve both model and provider index"
+    );
+
+    let _ = std::fs::remove_file(path);
 }

--- a/src/core/pricing_service/tests.rs
+++ b/src/core/pricing_service/tests.rs
@@ -515,7 +515,11 @@ fn provider_pricing_fails_closed_for_mismatched_flat_image_variant() {
         .push("1024-x-1024/flat-variant-model".to_string());
 
     let error = service
-        .calculate_loaded_usage_cost_for_provider("bedrock", "flat-variant-model", &usage)
+        .calculate_loaded_usage_cost_for_provider(
+            "bedrock",
+            "1024-x-1024/50-steps/flat-variant-model",
+            &usage,
+        )
         .unwrap_err();
 
     assert!(error.to_string().contains("output_image_pricing_keys"));

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -6,10 +6,11 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 /// Consolidated pricing data - single lock for all pricing state
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(super) struct PricingData {
     /// Model pricing data (model_name -> LiteLLMModelInfo)
     pub models: HashMap<String, LiteLLMModelInfo>,
+    pub exact_by_provider: HashMap<String, HashMap<String, Vec<String>>>,
     /// Last update time
     pub last_updated: SystemTime,
 }
@@ -18,6 +19,7 @@ impl Default for PricingData {
     fn default() -> Self {
         Self {
             models: HashMap::new(),
+            exact_by_provider: HashMap::new(),
             last_updated: SystemTime::UNIX_EPOCH,
         }
     }
@@ -462,6 +464,7 @@ mod tests {
 
         let data = PricingData {
             models,
+            exact_by_provider: HashMap::new(),
             last_updated: SystemTime::now(),
         };
 

--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -102,6 +102,7 @@ pub async fn audio_speech(
                         pricing_service.as_ref(),
                         &provider,
                         &selected_model,
+                        ProviderCapability::TextToSpeech,
                     );
                 request.model = selected_model.clone();
                 let reserve_pricing_service = pricing_service.clone();

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -177,6 +177,7 @@ pub async fn audio_transcriptions(
                         pricing_service.as_ref(),
                         &provider,
                         &selected_model,
+                        ProviderCapability::AudioTranscription,
                     );
                 request.model = selected_model.clone();
                 let reserve_pricing_service = pricing_service.clone();

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -165,6 +165,7 @@ pub async fn audio_translations(
                         pricing_service.as_ref(),
                         &provider,
                         &selected_model,
+                        ProviderCapability::AudioTranslation,
                     );
                 request.model = selected_model.clone();
                 let reserve_pricing_service = pricing_service.clone();

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -154,6 +154,7 @@ async fn handle_chat_completion_internal(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                    ProviderCapability::ChatCompletion,
                 );
                 let request_for_provider = super::token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -86,6 +86,7 @@ pub(super) async fn handle_streaming_chat_completion(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                    ProviderCapability::ChatCompletionStream,
                 );
                 let request_for_provider = token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -82,6 +82,7 @@ pub(super) async fn handle_streaming_completion(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                    ProviderCapability::ChatCompletionStream,
                 );
                 let request_for_provider = token_policy::prepare_chat_request_for_provider(
                     context.api_key_max_tokens_per_request(),

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -146,6 +146,7 @@ async fn handle_embedding_internal(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                    ProviderCapability::Embeddings,
                 );
                 let mut request_for_provider = core_request.clone();
                 request_for_provider.model = selected_model.clone();

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -58,6 +58,7 @@ pub async fn handle_image_generation_with_state(
                         pricing_service.as_ref(),
                         &provider,
                         &selected_model,
+                        ProviderCapability::ImageGeneration,
                     );
                 let mut usage_pricing_model =
                     if super::pricing_keys::is_variant_image_pricing_key(&pricing_model) {
@@ -65,22 +66,13 @@ pub async fn handle_image_generation_with_state(
                     } else {
                         pricing_model.clone()
                     };
-                if let Some(variant_model) = super::pricing_keys::resolve_image_pricing_model(
+                if let Some(variant_model) = resolve_authoritative_image_pricing_model(
                     pricing_service.as_ref(),
                     &pricing_provider,
-                    &selected_model,
+                    &pricing_model,
                     core_request.size.as_deref(),
                     core_request.quality.as_deref(),
-                )
-                .or_else(|| {
-                    super::pricing_keys::resolve_image_pricing_model(
-                        pricing_service.as_ref(),
-                        &pricing_provider,
-                        &pricing_model,
-                        core_request.size.as_deref(),
-                        core_request.quality.as_deref(),
-                    )
-                }) {
+                ) {
                     usage_pricing_model = variant_model.clone();
                     pricing_model = variant_model;
                 }
@@ -172,6 +164,22 @@ pub async fn handle_image_generation_with_state(
     Ok(response)
 }
 
+fn resolve_authoritative_image_pricing_model(
+    pricing_service: &crate::core::pricing_service::PricingService,
+    pricing_provider: &str,
+    pricing_model: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+) -> Option<String> {
+    super::pricing_keys::resolve_image_pricing_model(
+        pricing_service,
+        pricing_provider,
+        pricing_model,
+        size,
+        quality,
+    )
+}
+
 fn estimated_image_generation_usage(
     request: &CoreImageRequest,
     pricing_provider: &str,
@@ -194,4 +202,80 @@ fn estimated_image_generation_usage(
         request.quality.as_deref(),
     );
     usage
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::pricing_service::LiteLLMModelInfo;
+    use std::collections::HashMap;
+
+    fn image_model_info(provider: &str, price: f64) -> LiteLLMModelInfo {
+        LiteLLMModelInfo {
+            max_tokens: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            input_cost_per_token: None,
+            output_cost_per_token: None,
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: provider.to_string(),
+            mode: "image_generation".to_string(),
+            supports_function_calling: None,
+            supports_vision: None,
+            supports_streaming: None,
+            supports_parallel_function_calling: None,
+            supports_system_message: None,
+            extra: HashMap::from([(
+                "output_cost_per_image".to_string(),
+                serde_json::Value::from(price),
+            )]),
+        }
+    }
+
+    #[test]
+    fn authoritative_pricing_identity_beats_raw_alias_image_variant() {
+        let pricing = crate::core::pricing_service::PricingService::new(None);
+        pricing.add_custom_model(
+            "hd/1024-x-1024/review-public-alias".to_string(),
+            image_model_info("review-provider", 0.99),
+        );
+        pricing.add_custom_model(
+            "hd/1024-x-1024/review-canonical".to_string(),
+            image_model_info("review-provider", 0.01),
+        );
+
+        let resolved = resolve_authoritative_image_pricing_model(
+            &pricing,
+            "review-provider",
+            "review-canonical",
+            Some("1024x1024"),
+            Some("hd"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some("hd/1024-x-1024/review-canonical".to_string())
+        );
+    }
+
+    #[test]
+    fn unpriced_authoritative_identity_never_falls_back_to_raw_alias_variant() {
+        let pricing = crate::core::pricing_service::PricingService::new(None);
+        pricing.add_custom_model(
+            "hd/1024-x-1024/review-public-alias".to_string(),
+            image_model_info("review-provider", 0.99),
+        );
+
+        let resolved = resolve_authoritative_image_pricing_model(
+            &pricing,
+            "review-provider",
+            "review-canonical-unpriced",
+            Some("1024x1024"),
+            Some("hd"),
+        );
+
+        assert_eq!(resolved, None);
+    }
 }

--- a/src/server/routes/ai/images/pricing_keys.rs
+++ b/src/server/routes/ai/images/pricing_keys.rs
@@ -237,6 +237,28 @@ mod tests {
     }
 
     #[test]
+    fn unpriced_canonical_image_identity_does_not_fall_back_to_raw_alias_variant() {
+        let service = PricingService::new(None);
+        service.add_custom_model(
+            "hd/1024-x-1024/review-public-alias".to_string(),
+            model_info(HashMap::from([(
+                "output_cost_per_image".to_string(),
+                serde_json::Value::from(0.10),
+            )])),
+        );
+
+        let resolved = resolve_image_pricing_model(
+            &service,
+            "openai",
+            "review-canonical-unpriced",
+            Some("1024x1024"),
+            Some("hd"),
+        );
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
     fn image_pricing_keys_include_bedrock_hd_step_alias() {
         let keys = image_pricing_keys(
             "bedrock",

--- a/src/server/routes/ai/response_cache.rs
+++ b/src/server/routes/ai/response_cache.rs
@@ -156,6 +156,7 @@ pub(super) fn ensure_chat_cache_pricing_gate(
                 pricing.as_ref(),
                 provider,
                 selected_model,
+                ProviderCapability::ChatCompletion,
             );
             pricing
                 .estimate_loaded_completion_cost_for_provider(
@@ -187,6 +188,7 @@ pub(super) fn ensure_embedding_cache_pricing_gate(
                 pricing.as_ref(),
                 provider,
                 selected_model,
+                ProviderCapability::Embeddings,
             );
             pricing
                 .calculate_loaded_usage_cost_for_provider(&pricing_provider, &pricing_model, &usage)

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -113,6 +113,7 @@ pub(crate) async fn handle_streaming_response(
                     pricing_service.as_ref(),
                     &provider,
                     &selected_model,
+                    ProviderCapability::ChatCompletionStream,
                 );
                 let req = super::token_policy::prepare_chat_request_for_provider(
                     ctx.api_key_max_tokens_per_request(),

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -40,12 +40,15 @@ pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
             });
 
     let mut model_candidates = vec![model.to_string()];
-    if let Provider::OpenAI(provider) = provider {
+    let mapped_model = if let Provider::OpenAI(provider) = provider {
         let mapped = provider.config.get_model_mapping(model);
         if !model_candidates.contains(&mapped) {
-            model_candidates.insert(0, mapped);
+            model_candidates.insert(0, mapped.clone());
         }
-    }
+        Some(mapped)
+    } else {
+        None
+    };
 
     for pricing_provider in &provider_candidates {
         for pricing_model in &model_candidates {
@@ -57,7 +60,26 @@ pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
         }
     }
 
+    if let Some(identity) = mapped_model.as_deref().and_then(|mapped| {
+        unpriced_openai_mapping_identity(&provider.provider_type(), model, mapped)
+    }) {
+        return identity;
+    }
+
     (provider_name.to_string(), model.to_string())
+}
+
+fn unpriced_openai_mapping_identity(
+    provider_type: &ProviderType,
+    requested_model: &str,
+    mapped_model: &str,
+) -> Option<(String, String)> {
+    (mapped_model != requested_model
+        && matches!(
+            provider_type,
+            ProviderType::OpenAI | ProviderType::OpenAICompatible
+        ))
+    .then(|| ("openai".to_string(), mapped_model.to_string()))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -266,4 +288,53 @@ fn estimate_embedding_input_tokens(model: &str, input: &EmbeddingInput) -> u32 {
             });
         total.saturating_add(tokens)
     })
+}
+
+#[cfg(test)]
+mod mapped_identity_tests {
+    use super::*;
+
+    #[test]
+    fn unpriced_openai_mapping_retains_canonical_identity_only_for_real_mapping() {
+        assert_eq!(
+            unpriced_openai_mapping_identity(
+                &ProviderType::OpenAICompatible,
+                "public-alias",
+                "canonical-model",
+            ),
+            Some(("openai".to_string(), "canonical-model".to_string()))
+        );
+        assert_eq!(
+            unpriced_openai_mapping_identity(
+                &ProviderType::OpenAICompatible,
+                "same-model",
+                "same-model",
+            ),
+            None
+        );
+        assert_eq!(
+            unpriced_openai_mapping_identity(
+                &ProviderType::Anthropic,
+                "public-alias",
+                "canonical-model",
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn retained_mapping_identity_does_not_price_non_image_requests() {
+        let pricing = PricingService::new(None);
+        let (provider, model) = unpriced_openai_mapping_identity(
+            &ProviderType::OpenAICompatible,
+            "public-alias",
+            "canonical-model",
+        )
+        .expect("real mapping should retain canonical identity");
+
+        let error = pricing
+            .calculate_loaded_usage_cost_for_provider(&provider, &model, &PricingUsage::new(10, 5))
+            .expect_err("identity retention must not invent a non-image price");
+        assert!(error.to_string().contains("Model not found"));
+    }
 }

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -39,16 +39,15 @@ pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
                 unique
             });
 
-    let mut model_candidates = vec![model.to_string()];
     let mapped_model = if let Provider::OpenAI(provider) = provider {
-        let mapped = provider.config.get_model_mapping(model);
-        if !model_candidates.contains(&mapped) {
-            model_candidates.insert(0, mapped.clone());
-        }
-        Some(mapped)
+        Some(provider.config.get_model_mapping(model))
     } else {
         None
     };
+    let model_candidates = mapped_model
+        .as_ref()
+        .filter(|mapped| mapped.as_str() != model)
+        .map_or_else(|| vec![model.to_string()], |mapped| vec![mapped.clone()]);
 
     for pricing_provider in &provider_candidates {
         for pricing_model in &model_candidates {
@@ -294,6 +293,27 @@ fn estimate_embedding_input_tokens(model: &str, input: &EmbeddingInput) -> u32 {
 mod mapped_identity_tests {
     use super::*;
 
+    fn priced_model_info() -> crate::core::pricing_service::LiteLLMModelInfo {
+        crate::core::pricing_service::LiteLLMModelInfo {
+            max_tokens: Some(4096),
+            max_input_tokens: Some(4096),
+            max_output_tokens: Some(4096),
+            input_cost_per_token: Some(0.001),
+            output_cost_per_token: Some(0.002),
+            input_cost_per_character: None,
+            output_cost_per_character: None,
+            cost_per_second: None,
+            litellm_provider: "openai".to_string(),
+            mode: "chat".to_string(),
+            supports_function_calling: Some(true),
+            supports_vision: Some(false),
+            supports_streaming: Some(true),
+            supports_parallel_function_calling: Some(true),
+            supports_system_message: Some(true),
+            extra: std::collections::HashMap::new(),
+        }
+    }
+
     #[test]
     fn unpriced_openai_mapping_retains_canonical_identity_only_for_real_mapping() {
         assert_eq!(
@@ -336,5 +356,32 @@ mod mapped_identity_tests {
             .calculate_loaded_usage_cost_for_provider(&provider, &model, &PricingUsage::new(10, 5))
             .expect_err("identity retention must not invent a non-image price");
         assert!(error.to_string().contains("Model not found"));
+    }
+
+    #[tokio::test]
+    async fn production_resolver_preserves_explicit_unpriced_mapping_over_priced_raw_alias() {
+        let pricing = PricingService::new(None);
+        pricing.add_custom_model("review-public-alias".to_string(), priced_model_info());
+        let mut config = crate::core::providers::openai::OpenAIConfig::default();
+        config.base.api_key = Some("sk-test".to_string());
+        config.model_mappings.insert(
+            "review-public-alias".to_string(),
+            "review-canonical-unpriced".to_string(),
+        );
+        let provider = Provider::OpenAI(
+            crate::core::providers::openai::OpenAIProvider::new(config)
+                .await
+                .expect("test provider should build"),
+        );
+
+        let identity = pricing_identity_for_provider(&pricing, &provider, "review-public-alias");
+
+        assert_eq!(
+            identity,
+            (
+                "openai".to_string(),
+                "review-canonical-unpriced".to_string()
+            )
+        );
     }
 }

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -8,12 +8,14 @@ use crate::core::providers::Provider;
 use crate::core::providers::provider_type::ProviderType;
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::embedding::EmbeddingInput;
+use crate::core::types::model::ProviderCapability;
 use crate::utils::ai::counter::token_counter::TokenCounter;
 
 pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
     pricing_service: &PricingService,
     provider: &Provider,
     model: &str,
+    surface: ProviderCapability,
 ) -> (String, String) {
     let provider_name = provider.name();
     let mut provider_candidates = vec![provider_name.to_string()];
@@ -39,8 +41,15 @@ pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
                 unique
             });
 
-    let mapped_model = if let Provider::OpenAI(provider) = provider {
-        Some(provider.config.get_model_mapping(model))
+    let mapped_model = if matches!(
+        surface,
+        ProviderCapability::ChatCompletion | ProviderCapability::ChatCompletionStream
+    ) {
+        if let Provider::OpenAI(provider) = provider {
+            Some(provider.config.get_model_mapping(model))
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -60,7 +69,7 @@ pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
     }
 
     if let Some(identity) = mapped_model.as_deref().and_then(|mapped| {
-        unpriced_openai_mapping_identity(&provider.provider_type(), model, mapped)
+        unpriced_openai_mapping_identity(&provider.provider_type(), provider_name, model, mapped)
     }) {
         return identity;
     }
@@ -70,6 +79,7 @@ pub(in crate::server::routes::ai) fn pricing_identity_for_provider(
 
 fn unpriced_openai_mapping_identity(
     provider_type: &ProviderType,
+    pricing_provider: &str,
     requested_model: &str,
     mapped_model: &str,
 ) -> Option<(String, String)> {
@@ -78,7 +88,7 @@ fn unpriced_openai_mapping_identity(
             provider_type,
             ProviderType::OpenAI | ProviderType::OpenAICompatible
         ))
-    .then(|| ("openai".to_string(), mapped_model.to_string()))
+    .then(|| (pricing_provider.to_string(), mapped_model.to_string()))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -292,6 +302,7 @@ fn estimate_embedding_input_tokens(model: &str, input: &EmbeddingInput) -> u32 {
 #[cfg(test)]
 mod mapped_identity_tests {
     use super::*;
+    use crate::core::types::model::ProviderCapability;
 
     fn priced_model_info() -> crate::core::pricing_service::LiteLLMModelInfo {
         crate::core::pricing_service::LiteLLMModelInfo {
@@ -319,6 +330,7 @@ mod mapped_identity_tests {
         assert_eq!(
             unpriced_openai_mapping_identity(
                 &ProviderType::OpenAICompatible,
+                "openai",
                 "public-alias",
                 "canonical-model",
             ),
@@ -327,6 +339,7 @@ mod mapped_identity_tests {
         assert_eq!(
             unpriced_openai_mapping_identity(
                 &ProviderType::OpenAICompatible,
+                "openai",
                 "same-model",
                 "same-model",
             ),
@@ -335,6 +348,7 @@ mod mapped_identity_tests {
         assert_eq!(
             unpriced_openai_mapping_identity(
                 &ProviderType::Anthropic,
+                "anthropic",
                 "public-alias",
                 "canonical-model",
             ),
@@ -347,6 +361,7 @@ mod mapped_identity_tests {
         let pricing = PricingService::new(None);
         let (provider, model) = unpriced_openai_mapping_identity(
             &ProviderType::OpenAICompatible,
+            "openai",
             "public-alias",
             "canonical-model",
         )
@@ -374,7 +389,12 @@ mod mapped_identity_tests {
                 .expect("test provider should build"),
         );
 
-        let identity = pricing_identity_for_provider(&pricing, &provider, "review-public-alias");
+        let identity = pricing_identity_for_provider(
+            &pricing,
+            &provider,
+            "review-public-alias",
+            ProviderCapability::ChatCompletion,
+        );
 
         assert_eq!(
             identity,
@@ -383,5 +403,75 @@ mod mapped_identity_tests {
                 "review-canonical-unpriced".to_string()
             )
         );
+    }
+
+    #[tokio::test]
+    async fn chat_mapping_preserves_configured_provider_when_target_is_unpriced() {
+        let pricing = PricingService::new(None);
+        let mut config = crate::core::providers::openai::OpenAIConfig {
+            provider_name: "review-custom-openai".to_string(),
+            ..Default::default()
+        };
+        config.base.api_key = Some("sk-test".to_string());
+        config.model_mappings.insert(
+            "review-public-alias".to_string(),
+            "review-canonical-unpriced".to_string(),
+        );
+        let provider = Provider::OpenAI(
+            crate::core::providers::openai::OpenAIProvider::new(config)
+                .await
+                .expect("test provider should build"),
+        );
+
+        let identity = pricing_identity_for_provider(
+            &pricing,
+            &provider,
+            "review-public-alias",
+            ProviderCapability::ChatCompletion,
+        );
+
+        assert_eq!(
+            identity,
+            (
+                "review-custom-openai".to_string(),
+                "review-canonical-unpriced".to_string()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_only_mapping_does_not_change_non_chat_pricing_identity() {
+        let pricing = PricingService::new(None);
+        let mut raw_info = priced_model_info();
+        raw_info.litellm_provider = "review-custom-openai".to_string();
+        pricing.add_custom_model("review-public-alias".to_string(), raw_info);
+        let mut config = crate::core::providers::openai::OpenAIConfig {
+            provider_name: "review-custom-openai".to_string(),
+            ..Default::default()
+        };
+        config.base.api_key = Some("sk-test".to_string());
+        config.model_mappings.insert(
+            "review-public-alias".to_string(),
+            "review-canonical-unpriced".to_string(),
+        );
+        let provider = Provider::OpenAI(
+            crate::core::providers::openai::OpenAIProvider::new(config)
+                .await
+                .expect("test provider should build"),
+        );
+
+        for surface in [
+            ProviderCapability::Embeddings,
+            ProviderCapability::ImageGeneration,
+            ProviderCapability::AudioTranscription,
+        ] {
+            assert_eq!(
+                pricing_identity_for_provider(&pricing, &provider, "review-public-alias", surface,),
+                (
+                    "review-custom-openai".to_string(),
+                    "review-public-alias".to_string()
+                )
+            );
+        }
     }
 }

--- a/src/server/routes/pricing.rs
+++ b/src/server/routes/pricing.rs
@@ -315,7 +315,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body: Value = test::read_body_json(response).await;
-        assert_eq!(body["model"], "xai/grok-4.3-latest");
+        assert_eq!(body["model"], "xai/grok-4.3");
         assert_eq!(body["provider"], "xai");
         let total_cost = match body["total_cost"].as_f64() {
             Some(total_cost) => total_cost,
@@ -347,7 +347,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body: Value = test::read_body_json(response).await;
-        assert_eq!(body["model"], "azure/gpt-5.5-2026-04-23");
+        assert_eq!(body["model"], "azure/gpt-5.5");
         assert_eq!(body["provider"], "azure");
         let total_cost = match body["total_cost"].as_f64() {
             Some(total_cost) => total_cost,

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -23,11 +23,13 @@ mod tests {
     #[derive(Clone)]
     struct MockImageState {
         paths: Arc<Mutex<Vec<String>>>,
+        generation_bodies: Arc<Mutex<Vec<Value>>>,
     }
 
     struct MockImageServer {
         base_url: String,
         paths: Arc<Mutex<Vec<String>>>,
+        generation_bodies: Arc<Mutex<Vec<Value>>>,
         handle: actix_web::dev::ServerHandle,
         task: tokio::task::JoinHandle<std::io::Result<()>>,
     }
@@ -35,8 +37,10 @@ mod tests {
     impl MockImageServer {
         async fn start() -> Self {
             let paths = Arc::new(Mutex::new(Vec::new()));
+            let generation_bodies = Arc::new(Mutex::new(Vec::new()));
             let state = MockImageState {
                 paths: Arc::clone(&paths),
+                generation_bodies: Arc::clone(&generation_bodies),
             };
             let listener =
                 std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -60,6 +64,7 @@ mod tests {
             Self {
                 base_url: format!("http://{address}/v1"),
                 paths,
+                generation_bodies,
                 handle,
                 task,
             }
@@ -67,6 +72,10 @@ mod tests {
 
         fn paths(&self) -> Vec<String> {
             self.paths.lock().unwrap().clone()
+        }
+
+        fn generation_bodies(&self) -> Vec<Value> {
+            self.generation_bodies.lock().unwrap().clone()
         }
 
         async fn stop(self) {
@@ -103,9 +112,14 @@ mod tests {
     async fn mock_image_generation(
         state: web::Data<MockImageState>,
         request: HttpRequest,
-        _body: Bytes,
+        body: Bytes,
     ) -> HttpResponse {
         state.paths.lock().unwrap().push(request.path().to_string());
+        state
+            .generation_bodies
+            .lock()
+            .unwrap()
+            .push(serde_json::from_slice(&body).expect("image request should be valid JSON"));
         HttpResponse::Ok().json(json!({
             "created": 1710000002,
             "data": [{ "url": "https://images.example.test/generated.png" }]
@@ -212,6 +226,13 @@ mod tests {
     }
 
     fn flat_image_model_info(output_cost_per_image: f64) -> LiteLLMModelInfo {
+        flat_image_model_info_for_provider("openai", output_cost_per_image)
+    }
+
+    fn flat_image_model_info_for_provider(
+        provider: &str,
+        output_cost_per_image: f64,
+    ) -> LiteLLMModelInfo {
         let mut extra = HashMap::new();
         extra.insert(
             "output_cost_per_image".to_string(),
@@ -226,7 +247,7 @@ mod tests {
             input_cost_per_character: None,
             output_cost_per_character: None,
             cost_per_second: None,
-            litellm_provider: "openai".to_string(),
+            litellm_provider: provider.to_string(),
             mode: "image_generation".to_string(),
             supports_function_calling: None,
             supports_vision: None,
@@ -235,6 +256,21 @@ mod tests {
             supports_system_message: None,
             extra,
         }
+    }
+
+    fn add_raw_image_alias_pricing(
+        state: &litellm_rs::server::state::AppState,
+        alias: &str,
+        catalog_model: &str,
+    ) {
+        let (_, info) = state
+            .pricing
+            .get_model_info_for_provider("openai", catalog_model)
+            .unwrap_or_else(|| panic!("catalog pricing should exist for {catalog_model}"));
+        // OpenAI model_mappings are chat-only. Image transport sends the selected alias,
+        // so the fixture must price that exact wire identity instead of borrowing the
+        // mapped chat target accidentally.
+        state.pricing.add_custom_model(alias.to_string(), info);
     }
 
     fn token_priced_image_model_info(input_cost_per_token: f64) -> LiteLLMModelInfo {
@@ -308,6 +344,7 @@ mod tests {
             "gpt-image-1-mini",
         )])
         .await;
+        add_raw_image_alias_pricing(&state, "image-alias", "gpt-image-1-mini");
         state
             .unified_router
             .add_model_alias("public-image", "image-alias")
@@ -352,6 +389,7 @@ mod tests {
             "gpt-image-1-mini",
         )])
         .await;
+        add_raw_image_alias_pricing(&state, "image-alias", "gpt-image-1-mini");
         let api_key = api_key_with_allowed_models(&["image-alias"]);
         let app = test::init_service(
             App::new()
@@ -477,6 +515,7 @@ mod tests {
             "gpt-image-1-mini",
         )])
         .await;
+        add_raw_image_alias_pricing(&state, "image-alias", "gpt-image-1-mini");
         state.budget_limits.providers.set_provider_limit(
             "openai-primary",
             ProviderLimitConfig::new(0.01, ResetPeriod::Monthly),
@@ -522,6 +561,7 @@ mod tests {
             "gpt-image-1-mini",
         )])
         .await;
+        add_raw_image_alias_pricing(&state, "image-alias", "gpt-image-1-mini");
         state.budget_limits.providers.set_provider_limit(
             "openai-primary",
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
@@ -531,7 +571,7 @@ mod tests {
         expected_usage.image_tokens = Some(1024);
         let expected_cost = state
             .pricing
-            .calculate_loaded_usage_cost_for_provider("openai", "gpt-image-1-mini", &expected_usage)
+            .calculate_loaded_usage_cost_for_provider("openai", "image-alias", &expected_usage)
             .expect("image generation pricing should be available")
             .total_cost;
         let app = test::init_service(
@@ -556,6 +596,11 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(mock.paths(), vec!["/v1/images/generations".to_string()]);
+        assert_eq!(
+            mock.generation_bodies()[0]["model"],
+            "image-alias",
+            "chat-only model mapping must not change the image wire identity"
+        );
         let spent = budget_limits
             .providers
             .get_provider_usage("openai-primary")
@@ -581,6 +626,9 @@ mod tests {
         state
             .pricing
             .add_custom_model("flat-image-model".to_string(), flat_image_model_info(0.06));
+        state
+            .pricing
+            .add_custom_model("flat-image-alias".to_string(), flat_image_model_info(0.06));
         state.budget_limits.providers.set_provider_limit(
             "openai-primary",
             ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
@@ -685,6 +733,16 @@ mod tests {
         state.pricing.add_custom_model(
             "hd/512-x-512/flat-variant-model".to_string(),
             flat_image_model_info(0.10),
+        );
+        // Variant pricing follows the unchanged image wire identity and the selected
+        // custom provider; the chat mapping target is intentionally irrelevant here.
+        state.pricing.add_custom_model(
+            "standard/512-x-512/flat-variant-alias".to_string(),
+            flat_image_model_info_for_provider("openai-primary", 0.05),
+        );
+        state.pricing.add_custom_model(
+            "hd/512-x-512/flat-variant-alias".to_string(),
+            flat_image_model_info_for_provider("openai-primary", 0.10),
         );
         state.budget_limits.providers.set_provider_limit(
             "openai-primary",


### PR DESCRIPTION
## Summary

- replace catalog-wide fuzzy/last-segment pricing lookup with bounded provider-scoped exact resolution
- publish models, provider/casefold indexes, and timestamp as one immutable atomic snapshot
- preserve provider-native slash IDs, explicit Google/Vertex aliases, region/deployment qualifiers, and deterministic case collisions
- retain OpenAI/OpenAICompatible mapped identity so the existing bounded image size/quality resolver can choose an exact variant; non-image misses still fail closed

## Dependency

Depends on #1206. This PR is intentionally stacked on `refactor/openai-model-id-lookup` at `618c35a973180114c209f959193ac1198336841e` and must not be retargeted before that dependency lands.

This replaces the frozen resolver approach in #1204. It does not modify or close #1204; supersession should happen only after this replacement is review-ready.

Related: #1203, #1205, #1201.

## Resolution contract

- provider identity is part of every case-insensitive index key; cross-provider collisions cannot overwrite one another
- only a first segment matching the requested provider or an explicit alias is stripped once
- provider-native namespaces such as Together `BAAI/...` and `openai/...` and Anyscale `google/...` remain complete model IDs
- live lookup is bounded exact/casefolded exact plus explicit Google/Vertex and provider catalog fallbacks; no catalog scan, suffix fuzzy match, or last-segment match remains
- insert and refresh rebuild a prospective snapshot and atomically publish models/index/timestamp under one writer lock; failed refreshes preserve the previous snapshot

## Test notes

- Azure and xAI route expectations now assert the canonical exact rows (`azure/gpt-5.5`, `xai/grok-4.3`) instead of fuzzy dated/latest rows
- the flat image mismatch fixture now requests its complete exact variant key; the old fixture accidentally depended on removed last-segment fuzzy lookup, while the original mismatch assertion remains unchanged
- mapped OpenAI identities are retained without inventing a price; a direct non-image negative test remains `Model not found`

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- pricing-service targeted suite: 138 passed
- pricing route targeted suite: 3 passed
- image-router integration suite: 18 passed
- mapped-identity tests: 2 passed
- bounded full `cargo test`: green, including 9,159 library tests, all integration tests, and doctests

Fixes #1210
