### PR TITLE
fix(runtime): select capable facade deployments

### DIFF
--- a/src/core/completion/default_router/router_impl.rs
+++ b/src/core/completion/default_router/router_impl.rs
@@ -7,6 +7,7 @@ use crate::core::completion::{
 };
 use crate::core::router::RuntimeHandle;
 use crate::core::types::context::RequestContext;
+use crate::core::types::model::ProviderCapability;
 use futures::stream::StreamExt;
 
 fn reject_provider_overrides(options: &CompletionOptions) -> Result<()> {
@@ -39,23 +40,27 @@ pub(super) async fn complete_with_runtime_handle(
     let chat_request = convert_to_chat_completion_request(model, chat_messages, options)?;
     let context = RequestContext::new();
     let execution = handle
-        .execute_with_selected_deployment_typed(model, move |deployment| {
-            let mut request = chat_request.clone();
-            let context = context.clone();
-            async move {
-                request.model = deployment.model.clone();
-                let response = deployment
-                    .provider
-                    .chat_completion(request, context)
-                    .await?;
-                let tokens = response
-                    .usage
-                    .as_ref()
-                    .map(|usage| u64::from(usage.total_tokens))
-                    .unwrap_or_default();
-                Ok((response, tokens))
-            }
-        })
+        .execute_with_selected_deployment_capability_typed(
+            model,
+            &ProviderCapability::ChatCompletion,
+            move |deployment| {
+                let mut request = chat_request.clone();
+                let context = context.clone();
+                async move {
+                    request.model = deployment.model.clone();
+                    let response = deployment
+                        .provider
+                        .chat_completion(request, context)
+                        .await?;
+                    let tokens = response
+                        .usage
+                        .as_ref()
+                        .map(|usage| u64::from(usage.total_tokens))
+                        .unwrap_or_default();
+                    Ok((response, tokens))
+                }
+            },
+        )
         .await
         .map_err(GatewayError::from)?;
 
@@ -74,7 +79,10 @@ pub(super) async fn complete_stream_with_runtime_handle(
     chat_request.stream = true;
     let context = RequestContext::new();
     let lease = handle
-        .select_deployment_lease_typed(model)
+        .select_deployment_lease_for_capability_typed(
+            model,
+            &ProviderCapability::ChatCompletionStream,
+        )
         .map_err(GatewayError::from)?;
     let deployment = lease.clone_deployment();
     chat_request.model = deployment.model.clone();

--- a/src/core/completion/tests.rs
+++ b/src/core/completion/tests.rs
@@ -486,9 +486,6 @@ fn unary_completion_source_has_no_legacy_execution_fallback() {
             "unary completion must not contain legacy fallback: {forbidden}"
         );
     }
-    assert!(unary.contains("execute_with_selected_deployment_capability_typed"));
-    assert!(unary.contains("ProviderCapability::ChatCompletion"));
-
     let stream_start = end;
     let stream_end = source[stream_start..]
         .find("#[async_trait]")
@@ -507,8 +504,6 @@ fn unary_completion_source_has_no_legacy_execution_fallback() {
             "streaming completion must not contain legacy fallback: {forbidden}"
         );
     }
-    assert!(stream.contains("select_deployment_lease_for_capability_typed"));
-    assert!(stream.contains("ProviderCapability::ChatCompletionStream"));
     assert!(stream.contains("let _lease = &lease"));
 
     let facade = include_str!("default_router/mod.rs");

--- a/src/core/completion/tests.rs
+++ b/src/core/completion/tests.rs
@@ -2,10 +2,11 @@
 
 use super::*;
 use crate::core::net::ProviderEndpointAccess;
-use crate::core::providers::Provider;
 use crate::core::providers::base::BaseConfig;
 use crate::core::providers::openai::{OpenAIConfig, OpenAIProvider};
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::providers::{DeepgramProvider, Provider};
+use crate::core::router::config::{RouterConfig, RoutingStrategy};
 use crate::core::router::{Deployment, RuntimeBinding, UnifiedRouter};
 use crate::core::types::message::MessageRole;
 use crate::sdk::LLMClient;
@@ -15,6 +16,23 @@ use crate::utils::error::gateway_error::GatewayError;
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+fn non_chat_deployment(id: &str, public_model: &str) -> Deployment {
+    let mut deployment = Deployment::new(
+        id.to_string(),
+        Provider::Deepgram(
+            DeepgramProvider::new(BaseConfig {
+                api_key: Some("deepgram-test-key".to_string()),
+                ..Default::default()
+            })
+            .expect("non-chat provider should build"),
+        ),
+        "nova-3".to_string(),
+        public_model.to_string(),
+    );
+    deployment.config.priority = 0;
+    deployment
+}
 
 #[test]
 fn test_message_creation() {
@@ -123,36 +141,38 @@ async fn explicit_completion_facade_executes_selected_runtime_deployment() {
 }
 
 #[tokio::test]
-async fn explicit_completion_stream_executes_selected_runtime_deployment() {
+async fn runtime_handle_capability_filters_non_streaming_for_completion_and_sdk() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("mock provider should bind");
     let address = listener.local_addr().expect("mock address should exist");
     let upstream = tokio::spawn(async move {
-        let (mut socket, _) = listener.accept().await.expect("request should arrive");
-        let mut request = vec![0_u8; 8192];
-        let bytes = socket
-            .read(&mut request)
-            .await
-            .expect("request should read");
-        let request = String::from_utf8_lossy(&request[..bytes]);
-        assert!(request.starts_with("POST /v1/chat/completions HTTP/1.1"));
-        assert!(request.contains(r#""model":"canonical-stream-model""#));
-        assert!(request.contains(r#""stream":true"#));
+        for _ in 0..2 {
+            let (mut socket, _) = listener.accept().await.expect("request should arrive");
+            let mut request = vec![0_u8; 8192];
+            let bytes = socket
+                .read(&mut request)
+                .await
+                .expect("request should read");
+            let request = String::from_utf8_lossy(&request[..bytes]);
+            assert!(request.starts_with("POST /v1/chat/completions HTTP/1.1"));
+            assert!(request.contains(r#""model":"canonical-stream-model""#));
+            assert!(request.contains(r#""stream":true"#));
 
-        let body = concat!(
-            "data: {\"id\":\"chatcmpl-runtime-stream\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"canonical-stream-model\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"runtime-stream\"},\"finish_reason\":null}]}\n\n",
-            "data: [DONE]\n\n"
-        );
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket
-            .write_all(response.as_bytes())
-            .await
-            .expect("response should write");
+            let body = concat!(
+                "data: {\"id\":\"chatcmpl-runtime-stream\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"canonical-stream-model\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"runtime-stream\"},\"finish_reason\":null}]}\n\n",
+                "data: [DONE]\n\n"
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("response should write");
+        }
     });
 
     let provider = OpenAIProvider::new(OpenAIConfig {
@@ -166,17 +186,29 @@ async fn explicit_completion_stream_executes_selected_runtime_deployment() {
     })
     .await
     .expect("provider should build");
-    let runtime = Arc::new(UnifiedRouter::default());
-    runtime.add_deployment(Deployment::new(
+    let runtime = Arc::new(UnifiedRouter::new(RouterConfig {
+        routing_strategy: RoutingStrategy::PriorityBased,
+        ..Default::default()
+    }));
+    runtime.add_deployment(non_chat_deployment(
+        "non-streaming-deployment",
+        "stream-facade-model",
+    ));
+    let mut stream_deployment = Deployment::new(
         "canonical-stream-deployment".to_string(),
         Provider::OpenAI(provider),
         "canonical-stream-model".to_string(),
         "stream-facade-model".to_string(),
-    ));
+    );
+    stream_deployment.config.priority = 10;
+    runtime.add_deployment(stream_deployment);
     let deployment = runtime
         .get_deployment("canonical-stream-deployment")
         .expect("stream deployment should exist");
-    let facade = DefaultRouter::from_runtime(RuntimeBinding::new(runtime));
+    let binding = RuntimeBinding::new(runtime);
+    let facade = DefaultRouter::from_runtime(binding.clone());
+    let sdk_facade = LLMClient::from_runtime(binding, "stream-facade-model")
+        .expect("SDK runtime facade should build");
 
     let mut stream = facade
         .complete_stream(
@@ -213,11 +245,47 @@ async fn explicit_completion_stream_executes_selected_runtime_deployment() {
             .load(std::sync::atomic::Ordering::Relaxed),
         0
     );
+
+    let mut sdk_stream = sdk_facade
+        .chat_stream(vec![SdkMessage {
+            role: SdkRole::User,
+            content: Some(SdkContent::Text("hello".to_string())),
+            name: None,
+            tool_calls: None,
+        }])
+        .await
+        .expect("canonical SDK stream should start");
+    assert_eq!(
+        deployment
+            .state
+            .active_requests
+            .load(std::sync::atomic::Ordering::Relaxed),
+        1
+    );
+    let sdk_chunk = sdk_stream
+        .next()
+        .await
+        .expect("SDK stream should yield a chunk")
+        .expect("SDK chunk should succeed");
+    assert_eq!(sdk_chunk.id, "chatcmpl-runtime-stream");
+    assert_eq!(sdk_chunk.model, "canonical-stream-model");
+    assert_eq!(
+        sdk_chunk.choices[0].delta.content.as_deref(),
+        Some("runtime-stream")
+    );
+    drop(sdk_stream);
+    assert_eq!(
+        deployment
+            .state
+            .active_requests
+            .load(std::sync::atomic::Ordering::Relaxed),
+        0
+    );
     upstream.await.expect("mock provider should finish");
 }
 
 #[tokio::test]
-async fn completion_and_sdk_facades_share_runtime_selection_and_error_categories() {
+async fn runtime_handle_capability_filters_non_chat_for_completion_and_sdk() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("mock provider should bind");
@@ -257,13 +325,22 @@ async fn completion_and_sdk_facades_share_runtime_selection_and_error_categories
     })
     .await
     .expect("provider should build");
-    let runtime = Arc::new(UnifiedRouter::default());
-    runtime.add_deployment(Deployment::new(
+    let runtime = Arc::new(UnifiedRouter::new(RouterConfig {
+        routing_strategy: RoutingStrategy::PriorityBased,
+        ..Default::default()
+    }));
+    runtime.add_deployment(non_chat_deployment(
+        "non-chat-deployment",
+        "public-runtime-model",
+    ));
+    let mut chat = Deployment::new(
         "shared-runtime-deployment".to_string(),
         Provider::OpenAI(provider),
         "shared-runtime-model".to_string(),
         "public-runtime-model".to_string(),
-    ));
+    );
+    chat.config.priority = 10;
+    runtime.add_deployment(chat);
     let binding = RuntimeBinding::new(runtime);
     let completion_facade = DefaultRouter::from_runtime(binding.clone());
     let sdk_facade = LLMClient::from_runtime(binding, "public-runtime-model")
@@ -409,7 +486,8 @@ fn unary_completion_source_has_no_legacy_execution_fallback() {
             "unary completion must not contain legacy fallback: {forbidden}"
         );
     }
-    assert!(unary.contains("execute_with_selected_deployment_typed"));
+    assert!(unary.contains("execute_with_selected_deployment_capability_typed"));
+    assert!(unary.contains("ProviderCapability::ChatCompletion"));
 
     let stream_start = end;
     let stream_end = source[stream_start..]
@@ -429,7 +507,8 @@ fn unary_completion_source_has_no_legacy_execution_fallback() {
             "streaming completion must not contain legacy fallback: {forbidden}"
         );
     }
-    assert!(stream.contains("select_deployment_lease_typed"));
+    assert!(stream.contains("select_deployment_lease_for_capability_typed"));
+    assert!(stream.contains("ProviderCapability::ChatCompletionStream"));
     assert!(stream.contains("let _lease = &lease"));
 
     let facade = include_str!("default_router/mod.rs");

--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -31,7 +31,7 @@ impl Router {
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
         let snapshot = self.load_routing_snapshot();
-        self.execute_with_retry_inner(snapshot.as_ref(), model_name, operation)
+        self.execute_with_retry_inner(snapshot.as_ref(), model_name, None, operation)
             .await
             .map(
                 |(value, deployment_id, _model_used, attempts, latency_us)| {
@@ -67,6 +67,7 @@ impl Router {
         &self,
         snapshot: &RoutingSnapshot,
         model_name: &str,
+        capability: Option<&ProviderCapability>,
         operation: F,
     ) -> Result<(T, DeploymentId, String, u32, u64), (ProviderError, u32)>
     where
@@ -82,11 +83,21 @@ impl Router {
             let start = std::time::Instant::now();
 
             // Try to select a deployment
-            let deployment_lease = match self.select_deployment_lease_matching_in_snapshot(
-                snapshot,
-                model_name,
-                |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
-            ) {
+            let selected = match capability {
+                Some(capability) => self
+                    .select_deployment_lease_for_capability_matching_in_snapshot(
+                        snapshot,
+                        model_name,
+                        capability,
+                        |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
+                    ),
+                None => self.select_deployment_lease_matching_in_snapshot(
+                    snapshot,
+                    model_name,
+                    |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
+                ),
+            };
+            let deployment_lease = match selected {
                 Ok(lease) => lease,
                 Err(router_err) => {
                     if !excluded_budget_deployments.is_empty()
@@ -178,7 +189,11 @@ impl Router {
         Err((
             last_error.unwrap_or_else(|| ProviderError::Other {
                 provider: "router",
-                message: "Unknown error during retry".to_string(),
+                message: if capability.is_some() {
+                    "Unknown error during capability retry".to_string()
+                } else {
+                    "Unknown error during retry".to_string()
+                },
             }),
             max_attempts,
         ))
@@ -197,110 +212,13 @@ impl Router {
         Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
     {
         let snapshot = self.load_routing_snapshot();
-        let max_attempts = self.config.num_retries + 1;
-        let mut attempt = 1;
-        let mut last_error = None;
-        let mut excluded_budget_deployments = HashSet::new();
-
-        while attempt <= max_attempts {
-            let start = std::time::Instant::now();
-
-            let deployment_lease = match self
-                .select_deployment_lease_for_capability_matching_in_snapshot(
-                    snapshot.as_ref(),
-                    model_name,
-                    capability,
-                    |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
-                ) {
-                Ok(lease) => lease,
-                Err(router_err) => {
-                    if !excluded_budget_deployments.is_empty()
-                        && let Some(err) = last_error.clone()
-                    {
-                        return Err((err, attempt));
-                    }
-
-                    let provider_err = router_error_to_provider_error(router_err);
-
-                    let retry_decision = RetryPolicy.decide(
-                        &self.config,
-                        &provider_err,
-                        RetryContext::unary(attempt, max_attempts),
-                    );
-                    if retry_decision.should_retry {
-                        last_error = Some(provider_err);
-                        attempt += 1;
-                        if let Some(delay) = retry_decision.delay {
-                            tokio::time::sleep(delay).await;
-                        }
-                        continue;
-                    } else {
-                        return Err((provider_err, attempt));
-                    }
-                }
-            };
-            let selected_deployment = deployment_lease.clone_deployment();
-            let deployment_id = selected_deployment.id.clone();
-
-            let result = operation(selected_deployment.clone()).await;
-            let latency_us = start.elapsed().as_micros() as u64;
-
-            match result {
-                Ok((value, tokens_used)) => {
-                    self.record_success_for_deployment(
-                        deployment_lease.deployment(),
-                        tokens_used,
-                        latency_us,
-                    );
-                    drop(deployment_lease);
-                    return Ok((value, deployment_id, attempt, latency_us));
-                }
-                Err(err) => {
-                    if retryable_budget_scope(&err).is_some() {
-                        excluded_budget_deployments.insert(deployment_id);
-                        drop(deployment_lease);
-                        last_error = Some(err);
-                        continue;
-                    }
-
-                    let retry_decision = RetryPolicy.decide_for_deployment(
-                        &self.config,
-                        &selected_deployment.config,
-                        &err,
-                        RetryContext::unary(attempt, max_attempts),
-                    );
-                    if retry_decision.should_retry {
-                        self.record_failure_with_reason_for_deployment(
-                            deployment_lease.deployment(),
-                            CooldownReason::ConsecutiveFailures,
-                        );
-                        drop(deployment_lease);
-                        last_error = Some(err);
-                        attempt += 1;
-                        if let Some(delay) = retry_decision.delay {
-                            tokio::time::sleep(delay).await;
-                        }
-                        continue;
-                    } else {
-                        let cooldown_reason = infer_cooldown_reason(&err);
-                        self.record_failure_with_reason_for_deployment(
-                            deployment_lease.deployment(),
-                            cooldown_reason,
-                        );
-                        drop(deployment_lease);
-                        return Err((err, attempt));
-                    }
-                }
-            }
-        }
-
-        Err((
-            last_error.unwrap_or_else(|| ProviderError::Other {
-                provider: "router",
-                message: "Unknown error during capability retry".to_string(),
-            }),
-            max_attempts,
-        ))
+        self.execute_with_retry_inner(snapshot.as_ref(), model_name, Some(capability), operation)
+            .await
+            .map(
+                |(value, deployment_id, _model_used, attempts, latency_us)| {
+                    (value, deployment_id, attempts, latency_us)
+                },
+            )
     }
 
     /// Execute a request for a single model with retry logic, constrained to
@@ -349,6 +267,7 @@ impl Router {
         self.execute_with_selected_deployment_in_snapshot_typed(
             snapshot.as_ref(),
             model_name,
+            None,
             operation,
         )
         .await
@@ -359,6 +278,7 @@ impl Router {
         &self,
         snapshot: &RoutingSnapshot,
         model_name: &str,
+        capability: Option<&ProviderCapability>,
         operation: F,
     ) -> Result<ExecutionResult<T>, ProviderError>
     where
@@ -400,7 +320,7 @@ impl Router {
             }
 
             match self
-                .execute_with_retry_inner(snapshot, model, operation.clone())
+                .execute_with_retry_inner(snapshot, model, capability, operation.clone())
                 .await
             {
                 Ok((result, deployment_id, model_used, attempts, _latency_us)) => {
@@ -544,6 +464,28 @@ impl RuntimeHandle {
             .execute_with_selected_deployment_in_snapshot_typed(
                 self.snapshot.as_ref(),
                 model_name,
+                None,
+                operation,
+            )
+            .await
+    }
+
+    pub(crate) async fn execute_with_selected_deployment_capability_typed<T, F, Fut>(
+        &self,
+        model_name: &str,
+        capability: &ProviderCapability,
+        operation: F,
+    ) -> Result<ExecutionResult<T>, ProviderError>
+    where
+        F: Fn(Arc<Deployment>) -> Fut + Clone,
+        Fut: std::future::Future<Output = Result<(T, u64), ProviderError>>,
+    {
+        self.binding
+            .router
+            .execute_with_selected_deployment_in_snapshot_typed(
+                self.snapshot.as_ref(),
+                model_name,
+                Some(capability),
                 operation,
             )
             .await

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -501,16 +501,18 @@ impl Router {
 }
 
 impl RuntimeHandle {
-    /// Select and reserve a deployment from this handle's pinned generation.
-    pub(crate) fn select_deployment_lease_typed(
+    /// Select and reserve a capable deployment from this handle's pinned generation.
+    pub(crate) fn select_deployment_lease_for_capability_typed(
         &self,
         model_name: &str,
+        capability: &ProviderCapability,
     ) -> Result<DeploymentLease, crate::core::providers::ProviderError> {
         self.binding
             .router
-            .select_deployment_lease_matching_in_snapshot(
+            .select_deployment_lease_for_capability_matching_in_snapshot(
                 self.snapshot.as_ref(),
                 model_name,
+                capability,
                 |_| true,
             )
             .map_err(router_error_to_provider_error)

--- a/src/sdk/client/runtime.rs
+++ b/src/sdk/client/runtime.rs
@@ -4,6 +4,7 @@ use super::LLMClient;
 use crate::core::router::RuntimeHandle;
 use crate::core::types::chat::{ChatMessage as CoreMessage, ChatRequest as CoreChatRequest};
 use crate::core::types::context::RequestContext;
+use crate::core::types::model::ProviderCapability;
 use crate::core::types::responses::{
     ChatChunk as CoreChatChunk, ChatResponse as CoreChatResponse, FinishReason,
 };
@@ -45,23 +46,27 @@ impl LLMClient {
         let context = RequestContext::new();
         let execution = self
             .runtime_handle()?
-            .execute_with_selected_deployment_typed(&model, move |deployment| {
-                let mut request = core_request.clone();
-                let context = context.clone();
-                async move {
-                    request.model = deployment.model.clone();
-                    let response = deployment
-                        .provider
-                        .chat_completion(request, context)
-                        .await?;
-                    let tokens = response
-                        .usage
-                        .as_ref()
-                        .map(|usage| u64::from(usage.total_tokens))
-                        .unwrap_or_default();
-                    Ok((response, tokens))
-                }
-            })
+            .execute_with_selected_deployment_capability_typed(
+                &model,
+                &ProviderCapability::ChatCompletion,
+                move |deployment| {
+                    let mut request = core_request.clone();
+                    let context = context.clone();
+                    async move {
+                        request.model = deployment.model.clone();
+                        let response = deployment
+                            .provider
+                            .chat_completion(request, context)
+                            .await?;
+                        let tokens = response
+                            .usage
+                            .as_ref()
+                            .map(|usage| u64::from(usage.total_tokens))
+                            .unwrap_or_default();
+                        Ok((response, tokens))
+                    }
+                },
+            )
             .await
             .map_err(SDKError::from)?;
 
@@ -85,7 +90,10 @@ impl LLMClient {
         let context = RequestContext::new();
         let handle = self.runtime_handle()?;
         let lease = handle
-            .select_deployment_lease_typed(&model)
+            .select_deployment_lease_for_capability_typed(
+                &model,
+                &ProviderCapability::ChatCompletionStream,
+            )
             .map_err(SDKError::from)?;
         let deployment = lease.clone_deployment();
         let mut core_request = core_request;


### PR DESCRIPTION
## Summary

- make runtime-backed unary chat selection require ChatCompletion
- make runtime-backed streaming selection require ChatCompletionStream
- keep capability filtering inside the pinned RuntimeHandle snapshot across fallback and retry
- preserve typed provider errors and streaming lease accounting for DefaultRouter and LLMClient

## TDD evidence

RED:
- cargo test --lib runtime_handle_capability -- --nocapture selected higher-priority Deepgram and failed with NotSupported for chat completion
- cargo test --lib runtime_handle_capability_filters_non_streaming -- --nocapture selected higher-priority Deepgram and failed with NotSupported for streaming

GREEN:
- cargo test --lib runtime_handle_capability — 2 passed
- cargo test --lib core::completion — 74 passed
- cargo test --lib sdk::client — 101 passed
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test — 9335 passed, 1 ignored

All verification was rerun after syncing to latest origin/main.

Fixes #1254