### PR TITLE
feat(types): add safe thinking continuation carrier

### DIFF
--- a/src/core/models/openai/messages.rs
+++ b/src/core/models/openai/messages.rs
@@ -8,6 +8,7 @@ use std::hash::{Hash, Hasher};
 
 use super::audio::AudioContent;
 use super::tools::{FunctionCall, ToolCall};
+use crate::core::types::anthropic_continuation::ChatMessageExtensions;
 
 /// Chat message
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,6 +27,51 @@ pub struct ChatMessage {
     pub tool_call_id: Option<String>,
     /// Audio content
     pub audio: Option<AudioContent>,
+}
+
+/// Additive chat-message DTO with explicit provider continuation extensions.
+///
+/// The existing public [`ChatMessage`] remains unchanged for Rust source
+/// compatibility. HTTP paths that need lossless provider continuation state can
+/// opt into this wrapper without adding fields to the legacy struct.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessageWithExtensions {
+    #[serde(flatten)]
+    message: ChatMessage,
+    #[serde(default, skip_serializing_if = "ChatMessageExtensions::is_empty")]
+    extensions: ChatMessageExtensions,
+}
+
+impl ChatMessageWithExtensions {
+    /// Wrap a legacy-compatible chat message with no extensions.
+    pub fn new(message: ChatMessage) -> Self {
+        Self {
+            message,
+            extensions: ChatMessageExtensions::new(),
+        }
+    }
+
+    /// Attach validated provider continuation extensions.
+    pub fn with_extensions(mut self, extensions: ChatMessageExtensions) -> Self {
+        self.extensions = extensions;
+        self
+    }
+
+    /// Return the unchanged legacy-compatible message.
+    pub fn message(&self) -> &ChatMessage {
+        &self.message
+    }
+
+    /// Return the provider continuation extensions.
+    pub fn extensions(&self) -> &ChatMessageExtensions {
+        &self.extensions
+    }
+
+    /// Consume the wrapper into its legacy message and extensions.
+    pub fn into_parts(self) -> (ChatMessage, ChatMessageExtensions) {
+        (self.message, self.extensions)
+    }
 }
 
 /// Message role

--- a/src/core/types/anthropic_continuation.rs
+++ b/src/core/types/anthropic_continuation.rs
@@ -39,7 +39,11 @@ impl TryFrom<&str> for AnthropicSignature {
     type Error = AnthropicContinuationError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::try_from(value.to_string())
+        if value.is_empty() {
+            Err(AnthropicContinuationError::EmptySignature)
+        } else {
+            Ok(Self(value.to_string()))
+        }
     }
 }
 
@@ -108,7 +112,11 @@ impl TryFrom<&str> for AnthropicRedactedData {
     type Error = AnthropicContinuationError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::try_from(value.to_string())
+        if value.is_empty() {
+            Err(AnthropicContinuationError::EmptyRedactedData)
+        } else {
+            Ok(Self(value.to_string()))
+        }
     }
 }
 

