### PR TITLE
feat(xai): add Grok 4.5 and 4.6 catalog

### DIFF
--- a/src/core/providers/openai_like/models.rs
+++ b/src/core/providers/openai_like/models.rs
@@ -11,6 +11,7 @@ const XAI_GROK_43_CONTEXT_LENGTH: u32 = 1_000_000;
 const XAI_GROK_BUILD_INPUT_COST_PER_1K: f64 = 0.001;
 const XAI_GROK_BUILD_OUTPUT_COST_PER_1K: f64 = 0.002;
 const XAI_GROK_BUILD_CONTEXT_LENGTH: u32 = 256_000;
+const XAI_CURRENT_CONTEXT_LENGTH: u32 = 500_000;
 
 const XAI_GROK_43_MODEL_IDS: &[&str] = &[
     "grok-4.3",
@@ -88,6 +89,11 @@ const XAI_GROK_BUILD_MODEL_IDS: &[&str] = &[
     "grok-code-fast",
     "grok-code-fast-1-0825",
 ];
+
+const XAI_GROK_45_MODEL_IDS: &[&str] = &["grok-4.5", "grok-4.5-latest", "grok-build-latest"];
+const XAI_GROK_46_MODEL_IDS: &[&str] = &["grok-4.6"];
+const XAI_GROK_45_REASONING_EFFORTS: &[&str] = &["low", "medium", "high"];
+const XAI_GROK_46_REASONING_EFFORTS: &[&str] = &["low", "medium", "high", "xhigh"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum XaiReasoningParam {
@@ -184,6 +190,8 @@ impl OpenAILikeModelRegistry {
             XAI_GROK_BUILD_INPUT_COST_PER_1K,
             XAI_GROK_BUILD_OUTPUT_COST_PER_1K,
         );
+        registry.register_current_xai_model_family(XAI_GROK_45_MODEL_IDS);
+        registry.register_current_xai_model_family(XAI_GROK_46_MODEL_IDS);
         registry
     }
 
@@ -225,6 +233,23 @@ impl OpenAILikeModelRegistry {
         }
     }
 
+    fn register_current_xai_model_family(&mut self, model_ids: &[&str]) {
+        for model_id in model_ids {
+            self.register_model(OpenAILikeModelConfig {
+                id: (*model_id).to_string(),
+                max_context_length: XAI_CURRENT_CONTEXT_LENGTH,
+                // xAI does not publish a separate maximum output-token limit.
+                max_output_length: None,
+                supports_streaming: true,
+                supports_tools: true,
+                supports_multimodal: true,
+                // The legacy fallback cannot represent cached or long-context tiers.
+                input_cost_per_1k: None,
+                output_cost_per_1k: None,
+            });
+        }
+    }
+
     fn known_config_for_model(&self, model_id: &str) -> Option<&OpenAILikeModelConfig> {
         self.known_models.get(model_id).or_else(|| {
             model_id
@@ -254,7 +279,7 @@ impl OpenAILikeModelRegistry {
                 currency: "USD".to_string(),
                 created_at: None,
                 updated_at: None,
-                metadata: HashMap::new(),
+                metadata: self.build_metadata(config),
             }
         } else {
             // Return default info for unknown models
@@ -304,6 +329,21 @@ impl OpenAILikeModelRegistry {
         capabilities
     }
 
+    fn build_metadata(&self, config: &OpenAILikeModelConfig) -> HashMap<String, serde_json::Value> {
+        let mut metadata = HashMap::new();
+
+        if let Some(efforts) = xai_reasoning_efforts_for_model(&config.id) {
+            metadata.insert(
+                "supports_structured_outputs".to_string(),
+                serde_json::Value::Bool(true),
+            );
+            metadata.insert("supports_batch".to_string(), serde_json::Value::Bool(false));
+            metadata.insert("reasoning_efforts".to_string(), serde_json::json!(efforts));
+        }
+
+        metadata
+    }
+
     /// Check if a model is known (has explicit configuration)
     pub fn is_known_model(&self, model_id: &str) -> bool {
         self.known_config_for_model(model_id).is_some()
@@ -329,10 +369,24 @@ impl OpenAILikeModelRegistry {
 pub fn xai_reasoning_param_for_model(model_id: &str) -> Option<XaiReasoningParam> {
     let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
 
-    if is_xai_grok_43_reasoning_effort_model(model_id) {
+    if is_xai_grok_43_reasoning_effort_model(model_id)
+        || xai_reasoning_efforts_for_model(model_id).is_some()
+    {
         Some(XaiReasoningParam::TopLevelReasoningEffort)
     } else if is_xai_grok_420_multi_agent_model(model_id) {
         Some(XaiReasoningParam::NestedReasoningEffort)
+    } else {
+        None
+    }
+}
+
+pub fn xai_reasoning_efforts_for_model(model_id: &str) -> Option<&'static [&'static str]> {
+    let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
+
+    if XAI_GROK_45_MODEL_IDS.contains(&model_id) {
+        Some(XAI_GROK_45_REASONING_EFFORTS)
+    } else if XAI_GROK_46_MODEL_IDS.contains(&model_id) {
+        Some(XAI_GROK_46_REASONING_EFFORTS)
     } else {
         None
     }
@@ -344,6 +398,12 @@ pub fn is_xai_priced_model(model_id: &str) -> bool {
     XAI_GROK_43_MODEL_IDS.contains(&model_id)
         || XAI_GROK_420_MODEL_IDS.contains(&model_id)
         || XAI_GROK_BUILD_MODEL_IDS.contains(&model_id)
+}
+
+pub fn is_xai_current_model(model_id: &str) -> bool {
+    let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
+
+    XAI_GROK_45_MODEL_IDS.contains(&model_id) || XAI_GROK_46_MODEL_IDS.contains(&model_id)
 }
 
 fn is_xai_grok_43_reasoning_effort_model(model_id: &str) -> bool {
@@ -507,5 +567,70 @@ mod tests {
         assert!(is_xai_priced_model("xai/grok-4.3"));
         assert!(is_xai_priced_model("grok-build-0.1"));
         assert!(!is_xai_priced_model("unknown-grok"));
+    }
+
+    #[test]
+    fn test_current_xai_models_have_official_catalog_metadata() {
+        let registry = get_openai_like_registry();
+
+        for model_id in [
+            "grok-4.5",
+            "grok-4.5-latest",
+            "grok-build-latest",
+            "grok-4.6",
+        ] {
+            let info = registry.get_model_info(model_id);
+
+            assert!(registry.is_known_model(model_id), "{model_id}");
+            assert_eq!(info.id, model_id);
+            assert_eq!(info.max_context_length, 500_000);
+            assert!(info.supports_streaming);
+            assert!(info.supports_tools);
+            assert!(info.supports_multimodal);
+            assert_eq!(info.metadata["supports_structured_outputs"], true);
+            assert_eq!(info.metadata["supports_batch"], false);
+            assert_eq!(
+                xai_reasoning_param_for_model(model_id),
+                Some(XaiReasoningParam::TopLevelReasoningEffort)
+            );
+        }
+
+        let qualified = registry.get_model_info("xai/grok-4.6");
+        assert_eq!(qualified.id, "xai/grok-4.6");
+        assert_eq!(qualified.name, "grok-4.6");
+        assert_eq!(qualified.max_context_length, 500_000);
+    }
+
+    #[test]
+    fn test_current_xai_catalog_matching_is_exact() {
+        let registry = get_openai_like_registry();
+
+        for lookalike in [
+            "grok-4.6-latest",
+            "grok-4.6-2026-08-12",
+            "grok-4.60",
+            "grok-4.5-preview",
+            "xaii/grok-4.6",
+        ] {
+            assert!(!registry.is_known_model(lookalike), "{lookalike}");
+            assert_eq!(xai_reasoning_param_for_model(lookalike), None);
+            assert!(!is_xai_priced_model(lookalike));
+        }
+    }
+
+    #[test]
+    fn test_current_xai_models_fail_closed_in_legacy_single_rate_pricing() {
+        for model_id in [
+            "grok-4.5",
+            "grok-4.5-latest",
+            "grok-build-latest",
+            "grok-4.6",
+        ] {
+            let info = get_openai_like_registry().get_model_info(model_id);
+
+            assert_eq!(info.input_cost_per_1k_tokens, None);
+            assert_eq!(info.output_cost_per_1k_tokens, None);
+            assert!(!is_xai_priced_model(model_id));
+        }
     }
 }

--- a/src/core/providers/openai_like/models.rs
+++ b/src/core/providers/openai_like/models.rs
@@ -3,7 +3,10 @@
 //! Dynamic model support - accepts any model name and passes it through
 
 use crate::core::types::{model::ModelInfo, model::ProviderCapability};
+use serde_json::Value;
 use std::collections::HashMap;
+
+use super::error::{OpenAILikeError, PROVIDER_NAME};
 
 const XAI_GROK_43_INPUT_COST_PER_1K: f64 = 0.00125;
 const XAI_GROK_43_OUTPUT_COST_PER_1K: f64 = 0.0025;
@@ -378,6 +381,53 @@ pub fn xai_reasoning_param_for_model(model_id: &str) -> Option<XaiReasoningParam
     } else {
         None
     }
+}
+
+pub fn xai_native_wire_model(provider_name: &str, mut model: String) -> String {
+    if provider_name == "xai" && model.starts_with("xai/") {
+        model.drain(.."xai/".len());
+    }
+    model
+}
+
+pub fn take_xai_reasoning_effort(
+    provider_name: &str,
+    typed: Option<String>,
+    extra_params: &mut HashMap<String, Value>,
+) -> Result<Option<String>, OpenAILikeError> {
+    if provider_name != "xai" {
+        return Ok(typed);
+    }
+
+    let extra = extra_params.remove("reasoning_effort");
+    match (typed, extra) {
+        (Some(effort), _) => Ok(Some(effort)),
+        (None, Some(Value::String(effort))) => Ok(Some(effort)),
+        (None, Some(_)) => Err(OpenAILikeError::configuration(
+            PROVIDER_NAME,
+            "xAI reasoning_effort must be a string",
+        )),
+        (None, None) => Ok(None),
+    }
+}
+
+pub fn reject_xai_reasoning_incompatible_params(request: &Value) -> Result<(), OpenAILikeError> {
+    let incompatible_params = ["stop", "presence_penalty", "frequency_penalty"]
+        .into_iter()
+        .filter(|field| request.get(*field).is_some())
+        .collect::<Vec<_>>();
+
+    if incompatible_params.is_empty() {
+        return Ok(());
+    }
+
+    Err(OpenAILikeError::configuration(
+        PROVIDER_NAME,
+        format!(
+            "xAI reasoning_effort is incompatible with {}",
+            incompatible_params.join(", ")
+        ),
+    ))
 }
 
 pub fn xai_reasoning_efforts_for_model(model_id: &str) -> Option<&'static [&'static str]> {

--- a/src/core/providers/openai_like/models.rs
+++ b/src/core/providers/openai_like/models.rs
@@ -459,7 +459,10 @@ pub fn is_xai_priced_model(model_id: &str) -> bool {
 
 pub fn is_xai_current_model(model_id: &str) -> bool {
     let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
+    is_xai_current_effective_model(model_id)
+}
 
+pub fn is_xai_current_effective_model(model_id: &str) -> bool {
     XAI_GROK_45_MODEL_IDS.contains(&model_id) || XAI_GROK_46_MODEL_IDS.contains(&model_id)
 }
 

--- a/src/core/providers/openai_like/models.rs
+++ b/src/core/providers/openai_like/models.rs
@@ -401,12 +401,19 @@ pub fn take_xai_reasoning_effort(
 
     let extra = extra_params.remove("reasoning_effort");
     match (typed, extra) {
-        (Some(effort), _) => Ok(Some(effort)),
+        (Some(typed), Some(Value::String(extra))) if typed == extra => Ok(Some(typed)),
+        (Some(typed), Some(Value::String(extra))) => Err(OpenAILikeError::configuration(
+            PROVIDER_NAME,
+            format!(
+                "conflicting xAI reasoning_effort values: typed '{typed}' and extra_body '{extra}'"
+            ),
+        )),
         (None, Some(Value::String(effort))) => Ok(Some(effort)),
-        (None, Some(_)) => Err(OpenAILikeError::configuration(
+        (Some(_), Some(_)) | (None, Some(_)) => Err(OpenAILikeError::configuration(
             PROVIDER_NAME,
             "xAI reasoning_effort must be a string",
         )),
+        (Some(effort), None) => Ok(Some(effort)),
         (None, None) => Ok(None),
     }
 }

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -455,7 +455,17 @@ impl OpenAILikeProvider {
         }
 
         Self::reject_xai_reasoning_incompatible_params(request)?;
-
+        if let Some(allowed) = super::models::xai_reasoning_efforts_for_model(model)
+            && !allowed.contains(&effort.as_str())
+        {
+            return Err(OpenAILikeError::configuration(
+                PROVIDER_NAME,
+                format!(
+                    "xAI model {model} supports reasoning_effort values: {}",
+                    allowed.join(", ")
+                ),
+            ));
+        }
         match super::models::xai_reasoning_param_for_model(model) {
             Some(super::models::XaiReasoningParam::TopLevelReasoningEffort) => {
                 request["reasoning_effort"] = Value::String(effort);
@@ -707,19 +717,24 @@ impl LLMProvider for OpenAILikeProvider {
         if self.config.provider_name != "xai" && super::models::is_xai_priced_model(model) {
             return Ok(0.0);
         }
-
         let model_info = self.get_model_info(model);
-        if self.config.provider_name == "meta_llama"
+        if ((self.config.provider_name == "meta_llama"
             && crate::core::providers::registry::catalog_policy::catalog_model_info(
                 &self.provider_name,
                 model,
             )
-            .is_some()
+            .is_some())
+            || (self.config.provider_name == "xai" && super::models::is_xai_current_model(model)))
             && (model_info.input_cost_per_1k_tokens.is_none()
                 || model_info.output_cost_per_1k_tokens.is_none())
         {
+            let provider = if self.provider_name == "xai" {
+                "xai"
+            } else {
+                "meta_llama"
+            };
             return Err(ProviderError::invalid_request(
-                "meta_llama",
+                provider,
                 format!("pricing is unavailable for model '{model}'"),
             ));
         }

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -376,6 +376,7 @@ impl OpenAILikeProvider {
             request.reasoning_effort,
             &mut extra_params,
         )?;
+        let has_reasoning_effort = reasoning_effort.is_some();
 
         let openrouter_thinking_params = if self.config.provider_name == "openrouter" {
             if let Some(thinking_config) = &request.thinking {
@@ -443,6 +444,10 @@ impl OpenAILikeProvider {
             }
         }
 
+        if self.config.provider_name == "xai" && has_reasoning_effort {
+            super::models::reject_xai_reasoning_incompatible_params(&openai_request)?;
+        }
+
         crate::core::providers::registry::catalog_policy::filter_request(
             &self.provider_name,
             &mut openai_request,
@@ -462,7 +467,6 @@ impl OpenAILikeProvider {
             return Ok(());
         }
 
-        super::models::reject_xai_reasoning_incompatible_params(request)?;
         if let Some(allowed) = super::models::xai_reasoning_efforts_for_model(model)
             && !allowed.contains(&effort.as_str())
         {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -306,7 +306,10 @@ impl OpenAILikeProvider {
 
     /// Transform ChatRequest to OpenAI API format
     fn transform_chat_request(&self, request: ChatRequest) -> Result<Value, OpenAILikeError> {
-        let model = self.config.get_effective_model(&request.model);
+        let model = super::models::xai_native_wire_model(
+            &self.config.provider_name,
+            self.config.get_effective_model(&request.model),
+        );
 
         let mut openai_request = serde_json::json!({
             "model": model,
@@ -367,7 +370,12 @@ impl OpenAILikeProvider {
                 .map_err(|e| OpenAILikeError::serialization(PROVIDER_NAME, e.to_string()))?;
         }
 
-        let reasoning_effort = request.reasoning_effort;
+        let mut extra_params = request.extra_params;
+        let reasoning_effort = super::models::take_xai_reasoning_effort(
+            &self.config.provider_name,
+            request.reasoning_effort,
+            &mut extra_params,
+        )?;
 
         let openrouter_thinking_params = if self.config.provider_name == "openrouter" {
             if let Some(thinking_config) = &request.thinking {
@@ -412,7 +420,7 @@ impl OpenAILikeProvider {
         }
 
         if let Some(obj) = openai_request.as_object_mut() {
-            for (key, value) in request.extra_params {
+            for (key, value) in extra_params {
                 obj.entry(key).or_insert(value);
             }
 
@@ -454,7 +462,7 @@ impl OpenAILikeProvider {
             return Ok(());
         }
 
-        Self::reject_xai_reasoning_incompatible_params(request)?;
+        super::models::reject_xai_reasoning_incompatible_params(request)?;
         if let Some(allowed) = super::models::xai_reasoning_efforts_for_model(model)
             && !allowed.contains(&effort.as_str())
         {
@@ -480,25 +488,6 @@ impl OpenAILikeProvider {
                 format!("xAI model {model} does not support reasoning_effort"),
             )),
         }
-    }
-
-    fn reject_xai_reasoning_incompatible_params(request: &Value) -> Result<(), OpenAILikeError> {
-        let incompatible_params = ["stop", "presence_penalty", "frequency_penalty"]
-            .into_iter()
-            .filter(|field| request.get(*field).is_some())
-            .collect::<Vec<_>>();
-
-        if incompatible_params.is_empty() {
-            return Ok(());
-        }
-
-        Err(OpenAILikeError::configuration(
-            PROVIDER_NAME,
-            format!(
-                "xAI reasoning_effort is incompatible with {}",
-                incompatible_params.join(", ")
-            ),
-        ))
     }
 
     fn transform_chat_response(&self, response: Value) -> Result<ChatResponse, OpenAILikeError> {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -304,12 +304,17 @@ impl OpenAILikeProvider {
         )))
     }
 
-    /// Transform ChatRequest to OpenAI API format
+    fn effective_model(&self, model: &str) -> String {
+        let configured = self.config.get_effective_model(model);
+        if self.config.model_prefix.is_some() {
+            configured
+        } else {
+            super::models::xai_native_wire_model(&self.config.provider_name, configured)
+        }
+    }
+
     fn transform_chat_request(&self, request: ChatRequest) -> Result<Value, OpenAILikeError> {
-        let model = super::models::xai_native_wire_model(
-            &self.config.provider_name,
-            self.config.get_effective_model(&request.model),
-        );
+        let model = self.effective_model(&request.model);
 
         let mut openai_request = serde_json::json!({
             "model": model,
@@ -707,6 +712,8 @@ impl LLMProvider for OpenAILikeProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
+        let model = self.effective_model(model);
+        let model = model.as_str();
         if self.config.provider_name != "xai" && super::models::is_xai_priced_model(model) {
             return Ok(0.0);
         }
@@ -717,7 +724,8 @@ impl LLMProvider for OpenAILikeProvider {
                 model,
             )
             .is_some())
-            || (self.config.provider_name == "xai" && super::models::is_xai_current_model(model)))
+            || (self.config.provider_name == "xai"
+                && super::models::is_xai_current_effective_model(model)))
             && (model_info.input_cost_per_1k_tokens.is_none()
                 || model_info.output_cost_per_1k_tokens.is_none())
         {

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -424,6 +424,53 @@ async fn test_xai_grok_43_reasoning_effort_is_top_level() {
 }
 
 #[tokio::test]
+async fn test_xai_current_models_use_top_level_reasoning_effort() {
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    for (model, effort) in [
+        ("grok-4.5", "low"),
+        ("grok-4.5-latest", "medium"),
+        ("grok-build-latest", "high"),
+        ("grok-4.6", "low"),
+        ("xai/grok-4.6", "medium"),
+        ("grok-4.6", "high"),
+        ("grok-4.6", "xhigh"),
+    ] {
+        let request = ChatRequest {
+            model: model.to_string(),
+            messages: vec![],
+            reasoning_effort: Some(effort.to_string()),
+            ..Default::default()
+        };
+
+        let json = provider.transform_chat_request(request).unwrap();
+        assert_eq!(json["reasoning_effort"], effort);
+        assert!(json.get("reasoning").is_none());
+    }
+}
+
+#[tokio::test]
+async fn test_xai_current_models_enforce_reasoning_effort_levels() {
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    let request = ChatRequest {
+        model: "grok-4.5".to_string(),
+        messages: vec![],
+        reasoning_effort: Some("xhigh".to_string()),
+        ..Default::default()
+    };
+
+    let err = provider.transform_chat_request(request).unwrap_err();
+    assert!(err.to_string().contains("low, medium, high"));
+}
+
+#[tokio::test]
 async fn test_xai_multi_agent_reasoning_effort_is_nested() {
     let config = OpenAILikeConfig::new("https://api.x.ai/v1")
         .with_provider_name("xai")
@@ -477,6 +524,28 @@ async fn test_xai_high_context_uses_registered_pricing() {
         .unwrap();
 
     assert!((cost - 0.315).abs() < 1e-12);
+}
+
+#[tokio::test]
+async fn test_xai_current_model_cost_fails_closed_until_tiered_authority() {
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    for (model, input_tokens) in [
+        ("grok-4.5", 199_999),
+        ("grok-4.5", 200_000),
+        ("grok-4.6", 199_999),
+        ("grok-4.6", 200_000),
+    ] {
+        let error = LLMProvider::calculate_cost(&provider, model, input_tokens, 1_000)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("pricing is unavailable"));
+    }
 }
 
 #[tokio::test]

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -522,6 +522,94 @@ async fn test_xai_extra_reasoning_effort_uses_the_same_validation_path() {
 }
 
 #[tokio::test]
+async fn test_xai_duplicate_reasoning_effort_requires_identical_strings() {
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    for (extra, expected_error) in [
+        (serde_json::json!("high"), None),
+        (serde_json::json!("low"), Some("conflicting")),
+        (serde_json::json!(7), Some("must be a string")),
+    ] {
+        let request = ChatRequest {
+            model: "grok-4.6".to_string(),
+            messages: vec![],
+            reasoning_effort: Some("high".to_string()),
+            extra_params: std::collections::HashMap::from([(
+                "reasoning_effort".to_string(),
+                extra,
+            )]),
+            ..Default::default()
+        };
+
+        match expected_error {
+            Some(expected) => assert!(
+                provider
+                    .transform_chat_request(request)
+                    .unwrap_err()
+                    .to_string()
+                    .contains(expected)
+            ),
+            None => {
+                let json = provider.transform_chat_request(request).unwrap();
+                assert_eq!(json["reasoning_effort"], "high");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_xai_reasoning_validates_incompatible_fields_after_extra_merge() {
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    for (typed, field, value) in [
+        (None, "stop", serde_json::json!(["done"])),
+        (None, "presence_penalty", serde_json::json!(0.1)),
+        (None, "frequency_penalty", serde_json::json!(0.1)),
+        (Some("high"), "stop", serde_json::json!(["done"])),
+        (Some("high"), "presence_penalty", serde_json::json!(0.1)),
+        (Some("high"), "frequency_penalty", serde_json::json!(0.1)),
+    ] {
+        let mut extra_params = std::collections::HashMap::from([(field.to_string(), value)]);
+        if typed.is_none() {
+            extra_params.insert("reasoning_effort".to_string(), serde_json::json!("high"));
+        }
+        let request = ChatRequest {
+            model: "grok-4.6".to_string(),
+            messages: vec![],
+            reasoning_effort: typed.map(str::to_string),
+            extra_params,
+            ..Default::default()
+        };
+
+        let error = provider.transform_chat_request(request).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("reasoning_effort is incompatible"));
+        assert!(message.contains(field));
+    }
+
+    let allowed_without_reasoning = ChatRequest {
+        model: "grok-4.6".to_string(),
+        messages: vec![],
+        extra_params: std::collections::HashMap::from([(
+            "stop".to_string(),
+            serde_json::json!(["done"]),
+        )]),
+        ..Default::default()
+    };
+    let json = provider
+        .transform_chat_request(allowed_without_reasoning)
+        .unwrap();
+    assert_eq!(json["stop"], serde_json::json!(["done"]));
+    assert!(json.get("reasoning_effort").is_none());
+}
+
+#[tokio::test]
 async fn test_xai_multi_agent_reasoning_effort_is_nested() {
     let config = OpenAILikeConfig::new("https://api.x.ai/v1")
         .with_provider_name("xai")

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -688,6 +688,51 @@ async fn test_xai_current_model_cost_fails_closed_until_tiered_authority() {
 }
 
 #[tokio::test]
+async fn test_xai_custom_prefix_uses_one_effective_identity_for_wire_and_cost() {
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_model_prefix("custom/")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    let request = ChatRequest {
+        model: "custom/grok-4.6".to_string(),
+        messages: vec![],
+        ..Default::default()
+    };
+    let json = provider.transform_chat_request(request).unwrap();
+    assert_eq!(json["model"], "grok-4.6");
+    let error = LLMProvider::calculate_cost(&provider, "custom/grok-4.6", 1, 1)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("pricing is unavailable"));
+
+    for (model, effective) in [
+        ("custom/unknown-model", "unknown-model"),
+        ("custom/custom/grok-4.6", "custom/grok-4.6"),
+        ("custom/xai/grok-4.6", "xai/grok-4.6"),
+        ("customized/grok-4.6", "customized/grok-4.6"),
+        ("wrong/grok-4.6", "wrong/grok-4.6"),
+    ] {
+        let request = ChatRequest {
+            model: model.to_string(),
+            messages: vec![],
+            ..Default::default()
+        };
+        let json = provider.transform_chat_request(request).unwrap();
+        assert_eq!(json["model"], effective);
+        assert_eq!(
+            LLMProvider::calculate_cost(&provider, model, 1, 1)
+                .await
+                .unwrap(),
+            0.0
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_non_xai_provider_does_not_use_xai_pricing() {
     use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -430,14 +430,14 @@ async fn test_xai_current_models_use_top_level_reasoning_effort() {
         .with_skip_api_key(true);
     let provider = OpenAILikeProvider::new(config).await.unwrap();
 
-    for (model, effort) in [
-        ("grok-4.5", "low"),
-        ("grok-4.5-latest", "medium"),
-        ("grok-build-latest", "high"),
-        ("grok-4.6", "low"),
-        ("xai/grok-4.6", "medium"),
-        ("grok-4.6", "high"),
-        ("grok-4.6", "xhigh"),
+    for (model, wire_model, effort) in [
+        ("grok-4.5", "grok-4.5", "low"),
+        ("grok-4.5-latest", "grok-4.5-latest", "medium"),
+        ("grok-build-latest", "grok-build-latest", "high"),
+        ("grok-4.6", "grok-4.6", "low"),
+        ("xai/grok-4.6", "grok-4.6", "medium"),
+        ("grok-4.6", "grok-4.6", "high"),
+        ("grok-4.6", "grok-4.6", "xhigh"),
     ] {
         let request = ChatRequest {
             model: model.to_string(),
@@ -447,9 +447,27 @@ async fn test_xai_current_models_use_top_level_reasoning_effort() {
         };
 
         let json = provider.transform_chat_request(request).unwrap();
+        assert_eq!(json["model"], wire_model);
         assert_eq!(json["reasoning_effort"], effort);
         assert!(json.get("reasoning").is_none());
     }
+}
+
+#[tokio::test]
+async fn test_non_xai_transport_preserves_qualified_xai_model_id() {
+    let config = OpenAILikeConfig::new("https://vertex.example.com/v1")
+        .with_provider_name("vertex_ai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    let request = ChatRequest {
+        model: "xai/grok-4.6".to_string(),
+        messages: vec![],
+        ..Default::default()
+    };
+
+    let json = provider.transform_chat_request(request).unwrap();
+    assert_eq!(json["model"], "xai/grok-4.6");
 }
 
 #[tokio::test]
@@ -468,6 +486,39 @@ async fn test_xai_current_models_enforce_reasoning_effort_levels() {
 
     let err = provider.transform_chat_request(request).unwrap_err();
     assert!(err.to_string().contains("low, medium, high"));
+}
+
+#[tokio::test]
+async fn test_xai_extra_reasoning_effort_uses_the_same_validation_path() {
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+
+    let invalid = ChatRequest {
+        model: "grok-4.5".to_string(),
+        messages: vec![],
+        extra_params: std::collections::HashMap::from([(
+            "reasoning_effort".to_string(),
+            serde_json::json!("xhigh"),
+        )]),
+        ..Default::default()
+    };
+    let error = provider.transform_chat_request(invalid).unwrap_err();
+    assert!(error.to_string().contains("low, medium, high"));
+
+    let valid = ChatRequest {
+        model: "grok-4.6".to_string(),
+        messages: vec![],
+        extra_params: std::collections::HashMap::from([(
+            "reasoning_effort".to_string(),
+            serde_json::json!("xhigh"),
+        )]),
+        ..Default::default()
+    };
+    let json = provider.transform_chat_request(valid).unwrap();
+    assert_eq!(json["reasoning_effort"], "xhigh");
+    assert!(json.get("reasoning").is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- register the official `grok-4.5`, `grok-4.5-latest`, `grok-build-latest`, and `grok-4.6` xAI catalog identities
- expose 500,000-token context, text/image input, tools/function calling, structured-output metadata, and documented reasoning levels
- preserve qualified publisher IDs for non-xAI transports while sending the native xAI API its documented bare model ID
- use one exact, single-layer effective model identity for request serialization and provider-local cost checks, including configured custom prefixes
- normalize identical typed/`extra_body` `reasoning_effort` values, reject conflicts/non-strings, and validate the final merged request through one model-specific contract
- keep lookalikes, invented snapshots, and undocumented aliases outside known/priced classification
- fail closed for provider-local cost calculation because the legacy config cannot represent cached-token prices or the `>= 200,000` prompt tier

## Pricing dependency

This PR deliberately does not add a single static input/output price for Grok
4.5 or 4.6. `OpenAILikeModelConfig` cannot represent cached-token rates or the
long-context tier, so doing so would undercharge requests and misstate xAI
pricing. Authoritative tiered and cached pricing depends on #1222. The 199,999
and 200,000 token boundary tests continue to assert a clear error in this
static fallback until that central runtime authority is available.

## Official sources

- https://docs.x.ai/developers/models/grok-4.5
- https://docs.x.ai/developers/models/grok-4.6
- https://docs.x.ai/developers/model-capabilities/text/reasoning
- https://docs.x.ai/developers/community/google-cloud-vertex-ai
- https://docs.x.ai/developers/pricing
- https://docs.x.ai/developers/release-notes

The native xAI examples use `grok-4.6`; the documented Vertex publisher form is
`xai/grok-4.6`. Grok 4.5 advertises low/medium/high and Grok 4.6 additionally
advertises xhigh. This PR preserves the existing strict local allowlist and now
applies it consistently to both typed and `extra_body` inputs.

## Verification

- `cargo fmt --check`
- `cargo test core::providers::openai_like --lib --features providers-extended` (78 passed)
- `cargo test xai_ --lib --features providers-extended` (25 passed, including pricing authority/routes)
- `cargo check --features providers-extended`
- `cargo clippy --lib --features providers-extended -- -D warnings`

Depends on #1222 for complete runtime tiered/cached pricing.

Fixes #1213
