### PR TITLE
fix(anthropic): unify public request transform

### DIFF
--- a/src/core/providers/anthropic/client.rs
+++ b/src/core/providers/anthropic/client.rs
@@ -717,6 +717,14 @@ impl AnthropicClient {
             }
         }
     }
+
+    fn manual_thinking_supports_tool_choice(tool_choice: Option<&ToolChoice>) -> bool {
+        match tool_choice {
+            Some(ToolChoice::String(choice)) => matches!(choice.as_str(), "auto" | "none"),
+            Some(ToolChoice::Specific { .. }) => false,
+            None => true,
+        }
+    }
 }
 
 mod request;

--- a/src/core/providers/anthropic/client/request.rs
+++ b/src/core/providers/anthropic/client/request.rs
@@ -257,6 +257,12 @@ impl AnthropicClient {
         } else if let Some(thinking) = &request.thinking
             && thinking.enabled
         {
+            if !Self::manual_thinking_supports_tool_choice(request.tool_choice.as_ref()) {
+                return Err(ProviderError::invalid_request(
+                    "anthropic",
+                    "Anthropic manual thinking only supports tool_choice auto or none",
+                ));
+            }
             let Some(model_spec) = model_spec else {
                 return Err(ProviderError::not_supported(
                     "anthropic",

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -39,50 +39,6 @@ fn tool(name: &str) -> Tool {
     }
 }
 
-#[test]
-fn manual_thinking_rejects_forced_tool_choice() {
-    let mut request = ChatRequest::new("claude-sonnet-4-6").add_user_message("Use the lookup tool");
-    request.max_tokens = Some(2_048);
-    request.thinking = Some(ThinkingConfig::new().enabled().with_budget(1_024));
-    request.tools = Some(vec![tool("lookup")]);
-    request.tool_choice = Some(ToolChoice::String("required".to_string()));
-
-    let error = anthropic_client()
-        .transform_chat_request(&request)
-        .expect_err("manual thinking must reject forced tool choice");
-
-    assert!(error.to_string().contains("manual thinking"));
-    assert!(error.to_string().contains("tool_choice"));
-}
-
-#[test]
-fn adaptive_thinking_accepts_forced_and_named_tool_choice() {
-    let client = anthropic_client();
-    let mut required = ChatRequest::new("claude-opus-5").add_user_message("Use the lookup tool");
-    required.tools = Some(vec![tool("lookup")]);
-    required.tool_choice = Some(ToolChoice::String("required".to_string()));
-    let required_wire = client
-        .transform_chat_request(&required)
-        .expect("adaptive thinking should allow required tool choice");
-    assert_eq!(required_wire["thinking"]["type"], "adaptive");
-    assert_eq!(required_wire["tool_choice"]["type"], "any");
-
-    let mut named = ChatRequest::new("claude-opus-5").add_user_message("Use lookup");
-    named.tools = Some(vec![tool("lookup")]);
-    named.tool_choice = Some(ToolChoice::Specific {
-        choice_type: "function".to_string(),
-        function: Some(FunctionChoice {
-            name: "lookup".to_string(),
-        }),
-    });
-    let named_wire = client
-        .transform_chat_request(&named)
-        .expect("adaptive thinking should allow named tool choice");
-    assert_eq!(named_wire["thinking"]["type"], "adaptive");
-    assert_eq!(named_wire["tool_choice"]["type"], "tool");
-    assert_eq!(named_wire["tool_choice"]["name"], "lookup");
-}
-
 async fn continuation_capture_server() -> (String, oneshot::Receiver<String>) {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
     let address = listener.local_addr().unwrap();

--- a/src/core/providers/anthropic/client/request_tests.rs
+++ b/src/core/providers/anthropic/client/request_tests.rs
@@ -39,6 +39,50 @@ fn tool(name: &str) -> Tool {
     }
 }
 
+#[test]
+fn manual_thinking_rejects_forced_tool_choice() {
+    let mut request = ChatRequest::new("claude-sonnet-4-6").add_user_message("Use the lookup tool");
+    request.max_tokens = Some(2_048);
+    request.thinking = Some(ThinkingConfig::new().enabled().with_budget(1_024));
+    request.tools = Some(vec![tool("lookup")]);
+    request.tool_choice = Some(ToolChoice::String("required".to_string()));
+
+    let error = anthropic_client()
+        .transform_chat_request(&request)
+        .expect_err("manual thinking must reject forced tool choice");
+
+    assert!(error.to_string().contains("manual thinking"));
+    assert!(error.to_string().contains("tool_choice"));
+}
+
+#[test]
+fn adaptive_thinking_accepts_forced_and_named_tool_choice() {
+    let client = anthropic_client();
+    let mut required = ChatRequest::new("claude-opus-5").add_user_message("Use the lookup tool");
+    required.tools = Some(vec![tool("lookup")]);
+    required.tool_choice = Some(ToolChoice::String("required".to_string()));
+    let required_wire = client
+        .transform_chat_request(&required)
+        .expect("adaptive thinking should allow required tool choice");
+    assert_eq!(required_wire["thinking"]["type"], "adaptive");
+    assert_eq!(required_wire["tool_choice"]["type"], "any");
+
+    let mut named = ChatRequest::new("claude-opus-5").add_user_message("Use lookup");
+    named.tools = Some(vec![tool("lookup")]);
+    named.tool_choice = Some(ToolChoice::Specific {
+        choice_type: "function".to_string(),
+        function: Some(FunctionChoice {
+            name: "lookup".to_string(),
+        }),
+    });
+    let named_wire = client
+        .transform_chat_request(&named)
+        .expect("adaptive thinking should allow named tool choice");
+    assert_eq!(named_wire["thinking"]["type"], "adaptive");
+    assert_eq!(named_wire["tool_choice"]["type"], "tool");
+    assert_eq!(named_wire["tool_choice"]["name"], "lookup");
+}
+
 async fn continuation_capture_server() -> (String, oneshot::Receiver<String>) {
     let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
     let address = listener.local_addr().unwrap();

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -5,7 +5,7 @@ use crate::core::types::{
     context::RequestContext,
     message::{MessageContent, MessageRole},
     thinking::{ThinkingConfig, ThinkingContent},
-    tools::FunctionCall,
+    tools::{FunctionCall, FunctionDefinition, Tool, ToolChoice, ToolType},
 };
 
 fn compatible_provider() -> AnthropicProvider {
@@ -35,6 +35,32 @@ async fn public_transform_uses_native_anthropic_serialization() {
     assert_eq!(transformed["messages"].as_array().map(Vec::len), Some(1));
     assert_eq!(transformed["thinking"]["type"], "enabled");
     assert_eq!(transformed["thinking"]["budget_tokens"], 1_024);
+}
+
+#[tokio::test]
+async fn public_transform_allows_forced_tools_with_adaptive_thinking() {
+    let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
+        .unwrap_or_else(|err| panic!("provider should build: {err}"));
+    let mut request = ChatRequest::new("claude-opus-5").add_user_message("Use lookup");
+    request.reasoning_effort = Some("high".to_string());
+    request.tools = Some(vec![Tool {
+        tool_type: ToolType::Function,
+        function: FunctionDefinition {
+            name: "lookup".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({"type": "object"})),
+        },
+    }]);
+    request.tool_choice = Some(ToolChoice::String("required".to_string()));
+
+    let transformed = provider
+        .transform_request(request, RequestContext::new())
+        .await
+        .unwrap_or_else(|err| panic!("adaptive thinking should allow forced tools: {err}"));
+
+    assert_eq!(transformed["thinking"]["type"], "adaptive");
+    assert_eq!(transformed["output_config"]["effort"], "high");
+    assert_eq!(transformed["tool_choice"]["type"], "any");
 }
 
 #[tokio::test]

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -1,11 +1,12 @@
 use super::{AnthropicConfig, AnthropicProvider};
+use crate::core::providers::unified_provider::ProviderError;
 use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
 use crate::core::types::{
     chat::{ChatMessage, ChatRequest},
     context::RequestContext,
     message::{MessageContent, MessageRole},
     thinking::{ThinkingConfig, ThinkingContent},
-    tools::{FunctionCall, FunctionDefinition, Tool, ToolChoice, ToolType},
+    tools::{FunctionCall, FunctionChoice, FunctionDefinition, Tool, ToolChoice, ToolType},
 };
 
 fn compatible_provider() -> AnthropicProvider {
@@ -14,6 +15,17 @@ fn compatible_provider() -> AnthropicProvider {
         .with_allow_unknown_models(true)
         .with_configured_models(vec!["mimo-v2.5".to_string()]);
     AnthropicProvider::new(config).unwrap_or_else(|err| panic!("provider should build: {err}"))
+}
+
+fn tool(name: &str) -> Tool {
+    Tool {
+        tool_type: ToolType::Function,
+        function: FunctionDefinition {
+            name: name.to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({"type": "object"})),
+        },
+    }
 }
 
 #[tokio::test]
@@ -38,19 +50,28 @@ async fn public_transform_uses_native_anthropic_serialization() {
 }
 
 #[tokio::test]
+async fn public_transform_preserves_streaming_mode() {
+    let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
+        .unwrap_or_else(|err| panic!("provider should build: {err}"));
+    let request = ChatRequest::new("claude-sonnet-4-6")
+        .add_user_message("Stream the result")
+        .with_streaming();
+
+    let transformed = provider
+        .transform_request(request, RequestContext::new())
+        .await
+        .unwrap_or_else(|err| panic!("public transform should accept streaming: {err}"));
+
+    assert_eq!(transformed["stream"], true);
+}
+
+#[tokio::test]
 async fn public_transform_allows_forced_tools_with_adaptive_thinking() {
     let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
         .unwrap_or_else(|err| panic!("provider should build: {err}"));
     let mut request = ChatRequest::new("claude-opus-5").add_user_message("Use lookup");
     request.reasoning_effort = Some("high".to_string());
-    request.tools = Some(vec![Tool {
-        tool_type: ToolType::Function,
-        function: FunctionDefinition {
-            name: "lookup".to_string(),
-            description: None,
-            parameters: Some(serde_json::json!({"type": "object"})),
-        },
-    }]);
+    request.tools = Some(vec![tool("lookup")]);
     request.tool_choice = Some(ToolChoice::String("required".to_string()));
 
     let transformed = provider
@@ -61,6 +82,86 @@ async fn public_transform_allows_forced_tools_with_adaptive_thinking() {
     assert_eq!(transformed["thinking"]["type"], "adaptive");
     assert_eq!(transformed["output_config"]["effort"], "high");
     assert_eq!(transformed["tool_choice"]["type"], "any");
+
+    let mut named = ChatRequest::new("claude-opus-5").add_user_message("Use lookup");
+    named.tools = Some(vec![tool("lookup")]);
+    named.tool_choice = Some(ToolChoice::Specific {
+        choice_type: "function".to_string(),
+        function: Some(FunctionChoice {
+            name: "lookup".to_string(),
+        }),
+    });
+    let named = provider
+        .transform_request(named, RequestContext::new())
+        .await
+        .unwrap_or_else(|err| panic!("adaptive thinking should allow named tools: {err}"));
+    assert_eq!(named["thinking"]["type"], "adaptive");
+    assert_eq!(named["tool_choice"]["type"], "tool");
+    assert_eq!(named["tool_choice"]["name"], "lookup");
+}
+
+#[tokio::test]
+async fn public_transform_rejects_forced_tools_with_manual_thinking() {
+    let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
+        .unwrap_or_else(|err| panic!("provider should build: {err}"));
+    let mut request = ChatRequest::new("claude-sonnet-4-6").add_user_message("Use the lookup tool");
+    request.max_tokens = Some(2_048);
+    request.thinking = Some(ThinkingConfig::new().enabled().with_budget(1_024));
+    request.tools = Some(vec![tool("lookup")]);
+    request.tool_choice = Some(ToolChoice::String("required".to_string()));
+
+    let error = provider
+        .transform_request(request, RequestContext::new())
+        .await
+        .expect_err("manual thinking must reject forced tool choice");
+
+    assert!(error.to_string().contains("manual thinking"));
+    assert!(error.to_string().contains("tool_choice"));
+}
+
+#[tokio::test]
+async fn public_claude5_transform_applies_common_and_protocol_validation() {
+    let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
+        .unwrap_or_else(|err| panic!("provider should build: {err}"));
+
+    let empty = provider
+        .transform_request(ChatRequest::new("claude-opus-5"), RequestContext::new())
+        .await
+        .expect_err("public transform must reject an empty message list");
+    match empty {
+        ProviderError::InvalidRequest { provider, message } => {
+            assert_eq!(provider, "anthropic");
+            assert_eq!(message, "Messages cannot be empty");
+        }
+        other => panic!("expected invalid request, got {other:?}"),
+    }
+
+    let too_many = ChatRequest::new("claude-opus-5")
+        .add_user_message("Hello")
+        .with_max_tokens(128_001);
+    let too_many = provider
+        .transform_request(too_many, RequestContext::new())
+        .await
+        .expect_err("public transform must enforce the catalog output limit");
+    assert!(too_many.to_string().contains("128001"));
+
+    let sampling = ChatRequest::new("claude-opus-5")
+        .add_user_message("Hello")
+        .with_temperature(0.5);
+    let sampling = provider
+        .transform_request(sampling, RequestContext::new())
+        .await
+        .expect_err("public transform must reject unsupported sampling");
+    assert!(sampling.to_string().contains("temperature"));
+
+    let prefill = ChatRequest::new("claude-opus-5")
+        .add_user_message("Hello")
+        .add_assistant_message("Partial");
+    let prefill = provider
+        .transform_request(prefill, RequestContext::new())
+        .await
+        .expect_err("public transform must reject assistant prefill");
+    assert!(prefill.to_string().contains("assistant prefill"));
 }
 
 #[tokio::test]

--- a/src/core/providers/anthropic/compatible_provider_tests.rs
+++ b/src/core/providers/anthropic/compatible_provider_tests.rs
@@ -4,7 +4,7 @@ use crate::core::types::{
     chat::{ChatMessage, ChatRequest},
     context::RequestContext,
     message::{MessageContent, MessageRole},
-    thinking::ThinkingContent,
+    thinking::{ThinkingConfig, ThinkingContent},
     tools::FunctionCall,
 };
 
@@ -14,6 +14,27 @@ fn compatible_provider() -> AnthropicProvider {
         .with_allow_unknown_models(true)
         .with_configured_models(vec!["mimo-v2.5".to_string()]);
     AnthropicProvider::new(config).unwrap_or_else(|err| panic!("provider should build: {err}"))
+}
+
+#[tokio::test]
+async fn public_transform_uses_native_anthropic_serialization() {
+    let provider = AnthropicProvider::new(AnthropicConfig::new_test("test-key"))
+        .unwrap_or_else(|err| panic!("provider should build: {err}"));
+    let request = ChatRequest::new("claude-sonnet-4-6")
+        .add_system_message("Answer briefly")
+        .add_user_message("Explain the result")
+        .with_max_tokens(2_048)
+        .with_thinking(ThinkingConfig::new().enabled().with_budget(1_024));
+
+    let transformed = provider
+        .transform_request(request, RequestContext::new())
+        .await
+        .unwrap_or_else(|err| panic!("public transform should accept the request: {err}"));
+
+    assert_eq!(transformed["system"], "Answer briefly");
+    assert_eq!(transformed["messages"].as_array().map(Vec::len), Some(1));
+    assert_eq!(transformed["thinking"]["type"], "enabled");
+    assert_eq!(transformed["thinking"]["budget_tokens"], 1_024);
 }
 
 #[tokio::test]

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -273,52 +273,7 @@ impl LLMProvider for AnthropicProvider {
         _context: RequestContext,
     ) -> Result<Value, ProviderError> {
         self.validate_request(&request)?;
-
-        let mut anthropic_request = serde_json::json!({
-            "model": request.model,
-            "messages": request.messages,
-        });
-
-        if let Some(max_tokens) = request.max_tokens {
-            anthropic_request["max_tokens"] = Value::Number(max_tokens.into());
-        }
-
-        if let Some(temperature) = request.temperature {
-            let temp_f64: f64 = temperature.into();
-            anthropic_request["temperature"] = Value::Number(
-                serde_json::Number::from_f64(temp_f64).ok_or_else(|| {
-                    ProviderError::invalid_request(
-                        "anthropic",
-                        format!("invalid temperature value: {temp_f64} (NaN and Infinity are not allowed)"),
-                    )
-                })?,
-            );
-        }
-
-        if let Some(top_p) = request.top_p {
-            let top_p_f64: f64 = top_p.into();
-            anthropic_request["top_p"] =
-                Value::Number(serde_json::Number::from_f64(top_p_f64).ok_or_else(|| {
-                    ProviderError::invalid_request(
-                        "anthropic",
-                        format!(
-                            "invalid top_p value: {top_p_f64} (NaN and Infinity are not allowed)"
-                        ),
-                    )
-                })?);
-        }
-
-        if request.stream {
-            anthropic_request["stream"] = Value::Bool(request.stream);
-        }
-
-        if let Some(tools) = request.tools
-            && !tools.is_empty()
-        {
-            anthropic_request["tools"] = serde_json::to_value(tools)?;
-        }
-
-        Ok(anthropic_request)
+        self.client.transform_chat_request(&request)
     }
 
     async fn transform_response(
@@ -676,10 +631,11 @@ mod tests {
         };
 
         assert_eq!(transformed["model"], "mimo-v2.5");
-        assert_eq!(
-            transformed["messages"][0]["content"][1]["type"],
-            "image_url"
-        );
+        let image = &transformed["messages"][0]["content"][1];
+        assert_eq!(image["type"], "image");
+        assert_eq!(image["source"]["type"], "base64");
+        assert_eq!(image["source"]["media_type"], "image/png");
+        assert_eq!(image["source"]["data"], "aGVsbG8=");
     }
 
     #[tokio::test]

--- a/src/core/providers/anthropic/provider.rs
+++ b/src/core/providers/anthropic/provider.rs
@@ -273,7 +273,11 @@ impl LLMProvider for AnthropicProvider {
         _context: RequestContext,
     ) -> Result<Value, ProviderError> {
         self.validate_request(&request)?;
-        self.client.transform_chat_request(&request)
+        let mut transformed = self.client.transform_chat_request(&request)?;
+        if request.stream {
+            transformed["stream"] = Value::Bool(true);
+        }
+        Ok(transformed)
     }
 
     async fn transform_response(


### PR DESCRIPTION
## What

- route the public Anthropic transform through the production request serializer
- preserve public streaming mode after serialization
- reject forced or named tool choice only for manual extended thinking
- keep adaptive Claude 5 tool selection valid
- cover common and Claude protocol validation on the public path

## Why

The public transform used a parallel request-shaping path, so its validation and wire payload could drift from real provider execution.

Fixes #1230

## Test plan

- `cargo fmt --all -- --check`
- `cargo test --lib core::providers::anthropic -- --test-threads=1` (144 passed)
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`

## Compatibility

No new configuration surface. The public transform now returns the same native Anthropic request shape as provider execution and preserves `stream: true`.