--- a/src/core/types/anthropic_continuation.rs
+++ b/src/core/types/anthropic_continuation.rs
@@ -165,7 +165,7 @@ impl fmt::Display for AnthropicRedactedData {
 /// `ThinkingContent` enum, preserving exhaustive-match source compatibility.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum AnthropicThinkingBlock {
     /// Visible or omitted thinking with its required verification signature.
     Thinking {
@@ -242,6 +242,7 @@ impl AnthropicThinkingContent {
 /// literals. Callers opt in through constructors and accessors.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct ChatMessageExtensions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     anthropic_thinking: Option<AnthropicThinkingContent>,

--- a/src/core/types/anthropic_continuation.rs
+++ b/src/core/types/anthropic_continuation.rs
@@ -1,0 +1,271 @@
+//! Lossless Anthropic thinking continuation types.
+//!
+//! These additive extension types keep opaque provider continuation data out of
+//! the existing public `ThinkingContent` enum and chat-message structs. HTTP,
+//! Responses, and SSE adapters can opt into this carrier without breaking
+//! existing exhaustive matches or struct literals.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+use std::{borrow::Cow, fmt};
+use thiserror::Error;
+
+/// Invalid opaque data in an Anthropic thinking continuation.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Error, PartialEq, Eq)]
+pub enum AnthropicContinuationError {
+    /// A thinking block omitted its required verification signature.
+    #[error("Anthropic thinking signature must not be empty")]
+    EmptySignature,
+    /// A redacted block omitted its required encrypted payload.
+    #[error("Anthropic redacted thinking data must not be empty")]
+    EmptyRedactedData,
+}
+
+/// An opaque, non-empty Anthropic thinking verification signature.
+///
+/// `Debug` and `Display` intentionally redact the value. Provider adapters that
+/// must replay the signature can access it explicitly with [`Self::expose`].
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct AnthropicSignature(String);
+
+impl AnthropicSignature {
+    /// Expose the opaque signature for lossless provider forwarding.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for AnthropicSignature {
+    type Error = AnthropicContinuationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_string())
+    }
+}
+
+impl TryFrom<String> for AnthropicSignature {
+    type Error = AnthropicContinuationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            Err(AnthropicContinuationError::EmptySignature)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl Serialize for AnthropicSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.expose())
+    }
+}
+
+impl<'de> Deserialize<'de> for AnthropicSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::try_from(value).map_err(D::Error::custom)
+    }
+}
+
+impl fmt::Debug for AnthropicSignature {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "AnthropicSignature([redacted; {} bytes])",
+            self.0.len()
+        )
+    }
+}
+
+impl fmt::Display for AnthropicSignature {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "[redacted; {} bytes]", self.0.len())
+    }
+}
+
+/// An opaque, non-empty Anthropic safety-redacted thinking payload.
+///
+/// `Debug` and `Display` intentionally redact the value. Provider adapters that
+/// must replay the payload can access it explicitly with [`Self::expose`].
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct AnthropicRedactedData(String);
+
+impl AnthropicRedactedData {
+    /// Expose the opaque payload for lossless provider forwarding.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for AnthropicRedactedData {
+    type Error = AnthropicContinuationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_string())
+    }
+}
+
+impl TryFrom<String> for AnthropicRedactedData {
+    type Error = AnthropicContinuationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            Err(AnthropicContinuationError::EmptyRedactedData)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl Serialize for AnthropicRedactedData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.expose())
+    }
+}
+
+impl<'de> Deserialize<'de> for AnthropicRedactedData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::try_from(value).map_err(D::Error::custom)
+    }
+}
+
+impl fmt::Debug for AnthropicRedactedData {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "AnthropicRedactedData([redacted; {} bytes])",
+            self.0.len()
+        )
+    }
+}
+
+impl fmt::Display for AnthropicRedactedData {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "[redacted; {} bytes]", self.0.len())
+    }
+}
+
+/// A lossless Anthropic Messages API thinking continuation block.
+///
+/// This is a new extension type rather than a variant on the existing public
+/// `ThinkingContent` enum, preserving exhaustive-match source compatibility.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicThinkingBlock {
+    /// Visible or omitted thinking with its required verification signature.
+    Thinking {
+        /// Summarized thinking text, empty when display is omitted.
+        thinking: String,
+        /// Opaque signature required for continuation replay.
+        signature: AnthropicSignature,
+    },
+    /// Safety-redacted thinking with its required opaque encrypted payload.
+    RedactedThinking {
+        /// Opaque data required for continuation replay.
+        data: AnthropicRedactedData,
+    },
+}
+
+/// Ordered, lossless Anthropic thinking continuation blocks.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct AnthropicThinkingContent(Vec<AnthropicThinkingBlock>);
+
+impl AnthropicThinkingContent {
+    /// Create an ordered continuation from validated blocks.
+    pub fn new(blocks: Vec<AnthropicThinkingBlock>) -> Self {
+        Self(blocks)
+    }
+
+    /// Return every block in upstream order.
+    pub fn blocks(&self) -> &[AnthropicThinkingBlock] {
+        &self.0
+    }
+
+    /// Consume the continuation and return every block in upstream order.
+    pub fn into_blocks(self) -> Vec<AnthropicThinkingBlock> {
+        self.0
+    }
+
+    /// Return all non-empty visible thinking text in upstream order.
+    ///
+    /// A single visible block is borrowed. Multiple visible blocks are joined
+    /// without separators because upstream block boundaries already determine
+    /// the exact text fragments.
+    pub fn as_text(&self) -> Option<Cow<'_, str>> {
+        let mut visible = self.0.iter().filter_map(|block| match block {
+            AnthropicThinkingBlock::Thinking { thinking, .. } if !thinking.is_empty() => {
+                Some(thinking.as_str())
+            }
+            _ => None,
+        });
+        let first = visible.next()?;
+        let Some(second) = visible.next() else {
+            return Some(Cow::Borrowed(first));
+        };
+
+        let mut joined = String::with_capacity(first.len() + second.len());
+        joined.push_str(first);
+        joined.push_str(second);
+        for text in visible {
+            joined.push_str(text);
+        }
+        Some(Cow::Owned(joined))
+    }
+
+    /// Whether the continuation contains at least one redacted block.
+    pub fn has_redacted_block(&self) -> bool {
+        self.0
+            .iter()
+            .any(|block| matches!(block, AnthropicThinkingBlock::RedactedThinking { .. }))
+    }
+}
+
+/// Additive, provider-explicit continuation extensions for a chat message.
+///
+/// Fields are private so this carrier can grow without breaking external struct
+/// literals. Callers opt in through constructors and accessors.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatMessageExtensions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    anthropic_thinking: Option<AnthropicThinkingContent>,
+}
+
+impl ChatMessageExtensions {
+    /// Create an empty extension carrier.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attach an Anthropic thinking continuation.
+    pub fn with_anthropic_thinking(mut self, content: AnthropicThinkingContent) -> Self {
+        self.anthropic_thinking = Some(content);
+        self
+    }
+
+    /// Return the Anthropic thinking continuation, if present.
+    pub fn anthropic_thinking(&self) -> Option<&AnthropicThinkingContent> {
+        self.anthropic_thinking.as_ref()
+    }
+
+    /// Whether this carrier has no provider extensions.
+    pub fn is_empty(&self) -> bool {
+        self.anthropic_thinking.is_none()
+    }
+}

