### PR TITLE
feat(pricing): support batch token rates

### DIFF
--- a/config/model_prices_extended.json
+++ b/config/model_prices_extended.json
@@ -23303,7 +23303,10 @@
     },
     "web_search_billing_unit": "per_query",
     "google_maps_grounding_cost_per_query": 0.014,
-    "pricing_valid_through": "2026-12-31"
+    "pricing_valid_through": "2026-12-31",
+    "input_cost_per_token_batches": 3.75e-07,
+    "output_cost_per_token_batches": 1.875e-06,
+    "cache_read_input_token_cost_batches": 3.75e-08
   },
   "gemini/gemini-3.7-flash": {
     "prompt_cache_min_tokens": 4096,
@@ -23361,7 +23364,10 @@
     },
     "web_search_billing_unit": "per_query",
     "google_maps_grounding_cost_per_query": 0.014,
-    "pricing_valid_through": "2026-12-31"
+    "pricing_valid_through": "2026-12-31",
+    "input_cost_per_token_batches": 3.75e-07,
+    "output_cost_per_token_batches": 1.875e-06,
+    "cache_read_input_token_cost_batches": 3.75e-08
   },
   "gemini/gemini-omni-flash-preview": {
     "input_cost_per_audio_token": 1.5e-06,
@@ -23583,7 +23589,10 @@
     "supports_system_message": true,
     "source": "https://ai.google.dev/gemini-api/docs/pricing",
     "cache_read_input_token_cost": 7.5e-08,
-    "pricing_valid_through": "2026-12-31"
+    "pricing_valid_through": "2026-12-31",
+    "input_cost_per_token_batches": 3.75e-07,
+    "output_cost_per_token_batches": 1.875e-06,
+    "cache_read_input_token_cost_batches": 3.75e-08
   },
   "gemini-3.7-flash": {
     "prompt_cache_min_tokens": 4096,
@@ -23639,7 +23648,10 @@
     },
     "web_search_billing_unit": "per_query",
     "google_maps_grounding_cost_per_query": 0.014,
