### PR TITLE
fix(k8s): make raw manifests bootable

### DIFF
--- a/deployment/kubernetes/configmap.yaml
+++ b/deployment/kubernetes/configmap.yaml
@@ -8,91 +8,117 @@ metadata:
     app.kubernetes.io/component: config
 data:
   gateway.yaml: |
+    schema_version: "1.0"
+
     server:
       host: "0.0.0.0"
       port: 8000
       workers: 4
+      max_connections: 1000
       timeout: 30
       max_body_size: 10485760
-      
+      dev_mode: false
+
+    # This credential-free local profile lets the gateway boot before an
+    # external provider is configured. Replace it for production traffic.
     providers:
-      - name: "openai-primary"
-        provider_type: "openai"
-        enabled: true
-        weight: 100
-        config:
-          api_key: "${OPENAI_API_KEY}"
-          base_url: "https://api.openai.com/v1"
+      - name: "local-vllm"
+        provider_type: "vllm"
+        api_key: ""
+        weight: 1.0
+        priority: 0
+        rpm: 1000
+        tpm: 100000
+        max_concurrent_requests: 100
+        timeout: 30
+        max_retries: 3
         models:
-          - "gpt-4"
-          - "gpt-3.5-turbo"
-        health_check:
-          enabled: true
-          interval: 30
-          timeout: 10
-          retries: 3
-          
-      - name: "anthropic-backup"
-        provider_type: "anthropic"
+          - "local-model"
+        tags: ["local"]
         enabled: true
-        weight: 80
-        config:
-          api_key: "${ANTHROPIC_API_KEY}"
-          base_url: "https://api.anthropic.com"
-        models:
-          - "claude-3-opus-20240229"
-          - "claude-3-sonnet-20240229"
-          
+
     router:
-      strategy: "least_latency"
-      health_check_interval: 30
-      retry_attempts: 3
-      provider_timeout: 30
-      
-    auth:
-      jwt:
-        enabled: true
-        secret: "${JWT_SECRET}"
-        expiration: 3600
-      api_key:
-        enabled: true
-        header: "Authorization"
-      rbac:
-        enabled: true
-        default_role: "user"
-        
+      strategy: "round_robin"
+      circuit_breaker:
+        failure_threshold: 5
+        recovery_timeout: 60
+        min_requests: 10
+        success_threshold: 3
+      load_balancer:
+        health_check_enabled: false
+        sticky_sessions: false
+        session_timeout: 3600
+
     storage:
       database:
-        url: "${DATABASE_URL}"
-        max_connections: 10
-        connection_timeout: 30
-      redis:
-        url: "${REDIS_URL}"
+        url: "postgresql://localhost/litellm"
         max_connections: 10
         connection_timeout: 5
-        
-    caching:
-      memory:
-        enabled: true
-        max_size: 1000
-        ttl: 300
+        ssl: false
+        enabled: false
+        auto_migrate: false
       redis:
-        enabled: true
-        ttl: 3600
-        key_prefix: "gateway:"
-        
+        url: "redis://localhost:6379"
+        enabled: false
+        max_connections: 20
+        connection_timeout: 5
+        cluster: false
+      vector_db: null
+
+    auth:
+      enable_jwt: false
+      enable_api_key: true
+      jwt_secret: ""
+      jwt_expiration: 86400
+      api_key_header: "Authorization"
+      allow_anonymous: false
+      rbac:
+        enabled: false
+        default_role: "user"
+        admin_roles: ["admin", "superuser"]
+
     monitoring:
       metrics:
         enabled: true
         port: 9090
         path: "/metrics"
-      health:
-        enabled: true
-        path: "/health"
-      logging:
-        level: "info"
-        format: "json"
+        interval_seconds: 15
       tracing:
