### PR TITLE
fix(anthropic): preserve thinking continuations

### DIFF
--- a/benches/performance_benchmarks.rs
+++ b/benches/performance_benchmarks.rs
@@ -328,6 +328,7 @@ fn bench_serialization(c: &mut Criterion) {
                 content: Some(MessageContent::Text(
                     "You are a helpful assistant.".to_string(),
                 )),
+                thinking: None,
                 name: None,
                 function_call: None,
                 tool_calls: None,
@@ -337,6 +338,7 @@ fn bench_serialization(c: &mut Criterion) {
             ChatMessage {
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Hello, how are you?".to_string())),
+                thinking: None,
                 name: None,
                 function_call: None,
                 tool_calls: None,

--- a/examples/test_thinking.rs
+++ b/examples/test_thinking.rs
@@ -143,8 +143,6 @@ async fn test_deepseek_r1(provider: &OpenAILikeProvider) -> Result<(), Box<dyn s
             "message.thinking is_some: {}",
             choice.message.thinking.is_some()
         );
-        println!("message.thinking: {:?}", choice.message.thinking);
-
         if let Some(thinking) = &choice.message.thinking {
             println!("\n--- Thinking Content Found! ---");
             match thinking {
@@ -161,7 +159,7 @@ async fn test_deepseek_r1(provider: &OpenAILikeProvider) -> Result<(), Box<dyn s
                     };
                     println!("Thinking:\n{}", display_text);
                     if let Some(sig) = signature {
-                        println!("Signature: {}", sig);
+                        println!("Signature: [opaque, {} bytes]", sig.len());
                     }
                 }
                 ThinkingContent::Block {
@@ -185,10 +183,10 @@ async fn test_deepseek_r1(provider: &OpenAILikeProvider) -> Result<(), Box<dyn s
                                 signature,
                             } => {
                                 println!("Thinking:\n{}", thinking);
-                                println!("Signature: {}", signature);
+                                println!("Signature: [opaque, {} bytes]", signature.len());
                             }
                             AnthropicThinkingBlock::RedactedThinking { data } => {
-                                println!("Redacted Data: {}", data);
+                                println!("Redacted Data: [redacted, {} bytes]", data.len());
                             }
                         }
                     }

--- a/examples/test_thinking.rs
+++ b/examples/test_thinking.rs
@@ -8,7 +8,9 @@ use litellm_rs::core::providers::thinking::{
 };
 use litellm_rs::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use litellm_rs::core::types::context::RequestContext;
-use litellm_rs::core::types::thinking::{ThinkingConfig, ThinkingContent, ThinkingEffort};
+use litellm_rs::core::types::thinking::{
+    AnthropicThinkingBlock, ThinkingConfig, ThinkingContent, ThinkingEffort,
+};
 use litellm_rs::core::types::{
     chat::ChatMessage, chat::ChatRequest, message::MessageContent, message::MessageRole,
 };
