### PR TITLE
refactor(openai): resolve exact catalog identities

### DIFF
--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -21,9 +21,10 @@ impl Provider {
                     model_spec.model_info.capabilities.contains(capability)
                 }
                 OpenAICatalogRuntimeResolution::PricingOnly(_) => false,
-                OpenAICatalogRuntimeResolution::Unresolved(_) => {
+                OpenAICatalogRuntimeResolution::UnregisteredDeployment { .. } => {
                     LLMProvider::supports_capability(provider, capability)
                 }
+                OpenAICatalogRuntimeResolution::Invalid(_) => false,
             },
             Provider::OpenAILike(provider) if capability == &ProviderCapability::Rerank => {
                 openai_like_provider_supports_rerank(provider.name())
@@ -129,6 +130,29 @@ mod tests {
                 provider.supports_capability_for_model("custom-openai-deployment", &capability),
                 "unresolved OpenAI deployments retain provider-level pass-through"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_openai_identities_fail_closed_for_all_production_routes() {
+        let provider = openai_provider().await;
+
+        for model in [
+            "anthropic/gpt-4",
+            "openai/openai/gpt-4",
+            "openai/fake-gpt-5",
+            "unknown/a/b",
+        ] {
+            for capability in [
+                ProviderCapability::ChatCompletion,
+                ProviderCapability::ChatCompletionStream,
+                ProviderCapability::Embeddings,
+            ] {
+                assert!(
+                    !provider.supports_capability_for_model(model, &capability),
+                    "invalid model identity {model} must not inherit {capability:?}"
+                );
+            }
         }
     }
 

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -1,4 +1,5 @@
 use crate::core::providers::Provider;
+use crate::core::providers::openai::models::OpenAICatalogRuntimeResolution;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::model::ProviderCapability;
 
@@ -15,13 +16,15 @@ impl Provider {
         capability: &ProviderCapability,
     ) -> bool {
         match self {
-            Provider::OpenAI(provider) => {
-                if provider.get_model_config(model).is_some() {
-                    provider.model_supports_capability(model, capability)
-                } else {
+            Provider::OpenAI(provider) => match provider.resolve_model_runtime(model) {
+                OpenAICatalogRuntimeResolution::Callable(model_spec) => {
+                    model_spec.model_info.capabilities.contains(capability)
+                }
+                OpenAICatalogRuntimeResolution::PricingOnly(_) => false,
+                OpenAICatalogRuntimeResolution::Unresolved(_) => {
                     LLMProvider::supports_capability(provider, capability)
                 }
-            }
+            },
             Provider::OpenAILike(provider) if capability == &ProviderCapability::Rerank => {
                 openai_like_provider_supports_rerank(provider.name())
             }
@@ -65,8 +68,69 @@ fn normalize_provider_name(provider_name: &str) -> String {
 mod tests {
     use super::{openai_like_provider_supports_gemini, openai_like_provider_supports_rerank};
     use crate::core::net::ProviderEndpointAccess;
+    use crate::core::providers::openai::OpenAIProvider;
     use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
-    use crate::core::providers::{GeminiNativeRequest, ProviderError};
+    use crate::core::providers::{GeminiNativeRequest, Provider, ProviderError};
+    use crate::core::types::model::ProviderCapability;
+
+    async fn openai_provider() -> Provider {
+        Provider::OpenAI(
+            OpenAIProvider::with_api_key("sk-test-key")
+                .await
+                .expect("test OpenAI provider should build"),
+        )
+    }
+
+    #[tokio::test]
+    async fn openai_pricing_only_catalog_entries_do_not_inherit_provider_capabilities() {
+        let provider = openai_provider().await;
+
+        for model in ["1024-x-1024/dall-e-2", "openai/1024-x-1024/dall-e-2"] {
+            for capability in [
+                ProviderCapability::ChatCompletion,
+                ProviderCapability::ChatCompletionStream,
+                ProviderCapability::Embeddings,
+            ] {
+                assert!(
+                    !provider.supports_capability_for_model(model, &capability),
+                    "pricing-only catalog key {model} must not inherit {capability:?}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_callable_and_unknown_models_keep_existing_route_contracts() {
+        let provider = openai_provider().await;
+
+        assert!(
+            provider
+                .supports_capability_for_model("openai/gpt-4", &ProviderCapability::ChatCompletion)
+        );
+        assert!(
+            !provider
+                .supports_capability_for_model("openai/gpt-4", &ProviderCapability::Embeddings)
+        );
+        assert!(provider.supports_capability_for_model(
+            "text-embedding-3-small",
+            &ProviderCapability::Embeddings
+        ));
+        assert!(!provider.supports_capability_for_model(
+            "text-embedding-3-small",
+            &ProviderCapability::ChatCompletion
+        ));
+
+        for capability in [
+            ProviderCapability::ChatCompletion,
+            ProviderCapability::ChatCompletionStream,
+            ProviderCapability::Embeddings,
+        ] {
+            assert!(
+                provider.supports_capability_for_model("custom-openai-deployment", &capability),
+                "unresolved OpenAI deployments retain provider-level pass-through"
+            );
+        }
+    }
 
     #[test]
     fn gemini_compatibility_name_set_is_closed_and_normalized() {

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -335,7 +335,8 @@ impl OpenAIProvider {
                 model_spec.model_info.capabilities.contains(capability)
             }
             OpenAICatalogRuntimeResolution::PricingOnly(_)
-            | OpenAICatalogRuntimeResolution::Unresolved(_) => false,
+            | OpenAICatalogRuntimeResolution::UnregisteredDeployment { .. }
+            | OpenAICatalogRuntimeResolution::Invalid(_) => false,
         }
     }
 
@@ -344,7 +345,8 @@ impl OpenAIProvider {
         match self.resolve_model_runtime(model_id) {
             OpenAICatalogRuntimeResolution::Callable(model_spec) => Some(&model_spec.config),
             OpenAICatalogRuntimeResolution::PricingOnly(_)
-            | OpenAICatalogRuntimeResolution::Unresolved(_) => None,
+            | OpenAICatalogRuntimeResolution::UnregisteredDeployment { .. }
+            | OpenAICatalogRuntimeResolution::Invalid(_) => None,
         }
     }
 
@@ -657,9 +659,10 @@ impl LLMProvider for OpenAIProvider {
                     "user",
                 ],
             }
-        } else if matches!(resolution, OpenAICatalogRuntimeResolution::PricingOnly(_)) {
-            &[]
-        } else {
+        } else if matches!(
+            resolution,
+            OpenAICatalogRuntimeResolution::UnregisteredDeployment { .. }
+        ) {
             &[
                 "messages",
                 "model",
@@ -669,6 +672,8 @@ impl LLMProvider for OpenAIProvider {
                 "stream",
                 "user",
             ]
+        } else {
+            &[]
         }
     }
 

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -30,7 +30,7 @@ use crate::core::types::{
 
 use super::{
     config::OpenAIConfig,
-    models::{OpenAIModelRegistry, get_openai_registry},
+    models::{OpenAICatalogRuntimeResolution, OpenAIModelRegistry, get_openai_registry},
 };
 use crate::core::traits::error_mapper::trait_def::ErrorMapper;
 
@@ -330,20 +330,29 @@ impl OpenAIProvider {
         model_id: &str,
         capability: &ProviderCapability,
     ) -> bool {
-        self.model_registry
-            .resolve_catalog_identity(model_id)
-            .ok()
-            .and_then(|identity| identity.capability_spec())
-            .is_some_and(|model_spec| model_spec.model_info.capabilities.contains(capability))
+        match self.resolve_model_runtime(model_id) {
+            OpenAICatalogRuntimeResolution::Callable(model_spec) => {
+                model_spec.model_info.capabilities.contains(capability)
+            }
+            OpenAICatalogRuntimeResolution::PricingOnly(_)
+            | OpenAICatalogRuntimeResolution::Unresolved(_) => false,
+        }
     }
 
     /// Get model configuration
     pub fn get_model_config(&self, model_id: &str) -> Option<&super::models::OpenAIModelConfig> {
-        self.model_registry
-            .resolve_catalog_identity(model_id)
-            .ok()
-            .and_then(|identity| identity.capability_spec())
-            .map(|spec| &spec.config)
+        match self.resolve_model_runtime(model_id) {
+            OpenAICatalogRuntimeResolution::Callable(model_spec) => Some(&model_spec.config),
+            OpenAICatalogRuntimeResolution::PricingOnly(_)
+            | OpenAICatalogRuntimeResolution::Unresolved(_) => None,
+        }
+    }
+
+    pub(crate) fn resolve_model_runtime<'input>(
+        &self,
+        model_id: &'input str,
+    ) -> OpenAICatalogRuntimeResolution<'static, 'input> {
+        self.model_registry.resolve_runtime_identity(model_id)
     }
 }
 
@@ -506,13 +515,8 @@ impl LLMProvider for OpenAIProvider {
     // ==================== Python LiteLLM Compatible Interface ====================
 
     fn get_supported_openai_params(&self, model: &str) -> &'static [&'static str] {
-        // Return parameters based on model capabilities
-        if let Some(model_spec) = self
-            .model_registry
-            .resolve_catalog_identity(model)
-            .ok()
-            .and_then(|identity| identity.capability_spec())
-        {
+        let resolution = self.resolve_model_runtime(model);
+        if let OpenAICatalogRuntimeResolution::Callable(model_spec) = resolution {
             match model_spec.family {
                 super::models::OpenAIModelFamily::GPT5
                 | super::models::OpenAIModelFamily::GPT5Mini
@@ -653,6 +657,8 @@ impl LLMProvider for OpenAIProvider {
                     "user",
                 ],
             }
+        } else if matches!(resolution, OpenAICatalogRuntimeResolution::PricingOnly(_)) {
+            &[]
         } else {
             &[
                 "messages",

--- a/src/core/providers/openai/client.rs
+++ b/src/core/providers/openai/client.rs
@@ -330,17 +330,19 @@ impl OpenAIProvider {
         model_id: &str,
         capability: &ProviderCapability,
     ) -> bool {
-        if let Some(model_spec) = self.model_registry.get_model_spec(model_id) {
-            model_spec.model_info.capabilities.contains(capability)
-        } else {
-            false
-        }
+        self.model_registry
+            .resolve_catalog_identity(model_id)
+            .ok()
+            .and_then(|identity| identity.capability_spec())
+            .is_some_and(|model_spec| model_spec.model_info.capabilities.contains(capability))
     }
 
     /// Get model configuration
     pub fn get_model_config(&self, model_id: &str) -> Option<&super::models::OpenAIModelConfig> {
         self.model_registry
-            .get_model_spec(model_id)
+            .resolve_catalog_identity(model_id)
+            .ok()
+            .and_then(|identity| identity.capability_spec())
             .map(|spec| &spec.config)
     }
 }
@@ -504,10 +506,13 @@ impl LLMProvider for OpenAIProvider {
     // ==================== Python LiteLLM Compatible Interface ====================
 
     fn get_supported_openai_params(&self, model: &str) -> &'static [&'static str] {
-        let model = model.strip_prefix("openai/").unwrap_or(model);
-
         // Return parameters based on model capabilities
-        if let Some(model_spec) = self.model_registry.get_model_spec(model) {
+        if let Some(model_spec) = self
+            .model_registry
+            .resolve_catalog_identity(model)
+            .ok()
+            .and_then(|identity| identity.capability_spec())
+        {
             match model_spec.family {
                 super::models::OpenAIModelFamily::GPT5
                 | super::models::OpenAIModelFamily::GPT5Mini

--- a/src/core/providers/openai/client_tests/provider_support_tests.rs
+++ b/src/core/providers/openai/client_tests/provider_support_tests.rs
@@ -162,6 +162,27 @@ fn test_pricing_only_params_are_not_promoted_but_unknown_models_pass_through() {
 }
 
 #[test]
+fn test_invalid_qualified_model_ids_do_not_advertise_openai_params() {
+    let provider = create_test_provider();
+
+    for model in [
+        "anthropic/gpt-4",
+        "openai/openai/gpt-4",
+        "openai/fake-gpt-5",
+        "unknown/a/b",
+    ] {
+        assert!(
+            provider.get_supported_openai_params(model).is_empty(),
+            "invalid model identity {model} must fail closed"
+        );
+    }
+
+    let deployment_params = provider.get_supported_openai_params("custom-openai-deployment");
+    assert!(deployment_params.contains(&"messages"));
+    assert!(deployment_params.contains(&"stream"));
+}
+
+#[test]
 fn test_get_model_info() {
     let provider = create_test_provider();
 

--- a/src/core/providers/openai/client_tests/provider_support_tests.rs
+++ b/src/core/providers/openai/client_tests/provider_support_tests.rs
@@ -105,6 +105,47 @@ fn test_model_supports_capability_unknown_model() {
 }
 
 #[test]
+fn test_model_capability_lookup_uses_exact_catalog_identity() {
+    let provider = create_test_provider();
+
+    assert!(
+        provider.model_supports_capability("openai/gpt-4", &ProviderCapability::ChatCompletion)
+    );
+    assert!(
+        provider.model_supports_capability("OPENAI/gpt-4", &ProviderCapability::ChatCompletion)
+    );
+    assert!(
+        !provider.model_supports_capability("openai/GPT-4", &ProviderCapability::ChatCompletion)
+    );
+    assert!(
+        !provider
+            .model_supports_capability("openai/gpt-4-fake", &ProviderCapability::ChatCompletion)
+    );
+    assert!(!provider.model_supports_capability(
+        "1024-x-1024/dall-e-2",
+        &ProviderCapability::ChatCompletionStream
+    ));
+}
+
+#[test]
+fn test_qualified_model_config_and_params_match_exact_model() {
+    let provider = create_test_provider();
+
+    assert_eq!(
+        provider
+            .get_model_config("OPENAI/gpt-4")
+            .map(|config| (config.max_rpm, config.max_tpm)),
+        provider
+            .get_model_config("gpt-4")
+            .map(|config| (config.max_rpm, config.max_tpm))
+    );
+    assert_eq!(
+        provider.get_supported_openai_params("OPENAI/gpt-4"),
+        provider.get_supported_openai_params("gpt-4")
+    );
+}
+
+#[test]
 fn test_get_model_info() {
     let provider = create_test_provider();
 

--- a/src/core/providers/openai/client_tests/provider_support_tests.rs
+++ b/src/core/providers/openai/client_tests/provider_support_tests.rs
@@ -146,6 +146,22 @@ fn test_qualified_model_config_and_params_match_exact_model() {
 }
 
 #[test]
+fn test_pricing_only_params_are_not_promoted_but_unknown_models_pass_through() {
+    let provider = create_test_provider();
+
+    for model in ["1024-x-1024/dall-e-2", "openai/1024-x-1024/dall-e-2"] {
+        assert!(
+            provider.get_supported_openai_params(model).is_empty(),
+            "pricing-only catalog key {model} must not advertise callable parameters"
+        );
+    }
+
+    let unknown_params = provider.get_supported_openai_params("custom-openai-deployment");
+    assert!(unknown_params.contains(&"messages"));
+    assert!(unknown_params.contains(&"stream"));
+}
+
+#[test]
 fn test_get_model_info() {
     let provider = create_test_provider();
 

--- a/src/core/providers/openai/models/mod.rs
+++ b/src/core/providers/openai/models/mod.rs
@@ -7,11 +7,13 @@
 //! - `api_types`: OpenAI API request/response serialization types
 
 mod api_types;
+mod model_id;
 mod registry;
 mod registry_types;
 mod static_models;
 
 // Re-export everything at the same path as before
 pub use api_types::*;
+pub use model_id::*;
 pub use registry::*;
 pub use registry_types::*;

--- a/src/core/providers/openai/models/model_id.rs
+++ b/src/core/providers/openai/models/model_id.rs
@@ -63,8 +63,13 @@ pub enum OpenAICatalogRuntimeResolution<'registry, 'input> {
     Callable(&'registry OpenAIModelSpec),
     /// An exact catalog row used only for pricing/metadata.
     PricingOnly(&'registry OpenAIModelSpec),
-    /// No exact OpenAI catalog identity was resolved.
-    Unresolved(OpenAICatalogResolveError<'input>),
+    /// A syntactically unqualified deployment absent from the static catalog.
+    ///
+    /// Provider dispatch preserves the existing pass-through behavior for this
+    /// state until deployment-aware identity is introduced by issue #1207.
+    UnregisteredDeployment { model_id: &'input str },
+    /// A qualified, slash-bearing, or otherwise invalid OpenAI runtime identity.
+    Invalid(OpenAICatalogResolveError<'input>),
 }
 
 /// An exact OpenAI catalog entry and its optional runnable-model identity.
@@ -159,10 +164,37 @@ mod tests {
         ));
         assert!(matches!(
             registry.resolve_runtime_identity("custom-openai-deployment"),
-            OpenAICatalogRuntimeResolution::Unresolved(
-                OpenAICatalogResolveError::UnknownModel { .. }
-            )
+            OpenAICatalogRuntimeResolution::UnregisteredDeployment { .. }
         ));
+    }
+
+    #[test]
+    fn runtime_resolution_passes_through_only_unqualified_deployments() {
+        let registry = OpenAIModelRegistry::new();
+
+        assert!(matches!(
+            registry.resolve_runtime_identity("custom-openai-deployment"),
+            OpenAICatalogRuntimeResolution::UnregisteredDeployment {
+                model_id: "custom-openai-deployment"
+            }
+        ));
+
+        for model in [
+            "anthropic/gpt-4",
+            "openai/openai/gpt-4",
+            "openai/fake-gpt-5",
+            "unknown/a/b",
+            "BAAI/unregistered-native-key",
+            "",
+        ] {
+            assert!(
+                matches!(
+                    registry.resolve_runtime_identity(model),
+                    OpenAICatalogRuntimeResolution::Invalid(_)
+                ),
+                "{model:?} must fail closed rather than inherit provider behavior"
+            );
+        }
     }
 
     #[test]

--- a/src/core/providers/openai/models/model_id.rs
+++ b/src/core/providers/openai/models/model_id.rs
@@ -1,0 +1,264 @@
+//! Exact OpenAI catalog identity resolution types.
+//!
+//! [`ModelIdRef`](crate::core::types::model_id::ModelIdRef) remains a lossless
+//! syntax view. These types describe semantic results only after an OpenAI
+//! registry has accepted an exact key or one provider-qualified form.
+
+use super::OpenAIModelSpec;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ExplicitOpenAIModelIdentity {
+    pub catalog_key: &'static str,
+    pub canonical_base_model_id: &'static str,
+    pub source: &'static str,
+}
+
+// OpenAI documents these exact dated IDs as snapshots of the corresponding
+// base aliases. No date-shape or family-shape inference is permitted here.
+const EXPLICIT_MODEL_IDENTITIES: &[ExplicitOpenAIModelIdentity] = &[
+    ExplicitOpenAIModelIdentity {
+        catalog_key: "gpt-5.5-2026-04-23",
+        canonical_base_model_id: "gpt-5.5",
+        source: "https://developers.openai.com/api/docs/models/gpt-5.5",
+    },
+    ExplicitOpenAIModelIdentity {
+        catalog_key: "gpt-5.5-pro-2026-04-23",
+        canonical_base_model_id: "gpt-5.5-pro",
+        source: "https://developers.openai.com/api/docs/models/gpt-5.5-pro",
+    },
+];
+
+pub(super) fn explicit_identity_for(catalog_key: &str) -> Option<ExplicitOpenAIModelIdentity> {
+    EXPLICIT_MODEL_IDENTITIES
+        .iter()
+        .copied()
+        .find(|identity| identity.catalog_key == catalog_key)
+}
+
+/// Why a catalog lookup failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum OpenAICatalogResolveError<'input> {
+    /// No exact catalog key or explicit provider-qualified form exists.
+    #[error("OpenAI catalog has no exact entry for `{model_id}`")]
+    UnknownModel { model_id: &'input str },
+    /// The caller explicitly selected another provider.
+    #[error("model `{model_id}` is qualified for `{provider}`, not `openai`")]
+    WrongProvider {
+        model_id: &'input str,
+        provider: &'input str,
+    },
+    /// More than one OpenAI provider layer was supplied.
+    #[error("model `{model_id}` contains more than one `openai` provider qualifier")]
+    DoubleQualification { model_id: &'input str },
+}
+
+/// An exact OpenAI catalog entry and its optional runnable-model identity.
+///
+/// Slash-bearing raw catalog keys are conservatively treated as pricing-only.
+/// They may gain capabilities only through a separately reviewed, explicit
+/// alias; this resolver never infers an alias from a final path segment.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedOpenAICatalogEntry<'registry, 'input> {
+    raw_id: &'input str,
+    catalog_key: &'registry str,
+    catalog_spec: &'registry OpenAIModelSpec,
+    capability_identity: Option<(&'registry str, &'registry OpenAIModelSpec)>,
+    canonical_base_model_id: Option<&'static str>,
+    alias_source: Option<&'static str>,
+}
+
+impl<'registry, 'input> ResolvedOpenAICatalogEntry<'registry, 'input> {
+    pub(super) fn new(
+        raw_id: &'input str,
+        catalog_key: &'registry str,
+        catalog_spec: &'registry OpenAIModelSpec,
+        capability_identity: Option<(&'registry str, &'registry OpenAIModelSpec)>,
+        canonical_base_model_id: Option<&'static str>,
+        alias_source: Option<&'static str>,
+    ) -> Self {
+        Self {
+            raw_id,
+            catalog_key,
+            catalog_spec,
+            capability_identity,
+            canonical_base_model_id,
+            alias_source,
+        }
+    }
+
+    /// Return the exact identifier supplied by the caller for wire forwarding.
+    pub fn raw_id(&self) -> &'input str {
+        self.raw_id
+    }
+
+    /// Return the exact key stored in the OpenAI catalog.
+    pub fn catalog_key(&self) -> &'registry str {
+        self.catalog_key
+    }
+
+    /// Return metadata for the exact catalog entry, including pricing-only rows.
+    pub fn catalog_spec(&self) -> &'registry OpenAIModelSpec {
+        self.catalog_spec
+    }
+
+    /// Return the exact runnable-model key, if this entry has capability semantics.
+    pub fn capability_model_id(&self) -> Option<&'registry str> {
+        self.capability_identity.map(|(model_id, _)| model_id)
+    }
+
+    /// Return model capability metadata without promoting pricing-only rows.
+    pub fn capability_spec(&self) -> Option<&'registry OpenAIModelSpec> {
+        self.capability_identity.map(|(_, spec)| spec)
+    }
+
+    /// Return the explicitly sourced base alias for a dated identity.
+    pub fn canonical_base_model_id(&self) -> Option<&'static str> {
+        self.canonical_base_model_id
+    }
+
+    /// Return the official source supporting the explicit base/snapshot relation.
+    pub fn alias_source(&self) -> Option<&'static str> {
+        self.alias_source
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::OpenAIModelRegistry, OpenAICatalogResolveError};
+
+    #[test]
+    fn resolves_exact_and_single_openai_qualification() {
+        let registry = OpenAIModelRegistry::new();
+
+        let exact = registry
+            .resolve_catalog_identity("gpt-4")
+            .expect("exact model should resolve");
+        let qualified = registry
+            .resolve_catalog_identity("openai/gpt-4")
+            .expect("qualified model should resolve");
+        let mixed_provider_case = registry
+            .resolve_catalog_identity("OPENAI/gpt-4")
+            .expect("provider segment should be ASCII-case-insensitive");
+
+        assert_eq!(exact.raw_id(), "gpt-4");
+        assert_eq!(qualified.raw_id(), "openai/gpt-4");
+        assert_eq!(mixed_provider_case.raw_id(), "OPENAI/gpt-4");
+        assert_eq!(exact.catalog_key(), "gpt-4");
+        assert_eq!(qualified.catalog_key(), "gpt-4");
+        assert_eq!(mixed_provider_case.catalog_key(), "gpt-4");
+        assert!(exact.capability_spec().is_some());
+        assert!(qualified.capability_spec().is_some());
+    }
+
+    #[test]
+    fn prefers_exact_native_slash_keys() {
+        let registry = OpenAIModelRegistry::new();
+        let key = "1024-x-1024/dall-e-2";
+
+        let exact = registry
+            .resolve_catalog_identity(key)
+            .expect("exact slash-bearing pricing key should resolve");
+        let qualified = registry
+            .resolve_catalog_identity("openai/1024-x-1024/dall-e-2")
+            .expect("one OpenAI provider layer should resolve the exact nested key");
+
+        assert_eq!(exact.raw_id(), key);
+        assert_eq!(exact.catalog_key(), key);
+        assert_eq!(qualified.catalog_key(), key);
+        assert!(exact.capability_spec().is_none());
+        assert!(qualified.capability_spec().is_none());
+    }
+
+    #[test]
+    fn every_exact_slash_catalog_key_is_reachable() {
+        let registry = OpenAIModelRegistry::new();
+
+        for model in registry
+            .get_all_models()
+            .into_iter()
+            .filter(|model| model.id.contains('/'))
+        {
+            let resolved = registry
+                .resolve_catalog_identity(&model.id)
+                .unwrap_or_else(|error| panic!("{} should resolve exactly: {error}", model.id));
+
+            assert_eq!(resolved.catalog_key(), model.id);
+        }
+    }
+
+    #[test]
+    fn normalizes_only_the_provider_segment_for_stored_openai_keys() {
+        let registry = OpenAIModelRegistry::new();
+
+        let resolved = registry
+            .resolve_catalog_identity("OPENAI/container")
+            .expect("canonical stored key should resolve with provider-case normalization");
+        assert_eq!(resolved.catalog_key(), "openai/container");
+        assert!(resolved.capability_spec().is_none());
+
+        assert!(matches!(
+            registry.resolve_catalog_identity("openai/GPT-4"),
+            Err(OpenAICatalogResolveError::UnknownModel { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_collisions_and_wrong_qualifiers() {
+        let registry = OpenAIModelRegistry::new();
+
+        for model in [
+            "gpt-4-fake",
+            "gpt-4-2099-01-01",
+            "prefix-gpt-4",
+            "openai/gpt-4-fake",
+        ] {
+            assert!(matches!(
+                registry.resolve_catalog_identity(model),
+                Err(OpenAICatalogResolveError::UnknownModel { .. })
+            ));
+        }
+
+        assert!(matches!(
+            registry.resolve_catalog_identity("anthropic/gpt-4"),
+            Err(OpenAICatalogResolveError::WrongProvider {
+                provider: "anthropic",
+                ..
+            })
+        ));
+        assert!(matches!(
+            registry.resolve_catalog_identity("openai/openai/gpt-4"),
+            Err(OpenAICatalogResolveError::DoubleQualification { .. })
+        ));
+    }
+
+    #[test]
+    fn keeps_base_and_dated_catalog_identities_distinct() {
+        let registry = OpenAIModelRegistry::new();
+
+        let base = registry
+            .resolve_catalog_identity("openai/gpt-5.5")
+            .expect("base model should resolve");
+        let dated = registry
+            .resolve_catalog_identity("openai/gpt-5.5-2026-04-23")
+            .expect("dated model should resolve");
+
+        assert_eq!(base.catalog_key(), "gpt-5.5");
+        assert_eq!(dated.catalog_key(), "gpt-5.5-2026-04-23");
+        assert_ne!(base.catalog_key(), dated.catalog_key());
+        assert_eq!(base.canonical_base_model_id(), None);
+        assert_eq!(dated.canonical_base_model_id(), Some("gpt-5.5"));
+        assert_eq!(
+            dated.alias_source(),
+            Some("https://developers.openai.com/api/docs/models/gpt-5.5")
+        );
+
+        let pro_snapshot = registry
+            .resolve_catalog_identity("gpt-5.5-pro-2026-04-23")
+            .expect("Pro snapshot should resolve");
+        assert_eq!(pro_snapshot.canonical_base_model_id(), Some("gpt-5.5-pro"));
+        assert_eq!(
+            pro_snapshot.alias_source(),
+            Some("https://developers.openai.com/api/docs/models/gpt-5.5-pro")
+        );
+    }
+}

--- a/src/core/providers/openai/models/model_id.rs
+++ b/src/core/providers/openai/models/model_id.rs
@@ -52,6 +52,21 @@ pub enum OpenAICatalogResolveError<'input> {
     DoubleQualification { model_id: &'input str },
 }
 
+/// Runtime meaning of an OpenAI catalog lookup.
+///
+/// Keeping these states distinct prevents exact pricing rows from inheriting
+/// provider-wide capabilities while preserving pass-through for deployments
+/// that are absent from the static catalog.
+#[derive(Debug, Clone, Copy)]
+pub enum OpenAICatalogRuntimeResolution<'registry, 'input> {
+    /// An exact catalog model with callable capability metadata.
+    Callable(&'registry OpenAIModelSpec),
+    /// An exact catalog row used only for pricing/metadata.
+    PricingOnly(&'registry OpenAIModelSpec),
+    /// No exact OpenAI catalog identity was resolved.
+    Unresolved(OpenAICatalogResolveError<'input>),
+}
+
 /// An exact OpenAI catalog entry and its optional runnable-model identity.
 ///
 /// Slash-bearing raw catalog keys are conservatively treated as pricing-only.
@@ -124,7 +139,31 @@ impl<'registry, 'input> ResolvedOpenAICatalogEntry<'registry, 'input> {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::OpenAIModelRegistry, OpenAICatalogResolveError};
+    use super::{
+        super::OpenAIModelRegistry, OpenAICatalogResolveError, OpenAICatalogRuntimeResolution,
+    };
+
+    #[test]
+    fn runtime_resolution_keeps_callable_pricing_only_and_unknown_distinct() {
+        let registry = OpenAIModelRegistry::new();
+
+        assert!(matches!(
+            registry.resolve_runtime_identity("openai/gpt-4"),
+            OpenAICatalogRuntimeResolution::Callable(spec)
+                if spec.model_info.id == "gpt-4"
+        ));
+        assert!(matches!(
+            registry.resolve_runtime_identity("openai/1024-x-1024/dall-e-2"),
+            OpenAICatalogRuntimeResolution::PricingOnly(spec)
+                if spec.model_info.id == "1024-x-1024/dall-e-2"
+        ));
+        assert!(matches!(
+            registry.resolve_runtime_identity("custom-openai-deployment"),
+            OpenAICatalogRuntimeResolution::Unresolved(
+                OpenAICatalogResolveError::UnknownModel { .. }
+            )
+        ));
+    }
 
     #[test]
     fn resolves_exact_and_single_openai_qualification() {

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -506,7 +506,12 @@ impl OpenAIModelRegistry {
                 Some(spec) => OpenAICatalogRuntimeResolution::Callable(spec),
                 None => OpenAICatalogRuntimeResolution::PricingOnly(identity.catalog_spec()),
             },
-            Err(error) => OpenAICatalogRuntimeResolution::Unresolved(error),
+            Err(OpenAICatalogResolveError::UnknownModel { model_id })
+                if ModelIdRef::parse(model_id).provider().is_none() && !model_id.is_empty() =>
+            {
+                OpenAICatalogRuntimeResolution::UnregisteredDeployment { model_id }
+            }
+            Err(error) => OpenAICatalogRuntimeResolution::Invalid(error),
         }
     }
 

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -8,7 +8,11 @@ use std::sync::OnceLock;
 
 use crate::core::pricing::get_pricing_db;
 use crate::core::types::model::ModelInfo;
+use crate::core::types::model_id::ModelIdRef;
 
+use super::model_id::{
+    OpenAICatalogResolveError, ResolvedOpenAICatalogEntry, explicit_identity_for,
+};
 use super::registry_types::{
     OpenAIModelConfig, OpenAIModelFamily, OpenAIModelFeature, OpenAIModelSpec, OpenAIUseCase,
 };
@@ -438,6 +442,78 @@ impl OpenAIModelRegistry {
     /// Get specific model specification
     pub fn get_model_spec(&self, model_id: &str) -> Option<&OpenAIModelSpec> {
         self.models.get(model_id)
+    }
+
+    /// Resolve a wire model ID to exact OpenAI catalog and capability identities.
+    ///
+    /// Raw exact catalog keys take precedence so slash-bearing pricing keys stay
+    /// reachable. Otherwise, exactly one case-insensitive `openai` provider
+    /// segment may be removed; the remaining model key is always case-sensitive.
+    pub fn resolve_catalog_identity<'registry, 'input>(
+        &'registry self,
+        raw_id: &'input str,
+    ) -> Result<ResolvedOpenAICatalogEntry<'registry, 'input>, OpenAICatalogResolveError<'input>>
+    {
+        if let Some((catalog_key, spec)) = self.models.get_key_value(raw_id) {
+            return Ok(self.resolved_entry(raw_id, catalog_key, spec));
+        }
+
+        let parsed = ModelIdRef::parse(raw_id);
+        let Some(provider) = parsed.provider() else {
+            return Err(OpenAICatalogResolveError::UnknownModel { model_id: raw_id });
+        };
+
+        if !provider.eq_ignore_ascii_case("openai") {
+            return Err(OpenAICatalogResolveError::WrongProvider {
+                model_id: raw_id,
+                provider,
+            });
+        }
+
+        let model_id = parsed.model();
+        if ModelIdRef::parse(model_id)
+            .provider()
+            .is_some_and(|nested| nested.eq_ignore_ascii_case("openai"))
+        {
+            return Err(OpenAICatalogResolveError::DoubleQualification { model_id: raw_id });
+        }
+
+        // A stored `openai/...` key remains distinct from an unqualified key.
+        // Search by exact segments to normalize only provider casing without
+        // allocating or changing model casing.
+        if let Some((catalog_key, spec)) = self.models.iter().find(|(catalog_key, _)| {
+            catalog_key
+                .split_once('/')
+                .is_some_and(|(stored_provider, stored_model)| {
+                    stored_provider == "openai" && stored_model == model_id
+                })
+        }) {
+            return Ok(self.resolved_entry(raw_id, catalog_key, spec));
+        }
+
+        self.models
+            .get_key_value(model_id)
+            .map(|(catalog_key, spec)| self.resolved_entry(raw_id, catalog_key, spec))
+            .ok_or(OpenAICatalogResolveError::UnknownModel { model_id: raw_id })
+    }
+
+    fn resolved_entry<'registry, 'input>(
+        &'registry self,
+        raw_id: &'input str,
+        catalog_key: &'registry str,
+        spec: &'registry OpenAIModelSpec,
+    ) -> ResolvedOpenAICatalogEntry<'registry, 'input> {
+        let capability_identity = (!catalog_key.contains('/')).then_some((catalog_key, spec));
+        let explicit_identity = explicit_identity_for(catalog_key)
+            .filter(|identity| self.models.contains_key(identity.canonical_base_model_id));
+        ResolvedOpenAICatalogEntry::new(
+            raw_id,
+            catalog_key,
+            spec,
+            capability_identity,
+            explicit_identity.map(|identity| identity.canonical_base_model_id),
+            explicit_identity.map(|identity| identity.source),
+        )
     }
 
     /// Check if model supports a feature

--- a/src/core/providers/openai/models/registry.rs
+++ b/src/core/providers/openai/models/registry.rs
@@ -11,7 +11,8 @@ use crate::core::types::model::ModelInfo;
 use crate::core::types::model_id::ModelIdRef;
 
 use super::model_id::{
-    OpenAICatalogResolveError, ResolvedOpenAICatalogEntry, explicit_identity_for,
+    OpenAICatalogResolveError, OpenAICatalogRuntimeResolution, ResolvedOpenAICatalogEntry,
+    explicit_identity_for,
 };
 use super::registry_types::{
     OpenAIModelConfig, OpenAIModelFamily, OpenAIModelFeature, OpenAIModelSpec, OpenAIUseCase,
@@ -478,23 +479,35 @@ impl OpenAIModelRegistry {
             return Err(OpenAICatalogResolveError::DoubleQualification { model_id: raw_id });
         }
 
-        // A stored `openai/...` key remains distinct from an unqualified key.
-        // Search by exact segments to normalize only provider casing without
-        // allocating or changing model casing.
-        if let Some((catalog_key, spec)) = self.models.iter().find(|(catalog_key, _)| {
-            catalog_key
-                .split_once('/')
-                .is_some_and(|(stored_provider, stored_model)| {
-                    stored_provider == "openai" && stored_model == model_id
-                })
-        }) {
-            return Ok(self.resolved_entry(raw_id, catalog_key, spec));
+        // The raw exact lookup above already checked canonical lowercase
+        // `openai/...` keys. Mixed-case provider input needs one normalized key
+        // allocation; both paths remain O(1) HashMap lookups and model casing is
+        // never changed.
+        if provider != "openai" {
+            let canonical_qualified_id = format!("openai/{model_id}");
+            if let Some((catalog_key, spec)) = self.models.get_key_value(&canonical_qualified_id) {
+                return Ok(self.resolved_entry(raw_id, catalog_key, spec));
+            }
         }
 
         self.models
             .get_key_value(model_id)
             .map(|(catalog_key, spec)| self.resolved_entry(raw_id, catalog_key, spec))
             .ok_or(OpenAICatalogResolveError::UnknownModel { model_id: raw_id })
+    }
+
+    /// Resolve the runtime meaning of an exact OpenAI catalog lookup.
+    pub fn resolve_runtime_identity<'registry, 'input>(
+        &'registry self,
+        raw_id: &'input str,
+    ) -> OpenAICatalogRuntimeResolution<'registry, 'input> {
+        match self.resolve_catalog_identity(raw_id) {
+            Ok(identity) => match identity.capability_spec() {
+                Some(spec) => OpenAICatalogRuntimeResolution::Callable(spec),
+                None => OpenAICatalogRuntimeResolution::PricingOnly(identity.catalog_spec()),
+            },
+            Err(error) => OpenAICatalogRuntimeResolution::Unresolved(error),
+        }
     }
 
     fn resolved_entry<'registry, 'input>(


### PR DESCRIPTION
## Summary

- add a borrowed, exact-only OpenAI catalog identity resolver on top of the lossless `ModelIdRef` parser
- preserve raw wire IDs while resolving unqualified and single-layer `openai/` identifiers
- distinguish callable, pricing-only, and unresolved runtime states through capability and supported-parameter dispatch
- keep raw slash-bearing pricing keys reachable without granting them runnable-model capabilities
- avoid registry-wide scans for ordinary provider-qualified IDs; raw and peeled keys use exact hash lookups
- record only officially documented GPT-5.5 / GPT-5.5 Pro snapshot-to-base identities

## Resolution contract

- raw exact catalog lookup always wins
- the provider segment is ASCII-case-insensitive; the model segment remains case-sensitive
- only one OpenAI provider layer is removed
- no prefix, suffix, date-shape, family-shape, or last-segment inference
- callable entries use model-specific capabilities and parameters
- pricing-only exact entries are explicitly unsupported for Chat, streaming, Embeddings, and OpenAI parameters
- unresolved custom deployments retain the existing provider-level pass-through contract
- slash-bearing pricing entries expose catalog metadata but no capability identity
- dated/base relationships are exact declarations with official sources

## Review fix

- replace the `Option` collapse at production dispatch with explicit `Callable`, `PricingOnly`, and `Unresolved(error)` states
- add production `Provider::supports_capability_for_model` coverage for ChatCompletion, ChatCompletionStream, and Embeddings
- keep generic parameter fallback only for unresolved deployments; pricing-only identities return no supported parameters
- replace the qualified-key full-registry scan with raw exact lookup plus at most two O(1) `HashMap` lookups; mixed provider casing allocates only the normalized provider-qualified key

## Scope

Changed files are limited to:

- `src/core/providers/openai/models/model_id.rs`
- `src/core/providers/openai/models/mod.rs`
- `src/core/providers/openai/models/registry.rs`
- `src/core/providers/openai/client.rs`
- `src/core/providers/openai/client_tests/provider_support_tests.rs`
- `src/core/providers/capability_dispatch.rs`

No model catalog additions, central pricing changes, Azure deployment identity, token/spend handling, SDK/preset work, or #1202 changes.

## Verification

- TDD RED: pricing-only identity inherited ChatCompletion in production dispatch
- TDD RED: pricing-only identity advertised generic OpenAI chat parameters
- resolver/runtime-state tests: 7 passed
- registry tests: 9 passed
- OpenAI provider-support tests: 23 passed
- production capability-dispatch tests: 4 passed
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- bounded `cargo test --lib`: 9,160 passed, 1 ignored

## Sources

- https://developers.openai.com/api/docs/models/gpt-5.5
- https://developers.openai.com/api/docs/models/gpt-5.5-pro

Depends on #1206 and is stacked on exact head `618c35a973180114c209f959193ac1198336841e`.

Fixes #1209


## Review fix cycle 2

- split runtime resolution into exact callable, pricing-only, unregistered unqualified deployment, and invalid identity states
- retain provider pass-through only for non-empty unqualified IDs with no slash
- fail closed for wrong providers, double OpenAI qualification, explicit openai/<unknown> IDs, and all unknown slash-bearing keys
- cover ChatCompletion, ChatCompletionStream, Embeddings, and supported-parameter dispatch with anthropic/gpt-4, openai/openai/gpt-4, openai/fake-gpt-5, unknown/a/b, and custom-openai-deployment
- preserve pricing-only denial and O(1) exact resolver lookup

Cycle-2 verification: resolver 8 passed; registry 9 passed; provider-support 24 passed; capability-dispatch 5 passed; fmt, check, clippy, and diff-check passed. The bounded full lib result from cycle 1 remains 9,160 passed / 1 ignored and was not rerun.