--- a/src/core/types/mod.rs
+++ b/src/core/types/mod.rs
@@ -12,6 +12,7 @@ pub mod service;
 
 // Split from requests.rs (new modules)
 pub mod anthropic;
+pub mod anthropic_continuation;
 pub mod chat;
 pub mod codex;
 pub mod content;

--- a/tests/integration/types_tests.rs
+++ b/tests/integration/types_tests.rs
@@ -245,6 +245,29 @@ mod tests {
         );
         assert!(AnthropicSignature::try_from("").is_err());
         assert!(AnthropicRedactedData::try_from("").is_err());
+
+        let unknown_block_integrity = serde_json::from_str::<AnthropicThinkingContent>(
+            r#"[{"type":"thinking","thinking":"visible","signature":"opaque","future_integrity":"must-not-drop"}]"#,
+        );
+        assert!(unknown_block_integrity.is_err());
+
+        let unknown_provider_extension =
+            serde_json::from_value::<ChatMessageWithExtensions>(serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "extensions": {
+                    "future_provider": {"opaque": "must-not-drop"}
+                }
+            }));
+        assert!(unknown_provider_extension.is_err());
+
+        let legacy_with_unknown_top_level =
+            serde_json::from_value::<OpenAiChatMessage>(serde_json::json!({
+                "role": "assistant",
+                "content": "done",
+                "future_top_level": "legacy-compatible"
+            }));
+        assert!(legacy_with_unknown_top_level.is_ok());
     }
 
     // ==================== ChatRequest Tests ====================

--- a/tests/integration/types_tests.rs
+++ b/tests/integration/types_tests.rs
@@ -4,6 +4,17 @@
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
+    use litellm_rs::core::models::openai::messages::ChatMessageWithExtensions;
+    use litellm_rs::core::models::openai::{
+        ChatMessage as OpenAiChatMessage, MessageContent as OpenAiMessageContent,
+        MessageRole as OpenAiMessageRole,
+    };
+    use litellm_rs::core::types::anthropic_continuation::{
+        AnthropicRedactedData, AnthropicSignature, AnthropicThinkingBlock,
+        AnthropicThinkingContent, ChatMessageExtensions,
+    };
     use litellm_rs::core::types::chat::{ChatMessage, ChatRequest};
     use litellm_rs::core::types::message::{MessageContent, MessageRole};
     use litellm_rs::core::types::responses::Usage;