@@ -173,6 +175,23 @@ async fn test_deepseek_r1(provider: &OpenAILikeProvider) -> Result<(), Box<dyn s
                 ThinkingContent::Redacted { token_count } => {
                     println!("Type: Redacted");
                     println!("Token Count: {:?}", token_count);
+                }
+                ThinkingContent::AnthropicBlocks { content } => {
+                    println!("Type: AnthropicBlocks");
+                    for block in content.blocks() {
+                        match block {
+                            AnthropicThinkingBlock::Thinking {
+                                thinking,
+                                signature,
+                            } => {
+                                println!("Thinking:\n{}", thinking);
+                                println!("Signature: {}", signature);
+                            }
+                            AnthropicThinkingBlock::RedactedThinking { data } => {
+                                println!("Redacted Data: {}", data);
+                            }
+                        }
+                    }
                 }
             }
         } else {

--- a/src/core/cache/key_generator.rs
+++ b/src/core/cache/key_generator.rs
@@ -218,6 +218,7 @@ mod tests {
     // Helper to create a test chat message
     fn create_user_message(content: &str) -> ChatMessage {
         ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text(content.to_string())),
             name: None,

--- a/src/core/cache/llm_cache_tests.rs
+++ b/src/core/cache/llm_cache_tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 fn create_user_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -17,6 +18,7 @@ fn create_user_message(content: &str) -> ChatMessage {
 
 fn create_assistant_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::Assistant,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,

--- a/src/core/cache/mod.rs
+++ b/src/core/cache/mod.rs
@@ -186,6 +186,7 @@ mod tests {
         let request = ChatCompletionRequest {
             model: "gpt-4".to_string(),
             messages: vec![ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Hello".to_string())),
                 name: None,
@@ -274,6 +275,7 @@ mod tests {
         let request = ChatCompletionRequest {
             model: "gpt-4".to_string(),
             messages: vec![ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Hello".to_string())),
                 name: None,
@@ -293,6 +295,7 @@ mod tests {
             choices: vec![ChatChoice {
                 index: 0,
                 message: ChatMessage {
+                    thinking: None,
                     role: MessageRole::Assistant,
                     content: Some(MessageContent::Text("Hello! How can I help?".to_string())),
                     name: None,

--- a/src/core/function_calling/processing.rs
+++ b/src/core/function_calling/processing.rs
@@ -43,6 +43,7 @@ impl FunctionCallingHandler {
                 match executor.execute(arguments).await {
                     Ok(result) => {
                         let tool_message = ChatMessage {
+                            thinking: None,
                             role: MessageRole::Tool,
                             content: Some(MessageContent::Text(result.to_string())),
                             name: Some(function_name.clone()),
@@ -56,6 +57,7 @@ impl FunctionCallingHandler {
                     Err(e) => {
                         error!("Function execution failed: {}", e);
                         let error_message = ChatMessage {
+                            thinking: None,
                             role: MessageRole::Tool,
                             content: Some(MessageContent::Text(format!("Error: {}", e))),
                             name: Some(function_name.clone()),
@@ -70,6 +72,7 @@ impl FunctionCallingHandler {
             } else {
                 warn!("Unknown function: {}", function_name);
                 let error_message = ChatMessage {
+                    thinking: None,
                     role: MessageRole::Tool,
                     content: Some(MessageContent::Text(format!(
                         "Unknown function: {}",

--- a/src/core/models/openai/helpers.rs
+++ b/src/core/models/openai/helpers.rs
@@ -32,6 +32,7 @@ mod tests {
         let request = ChatCompletionRequest {
             model: "gpt-4".to_string(),
             messages: vec![ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Hello".to_string())),
                 name: None,

--- a/src/core/models/openai/messages.rs
+++ b/src/core/models/openai/messages.rs
@@ -8,6 +8,7 @@ use std::hash::{Hash, Hasher};
 
 use super::audio::AudioContent;
 use super::tools::{FunctionCall, ToolCall};
+use crate::core::types::thinking::ThinkingContent;
 
 /// Chat message
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,6 +17,9 @@ pub struct ChatMessage {
     pub role: MessageRole,
     /// Message content
     pub content: Option<MessageContent>,
+    /// Provider thinking/reasoning content preserved for continuation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingContent>,
     /// Message name (for function/tool messages)
     pub name: Option<String>,
     /// Function call (legacy)
@@ -401,7 +405,7 @@ impl From<ChatMessage> for crate::core::types::chat::ChatMessage {
         Self {
             role: value.role.into(),
             content: value.content.map(Into::into),
-            thinking: None,
+            thinking: value.thinking,
             audio: value
                 .audio
                 .map(|audio| crate::core::types::content::AudioData {
@@ -423,6 +427,7 @@ impl From<crate::core::types::chat::ChatMessage> for ChatMessage {
         Self {
             role: value.role.into(),
             content: value.content.map(Into::into),
+            thinking: value.thinking,
             name: value.name,
             function_call: value.function_call.map(Into::into),
             tool_calls: value
@@ -446,6 +451,7 @@ mod tests {
         let msg = ChatMessage {
             role: MessageRole::Assistant,
             content: Some(MessageContent::Text("hello".to_string())),
+            thinking: None,
             name: Some("assistant".to_string()),
             function_call: Some(FunctionCall {
                 name: "sum".to_string(),
@@ -496,10 +502,44 @@ mod tests {
     }
 
     #[test]
+    fn test_chat_message_anthropic_thinking_roundtrip() {
+        use crate::core::types::thinking::{
+            AnthropicThinkingBlock, AnthropicThinkingContent, ThinkingContent,
+        };
+
+        let content = AnthropicThinkingContent::try_from(vec![
+            AnthropicThinkingBlock::Thinking {
+                thinking: "plan".to_string(),
+                signature: "opaque-signature".to_string(),
+            },
+            AnthropicThinkingBlock::RedactedThinking {
+                data: "opaque-redacted-data".to_string(),
+            },
+        ])
+        .expect("valid Anthropic thinking blocks");
+        let expected = ThinkingContent::AnthropicBlocks { content };
+        let core_msg = crate::core::types::chat::ChatMessage {
+            role: crate::core::types::message::MessageRole::Assistant,
+            thinking: Some(expected.clone()),
+            ..Default::default()
+        };
+
+        let wire_msg: ChatMessage = core_msg.into();
+        let encoded = serde_json::to_value(&wire_msg).expect("serialize HTTP message DTO");
+        assert_eq!(encoded["thinking"]["type"], "anthropic_blocks");
+        let decoded: ChatMessage =
+            serde_json::from_value(encoded).expect("deserialize HTTP message DTO");
+        let roundtripped: crate::core::types::chat::ChatMessage = decoded.into();
+
+        assert_eq!(roundtripped.thinking, Some(expected));
+    }
+
+    #[test]
     fn test_chat_message_audio_roundtrip() {
         let msg = ChatMessage {
             role: MessageRole::Assistant,
             content: Some(MessageContent::Text("audio response".to_string())),
+            thinking: None,
             name: None,
             function_call: None,
             tool_calls: None,

--- a/src/core/models/openai/responses_tests.rs
+++ b/src/core/models/openai/responses_tests.rs
@@ -210,6 +210,7 @@ fn test_chat_choice_creation() {
     let choice = ChatChoice {
         index: 0,
         message: ChatMessage {
+            thinking: None,
             role: MessageRole::Assistant,
             content: Some(MessageContent::Text("Hello!".to_string())),
             name: None,
@@ -231,6 +232,7 @@ fn test_chat_choice_serialize() {
     let choice = ChatChoice {
         index: 1,
         message: ChatMessage {
+            thinking: None,
             role: MessageRole::Assistant,
             content: Some(MessageContent::Text("Test response".to_string())),
             name: None,

--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -20,6 +20,7 @@ use crate::core::types::{
     content::ContentPart,
     message::{MessageContent, MessageRole},
     responses::ChatResponse,
+    thinking::{AnthropicThinkingBlock, ThinkingContent},
     tools::{Tool, ToolChoice},
 };
 
@@ -427,6 +428,20 @@ impl AnthropicClient {
                 "content": content
             });
 
+            if let Some(thinking) = &message.thinking {
+                if role != "assistant" {
+                    return Err(ProviderError::invalid_request(
+                        "anthropic",
+                        "Anthropic thinking blocks require an assistant message",
+                    ));
+                }
+                let mut anthropic_content =
+                    Self::content_value_to_blocks(&anthropic_message["content"]);
+                let thinking_blocks = Self::thinking_content_to_blocks(thinking)?;
+                anthropic_content.splice(0..0, thinking_blocks);
+                anthropic_message["content"] = json!(anthropic_content);
+            }
+
             // Add tool_call
             if let Some(tool_calls) = &message.tool_calls {
                 let mut anthropic_content =
@@ -642,6 +657,43 @@ impl AnthropicClient {
         } else {
             content.as_array().cloned().unwrap_or_default()
         }
+    }
+
+    fn thinking_content_to_blocks(thinking: &ThinkingContent) -> Result<Vec<Value>, ProviderError> {
+        let blocks = match thinking {
+            ThinkingContent::AnthropicBlocks { content } => content.blocks().to_vec(),
+            ThinkingContent::Text {
+                text,
+                signature: Some(signature),
+            } if !signature.is_empty() => vec![AnthropicThinkingBlock::Thinking {
+                thinking: text.clone(),
+                signature: signature.clone(),
+            }],
+            ThinkingContent::Text { .. } | ThinkingContent::Block { .. } => {
+                return Err(ProviderError::invalid_request(
+                    "anthropic",
+                    "Anthropic thinking history requires a non-empty verification signature",
+                ));
+            }
+            ThinkingContent::Redacted { .. } => {
+                return Err(ProviderError::invalid_request(
+                    "anthropic",
+                    "Anthropic redacted thinking history requires its encrypted data payload",
+                ));
+            }
+        };
+
+        blocks
+            .iter()
+            .map(|block| {
+                serde_json::to_value(block).map_err(|error| {
+                    ProviderError::invalid_request(
+                        "anthropic",
+                        format!("Failed to serialize Anthropic thinking block: {error}"),
+                    )
+                })
+            })
+            .collect()
     }
 
     fn tool_result_content(

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -348,7 +348,10 @@ impl AnthropicClient {
                 ),
             ));
         }
-        if request.top_p.is_some_and(|top_p| top_p < 0.99) {
+        if request
+            .top_p
+            .is_some_and(|top_p| !top_p.is_finite() || !(0.99..=1.0).contains(&top_p))
+        {
             return Err(ProviderError::invalid_request(
                 "anthropic",
                 format!("Model {} does not support non-default top_p", request.model),

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -102,6 +102,7 @@ impl AnthropicClient {
             ));
         }
         if model_spec.is_none()
+            && claude_5_protocol.is_none()
             && Self::has_image_content(request)
             && !self.config.allows_unknown_model_image_input(&request.model)
         {
@@ -391,6 +392,10 @@ impl AnthropicClient {
             .as_ref()
             .is_some_and(|functions| !functions.is_empty())
             || request.function_call.is_some()
+            || request
+                .messages
+                .iter()
+                .any(|message| message.function_call.is_some())
         {
             return Err(ProviderError::not_supported(
                 "anthropic",

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -54,6 +54,23 @@ impl AnthropicClient {
         if let Some(protocol) = claude_5_protocol {
             Self::validate_claude_5_request(request, protocol)?;
         }
+        if claude_5_protocol.is_none()
+            && model_spec.is_some_and(|model_spec| {
+                !model_spec.features.contains(&ModelFeature::ThinkingMode)
+            })
+            && request
+                .messages
+                .iter()
+                .any(|message| message.thinking.is_some())
+        {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Model {} does not support Anthropic thinking history",
+                    request.model
+                ),
+            ));
+        }
         if model_spec.is_none()
             && claude_5_protocol.is_none()
             && (request
@@ -231,7 +248,9 @@ impl AnthropicClient {
                 } else {
                     anthropic_request["thinking"] = json!({"type": "disabled"});
                 }
-                if let Some(effort) = thinking.effort {
+                if thinking.enabled
+                    && let Some(effort) = thinking.effort
+                {
                     anthropic_request["output_config"] = json!({"effort": effort.as_str()});
                 }
             } else if model_spec.is_none() {

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -6,11 +6,18 @@ use crate::core::providers::anthropic::error::anthropic_api_error;
 use crate::core::providers::anthropic::models::{ModelFeature, get_anthropic_registry};
 use crate::core::providers::unified_provider::ProviderError;
 use crate::core::types::chat::ChatRequest;
+use crate::core::types::message::MessageRole;
+use crate::core::types::tools::ToolChoice;
 
 use super::AnthropicClient;
 
+#[derive(Debug, Clone, Copy)]
+struct Claude5Protocol {
+    thinking_always_on: bool,
+}
+
 impl AnthropicClient {
-    pub(super) fn transform_chat_request(
+    pub(in crate::core::providers::anthropic) fn transform_chat_request(
         &self,
         request: &ChatRequest,
     ) -> Result<Value, ProviderError> {
@@ -24,19 +31,31 @@ impl AnthropicClient {
         }
 
         let registry = get_anthropic_registry();
+        let claude_5_protocol = if self.config.uses_compatible_model_allow_list() {
+            None
+        } else {
+            Self::claude_5_protocol(&request.model)
+        };
 
         let model_spec = if self.config.uses_compatible_model_allow_list() {
             None
         } else {
             registry.get_model_spec(&request.model)
         };
-        if model_spec.is_none() && !self.config.allows_unknown_model(&request.model) {
+        if model_spec.is_none()
+            && claude_5_protocol.is_none()
+            && !self.config.allows_unknown_model(&request.model)
+        {
             return Err(anthropic_api_error(
                 400,
                 format!("Unsupported model: {}", request.model),
             ));
         }
+        if let Some(protocol) = claude_5_protocol {
+            Self::validate_claude_5_request(request, protocol)?;
+        }
         if model_spec.is_none()
+            && claude_5_protocol.is_none()
             && (request
                 .tools
                 .as_ref()
@@ -53,7 +72,10 @@ impl AnthropicClient {
                 ),
             ));
         }
-        if model_spec.is_none() && Self::has_unsupported_unknown_model_content(request) {
+        if model_spec.is_none()
+            && claude_5_protocol.is_none()
+            && Self::has_unsupported_unknown_model_content(request)
+        {
             return Err(ProviderError::not_supported(
                 "anthropic",
                 format!(
@@ -148,11 +170,15 @@ impl AnthropicClient {
             anthropic_request["stop_sequences"] = json!(stop);
         }
 
+        if request.stream {
+            anthropic_request["stream"] = json!(true);
+        }
+
         // Add tool support
         if let Some(tools) = &request.tools
             && !tools.is_empty()
         {
-            let Some(model_spec) = model_spec else {
+            if model_spec.is_none() && claude_5_protocol.is_none() {
                 return Err(ProviderError::not_supported(
                     "anthropic",
                     format!(
@@ -160,8 +186,10 @@ impl AnthropicClient {
                         request.model
                     ),
                 ));
-            };
-            if !model_spec.features.contains(&ModelFeature::ToolCalling) {
+            }
+            if model_spec
+                .is_some_and(|model_spec| !model_spec.features.contains(&ModelFeature::ToolCalling))
+            {
                 return Err(ProviderError::not_supported(
                     "anthropic",
                     format!("Model {} does not support tool calling", request.model),
@@ -176,11 +204,37 @@ impl AnthropicClient {
             }
         }
 
-        // Add thinking configuration
-        if let Some(thinking) = &request.thinking
-            && thinking.enabled
+        if request
+            .thinking
+            .as_ref()
+            .is_some_and(|thinking| thinking.enabled)
+            && claude_5_protocol.is_none()
+            && request
+                .tool_choice
+                .as_ref()
+                .is_some_and(Self::is_forced_tool_choice)
         {
-            let Some(model_spec) = model_spec else {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                "Manual extended thinking only supports auto or none tool_choice",
+            ));
+        }
+
+        // Add thinking configuration
+        if let Some(thinking) = &request.thinking {
+            if claude_5_protocol.is_some() {
+                if thinking.enabled {
+                    anthropic_request["thinking"] = json!({
+                        "type": "adaptive",
+                        "display": if thinking.include_thinking { "summarized" } else { "omitted" }
+                    });
+                } else {
+                    anthropic_request["thinking"] = json!({"type": "disabled"});
+                }
+                if let Some(effort) = thinking.effort {
+                    anthropic_request["output_config"] = json!({"effort": effort.as_str()});
+                }
+            } else if model_spec.is_none() {
                 return Err(ProviderError::not_supported(
                     "anthropic",
                     format!(
@@ -188,24 +242,28 @@ impl AnthropicClient {
                         request.model
                     ),
                 ));
-            };
-            if !model_spec.features.contains(&ModelFeature::ThinkingMode) {
+            } else if thinking.enabled
+                && model_spec.is_some_and(|model_spec| {
+                    !model_spec.features.contains(&ModelFeature::ThinkingMode)
+                })
+            {
                 return Err(ProviderError::not_supported(
                     "anthropic",
                     format!("Model {} does not support thinking", request.model),
                 ));
+            } else if thinking.enabled {
+                let budget = thinking.budget_tokens.unwrap_or(10_000);
+                // Anthropic requires max_tokens > budget_tokens. If the default (4096)
+                // is not greater than budget_tokens, raise max_tokens to budget + 1.
+                let current_max = request.max_tokens.unwrap_or(4096);
+                if current_max <= budget {
+                    anthropic_request["max_tokens"] = json!(budget + 1);
+                }
+                anthropic_request["thinking"] = json!({
+                    "type": "enabled",
+                    "budget_tokens": budget
+                });
             }
-            let budget = thinking.budget_tokens.unwrap_or(10_000);
-            // Anthropic requires max_tokens > budget_tokens. If the default (4096)
-            // is not greater than budget_tokens, raise max_tokens to budget + 1.
-            let current_max = request.max_tokens.unwrap_or(4096);
-            if current_max <= budget {
-                anthropic_request["max_tokens"] = json!(budget + 1);
-            }
-            anthropic_request["thinking"] = json!({
-                "type": "enabled",
-                "budget_tokens": budget
-            });
         }
 
         // Structured outputs: pass json_schema response_format to Anthropic.
@@ -237,5 +295,110 @@ impl AnthropicClient {
         }
 
         Ok(anthropic_request)
+    }
+
+    pub(in crate::core::providers::anthropic) fn is_claude_5_protocol_model(model: &str) -> bool {
+        Self::claude_5_protocol(model).is_some()
+    }
+
+    fn claude_5_protocol(model: &str) -> Option<Claude5Protocol> {
+        match model {
+            "claude-fable-5" => Some(Claude5Protocol {
+                thinking_always_on: true,
+            }),
+            "claude-opus-5" | "claude-sonnet-5" => Some(Claude5Protocol {
+                thinking_always_on: false,
+            }),
+            _ => None,
+        }
+    }
+
+    fn validate_claude_5_request(
+        request: &ChatRequest,
+        protocol: Claude5Protocol,
+    ) -> Result<(), ProviderError> {
+        if request
+            .temperature
+            .is_some_and(|temperature| temperature != 1.0)
+        {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!(
+                    "Model {} does not support non-default temperature",
+                    request.model
+                ),
+            ));
+        }
+        if request.top_p.is_some_and(|top_p| top_p < 0.99) {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!("Model {} does not support non-default top_p", request.model),
+            ));
+        }
+        if request.extra_params.contains_key("top_k") {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!("Model {} does not support top_k", request.model),
+            ));
+        }
+        if request
+            .messages
+            .iter()
+            .rev()
+            .find(|message| !matches!(message.role, MessageRole::System | MessageRole::Developer))
+            .is_some_and(|message| message.role == MessageRole::Assistant)
+        {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!("Model {} does not support assistant prefill", request.model),
+            ));
+        }
+        if protocol.thinking_always_on
+            && request
+                .thinking
+                .as_ref()
+                .is_some_and(|thinking| !thinking.enabled)
+        {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!("Model {} cannot disable thinking", request.model),
+            ));
+        }
+        if request
+            .functions
+            .as_ref()
+            .is_some_and(|functions| !functions.is_empty())
+            || request.function_call.is_some()
+        {
+            return Err(ProviderError::not_supported(
+                "anthropic",
+                format!(
+                    "Model {} does not support legacy functions/function_call; use tools/tool_choice",
+                    request.model
+                ),
+            ));
+        }
+        if request
+            .thinking
+            .as_ref()
+            .is_some_and(|thinking| thinking.enabled && thinking.budget_tokens.is_some())
+        {
+            return Err(ProviderError::invalid_request(
+                "anthropic",
+                format!(
+                    "Model {} uses adaptive thinking and does not support budget_tokens",
+                    request.model
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn is_forced_tool_choice(tool_choice: &ToolChoice) -> bool {
+        match tool_choice {
+            ToolChoice::String(choice) => choice == "required",
+            ToolChoice::Specific { function, .. } => function.is_some(),
+        }
     }
 }

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -9,6 +9,7 @@ use crate::core::types::content::{
 use crate::core::types::message::{MessageContent, MessageRole};
 use crate::core::types::thinking::{
     AnthropicThinkingBlock, AnthropicThinkingContent, ThinkingConfig, ThinkingContent,
+    ThinkingEffort,
 };
 use crate::core::types::tools::{
     FunctionCall, FunctionChoice, FunctionDefinition, Tool, ToolCall, ToolChoice, ToolType,
@@ -82,12 +83,40 @@ fn current_claude_5_protocol_serializes_adaptive_disabled_and_sampling_rules() {
 
     for model in ["claude-opus-5", "claude-sonnet-5"] {
         let mut disabled = ChatRequest::new(model).add_user_message("Hello");
-        disabled.thinking = Some(ThinkingConfig::default());
+        disabled.thinking = Some(ThinkingConfig::new().with_effort(ThinkingEffort::High));
         let transformed = anthropic_client()
             .transform_chat_request(&disabled)
             .expect("Opus and Sonnet can disable thinking");
         assert_eq!(transformed["thinking"], json!({"type": "disabled"}));
+        assert!(transformed.get("output_config").is_none());
     }
+}
+
+#[test]
+fn thinking_history_rejects_models_without_thinking_support() {
+    let content = AnthropicThinkingContent::try_from(vec![AnthropicThinkingBlock::Thinking {
+        thinking: "history".to_string(),
+        signature: "sig-history".to_string(),
+    }])
+    .expect("valid signed history");
+    let mut request = ChatRequest::new("claude-3-haiku-20240307");
+    request.messages = vec![
+        ChatMessage {
+            role: MessageRole::Assistant,
+            thinking: Some(ThinkingContent::AnthropicBlocks { content }),
+            ..Default::default()
+        },
+        ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Continue".to_string())),
+            ..Default::default()
+        },
+    ];
+
+    let error = anthropic_client()
+        .transform_chat_request(&request)
+        .expect_err("thinking history must not cross into a non-thinking model");
+    assert!(error.to_string().contains("thinking history"));
 }
 
 #[test]

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -64,6 +64,18 @@ fn current_claude_5_protocol_serializes_adaptive_disabled_and_sampling_rules() {
         );
     }
 
+    for top_p in [1.0001, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut invalid = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+        invalid.top_p = Some(top_p);
+        assert!(
+            anthropic_client()
+                .transform_chat_request(&invalid)
+                .expect_err("Claude 5 top_p must be finite and no greater than 1")
+                .to_string()
+                .contains("top_p")
+        );
+    }
+
     let mut omitted = ChatRequest::new("claude-opus-5").add_user_message("Hello");
     omitted.thinking = Some(ThinkingConfig::medium_effort().include_in_response(false));
     let transformed = anthropic_client()

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -7,6 +7,9 @@ use crate::core::types::content::{
     AudioData, CacheControl, ContentPart, DocumentSource, ImageSource,
 };
 use crate::core::types::message::{MessageContent, MessageRole};
+use crate::core::types::thinking::{
+    AnthropicThinkingBlock, AnthropicThinkingContent, ThinkingConfig, ThinkingContent,
+};
 use crate::core::types::tools::{
     FunctionCall, FunctionChoice, FunctionDefinition, Tool, ToolCall, ToolChoice, ToolType,
 };
@@ -24,6 +27,219 @@ fn tool(name: &str) -> Tool {
             parameters: Some(json!({"type": "object"})),
         },
     }
+}
+
+#[test]
+fn current_claude_5_protocol_serializes_adaptive_disabled_and_sampling_rules() {
+    for model in ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"] {
+        let mut request = ChatRequest::new(model).add_user_message("Solve this");
+        request.thinking = Some(ThinkingConfig::medium_effort());
+        let transformed = anthropic_client()
+            .transform_chat_request(&request)
+            .expect("exact Claude 5 protocol IDs use adaptive thinking without catalog entries");
+        assert_eq!(transformed["thinking"]["type"], "adaptive");
+        assert_eq!(transformed["thinking"]["display"], "summarized");
+        assert_eq!(transformed["output_config"]["effort"], "medium");
+
+        let mut top_k = ChatRequest::new(model).add_user_message("Hello");
+        top_k.extra_params.insert("top_k".to_string(), json!(1));
+        assert!(
+            anthropic_client()
+                .transform_chat_request(&top_k)
+                .expect_err("Claude 5 rejects every top_k")
+                .to_string()
+                .contains("top_k")
+        );
+    }
+
+    for top_p in [0.99, 1.0] {
+        let mut compatible = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+        compatible.temperature = Some(1.0);
+        compatible.top_p = Some(top_p);
+        assert!(
+            anthropic_client()
+                .transform_chat_request(&compatible)
+                .is_ok()
+        );
+    }
+
+    let mut omitted = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+    omitted.thinking = Some(ThinkingConfig::medium_effort().include_in_response(false));
+    let transformed = anthropic_client()
+        .transform_chat_request(&omitted)
+        .expect("adaptive thinking supports omitted display");
+    assert_eq!(transformed["thinking"]["display"], "omitted");
+
+    let mut fable_disabled = ChatRequest::new("claude-fable-5").add_user_message("Hello");
+    fable_disabled.thinking = Some(ThinkingConfig::default());
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&fable_disabled)
+            .expect_err("Fable thinking is always on")
+            .to_string()
+            .contains("cannot disable thinking")
+    );
+
+    for model in ["claude-opus-5", "claude-sonnet-5"] {
+        let mut disabled = ChatRequest::new(model).add_user_message("Hello");
+        disabled.thinking = Some(ThinkingConfig::default());
+        let transformed = anthropic_client()
+            .transform_chat_request(&disabled)
+            .expect("Opus and Sonnet can disable thinking");
+        assert_eq!(transformed["thinking"], json!({"type": "disabled"}));
+    }
+}
+
+#[test]
+fn current_claude_5_protocol_fails_closed_on_unsupported_request_shapes() {
+    let mut temperature = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+    temperature.temperature = Some(0.5);
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&temperature)
+            .expect_err("non-default temperature must fail")
+            .to_string()
+            .contains("temperature")
+    );
+
+    let mut top_p = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+    top_p.top_p = Some(0.5);
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&top_p)
+            .expect_err("non-compatible top_p must fail")
+            .to_string()
+            .contains("top_p")
+    );
+
+    let prefill = ChatRequest::new("claude-opus-5")
+        .add_user_message("Choose")
+        .add_assistant_message("The answer is");
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&prefill)
+            .expect_err("assistant prefill must fail")
+            .to_string()
+            .contains("assistant prefill")
+    );
+
+    let mut legacy = ChatRequest::new("claude-opus-5").add_user_message("lookup");
+    legacy.functions = Some(vec![json!({"name":"lookup"})]);
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&legacy)
+            .expect_err("legacy function fields must fail")
+            .to_string()
+            .contains("legacy functions")
+    );
+
+    let mut budget = ChatRequest::new("claude-opus-5").add_user_message("Solve");
+    budget.thinking = Some(ThinkingConfig::new().enabled().with_budget(4_096));
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&budget)
+            .expect_err("adaptive thinking does not accept manual budgets")
+            .to_string()
+            .contains("budget_tokens")
+    );
+}
+
+#[test]
+fn adaptive_thinking_allows_forced_tools_but_manual_thinking_rejects_them() {
+    for tool_choice in [
+        ToolChoice::String("required".to_string()),
+        ToolChoice::Specific {
+            choice_type: "function".to_string(),
+            function: Some(FunctionChoice {
+                name: "lookup".to_string(),
+            }),
+        },
+    ] {
+        let mut adaptive = ChatRequest::new("claude-opus-5")
+            .add_user_message("lookup")
+            .with_tools(vec![tool("lookup")]);
+        adaptive.thinking = Some(ThinkingConfig::medium_effort());
+        adaptive.tool_choice = Some(tool_choice.clone());
+        let transformed = anthropic_client()
+            .transform_chat_request(&adaptive)
+            .expect("adaptive thinking supports forced tool use");
+        assert!(matches!(
+            transformed["tool_choice"]["type"].as_str(),
+            Some("any" | "tool")
+        ));
+
+        let mut manual = ChatRequest::new("claude-sonnet-4-20250514")
+            .add_user_message("lookup")
+            .with_tools(vec![tool("lookup")]);
+        manual.thinking = Some(ThinkingConfig::new().enabled().with_budget(2_048));
+        manual.tool_choice = Some(tool_choice);
+        assert!(
+            anthropic_client()
+                .transform_chat_request(&manual)
+                .expect_err("manual thinking only supports auto or none")
+                .to_string()
+                .contains("tool_choice")
+        );
+    }
+}
+
+#[test]
+fn typed_thinking_history_replays_every_block_before_tool_use() {
+    let history = AnthropicThinkingContent::try_from(vec![
+        AnthropicThinkingBlock::Thinking {
+            thinking: "first".to_string(),
+            signature: "sig-first".to_string(),
+        },
+        AnthropicThinkingBlock::RedactedThinking {
+            data: "encrypted-payload".to_string(),
+        },
+        AnthropicThinkingBlock::Thinking {
+            thinking: "second".to_string(),
+            signature: "sig-second".to_string(),
+        },
+    ])
+    .expect("valid signed history");
+    let assistant = ChatMessage {
+        role: MessageRole::Assistant,
+        thinking: Some(ThinkingContent::AnthropicBlocks { content: history }),
+        tool_calls: Some(vec![ToolCall {
+            id: "toolu_1".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "lookup".to_string(),
+                arguments: r#"{"id":7}"#.to_string(),
+            },
+        }]),
+        ..Default::default()
+    };
+    let tool_result = ChatMessage {
+        role: MessageRole::Tool,
+        content: Some(MessageContent::Text("done".to_string())),
+        tool_call_id: Some("toolu_1".to_string()),
+        ..Default::default()
+    };
+    let mut request = ChatRequest::new("claude-opus-5").with_tools(vec![tool("lookup")]);
+    request.messages = vec![assistant, tool_result];
+
+    let transformed = anthropic_client()
+        .transform_chat_request(&request)
+        .expect("lossless thinking history is replayable");
+    let blocks = transformed["messages"][0]["content"]
+        .as_array()
+        .expect("assistant content blocks");
+    assert_eq!(
+        blocks[0],
+        json!({"type":"thinking","thinking":"first","signature":"sig-first"})
+    );
+    assert_eq!(
+        blocks[1],
+        json!({"type":"redacted_thinking","data":"encrypted-payload"})
+    );
+    assert_eq!(
+        blocks[2],
+        json!({"type":"thinking","thinking":"second","signature":"sig-second"})
+    );
+    assert_eq!(blocks[3]["type"], "tool_use");
 }
 
 #[test]

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -105,6 +105,28 @@ fn current_claude_5_protocol_serializes_adaptive_disabled_and_sampling_rules() {
 }
 
 #[test]
+fn current_claude_5_protocol_accepts_image_input_without_catalog_metadata() {
+    let mut request = ChatRequest::new("claude-opus-5");
+    request.messages.push(ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Parts(vec![ContentPart::Image {
+            source: ImageSource {
+                media_type: "image/png".to_string(),
+                data: "iVBORw0KGgo=".to_string(),
+            },
+            detail: None,
+            image_url: None,
+        }])),
+        ..Default::default()
+    });
+
+    let transformed = anthropic_client()
+        .transform_chat_request(&request)
+        .expect("exact Claude 5 protocol IDs support Anthropic image blocks");
+    assert_eq!(transformed["messages"][0]["content"][0]["type"], "image");
+}
+
+#[test]
 fn thinking_history_rejects_models_without_thinking_support() {
     let content = AnthropicThinkingContent::try_from(vec![AnthropicThinkingBlock::Thinking {
         thinking: "history".to_string(),
@@ -170,6 +192,30 @@ fn current_claude_5_protocol_fails_closed_on_unsupported_request_shapes() {
         anthropic_client()
             .transform_chat_request(&legacy)
             .expect_err("legacy function fields must fail")
+            .to_string()
+            .contains("legacy functions")
+    );
+
+    let mut message_legacy = ChatRequest::new("claude-opus-5");
+    message_legacy.messages = vec![
+        ChatMessage {
+            role: MessageRole::Assistant,
+            function_call: Some(FunctionCall {
+                name: "lookup".to_string(),
+                arguments: "{}".to_string(),
+            }),
+            ..Default::default()
+        },
+        ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("continue".to_string())),
+            ..Default::default()
+        },
+    ];
+    assert!(
+        anthropic_client()
+            .transform_chat_request(&message_legacy)
+            .expect_err("message-level legacy function calls must fail")
             .to_string()
             .contains("legacy functions")
     );

--- a/src/core/providers/anthropic/client/response.rs
+++ b/src/core/providers/anthropic/client/response.rs
@@ -7,7 +7,7 @@ use crate::core::types::{
     chat::ChatMessage,
     message::{MessageContent, MessageRole},
     responses::{ChatChoice, ChatResponse, FinishReason},
-    thinking::ThinkingContent,
+    thinking::{AnthropicThinkingBlock, AnthropicThinkingContent, ThinkingContent},
     tools::{FunctionCall, ToolCall},
 };
 
@@ -65,9 +65,7 @@ impl AnthropicClient {
             .ok_or_else(|| anthropic_parse_error("Missing or invalid content array"))?;
 
         let mut message_content = String::new();
-        let mut thinking_parts = Vec::new();
-        let mut thinking_signature = None;
-        let mut has_redacted_thinking = false;
+        let mut anthropic_thinking_blocks = Vec::new();
         let mut tool_calls = Vec::new();
 
         for item in content {
@@ -94,15 +92,31 @@ impl AnthropicClient {
                     }
                 }
                 Some("thinking") => {
-                    if let Some(thinking) = item.get("thinking").and_then(|t| t.as_str()) {
-                        thinking_parts.push(thinking.to_string());
-                    }
-                    if let Some(signature) = item.get("signature").and_then(|s| s.as_str()) {
-                        thinking_signature = Some(signature.to_string());
-                    }
+                    let thinking = item
+                        .get("thinking")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| anthropic_parse_error("Thinking block missing thinking"))?;
+                    let signature = item
+                        .get("signature")
+                        .and_then(Value::as_str)
+                        .filter(|signature| !signature.is_empty())
+                        .ok_or_else(|| anthropic_parse_error("Thinking block missing signature"))?;
+                    anthropic_thinking_blocks.push(AnthropicThinkingBlock::Thinking {
+                        thinking: thinking.to_string(),
+                        signature: signature.to_string(),
+                    });
                 }
                 Some("redacted_thinking") => {
-                    has_redacted_thinking = true;
+                    let data = item
+                        .get("data")
+                        .and_then(Value::as_str)
+                        .filter(|data| !data.is_empty())
+                        .ok_or_else(|| {
+                            anthropic_parse_error("Redacted thinking block missing data")
+                        })?;
+                    anthropic_thinking_blocks.push(AnthropicThinkingBlock::RedactedThinking {
+                        data: data.to_string(),
+                    });
                 }
                 Some("refusal") => {
                     if let Some(refusal) = item.get("refusal").and_then(|r| r.as_str()) {
@@ -113,15 +127,12 @@ impl AnthropicClient {
             }
         }
 
-        let thinking = if !thinking_parts.is_empty() {
-            Some(ThinkingContent::Text {
-                text: thinking_parts.join(""),
-                signature: thinking_signature,
-            })
-        } else if has_redacted_thinking {
-            Some(ThinkingContent::Redacted { token_count: None })
-        } else {
+        let thinking = if anthropic_thinking_blocks.is_empty() {
             None
+        } else {
+            let content = AnthropicThinkingContent::try_from(anthropic_thinking_blocks)
+                .map_err(|error| anthropic_parse_error(error.to_string()))?;
+            Some(ThinkingContent::AnthropicBlocks { content })
         };
 
         // Build message

--- a/src/core/providers/anthropic/client/tests/response_tests.rs
+++ b/src/core/providers/anthropic/client/tests/response_tests.rs
@@ -92,7 +92,7 @@ fn test_anthropic_client_preserves_thinking_blocks() {
 
     let response = json!({
         "id": "msg_123",
-        "model": "claude-3-opus-20240229",
+        "model": "claude-sonnet-4-20250514",
         "content": [
             {
                 "type": "thinking",
@@ -149,7 +149,7 @@ fn test_anthropic_client_preserves_thinking_blocks() {
             .is_some_and(ThinkingContent::is_redacted)
     );
 
-    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    let mut request = ChatRequest::new("claude-sonnet-4-20250514");
     request.messages = vec![
         result.choices[0].message.clone(),
         ChatMessage {

--- a/src/core/providers/anthropic/client/tests/response_tests.rs
+++ b/src/core/providers/anthropic/client/tests/response_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::core::types::chat::ChatRequest;
+use crate::core::types::thinking::{AnthropicThinkingBlock, AnthropicThinkingContent};
 
 // ==================== Chat Response Transformation Tests ====================
 
@@ -100,7 +102,9 @@ fn test_anthropic_client_preserves_thinking_blocks() {
             {
                 "type": "thinking",
                 "thinking": "Second thought."
+                ,"signature": "sig_456"
             },
+            {"type": "redacted_thinking", "data": "opaque-data"},
             {"type": "text", "text": "Answer."}
         ],
         "stop_reason": "end_turn"
@@ -115,16 +119,68 @@ fn test_anthropic_client_preserves_thinking_blocks() {
             .message
             .thinking
             .as_ref()
-            .and_then(|thinking| thinking.as_text()),
+            .and_then(|thinking| thinking.as_text())
+            .as_deref(),
         Some("First thought. Second thought.")
     );
+    let content = AnthropicThinkingContent::try_from(vec![
+        AnthropicThinkingBlock::Thinking {
+            thinking: "First thought. ".to_string(),
+            signature: "sig_123".to_string(),
+        },
+        AnthropicThinkingBlock::Thinking {
+            thinking: "Second thought.".to_string(),
+            signature: "sig_456".to_string(),
+        },
+        AnthropicThinkingBlock::RedactedThinking {
+            data: "opaque-data".to_string(),
+        },
+    ])
+    .expect("valid Anthropic thinking history");
     assert_eq!(
         result.choices.first().unwrap().message.thinking.as_ref(),
-        Some(&ThinkingContent::Text {
-            text: "First thought. Second thought.".to_string(),
-            signature: Some("sig_123".to_string()),
-        })
+        Some(&ThinkingContent::AnthropicBlocks { content })
     );
+    assert!(
+        result.choices[0]
+            .message
+            .thinking
+            .as_ref()
+            .is_some_and(ThinkingContent::is_redacted)
+    );
+
+    let mut request = ChatRequest::new("claude-3-opus-20240229");
+    request.messages = vec![
+        result.choices[0].message.clone(),
+        ChatMessage {
+            role: MessageRole::User,
+            content: Some(MessageContent::Text("Continue".to_string())),
+            ..Default::default()
+        },
+    ];
+    let replay = client
+        .transform_chat_request(&request)
+        .expect("non-tool thinking responses must remain replayable");
+    assert_eq!(
+        replay["messages"][0]["content"][2],
+        json!({"type":"redacted_thinking","data":"opaque-data"})
+    );
+}
+
+#[test]
+fn anthropic_response_rejects_thinking_without_signature() {
+    let client = AnthropicClient::new(AnthropicConfig::new_test("test-key")).unwrap();
+    let response = json!({
+        "id": "msg_missing_signature",
+        "model": "claude-opus-5",
+        "content": [{"type":"thinking","thinking":"unverifiable"}],
+        "stop_reason": "end_turn"
+    });
+
+    let error = client
+        .transform_chat_response(response)
+        .expect_err("thinking signatures are required for lossless replay");
+    assert!(error.to_string().contains("signature"));
 }
 
 #[test]

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -4,9 +4,14 @@ use crate::core::types::{
     chat::{ChatMessage, ChatRequest},
     context::RequestContext,
     message::{MessageContent, MessageRole},
-    thinking::ThinkingContent,
+    thinking::{ThinkingConfig, ThinkingContent},
     tools::FunctionCall,
 };
+
+fn first_party_provider() -> AnthropicProvider {
+    AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
+        .unwrap_or_else(|error| panic!("provider should build: {error}"))
+}
 
 fn compatible_provider() -> AnthropicProvider {
     let config = AnthropicConfig::new_test("test-key")
@@ -111,4 +116,48 @@ async fn compatible_models_reject_message_thinking() {
     };
 
     assert!(format!("{err}").contains("only supports text and image content"));
+}
+
+#[test]
+fn claude_5_protocol_supported_params_exclude_top_k() {
+    let provider = first_party_provider();
+
+    for model in ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"] {
+        assert!(
+            !provider
+                .get_supported_openai_params(model)
+                .contains(&"top_k")
+        );
+    }
+    assert!(
+        provider
+            .get_supported_openai_params("claude-3-opus-20240229")
+            .contains(&"top_k")
+    );
+}
+
+#[tokio::test]
+async fn claude_5_public_transform_shares_production_protocol() {
+    let provider = first_party_provider();
+    let mut request = ChatRequest::new("claude-opus-5").add_user_message("Solve this");
+    request.thinking = Some(ThinkingConfig::medium_effort());
+    request.stream = true;
+
+    let transformed = provider
+        .transform_request(request, RequestContext::new())
+        .await
+        .expect("public transformer should use adaptive production serialization");
+    assert_eq!(transformed["thinking"]["type"], "adaptive");
+    assert_eq!(transformed["output_config"]["effort"], "medium");
+    assert_eq!(transformed["stream"], true);
+
+    let mut top_k = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+    top_k
+        .extra_params
+        .insert("top_k".to_string(), serde_json::json!(1));
+    let error = provider
+        .transform_request(top_k, RequestContext::new())
+        .await
+        .expect_err("public transformer must share Claude 5 validation");
+    assert!(error.to_string().contains("top_k"));
 }

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -80,8 +80,11 @@ impl AnthropicProvider {
     /// Validate request
     fn validate_request(&self, request: &ChatRequest) -> Result<(), ProviderError> {
         let registry = get_anthropic_registry();
+        let uses_compatible_model_allow_list = self.client.uses_compatible_model_allow_list();
+        let uses_claude_5_protocol = !uses_compatible_model_allow_list
+            && AnthropicClient::is_claude_5_protocol_model(&request.model);
 
-        let model_spec = if self.client.uses_compatible_model_allow_list() {
+        let model_spec = if uses_compatible_model_allow_list {
             if !self.client.allows_unknown_model(&request.model) {
                 return Err(ProviderError::invalid_request(
                     "anthropic",
@@ -92,6 +95,14 @@ impl AnthropicProvider {
         } else {
             registry.get_model_spec(&request.model)
         };
+
+        if model_spec.is_none() && uses_claude_5_protocol {
+            return crate::core::providers::base::validate_chat_request_common(
+                "anthropic",
+                request,
+                COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS,
+            );
+        }
 
         let Some(model_spec) = model_spec else {
             if !self.client.allows_unknown_model(&request.model) {
@@ -230,7 +241,8 @@ impl LLMProvider for AnthropicProvider {
             return self.client.allows_unknown_model(model);
         }
 
-        self.supported_models.iter().any(|info| info.id == model)
+        AnthropicClient::is_claude_5_protocol_model(model)
+            || self.supported_models.iter().any(|info| info.id == model)
             || self.client.allows_unknown_model(model)
     }
 
@@ -277,9 +289,7 @@ impl LLMProvider for AnthropicProvider {
         request: ChatRequest,
         _context: RequestContext,
     ) -> Result<Value, ProviderError> {
-        if !AnthropicClient::is_claude_5_protocol_model(&request.model) {
-            self.validate_request(&request)?;
-        }
+        self.validate_request(&request)?;
         self.client.transform_chat_request(&request)
     }
 
@@ -487,6 +497,23 @@ mod tests {
         assert!(provider.supports_model("claude-3-5-sonnet-20241022"));
         assert!(provider.supports_model("claude-3-haiku-20240307"));
         assert!(!provider.supports_model("gpt-4"));
+    }
+
+    #[test]
+    fn claude_5_protocol_models_share_production_validation_without_catalog_entries() {
+        let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key")).unwrap();
+        assert!(provider.supports_model("claude-opus-5"));
+        let valid = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+        provider
+            .validate_request(&valid)
+            .expect("production validation must accept an exact protocol model");
+
+        let empty = ChatRequest::new("claude-opus-5");
+        assert!(provider.validate_request(&empty).is_err());
+
+        let mut too_many_tokens = ChatRequest::new("claude-opus-5").add_user_message("Hello");
+        too_many_tokens.max_tokens = Some(COMPATIBLE_MODEL_MAX_OUTPUT_TOKENS + 1);
+        assert!(provider.validate_request(&too_many_tokens).is_err());
     }
 
     #[test]

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -234,7 +234,19 @@ impl LLMProvider for AnthropicProvider {
             || self.client.allows_unknown_model(model)
     }
 
-    fn get_supported_openai_params(&self, _model: &str) -> &'static [&'static str] {
+    fn get_supported_openai_params(&self, model: &str) -> &'static [&'static str] {
+        if AnthropicClient::is_claude_5_protocol_model(model) {
+            return &[
+                "temperature",
+                "max_tokens",
+                "top_p",
+                "tools",
+                "tool_choice",
+                "stream",
+                "stop",
+            ];
+        }
+
         &[
             "temperature",
             "max_tokens",
@@ -265,55 +277,10 @@ impl LLMProvider for AnthropicProvider {
         request: ChatRequest,
         _context: RequestContext,
     ) -> Result<Value, ProviderError> {
-        self.validate_request(&request)?;
-
-        // Request
-        let mut anthropic_request = serde_json::json!({
-            "model": request.model,
-            "messages": request.messages,
-        });
-
-        // Add optional parameters
-        if let Some(max_tokens) = request.max_tokens {
-            anthropic_request["max_tokens"] = Value::Number(max_tokens.into());
+        if !AnthropicClient::is_claude_5_protocol_model(&request.model) {
+            self.validate_request(&request)?;
         }
-
-        if let Some(temperature) = request.temperature {
-            let temp_f64: f64 = temperature.into();
-            anthropic_request["temperature"] = Value::Number(
-                serde_json::Number::from_f64(temp_f64).ok_or_else(|| {
-                    ProviderError::invalid_request(
-                        "anthropic",
-                        format!("invalid temperature value: {temp_f64} (NaN and Infinity are not allowed)"),
-                    )
-                })?,
-            );
-        }
-
-        if let Some(top_p) = request.top_p {
-            let top_p_f64: f64 = top_p.into();
-            anthropic_request["top_p"] =
-                Value::Number(serde_json::Number::from_f64(top_p_f64).ok_or_else(|| {
-                    ProviderError::invalid_request(
-                        "anthropic",
-                        format!(
-                            "invalid top_p value: {top_p_f64} (NaN and Infinity are not allowed)"
-                        ),
-                    )
-                })?);
-        }
-
-        if request.stream {
-            anthropic_request["stream"] = Value::Bool(request.stream);
-        }
-
-        if let Some(tools) = request.tools
-            && !tools.is_empty()
-        {
-            anthropic_request["tools"] = serde_json::to_value(tools)?;
-        }
-
-        Ok(anthropic_request)
+        self.client.transform_chat_request(&request)
     }
 
     async fn transform_response(
@@ -672,9 +639,10 @@ mod tests {
         };
 
         assert_eq!(transformed["model"], "mimo-v2.5");
+        assert_eq!(transformed["messages"][0]["content"][1]["type"], "image");
         assert_eq!(
-            transformed["messages"][0]["content"][1]["type"],
-            "image_url"
+            transformed["messages"][0]["content"][1]["source"]["type"],
+            "base64"
         );
     }
 

--- a/src/core/providers/base/sse/anthropic.rs
+++ b/src/core/providers/base/sse/anthropic.rs
@@ -224,9 +224,28 @@ impl SSETransformer for AnthropicTransformer {
 
                         Ok(Some(self.chunk_with_choice(created, delta, None, None)))
                     }
-                    "thinking" | "redacted_thinking" => {
+                    "thinking" => {
                         let mut delta = Self::empty_delta();
                         delta.thinking = Some(ThinkingDelta::start());
+                        Ok(Some(self.chunk_with_choice(created, delta, None, None)))
+                    }
+                    "redacted_thinking" => {
+                        let data = content_block
+                            .get("data")
+                            .and_then(Value::as_str)
+                            .filter(|data| !data.is_empty())
+                            .ok_or_else(|| {
+                                ProviderError::response_parsing(
+                                    "anthropic",
+                                    "Redacted thinking block missing data".to_string(),
+                                )
+                            })?;
+                        let mut delta = Self::empty_delta();
+                        delta.thinking = Some(ThinkingDelta {
+                            redacted_data: Some(data.to_string()),
+                            is_start: Some(true),
+                            ..Default::default()
+                        });
                         Ok(Some(self.chunk_with_choice(created, delta, None, None)))
                     }
                     "text" => Ok(None),
@@ -444,6 +463,31 @@ mod tests {
         let chunk = t.transform_chunk(&event.to_string()).unwrap().unwrap();
         let usage = chunk.usage.as_ref().unwrap();
         assert!(usage.prompt_tokens_details.is_none());
+    }
+
+    #[test]
+    fn streamed_redacted_thinking_preserves_opaque_data() {
+        let transformer = AnthropicTransformer::new("claude-opus-5");
+        let chunk = chunk_from_event(
+            &transformer,
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "redacted_thinking",
+                    "data": "opaque-stream-data"
+                }
+            }),
+        );
+
+        assert_eq!(
+            chunk.choices[0]
+                .delta
+                .thinking
+                .as_ref()
+                .and_then(|thinking| thinking.redacted_data.as_deref()),
+            Some("opaque-stream-data")
+        );
     }
 
     #[test]

--- a/src/core/providers/base/sse/anthropic.rs
+++ b/src/core/providers/base/sse/anthropic.rs
@@ -22,6 +22,9 @@ pub struct AnthropicTransformer {
     model: String,
     tool_name_map: HashMap<String, String>,
     message_id: Mutex<Option<String>>,
+    /// Active thinking blocks by content index. `Some` accumulates a regular block signature;
+    /// `None` denotes an already validated redacted block.
+    thinking_blocks: Mutex<HashMap<u32, Option<String>>>,
 }
 
 impl Clone for AnthropicTransformer {
@@ -30,6 +33,7 @@ impl Clone for AnthropicTransformer {
             model: self.model.clone(),
             tool_name_map: self.tool_name_map.clone(),
             message_id: Mutex::new(None),
+            thinking_blocks: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -40,6 +44,7 @@ impl AnthropicTransformer {
             model: model.into(),
             tool_name_map: HashMap::new(),
             message_id: Mutex::new(None),
+            thinking_blocks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -80,6 +85,61 @@ impl AnthropicTransformer {
             Err(poisoned) => poisoned.into_inner(),
         };
         *guard = None;
+    }
+
+    fn start_thinking_block(
+        &self,
+        index: u32,
+        signature: Option<String>,
+    ) -> Result<(), ProviderError> {
+        let mut blocks = self
+            .thinking_blocks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if blocks.insert(index, signature).is_some() {
+            return Err(ProviderError::response_parsing(
+                "anthropic",
+                format!("Duplicate thinking content block index {index}"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn append_thinking_signature(&self, index: u32, signature: &str) -> Result<(), ProviderError> {
+        let mut blocks = self
+            .thinking_blocks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(Some(accumulated)) = blocks.get_mut(&index) else {
+            return Err(ProviderError::response_parsing(
+                "anthropic",
+                format!("Signature received for inactive thinking content block {index}"),
+            ));
+        };
+        if signature.is_empty() {
+            return Err(ProviderError::response_parsing(
+                "anthropic",
+                format!("Thinking content block {index} received an empty signature"),
+            ));
+        }
+        accumulated.push_str(signature);
+        Ok(())
+    }
+
+    fn complete_thinking_block(&self, index: u32) -> Result<bool, ProviderError> {
+        let state = self
+            .thinking_blocks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&index);
+        match state {
+            Some(Some(signature)) if signature.is_empty() => Err(ProviderError::response_parsing(
+                "anthropic",
+                format!("Thinking content block {index} is missing its signature"),
+            )),
+            Some(_) => Ok(true),
+            None => Ok(false),
+        }
     }
 
     fn parse_anthropic_finish_reason(reason: &str) -> FinishReason {
@@ -148,6 +208,10 @@ impl SSETransformer for AnthropicTransformer {
 
         match event_type {
             "message_start" => {
+                self.thinking_blocks
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clear();
                 let message_id = json
                     .get("message")
                     .and_then(|m| m.get("id"))
@@ -225,6 +289,7 @@ impl SSETransformer for AnthropicTransformer {
                         Ok(Some(self.chunk_with_choice(created, delta, None, None)))
                     }
                     "thinking" => {
+                        self.start_thinking_block(index, Some(String::new()))?;
                         let mut delta = Self::empty_delta();
                         delta.thinking = Some(ThinkingDelta::start());
                         Ok(Some(self.chunk_with_choice(created, delta, None, None)))
@@ -240,6 +305,7 @@ impl SSETransformer for AnthropicTransformer {
                                     "Redacted thinking block missing data".to_string(),
                                 )
                             })?;
+                        self.start_thinking_block(index, None)?;
                         let mut delta = Self::empty_delta();
                         delta.thinking = Some(ThinkingDelta {
                             redacted_data: Some(data.to_string()),
@@ -311,7 +377,15 @@ impl SSETransformer for AnthropicTransformer {
                         let signature = delta_json
                             .get("signature")
                             .and_then(|value| value.as_str())
-                            .unwrap_or("");
+                            .ok_or_else(|| {
+                                ProviderError::response_parsing(
+                                    "anthropic",
+                                    format!(
+                                        "Thinking content block {index} is missing its signature"
+                                    ),
+                                )
+                            })?;
+                        self.append_thinking_signature(index, signature)?;
                         let mut delta = Self::empty_delta();
                         delta.thinking = Some(ThinkingDelta {
                             signature: Some(signature.to_string()),
@@ -376,6 +450,18 @@ impl SSETransformer for AnthropicTransformer {
                 )))
             }
             "message_stop" => {
+                if !self
+                    .thinking_blocks
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .is_empty()
+                {
+                    return Err(ProviderError::response_parsing(
+                        "anthropic",
+                        "Anthropic stream ended with an incomplete thinking content block"
+                            .to_string(),
+                    ));
+                }
                 let message_id = self.current_message_id();
                 self.clear_message_id();
                 Ok(Some(ChatChunk {
@@ -402,7 +488,17 @@ impl SSETransformer for AnthropicTransformer {
                     msg.to_string(),
                 ))
             }
-            "content_block_stop" | "ping" => Ok(None),
+            "content_block_stop" => {
+                let index = json.get("index").and_then(Value::as_u64).unwrap_or(0) as u32;
+                if self.complete_thinking_block(index)? {
+                    let mut delta = Self::empty_delta();
+                    delta.thinking = Some(ThinkingDelta::complete());
+                    Ok(Some(self.chunk_with_choice(created, delta, None, None)))
+                } else {
+                    Ok(None)
+                }
+            }
+            "ping" => Ok(None),
             _ => {
                 warn!(
                     provider = "anthropic",
@@ -487,6 +583,84 @@ mod tests {
                 .as_ref()
                 .and_then(|thinking| thinking.redacted_data.as_deref()),
             Some("opaque-stream-data")
+        );
+    }
+
+    fn thinking_event(index: u32, event_type: &str, payload: Value) -> Value {
+        match event_type {
+            "start" => serde_json::json!({"type":"content_block_start","index":index,
+                "content_block":{"type":"thinking","thinking":""}}),
+            "signature" => serde_json::json!({"type":"content_block_delta","index":index,
+                "delta":{"type":"signature_delta","signature":payload}}),
+            _ => serde_json::json!({"type":"content_block_stop","index":index}),
+        }
+    }
+
+    #[test]
+    fn streamed_thinking_requires_a_non_empty_signature_before_block_stop() {
+        for signature in [None, Some("")] {
+            let t = AnthropicTransformer::new("claude-opus-5");
+            let _ = chunk_from_event(&t, thinking_event(0, "start", Value::Null));
+            let event = signature.map_or_else(
+                || thinking_event(0, "stop", Value::Null),
+                |value| thinking_event(0, "signature", Value::String(value.to_string())),
+            );
+            let error = t
+                .transform_chunk(&event.to_string())
+                .expect_err("must fail");
+            assert!(error.to_string().contains("signature"));
+        }
+    }
+
+    #[test]
+    fn streamed_thinking_emits_complete_boundaries_for_multiple_lossless_blocks() {
+        let t = AnthropicTransformer::new("claude-opus-5");
+        for index in [0, 2] {
+            let _ = chunk_from_event(&t, thinking_event(index, "start", Value::Null));
+            let signature = format!("sig-{index}");
+            let signed = chunk_from_event(
+                &t,
+                thinking_event(index, "signature", Value::String(signature.clone())),
+            );
+            assert_eq!(
+                signed.choices[0]
+                    .delta
+                    .thinking
+                    .as_ref()
+                    .and_then(|thinking| thinking.signature.as_deref()),
+                Some(signature.as_str())
+            );
+            let complete = chunk_from_event(&t, thinking_event(index, "stop", Value::Null));
+            assert_eq!(
+                complete.choices[0]
+                    .delta
+                    .thinking
+                    .as_ref()
+                    .and_then(|thinking| thinking.is_complete),
+                Some(true)
+            );
+        }
+        let redacted = chunk_from_event(
+            &t,
+            serde_json::json!({"type":"content_block_start",
+            "index":1,"content_block":{"type":"redacted_thinking","data":"opaque"}}),
+        );
+        assert_eq!(
+            redacted.choices[0]
+                .delta
+                .thinking
+                .as_ref()
+                .and_then(|thinking| thinking.redacted_data.as_deref()),
+            Some("opaque")
+        );
+        let complete = chunk_from_event(&t, thinking_event(1, "stop", Value::Null));
+        assert_eq!(
+            complete.choices[0]
+                .delta
+                .thinking
+                .as_ref()
+                .and_then(|thinking| thinking.is_complete),
+            Some(true)
         );
     }
 

--- a/src/core/providers/ollama/streaming.rs
+++ b/src/core/providers/ollama/streaming.rs
@@ -194,6 +194,7 @@ where
                     .map(|t| crate::core::types::thinking::ThinkingDelta {
                         content: Some(t.clone()),
                         signature: None,
+                        redacted_data: None,
                         is_start: None,
                         is_complete: None,
                     });

--- a/src/core/providers/openai/models/api_types.rs
+++ b/src/core/providers/openai/models/api_types.rs
@@ -241,6 +241,7 @@ impl OpenAIMessage {
         Ok(crate::core::models::openai::ChatMessage {
             role,
             content,
+            thinking: None,
             name: self.name,
             function_call: self.function_call.map(|call| {
                 crate::core::models::openai::FunctionCall {

--- a/src/core/semantic_cache/tests.rs
+++ b/src/core/semantic_cache/tests.rs
@@ -19,6 +19,7 @@ fn test_semantic_cache_config_default() {
 async fn test_extract_prompt_text() {
     let messages = vec![
         ChatMessage {
+            thinking: None,
             role: MessageRole::System,
             content: Some(MessageContent::Text(
                 "You are a helpful assistant".to_string(),
@@ -30,6 +31,7 @@ async fn test_extract_prompt_text() {
             audio: None,
         },
         ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello world".to_string())),
             name: None,

--- a/src/core/semantic_cache/types.rs
+++ b/src/core/semantic_cache/types.rs
@@ -118,6 +118,7 @@ mod tests {
             choices: vec![ChatChoice {
                 index: 0,
                 message: ChatMessage {
+                    thinking: None,
                     role: MessageRole::Assistant,
                     content: Some(MessageContent::Text("Test response".to_string())),
                     name: None,

--- a/src/core/semantic_cache/utils.rs
+++ b/src/core/semantic_cache/utils.rs
@@ -113,6 +113,7 @@ mod tests {
     #[test]
     fn test_extract_prompt_text_single_text_message() {
         let messages = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -130,6 +131,7 @@ mod tests {
     fn test_extract_prompt_text_multiple_messages() {
         let messages = vec![
             ChatMessage {
+                thinking: None,
                 role: MessageRole::System,
                 content: Some(MessageContent::Text("You are a helper.".to_string())),
                 name: None,
@@ -139,6 +141,7 @@ mod tests {
                 audio: None,
             },
             ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Help me.".to_string())),
                 name: None,
@@ -157,6 +160,7 @@ mod tests {
     fn test_extract_prompt_text_with_none_content() {
         let messages = vec![
             ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Hello".to_string())),
                 name: None,
@@ -166,6 +170,7 @@ mod tests {
                 audio: None,
             },
             ChatMessage {
+                thinking: None,
                 role: MessageRole::Assistant,
                 content: None,
                 name: None,
@@ -183,6 +188,7 @@ mod tests {
     #[test]
     fn test_extract_prompt_text_with_parts() {
         let messages = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Parts(vec![
                 ContentPart::Text {
@@ -206,6 +212,7 @@ mod tests {
     #[test]
     fn test_extract_prompt_text_with_image_parts() {
         let messages = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Parts(vec![
                 ContentPart::Text {
@@ -233,6 +240,7 @@ mod tests {
     #[test]
     fn test_extract_prompt_text_empty_parts() {
         let messages = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Parts(vec![])),
             name: None,
@@ -249,6 +257,7 @@ mod tests {
     #[test]
     fn test_extract_prompt_text_only_image_parts() {
         let messages = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Parts(vec![ContentPart::ImageUrl {
                 image_url: ImageUrl {
@@ -271,6 +280,7 @@ mod tests {
     fn test_extract_prompt_text_mixed_content() {
         let messages = vec![
             ChatMessage {
+                thinking: None,
                 role: MessageRole::System,
                 content: Some(MessageContent::Text("System prompt".to_string())),
                 name: None,
@@ -280,6 +290,7 @@ mod tests {
                 audio: None,
             },
             ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Parts(vec![ContentPart::Text {
                     text: "User text".to_string(),
@@ -301,6 +312,7 @@ mod tests {
     #[test]
     fn test_extract_and_hash() {
         let messages = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("What is 2+2?".to_string())),
             name: None,
@@ -320,6 +332,7 @@ mod tests {
     #[test]
     fn test_same_messages_same_hash() {
         let messages1 = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -330,6 +343,7 @@ mod tests {
         }];
 
         let messages2 = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -348,6 +362,7 @@ mod tests {
     #[test]
     fn test_different_messages_different_hash() {
         let messages1 = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -358,6 +373,7 @@ mod tests {
         }];
 
         let messages2 = vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Goodbye".to_string())),
             name: None,

--- a/src/core/semantic_cache/validation.rs
+++ b/src/core/semantic_cache/validation.rs
@@ -58,6 +58,7 @@ mod tests {
         ChatCompletionRequest {
             model: "gpt-4".to_string(),
             messages: vec![ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text("Hello".to_string())),
                 name: None,

--- a/src/core/types/chat.rs
+++ b/src/core/types/chat.rs
@@ -5,6 +5,7 @@ use super::message::{MessageContent, MessageRole};
 use super::thinking::{ThinkingConfig, ThinkingContent};
 use super::tools::{FunctionCall, ResponseFormat, Tool, ToolCall, ToolChoice};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Stream options for controlling streaming behavior
@@ -74,7 +75,7 @@ impl ChatMessage {
     }
 
     /// Get thinking content as text (if available)
-    pub fn thinking_text(&self) -> Option<&str> {
+    pub fn thinking_text(&self) -> Option<Cow<'_, str>> {
         self.thinking.as_ref().and_then(|t| t.as_text())
     }
 }

--- a/src/core/types/responses/delta.rs
+++ b/src/core/types/responses/delta.rs
@@ -143,6 +143,7 @@ mod tests {
             thinking: Some(ThinkingDelta {
                 content: Some("thinking...".to_string()),
                 signature: None,
+                redacted_data: None,
                 is_start: None,
                 is_complete: None,
             }),
@@ -157,6 +158,7 @@ mod tests {
             thinking: Some(ThinkingDelta {
                 content: Some("Let me think...".to_string()),
                 signature: None,
+                redacted_data: None,
                 is_start: None,
                 is_complete: None,
             }),
@@ -446,6 +448,7 @@ mod tests {
             thinking: Some(ThinkingDelta {
                 content: None,
                 signature: None,
+                redacted_data: None,
                 is_start: None,
                 is_complete: None,
             }),

--- a/src/core/types/thinking.rs
+++ b/src/core/types/thinking.rs
@@ -56,16 +56,14 @@ impl AnthropicThinkingContent {
         &self.blocks
     }
 
-    fn visible_text(&self) -> Cow<'_, str> {
+    fn visible_text(&self) -> Option<Cow<'_, str>> {
         let mut visible = self.blocks.iter().filter_map(|block| match block {
             AnthropicThinkingBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
             AnthropicThinkingBlock::RedactedThinking { .. } => None,
         });
-        let Some(first) = visible.next() else {
-            return Cow::Borrowed("");
-        };
+        let first = visible.next()?;
         let Some(second) = visible.next() else {
-            return Cow::Borrowed(first);
+            return Some(Cow::Borrowed(first));
         };
 
         let mut joined = String::with_capacity(first.len() + second.len());
@@ -74,7 +72,7 @@ impl AnthropicThinkingContent {
         for text in visible {
             joined.push_str(text);
         }
-        Cow::Owned(joined)
+        Some(Cow::Owned(joined))
     }
 
     fn has_redacted_block(&self) -> bool {
@@ -209,7 +207,7 @@ impl ThinkingContent {
             Self::Text { text, .. } => Some(Cow::Borrowed(text)),
             Self::Block { thinking, .. } => Some(Cow::Borrowed(thinking)),
             Self::Redacted { .. } => None,
-            Self::AnthropicBlocks { content } => Some(content.visible_text()),
+            Self::AnthropicBlocks { content } => content.visible_text(),
         }
     }
 

--- a/src/core/types/thinking.rs
+++ b/src/core/types/thinking.rs
@@ -3,8 +3,131 @@
 //! This module provides a unified abstraction for thinking/reasoning features
 //! across all AI providers (OpenAI o-series, Anthropic Claude, DeepSeek R1, Gemini).
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+use std::borrow::Cow;
 use std::collections::HashMap;
+use thiserror::Error;
+
+/// A lossless Anthropic Messages API thinking block.
+///
+/// The Anthropic adapter owns this wire-specific representation. Generic callers should keep
+/// these blocks opaque and pass them back unchanged when continuing a tool-use turn.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicThinkingBlock {
+    /// Visible or omitted thinking plus its required verification signature.
+    Thinking {
+        /// Thinking text returned by Anthropic. This is empty when display is omitted.
+        thinking: String,
+        /// Opaque signature used by Anthropic to validate replayed thinking.
+        signature: String,
+    },
+    /// Safety-redacted thinking with an opaque encrypted payload.
+    RedactedThinking {
+        /// Opaque encrypted data that must be replayed unchanged.
+        data: String,
+    },
+}
+
+/// Invalid Anthropic thinking history.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum AnthropicThinkingContentError {
+    /// A thinking block did not include its required verification signature.
+    #[error("Anthropic thinking block requires a non-empty verification signature")]
+    MissingSignature,
+    /// A redacted block did not include its required encrypted payload.
+    #[error("Anthropic redacted thinking block requires a non-empty data payload")]
+    MissingRedactedData,
+}
+
+/// Ordered Anthropic thinking history.
+///
+/// Construction and deserialization validate required integrity fields, while serialization
+/// exposes only the canonical block sequence. This keeps invalid replay state out of the public
+/// typed representation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnthropicThinkingContent {
+    blocks: Vec<AnthropicThinkingBlock>,
+}
+
+impl AnthropicThinkingContent {
+    /// Return the complete ordered block sequence.
+    pub fn blocks(&self) -> &[AnthropicThinkingBlock] {
+        &self.blocks
+    }
+
+    fn visible_text(&self) -> Cow<'_, str> {
+        let mut visible = self.blocks.iter().filter_map(|block| match block {
+            AnthropicThinkingBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
+            AnthropicThinkingBlock::RedactedThinking { .. } => None,
+        });
+        let Some(first) = visible.next() else {
+            return Cow::Borrowed("");
+        };
+        let Some(second) = visible.next() else {
+            return Cow::Borrowed(first);
+        };
+
+        let mut joined = String::with_capacity(first.len() + second.len());
+        joined.push_str(first);
+        joined.push_str(second);
+        for text in visible {
+            joined.push_str(text);
+        }
+        Cow::Owned(joined)
+    }
+
+    fn has_redacted_block(&self) -> bool {
+        self.blocks
+            .iter()
+            .any(|block| matches!(block, AnthropicThinkingBlock::RedactedThinking { .. }))
+    }
+}
+
+impl TryFrom<Vec<AnthropicThinkingBlock>> for AnthropicThinkingContent {
+    type Error = AnthropicThinkingContentError;
+
+    fn try_from(blocks: Vec<AnthropicThinkingBlock>) -> Result<Self, Self::Error> {
+        for block in &blocks {
+            match block {
+                AnthropicThinkingBlock::Thinking {
+                    thinking: _,
+                    signature,
+                } => {
+                    if signature.is_empty() {
+                        return Err(AnthropicThinkingContentError::MissingSignature);
+                    }
+                }
+                AnthropicThinkingBlock::RedactedThinking { data } => {
+                    if data.is_empty() {
+                        return Err(AnthropicThinkingContentError::MissingRedactedData);
+                    }
+                }
+            }
+        }
+
+        Ok(Self { blocks })
+    }
+}
+
+impl Serialize for AnthropicThinkingContent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.blocks.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AnthropicThinkingContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let blocks = Vec::<AnthropicThinkingBlock>::deserialize(deserializer)?;
+        Self::try_from(blocks).map_err(D::Error::custom)
+    }
+}
 
 /// Unified thinking content - provider agnostic
 ///
@@ -40,6 +163,14 @@ pub enum ThinkingContent {
         #[serde(skip_serializing_if = "Option::is_none")]
         token_count: Option<u32>,
     },
+    /// Ordered Anthropic blocks retained losslessly for multi-turn replay.
+    ///
+    /// This provider-owned variant is an additive public API change. Existing variants remain
+    /// wire-compatible; exhaustive callers must handle this variant when upgrading.
+    AnthropicBlocks {
+        /// Validated signed and redacted blocks in upstream order.
+        content: AnthropicThinkingContent,
+    },
 }
 
 impl ThinkingContent {
@@ -73,17 +204,19 @@ impl ThinkingContent {
     }
 
     /// Get the thinking text content (if available)
-    pub fn as_text(&self) -> Option<&str> {
+    pub fn as_text(&self) -> Option<Cow<'_, str>> {
         match self {
-            Self::Text { text, .. } => Some(text),
-            Self::Block { thinking, .. } => Some(thinking),
+            Self::Text { text, .. } => Some(Cow::Borrowed(text)),
+            Self::Block { thinking, .. } => Some(Cow::Borrowed(thinking)),
             Self::Redacted { .. } => None,
+            Self::AnthropicBlocks { content } => Some(content.visible_text()),
         }
     }
 
     /// Check if thinking is redacted
     pub fn is_redacted(&self) -> bool {
         matches!(self, Self::Redacted { .. })
+            || matches!(self, Self::AnthropicBlocks { content } if content.has_redacted_block())
     }
 }
 
@@ -388,6 +521,10 @@ pub struct ThinkingDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
 
+    /// Opaque payload for a streamed Anthropic `redacted_thinking` block.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redacted_data: Option<String>,
+
     /// Whether this is the start of thinking
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_start: Option<bool>,
@@ -403,6 +540,7 @@ impl ThinkingDelta {
         Self {
             content: Some(content.into()),
             signature: None,
+            redacted_data: None,
             is_start: None,
             is_complete: None,
         }
@@ -413,6 +551,7 @@ impl ThinkingDelta {
         Self {
             content: None,
             signature: None,
+            redacted_data: None,
             is_start: Some(true),
             is_complete: None,
         }
@@ -423,6 +562,7 @@ impl ThinkingDelta {
         Self {
             content: None,
             signature: None,
+            redacted_data: None,
             is_start: None,
             is_complete: Some(true),
         }
@@ -436,14 +576,20 @@ mod tests {
     #[test]
     fn test_thinking_content_text() {
         let content = ThinkingContent::text("Let me think about this...");
-        assert_eq!(content.as_text(), Some("Let me think about this..."));
+        assert_eq!(
+            content.as_text().as_deref(),
+            Some("Let me think about this...")
+        );
         assert!(!content.is_redacted());
     }
 
     #[test]
     fn test_thinking_content_block() {
         let content = ThinkingContent::block("Step 1: Analyze the problem");
-        assert_eq!(content.as_text(), Some("Step 1: Analyze the problem"));
+        assert_eq!(
+            content.as_text().as_deref(),
+            Some("Step 1: Analyze the problem")
+        );
     }
 
     #[test]
@@ -588,5 +734,47 @@ mod tests {
         let json = r#"{"enabled": true}"#;
         let config: ThinkingConfig = serde_json::from_str(json).unwrap();
         assert!(config.include_thinking); // default should be true
+    }
+
+    #[test]
+    fn anthropic_blocks_are_lossless_and_join_all_visible_text() {
+        let content = AnthropicThinkingContent::try_from(vec![
+            AnthropicThinkingBlock::Thinking {
+                thinking: "first ".to_string(),
+                signature: "sig-1".to_string(),
+            },
+            AnthropicThinkingBlock::RedactedThinking {
+                data: "opaque-data".to_string(),
+            },
+            AnthropicThinkingBlock::Thinking {
+                thinking: "second".to_string(),
+                signature: "sig-2".to_string(),
+            },
+        ])
+        .expect("valid Anthropic blocks");
+        let thinking = ThinkingContent::AnthropicBlocks { content };
+
+        assert_eq!(thinking.as_text().as_deref(), Some("first second"));
+        assert!(thinking.is_redacted());
+        let encoded = serde_json::to_string(&thinking).expect("serialize typed blocks");
+        let decoded: ThinkingContent =
+            serde_json::from_str(&encoded).expect("deserialize typed blocks");
+        assert_eq!(decoded, thinking);
+    }
+
+    #[test]
+    fn anthropic_blocks_reject_empty_integrity_fields() {
+        let missing_signature =
+            AnthropicThinkingContent::try_from(vec![AnthropicThinkingBlock::Thinking {
+                thinking: "visible".to_string(),
+                signature: String::new(),
+            }]);
+        assert!(missing_signature.is_err());
+
+        let missing_data =
+            AnthropicThinkingContent::try_from(vec![AnthropicThinkingBlock::RedactedThinking {
+                data: String::new(),
+            }]);
+        assert!(missing_data.is_err());
     }
 }

--- a/src/core/types/thinking.rs
+++ b/src/core/types/thinking.rs
@@ -58,7 +58,9 @@ impl AnthropicThinkingContent {
 
     fn visible_text(&self) -> Option<Cow<'_, str>> {
         let mut visible = self.blocks.iter().filter_map(|block| match block {
-            AnthropicThinkingBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
+            AnthropicThinkingBlock::Thinking { thinking, .. } => {
+                (!thinking.is_empty()).then_some(thinking.as_str())
+            }
             AnthropicThinkingBlock::RedactedThinking { .. } => None,
         });
         let first = visible.next()?;
@@ -758,6 +760,22 @@ mod tests {
         let decoded: ThinkingContent =
             serde_json::from_str(&encoded).expect("deserialize typed blocks");
         assert_eq!(decoded, thinking);
+    }
+
+    #[test]
+    fn anthropic_omitted_blocks_have_no_visible_text() {
+        let content = AnthropicThinkingContent::try_from(vec![
+            AnthropicThinkingBlock::Thinking {
+                thinking: String::new(),
+                signature: "sig-omitted".to_string(),
+            },
+            AnthropicThinkingBlock::RedactedThinking {
+                data: "opaque-data".to_string(),
+            },
+        ])
+        .expect("omitted thinking still has a valid signature");
+
+        assert_eq!(ThinkingContent::AnthropicBlocks { content }.as_text(), None);
     }
 
     #[test]

--- a/src/server/guardrails.rs
+++ b/src/server/guardrails.rs
@@ -113,6 +113,7 @@ mod tests {
         ChatCompletionRequest {
             model: "test-model".to_string(),
             messages: vec![ChatMessage {
+                thinking: None,
                 role: MessageRole::User,
                 content: Some(MessageContent::Text(content.to_string())),
                 name: None,
@@ -135,6 +136,7 @@ mod tests {
             choices: vec![ChatChoice {
                 index: 0,
                 message: ChatMessage {
+                    thinking: None,
                     role: MessageRole::Assistant,
                     content: Some(MessageContent::Text(content.to_string())),
                     name: None,

--- a/src/server/guardrails/input_scan.rs
+++ b/src/server/guardrails/input_scan.rs
@@ -403,6 +403,7 @@ mod tests {
 
     fn message(content: Option<MessageContent>) -> ChatMessage {
         ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content,
             name: None,

--- a/src/server/routes/ai/chat_tests.rs
+++ b/src/server/routes/ai/chat_tests.rs
@@ -280,6 +280,7 @@ fn test_build_core_chat_request_minimal() {
     let request = ChatCompletionRequest {
         model: "gpt-4".to_string(),
         messages: vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -304,6 +305,7 @@ fn test_build_core_chat_request_preserves_transport_fields() {
     let request = ChatCompletionRequest {
         model: "gpt-4".to_string(),
         messages: vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -444,6 +446,7 @@ fn test_build_core_chat_request_usage_override_does_not_mutate_original() {
     let request = ChatCompletionRequest {
         model: "gpt-4".to_string(),
         messages: vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,
@@ -489,6 +492,7 @@ fn test_build_core_chat_request_rejects_seed_overflow() {
     let request = ChatCompletionRequest {
         model: "gpt-4".to_string(),
         messages: vec![ChatMessage {
+            thinking: None,
             role: MessageRole::User,
             content: Some(MessageContent::Text("Hello".to_string())),
             name: None,

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -159,6 +159,7 @@ fn completion_request_from_value(
             messages: vec![ChatMessage {
                 role: MessageRole::User,
                 content: Some(MessageContent::Text(prompt)),
+                thinking: None,
                 name: None,
                 function_call: None,
                 tool_calls: None,

--- a/src/server/routes/ai/responses.rs
+++ b/src/server/routes/ai/responses.rs
@@ -180,6 +180,7 @@ fn build_chat_request_from_turn(
         messages.push(ChatMessage {
             role: MessageRole::System,
             content: Some(MessageContent::Text(instructions.to_string())),
+            thinking: None,
             name: None,
             function_call: None,
             tool_calls: None,
@@ -193,6 +194,7 @@ fn build_chat_request_from_turn(
             CodexTurnItem::Text(text) => ChatMessage {
                 role: MessageRole::User,
                 content: Some(MessageContent::Text(text.clone())),
+                thinking: None,
                 name: None,
                 function_call: None,
                 tool_calls: None,
@@ -331,6 +333,7 @@ fn response_message_to_chat(
     Ok(ChatMessage {
         role: parse_role(&message.role)?,
         content: Some(content),
+        thinking: None,
         name: None,
         function_call: None,
         tool_calls: None,
@@ -359,6 +362,7 @@ fn push_tool_call(messages: &mut Vec<ChatMessage>, call_id: &str, name: &str, ar
     messages.push(ChatMessage {
         role: MessageRole::Assistant,
         content: None,
+        thinking: None,
         name: None,
         function_call: None,
         tool_calls: Some(vec![tool_call]),
@@ -371,6 +375,7 @@ fn tool_output_message(call_id: &str, output: String) -> ChatMessage {
     ChatMessage {
         role: MessageRole::Tool,
         content: Some(MessageContent::Text(output)),
+        thinking: None,
         name: None,
         function_call: None,
         tool_calls: None,

--- a/src/server/routes/ai/responses/codex_compat_tests.rs
+++ b/src/server/routes/ai/responses/codex_compat_tests.rs
@@ -229,6 +229,7 @@ fn codex_non_streaming_reconstructs_custom_tool_output() {
         choices: vec![ChatChoice {
             index: 0,
             message: ChatMessage {
+                thinking: None,
                 role: MessageRole::Assistant,
                 content: None,
                 name: None,

--- a/src/server/routes/ai/spend/completion.rs
+++ b/src/server/routes/ai/spend/completion.rs
@@ -526,6 +526,7 @@ mod budget_request_tests {
     fn budget_request_view_borrows_large_request_parts() {
         let request = ChatCompletionRequest {
             messages: vec![ChatMessage {
+                thinking: None,
                 role: crate::core::models::openai::MessageRole::User,
                 content: Some(MessageContent::Text("x".repeat(64 * 1024))),
                 name: None,

--- a/src/server/routes/ai/spend_provider_reservation_tests.rs
+++ b/src/server/routes/ai/spend_provider_reservation_tests.rs
@@ -11,6 +11,7 @@ fn reserve_with_provider_limit(
 ) -> UnifiedBudgetReservation {
     let budget = UnifiedBudgetLimits::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text("hello".to_string())),
         name: None,
@@ -66,6 +67,7 @@ fn openai_like_prefixed_chat_reservation_uses_provider_pricing() {
 fn openai_chat_reservation_uses_exact_tiktoken_prompt_count() {
     let budget = UnifiedBudgetLimits::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text("Hello, how are you?".to_string())),
         name: None,
@@ -104,6 +106,7 @@ fn openai_chat_reservation_uses_exact_tiktoken_prompt_count() {
 fn chat_prompt_estimate_accounts_for_serialized_tool_parts() {
     let payload = "x".repeat(4_000);
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Parts(vec![
             ContentPart::ToolResult {

--- a/src/server/routes/ai/spend_tests.rs
+++ b/src/server/routes/ai/spend_tests.rs
@@ -23,6 +23,7 @@ fn usage(prompt: u32, completion: u32) -> Usage {
 
 fn user_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -383,6 +384,7 @@ fn chat_reservation_multiplies_output_budget_by_choice_count() {
 #[test]
 fn chat_reservation_uses_conservative_multimodal_prompt_floor() {
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Parts(vec![ContentPart::ImageUrl {
             image_url: ImageUrl {
@@ -405,6 +407,7 @@ fn chat_reservation_uses_conservative_multimodal_prompt_floor() {
 fn chat_reservation_uses_encoded_audio_prompt_floor() {
     let encoded_audio = "a".repeat(8_000);
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Parts(vec![ContentPart::Audio {
             audio: AudioContent {

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -20,6 +20,7 @@ fn test_text_token_estimation() {
 fn test_chat_token_counting() {
     let counter = TokenCounter::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text("Hello, how are you?".to_string())),
         name: None,
@@ -55,6 +56,7 @@ fn test_openai_completion_token_count_uses_tiktoken() {
 fn test_openai_chat_system_message_uses_tiktoken() {
     let counter = TokenCounter::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::System,
         content: Some(MessageContent::Text("You are a bot.".to_string())),
         name: None,
@@ -76,6 +78,7 @@ fn test_openai_chat_system_message_uses_tiktoken() {
 fn test_multimodal_chat_token_count_remains_marked_approximate() {
     let counter = TokenCounter::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Parts(vec![ContentPart::ImageUrl {
             image_url: ImageUrl {
@@ -100,6 +103,7 @@ fn test_multimodal_chat_token_count_remains_marked_approximate() {
 fn test_text_part_chat_token_count_remains_marked_approximate() {
     let counter = TokenCounter::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Parts(vec![ContentPart::Text {
             text: "Hello".to_string(),
@@ -145,6 +149,7 @@ fn test_unknown_openai_like_model_remains_marked_approximate() {
 fn test_tool_call_chat_token_count_remains_marked_approximate() {
     let counter = TokenCounter::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::Assistant,
         content: None,
         name: None,
@@ -171,6 +176,7 @@ fn test_tool_call_chat_token_count_remains_marked_approximate() {
 fn test_tool_result_chat_token_count_remains_marked_approximate() {
     let counter = TokenCounter::new();
     let messages = vec![ChatMessage {
+        thinking: None,
         role: MessageRole::Tool,
         content: Some(MessageContent::Text("done".to_string())),
         name: None,

--- a/src/utils/data/validation/request_validator/tests.rs
+++ b/src/utils/data/validation/request_validator/tests.rs
@@ -7,6 +7,7 @@ use crate::core::models::openai::{
 
 fn create_user_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -19,6 +20,7 @@ fn create_user_message(content: &str) -> ChatMessage {
 
 fn create_system_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::System,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -31,6 +33,7 @@ fn create_system_message(content: &str) -> ChatMessage {
 
 fn create_assistant_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::Assistant,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -297,6 +300,7 @@ fn test_validate_audio_data_invalid() {
 #[test]
 fn test_validate_message_content_empty_text() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text("   ".to_string())),
         name: None,
@@ -314,6 +318,7 @@ fn test_validate_message_content_empty_text() {
 fn test_validate_message_content_too_long() {
     let long_text = "a".repeat(1_000_001);
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text(long_text)),
         name: None,
@@ -330,6 +335,7 @@ fn test_validate_message_content_too_long() {
 #[test]
 fn test_validate_message_content_parts_empty() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Parts(vec![])),
         name: None,
@@ -407,6 +413,7 @@ fn test_validate_content_part_image_valid_details() {
 #[test]
 fn test_validate_function_message_without_name() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Function,
         content: Some(MessageContent::Text("result".to_string())),
         name: None,
@@ -423,6 +430,7 @@ fn test_validate_function_message_without_name() {
 #[test]
 fn test_validate_function_message_without_content() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Function,
         content: None,
         name: Some("get_weather".to_string()),
@@ -439,6 +447,7 @@ fn test_validate_function_message_without_content() {
 #[test]
 fn test_validate_tool_message_without_tool_call_id() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Tool,
         content: Some(MessageContent::Text("result".to_string())),
         name: None,
@@ -455,6 +464,7 @@ fn test_validate_tool_message_without_tool_call_id() {
 #[test]
 fn test_validate_tool_message_valid() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Tool,
         content: Some(MessageContent::Text("result".to_string())),
         name: None,
@@ -470,6 +480,7 @@ fn test_validate_tool_message_valid() {
 #[test]
 fn test_validate_user_message_without_content() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: None,
         name: None,
@@ -486,6 +497,7 @@ fn test_validate_user_message_without_content() {
 #[test]
 fn test_validate_assistant_message_without_content() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Assistant,
         content: None,
         name: None,

--- a/src/utils/data/validation/tests.rs
+++ b/src/utils/data/validation/tests.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 fn create_user_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -21,6 +22,7 @@ fn create_user_message(content: &str) -> ChatMessage {
 
 fn create_system_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::System,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -33,6 +35,7 @@ fn create_system_message(content: &str) -> ChatMessage {
 
 fn create_assistant_message(content: &str) -> ChatMessage {
     ChatMessage {
+        thinking: None,
         role: MessageRole::Assistant,
         content: Some(MessageContent::Text(content.to_string())),
         name: None,
@@ -272,6 +275,7 @@ fn test_multiple_messages() {
 #[test]
 fn test_message_without_content() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: None,
         name: None,
@@ -295,6 +299,7 @@ fn test_message_without_content() {
 #[test]
 fn test_empty_text_content() {
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::User,
         content: Some(MessageContent::Text("   ".to_string())),
         name: None,
@@ -319,6 +324,7 @@ fn test_empty_text_content() {
 fn test_function_message_validation() {
     // Function message without name
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Function,
         content: Some(MessageContent::Text("result".to_string())),
         name: None,
@@ -340,6 +346,7 @@ fn test_function_message_validation() {
 
     // Function message with name
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Function,
         content: Some(MessageContent::Text("result".to_string())),
         name: Some("get_weather".to_string()),
@@ -364,6 +371,7 @@ fn test_function_message_validation() {
 fn test_tool_message_validation() {
     // Tool message without tool_call_id
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Tool,
         content: Some(MessageContent::Text("result".to_string())),
         name: None,
@@ -385,6 +393,7 @@ fn test_tool_message_validation() {
 
     // Tool message with tool_call_id
     let message = ChatMessage {
+        thinking: None,
         role: MessageRole::Tool,
         content: Some(MessageContent::Text("result".to_string())),
         name: None,

--- a/tests/integration/types_tests.rs
+++ b/tests/integration/types_tests.rs
@@ -91,6 +91,21 @@ mod tests {
         assert_eq!(msg.thinking_text().as_deref(), Some("Step 1: Analyze"));
     }
 
+    #[test]
+    fn anthropic_thinking_without_visible_text_returns_none() {
+        use litellm_rs::core::types::thinking::{AnthropicThinkingBlock, AnthropicThinkingContent};
+
+        for content in [
+            AnthropicThinkingContent::try_from(Vec::new()).expect("valid empty history"),
+            AnthropicThinkingContent::try_from(vec![AnthropicThinkingBlock::RedactedThinking {
+                data: "opaque-data".to_string(),
+            }])
+            .expect("valid redacted history"),
+        ] {
+            assert_eq!(ThinkingContent::AnthropicBlocks { content }.as_text(), None);
+        }
+    }
+
     // ==================== ChatRequest Tests ====================
 
     /// Test chat request creation

--- a/tests/integration/types_tests.rs
+++ b/tests/integration/types_tests.rs
@@ -88,7 +88,7 @@ mod tests {
         assert!(msg.thinking_text().is_none());
 
         msg.thinking = Some(ThinkingContent::text("Step 1: Analyze"));
-        assert_eq!(msg.thinking_text(), Some("Step 1: Analyze"));
+        assert_eq!(msg.thinking_text().as_deref(), Some("Step 1: Analyze"));
     }
 
     // ==================== ChatRequest Tests ====================
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn test_thinking_content_text() {
         let content = ThinkingContent::text("Let me think...");
-        assert_eq!(content.as_text(), Some("Let me think..."));
+        assert_eq!(content.as_text().as_deref(), Some("Let me think..."));
         assert!(!content.is_redacted());
     }
 
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_thinking_content_block() {
         let content = ThinkingContent::block("Analyzing the problem");
-        assert_eq!(content.as_text(), Some("Analyzing the problem"));
+        assert_eq!(content.as_text().as_deref(), Some("Analyzing the problem"));
     }
 
     /// Test thinking content redacted


### PR DESCRIPTION
## What

- preserve ordered Anthropic `thinking` and `redacted_thinking` blocks as validated typed content
- require non-empty verification signatures and opaque redacted payloads before history can be replayed
- preserve normal/tool response blocks and streamed redacted data; accumulate and validate each streamed thinking signature at its content-block boundary
- expose all visible thinking through `Option<Cow<'_, str>>`: borrow one block, own joined blocks, and return `None` when no visible text exists
- distinguish adaptive thinking, which supports forced/named tools, from manual thinking, which permits only auto/none
- enforce exact Claude 5 disabled-thinking, `top_k`, and finite `top_p` 0.99..=1.0 rules through one internal protocol classifier
- make support checks and common validation accept only those exact protocol IDs so public transform and production chat/stream share the same validation and serializer before #1216 adds catalog metadata
- prevent the example from logging opaque signatures or redacted payloads

Fixes #1230

This is the protocol prerequisite for #1211 / PR #1216. It intentionally contains no Claude 5 catalog registration and no pricing data. The exact internal classifier supplies wire policy only; #1216 remains responsible for model discovery and catalog capability declarations. Runtime pricing remains owned by #1201 / PR #1222.

## Public API / SemVer note

This change is source-visible:

- `ThinkingContent` gains the `AnthropicBlocks` variant. Exhaustive matches must add an arm.
- `ThinkingContent::as_text()` and `ChatMessage::thinking_text()` now return `Option<Cow<'_, str>>`. A single visible block is borrowed, multiple blocks are joined into owned text, and empty/redacted-only content returns `None`.
- `ThinkingDelta` gains the optional `redacted_data` field. Explicit struct literals must initialize it or use `..Default::default()`; the in-repository Ollama literal is migrated with `None` and no other Ollama behavior changes.

Existing `Text`, `Block`, and `Redacted` variants keep their serialization and behavior. The example and direct API tests document the upgrade.

## Contract evidence

- adaptive thinking supports forced tool use; only manual thinking is restricted to auto/none: https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools
- signatures, redacted payloads, ordering, and display: https://platform.claude.com/docs/en/about-claude/models/extended-thinking-models
- request block schema and `top_p` maximum: https://platform.claude.com/docs/en/api/http/messages/create
- streaming signature lifecycle: https://platform.claude.com/docs/en/build-with-claude/streaming

## Scope

- cumulative diff: 14 files, 1,165 insertions, 119 deletions
- 13 Anthropic/protocol/type/direct-test files plus the approved one-line Ollama `ThinkingDelta` construction migration
- no `models.rs`, catalog module, central JSON, pricing sync, provider pricing, or other provider logic changes

## Verification

- [x] RED: production validation rejected exact protocol IDs while public transform accepted them
- [x] RED: streamed thinking blocks could stop without a signature and emitted no completion boundary
- [x] RED: `top_p > 1` and non-finite values were not rejected
- [x] RED: empty/redacted-only typed content returned `Some("")`
- [x] `cargo test anthropic --lib` — 289 passed
- [x] `cargo test core::providers::base::sse::anthropic --lib` — 8 passed
- [x] focused typed/request/provider/public API tests
- [x] `cargo check --example test_thinking`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check`
- [x] `cargo check --all-features`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] fresh CI full suite (not manually rerun in this cycle)