-        enabled: true
-        endpoint: "${JAEGER_ENDPOINT}"
-        service_name: "rust-litellm-gateway"
+        enabled: false
+        endpoint: null
+        service_name: "litellm-rs"
+        sampling_rate: 0.1
+        jaeger: null
+      health:
+        path: "/health"
+        detailed: true
+      logging: null
+
+    cache:
+      enabled: false
+      ttl: 3600
+      max_size: 1000
+      semantic_cache: false
+      similarity_threshold: 0.95
+
+    pricing:
+      source: "embedded://model_prices_extended"
+      allow_degraded: false
+      unpriced_model_policy: allow_unpriced
+      unpriced_fallback_cost_per_1k_tokens: 0.0
+
+    rate_limit:
+      enabled: true
+      strategy: token_bucket
+      default_rpm: 1000
+      default_tpm: 100000
+      requests_per_second: null
+      requests_per_minute: null
+      tokens_per_minute: null
+      burst_size: null
+
+    enterprise:
+      enabled: false
+      sso: null
+      audit_logging: false
+      advanced_analytics: false

--- a/deployment/kubernetes/deployment.yaml
+++ b/deployment/kubernetes/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: litellm-gateway
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.6.0"
 spec:
   replicas: 3
   strategy:
@@ -23,20 +23,20 @@ spec:
       labels:
         app.kubernetes.io/name: litellm-gateway
         app.kubernetes.io/component: gateway
-        app.kubernetes.io/version: "0.1.0"
+        app.kubernetes.io/version: "0.6.0"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
     spec:
-      serviceAccountName: litellm-gateway
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
         fsGroup: 1001
       containers:
       - name: gateway
-        image: majiayu000/litellm-rs:0.1.0
+        # Replace with the immutable image promoted by your deployment pipeline.
+        image: litellm-rs:latest
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -50,9 +50,6 @@ spec:
           value: "info"
         - name: RUST_BACKTRACE
           value: "1"
-        envFrom:
-        - secretRef:
-            name: litellm-gateway-secrets
         volumeMounts:
         - name: config
           mountPath: /app/config
@@ -76,7 +73,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /health
+            path: /health/ready
             port: http
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/deployment/kubernetes/namespace.yaml
+++ b/deployment/kubernetes/namespace.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     name: litellm-gateway
     app.kubernetes.io/name: litellm-gateway
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.6.0"

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -66,6 +66,24 @@ mod tests {
         assert!(config.providers()[0].base_url.is_none());
     }
 
+    #[test]
+    fn test_kubernetes_configmap_matches_gateway_schema() {
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("deployment/kubernetes/configmap.yaml");
+        let content = fs::read_to_string(path).expect("Kubernetes ConfigMap should exist");
+        let manifest: serde_yml::Value =
+            serde_yml::from_str(&content).expect("ConfigMap should be valid YAML");
+        let gateway_yaml = manifest["data"]["gateway.yaml"]
+            .as_str()
+            .expect("ConfigMap data.gateway.yaml should be a string");
+        let gateway: GatewayConfig =
+            serde_yml::from_str(gateway_yaml).expect("embedded gateway config should deserialize");
+
+        Config { gateway }
+            .validate()
+            .expect("embedded gateway config should validate");
+    }
+
     /// Test that server port 0 fails validation
     #[test]
     fn test_gateway_config_port_zero() {


### PR DESCRIPTION
## Summary

- replace the stale ConfigMap with a current, validated GatewayConfig
- remove the unused missing ServiceAccount reference and stale secret dependency
- use the correct liveness/readiness endpoints and a replaceable image value
- add a regression test that parses and validates the embedded gateway configuration

## Verification

- RED: focused config test failed on the old providers[].config field
- cargo test --test lib test_kubernetes_configmap_matches_gateway_schema
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test -- --test-threads=1
- kubectl apply --dry-run=client -f deployment/kubernetes/ against an ephemeral Kind v1.32.2 cluster
- git diff --check

The ephemeral cluster was deleted and the previous kubectl context was restored after validation.

Closes #1284