### PR TITLE
feat(xai): unify current model identity

### DIFF
--- a/config/model_catalog_authority.json
+++ b/config/model_catalog_authority.json
@@ -2,9 +2,9 @@
   "_metadata": {
     "schema_version": 1,
     "revision": "classification-1241-v1",
-    "decision_source_sha256": "e6f047d1f6c2d644dd236bc0b51bbf4a82b0354a56c89b00eb68c816bce6e032",
+    "decision_source_sha256": "e03662421df3507e8a5be175f8976b968f0f59d9acc51aa5bc67f7569b168476",
     "pricing_universe_sha256": "98a6b49d858d0cd466482284f880f24529b304fb840743f8da279bad2cbfe23f",
-    "classification_sha256": "57d6bc1901811975420c2cfb43e208e2b578dd9dd99d6cd3cb379980d67bf1a0",
+    "classification_sha256": "1454b3bc526e00b6cafdc0fcf585a8aebb4c98a045cda5b3cd58b5c7c33df311",
     "total_entry_count": 3474,
     "enforced_providers": [
       "azure",
@@ -638,9 +638,9 @@
         "unreviewed": 29
       },
       "xai": {
-        "callable": 0,
+        "callable": 3,
         "pricing_only": 0,
-        "unreviewed": 36
+        "unreviewed": 33
       },
       "xiaomi_mimo": {
         "callable": 0,
@@ -29174,26 +29174,85 @@
     {
       "provider": "xai",
       "pricing_key": "xai/grok-4.5",
-      "decision": "unreviewed",
+      "decision": "callable",
       "evidence_sources": [
-        "evidence-001"
+        "evidence-104",
+        "evidence-106"
+      ],
+      "catalog_model_id": "grok-4.5",
+      "endpoints": [
+        "chat_completions",
+        "responses"
+      ],
+      "capabilities": [
+        "chat_completion",
+        "chat_completion_stream",
+        "function_calling",
+        "tool_calling"
+      ],
+      "supported_parameters": [
+        "messages",
+        "reasoning_effort",
+        "response_format",
+        "tools"
+      ],
+      "aliases": [
+        "grok-build-latest"
       ]
     },
     {
       "provider": "xai",
       "pricing_key": "xai/grok-4.5-latest",
-      "decision": "unreviewed",
+      "decision": "callable",
       "evidence_sources": [
-        "evidence-001"
-      ]
+        "evidence-104",
+        "evidence-106"
+      ],
+      "catalog_model_id": "grok-4.5-latest",
+      "endpoints": [
+        "chat_completions",
+        "responses"
+      ],
+      "capabilities": [
+        "chat_completion",
+        "chat_completion_stream",
+        "function_calling",
+        "tool_calling"
+      ],
+      "supported_parameters": [
+        "messages",
+        "reasoning_effort",
+        "response_format",
+        "tools"
+      ],
+      "aliases": []
     },
     {
       "provider": "xai",
       "pricing_key": "xai/grok-4.6",
-      "decision": "unreviewed",
+      "decision": "callable",
       "evidence_sources": [
-        "evidence-001"
-      ]
+        "evidence-105",
+        "evidence-106"
+      ],
+      "catalog_model_id": "grok-4.6",
+      "endpoints": [
+        "chat_completions",
+        "responses"
+      ],
+      "capabilities": [
+        "chat_completion",
+        "chat_completion_stream",
+        "function_calling",
+        "tool_calling"
+      ],
+      "supported_parameters": [
+        "messages",
+        "reasoning_effort",
+        "response_format",
+        "tools"
+      ],
+      "aliases": []
     },
     {
       "provider": "xai",

--- a/config/model_catalog_decisions.json
+++ b/config/model_catalog_decisions.json
@@ -620,6 +620,24 @@
       "location": "https://developers.openai.com/api/docs/pricing",
       "reviewed_on": "2026-08-28",
       "revision": "classification-1241-v1"
+    },
+    "evidence-104": {
+      "kind": "official_xai_model_contract",
+      "location": "https://docs.x.ai/developers/models/grok-4.5",
+      "reviewed_on": "2026-08-30",
+      "revision": "classification-1234-v1"
+    },
+    "evidence-105": {
+      "kind": "official_xai_model_contract",
+      "location": "https://docs.x.ai/developers/models/grok-4.6",
+      "reviewed_on": "2026-08-30",
+      "revision": "classification-1234-v1"
+    },
+    "evidence-106": {
+      "kind": "official_xai_reasoning_contract",
+      "location": "https://docs.x.ai/developers/model-capabilities/text/reasoning",
+      "reviewed_on": "2026-08-30",
+      "revision": "classification-1234-v1"
     }
   },
   "provider_aliases": {
@@ -29137,26 +29155,85 @@
     {
       "provider": "xai",
       "pricing_key": "xai/grok-4.5",
-      "decision": "unreviewed",
+      "decision": "callable",
       "evidence_sources": [
-        "evidence-001"
+        "evidence-104",
+        "evidence-106"
+      ],
+      "catalog_model_id": "grok-4.5",
+      "endpoints": [
+        "chat_completions",
+        "responses"
+      ],
+      "capabilities": [
+        "chat_completion",
+        "chat_completion_stream",
+        "function_calling",
+        "tool_calling"
+      ],
+      "supported_parameters": [
+        "messages",
+        "reasoning_effort",
+        "response_format",
+        "tools"
+      ],
+      "aliases": [
+        "grok-build-latest"
       ]
     },
     {
       "provider": "xai",
       "pricing_key": "xai/grok-4.5-latest",
-      "decision": "unreviewed",
+      "decision": "callable",
       "evidence_sources": [
-        "evidence-001"
-      ]
+        "evidence-104",
+        "evidence-106"
+      ],
+      "catalog_model_id": "grok-4.5-latest",
+      "endpoints": [
+        "chat_completions",
+        "responses"
+      ],
+      "capabilities": [
+        "chat_completion",
+        "chat_completion_stream",
+        "function_calling",
+        "tool_calling"
+      ],
+      "supported_parameters": [
+        "messages",
+        "reasoning_effort",
+        "response_format",
+        "tools"
+      ],
+      "aliases": []
     },
     {
       "provider": "xai",
       "pricing_key": "xai/grok-4.6",
-      "decision": "unreviewed",
+      "decision": "callable",
       "evidence_sources": [
-        "evidence-001"
-      ]
+        "evidence-105",
+        "evidence-106"
+      ],
+      "catalog_model_id": "grok-4.6",
+      "endpoints": [
+        "chat_completions",
+        "responses"
+      ],
+      "capabilities": [
+        "chat_completion",
+        "chat_completion_stream",
+        "function_calling",
+        "tool_calling"
+      ],
+      "supported_parameters": [
+        "messages",
+        "reasoning_effort",
+        "response_format",
+        "tools"
+      ],
+      "aliases": []
     },
     {
       "provider": "xai",

--- a/config/model_prices_extended.json
+++ b/config/model_prices_extended.json
@@ -196,8 +196,8 @@
     ],
     "total_model_count": 3474,
     "catalog_decision_revision": "classification-1241-v1",
-    "catalog_decision_source_sha256": "e6f047d1f6c2d644dd236bc0b51bbf4a82b0354a56c89b00eb68c816bce6e032",
-    "catalog_authority_sha256": "57d6bc1901811975420c2cfb43e208e2b578dd9dd99d6cd3cb379980d67bf1a0",
+    "catalog_decision_source_sha256": "e03662421df3507e8a5be175f8976b968f0f59d9acc51aa5bc67f7569b168476",
+    "catalog_authority_sha256": "1454b3bc526e00b6cafdc0fcf585a8aebb4c98a045cda5b3cd58b5c7c33df311",
     "catalog_authority_entry_count": 3474,
     "catalog_authority_enforced_providers": [
       "azure",
@@ -831,9 +831,9 @@
         "unreviewed": 29
       },
       "xai": {
-        "callable": 0,
+        "callable": 3,
         "pricing_only": 0,
-        "unreviewed": 36
+        "unreviewed": 33
       },
       "xiaomi_mimo": {
         "callable": 0,

--- a/scripts/test/test_sync_litellm_pricing.py
+++ b/scripts/test/test_sync_litellm_pricing.py
@@ -732,7 +732,7 @@ class CatalogAuthorityTests(unittest.TestCase):
 
         target_counts = {"callable": 0, "pricing_only": 0, "unreviewed": 0}
         target_providers = {"openai", "azure", "azure_ai"}
-        callable_with_explicit_contract = 0
+        callable_with_explicit_contract = []
         for entry in authority["entries"]:
             if entry["provider"] in target_providers:
                 target_counts[entry["decision"]] += 1
@@ -740,14 +740,23 @@ class CatalogAuthorityTests(unittest.TestCase):
                 field in entry
                 for field in ("endpoints", "capabilities", "supported_parameters")
             ):
-                callable_with_explicit_contract += 1
+                callable_with_explicit_contract.append(
+                    (entry["provider"], entry["pricing_key"])
+                )
 
         self.assertEqual(authority["_metadata"]["total_entry_count"], 3474)
         self.assertEqual(
             target_counts,
             {"callable": 179, "pricing_only": 293, "unreviewed": 87},
         )
-        self.assertEqual(callable_with_explicit_contract, 0)
+        self.assertEqual(
+            sorted(callable_with_explicit_contract),
+            [
+                ("xai", "xai/grok-4.5"),
+                ("xai", "xai/grok-4.5-latest"),
+                ("xai", "xai/grok-4.6"),
+            ],
+        )
         historical = next(
             entry
             for entry in authority["entries"]

--- a/src/core/providers/capability_dispatch.rs
+++ b/src/core/providers/capability_dispatch.rs
@@ -51,6 +51,14 @@ impl Provider {
                             _ => false,
                         }
                 }
