### PR TITLE
fix(tokens): require explicit tokenizer identity

### DIFF
--- a/src/core/streaming/handler.rs
+++ b/src/core/streaming/handler.rs
@@ -3,6 +3,7 @@
 use super::types::{ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionDelta, Event};
 use crate::core::models::openai::Usage;
 use crate::core::types::message::MessageRole;
+use crate::utils::ai::counter::token_counter::{TokenCounter, TokenizerIdentity};
 use crate::utils::error::gateway_error::Result;
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
@@ -45,6 +46,7 @@ impl StreamingHandler {
         mut self,
         provider_stream: S,
         cancel: Option<CancellationToken>,
+        tokenizer_identity: TokenizerIdentity,
     ) -> impl Stream<Item = Result<Bytes>>
     where
         S: Stream<Item = Result<String>> + Send + 'static,
@@ -103,8 +105,16 @@ impl StreamingHandler {
             }
 
             // Send final chunk with usage information
-            if let Ok(final_event) = self.create_final_chunk().await {
-                let _ = tx.send(Ok(final_event.to_bytes())).await;
+            match self.create_final_chunk(&tokenizer_identity).await {
+                Ok(final_event) => {
+                    if tx.send(Ok(final_event.to_bytes())).await.is_err() {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    let _ = tx.send(Err(error)).await;
+                    return;
+                }
             }
 
             // Send done event
@@ -197,13 +207,12 @@ impl StreamingHandler {
     }
 
     /// Create the final chunk with usage information
-    async fn create_final_chunk(&self) -> Result<Event> {
+    async fn create_final_chunk(&self, tokenizer_identity: &TokenizerIdentity) -> Result<Event> {
         // Calculate actual token counts using the token counter
-        let token_counter = crate::utils::ai::counter::token_counter::TokenCounter::new();
+        let token_counter = TokenCounter::new();
         let completion_tokens = token_counter
-            .count_completion_tokens(&self.model, &self.accumulated_content)
-            .map(|estimate| estimate.input_tokens)
-            .unwrap_or_else(|_| self.estimate_token_count(&self.accumulated_content));
+            .count_completion_tokens(tokenizer_identity, &self.accumulated_content)?
+            .input_tokens;
 
         // For prompt tokens, we'd need the original request context
         // For now, use a reasonable estimate based on typical chat requests
@@ -242,12 +251,6 @@ impl StreamingHandler {
         let event = Event::default().data(&serde_json::to_string(&final_chunk)?);
 
         Ok(event)
-    }
-
-    /// Estimate token count from text (simplified)
-    pub(crate) fn estimate_token_count(&self, text: &str) -> u32 {
-        // Very rough estimation: ~4 characters per token
-        (text.len() as f64 / 4.0).ceil() as u32
     }
 
     /// Estimate prompt tokens based on typical chat requests
@@ -298,45 +301,6 @@ mod tests {
         let handler2 = StreamingHandler::new("gpt-4".to_string());
 
         assert_ne!(handler1.request_id, handler2.request_id);
-    }
-
-    // ==================== Token Estimation Tests ====================
-
-    #[test]
-    fn test_estimate_token_count_empty() {
-        let handler = StreamingHandler::new("gpt-4".to_string());
-        assert_eq!(handler.estimate_token_count(""), 0);
-    }
-
-    #[test]
-    fn test_estimate_token_count_short_text() {
-        let handler = StreamingHandler::new("gpt-4".to_string());
-        // "Hi" = 2 chars => 2/4 = 0.5 => ceil = 1
-        assert_eq!(handler.estimate_token_count("Hi"), 1);
-    }
-
-    #[test]
-    fn test_estimate_token_count_medium_text() {
-        let handler = StreamingHandler::new("gpt-4".to_string());
-        // "Hello world" = 11 chars => 11/4 = 2.75 => ceil = 3
-        assert_eq!(handler.estimate_token_count("Hello world"), 3);
-    }
-
-    #[test]
-    fn test_estimate_token_count_long_text() {
-        let handler = StreamingHandler::new("gpt-4".to_string());
-        // 100 chars => 100/4 = 25
-        let text = "a".repeat(100);
-        assert_eq!(handler.estimate_token_count(&text), 25);
-    }
-
-    #[test]
-    fn test_estimate_token_count_unicode() {
-        let handler = StreamingHandler::new("gpt-4".to_string());
-        // Unicode characters are counted by byte length in Rust's len()
-        let text = "你好世界"; // 4 Chinese chars = 12 bytes
-        let estimated = handler.estimate_token_count(text);
-        assert!(estimated > 0);
     }
 
     #[test]
@@ -566,7 +530,9 @@ mod tests {
         let mut handler = StreamingHandler::new("gpt-4".to_string());
         handler.accumulated_content = "Hello world".to_string();
 
-        let result = handler.create_final_chunk().await;
+        let result = handler
+            .create_final_chunk(&TokenizerIdentity::exact_openai("gpt-4"))
+            .await;
         assert!(result.is_ok());
 
         let event = result.unwrap();
@@ -583,7 +549,10 @@ mod tests {
         let mut handler = StreamingHandler::new("gpt-4".to_string());
         handler.accumulated_content = "This is a test response with some content.".to_string();
 
-        let result = handler.create_final_chunk().await.unwrap();
+        let result = handler
+            .create_final_chunk(&TokenizerIdentity::exact_openai("gpt-4"))
+            .await
+            .unwrap();
         let bytes = result.to_bytes();
         let event_str = String::from_utf8_lossy(&bytes);
 
@@ -591,6 +560,44 @@ mod tests {
         assert!(event_str.contains("prompt_tokens"));
         assert!(event_str.contains("completion_tokens"));
         assert!(event_str.contains("total_tokens"));
+    }
+
+    #[tokio::test]
+    async fn final_chunk_propagates_exact_tokenizer_failure() {
+        let mut handler = StreamingHandler::new("gpt-audio-1.5".to_string());
+        handler.accumulated_content = "This must not be silently estimated.".to_string();
+
+        let error = handler
+            .create_final_chunk(&TokenizerIdentity::exact_openai("gpt-audio-1.5"))
+            .await
+            .expect_err("missing exact tokenizer must fail the final chunk");
+
+        assert!(error.to_string().contains("tokenizer"));
+        assert!(error.to_string().contains("gpt-audio-1.5"));
+    }
+
+    #[tokio::test]
+    async fn sse_stream_propagates_final_tokenizer_failure() {
+        let handler = StreamingHandler::new("gpt-audio-1.5".to_string());
+        let provider_stream = futures::stream::empty::<Result<String>>();
+        let stream = handler.create_sse_stream(
+            provider_stream,
+            None,
+            TokenizerIdentity::exact_openai("gpt-audio-1.5"),
+        );
+        tokio::pin!(stream);
+
+        let error = stream
+            .next()
+            .await
+            .expect("the stream must report its finalization result")
+            .expect_err("missing exact tokenizer must fail the stream");
+
+        assert!(error.to_string().contains("tokenizer"));
+        assert!(
+            stream.next().await.is_none(),
+            "[DONE] must not hide the error"
+        );
     }
 
     // ==================== Edge Cases ====================

--- a/src/core/streaming/tests.rs
+++ b/src/core/streaming/tests.rs
@@ -31,20 +31,6 @@ fn test_extract_content_from_chunk() {
     assert!(content.is_empty());
 }
 
-#[test]
-fn test_token_estimation() {
-    let handler = StreamingHandler::new("gpt-4".to_string());
-
-    // Test token estimation
-    let text = "Hello world"; // 11 chars -> ~3 tokens
-    let tokens = handler.estimate_token_count(text);
-    assert_eq!(tokens, 3);
-
-    let longer_text = "This is a longer text for testing"; // 34 chars -> ~9 tokens
-    let tokens = handler.estimate_token_count(longer_text);
-    assert_eq!(tokens, 9);
-}
-
 #[tokio::test]
 async fn test_sse_utils() {
     // Test SSE line parsing

--- a/src/server/routes/ai/spend/completion.rs
+++ b/src/server/routes/ai/spend/completion.rs
@@ -236,8 +236,13 @@ pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_split_p
     request: impl Into<ChatCompletionBudgetRequest<'a>>,
 ) -> Result<Option<UnifiedBudgetReservation>, ProviderError> {
     let request = request.into();
+    let token_identity = if pricing_provider == "openai" {
+        TokenizerIdentity::exact_openai(pricing_model)
+    } else {
+        TokenizerIdentity::approximate(pricing_provider, pricing_model)
+    };
     let prompt_tokens = estimate_chat_prompt_tokens(
-        pricing_model,
+        &token_identity,
         request.messages,
         request.tools,
         request.functions,
@@ -321,7 +326,7 @@ pub(in crate::server::routes::ai) fn reserve_chat_completion_budget_with_request
 
 #[cfg(test)]
 pub(in crate::server::routes::ai) fn estimate_chat_prompt_tokens(
-    model: &str,
+    identity: &TokenizerIdentity,
     messages: &[ChatMessage],
     tools: Option<&[Tool]>,
     functions: Option<&[Function]>,
@@ -329,21 +334,21 @@ pub(in crate::server::routes::ai) fn estimate_chat_prompt_tokens(
     response_format: Option<&ResponseFormat>,
 ) -> u32 {
     let counter = TokenCounter::new();
-    let message_tokens = counter.count_chat_tokens(model, messages).map_or_else(
+    let message_tokens = counter.count_chat_tokens(identity, messages).map_or_else(
         |_| fallback_message_tokens(messages),
         |value| value.input_tokens,
     );
     let multimodal_tokens = conservative_multimodal_prompt_extra(messages);
-    let tool_tokens = serialized_prompt_tokens_auto(&counter, model, tools, |value| {
+    let tool_tokens = serialized_prompt_tokens_auto(&counter, identity, tools, |value| {
         value.len().saturating_mul(256)
     });
-    let function_tokens = serialized_prompt_tokens_auto(&counter, model, functions, |value| {
+    let function_tokens = serialized_prompt_tokens_auto(&counter, identity, functions, |value| {
         value.len().saturating_mul(256)
     });
     let function_call_tokens =
-        serialized_prompt_tokens_auto(&counter, model, function_call, |_| 64);
+        serialized_prompt_tokens_auto(&counter, identity, function_call, |_| 64);
     let response_format_tokens =
-        serialized_prompt_tokens_auto(&counter, model, response_format, |_| 128);
+        serialized_prompt_tokens_auto(&counter, identity, response_format, |_| 128);
 
     message_tokens
         .saturating_add(multimodal_tokens)
@@ -362,7 +367,7 @@ pub(in crate::server::routes::ai) fn try_estimate_chat_prompt_tokens(
     response_format: Option<&ResponseFormat>,
 ) -> GatewayResult<u32> {
     let counter = TokenCounter::new();
-    let message_estimate = counter.count_chat_tokens_for_identity(identity, messages)?;
+    let message_estimate = counter.count_chat_tokens(identity, messages)?;
     observe_approximate_estimate(identity, "messages", &message_estimate);
     let message_tokens = message_estimate.input_tokens;
     let multimodal_tokens = conservative_multimodal_prompt_extra(messages);
@@ -392,13 +397,18 @@ fn reservation_output_tokens(
     choice_count: u32,
 ) -> Option<u32> {
     let counter = TokenCounter::new();
+    let identity = if provider == "openai" {
+        TokenizerIdentity::exact_openai(model)
+    } else {
+        TokenizerIdentity::approximate(provider, model)
+    };
     let choice_count = choice_count.max(1);
     let output_tokens = if let Some(requested) = requested_max_output_tokens {
         Some(requested)
     } else {
         catalog_max_output_tokens_with_pricing(pricing_service, provider, model).or_else(|| {
             counter
-                .estimate_output_tokens(None, prompt_tokens, model)
+                .estimate_output_tokens(None, prompt_tokens, &identity)
                 .ok()
         })
     };
@@ -539,7 +549,7 @@ fn encoded_media_tokens(data: &str) -> u32 {
 #[cfg(test)]
 fn serialized_prompt_tokens_auto<T, F>(
     counter: &TokenCounter,
-    model: &str,
+    identity: &TokenizerIdentity,
     value: Option<&T>,
     fallback_units: F,
 ) -> u32
@@ -553,10 +563,12 @@ where
     let Ok(json) = serde_json::to_string(value) else {
         return u32::try_from(fallback_units(value)).unwrap_or(u32::MAX);
     };
-    counter.count_completion_tokens(model, &json).map_or_else(
-        |_| u32::try_from(json.chars().count().div_ceil(4)).unwrap_or(u32::MAX),
-        |estimate| estimate.input_tokens,
-    )
+    counter
+        .count_completion_tokens(identity, &json)
+        .map_or_else(
+            |_| u32::try_from(json.chars().count().div_ceil(4)).unwrap_or(u32::MAX),
+            |estimate| estimate.input_tokens,
+        )
 }
 
 #[cfg(test)]
@@ -589,7 +601,7 @@ where
     };
     let json = serde_json::to_string(value)
         .map_err(|error| GatewayError::Config(format!("failed to serialize {input}: {error}")))?;
-    let estimate = counter.count_completion_tokens_for_identity(identity, &json)?;
+    let estimate = counter.count_completion_tokens(identity, &json)?;
     observe_approximate_estimate(identity, input, &estimate);
     Ok(estimate.input_tokens)
 }

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -549,7 +549,7 @@ pub(in crate::server::routes::ai) fn estimate_embedding_input_tokens(
 ) -> crate::utils::error::gateway_error::Result<u32> {
     let counter = TokenCounter::new();
     input.iter().try_fold(0u32, |total, text| {
-        let estimate = counter.count_completion_tokens_for_identity(identity, text)?;
+        let estimate = counter.count_completion_tokens(identity, text)?;
         if estimate.is_approximate {
             tracing::warn!(
                 token_provider = identity.provider(),

--- a/src/server/routes/ai/spend_provider_reservation_tests.rs
+++ b/src/server/routes/ai/spend_provider_reservation_tests.rs
@@ -3,6 +3,7 @@ use crate::core::budget::{ProviderLimitConfig, ResetPeriod};
 use crate::core::cost::calculator::estimate_cost;
 use crate::core::models::openai::requests::ChatCompletionRequest;
 use crate::core::models::openai::{ChatMessage, ContentPart, MessageContent, MessageRole};
+use crate::utils::ai::counter::token_counter::TokenizerIdentity;
 
 fn reserve_with_provider_limit(
     provider: &str,
@@ -19,7 +20,13 @@ fn reserve_with_provider_limit(
         tool_call_id: None,
         audio: None,
     }];
-    let prompt_tokens = estimate_chat_prompt_tokens(model, &messages, None, None, None, None);
+    let token_identity = if provider == "openai" {
+        TokenizerIdentity::exact_openai(model)
+    } else {
+        TokenizerIdentity::approximate(provider, model)
+    };
+    let prompt_tokens =
+        estimate_chat_prompt_tokens(&token_identity, &messages, None, None, None, None);
     let estimate = estimate_cost(model, provider, prompt_tokens, Some(max_output_tokens)).unwrap();
     budget.providers.set_provider_limit(
         provider,
@@ -74,8 +81,14 @@ fn openai_chat_reservation_uses_exact_tiktoken_prompt_count() {
         tool_call_id: None,
         audio: None,
     }];
-    let prompt_tokens =
-        estimate_chat_prompt_tokens("gpt-3.5-turbo", &messages, None, None, None, None);
+    let prompt_tokens = estimate_chat_prompt_tokens(
+        &TokenizerIdentity::exact_openai("gpt-3.5-turbo"),
+        &messages,
+        None,
+        None,
+        None,
+        None,
+    );
     assert_eq!(prompt_tokens, 13);
 
     let expected = estimate_cost("gpt-3.5-turbo", "openai", prompt_tokens, Some(10))
@@ -124,7 +137,14 @@ fn chat_prompt_estimate_accounts_for_serialized_tool_parts() {
         audio: None,
     }];
 
-    let prompt_tokens = estimate_chat_prompt_tokens("gpt-4o", &messages, None, None, None, None);
+    let prompt_tokens = estimate_chat_prompt_tokens(
+        &TokenizerIdentity::exact_openai("gpt-4o"),
+        &messages,
+        None,
+        None,
+        None,
+        None,
+    );
 
     assert!(
         prompt_tokens > 1_800,

--- a/src/server/routes/ai/spend_tests.rs
+++ b/src/server/routes/ai/spend_tests.rs
@@ -9,6 +9,7 @@ use crate::core::models::openai::{
     ResponseFormat,
 };
 use crate::core::types::responses::Usage;
+use crate::utils::ai::counter::token_counter::TokenizerIdentity;
 
 fn usage(prompt: u32, completion: u32) -> Usage {
     Usage {
@@ -31,6 +32,28 @@ fn user_message(content: &str) -> ChatMessage {
         tool_call_id: None,
         audio: None,
     }
+}
+
+fn exact_prompt_tokens(model: &str, messages: &[ChatMessage]) -> u32 {
+    estimate_chat_prompt_tokens(
+        &TokenizerIdentity::exact_openai(model),
+        messages,
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+fn approximate_prompt_tokens(provider: &str, model: &str, messages: &[ChatMessage]) -> u32 {
+    estimate_chat_prompt_tokens(
+        &TokenizerIdentity::approximate(provider, model),
+        messages,
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 fn chat_request(model: &str, messages: Vec<ChatMessage>) -> ChatCompletionRequest {
@@ -178,7 +201,7 @@ fn chat_reservation_without_max_tokens_uses_conservative_output_bound() {
         ModelLimitConfig::new(1000.0, ResetPeriod::Monthly),
     );
     let messages = vec![user_message("hello")];
-    let prompt_tokens = estimate_chat_prompt_tokens("gpt-4o", &messages, None, None, None, None);
+    let prompt_tokens = exact_prompt_tokens("gpt-4o", &messages);
     let default_estimate = estimate_cost("gpt-4o", "openai", prompt_tokens, Some(100))
         .unwrap()
         .max_cost;
@@ -201,7 +224,7 @@ fn chat_reservation_without_max_tokens_uses_catalog_output_limit() {
         ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
     );
     let messages = vec![user_message(&"x".repeat(40_000))];
-    let prompt_tokens = estimate_chat_prompt_tokens("gpt-4o", &messages, None, None, None, None);
+    let prompt_tokens = exact_prompt_tokens("gpt-4o", &messages);
     let input_only = estimate_cost("gpt-4o", "openai", prompt_tokens, Some(0))
         .unwrap()
         .max_cost;
@@ -224,7 +247,7 @@ fn chat_reservation_with_explicit_max_tokens_reserves_requested_output() {
         ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
     );
     let messages = vec![user_message(&"x".repeat(40_000))];
-    let prompt_tokens = estimate_chat_prompt_tokens("gpt-4o", &messages, None, None, None, None);
+    let prompt_tokens = exact_prompt_tokens("gpt-4o", &messages);
     let input_only = estimate_cost("gpt-4o", "openai", prompt_tokens, Some(0))
         .unwrap()
         .max_cost;
@@ -397,7 +420,7 @@ fn chat_reservation_uses_conservative_multimodal_prompt_floor() {
         audio: None,
     }];
 
-    let prompt_tokens = estimate_chat_prompt_tokens("gpt-4o", &messages, None, None, None, None);
+    let prompt_tokens = approximate_prompt_tokens("openai", "gpt-4o", &messages);
     assert!(prompt_tokens >= IMAGE_HIGH_DETAIL_PROMPT_TOKENS);
 }
 
@@ -419,7 +442,7 @@ fn chat_reservation_uses_encoded_audio_prompt_floor() {
         audio: None,
     }];
 
-    let prompt_tokens = estimate_chat_prompt_tokens("gpt-4o", &messages, None, None, None, None);
+    let prompt_tokens = exact_prompt_tokens("gpt-4o", &messages);
     assert!(prompt_tokens >= 2_000);
 }
 
@@ -470,8 +493,7 @@ fn gemini_max_completion_tokens_only_uses_catalog_output_bound() {
         ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly),
     );
     let messages = vec![user_message("hello")];
-    let prompt_tokens =
-        estimate_chat_prompt_tokens("gemini-3.1-flash-lite", &messages, None, None, None, None);
+    let prompt_tokens = approximate_prompt_tokens("gemini", "gemini-3.1-flash-lite", &messages);
     let ten_output_tokens =
         estimate_cost("gemini-3.1-flash-lite", "gemini", prompt_tokens, Some(10))
             .unwrap()
@@ -492,8 +514,7 @@ fn gemini_max_completion_tokens_only_uses_catalog_output_bound() {
 fn cohere_max_completion_tokens_reserves_provider_effective_output() {
     let budget = UnifiedBudgetLimits::new();
     let messages = vec![user_message("hello")];
-    let prompt_tokens =
-        estimate_chat_prompt_tokens("command-r-plus", &messages, None, None, None, None);
+    let prompt_tokens = approximate_prompt_tokens("cohere", "command-r-plus", &messages);
     let ten_output_tokens = estimate_cost("command-r-plus", "cohere", prompt_tokens, Some(10))
         .unwrap()
         .max_cost;

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -5,6 +5,8 @@ use crate::core::models::openai::{
     ChatMessage, ContentPart, FunctionCall, ImageUrl, MessageContent, MessageRole, ToolCall,
 };
 use crate::utils::ai::counter::token_counter::{TokenCounter, TokenizerIdentity};
+use crate::utils::ai::counter::types::ModelTokenConfig;
+use std::collections::HashMap;
 
 #[test]
 fn test_text_token_estimation() {
@@ -171,6 +173,103 @@ fn approximate_provider_identity_does_not_select_a_prefix_family_config() {
 
         assert!(!fits, "{provider}/gpt-4 must use the default 4k window");
     }
+}
+
+#[test]
+fn anthropic_approximation_uses_only_the_anthropic_family_config() {
+    let counter = TokenCounter::new();
+    let identity = TokenizerIdentity::approximate("anthropic", "claude-3-opus");
+    let messages = vec![ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Text("Hello world".to_string())),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
+    }];
+
+    assert_eq!(
+        counter
+            .count_completion_tokens(&identity, "Hello world")
+            .unwrap()
+            .input_tokens,
+        10
+    );
+    assert_eq!(
+        counter
+            .count_chat_tokens(&identity, &messages)
+            .unwrap()
+            .input_tokens,
+        17
+    );
+    assert_eq!(
+        counter
+            .count_embedding_tokens(&identity, &["Hello world".to_string()])
+            .unwrap()
+            .input_tokens,
+        10
+    );
+    assert!(
+        counter
+            .check_context_window(&identity, 100_000, None)
+            .unwrap()
+    );
+}
+
+#[test]
+fn explicit_custom_config_applies_to_every_approximate_entry_point() {
+    let mut counter = TokenCounter::new();
+    counter.add_model_config(ModelTokenConfig {
+        model: "tenant-model".to_string(),
+        chars_per_token: 1.0,
+        message_overhead: 11,
+        request_overhead: 17,
+        max_context_tokens: 12_345,
+        special_tokens: HashMap::new(),
+    });
+    let identity = TokenizerIdentity::approximate("custom", "tenant-model");
+    let messages = vec![ChatMessage {
+        role: MessageRole::User,
+        content: Some(MessageContent::Text("abcd".to_string())),
+        name: None,
+        function_call: None,
+        tool_calls: None,
+        tool_call_id: None,
+        audio: None,
+    }];
+
+    assert_eq!(
+        counter
+            .count_completion_tokens(&identity, "abcd")
+            .unwrap()
+            .input_tokens,
+        22
+    );
+    assert_eq!(
+        counter
+            .count_chat_tokens(&identity, &messages)
+            .unwrap()
+            .input_tokens,
+        38
+    );
+    assert_eq!(
+        counter
+            .count_embedding_tokens(&identity, &["abcd".to_string()])
+            .unwrap()
+            .input_tokens,
+        22
+    );
+    assert!(
+        counter
+            .check_context_window(&identity, 12_000, Some(300))
+            .unwrap()
+    );
+    assert!(
+        !counter
+            .check_context_window(&identity, 12_346, None)
+            .unwrap()
+    );
 }
 
 #[test]

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -30,7 +30,7 @@ fn test_chat_token_counting() {
     }];
 
     let estimate = counter
-        .count_chat_tokens("gpt-3.5-turbo", &messages)
+        .count_chat_tokens(&TokenizerIdentity::exact_openai("gpt-3.5-turbo"), &messages)
         .unwrap();
     assert!(estimate.input_tokens > 0);
     assert!(!estimate.is_approximate);
@@ -42,7 +42,10 @@ fn test_openai_completion_token_count_uses_tiktoken() {
     let counter = TokenCounter::new();
 
     let estimate = counter
-        .count_completion_tokens("gpt-3.5-turbo", "Hello world")
+        .count_completion_tokens(
+            &TokenizerIdentity::exact_openai("gpt-3.5-turbo"),
+            "Hello world",
+        )
         .unwrap();
 
     assert_eq!(estimate.input_tokens, 2);
@@ -65,7 +68,7 @@ fn test_openai_chat_system_message_uses_tiktoken() {
     }];
 
     let estimate = counter
-        .count_chat_tokens("openai/gpt-3.5-turbo", &messages)
+        .count_chat_tokens(&TokenizerIdentity::exact_openai("gpt-3.5-turbo"), &messages)
         .unwrap();
 
     assert_eq!(estimate.input_tokens, 12);
@@ -90,7 +93,12 @@ fn test_multimodal_chat_token_count_remains_marked_approximate() {
         audio: None,
     }];
 
-    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+    let estimate = counter
+        .count_chat_tokens(
+            &TokenizerIdentity::approximate("openai", "gpt-4o"),
+            &messages,
+        )
+        .unwrap();
 
     assert!(estimate.is_approximate);
     assert!(estimate.input_tokens >= 85);
@@ -111,7 +119,12 @@ fn test_text_part_chat_token_count_remains_marked_approximate() {
         audio: None,
     }];
 
-    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+    let estimate = counter
+        .count_chat_tokens(
+            &TokenizerIdentity::approximate("openai", "gpt-4o"),
+            &messages,
+        )
+        .unwrap();
 
     assert!(estimate.is_approximate);
     assert!(estimate.confidence < 1.0);
@@ -122,7 +135,10 @@ fn test_non_openai_token_count_remains_marked_approximate() {
     let counter = TokenCounter::new();
 
     let estimate = counter
-        .count_completion_tokens("claude-3-opus", "Hello world")
+        .count_completion_tokens(
+            &TokenizerIdentity::approximate("anthropic", "claude-3-opus"),
+            "Hello world",
+        )
         .unwrap();
 
     assert!(estimate.is_approximate);
@@ -130,11 +146,75 @@ fn test_non_openai_token_count_remains_marked_approximate() {
 }
 
 #[test]
+fn public_counter_requires_explicit_approximation_for_non_openai_providers() {
+    let counter = TokenCounter::new();
+
+    for provider in ["anthropic", "unknown"] {
+        let identity = TokenizerIdentity::approximate(provider, "gpt-4");
+        let estimate = counter
+            .count_completion_tokens(&identity, "Hello world")
+            .expect("an explicit approximate identity may use approximation");
+
+        assert!(
+            estimate.is_approximate,
+            "{provider}/gpt-4 must not select OpenAI BPE"
+        );
+    }
+}
+
+#[test]
+fn approximate_provider_identity_does_not_select_a_prefix_family_config() {
+    let counter = TokenCounter::new();
+
+    for provider in ["anthropic", "unknown"] {
+        let identity = TokenizerIdentity::approximate(provider, "gpt-4");
+        let fits = counter
+            .check_context_window(&identity, 5_000, None)
+            .expect("an approximate contract should have a default config");
+
+        assert!(!fits, "{provider}/gpt-4 must use the default 4k window");
+    }
+}
+
+#[test]
+fn public_exact_openai_failure_is_not_converted_to_approximation() {
+    let counter = TokenCounter::new();
+
+    let error = counter
+        .count_completion_tokens(
+            &TokenizerIdentity::exact_openai("gpt-audio-1.5"),
+            "Hello world",
+        )
+        .expect_err("an explicit OpenAI model without a tokenizer must fail closed");
+
+    assert!(error.to_string().contains("tokenizer"));
+    assert!(error.to_string().contains("gpt-audio-1.5"));
+}
+
+#[test]
+fn exact_openai_identity_rejects_provider_qualified_model_names() {
+    let counter = TokenCounter::new();
+
+    let error = counter
+        .count_completion_tokens(
+            &TokenizerIdentity::exact_openai("openai/gpt-4"),
+            "Hello world",
+        )
+        .expect_err("an exact identity must contain a canonical tokenizer model");
+
+    assert!(error.to_string().contains("tokenizer unavailable"));
+    assert!(error.to_string().contains("openai/gpt-4"));
+}
+
+#[test]
 fn test_unknown_openai_like_model_remains_marked_approximate() {
     let counter = TokenCounter::new();
 
     let estimate = counter
-        .count_completion_tokens("gpt-future-unknown", "Hello world")
+        .count_completion_tokens(
+            &TokenizerIdentity::approximate("openai", "gpt-future-unknown"),
+            "Hello world",
+        )
         .unwrap();
 
     assert!(estimate.is_approximate);
@@ -147,7 +227,7 @@ fn test_typed_openai_identity_requires_an_exact_tokenizer() {
     let identity = TokenizerIdentity::exact_openai("gpt-audio-1.5");
 
     let error = counter
-        .count_completion_tokens_for_identity(&identity, "Hello world")
+        .count_completion_tokens(&identity, "Hello world")
         .expect_err("a selected exact OpenAI identity without a BPE must fail closed");
 
     assert!(error.to_string().contains("tokenizer unavailable"));
@@ -169,7 +249,7 @@ fn test_typed_openai_chat_identity_requires_an_exact_tokenizer() {
     }];
 
     let error = counter
-        .count_chat_tokens_for_identity(&identity, &messages)
+        .count_chat_tokens(&identity, &messages)
         .expect_err("exact chat tokenization must not silently approximate a missing BPE");
 
     assert!(error.to_string().contains("tokenizer unavailable"));
@@ -181,7 +261,7 @@ fn test_typed_approximate_identity_stays_explicitly_approximate() {
     let identity = TokenizerIdentity::approximate("azure_ai", "Phi-4");
 
     let estimate = counter
-        .count_completion_tokens_for_identity(&identity, "Hello world")
+        .count_completion_tokens(&identity, "Hello world")
         .expect("an explicitly approximate identity may use estimation");
 
     assert!(estimate.is_approximate);
@@ -194,7 +274,7 @@ fn test_typed_approximate_identity_does_not_infer_from_openai_like_model_name() 
     let identity = TokenizerIdentity::approximate("azure", "gpt-4o");
 
     let estimate = counter
-        .count_completion_tokens_for_identity(&identity, "Hello world")
+        .count_completion_tokens(&identity, "Hello world")
         .expect("explicit approximate contract should remain available");
 
     assert!(estimate.is_approximate);
@@ -216,7 +296,7 @@ fn test_typed_approximate_chat_does_not_infer_from_openai_like_model_name() {
     }];
 
     let estimate = counter
-        .count_chat_tokens_for_identity(&identity, &messages)
+        .count_chat_tokens(&identity, &messages)
         .expect("explicit approximate chat contract should remain available");
 
     assert!(estimate.is_approximate);
@@ -243,7 +323,12 @@ fn test_tool_call_chat_token_count_remains_marked_approximate() {
         audio: None,
     }];
 
-    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+    let estimate = counter
+        .count_chat_tokens(
+            &TokenizerIdentity::approximate("openai", "gpt-4o"),
+            &messages,
+        )
+        .unwrap();
 
     assert!(estimate.is_approximate);
     assert!(estimate.confidence < 1.0);
@@ -262,7 +347,12 @@ fn test_tool_result_chat_token_count_remains_marked_approximate() {
         audio: None,
     }];
 
-    let estimate = counter.count_chat_tokens("gpt-4o", &messages).unwrap();
+    let estimate = counter
+        .count_chat_tokens(
+            &TokenizerIdentity::approximate("openai", "gpt-4o"),
+            &messages,
+        )
+        .unwrap();
 
     assert!(estimate.is_approximate);
     assert!(estimate.confidence < 1.0);
@@ -275,14 +365,22 @@ fn test_context_window_check() {
     // Should fit
     assert!(
         counter
-            .check_context_window("gpt-3.5-turbo", 1000, Some(1000))
+            .check_context_window(
+                &TokenizerIdentity::exact_openai("gpt-3.5-turbo"),
+                1000,
+                Some(1000),
+            )
             .unwrap()
     );
 
     // Should not fit
     assert!(
         !counter
-            .check_context_window("gpt-3.5-turbo", 3000, Some(2000))
+            .check_context_window(
+                &TokenizerIdentity::exact_openai("gpt-3.5-turbo"),
+                3000,
+                Some(2000),
+            )
             .unwrap()
     );
 }

--- a/src/utils/ai/counter/tests.rs
+++ b/src/utils/ai/counter/tests.rs
@@ -94,10 +94,7 @@ fn test_multimodal_chat_token_count_remains_marked_approximate() {
     }];
 
     let estimate = counter
-        .count_chat_tokens(
-            &TokenizerIdentity::approximate("openai", "gpt-4o"),
-            &messages,
-        )
+        .count_chat_tokens(&TokenizerIdentity::exact_openai("gpt-4o"), &messages)
         .unwrap();
 
     assert!(estimate.is_approximate);
@@ -324,10 +321,7 @@ fn test_tool_call_chat_token_count_remains_marked_approximate() {
     }];
 
     let estimate = counter
-        .count_chat_tokens(
-            &TokenizerIdentity::approximate("openai", "gpt-4o"),
-            &messages,
-        )
+        .count_chat_tokens(&TokenizerIdentity::exact_openai("gpt-4o"), &messages)
         .unwrap();
 
     assert!(estimate.is_approximate);

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -13,32 +13,33 @@ pub struct TokenCounter {
     model_configs: HashMap<String, ModelTokenConfig>,
 }
 
+/// Explicit tokenizer contract selected for a provider attempt.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum TokenizerIdentity {
+pub enum TokenizerIdentity {
     ExactOpenAi(String),
     Approximate { provider: String, model: String },
 }
 
 impl TokenizerIdentity {
-    pub(crate) fn exact_openai(model: impl Into<String>) -> Self {
+    pub fn exact_openai(model: impl Into<String>) -> Self {
         Self::ExactOpenAi(model.into())
     }
 
-    pub(crate) fn approximate(provider: impl Into<String>, model: impl Into<String>) -> Self {
+    pub fn approximate(provider: impl Into<String>, model: impl Into<String>) -> Self {
         Self::Approximate {
             provider: provider.into(),
             model: model.into(),
         }
     }
 
-    pub(crate) fn provider(&self) -> &str {
+    pub fn provider(&self) -> &str {
         match self {
             Self::ExactOpenAi(_) => "openai",
             Self::Approximate { provider, .. } => provider,
         }
     }
 
-    pub(crate) fn model(&self) -> &str {
+    pub fn model(&self) -> &str {
         match self {
             Self::ExactOpenAi(model) | Self::Approximate { model, .. } => model,
         }
@@ -64,61 +65,36 @@ impl TokenCounter {
         }
     }
 
-    pub(crate) fn count_completion_tokens_for_identity(
+    /// Count tokens in a completion request using an explicit tokenizer contract.
+    pub fn count_completion_tokens(
         &self,
         identity: &TokenizerIdentity,
         prompt: &str,
     ) -> Result<TokenEstimate> {
         match identity {
             TokenizerIdentity::ExactOpenAi(_) => {
-                self.count_completion_tokens(identity.tokenizer_model()?, prompt)
+                self.exact_completion_tokens(identity.tokenizer_model()?, prompt)
             }
-            TokenizerIdentity::Approximate { model, .. } => {
-                self.approximate_completion_tokens(model, prompt)
-            }
+            TokenizerIdentity::Approximate { .. } => self.approximate_completion_tokens(prompt),
         }
     }
 
-    pub(crate) fn count_chat_tokens_for_identity(
+    /// Count tokens in chat messages using an explicit tokenizer contract.
+    pub fn count_chat_tokens(
         &self,
         identity: &TokenizerIdentity,
         messages: &[ChatMessage],
     ) -> Result<TokenEstimate> {
         match identity {
             TokenizerIdentity::ExactOpenAi(_) => {
-                self.count_chat_tokens(identity.tokenizer_model()?, messages)
+                self.exact_chat_token_estimate(identity.tokenizer_model()?, messages)
             }
-            TokenizerIdentity::Approximate { model, .. } => {
-                self.approximate_chat_tokens(model, messages)
-            }
+            TokenizerIdentity::Approximate { .. } => self.approximate_chat_tokens(messages),
         }
     }
 
-    /// Count tokens in a chat completion request
-    pub fn count_chat_tokens(
-        &self,
-        model: &str,
-        messages: &[ChatMessage],
-    ) -> Result<TokenEstimate> {
-        if let Some(total_tokens) = self.exact_chat_tokens(model, messages)? {
-            return Ok(TokenEstimate {
-                input_tokens: total_tokens,
-                output_tokens: None,
-                total_tokens,
-                is_approximate: false,
-                confidence: 1.0,
-            });
-        }
-
-        self.approximate_chat_tokens(model, messages)
-    }
-
-    fn approximate_chat_tokens(
-        &self,
-        model: &str,
-        messages: &[ChatMessage],
-    ) -> Result<TokenEstimate> {
-        let config = self.get_model_config(model)?;
+    fn approximate_chat_tokens(&self, messages: &[ChatMessage]) -> Result<TokenEstimate> {
+        let config = self.approximate_model_config()?;
         let mut total_tokens = config.request_overhead;
 
         for message in messages {
@@ -231,23 +207,19 @@ impl TokenCounter {
         (estimated_tokens as f64 * 1.1).ceil() as u32
     }
 
-    /// Count tokens in completion request
-    pub fn count_completion_tokens(&self, model: &str, prompt: &str) -> Result<TokenEstimate> {
-        if let Some(input_tokens) = exact_text_tokens(model, prompt)? {
-            return Ok(TokenEstimate {
-                input_tokens,
-                output_tokens: None,
-                total_tokens: input_tokens,
-                is_approximate: false,
-                confidence: 1.0,
-            });
-        }
-
-        self.approximate_completion_tokens(model, prompt)
+    fn exact_completion_tokens(&self, model: &str, prompt: &str) -> Result<TokenEstimate> {
+        let input_tokens = exact_text_tokens(model, prompt)?;
+        Ok(TokenEstimate {
+            input_tokens,
+            output_tokens: None,
+            total_tokens: input_tokens,
+            is_approximate: false,
+            confidence: 1.0,
+        })
     }
 
-    fn approximate_completion_tokens(&self, model: &str, prompt: &str) -> Result<TokenEstimate> {
-        let config = self.get_model_config(model)?;
+    fn approximate_completion_tokens(&self, prompt: &str) -> Result<TokenEstimate> {
+        let config = self.approximate_model_config()?;
         let input_tokens = config.request_overhead + self.estimate_text_tokens(config, prompt);
 
         Ok(TokenEstimate {
@@ -260,13 +232,19 @@ impl TokenCounter {
     }
 
     /// Count tokens in embedding request
-    pub fn count_embedding_tokens(&self, model: &str, input: &[String]) -> Result<TokenEstimate> {
-        let exact_counts = input
-            .iter()
-            .map(|text| exact_text_tokens(model, text))
-            .collect::<Result<Vec<_>>>()?;
-        if exact_counts.iter().all(Option::is_some) {
-            let total_tokens = exact_counts.into_iter().flatten().sum();
+    pub fn count_embedding_tokens(
+        &self,
+        identity: &TokenizerIdentity,
+        input: &[String],
+    ) -> Result<TokenEstimate> {
+        if let TokenizerIdentity::ExactOpenAi(_) = identity {
+            let model = identity.tokenizer_model()?;
+            let total_tokens = input
+                .iter()
+                .map(|text| exact_text_tokens(model, text))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .sum();
             return Ok(TokenEstimate {
                 input_tokens: total_tokens,
                 output_tokens: None,
@@ -276,7 +254,7 @@ impl TokenCounter {
             });
         }
 
-        let config = self.get_model_config(model)?;
+        let config = self.approximate_model_config()?;
         let mut total_tokens = config.request_overhead;
 
         for text in input {
@@ -297,9 +275,9 @@ impl TokenCounter {
         &self,
         max_tokens: Option<u32>,
         input_tokens: u32,
-        model: &str,
+        identity: &TokenizerIdentity,
     ) -> Result<u32> {
-        let config = self.get_model_config(model)?;
+        let config = self.config_for_identity(identity)?;
 
         if let Some(max) = max_tokens {
             // Use the specified max_tokens, but cap at model's context window
@@ -315,11 +293,11 @@ impl TokenCounter {
     /// Check if request fits within context window
     pub fn check_context_window(
         &self,
-        model: &str,
+        identity: &TokenizerIdentity,
         input_tokens: u32,
         max_output_tokens: Option<u32>,
     ) -> Result<bool> {
-        let config = self.get_model_config(model)?;
+        let config = self.config_for_identity(identity)?;
         let output_tokens = max_output_tokens.unwrap_or(0);
         let total_tokens = input_tokens + output_tokens;
 
@@ -345,15 +323,21 @@ impl TokenCounter {
         })
     }
 
+    fn approximate_model_config(&self) -> Result<&ModelTokenConfig> {
+        self.model_configs
+            .get("default")
+            .ok_or_else(|| GatewayError::Config("No default token config found".to_string()))
+    }
+
+    fn config_for_identity(&self, identity: &TokenizerIdentity) -> Result<&ModelTokenConfig> {
+        match identity {
+            TokenizerIdentity::ExactOpenAi(_) => self.get_model_config(identity.tokenizer_model()?),
+            TokenizerIdentity::Approximate { .. } => self.approximate_model_config(),
+        }
+    }
+
     /// Extract model family from model name
     pub(super) fn extract_model_family(&self, model: &str) -> String {
-        // Remove provider prefix if present
-        let model = if let Some(pos) = model.find('/') {
-            &model[pos + 1..]
-        } else {
-            model
-        };
-
         // Extract family name
         if model.starts_with("gpt-4") {
             "gpt-4".to_string()
@@ -378,21 +362,21 @@ impl TokenCounter {
         self.model_configs.keys().cloned().collect()
     }
 
-    fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<Option<u32>> {
+    fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<u32> {
         let mut tiktoken_messages = Vec::with_capacity(messages.len());
         for message in messages {
             if message.tool_call_id.is_some() {
-                return Ok(None);
+                return Err(unsupported_exact_chat_input(model));
             }
             if message
                 .tool_calls
                 .as_ref()
                 .is_some_and(|calls| !calls.is_empty())
             {
-                return Ok(None);
+                return Err(unsupported_exact_chat_input(model));
             }
             let Some(content) = plain_text_message_content(message) else {
-                return Ok(None);
+                return Err(unsupported_exact_chat_input(model));
             };
             tiktoken_messages.push(ChatCompletionRequestMessage {
                 role: ToString::to_string(&message.role),
@@ -417,10 +401,28 @@ impl TokenCounter {
                 refusal: None,
             });
         }
-        match num_tokens_from_messages(tokenizer_model_name(model), &tiktoken_messages) {
-            Ok(tokens) => Ok(Some(usize_to_u32(tokens)?)),
-            Err(_) => Ok(None),
-        }
+        num_tokens_from_messages(model, &tiktoken_messages)
+            .map_err(|_| {
+                GatewayError::Config(format!(
+                    "tokenizer unavailable for exact identity 'openai/{model}'"
+                ))
+            })
+            .and_then(usize_to_u32)
+    }
+
+    fn exact_chat_token_estimate(
+        &self,
+        model: &str,
+        messages: &[ChatMessage],
+    ) -> Result<TokenEstimate> {
+        let total_tokens = self.exact_chat_tokens(model, messages)?;
+        Ok(TokenEstimate {
+            input_tokens: total_tokens,
+            output_tokens: None,
+            total_tokens,
+            is_approximate: false,
+            confidence: 1.0,
+        })
     }
 }
 
@@ -430,15 +432,18 @@ impl Default for TokenCounter {
     }
 }
 
-fn exact_text_tokens(model: &str, text: &str) -> Result<Option<u32>> {
-    match exact_bpe_for_model(model) {
-        Ok(bpe) => Ok(Some(usize_to_u32(bpe.count_with_special_tokens(text))?)),
-        Err(_) => Ok(None),
-    }
+fn exact_text_tokens(model: &str, text: &str) -> Result<u32> {
+    exact_bpe_for_model(model)
+        .map_err(|_| {
+            GatewayError::Config(format!(
+                "tokenizer unavailable for exact identity 'openai/{model}'"
+            ))
+        })
+        .and_then(|bpe| usize_to_u32(bpe.count_with_special_tokens(text)))
 }
 
 fn exact_bpe_for_model(model: &str) -> std::result::Result<&'static tiktoken_rs::CoreBPE, ()> {
-    bpe_for_model(tokenizer_model_name(model)).map_err(|_| ())
+    bpe_for_model(model).map_err(|_| ())
 }
 
 fn plain_text_message_content(message: &ChatMessage) -> Option<Option<String>> {
@@ -449,11 +454,10 @@ fn plain_text_message_content(message: &ChatMessage) -> Option<Option<String>> {
     }
 }
 
-fn tokenizer_model_name(model: &str) -> &str {
-    model
-        .rsplit_once('/')
-        .map(|(_, model)| model)
-        .unwrap_or(model)
+fn unsupported_exact_chat_input(model: &str) -> GatewayError {
+    GatewayError::Config(format!(
+        "exact tokenizer for 'openai/{model}' does not support this chat message shape"
+    ))
 }
 
 fn usize_to_u32(value: usize) -> Result<u32> {

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -87,7 +87,17 @@ impl TokenCounter {
     ) -> Result<TokenEstimate> {
         match identity {
             TokenizerIdentity::ExactOpenAi(_) => {
-                self.exact_chat_token_estimate(identity.tokenizer_model()?, messages)
+                let model = identity.tokenizer_model()?;
+                let Some(total_tokens) = self.exact_chat_tokens(model, messages)? else {
+                    return self.approximate_chat_tokens(messages);
+                };
+                Ok(TokenEstimate {
+                    input_tokens: total_tokens,
+                    output_tokens: None,
+                    total_tokens,
+                    is_approximate: false,
+                    confidence: 1.0,
+                })
             }
             TokenizerIdentity::Approximate { .. } => self.approximate_chat_tokens(messages),
         }
@@ -362,21 +372,21 @@ impl TokenCounter {
         self.model_configs.keys().cloned().collect()
     }
 
-    fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<u32> {
+    fn exact_chat_tokens(&self, model: &str, messages: &[ChatMessage]) -> Result<Option<u32>> {
         let mut tiktoken_messages = Vec::with_capacity(messages.len());
         for message in messages {
             if message.tool_call_id.is_some() {
-                return Err(unsupported_exact_chat_input(model));
+                return Ok(None);
             }
             if message
                 .tool_calls
                 .as_ref()
                 .is_some_and(|calls| !calls.is_empty())
             {
-                return Err(unsupported_exact_chat_input(model));
+                return Ok(None);
             }
             let Some(content) = plain_text_message_content(message) else {
-                return Err(unsupported_exact_chat_input(model));
+                return Ok(None);
             };
             tiktoken_messages.push(ChatCompletionRequestMessage {
                 role: ToString::to_string(&message.role),
@@ -408,21 +418,7 @@ impl TokenCounter {
                 ))
             })
             .and_then(usize_to_u32)
-    }
-
-    fn exact_chat_token_estimate(
-        &self,
-        model: &str,
-        messages: &[ChatMessage],
-    ) -> Result<TokenEstimate> {
-        let total_tokens = self.exact_chat_tokens(model, messages)?;
-        Ok(TokenEstimate {
-            input_tokens: total_tokens,
-            output_tokens: None,
-            total_tokens,
-            is_approximate: false,
-            confidence: 1.0,
-        })
+            .map(Some)
     }
 }
 
@@ -452,12 +448,6 @@ fn plain_text_message_content(message: &ChatMessage) -> Option<Option<String>> {
         Some(MessageContent::Text(text)) => Some(Some(text.clone())),
         Some(MessageContent::Parts(_)) => None,
     }
-}
-
-fn unsupported_exact_chat_input(model: &str) -> GatewayError {
-    GatewayError::Config(format!(
-        "exact tokenizer for 'openai/{model}' does not support this chat message shape"
-    ))
 }
 
 fn usize_to_u32(value: usize) -> Result<u32> {

--- a/src/utils/ai/counter/token_counter.rs
+++ b/src/utils/ai/counter/token_counter.rs
@@ -3,7 +3,7 @@
 use super::types::{ModelTokenConfig, TokenEstimate};
 use crate::core::models::openai::{ChatMessage, ContentPart, MessageContent};
 use crate::utils::error::gateway_error::{GatewayError, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tiktoken_rs::{ChatCompletionRequestMessage, bpe_for_model, num_tokens_from_messages};
 
 /// Token counter for different models
@@ -11,6 +11,8 @@ use tiktoken_rs::{ChatCompletionRequestMessage, bpe_for_model, num_tokens_from_m
 pub struct TokenCounter {
     /// Model-specific token counting configurations
     model_configs: HashMap<String, ModelTokenConfig>,
+    /// Models explicitly registered by callers.
+    custom_model_configs: HashSet<String>,
 }
 
 /// Explicit tokenizer contract selected for a provider attempt.
@@ -62,6 +64,7 @@ impl TokenCounter {
     pub fn new() -> Self {
         Self {
             model_configs: ModelTokenConfig::default_configs(),
+            custom_model_configs: HashSet::new(),
         }
     }
 
@@ -75,7 +78,9 @@ impl TokenCounter {
             TokenizerIdentity::ExactOpenAi(_) => {
                 self.exact_completion_tokens(identity.tokenizer_model()?, prompt)
             }
-            TokenizerIdentity::Approximate { .. } => self.approximate_completion_tokens(prompt),
+            TokenizerIdentity::Approximate { .. } => {
+                self.approximate_completion_tokens(identity, prompt)
+            }
         }
     }
 
@@ -89,7 +94,7 @@ impl TokenCounter {
             TokenizerIdentity::ExactOpenAi(_) => {
                 let model = identity.tokenizer_model()?;
                 let Some(total_tokens) = self.exact_chat_tokens(model, messages)? else {
-                    return self.approximate_chat_tokens(messages);
+                    return self.approximate_chat_tokens(identity, messages);
                 };
                 Ok(TokenEstimate {
                     input_tokens: total_tokens,
@@ -99,12 +104,18 @@ impl TokenCounter {
                     confidence: 1.0,
                 })
             }
-            TokenizerIdentity::Approximate { .. } => self.approximate_chat_tokens(messages),
+            TokenizerIdentity::Approximate { .. } => {
+                self.approximate_chat_tokens(identity, messages)
+            }
         }
     }
 
-    fn approximate_chat_tokens(&self, messages: &[ChatMessage]) -> Result<TokenEstimate> {
-        let config = self.approximate_model_config()?;
+    fn approximate_chat_tokens(
+        &self,
+        identity: &TokenizerIdentity,
+        messages: &[ChatMessage],
+    ) -> Result<TokenEstimate> {
+        let config = self.approximate_model_config(identity)?;
         let mut total_tokens = config.request_overhead;
 
         for message in messages {
@@ -228,8 +239,12 @@ impl TokenCounter {
         })
     }
 
-    fn approximate_completion_tokens(&self, prompt: &str) -> Result<TokenEstimate> {
-        let config = self.approximate_model_config()?;
+    fn approximate_completion_tokens(
+        &self,
+        identity: &TokenizerIdentity,
+        prompt: &str,
+    ) -> Result<TokenEstimate> {
+        let config = self.approximate_model_config(identity)?;
         let input_tokens = config.request_overhead + self.estimate_text_tokens(config, prompt);
 
         Ok(TokenEstimate {
@@ -264,7 +279,7 @@ impl TokenCounter {
             });
         }
 
-        let config = self.approximate_model_config()?;
+        let config = self.approximate_model_config(identity)?;
         let mut total_tokens = config.request_overhead;
 
         for text in input {
@@ -333,16 +348,32 @@ impl TokenCounter {
         })
     }
 
-    fn approximate_model_config(&self) -> Result<&ModelTokenConfig> {
-        self.model_configs
-            .get("default")
-            .ok_or_else(|| GatewayError::Config("No default token config found".to_string()))
+    fn approximate_model_config(&self, identity: &TokenizerIdentity) -> Result<&ModelTokenConfig> {
+        if self.custom_model_configs.contains(identity.model()) {
+            return self.model_configs.get(identity.model()).ok_or_else(|| {
+                GatewayError::Config(format!(
+                    "No token config found for explicitly configured model: {}",
+                    identity.model()
+                ))
+            });
+        }
+
+        let family = match identity.provider() {
+            "openai" if identity.model().starts_with("gpt-4") => "gpt-4",
+            "openai" if identity.model().starts_with("gpt-3.5") => "gpt-3.5-turbo",
+            "anthropic" if identity.model().starts_with("claude-3") => "claude-3",
+            "anthropic" if identity.model().starts_with("claude-2") => "claude-2",
+            _ => "default",
+        };
+        self.model_configs.get(family).ok_or_else(|| {
+            GatewayError::Config(format!("No token config found for family: {family}"))
+        })
     }
 
     fn config_for_identity(&self, identity: &TokenizerIdentity) -> Result<&ModelTokenConfig> {
         match identity {
             TokenizerIdentity::ExactOpenAi(_) => self.get_model_config(identity.tokenizer_model()?),
-            TokenizerIdentity::Approximate { .. } => self.approximate_model_config(),
+            TokenizerIdentity::Approximate { .. } => self.approximate_model_config(identity),
         }
     }
 
@@ -364,6 +395,7 @@ impl TokenCounter {
 
     /// Add or update model configuration
     pub fn add_model_config(&mut self, config: ModelTokenConfig) {
+        self.custom_model_configs.insert(config.model.clone());
         self.model_configs.insert(config.model.clone(), config);
     }
 

--- a/src/utils/ai/counter/token_counter_tests.rs
+++ b/src/utils/ai/counter/token_counter_tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+fn exact(model: &str) -> TokenizerIdentity {
+    TokenizerIdentity::exact_openai(model)
+}
+
 // ==================== TokenCounter Creation Tests ====================
 
 #[test]
@@ -101,12 +105,12 @@ fn test_extract_model_family_claude() {
 }
 
 #[test]
-fn test_extract_model_family_with_provider_prefix() {
+fn test_extract_model_family_does_not_strip_provider_prefix() {
     let counter = TokenCounter::new();
-    assert_eq!(counter.extract_model_family("openai/gpt-4"), "gpt-4");
+    assert_eq!(counter.extract_model_family("openai/gpt-4"), "default");
     assert_eq!(
         counter.extract_model_family("anthropic/claude-3-opus"),
-        "claude-3"
+        "default"
     );
 }
 
@@ -159,7 +163,7 @@ fn test_estimate_text_tokens_unicode() {
 #[test]
 fn test_count_completion_tokens_basic() {
     let counter = TokenCounter::new();
-    let result = counter.count_completion_tokens("gpt-4", "Hello, world!");
+    let result = counter.count_completion_tokens(&exact("gpt-4"), "Hello, world!");
     assert!(result.is_ok());
     let estimate = result.unwrap();
     assert!(estimate.input_tokens > 0);
@@ -169,7 +173,7 @@ fn test_count_completion_tokens_basic() {
 #[test]
 fn test_count_completion_tokens_empty() {
     let counter = TokenCounter::new();
-    let result = counter.count_completion_tokens("gpt-4", "");
+    let result = counter.count_completion_tokens(&exact("gpt-4"), "");
     assert!(result.is_ok());
     let estimate = result.unwrap();
     assert_eq!(estimate.input_tokens, 0);
@@ -180,7 +184,7 @@ fn test_count_completion_tokens_empty() {
 fn test_count_completion_tokens_long_text() {
     let counter = TokenCounter::new();
     let long_text = "word ".repeat(1000);
-    let result = counter.count_completion_tokens("gpt-4", &long_text);
+    let result = counter.count_completion_tokens(&exact("gpt-4"), &long_text);
     assert!(result.is_ok());
     let estimate = result.unwrap();
     assert!(estimate.input_tokens > 100);
@@ -189,7 +193,7 @@ fn test_count_completion_tokens_long_text() {
 #[test]
 fn test_count_completion_tokens_confidence() {
     let counter = TokenCounter::new();
-    let result = counter.count_completion_tokens("gpt-4", "test");
+    let result = counter.count_completion_tokens(&exact("gpt-4"), "test");
     assert!(result.is_ok());
     let estimate = result.unwrap();
     assert!(estimate.confidence > 0.0);
@@ -201,7 +205,7 @@ fn test_count_completion_tokens_confidence() {
 #[test]
 fn test_token_estimate_structure() {
     let counter = TokenCounter::new();
-    let result = counter.count_completion_tokens("gpt-4", "Hello");
+    let result = counter.count_completion_tokens(&exact("gpt-4"), "Hello");
     assert!(result.is_ok());
     let estimate = result.unwrap();
 
@@ -216,7 +220,7 @@ fn test_token_estimate_structure() {
 fn test_count_embedding_tokens_single() {
     let counter = TokenCounter::new();
     let input = vec!["Hello, world!".to_string()];
-    let result = counter.count_embedding_tokens("gpt-4", &input);
+    let result = counter.count_embedding_tokens(&exact("gpt-4"), &input);
     assert!(result.is_ok());
     let estimate = result.unwrap();
     assert!(estimate.input_tokens > 0);
@@ -232,7 +236,7 @@ fn test_count_embedding_tokens_multiple() {
         "Second text".to_string(),
         "Third text".to_string(),
     ];
-    let result = counter.count_embedding_tokens("gpt-4", &input);
+    let result = counter.count_embedding_tokens(&exact("gpt-4"), &input);
     assert!(result.is_ok());
     let estimate = result.unwrap();
     assert!(estimate.input_tokens > 0);
@@ -242,7 +246,7 @@ fn test_count_embedding_tokens_multiple() {
 fn test_count_embedding_tokens_empty() {
     let counter = TokenCounter::new();
     let input: Vec<String> = vec![];
-    let result = counter.count_embedding_tokens("gpt-4", &input);
+    let result = counter.count_embedding_tokens(&exact("gpt-4"), &input);
     assert!(result.is_ok());
 }
 
@@ -251,7 +255,7 @@ fn test_count_embedding_tokens_empty() {
 #[test]
 fn test_estimate_output_tokens_with_max() {
     let counter = TokenCounter::new();
-    let result = counter.estimate_output_tokens(Some(100), 50, "gpt-4");
+    let result = counter.estimate_output_tokens(Some(100), 50, &exact("gpt-4"));
     assert!(result.is_ok());
     let output = result.unwrap();
     assert_eq!(output, 100);
@@ -260,7 +264,7 @@ fn test_estimate_output_tokens_with_max() {
 #[test]
 fn test_estimate_output_tokens_without_max() {
     let counter = TokenCounter::new();
-    let result = counter.estimate_output_tokens(None, 100, "gpt-4");
+    let result = counter.estimate_output_tokens(None, 100, &exact("gpt-4"));
     assert!(result.is_ok());
     let output = result.unwrap();
     // Should be ~25% of remaining context
@@ -271,7 +275,7 @@ fn test_estimate_output_tokens_without_max() {
 fn test_estimate_output_tokens_capped_by_context() {
     let counter = TokenCounter::new();
     // Request more tokens than available
-    let result = counter.estimate_output_tokens(Some(1_000_000), 0, "gpt-4");
+    let result = counter.estimate_output_tokens(Some(1_000_000), 0, &exact("gpt-4"));
     assert!(result.is_ok());
     let output = result.unwrap();
     // Should be capped at model's max context
@@ -283,7 +287,7 @@ fn test_estimate_output_tokens_capped_by_context() {
 #[test]
 fn test_check_context_window_fits() {
     let counter = TokenCounter::new();
-    let result = counter.check_context_window("gpt-4", 1000, Some(1000));
+    let result = counter.check_context_window(&exact("gpt-4"), 1000, Some(1000));
     assert!(result.is_ok());
     assert!(result.unwrap());
 }
@@ -292,7 +296,7 @@ fn test_check_context_window_fits() {
 fn test_check_context_window_exceeds() {
     let counter = TokenCounter::new();
     // Try to use more tokens than the context window
-    let result = counter.check_context_window("gpt-4", 100_000, Some(100_000));
+    let result = counter.check_context_window(&exact("gpt-4"), 100_000, Some(100_000));
     assert!(result.is_ok());
     // Verify the function returns a boolean (regardless of value)
     let _fits = result.unwrap();
@@ -301,7 +305,7 @@ fn test_check_context_window_exceeds() {
 #[test]
 fn test_check_context_window_no_output() {
     let counter = TokenCounter::new();
-    let result = counter.check_context_window("gpt-4", 1000, None);
+    let result = counter.check_context_window(&exact("gpt-4"), 1000, None);
     assert!(result.is_ok());
     assert!(result.unwrap());
 }


### PR DESCRIPTION
## What

- require an explicit `TokenizerIdentity` at public token-counting and context-window entry points
- keep approximation explicit and stop inferring token families from arbitrary provider-qualified model names
- propagate exact tokenizer failures through final streaming usage instead of emitting a guessed count
- retain marked approximation for supported exact OpenAI tokenizers when a tool/multimodal message shape cannot be counted exactly

## Why

The typed request-pricing paths merged in #1221, but standalone public `TokenCounter` calls could still strip arbitrary prefixes and silently switch to approximation. The standalone streaming helper also discarded final tokenization failures.

Fixes #1208

## Test Plan

- [x] `CARGO_BUILD_JOBS=2 cargo test --lib utils::ai::counter -- --test-threads=1` (72 passed)
- [x] `CARGO_BUILD_JOBS=2 cargo test --lib core::streaming::handler -- --test-threads=1` (35 passed)
- [x] `CARGO_BUILD_JOBS=2 cargo test --lib server::routes::ai::spend -- --test-threads=1` (68 passed)
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_BUILD_JOBS=2 cargo check`
- [x] `CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings`
- [ ] Fresh GitHub Actions full suite for `4441a838`

## Compatibility

This intentionally removes raw model-string inference from the public token counter API. Callers must supply the tokenizer contract selected for the provider attempt.