-    "pricing_valid_through": "2026-12-31"
+    "pricing_valid_through": "2026-12-31",
+    "input_cost_per_token_batches": 3.75e-07,
+    "output_cost_per_token_batches": 1.875e-06,
+    "cache_read_input_token_cost_batches": 3.75e-08
   },
   "gemini/gemini-2.5-pro-preview-tts": {
     "cache_read_input_token_cost": 1.25e-07,

--- a/scripts/sync_litellm_pricing.py
+++ b/scripts/sync_litellm_pricing.py
@@ -53,11 +53,11 @@ GPT_PRO_TIER_FIELDS = (
     "output_cost_per_token_above_272k_tokens",
     "cache_read_input_token_cost_above_272k_tokens",
 )
-GEMINI_BATCH_FIELDS = (
-    "input_cost_per_token_batches",
-    "output_cost_per_token_batches",
-    "cache_read_input_token_cost_batches",
-)
+GEMINI_BATCH_RATES = {
+    "input_cost_per_token_batches": 0.000000375,
+    "output_cost_per_token_batches": 0.000001875,
+    "cache_read_input_token_cost_batches": 0.0000000375,
+}
 GEMINI_PROMO_VALID_THROUGH = date(2026, 12, 31)
 GEMINI_PROMO_MODELS = frozenset(
     (
@@ -70,10 +70,6 @@ GEMINI_PROMO_MODELS = frozenset(
 OFFICIAL_OVERRIDE_REMOVALS = {
     "gpt-5.5-pro": GPT_PRO_TIER_FIELDS,
     "gpt-5.5-pro-2026-04-23": GPT_PRO_TIER_FIELDS,
-    "gemini-3.6-flash": GEMINI_BATCH_FIELDS,
-    "gemini-3.7-flash": GEMINI_BATCH_FIELDS,
-    "gemini/gemini-3.6-flash": GEMINI_BATCH_FIELDS,
-    "gemini/gemini-3.7-flash": GEMINI_BATCH_FIELDS,
 }
 FORBIDDEN_PRICING_FIELDS = OFFICIAL_OVERRIDE_REMOVALS
 
@@ -125,6 +121,7 @@ OFFICIAL_OVERRIDE_PATCHES: dict[str, dict[str, Any]] = {
         "input_cost_per_token": 0.00000075,
         "output_cost_per_token": 0.00000375,
         "cache_read_input_token_cost": 0.000000075,
+        **GEMINI_BATCH_RATES,
         "pricing_valid_through": "2026-12-31",
         "source": GEMINI_SOURCE,
     },
@@ -132,6 +129,7 @@ OFFICIAL_OVERRIDE_PATCHES: dict[str, dict[str, Any]] = {
         "input_cost_per_token": 0.00000075,
         "output_cost_per_token": 0.00000375,
         "cache_read_input_token_cost": 0.000000075,
+        **GEMINI_BATCH_RATES,
         "pricing_valid_through": "2026-12-31",
         "source": GEMINI_SOURCE,
     },
@@ -139,6 +137,7 @@ OFFICIAL_OVERRIDE_PATCHES: dict[str, dict[str, Any]] = {
         "input_cost_per_token": 0.00000075,
         "output_cost_per_token": 0.00000375,
         "cache_read_input_token_cost": 0.000000075,
+        **GEMINI_BATCH_RATES,
         "pricing_valid_through": "2026-12-31",
         "source": GEMINI_SOURCE,
     },
@@ -146,6 +145,7 @@ OFFICIAL_OVERRIDE_PATCHES: dict[str, dict[str, Any]] = {
         "input_cost_per_token": 0.00000075,
         "output_cost_per_token": 0.00000375,
         "cache_read_input_token_cost": 0.000000075,
+        **GEMINI_BATCH_RATES,
         "pricing_valid_through": "2026-12-31",
         "source": GEMINI_SOURCE,
     },

--- a/scripts/test/test_sync_litellm_pricing.py
+++ b/scripts/test/test_sync_litellm_pricing.py
@@ -265,6 +265,9 @@ class SyncPricingTests(unittest.TestCase):
             "input_cost_per_token": 0.0000015,
             "output_cost_per_token": 0.0000075,
             "cache_read_input_token_cost": 0.00000015,
+            "input_cost_per_token_batches": 0.00000075,
+            "output_cost_per_token_batches": 0.00000375,
+            "cache_read_input_token_cost_batches": 0.000000075,
         }
         promotional = {
             "gemini-3.6-flash": {
@@ -292,6 +295,12 @@ class SyncPricingTests(unittest.TestCase):
         self.assertEqual(active["gemini-3.6-flash"], promotional["gemini-3.6-flash"])
         self.assertEqual(expired["gemini-3.6-flash"], source["gemini-3.6-flash"])
         self.assertEqual(preserved["gemini-3.6-flash"], corrected["gemini-3.6-flash"])
+        self.assertEqual(
+            active["gemini-3.6-flash"]["input_cost_per_token_batches"], 0.000000375
+        )
+        self.assertEqual(
+            expired["gemini-3.6-flash"]["input_cost_per_token_batches"], 0.00000075
+        )
 
 
 class PricingSchemaValidationTests(unittest.TestCase):
@@ -842,27 +851,20 @@ class OfficialPricingRegressionTests(unittest.TestCase):
             },
         )
 
-    def test_issue_1212_gemini_promo_exact_ids(self) -> None:
+    def test_issue_1212_and_1223_gemini_promo_exact_ids(self) -> None:
         expected = {
             "input_cost_per_token": 0.00000075,
             "output_cost_per_token": 0.00000375,
             "cache_read_input_token_cost": 0.000000075,
+            "input_cost_per_token_batches": 0.000000375,
+            "output_cost_per_token_batches": 0.000001875,
+            "cache_read_input_token_cost_batches": 0.0000000375,
             "pricing_valid_through": "2026-12-31",
         }
         self.assert_fields("gemini/gemini-3.6-flash", expected | {"litellm_provider": "gemini"})
         self.assert_fields("gemini/gemini-3.7-flash", expected | {"litellm_provider": "gemini"})
         self.assert_fields("gemini-3.6-flash", expected)
         self.assert_fields("gemini-3.7-flash", expected)
-        for model in (
-            "gemini-3.6-flash",
-            "gemini-3.7-flash",
-            "gemini/gemini-3.6-flash",
-            "gemini/gemini-3.7-flash",
-        ):
-            self.assertNotIn("input_cost_per_token_batches", self.catalog[model])
-            self.assertNotIn("output_cost_per_token_batches", self.catalog[model])
-            self.assertNotIn("cache_read_input_token_cost_batches", self.catalog[model])
-
     def test_issue_1213_xai_tiered_exact_ids(self) -> None:
         self.assert_fields(
             "xai/grok-4.5",

--- a/src/core/cost/calculator.rs
+++ b/src/core/cost/calculator.rs
@@ -251,6 +251,7 @@ fn amazon_nova_fallback_pricing_prefers_catalog_over_shared_bedrock() {
 }
 fn pricing_usage_from_cost_usage(usage: &UsageTokens) -> PricingUsage {
     PricingUsage {
+        billing_mode: Default::default(),
         prompt_tokens: usage.prompt_tokens,
         completion_tokens: usage.completion_tokens,
         total_tokens: usage.total_tokens,

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -274,6 +274,9 @@ impl PricingSnapshot {
         {
             Ok(breakdown) => Ok(breakdown),
             Err(error) => {
+                if usage.billing_mode == super::billing::PricingBillingMode::Batch {
+                    return Err(error);
+                }
                 let Some(text_usage) = text_only_usage_for_modal_settlement(usage) else {
                     return Err(error);
                 };

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -274,7 +274,7 @@ impl PricingSnapshot {
         {
             Ok(breakdown) => Ok(breakdown),
             Err(error) => {
-                if usage.billing_mode == super::billing::PricingBillingMode::Batch {
+                if usage.billing_mode == super::types::PricingBillingMode::Batch {
                     return Err(error);
                 }
                 let Some(text_usage) = text_only_usage_for_modal_settlement(usage) else {

--- a/src/core/pricing_service/authority_tests.rs
+++ b/src/core/pricing_service/authority_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::pricing_service::PricingBillingMode;
 
 fn test_model_info(provider: &str) -> LiteLLMModelInfo {
     LiteLLMModelInfo {
@@ -322,6 +323,173 @@ fn provider_aware_authority_rejects_missing_token_pricing() {
     };
 
     assert!(error.to_string().contains("output_cost_per_token"));
+}
+
+#[test]
+fn batch_usage_uses_exact_rates_for_reservation_and_settlement() {
+    let service = PricingService::new(None);
+    let mut model_info = test_model_info("runtime_provider");
+    model_info.extra.extend([
+        (
+            "input_cost_per_token_batches".to_string(),
+            serde_json::json!(0.000005),
+        ),
+        (
+            "output_cost_per_token_batches".to_string(),
+            serde_json::json!(0.000010),
+        ),
+        (
+            "cache_read_input_token_cost_batches".to_string(),
+            serde_json::json!(0.000001),
+        ),
+    ]);
+    service.add_custom_model("batch-priced-model".to_string(), model_info);
+
+    let mut usage = PricingUsage::new(1_000, 500);
+    usage.cached_tokens = Some(200);
+    usage.billing_mode = PricingBillingMode::Batch;
+
+    let reservation = service
+        .dry_run_loaded_usage_cost_for_provider("runtime_provider", "batch-priced-model", &usage)
+        .expect("batch reservation pricing");
+    let settlement = service
+        .calculate_loaded_settlement_cost_for_provider(
+            "runtime_provider",
+            "batch-priced-model",
+            &usage,
+        )
+        .expect("batch settlement pricing");
+
+    assert!((reservation.input_cost - 0.004).abs() < 1e-12);
+    assert!((reservation.output_cost - 0.005).abs() < 1e-12);
+    assert!((reservation.cache_cost - 0.0002).abs() < 1e-12);
+    assert!((reservation.total_cost - 0.0092).abs() < 1e-12);
+    assert!((settlement.total_cost - reservation.total_cost).abs() < 1e-12);
+    assert!(
+        service
+            .calculate_loaded_usage_cost_for_provider(
+                "runtime_provider",
+                "batch-priced-model-lookalike",
+                &usage,
+            )
+            .is_err(),
+        "batch pricing must retain exact model authority"
+    );
+}
+
+#[test]
+fn batch_usage_fails_closed_for_missing_rates_and_cache_storage() {
+    let service = PricingService::new(None);
+    let mut model_info = test_model_info("runtime_provider");
+    model_info.extra.extend([
+        (
+            "input_cost_per_token_batches".to_string(),
+            serde_json::json!(0.000005),
+        ),
+        (
+            "output_cost_per_token_batches".to_string(),
+            serde_json::json!(0.000010),
+        ),
+    ]);
+    service.add_custom_model("partial-batch-model".to_string(), model_info);
+
+    let mut cache_read = PricingUsage::new(1_000, 500);
+    cache_read.cached_tokens = Some(200);
+    cache_read.billing_mode = PricingBillingMode::Batch;
+    let error = service
+        .calculate_loaded_usage_cost_for_provider(
+            "runtime_provider",
+            "partial-batch-model",
+            &cache_read,
+        )
+        .expect_err("missing batch cache-read pricing must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("cache_read_input_token_cost_batches")
+    );
+
+    let mut cache_storage = PricingUsage::new(1_000, 500);
+    cache_storage.cache_creation_tokens = Some(200);
+    cache_storage.billing_mode = PricingBillingMode::Batch;
+    let error = service
+        .calculate_loaded_settlement_cost_for_provider(
+            "runtime_provider",
+            "partial-batch-model",
+            &cache_storage,
+        )
+        .expect_err("token-hour cache storage must not use a token rate");
+    assert!(error.to_string().contains("cache creation/storage"));
+
+    for (missing_key, prompt_tokens, completion_tokens) in [
+        ("input_cost_per_token_batches", 1_000, 0),
+        ("output_cost_per_token_batches", 0, 500),
+    ] {
+        let mut model_info = test_model_info("runtime_provider");
+        for (key, rate) in [
+            ("input_cost_per_token_batches", 0.000005),
+            ("output_cost_per_token_batches", 0.000010),
+            ("cache_read_input_token_cost_batches", 0.000001),
+        ] {
+            if key != missing_key {
+                model_info
+                    .extra
+                    .insert(key.to_string(), serde_json::json!(rate));
+            }
+        }
+        let model = format!("missing-{missing_key}");
+        service.add_custom_model(model.clone(), model_info);
+        let mut usage = PricingUsage::new(prompt_tokens, completion_tokens);
+        usage.billing_mode = PricingBillingMode::Batch;
+        let error = service
+            .calculate_loaded_usage_cost_for_provider("runtime_provider", &model, &usage)
+            .expect_err("a required batch token rate must not fall back to standard pricing");
+        assert!(error.to_string().contains(missing_key));
+    }
+}
+
+#[test]
+fn embedded_gemini_flash_batch_rates_cover_input_output_and_cache_read() {
+    let service = PricingService::with_embedded_default()
+        .unwrap_or_else(|error| panic!("embedded pricing should load: {error}"));
+    let mut usage = PricingUsage::new(1_000, 500);
+    usage.cached_tokens = Some(200);
+    usage.billing_mode = PricingBillingMode::Batch;
+
+    for model in ["gemini-3.6-flash", "gemini-3.7-flash"] {
+        let cost = service
+            .calculate_loaded_usage_cost_for_provider("gemini", model, &usage)
+            .unwrap_or_else(|error| panic!("{model} batch pricing should resolve: {error}"));
+        assert!((cost.input_cost - 0.0003).abs() < 1e-12, "{model}");
+        assert!((cost.output_cost - 0.0009375).abs() < 1e-12, "{model}");
+        assert!((cost.cache_cost - 0.0000075).abs() < 1e-12, "{model}");
+    }
+}
+
+#[test]
+fn standard_usage_ignores_batch_rates() {
+    let service = PricingService::new(None);
+    let mut model_info = test_model_info("runtime_provider");
+    model_info.extra.extend([
+        (
+            "input_cost_per_token_batches".to_string(),
+            serde_json::json!(0.5),
+        ),
+        (
+            "output_cost_per_token_batches".to_string(),
+            serde_json::json!(0.5),
+        ),
+    ]);
+    service.add_custom_model("standard-priced-model".to_string(), model_info);
+
+    let cost = service
+        .calculate_loaded_usage_cost_for_provider(
+            "runtime_provider",
+            "standard-priced-model",
+            &PricingUsage::new(1_000, 500),
+        )
+        .expect("standard pricing");
+    assert!((cost.total_cost - 0.025).abs() < 1e-12);
 }
 
 #[test]

--- a/src/core/pricing_service/billing.rs
+++ b/src/core/pricing_service/billing.rs
@@ -1,0 +1,7 @@
+/// Pricing schedule selected for one usage record.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum PricingBillingMode {
+    #[default]
+    Standard,
+    Batch,
+}

--- a/src/core/pricing_service/billing.rs
+++ b/src/core/pricing_service/billing.rs
@@ -1,7 +1,0 @@
-/// Pricing schedule selected for one usage record.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
-pub enum PricingBillingMode {
-    #[default]
-    Standard,
-    Batch,
-}

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -4,6 +4,7 @@
 //! unified cost calculation for all AI providers.
 
 mod authority;
+mod billing;
 mod cache;
 mod completion;
 mod events;
@@ -27,6 +28,7 @@ pub(super) const REMOTE_LITELLM_PRICING_SOURCE: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 
 // Re-export public types
+pub use billing::PricingBillingMode;
 pub use service::PricingService;
 pub(crate) use types::PricingSnapshot;
 pub use types::{

--- a/src/core/pricing_service/mod.rs
+++ b/src/core/pricing_service/mod.rs
@@ -4,7 +4,6 @@
 //! unified cost calculation for all AI providers.
 
 mod authority;
-mod billing;
 mod cache;
 mod completion;
 mod events;
@@ -28,10 +27,9 @@ pub(super) const REMOTE_LITELLM_PRICING_SOURCE: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 
 // Re-export public types
-pub use billing::PricingBillingMode;
 pub use service::PricingService;
 pub(crate) use types::PricingSnapshot;
 pub use types::{
-    CostRange, CostResult, CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingCostEstimate,
-    PricingEventType, PricingStatistics, PricingUpdateEvent, PricingUsage,
+    CostRange, CostResult, CostType, LiteLLMModelInfo, PricingBillingMode, PricingCostBreakdown,
+    PricingCostEstimate, PricingEventType, PricingStatistics, PricingUpdateEvent, PricingUsage,
 };

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -1,6 +1,5 @@
 //! Type definitions for the pricing service
 
-use super::billing::PricingBillingMode;
 pub use crate::core::pricing::LiteLLMModelInfo;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -83,7 +82,13 @@ pub struct CostResult {
     pub cost_type: CostType,
 }
 
-/// Usage information for authority-backed pricing calculations.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum PricingBillingMode {
+    #[default]
+    Standard,
+    Batch,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct PricingUsage {
     pub billing_mode: PricingBillingMode,
@@ -194,7 +199,6 @@ pub struct PricingCostEstimate {
     pub currency: String,
 }
 
-/// Type of cost calculation method
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum CostType {
     /// Cost calculated based on token count
@@ -207,7 +211,6 @@ pub enum CostType {
     Custom,
 }
 
-/// Pricing statistics
 #[derive(Debug, Clone)]
 pub struct PricingStatistics {
     /// Total number of models in the pricing database

--- a/src/core/pricing_service/types.rs
+++ b/src/core/pricing_service/types.rs
@@ -1,5 +1,6 @@
 //! Type definitions for the pricing service
 
+use super::billing::PricingBillingMode;
 pub use crate::core::pricing::LiteLLMModelInfo;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -35,8 +36,7 @@ pub(crate) struct PricingSnapshot {
     pub(super) data: Arc<PricingData>,
 }
 
-/// Pricing update event
-/// Event for pricing updates
+/// Event for pricing updates.
 #[derive(Debug, Clone)]
 pub struct PricingUpdateEvent {
     /// Type of pricing event that occurred
@@ -86,6 +86,7 @@ pub struct CostResult {
 /// Usage information for authority-backed pricing calculations.
 #[derive(Debug, Clone, Default)]
 pub struct PricingUsage {
+    pub billing_mode: PricingBillingMode,
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
@@ -103,6 +104,7 @@ pub struct PricingUsage {
 impl PricingUsage {
     pub fn new(prompt_tokens: u32, completion_tokens: u32) -> Self {
         Self {
+            billing_mode: PricingBillingMode::Standard,
             prompt_tokens,
             completion_tokens,
             total_tokens: prompt_tokens.saturating_add(completion_tokens),
@@ -145,6 +147,7 @@ impl From<&crate::core::types::responses::Usage> for PricingUsage {
         let prompt_details = usage.prompt_tokens_details.as_ref();
         let completion_details = usage.completion_tokens_details.as_ref();
         Self {
+            billing_mode: PricingBillingMode::Standard,
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens,
             total_tokens: usage.total_tokens,
@@ -229,10 +232,6 @@ pub struct CostRange {
     /// Maximum output cost per token
     pub output_max: f64,
 }
-
-// ====================================================================================
-// TESTS
-// ====================================================================================
 
 #[cfg(test)]
 mod tests {

--- a/src/core/pricing_service/usage_cost.rs
+++ b/src/core/pricing_service/usage_cost.rs
@@ -1,5 +1,6 @@
 //! Pure token and modality usage-cost calculation for loaded catalog rows.
 
+use super::billing::PricingBillingMode;
 use super::types::{CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingUsage};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use chrono::{DateTime, Utc};
@@ -44,57 +45,40 @@ fn calculate_usage_cost_with_rates(
     usage: &PricingUsage,
     peak_rates: Option<crate::core::pricing::time_of_use::TokenRates>,
 ) -> Result<PricingCostBreakdown> {
-    let (mut input_cost_per_token, mut output_cost_per_token) =
-        super::image_pricing::token_unit_prices(model, model_info, usage)?;
-    if let Some(rates) = peak_rates {
-        input_cost_per_token = rates.input_cost_per_token;
-        output_cost_per_token = rates.output_cost_per_token;
-    }
-
-    let input_cost_per_token = tiered_cost_per_token(
-        model_info,
-        input_cost_per_token,
-        "input_cost_per_token_above_",
-        usage.prompt_tokens,
-    );
-    let output_cost_per_token = tiered_cost_per_token(
-        model_info,
-        output_cost_per_token,
-        "output_cost_per_token_above_",
-        usage.prompt_tokens,
-    );
-    let base_cache_read_cost = peak_rates
-        .map(|rates| rates.cache_read_input_token_cost)
-        .unwrap_or_else(|| {
-            model_info
-                .extra
-                .get("cache_read_input_token_cost")
-                .and_then(serde_json::Value::as_f64)
-                .unwrap_or(input_cost_per_token)
-        });
-    let cache_read_cost_per_token = tiered_cost_per_token(
-        model_info,
-        base_cache_read_cost,
-        "cache_read_input_token_cost_above_",
-        usage.prompt_tokens,
-    );
-    let cache_creation_cost_per_token = tiered_cost_per_token(
-        model_info,
-        model_info
-            .extra
-            .get("cache_creation_input_token_cost")
-            .and_then(serde_json::Value::as_f64)
-            .unwrap_or(input_cost_per_token),
-        "cache_creation_input_token_cost_above_",
-        usage.prompt_tokens,
-    );
     let cache_creation_tokens = usage.cache_creation_token_count();
     let cache_read_tokens = usage.cache_read_token_count();
     let non_cached_tokens = usage.non_cached_prompt_tokens();
-    let input_cost = non_cached_tokens as f64 * input_cost_per_token;
-    let output_cost = usage.completion_tokens as f64 * output_cost_per_token;
-    let cache_cost = cache_creation_tokens as f64 * cache_creation_cost_per_token
-        + cache_read_tokens as f64 * cache_read_cost_per_token;
+    let (input_rate, output_rate, cache_read_rate, cache_creation_rate) = match usage.billing_mode {
+        PricingBillingMode::Batch => {
+            validate_batch_usage(model, usage)?;
+            (
+                required_batch_rate(
+                    model_info,
+                    model,
+                    "input_cost_per_token_batches",
+                    non_cached_tokens,
+                )?,
+                required_batch_rate(
+                    model_info,
+                    model,
+                    "output_cost_per_token_batches",
+                    usage.completion_tokens,
+                )?,
+                required_batch_rate(
+                    model_info,
+                    model,
+                    "cache_read_input_token_cost_batches",
+                    cache_read_tokens,
+                )?,
+                0.0,
+            )
+        }
+        PricingBillingMode::Standard => standard_token_rates(model, model_info, usage, peak_rates)?,
+    };
+    let input_cost = non_cached_tokens as f64 * input_rate;
+    let output_cost = usage.completion_tokens as f64 * output_rate;
+    let cache_cost = cache_creation_tokens as f64 * cache_creation_rate
+        + cache_read_tokens as f64 * cache_read_rate;
     let audio_cost = priced_extra_units(
         model_info,
         model,
@@ -131,6 +115,102 @@ fn calculate_usage_cost_with_rates(
         provider: requested_provider.to_string(),
         cost_type: CostType::TokenBased,
     })
+}
+
+fn standard_token_rates(
+    model: &str,
+    model_info: &LiteLLMModelInfo,
+    usage: &PricingUsage,
+    peak_rates: Option<crate::core::pricing::time_of_use::TokenRates>,
+) -> Result<(f64, f64, f64, f64)> {
+    let (mut input, mut output) =
+        super::image_pricing::token_unit_prices(model, model_info, usage)?;
+    if let Some(rates) = peak_rates {
+        input = rates.input_cost_per_token;
+        output = rates.output_cost_per_token;
+    }
+    input = tiered_cost_per_token(
+        model_info,
+        input,
+        "input_cost_per_token_above_",
+        usage.prompt_tokens,
+    );
+    output = tiered_cost_per_token(
+        model_info,
+        output,
+        "output_cost_per_token_above_",
+        usage.prompt_tokens,
+    );
+    let cache_read = peak_rates
+        .map(|rates| rates.cache_read_input_token_cost)
+        .unwrap_or_else(|| extra_f64_or(model_info, "cache_read_input_token_cost", input));
+    let cache_creation = extra_f64_or(model_info, "cache_creation_input_token_cost", input);
+    Ok((
+        input,
+        output,
+        tiered_cost_per_token(
+            model_info,
+            cache_read,
+            "cache_read_input_token_cost_above_",
+            usage.prompt_tokens,
+        ),
+        tiered_cost_per_token(
+            model_info,
+            cache_creation,
+            "cache_creation_input_token_cost_above_",
+            usage.prompt_tokens,
+        ),
+    ))
+}
+
+fn required_batch_rate(
+    pricing: &LiteLLMModelInfo,
+    model: &str,
+    key: &str,
+    units: u32,
+) -> Result<f64> {
+    if units == 0 {
+        return Ok(0.0);
+    }
+    let rate = pricing
+        .extra
+        .get(key)
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| {
+            GatewayError::Config(format!("Missing batch pricing for model {model}: {key}"))
+        })?;
+    if !rate.is_finite() || rate < 0.0 {
+        return Err(GatewayError::Config(format!(
+            "Invalid batch pricing for model {model}: {key} ({rate})"
+        )));
+    }
+    Ok(rate)
+}
+
+fn validate_batch_usage(model: &str, usage: &PricingUsage) -> Result<()> {
+    if usage.cache_creation_token_count() > 0 {
+        return Err(GatewayError::Config(format!(
+            "Missing batch cache creation/storage pricing for model {model}: token-hour storage cannot use a token rate"
+        )));
+    }
+    if usage.audio_token_count() > 0
+        || usage.image_tokens.unwrap_or(0) > 0
+        || usage.output_image_count.unwrap_or(0) > 0
+        || usage.reasoning_tokens.unwrap_or(0) > 0
+    {
+        return Err(GatewayError::Config(format!(
+            "Missing modality-specific batch pricing for model {model}"
+        )));
+    }
+    Ok(())
+}
+
+fn extra_f64_or(pricing: &LiteLLMModelInfo, key: &str, fallback: f64) -> f64 {
+    pricing
+        .extra
+        .get(key)
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(fallback)
 }
 
 fn extra_f64(pricing: &LiteLLMModelInfo, key: &str) -> f64 {

--- a/src/core/pricing_service/usage_cost.rs
+++ b/src/core/pricing_service/usage_cost.rs
@@ -1,7 +1,8 @@
 //! Pure token and modality usage-cost calculation for loaded catalog rows.
 
-use super::billing::PricingBillingMode;
-use super::types::{CostType, LiteLLMModelInfo, PricingCostBreakdown, PricingUsage};
+use super::types::{
+    CostType, LiteLLMModelInfo, PricingBillingMode, PricingCostBreakdown, PricingUsage,
+};
 use crate::utils::error::gateway_error::{GatewayError, Result};
 use chrono::{DateTime, Utc};
 


### PR DESCRIPTION
## What

- add an explicit `PricingBillingMode` carried by `PricingUsage`, so usage-based reservation and settlement select the same standard or batch schedule
- consume provider-specific batch input, output, and cache-read token rates through the existing exact provider/model pricing authority
- fail closed when a used batch dimension lacks its own rate, including cache creation/storage and unsupported modalities
- restore the official Gemini 3.6/3.7 Flash promotional batch rates through 2026-12-31 without treating token-hour cache storage as a scalar token price

## Why

The embedded catalog already understands provider pricing fields, but runtime settlement ignored batch token rates and could only expose a separate scalar discount. This closes #1223 while preserving standard pricing behavior and exact-ID resolution.

Official pricing evidence: https://ai.google.dev/gemini-api/docs/pricing

## Test Plan

- [x] `python3 -m unittest discover -s scripts/test -p "test_sync_litellm_pricing.py"`
- [x] `python3 scripts/sync_litellm_pricing.py --source-catalog config/model_prices_extended.json --check`
- [x] focused batch pricing tests
- [x] `cargo fmt --check`
- [x] `CARGO_BUILD_JOBS=2 cargo check`
- [x] `CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings`
- [x] `CARGO_BUILD_JOBS=2 cargo test`
- [ ] Tested manually against a live provider

## AI disclosure

AI assistance was used for repository analysis, implementation, and test review. The changes were validated with the commands above.