@@ -89,6 +100,151 @@ mod tests {
 
         msg.thinking = Some(ThinkingContent::text("Step 1: Analyze"));
         assert_eq!(msg.thinking_text(), Some("Step 1: Analyze"));
+    }
+
+    #[test]
+    fn public_chat_message_and_thinking_enum_remain_source_compatible() {
+        let message = OpenAiChatMessage {
+            role: OpenAiMessageRole::Assistant,
+            content: Some(OpenAiMessageContent::Text("done".to_string())),
+            name: None,
+            function_call: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: None,
+        };
+        assert!(matches!(
+            &message.content,
+            Some(OpenAiMessageContent::Text(_))
+        ));
+
+        let legacy_json = serde_json::to_value(&message).expect("serialize legacy message");
+        let wrapped_json = serde_json::to_value(ChatMessageWithExtensions::new(message))
+            .expect("serialize extension wrapper without extensions");
+        assert_eq!(wrapped_json, legacy_json);
+
+        fn existing_exhaustive_match(content: ThinkingContent) -> &'static str {
+            match content {
+                ThinkingContent::Text { .. } => "text",
+                ThinkingContent::Block { .. } => "block",
+                ThinkingContent::Redacted { .. } => "redacted",
+            }
+        }
+
+        assert_eq!(
+            existing_exhaustive_match(ThinkingContent::redacted(None)),
+            "redacted"
+        );
+    }
+
+    #[test]
+    fn typed_anthropic_continuation_has_lossless_cow_and_secret_safe_output() {
+        let signature =
+            AnthropicSignature::try_from("opaque-signature").expect("non-empty signature is valid");
+        let redacted = AnthropicRedactedData::try_from("opaque-redacted-data")
+            .expect("non-empty redacted data is valid");
+        let single = AnthropicThinkingContent::new(vec![AnthropicThinkingBlock::Thinking {
+            thinking: "visible".to_string(),
+            signature: signature.clone(),
+        }]);
+        assert!(matches!(single.as_text(), Some(Cow::Borrowed("visible"))));
+
+        let ordered = AnthropicThinkingContent::new(vec![
+            AnthropicThinkingBlock::Thinking {
+                thinking: "first ".to_string(),
+                signature: signature.clone(),
+            },
+            AnthropicThinkingBlock::RedactedThinking {
+                data: redacted.clone(),
+            },
+            AnthropicThinkingBlock::Thinking {
+                thinking: "second".to_string(),
+                signature: signature.clone(),
+            },
+        ]);
+        assert!(matches!(ordered.as_text(), Some(Cow::Owned(ref text)) if text == "first second"));
+
+        let omitted = AnthropicThinkingContent::new(vec![
+            AnthropicThinkingBlock::Thinking {
+                thinking: String::new(),
+                signature: signature.clone(),
+            },
+            AnthropicThinkingBlock::RedactedThinking {
+                data: redacted.clone(),
+            },
+        ]);
+        assert_eq!(omitted.as_text(), None);
+
+        for rendered in [
+            format!("{signature:?}"),
+            signature.to_string(),
+            format!("{redacted:?}"),
+            redacted.to_string(),
+            format!("{ordered:?}"),
+        ] {
+            assert!(!rendered.contains("opaque-signature"));
+            assert!(!rendered.contains("opaque-redacted-data"));
+        }
+    }
+
+    #[test]
+    fn extended_chat_message_roundtrips_validated_anthropic_blocks() {
+        let content = AnthropicThinkingContent::new(vec![
+            AnthropicThinkingBlock::Thinking {
+                thinking: "plan".to_string(),
+                signature: AnthropicSignature::try_from("opaque-signature")
+                    .expect("non-empty signature is valid"),
+            },
+            AnthropicThinkingBlock::RedactedThinking {
+                data: AnthropicRedactedData::try_from("opaque-redacted-data")
+                    .expect("non-empty redacted data is valid"),
+            },
+        ]);
+        let extensions = ChatMessageExtensions::new().with_anthropic_thinking(content.clone());
+        let message = OpenAiChatMessage {
+            role: OpenAiMessageRole::Assistant,
+            content: None,
+            name: None,
+            function_call: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: None,
+        };
+        let extended = ChatMessageWithExtensions::new(message).with_extensions(extensions);
+
+        let encoded = serde_json::to_value(&extended).expect("serialize extension DTO");
+        assert_eq!(encoded["role"], "assistant");
+        assert_eq!(
+            encoded["extensions"]["anthropic_thinking"][0]["type"],
+            "thinking"
+        );
+        let decoded: ChatMessageWithExtensions =
+            serde_json::from_value(encoded).expect("deserialize extension DTO");
+
+        assert_eq!(decoded.extensions().anthropic_thinking(), Some(&content));
+        assert_eq!(decoded.message().role, OpenAiMessageRole::Assistant);
+
+        let missing_signature = serde_json::from_str::<AnthropicThinkingContent>(
+            r#"[{"type":"thinking","thinking":"visible","signature":""}]"#,
+        );
+        assert!(missing_signature.is_err());
+        let missing_redacted_data = serde_json::from_str::<AnthropicThinkingContent>(
+            r#"[{"type":"redacted_thinking","data":""}]"#,
+        );
+        assert!(missing_redacted_data.is_err());
+
+        assert!(
+            serde_json::from_str::<AnthropicThinkingContent>(
+                r#"[{"type":"thinking","thinking":"visible"}]"#,
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<AnthropicThinkingContent>(r#"[{"type":"redacted_thinking"}]"#,)
+                .is_err()
+        );
+        assert!(AnthropicSignature::try_from("").is_err());
+        assert!(AnthropicRedactedData::try_from("").is_err());
     }
 
     // ==================== ChatRequest Tests ====================


### PR DESCRIPTION
## What

- add validated, ordered Anthropic signed-thinking and redacted-thinking continuation types
- keep opaque signature/redacted payload values lossless while redacting `Debug` and `Display`
- reject unknown fields inside typed thinking blocks and provider extensions instead of silently dropping future integrity data
- provide `Option<Cow<'_, str>>` visible-text semantics: none for empty/redacted-only, borrowed for one block, owned for multiple blocks
- add an opt-in `ChatMessageWithExtensions` wrapper while leaving the existing public `ChatMessage` struct and exhaustive `ThinkingContent` enum unchanged

This is only the typed foundation for #1236 and #1237. It does not wire the carrier into Anthropic HTTP, Responses, or SSE production paths.

Design and exact file boundary: https://github.com/majiayu000/litellm-rs/issues/1235#issuecomment-5451064729

## Why

The previous protocol attempt mixed provider transport behavior into public core types and risked source-breaking enum/struct changes. This additive carrier gives later protocol PRs a validated, secret-safe representation without changing existing public struct literals or exhaustive matches.

SemVer/API note: existing public types are unchanged. Newly introduced extensible structs/enums have private fields and/or `#[non_exhaustive]`; callers opt into the new wrapper explicitly. An empty wrapper serializes identically to the legacy message.

## Test Plan

- [x] RED: focused external integration test failed before the new types/API existed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --test lib integration::types_tests --features providers-extended` (41 passed)
- [x] `cargo test core::types::thinking --lib --features providers-extended` (17 passed)
- [x] `cargo check --all-features`
- [x] `cargo clippy --lib --all-features -- -D warnings`
- [x] `git diff --check`

The compatibility test also verifies that legacy `ChatMessage` continues to accept unknown top-level fields; strict deserialization is limited to the new opt-in provider boundary.

Diagnostic only: `cargo clippy --all-targets --all-features -- -D warnings` reaches three pre-existing, out-of-scope Ollama/Fal AI test warnings. This PR does not modify those provider tests.

AI-assisted development was used. The changes were manually scoped, reviewed, and verified with the commands above.

Fixes #1235