+                Provider::OpenAILike(provider) => {
+                    catalog_provider == "xai"
+                        && LLMProvider::supports_capability(provider, capability)
+                        && provider
+                            .get_model_info(catalog_model)
+                            .capabilities
+                            .contains(capability)
+                }
                 _ => false,
             };
         }
@@ -61,6 +69,10 @@ impl Provider {
                 } else {
                     LLMProvider::supports_capability(provider, capability)
                 }
+            }
+            Provider::OpenAILike(provider) if provider.name() == "xai" => {
+                LLMProvider::supports_model(provider, model)
+                    && LLMProvider::supports_capability(provider, capability)
             }
             Provider::OpenAILike(provider) if capability == &ProviderCapability::Rerank => {
                 openai_like_provider_supports_rerank(provider.name())

--- a/src/core/providers/mod.rs
+++ b/src/core/providers/mod.rs
@@ -469,6 +469,7 @@ impl Provider {
             Provider::Azure(provider) => provider.model_identity = Some(binding),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(provider) => provider.model_identity = Some(binding),
+            Provider::OpenAILike(provider) => provider.model_identity = Some(binding),
             _ => {
                 return Err(format!(
                     "provider '{}' does not use OpenAI-family deployment identity",
@@ -497,6 +498,10 @@ impl Provider {
                 .model_identity
                 .as_ref()
                 .map(model_identity::DeploymentProviderBinding::identity),
+            Provider::OpenAILike(provider) => provider
+                .model_identity
+                .as_ref()
+                .map(model_identity::DeploymentProviderBinding::identity),
             _ => None,
         }
     }
@@ -516,6 +521,10 @@ impl Provider {
                 .map(model_identity::DeploymentProviderBinding::pricing),
             #[cfg(feature = "providers-extra")]
             Provider::AzureAI(provider) => provider
+                .model_identity
+                .as_ref()
+                .map(model_identity::DeploymentProviderBinding::pricing),
+            Provider::OpenAILike(provider) => provider
                 .model_identity
                 .as_ref()
                 .map(model_identity::DeploymentProviderBinding::pricing),

--- a/src/core/providers/model_identity.rs
+++ b/src/core/providers/model_identity.rs
@@ -399,8 +399,17 @@ fn validate_pricing_target(
     let qualifier = single_identity_qualifier(provider_name, wire_model, target)?;
     let pricing_provider = match (selected_provider, qualifier) {
         ("openai_compatible", Some("xai")) => "xai",
+        ("openai_compatible", _) => {
+            return Err(invalid_field(
+                provider_name,
+                wire_model,
+                "pricing_model",
+                target,
+                "cross-provider target requires an exact provider qualifier",
+            ));
+        }
         (provider, Some(qualifier)) if provider == qualifier => provider,
-        ("openai_compatible", None) | (_, Some(_)) => {
+        (_, Some(_)) => {
             return Err(invalid_field(
                 provider_name,
                 wire_model,
@@ -411,15 +420,6 @@ fn validate_pricing_target(
         }
         (provider, None) => provider,
     };
-    if pricing_provider == "openai_compatible" {
-        return Err(invalid_field(
-            provider_name,
-            wire_model,
-            "pricing_model",
-            target,
-            "cross-provider target requires an exact provider qualifier",
-        ));
-    }
     let (model, _) = pricing
         .get_model_info_for_provider(pricing_provider, target)
         .ok_or_else(|| {

--- a/src/core/providers/model_identity.rs
+++ b/src/core/providers/model_identity.rs
@@ -329,7 +329,7 @@ fn validate_capability_target(
     let capability_provider = match (selected_provider, qualifier) {
         ("openai", Some("openai")) | ("azure", Some("openai")) => "openai",
         ("azure_ai", Some(provider @ ("openai" | "azure_ai"))) => provider,
-        ("openai_compatible", Some("xai")) => "xai",
+        ("openai_compatible", Some("xai")) | ("xai", Some("xai")) => "xai",
         (_, Some(_)) => {
             return Err(invalid_field(
                 provider_name,

--- a/src/core/providers/model_identity.rs
+++ b/src/core/providers/model_identity.rs
@@ -1,7 +1,4 @@
-//! Config-backed, exact model identity validation.
-
-use crate::core::pricing_service::PricingService;
-use crate::core::pricing_service::PricingSnapshot;
+use crate::core::pricing_service::{PricingService, PricingSnapshot};
 use crate::core::providers::registry::model_catalog_authority::{
     CatalogAuthority, CatalogResolution,
 };
@@ -12,7 +9,6 @@ use std::sync::Arc;
 
 pub const MODEL_IDENTITY_MAPPINGS_KEY: &str = "model_identity_mappings";
 
-/// Explicit semantic identities for one configured wire/deployment model.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ModelIdentityMapping {
@@ -31,14 +27,12 @@ impl ModelIdentityMapping {
     }
 }
 
-/// Exact provider-scoped price address pinned during startup validation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ExactPricingIdentity {
     provider: String,
     model: String,
 }
 
-/// Exact provider-scoped callable catalog address pinned during validation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ExactCapabilityIdentity {
     provider: String,
@@ -55,7 +49,6 @@ impl ExactPricingIdentity {
     }
 }
 
-/// Owned immutable identity attached to one provider clone in a deployment.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeploymentModelIdentity {
     wire_model: String,
@@ -76,7 +69,6 @@ pub(crate) enum DeploymentPricingIdentity<'a> {
     NotApplicable,
 }
 
-/// Immutable provider-private binding created from one startup pricing authority.
 #[derive(Clone, Debug)]
 pub(crate) struct DeploymentProviderBinding {
     identity: DeploymentModelIdentity,
@@ -189,8 +181,6 @@ pub enum ModelIdentityValidationError {
     },
 }
 
-/// Validate one deployment using the maintained catalog and the injected
-/// runtime pricing snapshot. Explicit mapping wins over legacy and raw catalog.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn validate_deployment_identity(
     provider_name: &str,
@@ -339,6 +329,7 @@ fn validate_capability_target(
     let capability_provider = match (selected_provider, qualifier) {
         ("openai", Some("openai")) | ("azure", Some("openai")) => "openai",
         ("azure_ai", Some(provider @ ("openai" | "azure_ai"))) => provider,
+        ("openai_compatible", Some("xai")) => "xai",
         (_, Some(_)) => {
             return Err(invalid_field(
                 provider_name,
@@ -349,6 +340,15 @@ fn validate_capability_target(
             ));
         }
         ("azure", None) => "openai",
+        ("openai_compatible", None) => {
+            return Err(invalid_field(
+                provider_name,
+                wire_model,
+                "capability_catalog_model",
+                target,
+                "cross-provider target requires an exact provider qualifier",
+            ));
+        }
         (provider, None) => provider,
     };
     match catalog.resolve_model(capability_provider, target) {
@@ -396,19 +396,32 @@ fn validate_pricing_target(
             "empty target",
         ));
     }
-    if single_identity_qualifier(provider_name, wire_model, target)?
-        .is_some_and(|qualifier| qualifier != selected_provider)
-    {
+    let qualifier = single_identity_qualifier(provider_name, wire_model, target)?;
+    let pricing_provider = match (selected_provider, qualifier) {
+        ("openai_compatible", Some("xai")) => "xai",
+        (provider, Some(qualifier)) if provider == qualifier => provider,
+        ("openai_compatible", None) | (_, Some(_)) => {
+            return Err(invalid_field(
+                provider_name,
+                wire_model,
+                "pricing_model",
+                target,
+                "wrong or missing provider qualifier",
+            ));
+        }
+        (provider, None) => provider,
+    };
+    if pricing_provider == "openai_compatible" {
         return Err(invalid_field(
             provider_name,
             wire_model,
             "pricing_model",
             target,
-            "wrong provider qualifier",
+            "cross-provider target requires an exact provider qualifier",
         ));
     }
     let (model, _) = pricing
-        .get_model_info_for_provider(selected_provider, target)
+        .get_model_info_for_provider(pricing_provider, target)
         .ok_or_else(|| {
             invalid_field(
                 provider_name,
@@ -419,7 +432,7 @@ fn validate_pricing_target(
             )
         })?;
     Ok(ExactPricingIdentity {
-        provider: selected_provider.to_string(),
+        provider: pricing_provider.to_string(),
         model,
     })
 }
@@ -457,6 +470,8 @@ pub(crate) fn canonical_identity_provider(provider: &str) -> Option<&'static str
         "openai" => Some("openai"),
         "azure" | "azure-openai" | "azure_openai" => Some("azure"),
         "azure_ai" | "azure-ai" | "azureai" => Some("azure_ai"),
+        "xai" => Some("xai"),
+        "openai_compatible" => Some("openai_compatible"),
         _ => None,
     }
 }
@@ -483,17 +498,9 @@ pub(crate) fn calculate_managed_provider_cost(
     input_tokens: u32,
     output_tokens: u32,
 ) -> Option<Result<f64, crate::core::providers::ProviderError>> {
-    let pricing_provider = canonical_identity_provider(match provider.provider_type() {
-        crate::core::providers::provider_type::ProviderType::OpenAI => "openai",
-        #[cfg(feature = "providers-extra")]
-        crate::core::providers::provider_type::ProviderType::Azure => "azure",
-        #[cfg(feature = "providers-extra")]
-        crate::core::providers::provider_type::ProviderType::AzureAI => "azure_ai",
-        _ => return None,
-    })?;
     let usage = crate::core::pricing_service::PricingUsage::new(input_tokens, output_tokens);
-    let result = if let Some(identity) = provider.deployment_model_identity() {
-        match (identity.pricing_provider(), identity.pricing_model()) {
+    if let Some(identity) = provider.deployment_model_identity() {
+        let result = match (identity.pricing_provider(), identity.pricing_model()) {
             (Some(pricing_provider), Some(pricing_model)) => provider
                 .runtime_pricing()
                 .ok_or_else(|| {
@@ -524,19 +531,41 @@ pub(crate) fn calculate_managed_provider_cost(
                     identity.wire_model()
                 ),
             )),
+        };
+        return Some(result);
+    }
+    let pricing_provider = match provider {
+        crate::core::providers::Provider::OpenAI(_) => "openai",
+        #[cfg(feature = "providers-extra")]
+        crate::core::providers::Provider::Azure(_) => "azure",
+        #[cfg(feature = "providers-extra")]
+        crate::core::providers::Provider::AzureAI(_) => "azure_ai",
+        crate::core::providers::Provider::OpenAILike(inner)
+            if inner.config().provider_name == "xai"
+                && super::openai_like::models::is_xai_current_model(wire_model) =>
+        {
+            "xai"
         }
-    } else {
+        _ => return None,
+    };
+    Some(
         crate::core::pricing_service::PricingService::shared_embedded_default()
             .and_then(|pricing| {
                 pricing
-                    .calculate_loaded_usage_cost_for_provider(pricing_provider, wire_model, &usage)
+                    .calculate_loaded_usage_cost_for_provider(
+                        pricing_provider,
+                        super::openai_like::models::xai_current_pricing_model(
+                            pricing_provider,
+                            wire_model,
+                        ),
+                        &usage,
+                    )
                     .map(|cost| cost.total_cost)
             })
             .map_err(|error| {
                 crate::core::providers::ProviderError::configuration("pricing", error.to_string())
-            })
-    };
-    Some(result)
+            }),
+    )
 }
 
 #[cfg(test)]
@@ -744,5 +773,27 @@ mod tests {
             .expect_err("wrong or double capability qualifier must fail closed");
             assert!(error.to_string().contains("provider"), "{error}");
         }
+    }
+
+    #[test]
+    fn explicit_openai_compatible_mapping_can_target_qualified_xai_only() {
+        let (catalog, pricing) = authorities();
+        pricing.add_custom_model("xai/grok-4.6".to_string(), pricing_info("xai"));
+        let validate = |mapping: &ModelIdentityMapping| {
+            validate_deployment_identity(
+                "vertex",
+                "openai_compatible",
+                "xai/grok-4.6",
+                Some(mapping),
+                None,
+                &catalog,
+                &pricing.snapshot(),
+            )
+        };
+        let qualified = "xai/grok-4.6".to_string();
+        let mapping = ModelIdentityMapping::new(Some(qualified.clone()), Some(qualified));
+        validate(&mapping).expect("qualified xAI mapping should validate");
+        let bare = ModelIdentityMapping::new(Some("grok-4.6".to_string()), None);
+        assert!(validate(&bare).is_err());
     }
 }

--- a/src/core/providers/openai_like/models.rs
+++ b/src/core/providers/openai_like/models.rs
@@ -3,7 +3,10 @@
 //! Dynamic model support - accepts any model name and passes it through
 
 use crate::core::types::{model::ModelInfo, model::ProviderCapability};
+use serde_json::Value;
 use std::collections::HashMap;
+
+use super::error::{OpenAILikeError, PROVIDER_NAME};
 
 const XAI_GROK_43_INPUT_COST_PER_1K: f64 = 0.00125;
 const XAI_GROK_43_OUTPUT_COST_PER_1K: f64 = 0.0025;
@@ -11,6 +14,7 @@ const XAI_GROK_43_CONTEXT_LENGTH: u32 = 1_000_000;
 const XAI_GROK_BUILD_INPUT_COST_PER_1K: f64 = 0.001;
 const XAI_GROK_BUILD_OUTPUT_COST_PER_1K: f64 = 0.002;
 const XAI_GROK_BUILD_CONTEXT_LENGTH: u32 = 256_000;
+const XAI_CURRENT_CONTEXT_LENGTH: u32 = 500_000;
 
 const XAI_GROK_43_MODEL_IDS: &[&str] = &[
     "grok-4.3",
@@ -88,6 +92,10 @@ const XAI_GROK_BUILD_MODEL_IDS: &[&str] = &[
     "grok-code-fast",
     "grok-code-fast-1-0825",
 ];
+const XAI_GROK_45_MODEL_IDS: &[&str] = &["grok-4.5", "grok-4.5-latest", "grok-build-latest"];
+const XAI_GROK_46_MODEL_IDS: &[&str] = &["grok-4.6"];
+const XAI_GROK_45_REASONING_EFFORTS: &[&str] = &["low", "medium", "high"];
+const XAI_GROK_46_REASONING_EFFORTS: &[&str] = &["low", "medium", "high", "xhigh"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum XaiReasoningParam {
@@ -184,6 +192,8 @@ impl OpenAILikeModelRegistry {
             XAI_GROK_BUILD_INPUT_COST_PER_1K,
             XAI_GROK_BUILD_OUTPUT_COST_PER_1K,
         );
+        registry.register_current_xai_models(XAI_GROK_45_MODEL_IDS);
+        registry.register_current_xai_models(XAI_GROK_46_MODEL_IDS);
         registry
     }
 
@@ -225,6 +235,21 @@ impl OpenAILikeModelRegistry {
         }
     }
 
+    fn register_current_xai_models(&mut self, model_ids: &[&str]) {
+        for model_id in model_ids {
+            self.register_model(OpenAILikeModelConfig {
+                id: (*model_id).to_string(),
+                max_context_length: XAI_CURRENT_CONTEXT_LENGTH,
+                max_output_length: None,
+                supports_streaming: true,
+                supports_tools: true,
+                supports_multimodal: true,
+                input_cost_per_1k: None,
+                output_cost_per_1k: None,
+            });
+        }
+    }
+
     fn known_config_for_model(&self, model_id: &str) -> Option<&OpenAILikeModelConfig> {
         self.known_models.get(model_id).or_else(|| {
             model_id
@@ -254,7 +279,15 @@ impl OpenAILikeModelRegistry {
                 currency: "USD".to_string(),
                 created_at: None,
                 updated_at: None,
-                metadata: HashMap::new(),
+                metadata: xai_reasoning_efforts_for_model(&config.id)
+                    .map(|efforts| {
+                        HashMap::from([
+                            ("supports_structured_outputs".to_string(), Value::Bool(true)),
+                            ("supports_batch".to_string(), Value::Bool(false)),
+                            ("reasoning_efforts".to_string(), serde_json::json!(efforts)),
+                        ])
+                    })
+                    .unwrap_or_default(),
             }
         } else {
             // Return default info for unknown models
@@ -329,12 +362,97 @@ impl OpenAILikeModelRegistry {
 pub fn xai_reasoning_param_for_model(model_id: &str) -> Option<XaiReasoningParam> {
     let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
 
-    if is_xai_grok_43_reasoning_effort_model(model_id) {
+    if is_xai_grok_43_reasoning_effort_model(model_id)
+        || xai_reasoning_efforts_for_model(model_id).is_some()
+    {
         Some(XaiReasoningParam::TopLevelReasoningEffort)
     } else if is_xai_grok_420_multi_agent_model(model_id) {
         Some(XaiReasoningParam::NestedReasoningEffort)
     } else {
         None
+    }
+}
+
+pub fn xai_native_wire_model(provider_name: &str, has_prefix: bool, mut model: String) -> String {
+    if provider_name == "xai" && !has_prefix && model.starts_with("xai/") {
+        model.drain(.."xai/".len());
+    }
+    model
+}
+
+pub fn take_xai_reasoning_effort(
+    is_xai_model: bool,
+    typed: Option<String>,
+    extra_params: &mut HashMap<String, Value>,
+) -> Result<Option<String>, OpenAILikeError> {
+    if !is_xai_model {
+        return Ok(typed);
+    }
+    match (typed, extra_params.remove("reasoning_effort")) {
+        (Some(typed), Some(Value::String(extra))) if typed == extra => Ok(Some(typed)),
+        (Some(typed), Some(Value::String(extra))) => Err(OpenAILikeError::configuration(
+            PROVIDER_NAME,
+            format!("conflicting xAI reasoning_effort values: '{typed}' and '{extra}'"),
+        )),
+        (_, Some(value)) if !value.is_string() => Err(OpenAILikeError::configuration(
+            PROVIDER_NAME,
+            "xAI reasoning_effort must be a string",
+        )),
+        (None, Some(Value::String(effort))) => Ok(Some(effort)),
+        (Some(effort), None) => Ok(Some(effort)),
+        (None, None) => Ok(None),
+        _ => unreachable!("non-string values are rejected above"),
+    }
+}
+
+pub fn reject_xai_reasoning_incompatible_params(request: &Value) -> Result<(), OpenAILikeError> {
+    let fields = ["stop", "presence_penalty", "frequency_penalty"]
+        .into_iter()
+        .filter(|field| request.get(*field).is_some())
+        .collect::<Vec<_>>();
+    if fields.is_empty() {
+        return Ok(());
+    }
+    Err(OpenAILikeError::configuration(
+        PROVIDER_NAME,
+        format!(
+            "xAI reasoning_effort is incompatible with {}",
+            fields.join(", ")
+        ),
+    ))
+}
+
+pub fn xai_reasoning_efforts_for_model(model_id: &str) -> Option<&'static [&'static str]> {
+    let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
+    if XAI_GROK_45_MODEL_IDS.contains(&model_id) {
+        Some(XAI_GROK_45_REASONING_EFFORTS)
+    } else if XAI_GROK_46_MODEL_IDS.contains(&model_id) {
+        Some(XAI_GROK_46_REASONING_EFFORTS)
+    } else {
+        None
+    }
+}
+
+pub fn xai_accepts_reasoning_effort(model_id: &str, effort: &str) -> bool {
+    xai_reasoning_efforts_for_model(model_id).is_some_and(|allowed| {
+        allowed.contains(&effort)
+            || (effort == "xhigh"
+                && XAI_GROK_45_MODEL_IDS
+                    .contains(&model_id.strip_prefix("xai/").unwrap_or(model_id)))
+    })
+}
+
+pub fn is_xai_current_model(model_id: &str) -> bool {
+    let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
+    XAI_GROK_45_MODEL_IDS.contains(&model_id) || XAI_GROK_46_MODEL_IDS.contains(&model_id)
+}
+
+pub fn xai_current_pricing_model<'a>(pricing_provider: &str, model_id: &'a str) -> &'a str {
+    let model_id = model_id.strip_prefix("xai/").unwrap_or(model_id);
+    if pricing_provider == "xai" && model_id == "grok-build-latest" {
+        "grok-4.5"
+    } else {
+        model_id
     }
 }
 
@@ -507,5 +625,36 @@ mod tests {
         assert!(is_xai_priced_model("xai/grok-4.3"));
         assert!(is_xai_priced_model("grok-build-0.1"));
         assert!(!is_xai_priced_model("unknown-grok"));
+    }
+
+    #[test]
+    fn current_xai_catalog_is_exact_and_uses_official_metadata() {
+        let registry = get_openai_like_registry();
+        for model in [
+            "grok-4.5",
+            "grok-4.5-latest",
+            "grok-build-latest",
+            "grok-4.6",
+        ] {
+            let info = registry.get_model_info(model);
+            assert!(registry.is_known_model(model), "{model}");
+            assert_eq!(info.max_context_length, 500_000);
+            assert_eq!(info.max_output_length, None);
+            assert!(info.supports_multimodal && info.supports_tools);
+            assert_eq!(info.metadata["supports_structured_outputs"], true);
+            assert_eq!(info.metadata["supports_batch"], false);
+            assert_eq!(info.input_cost_per_1k_tokens, None);
+            assert_eq!(info.output_cost_per_1k_tokens, None);
+        }
+        for lookalike in [
+            "grok-4.6-latest",
+            "grok-4.6-2026-08-12",
+            "grok-4.60",
+            "grok-4.5-preview",
+            "xaii/grok-4.6",
+        ] {
+            assert!(!registry.is_known_model(lookalike), "{lookalike}");
+            assert_eq!(xai_reasoning_param_for_model(lookalike), None);
+        }
     }
 }

--- a/src/core/providers/openai_like/models.rs
+++ b/src/core/providers/openai_like/models.rs
@@ -381,28 +381,40 @@ pub fn xai_native_wire_model(provider_name: &str, has_prefix: bool, mut model: S
 }
 
 pub fn take_xai_reasoning_effort(
-    is_xai_model: bool,
+    xai_model: Option<&str>,
     typed: Option<String>,
     extra_params: &mut HashMap<String, Value>,
 ) -> Result<Option<String>, OpenAILikeError> {
-    if !is_xai_model {
+    let Some(model) = xai_model else {
         return Ok(typed);
-    }
-    match (typed, extra_params.remove("reasoning_effort")) {
-        (Some(typed), Some(Value::String(extra))) if typed == extra => Ok(Some(typed)),
-        (Some(typed), Some(Value::String(extra))) => Err(OpenAILikeError::configuration(
-            PROVIDER_NAME,
-            format!("conflicting xAI reasoning_effort values: '{typed}' and '{extra}'"),
-        )),
-        (_, Some(value)) if !value.is_string() => Err(OpenAILikeError::configuration(
-            PROVIDER_NAME,
-            "xAI reasoning_effort must be a string",
-        )),
-        (None, Some(Value::String(effort))) => Ok(Some(effort)),
-        (Some(effort), None) => Ok(Some(effort)),
-        (None, None) => Ok(None),
+    };
+    let effort = match (typed, extra_params.remove("reasoning_effort")) {
+        (Some(typed), Some(Value::String(extra))) if typed == extra => Some(typed),
+        (Some(typed), Some(Value::String(extra))) => {
+            return Err(OpenAILikeError::configuration(
+                PROVIDER_NAME,
+                format!("conflicting xAI reasoning_effort values: '{typed}' and '{extra}'"),
+            ));
+        }
+        (_, Some(value)) if !value.is_string() => {
+            return Err(OpenAILikeError::configuration(
+                PROVIDER_NAME,
+                "xAI reasoning_effort must be a string",
+            ));
+        }
+        (None, Some(Value::String(effort))) | (Some(effort), None) => Some(effort),
+        (None, None) => None,
         _ => unreachable!("non-string values are rejected above"),
-    }
+    };
+    Ok(effort.map(|effort| {
+        if effort == "xhigh"
+            && XAI_GROK_45_MODEL_IDS.contains(&model.strip_prefix("xai/").unwrap_or(model))
+        {
+            "high".to_string()
+        } else {
+            effort
+        }
+    }))
 }
 
 pub fn reject_xai_reasoning_incompatible_params(request: &Value) -> Result<(), OpenAILikeError> {
@@ -434,12 +446,7 @@ pub fn xai_reasoning_efforts_for_model(model_id: &str) -> Option<&'static [&'sta
 }
 
 pub fn xai_accepts_reasoning_effort(model_id: &str, effort: &str) -> bool {
-    xai_reasoning_efforts_for_model(model_id).is_some_and(|allowed| {
-        allowed.contains(&effort)
-            || (effort == "xhigh"
-                && XAI_GROK_45_MODEL_IDS
-                    .contains(&model_id.strip_prefix("xai/").unwrap_or(model_id)))
-    })
+    xai_reasoning_efforts_for_model(model_id).is_some_and(|allowed| allowed.contains(&effort))
 }
 
 pub fn is_xai_current_model(model_id: &str) -> bool {

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -48,21 +48,15 @@ pub(crate) static OPENAI_COMPATIBLE_PROXY_CAPABILITIES: &[ProviderCapability] = 
     ProviderCapability::FunctionCalling,
 ];
 
-/// OpenAI-Like Provider implementation
-///
-/// Connects to any OpenAI-compatible API endpoint.
 #[derive(Debug, Clone)]
 pub struct OpenAILikeProvider {
-    /// Connection pool manager
     pool_manager: Arc<GlobalPoolManager>,
-    /// Provider configuration
     config: OpenAILikeConfig,
-    /// Model registry
     model_registry: &'static OpenAILikeModelRegistry,
-    /// Provider name returned by the LLM provider trait.
     provider_name: String,
-    /// Catalog or instance capability profile, validated against executable methods.
     capabilities: &'static [ProviderCapability],
+    pub(crate) model_identity:
+        Option<crate::core::providers::model_identity::DeploymentProviderBinding>,
 }
 
 impl OpenAILikeProvider {
@@ -179,6 +173,7 @@ impl OpenAILikeProvider {
             model_registry,
             provider_name,
             capabilities,
+            model_identity: None,
         })
     }
 
@@ -213,13 +208,11 @@ impl OpenAILikeProvider {
         Ok(())
     }
 
-    /// Create provider with just an API base URL (no API key required)
     pub async fn with_api_base(api_base: impl Into<String>) -> Result<Self, OpenAILikeError> {
         let config = OpenAILikeConfig::new(api_base).with_skip_api_key(true);
         Self::new(config).await
     }
 
-    /// Create provider with API base and key
     pub async fn with_api_key(
         api_base: impl Into<String>,
         api_key: impl Into<String>,
@@ -228,12 +221,10 @@ impl OpenAILikeProvider {
         Self::new(config).await
     }
 
-    /// Generate headers for API requests
     fn get_request_headers(&self) -> Vec<HeaderPair> {
         build_request_headers(&self.config)
     }
 
-    /// Execute chat completion request
     async fn execute_chat_completion(
         &self,
         request: ChatRequest,
@@ -272,7 +263,6 @@ impl OpenAILikeProvider {
         self.transform_chat_response(response_json)
     }
 
-    /// Execute streaming chat completion
     async fn execute_chat_completion_stream(
         &self,
         request: ChatRequest,
@@ -304,9 +294,25 @@ impl OpenAILikeProvider {
         )))
     }
 
-    /// Transform ChatRequest to OpenAI API format
     fn transform_chat_request(&self, request: ChatRequest) -> Result<Value, OpenAILikeError> {
-        let model = self.config.get_effective_model(&request.model);
+        let model = self
+            .model_identity
+            .as_ref()
+            .map(|binding| binding.identity().wire_model().to_string())
+            .unwrap_or_else(|| {
+                super::models::xai_native_wire_model(
+                    &self.provider_name,
+                    self.config.model_prefix.is_some(),
+                    self.config.get_effective_model(&request.model),
+                )
+            });
+        let xai_model = self
+            .model_identity
+            .as_ref()
+            .filter(|binding| binding.identity().capability_catalog_provider() == Some("xai"))
+            .and_then(|binding| binding.identity().capability_catalog_model())
+            .or_else(|| (self.provider_name == "xai").then_some(model.as_str()));
+        let xai_model = xai_model.map(str::to_string);
 
         let mut openai_request = serde_json::json!({
             "model": model,
@@ -367,7 +373,13 @@ impl OpenAILikeProvider {
                 .map_err(|e| OpenAILikeError::serialization(PROVIDER_NAME, e.to_string()))?;
         }
 
-        let reasoning_effort = request.reasoning_effort;
+        let mut extra_params = request.extra_params;
+        let reasoning_effort = super::models::take_xai_reasoning_effort(
+            xai_model.is_some(),
+            request.reasoning_effort,
+            &mut extra_params,
+        )?;
+        let has_reasoning_effort = reasoning_effort.is_some();
 
         let openrouter_thinking_params = if self.config.provider_name == "openrouter" {
             if let Some(thinking_config) = &request.thinking {
@@ -408,11 +420,11 @@ impl OpenAILikeProvider {
         insert_optional_param!(function_call);
 
         if let Some(effort) = reasoning_effort {
-            self.insert_reasoning_effort(&mut openai_request, &model, effort)?;
+            self.insert_reasoning_effort(&mut openai_request, xai_model.as_deref(), effort)?;
         }
 
         if let Some(obj) = openai_request.as_object_mut() {
-            for (key, value) in request.extra_params {
+            for (key, value) in extra_params {
                 obj.entry(key).or_insert(value);
             }
 
@@ -435,6 +447,10 @@ impl OpenAILikeProvider {
             }
         }
 
+        if xai_model.is_some() && has_reasoning_effort {
+            super::models::reject_xai_reasoning_incompatible_params(&openai_request)?;
+        }
+
         crate::core::providers::registry::catalog_policy::filter_request(
             &self.provider_name,
             &mut openai_request,
@@ -446,15 +462,21 @@ impl OpenAILikeProvider {
     fn insert_reasoning_effort(
         &self,
         request: &mut Value,
-        model: &str,
+        xai_model: Option<&str>,
         effort: String,
     ) -> Result<(), OpenAILikeError> {
-        if self.config.provider_name != "xai" {
+        let Some(model) = xai_model else {
             request["reasoning_effort"] = Value::String(effort);
             return Ok(());
+        };
+        if super::models::xai_reasoning_efforts_for_model(model).is_some()
+            && !super::models::xai_accepts_reasoning_effort(model, &effort)
+        {
+            return Err(OpenAILikeError::configuration(
+                PROVIDER_NAME,
+                format!("unsupported reasoning_effort '{effort}' for xAI model {model}"),
+            ));
         }
-
-        Self::reject_xai_reasoning_incompatible_params(request)?;
 
         match super::models::xai_reasoning_param_for_model(model) {
             Some(super::models::XaiReasoningParam::TopLevelReasoningEffort) => {
@@ -472,25 +494,6 @@ impl OpenAILikeProvider {
         }
     }
 
-    fn reject_xai_reasoning_incompatible_params(request: &Value) -> Result<(), OpenAILikeError> {
-        let incompatible_params = ["stop", "presence_penalty", "frequency_penalty"]
-            .into_iter()
-            .filter(|field| request.get(*field).is_some())
-            .collect::<Vec<_>>();
-
-        if incompatible_params.is_empty() {
-            return Ok(());
-        }
-
-        Err(OpenAILikeError::configuration(
-            PROVIDER_NAME,
-            format!(
-                "xAI reasoning_effort is incompatible with {}",
-                incompatible_params.join(", ")
-            ),
-        ))
-    }
-
     fn transform_chat_response(&self, response: Value) -> Result<ChatResponse, OpenAILikeError> {
         let resp: OpenAIChatResponse = serde_json::from_value(response)
             .map_err(|e| OpenAILikeError::response_parsing(PROVIDER_NAME, e.to_string()))?;
@@ -498,7 +501,6 @@ impl OpenAILikeProvider {
             .map_err(|e| OpenAILikeError::response_parsing(PROVIDER_NAME, e.to_string()))
     }
 
-    /// Map HTTP error response to OpenAILikeError
     fn map_error_response(&self, status: u16, body: &str) -> OpenAILikeError {
         if let Some(error) =
             crate::core::providers::registry::catalog_policy::catalog_error_response(
@@ -554,7 +556,6 @@ impl OpenAILikeProvider {
         }
     }
 
-    /// Get model information
     pub fn get_model_info(&self, model_id: &str) -> ModelInfo {
         if let Some(info) = crate::core::providers::registry::catalog_policy::catalog_model_info(
             &self.provider_name,
@@ -563,14 +564,13 @@ impl OpenAILikeProvider {
             return info;
         }
         let mut info = self.model_registry.get_model_info(model_id);
-        if self.provider_name == "amazon_nova" && super::models::is_xai_priced_model(model_id) {
+        if self.provider_name != "xai" && super::models::is_xai_priced_model(model_id) {
             info.input_cost_per_1k_tokens = None;
             info.output_cost_per_1k_tokens = None;
         }
         info
     }
 
-    /// Get the provider configuration
     pub fn config(&self) -> &OpenAILikeConfig {
         &self.config
     }
@@ -657,6 +657,11 @@ impl LLMProvider for OpenAILikeProvider {
     }
 
     fn supports_model(&self, model: &str) -> bool {
+        if self.provider_name == "xai" {
+            return self
+                .model_registry
+                .is_known_model(&self.config.get_effective_model(model));
+        }
         crate::core::providers::registry::catalog_policy::catalog_provider_supports_model(
             &self.provider_name,
             model,
@@ -704,10 +709,16 @@ impl LLMProvider for OpenAILikeProvider {
         input_tokens: u32,
         output_tokens: u32,
     ) -> Result<f64, ProviderError> {
-        if self.config.provider_name != "xai" && super::models::is_xai_priced_model(model) {
-            return Ok(0.0);
+        if let Some(result) =
+            crate::core::providers::model_identity::calculate_managed_provider_cost(
+                &crate::core::providers::Provider::OpenAILike(self.clone()),
+                model,
+                input_tokens,
+                output_tokens,
+            )
+        {
+            return result;
         }
-
         let model_info = self.get_model_info(model);
         if self.config.provider_name == "meta_llama"
             && crate::core::providers::registry::catalog_policy::catalog_model_info(

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -375,7 +375,7 @@ impl OpenAILikeProvider {
 
         let mut extra_params = request.extra_params;
         let reasoning_effort = super::models::take_xai_reasoning_effort(
-            xai_model.is_some(),
+            xai_model.as_deref(),
             request.reasoning_effort,
             &mut extra_params,
         )?;

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -750,7 +750,10 @@ async fn current_xai_reasoning_normalizes_after_extra_merge() {
         .with_provider_name("xai")
         .with_skip_api_key(true);
     let provider = OpenAILikeProvider::new(config).await.unwrap();
-    for (model, effort) in [("grok-4.5", "xhigh"), ("grok-4.6", "xhigh")] {
+    for (model, effort, expected) in [
+        ("grok-4.5", "xhigh", "high"),
+        ("grok-4.6", "xhigh", "xhigh"),
+    ] {
         let request = ChatRequest {
             model: model.to_string(),
             messages: vec![],
@@ -762,7 +765,7 @@ async fn current_xai_reasoning_normalizes_after_extra_merge() {
             ..Default::default()
         };
         let json = provider.transform_chat_request(request).unwrap();
-        assert_eq!(json["reasoning_effort"], effort);
+        assert_eq!(json["reasoning_effort"], expected);
     }
 
     for extra in [serde_json::json!("low"), serde_json::json!(7)] {

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -477,6 +477,10 @@ async fn test_xai_high_context_uses_registered_pricing() {
         .unwrap();
 
     assert!((cost - 0.315).abs() < 1e-12);
+    let current_alias = LLMProvider::calculate_cost(&provider, "grok-build-latest", 1_000, 1_000)
+        .await
+        .unwrap();
+    assert!((current_alias - 0.008).abs() < 1e-12);
 }
 
 #[tokio::test]
@@ -738,4 +742,51 @@ async fn test_openrouter_thinking_wired_in_transform() {
         Some("high"),
         "reasoning.effort must be forwarded"
     );
+}
+
+#[tokio::test]
+async fn current_xai_reasoning_normalizes_after_extra_merge() {
+    let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+        .with_provider_name("xai")
+        .with_skip_api_key(true);
+    let provider = OpenAILikeProvider::new(config).await.unwrap();
+    for (model, effort) in [("grok-4.5", "xhigh"), ("grok-4.6", "xhigh")] {
+        let request = ChatRequest {
+            model: model.to_string(),
+            messages: vec![],
+            reasoning_effort: Some(effort.to_string()),
+            extra_params: std::collections::HashMap::from([(
+                "reasoning_effort".to_string(),
+                serde_json::json!(effort),
+            )]),
+            ..Default::default()
+        };
+        let json = provider.transform_chat_request(request).unwrap();
+        assert_eq!(json["reasoning_effort"], effort);
+    }
+
+    for extra in [serde_json::json!("low"), serde_json::json!(7)] {
+        let request = ChatRequest {
+            model: "grok-4.6".to_string(),
+            messages: vec![],
+            reasoning_effort: Some("high".to_string()),
+            extra_params: std::collections::HashMap::from([(
+                "reasoning_effort".to_string(),
+                extra,
+            )]),
+            ..Default::default()
+        };
+        assert!(provider.transform_chat_request(request).is_err());
+    }
+
+    let request = ChatRequest {
+        model: "grok-4.6".to_string(),
+        messages: vec![],
+        extra_params: std::collections::HashMap::from([
+            ("reasoning_effort".to_string(), serde_json::json!("high")),
+            ("stop".to_string(), serde_json::json!(["done"])),
+        ]),
+        ..Default::default()
+    };
+    assert!(provider.transform_chat_request(request).is_err());
 }

--- a/src/core/router/gateway_config_tests.rs
+++ b/src/core/router/gateway_config_tests.rs
@@ -190,6 +190,8 @@ mod matrix {
 }
 
 use super::Router;
+use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+use crate::core::types::model::ProviderCapability;
 use std::collections::HashMap;
 
 fn function<'a>(source: &'a str, signature: &str) -> &'a str {
@@ -346,6 +348,38 @@ fn identity_provider_config(
         models: vec![model.to_string()],
         ..Default::default()
     };
+    if let Some(mapping) = mapping {
+        config.settings.insert(
+            crate::core::providers::model_identity::MODEL_IDENTITY_MAPPINGS_KEY.to_string(),
+            serde_json::json!({model: mapping}),
+        );
+    }
+    config
+}
+
+fn openai_like_identity_config(
+    name: &str,
+    provider_type: &str,
+    model: &str,
+    mapping: Option<crate::core::providers::model_identity::ModelIdentityMapping>,
+) -> crate::config::models::provider::ProviderConfig {
+    let mut config = crate::config::models::provider::ProviderConfig {
+        name: name.to_string(),
+        provider_type: provider_type.to_string(),
+        api_key: "test-key".to_string(),
+        models: vec![model.to_string()],
+        ..Default::default()
+    };
+    if provider_type == "openai_compatible" {
+        config.settings.insert(
+            "base_url".to_string(),
+            serde_json::json!("https://vertex.example.com/v1"),
+        );
+        config.settings.insert(
+            "provider_name".to_string(),
+            serde_json::json!("vertex_publisher"),
+        );
+    }
     if let Some(mapping) = mapping {
         config.settings.insert(
             crate::core::providers::model_identity::MODEL_IDENTITY_MAPPINGS_KEY.to_string(),
@@ -577,4 +611,185 @@ async fn pricing_aware_constructor_fails_absent_target_before_snapshot_publicati
             && text.contains("missing-runtime-price"),
         "{text}"
     );
+}
+
+#[tokio::test]
+async fn xai_identity_is_automatic_only_for_native_or_explicitly_mapped_publishers() {
+    let pricing = std::sync::Arc::new(
+        crate::core::pricing_service::PricingService::with_embedded_default()
+            .expect("embedded pricing should load"),
+    );
+    let qualified = "xai/grok-4.6";
+    let mapping = crate::core::providers::model_identity::ModelIdentityMapping::new(
+        Some(qualified.to_string()),
+        Some(qualified.to_string()),
+    );
+    let mut custom = openai_like_identity_config("custom-xai", "xai", "custom/grok-4.6", None);
+    custom.models = [
+        "custom/grok-4.6",
+        "custom/xai/grok-4.6",
+        "custom/custom/grok-4.6",
+        "customized/grok-4.6",
+        "wrong/grok-4.6",
+        "custom/grok-4.6-latest",
+    ]
+    .map(str::to_string)
+    .to_vec();
+    custom
+        .settings
+        .insert("model_prefix".to_string(), serde_json::json!("custom/"));
+    let providers = vec![
+        openai_like_identity_config("native-xai", "xai", qualified, None),
+        openai_like_identity_config(
+            "mapped-vertex",
+            "openai_compatible",
+            qualified,
+            Some(mapping),
+        ),
+        openai_like_identity_config("unmapped-vertex", "openai_compatible", qualified, None),
+        custom,
+    ];
+    let router = Router::from_gateway_config_with_pricing(&providers, None, pricing)
+        .await
+        .expect("exact native and explicitly mapped xAI identities should validate");
+    let ids = router.get_deployments_for_model(qualified);
+    let deployment = |name: &str| {
+        ids.iter()
+            .find(|id| id.starts_with(name))
+            .and_then(|id| router.get_deployment(id))
+            .unwrap_or_else(|| panic!("missing {name} deployment in {ids:?}"))
+    };
+
+    let native = deployment("native-xai");
+    let crate::core::providers::Provider::OpenAILike(native_provider) = &native.provider else {
+        panic!("xAI catalog provider must use OpenAI-compatible transport");
+    };
+    let native_json = LLMProvider::transform_request(
+        native_provider,
+        crate::core::types::chat::ChatRequest {
+            model: qualified.to_string(),
+            messages: vec![],
+            ..Default::default()
+        },
+        crate::core::types::context::RequestContext::default(),
+    )
+    .await
+    .expect("native xAI transform");
+    assert_eq!(native_json["model"], "grok-4.6");
+
+    let mapped = deployment("mapped-vertex");
+    assert!(
+        mapped
+            .provider
+            .supports_capability_for_model(qualified, &ProviderCapability::ChatCompletion)
+    );
+    assert!(
+        !mapped
+            .provider
+            .supports_capability_for_model(qualified, &ProviderCapability::BatchProcessing)
+    );
+    let crate::core::providers::Provider::OpenAILike(mapped_provider) = &mapped.provider else {
+        panic!("mapped publisher must use OpenAI-compatible transport");
+    };
+    let mapped_json = LLMProvider::transform_request(
+        mapped_provider,
+        crate::core::types::chat::ChatRequest {
+            model: qualified.to_string(),
+            messages: vec![],
+            extra_params: HashMap::from([(
+                "reasoning_effort".to_string(),
+                serde_json::json!("xhigh"),
+            )]),
+            ..Default::default()
+        },
+        crate::core::types::context::RequestContext::default(),
+    )
+    .await
+    .expect("mapped publisher transform");
+    assert_eq!(mapped_json["model"], qualified);
+    assert_eq!(mapped_json["reasoning_effort"], "xhigh");
+    for field in ["stop", "presence_penalty", "frequency_penalty"] {
+        let request = crate::core::types::chat::ChatRequest {
+            model: qualified.to_string(),
+            messages: vec![],
+            extra_params: HashMap::from([
+                ("reasoning_effort".to_string(), serde_json::json!("high")),
+                (field.to_string(), serde_json::json!(1)),
+            ]),
+            ..Default::default()
+        };
+        assert!(
+            LLMProvider::transform_request(
+                mapped_provider,
+                request,
+                crate::core::types::context::RequestContext::default(),
+            )
+            .await
+            .is_err(),
+            "{field} must be rejected after the final extra-body merge"
+        );
+    }
+
+    let unmapped = deployment("unmapped-vertex");
+    assert!(
+        !unmapped
+            .provider
+            .supports_capability_for_model(qualified, &ProviderCapability::ChatCompletion)
+    );
+    assert!(
+        unmapped
+            .provider
+            .calculate_cost(qualified, 1, 1)
+            .await
+            .is_err(),
+        "an unmapped publisher must not turn absent pricing into zero"
+    );
+
+    let short = native
+        .provider
+        .calculate_cost(qualified, 199_999, 0)
+        .await
+        .expect("short-context xAI pricing");
+    let long = native
+        .provider
+        .calculate_cost(qualified, 200_000, 0)
+        .await
+        .expect("long-context xAI pricing");
+    assert!((short - 0.399_998).abs() < 1e-12);
+    assert!((long - 0.8).abs() < 1e-12);
+
+    for (raw, wire) in [
+        ("custom/grok-4.6", "grok-4.6"),
+        ("custom/xai/grok-4.6", "xai/grok-4.6"),
+    ] {
+        let id = router
+            .get_deployments_for_model(raw)
+            .into_iter()
+            .next()
+            .expect("custom xAI deployment id");
+        let custom = router.get_deployment(&id).expect("custom xAI deployment");
+        let identity = custom
+            .provider
+            .deployment_model_identity()
+            .expect("custom xAI identity");
+        assert_eq!(identity.wire_model(), wire);
+        assert_eq!(identity.capability_catalog_model(), Some("grok-4.6"));
+        assert_eq!(identity.pricing_model(), Some(qualified));
+    }
+    for invalid in [
+        "custom/custom/grok-4.6",
+        "customized/grok-4.6",
+        "wrong/grok-4.6",
+        "custom/grok-4.6-latest",
+    ] {
+        assert!(
+            router
+                .select_deployment_lease_for_capability(
+                    invalid,
+                    &ProviderCapability::ChatCompletion,
+                )
+                .is_err(),
+            "{invalid} must not acquire xAI capability"
+        );
+    }
 }

--- a/src/core/router/gateway_identity.rs
+++ b/src/core/router/gateway_identity.rs
@@ -12,7 +12,7 @@ use crate::core::providers::model_identity::{
 };
 use crate::core::providers::provider_type::ProviderType;
 use crate::core::providers::registry::model_catalog_authority::{
-    CatalogAuthority, CatalogResolution,
+    CatalogAuthority, CatalogDecision, CatalogResolution,
 };
 use crate::core::types::model_id::ModelIdRef;
 use std::collections::HashMap;
@@ -47,18 +47,33 @@ impl GatewayIdentityAuthority {
         let (identity_provider, identity_model) = match provider {
             Provider::OpenAILike(openai_like) if openai_like.config().provider_name == "xai" => {
                 let configured = openai_like.config().get_effective_model(wire_model);
+                let parsed = ModelIdRef::parse(&configured);
+                if parsed.provider() == Some("xai")
+                    && ModelIdRef::parse(parsed.model()).provider() == Some("xai")
+                {
+                    return Err(RouterError::InvalidConfiguration(format!(
+                        "provider '{provider_name}' deployment '{wire_model}' has double provider qualification"
+                    )));
+                }
                 let effective = crate::core::providers::openai_like::models::xai_native_wire_model(
                     "xai",
                     openai_like.config().model_prefix.is_some(),
                     configured,
                 );
-                if mapping.is_none()
-                    && !matches!(
-                        self.catalog.resolve_model("xai", &effective),
-                        CatalogResolution::Callable(_)
-                    )
-                {
-                    return Ok(());
+                if mapping.is_none() {
+                    let resolution = self.catalog.resolve_model("xai", &effective);
+                    let pricing_key = if ModelIdRef::parse(&effective).provider() == Some("xai") {
+                        effective.clone()
+                    } else {
+                        format!("xai/{effective}")
+                    };
+                    let legacy_unreviewed = matches!(resolution, CatalogResolution::Unreviewed)
+                        || (matches!(resolution, CatalogResolution::Unknown)
+                            && self.catalog.decision_for_pricing_key("xai", &pricing_key)
+                                == Some(CatalogDecision::Unreviewed));
+                    if legacy_unreviewed {
+                        return Ok(());
+                    }
                 }
                 ("xai", effective)
             }
@@ -189,4 +204,70 @@ pub(super) fn take_identity_mappings(
         }
     }
     Ok(mappings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GatewayIdentityAuthority;
+    use crate::core::pricing_service::PricingService;
+    use crate::core::providers::Provider;
+    use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
+    use std::sync::Arc;
+
+    async fn native_xai_provider() -> Provider {
+        let config = OpenAILikeConfig::new("https://api.x.ai/v1")
+            .with_provider_name("xai")
+            .with_skip_api_key(true);
+        Provider::OpenAILike(
+            OpenAILikeProvider::new(config)
+                .await
+                .expect("native xAI provider"),
+        )
+    }
+
+    fn authority() -> GatewayIdentityAuthority {
+        let pricing = Arc::new(
+            PricingService::with_embedded_default().expect("embedded pricing should load"),
+        );
+        GatewayIdentityAuthority::new(pricing).expect("identity authority")
+    }
+
+    #[tokio::test]
+    async fn native_xai_rejects_double_qualifier_before_wire_normalization() {
+        let mut provider = native_xai_provider().await;
+        let error = authority()
+            .bind("native-xai", &mut provider, "xai/xai/grok-4.6", None)
+            .expect_err("double xAI qualification must fail before stripping");
+        assert!(error.to_string().contains("double provider qualification"));
+    }
+
+    #[tokio::test]
+    async fn native_xai_unknown_models_bind_unpriced_while_legacy_pricing_remains() {
+        for model in ["grok-4.6-latest", "unknown-xai-model"] {
+            let mut provider = native_xai_provider().await;
+            authority()
+                .bind("native-xai", &mut provider, model, None)
+                .expect("unknown configured model should bind without privilege");
+            let identity = provider
+                .deployment_model_identity()
+                .expect("unknown configured model must retain an identity");
+            assert_eq!(identity.wire_model(), model);
+            assert_eq!(identity.capability_catalog_model(), None);
+            assert_eq!(identity.pricing_model(), None);
+            assert!(provider.calculate_cost(model, 1, 1).await.is_err());
+        }
+
+        let mut legacy = native_xai_provider().await;
+        authority()
+            .bind("native-xai", &mut legacy, "grok-4.3", None)
+            .expect("legacy unreviewed model should preserve compatibility");
+        assert!(legacy.deployment_model_identity().is_none());
+        assert!(
+            legacy
+                .calculate_cost("grok-4.3", 1_000, 1_000)
+                .await
+                .unwrap()
+                > 0.0
+        );
+    }
 }

--- a/src/core/router/gateway_identity.rs
+++ b/src/core/router/gateway_identity.rs
@@ -47,10 +47,12 @@ impl GatewayIdentityAuthority {
         let (identity_provider, identity_model) = match provider {
             Provider::OpenAILike(openai_like) if openai_like.config().provider_name == "xai" => {
                 let configured = openai_like.config().get_effective_model(wire_model);
-                let parsed = ModelIdRef::parse(&configured);
-                if parsed.provider() == Some("xai")
-                    && ModelIdRef::parse(parsed.model()).provider() == Some("xai")
-                {
+                let has_double_xai_qualifier = |model: &str| {
+                    let parsed = ModelIdRef::parse(model);
+                    parsed.provider() == Some("xai")
+                        && ModelIdRef::parse(parsed.model()).provider() == Some("xai")
+                };
+                if has_double_xai_qualifier(wire_model) || has_double_xai_qualifier(&configured) {
                     return Err(RouterError::InvalidConfiguration(format!(
                         "provider '{provider_name}' deployment '{wire_model}' has double provider qualification"
                     )));
@@ -71,7 +73,12 @@ impl GatewayIdentityAuthority {
                         || (matches!(resolution, CatalogResolution::Unknown)
                             && self.catalog.decision_for_pricing_key("xai", &pricing_key)
                                 == Some(CatalogDecision::Unreviewed));
-                    if legacy_unreviewed {
+                    let registered_legacy = matches!(resolution, CatalogResolution::Unknown)
+                        && crate::core::traits::provider::llm_provider::trait_definition::LLMProvider::supports_model(
+                            openai_like,
+                            &effective,
+                        );
+                    if legacy_unreviewed || registered_legacy {
                         return Ok(());
                     }
                 }
@@ -223,6 +230,7 @@ mod tests {
     async fn native_xai_provider() -> Provider {
         let config = OpenAILikeConfig::new("https://api.x.ai/v1")
             .with_provider_name("xai")
+            .with_model_prefix("xai/")
             .with_skip_api_key(true);
         Provider::OpenAILike(
             OpenAILikeProvider::new(config)
@@ -263,18 +271,21 @@ mod tests {
             assert!(provider.calculate_cost(model, 1, 1).await.is_err());
         }
 
-        let mut legacy = native_xai_provider().await;
-        authority()
-            .bind("native-xai", &mut legacy, "grok-4.3", None)
-            .expect("legacy unreviewed model should preserve compatibility");
-        assert!(legacy.deployment_model_identity().is_none());
-        assert!(
-            legacy
-                .calculate_cost("grok-4.3", 1_000, 1_000)
-                .await
-                .unwrap()
-                > 0.0
-        );
+        for model in ["grok-4.3", "grok-latest", "grok-4-fast", "grok-4.20"] {
+            let mut legacy = native_xai_provider().await;
+            authority()
+                .bind("native-xai", &mut legacy, model, None)
+                .expect("registered legacy model should preserve compatibility");
+            assert!(
+                legacy.deployment_model_identity().is_none(),
+                "{model} must remain on the registered compatibility path"
+            );
+            assert!(legacy.supports_capability_for_model(
+                model,
+                &crate::core::types::model::ProviderCapability::ChatCompletion,
+            ));
+            assert!(legacy.calculate_cost(model, 1_000, 1_000).await.unwrap() > 0.0);
+        }
     }
 
     #[tokio::test]

--- a/src/core/router/gateway_identity.rs
+++ b/src/core/router/gateway_identity.rs
@@ -77,10 +77,13 @@ impl GatewayIdentityAuthority {
                 }
                 ("xai", effective)
             }
-            Provider::OpenAILike(_)
+            Provider::OpenAILike(openai_like)
                 if mapping.is_some() || ModelIdRef::parse(wire_model).provider() == Some("xai") =>
             {
-                ("openai_compatible", wire_model.to_string())
+                (
+                    "openai_compatible",
+                    openai_like.config().get_effective_model(wire_model),
+                )
             }
             _ => {
                 let Some(identity_provider) = identity_provider(provider) else {
@@ -211,7 +214,10 @@ mod tests {
     use super::GatewayIdentityAuthority;
     use crate::core::pricing_service::PricingService;
     use crate::core::providers::Provider;
+    use crate::core::providers::model_identity::ModelIdentityMapping;
     use crate::core::providers::openai_like::{OpenAILikeConfig, OpenAILikeProvider};
+    use crate::core::traits::provider::llm_provider::trait_definition::LLMProvider;
+    use crate::core::types::{chat::ChatRequest, context::RequestContext};
     use std::sync::Arc;
 
     async fn native_xai_provider() -> Provider {
@@ -269,5 +275,61 @@ mod tests {
                 .unwrap()
                 > 0.0
         );
+    }
+
+    #[tokio::test]
+    async fn native_xai_accepts_its_qualified_explicit_mapping() {
+        let mut provider = native_xai_provider().await;
+        let mapping = ModelIdentityMapping::new(
+            Some("xai/grok-4.6".to_string()),
+            Some("xai/grok-4.6".to_string()),
+        );
+        authority()
+            .bind("native-xai", &mut provider, "grok-4.6", Some(&mapping))
+            .expect("native xAI should accept its own exact qualifier");
+        let identity = provider
+            .deployment_model_identity()
+            .expect("explicit xAI mapping should bind");
+        assert_eq!(identity.capability_catalog_model(), Some("grok-4.6"));
+        assert_eq!(identity.pricing_model(), Some("xai/grok-4.6"));
+    }
+
+    #[tokio::test]
+    async fn bound_openai_compatible_identity_preserves_model_prefix_stripping() {
+        let config = OpenAILikeConfig::new("https://vertex.example.com/v1")
+            .with_provider_name("vertex_publisher")
+            .with_model_prefix("vertex/")
+            .with_skip_api_key(true);
+        let mut provider = Provider::OpenAILike(
+            OpenAILikeProvider::new(config)
+                .await
+                .expect("mapped provider"),
+        );
+        let mapping = ModelIdentityMapping::new(Some("xai/grok-4.6".to_string()), None);
+        authority()
+            .bind(
+                "mapped-vertex",
+                &mut provider,
+                "vertex/grok-4.6",
+                Some(&mapping),
+            )
+            .expect("mapped prefixed deployment should bind");
+        let identity = provider
+            .deployment_model_identity()
+            .expect("mapped identity should bind");
+        assert_eq!(identity.wire_model(), "grok-4.6");
+
+        let Provider::OpenAILike(provider) = provider else {
+            panic!("mapped provider should use OpenAI-compatible transport");
+        };
+        let request = ChatRequest {
+            model: "vertex/grok-4.6".to_string(),
+            messages: vec![],
+            ..Default::default()
+        };
+        let json = LLMProvider::transform_request(&provider, request, RequestContext::default())
+            .await
+            .expect("mapped prefixed request should transform");
+        assert_eq!(json["model"], "grok-4.6");
     }
 }

--- a/src/core/router/gateway_identity.rs
+++ b/src/core/router/gateway_identity.rs
@@ -14,6 +14,7 @@ use crate::core::providers::provider_type::ProviderType;
 use crate::core::providers::registry::model_catalog_authority::{
     CatalogAuthority, CatalogResolution,
 };
+use crate::core::types::model_id::ModelIdRef;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -43,8 +44,35 @@ impl GatewayIdentityAuthority {
         wire_model: &str,
         mapping: Option<&ModelIdentityMapping>,
     ) -> Result<(), RouterError> {
-        let Some(identity_provider) = identity_provider(provider) else {
-            return Ok(());
+        let (identity_provider, identity_model) = match provider {
+            Provider::OpenAILike(openai_like) if openai_like.config().provider_name == "xai" => {
+                let configured = openai_like.config().get_effective_model(wire_model);
+                let effective = crate::core::providers::openai_like::models::xai_native_wire_model(
+                    "xai",
+                    openai_like.config().model_prefix.is_some(),
+                    configured,
+                );
+                if mapping.is_none()
+                    && !matches!(
+                        self.catalog.resolve_model("xai", &effective),
+                        CatalogResolution::Callable(_)
+                    )
+                {
+                    return Ok(());
+                }
+                ("xai", effective)
+            }
+            Provider::OpenAILike(_)
+                if mapping.is_some() || ModelIdRef::parse(wire_model).provider() == Some("xai") =>
+            {
+                ("openai_compatible", wire_model.to_string())
+            }
+            _ => {
+                let Some(identity_provider) = identity_provider(provider) else {
+                    return Ok(());
+                };
+                (identity_provider, wire_model.to_string())
+            }
         };
         debug_assert!(canonical_identity_provider(identity_provider).is_some());
         let legacy_target = provider
@@ -53,7 +81,7 @@ impl GatewayIdentityAuthority {
         let identity = validate_deployment_identity(
             provider_name,
             identity_provider,
-            wire_model,
+            &identity_model,
             mapping,
             legacy_target.as_deref(),
             &self.catalog,

--- a/src/server/routes/ai/spend/pricing.rs
+++ b/src/server/routes/ai/spend/pricing.rs
@@ -209,10 +209,13 @@ fn request_pricing_for_provider_with_snapshot_hook(
 ) -> Result<RequestPricing, ProviderError> {
     let snapshot = pricing_service.snapshot();
     after_snapshot();
-    if matches!(
-        provider.provider_type(),
-        ProviderType::OpenAI | ProviderType::Azure | ProviderType::AzureAI
-    ) {
+    let bound_identity = provider.deployment_model_identity();
+    if bound_identity.is_some()
+        || matches!(
+            provider.provider_type(),
+            ProviderType::OpenAI | ProviderType::Azure | ProviderType::AzureAI
+        )
+    {
         let bound_pricing = provider.runtime_pricing().ok_or_else(|| {
             ProviderError::configuration(
                 "model_identity",
@@ -227,7 +230,7 @@ fn request_pricing_for_provider_with_snapshot_hook(
                 "selected deployment is bound to a different runtime pricing authority",
             ));
         }
-        let identity = provider.deployment_model_identity().ok_or_else(|| {
+        let identity = bound_identity.ok_or_else(|| {
             ProviderError::configuration(
                 "model_identity",
                 format!("deployment '{model}' lost its validated model identity"),

--- a/src/server/routes/ai/spend/pricing_tests.rs
+++ b/src/server/routes/ai/spend/pricing_tests.rs
@@ -130,6 +130,104 @@ mod mapped_identity_tests {
         }
     }
 
+    #[tokio::test]
+    async fn openai_compatible_request_pricing_consumes_exact_binding() {
+        use crate::core::providers::model_identity::{
+            MODEL_IDENTITY_MAPPINGS_KEY, ModelIdentityMapping,
+        };
+
+        let pricing = Arc::new(
+            PricingService::with_embedded_default().expect("embedded pricing should load"),
+        );
+        let mapped = ModelIdentityMapping::new(
+            Some("xai/grok-4.6".to_string()),
+            Some("xai/grok-4.6".to_string()),
+        );
+        let mut config = ProviderConfig {
+            name: "mapped-openai-compatible".to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "test-key".to_string(),
+            models: vec!["wire-grok".to_string()],
+            ..Default::default()
+        };
+        config.settings.insert(
+            "base_url".to_string(),
+            serde_json::json!("https://vertex.example.com/v1"),
+        );
+        config.settings.insert(
+            "provider_name".to_string(),
+            serde_json::json!("vertex_publisher"),
+        );
+        config.settings.insert(
+            MODEL_IDENTITY_MAPPINGS_KEY.to_string(),
+            serde_json::json!({"wire-grok": mapped}),
+        );
+        let router = Router::from_gateway_config_with_pricing(&[config], None, pricing.clone())
+            .await
+            .expect("mapped OpenAI-compatible deployment should bind");
+        let deployment = router
+            .get_deployment("mapped-openai-compatible-wire-grok")
+            .expect("mapped deployment should be published");
+
+        let request_pricing = request_pricing_for_provider(
+            &pricing,
+            &deployment.provider,
+            &deployment.model,
+            ProviderCapability::ChatCompletion,
+        )
+        .expect("bound request pricing should resolve");
+        assert_eq!(
+            request_pricing.priced_parts(),
+            Some(("xai", "xai/grok-4.6"))
+        );
+    }
+
+    #[tokio::test]
+    async fn explicitly_unpriced_openai_compatible_binding_never_uses_wire_price() {
+        use crate::core::providers::model_identity::{
+            MODEL_IDENTITY_MAPPINGS_KEY, ModelIdentityMapping,
+        };
+
+        let pricing = Arc::new(
+            PricingService::with_embedded_default().expect("embedded pricing should load"),
+        );
+        let mapped = ModelIdentityMapping::new(Some("xai/grok-4.6".to_string()), None);
+        let mut config = ProviderConfig {
+            name: "unpriced-openai-compatible".to_string(),
+            provider_type: "openai_compatible".to_string(),
+            api_key: "test-key".to_string(),
+            models: vec!["gpt-4".to_string()],
+            ..Default::default()
+        };
+        config.settings.insert(
+            "base_url".to_string(),
+            serde_json::json!("https://vertex.example.com/v1"),
+        );
+        config.settings.insert(
+            "provider_name".to_string(),
+            serde_json::json!("vertex_publisher"),
+        );
+        config.settings.insert(
+            MODEL_IDENTITY_MAPPINGS_KEY.to_string(),
+            serde_json::json!({"gpt-4": mapped}),
+        );
+        let router = Router::from_gateway_config_with_pricing(&[config], None, pricing.clone())
+            .await
+            .expect("explicitly unpriced deployment should bind");
+        let deployment = router
+            .get_deployment("unpriced-openai-compatible-gpt-4")
+            .expect("unpriced deployment should be published");
+
+        let request_pricing = request_pricing_for_provider(
+            &pricing,
+            &deployment.provider,
+            &deployment.model,
+            ProviderCapability::ChatCompletion,
+        )
+        .expect("explicitly unpriced identity should remain representable");
+        assert_eq!(request_pricing.priced_parts(), None);
+    }
+
     #[test]
     fn unpriced_openai_mapping_retains_canonical_identity_only_for_real_mapping() {
         assert_eq!(


### PR DESCRIPTION
## Summary

- register exact callable catalog entries for `grok-4.5`, `grok-4.5-latest`/`grok-build-latest`, and `grok-4.6`
- keep native xAI wire model names bare while requiring an explicit qualified `model_identity_mappings` entry for Vertex or another OpenAI-compatible publisher to inherit xAI capabilities and pricing
- normalize typed and extra-body reasoning effort once after the final merge, accepting 4.5 `xhigh` compatibility and rejecting unsupported efforts or incompatible parameters
- preserve the existing pricing payloads and legacy xAI behavior; generated pricing metadata is the only change in `model_prices_extended.json`

## Identity boundaries

- native exact xAI models resolve automatically
- an explicitly mapped `xai/grok-4.6` OpenAI-compatible deployment preserves that qualified wire value and uses xAI capability/pricing authority
- an unmapped compatible deployment remains unpriced and receives no xAI capability
- lookalikes, partial prefixes, double prefixes, and bare cross-provider mapping targets fail closed

## Test plan

- RED: exact current xAI catalog lookup failed before registration
- RED: qualified OpenAI-compatible xAI mapping was rejected before binding support
- RED: final typed/extra reasoning normalization was absent
- `CARGO_BUILD_JOBS=2 cargo test xai_ --lib -- --nocapture --test-threads=1` (20 passed)
- `python3 scripts/sync_litellm_pricing.py --check --source-catalog config/model_prices_extended.json`
- `cargo fmt --check`
- `CARGO_BUILD_JOBS=2 cargo check`
- `CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test -- --test-threads=1`

## Official sources

- [Grok 4.5 model contract](https://docs.x.ai/developers/models/grok-4.5)
- [Grok 4.6 model contract](https://docs.x.ai/developers/models/grok-4.6)
- [xAI reasoning contract](https://docs.x.ai/developers/model-capabilities/text/reasoning)

Related: #1213

Fixes #1234

## AI assistance disclosure

AI assistance was used for implementation, test drafting, and review. Maintainer review remains required.