### PR TITLE
docs(perf): add reproducible gateway benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A high-performance Rust library and gateway for calling LLM APIs in an OpenAI-co
 
 - **60+ runtime-wired providers** - OpenAI, Anthropic, AWS Bedrock, Mistral, Cloudflare, plus 50+ OpenAI-compatible providers via the Tier 1 catalog. See [Provider Support](#provider-support) for the full matrix.
 - **OpenAI-Compatible API** - Drop-in replacement for OpenAI SDK
-- **High Performance** - 10,000+ requests/second, <10ms routing overhead
+- **Measured Performance** - Reproducible [gateway-overhead benchmark methodology](./docs/benchmarks/gateway-overhead.md)
 - **Intelligent Routing** - Load balancing, failover, cost optimization
 - **Gateway Controls** - Default-on prompt-injection guardrails, configured IP access, auth, rate limiting, deterministic caching, metrics, and health endpoints
 
@@ -334,10 +334,13 @@ while let Some(chunk) = stream.next().await {
 
 ## Performance
 
-- **Throughput**: 10,000+ requests/second
-- **Latency**: <10ms routing overhead
-- **Memory**: ~50MB base footprint
-- **Concurrency**: Fully async with Tokio
+Gateway throughput and latency claims require a dated raw artifact tied to an
+exact Git revision. See the [reproducible gateway-overhead benchmark
+methodology](./docs/benchmarks/gateway-overhead.md) for the fixed workload,
+commands, environment metadata, percentile reporting, and artifact format.
+
+The Criterion benchmarks under `benches/` measure in-process components; they
+must not be presented as end-to-end HTTP gateway throughput.
 
 ## Troubleshooting
 

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -31,7 +31,7 @@ gateway, runs a 10-second warmup, then measures for 60 seconds at concurrency
 64. It rejects unrecorded Cargo/Rust build overrides and fails if the Git tree
 or HEAD changes, the exact tool version differs, either benchmark port is
 already owned, a spawned service exits, the output artifact exists, or any
-request fails.
+request fails or returns a status other than HTTP 200.
 
 Keep the load generator, gateway, and mock on an otherwise idle machine. Record
 every run rather than selecting the best result. For comparisons, use the same

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -1,0 +1,107 @@
+# Reproducible gateway-overhead benchmark
+
+This benchmark measures the HTTP gateway path around a deterministic local
+OpenAI-compatible upstream. It does not measure model inference, public network
+latency, provider quality, or a production configuration.
+
+The workload exercises request parsing, routing, provider HTTP transport,
+response parsing, and response serialization. Authentication, caching, rate
+limits, metrics, tracing, storage, and guardrails are disabled in the dedicated
+configuration so the result has one stated boundary.
+
+## Prerequisites and exact command
+
+- macOS or Linux
+- the repository's Rust toolchain
+- `python3`, `curl`, and `jq`
+- [`oha` 1.16.0](https://github.com/hatoo/oha/releases/tag/v1.16.0)
+
+Install the pinned load-generator release and run from a clean checkout:
+
+```bash
+cargo install oha --version 1.16.0 --locked
+scripts/bench/run_gateway_overhead.sh \
+  artifacts/benchmarks/gateway-overhead-$(date -u +%Y-%m-%d).json
+```
+
+The script builds `gateway` with the recorded `build_flags` of `--release --bin
+gateway`, validates the benchmark config, starts the deterministic mock and
+gateway, runs a 10-second warmup, then measures for 60 seconds at concurrency
+64. It fails if the Git tree is dirty, the tool version differs, a service
+cannot start, or any request fails.
+
+Keep the load generator, gateway, and mock on an otherwise idle machine. Record
+every run rather than selecting the best result. For comparisons, use the same
+host, toolchain, workload, and power settings. The load generator and gateway
+share CPU in this baseline, so the result is reproducible local-system evidence,
+not an absolute gateway ceiling.
+
+## Deterministic upstream boundary
+
+[`mock_openai.py`](../../scripts/bench/mock_openai.py) accepts only local HTTP
+requests and returns the same compact chat-completion bytes for every valid
+`POST /v1/chat/completions`. Its ID, timestamp, token usage, and content are
+fixed, and it injects no delay. The gateway is configured by
+[`gateway-overhead.yaml`](../../scripts/bench/gateway-overhead.yaml) to route
+only `benchmark-model` to that mock.
+
+This isolates gateway overhead from model and Internet latency. It does not
+subtract direct-to-mock latency: the published value is the complete observed
+gateway request latency under this stated topology.
+
+## Raw artifact format
+
+The output is JSON with stable top-level metadata, a concise result summary,
+and the unmodified `oha_raw` JSON. A result is publishable only with all fields
+below. `latency_ms` is end-to-end client-observed latency.
+
+```json
+{
+  "schema_version": 1,
+  "captured_at": "2026-08-31T00:00:00Z",
+  "source": {
+    "git_sha": "full Git commit SHA",
+    "git_dirty": false,
+    "build_flags": ["--release", "--bin", "gateway"]
+  },
+  "environment": {
+    "hardware": {
+      "cpu_model": "recorded CPU model",
+      "logical_cpus": 8,
+      "memory_bytes": 17179869184
+    },
+    "os": {"name": "Darwin", "release": "...", "architecture": "arm64"},
+    "rust": "complete rustc -Vv output",
+    "cargo": "cargo version",
+    "oha": "oha 1.16.0"
+  },
+  "workload": {
+    "concurrency": 64,
+    "warmup_seconds": 10,
+    "duration_seconds": 60,
+    "request_bytes": 88,
+    "response_bytes": 389,
+    "protocol": "HTTP/1.1 keep-alive",
+    "route": "POST /v1/chat/completions",
+    "upstream": "deterministic local mock, fixed response, zero injected delay"
+  },
+  "results": {
+    "requests_per_second": 0.0,
+    "latency_ms": {"p50": 0.0, "p95": 0.0, "p99": 0.0},
+    "error_rate": 0.0
+  },
+  "oha_raw": {}
+}
+```
+
+Throughput is `requests_per_second`; latency reporting must include `p50`,
+`p95`, and `p99`; `error_rate` is `1 - oha_raw.summary.successRate`. The raw
+payload retains the status-code and transport-error distributions needed to
+audit that summary.
+
+## Publishing claims
+
+A README throughput or latency number must link to a dated artifact produced by
+this command and identify its Git SHA. Criterion microbenchmarks in `benches/`
+are valuable for regression investigation, but they are not evidence for
+end-to-end gateway RPS or HTTP latency claims.

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -13,7 +13,8 @@ configuration so the result has one stated boundary.
 
 - macOS or Linux
 - the repository's Rust toolchain
-- `python3`, `curl`, and `jq`
+- `python3`, `curl`, and `jq` (`python3 -VV` is recorded because the mock is
+  part of the measured path)
 - [`oha` 1.16.0](https://github.com/hatoo/oha/releases/tag/v1.16.0)
 
 Install the pinned load-generator release and run from a clean checkout:
@@ -21,14 +22,16 @@ Install the pinned load-generator release and run from a clean checkout:
 ```bash
 cargo install oha --version 1.16.0 --locked
 scripts/bench/run_gateway_overhead.sh \
-  artifacts/benchmarks/gateway-overhead-$(date -u +%Y-%m-%d).json
+  artifacts/benchmarks/gateway-overhead-$(date -u +%Y-%m-%dT%H%M%SZ).json
 ```
 
 The script builds `gateway` with the recorded `build_flags` of `--release --bin
 gateway`, validates the benchmark config, starts the deterministic mock and
 gateway, runs a 10-second warmup, then measures for 60 seconds at concurrency
-64. It fails if the Git tree is dirty, the tool version differs, a service
-cannot start, or any request fails.
+64. It rejects unrecorded Cargo/Rust build overrides and fails if the Git tree
+or HEAD changes, the exact tool version differs, either benchmark port is
+already owned, a spawned service exits, the output artifact exists, or any
+request fails.
 
 Keep the load generator, gateway, and mock on an otherwise idle machine. Record
 every run rather than selecting the best result. For comparisons, use the same
@@ -73,6 +76,7 @@ below. `latency_ms` is end-to-end client-observed latency.
     "os": {"name": "Darwin", "release": "...", "architecture": "arm64"},
     "rust": "complete rustc -Vv output",
     "cargo": "cargo version",
+    "python": "complete python3 -VV output",
     "oha": "oha 1.16.0"
   },
   "workload": {

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -28,10 +28,12 @@ scripts/bench/run_gateway_overhead.sh \
 The script builds `gateway` with the recorded `build_flags` of `--release --bin
 gateway`, validates the benchmark config, starts the deterministic mock and
 gateway, runs a 10-second warmup, then measures for 60 seconds at concurrency
-64. It rejects unrecorded Cargo/Rust build overrides and fails if the Git tree
-or HEAD changes, the exact tool version differs, either benchmark port is
-already owned, a spawned service exits, the output artifact exists, or any
-request fails or returns a status other than HTTP 200.
+64. It rejects unrecorded Cargo/Rust environment overrides and Cargo
+configuration outside the checked-out repository. It fails if the Git tree or
+HEAD changes, the exact tool version differs, either benchmark port is already
+owned, a spawned service exits or misses its bounded readiness deadline, the
+output artifact exists, or any request fails or returns a status other than
+HTTP 200.
 
 Keep the load generator, gateway, and mock on an otherwise idle machine. Record
 every run rather than selecting the best result. For comparisons, use the same

--- a/scripts/bench/gateway-overhead.yaml
+++ b/scripts/bench/gateway-overhead.yaml
@@ -1,0 +1,82 @@
+schema_version: "1.0"
+
+server:
+  host: "127.0.0.1"
+  port: 18080
+  workers: 4
+  max_connections: 1024
+  dev_mode: false
+
+providers:
+  - name: "benchmark-vllm"
+    provider_type: "vllm"
+    api_key: ""
+    base_url: "http://127.0.0.1:18000/v1"
+    endpoint_access: private_network
+    rpm: 4294967295
+    tpm: 4294967295
+    max_concurrent_requests: 256
+    timeout: 10
+    max_retries: 0
+    models: ["benchmark-model"]
+    enabled: true
+
+router:
+  strategy: round_robin
+  circuit_breaker:
+    failure_threshold: 5
+    recovery_timeout: 60
+    min_requests: 10
+    success_threshold: 3
+  load_balancer:
+    health_check_enabled: false
+    sticky_sessions: false
+    session_timeout: 3600
+
+storage:
+  database:
+    url: "postgresql://127.0.0.1/litellm_benchmark_disabled"
+    max_connections: 1
+    connection_timeout: 1
+    ssl: false
+    enabled: false
+    auto_migrate: false
+  redis:
+    url: "redis://127.0.0.1:6379"
+    enabled: false
+    max_connections: 1
+    connection_timeout: 1
+    cluster: false
+  vector_db: null
+
+auth:
+  enable_jwt: false
+  enable_api_key: false
+  allow_anonymous: true
+
+monitoring:
+  metrics:
+    enabled: false
+  tracing:
+    enabled: false
+
+cache:
+  enabled: false
+
+rate_limit:
+  enabled: false
+
+guardrails:
+  enabled: false
+
+ip_access:
+  enabled: false
+
+enterprise:
+  enabled: false
+
+pricing:
+  source: embedded://model_prices_extended
+  allow_degraded: false
+  unpriced_model_policy: allow_unpriced
+  unpriced_fallback_cost_per_1k_tokens: 0.0

--- a/scripts/bench/mock_openai.py
+++ b/scripts/bench/mock_openai.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Deterministic OpenAI-compatible upstream for gateway overhead benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+CHAT_RESPONSE: dict[str, Any] = {
+    "id": "chatcmpl-benchmark",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "benchmark-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "pong"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+CHAT_RESPONSE_BYTES = json.dumps(
+    CHAT_RESPONSE, separators=(",", ":"), sort_keys=True
+).encode("utf-8")
+HEALTH_RESPONSE_BYTES = b'{"status":"ok"}'
+
+
+class MockOpenAIHandler(BaseHTTPRequestHandler):
+    """Serve one fixed chat response without timestamps, randomness, or delay."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path != "/health":
+            self._send_json(404, b'{"error":"not_found"}')
+            return
+        self._send_json(200, HEALTH_RESPONSE_BYTES)
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path != "/v1/chat/completions":
+            self._send_json(404, b'{"error":"not_found"}')
+            return
+
+        content_length = self.headers.get("content-length")
+        if content_length is None:
+            self._send_json(411, b'{"error":"content_length_required"}')
+            return
+        try:
+            payload = json.loads(self.rfile.read(int(content_length)))
+        except (ValueError, json.JSONDecodeError):
+            self._send_json(400, b'{"error":"invalid_json"}')
+            return
+        if not isinstance(payload, dict):
+            self._send_json(400, b'{"error":"invalid_request"}')
+            return
+
+        self._send_json(200, CHAT_RESPONSE_BYTES)
+
+    def _send_json(self, status: int, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+
+class MockOpenAIServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def create_server(host: str, port: int) -> MockOpenAIServer:
+    return MockOpenAIServer((host, port), MockOpenAIHandler)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=18000)
+    args = parser.parse_args()
+    server = create_server(args.host, args.port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        raise SystemExit(0) from None
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/run_gateway_overhead.sh
+++ b/scripts/bench/run_gateway_overhead.sh
@@ -40,6 +40,7 @@ for variable in \
   CARGO_BUILD_RUSTC_WRAPPER \
   CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER \
   CARGO_BUILD_TARGET \
+  CARGO_TARGET_DIR \
   CARGO_INCREMENTAL; do
   if [[ ${!variable+x} ]]; then
     echo "build override is not allowed: $variable" >&2
@@ -141,11 +142,12 @@ fi
 tmp_dir=$(mktemp -d)
 mock_pid=""
 gateway_pid=""
-artifact_tmp=""
+artifact_tmp="$tmp_dir/artifact.json"
+artifact_reserved=false
 cleanup() {
   if [[ -n "$gateway_pid" ]]; then kill "$gateway_pid" 2>/dev/null || true; fi
   if [[ -n "$mock_pid" ]]; then kill "$mock_pid" 2>/dev/null || true; fi
-  if [[ -n "$artifact_tmp" ]]; then rm -f "$artifact_tmp"; fi
+  if [[ "$artifact_reserved" == true ]]; then rm -f "$output_path"; fi
   rm -rf "$tmp_dir"
 }
 trap cleanup EXIT INT TERM
@@ -192,18 +194,25 @@ oha_args=(
 oha "${oha_args[@]}" \
   -z "${WARMUP_SECONDS}s" \
   http://127.0.0.1:18080/v1/chat/completions >"$tmp_dir/warmup.json"
-jq -e '.summary.successRate == 1 and (.errorDistribution | length == 0)' \
+jq -e '
+  .summary.successRate == 1 and
+  (.errorDistribution | length == 0) and
+  (.statusCodeDistribution | keys == ["200"])
+' \
   "$tmp_dir/warmup.json" >/dev/null
 
 oha "${oha_args[@]}" \
   -z "${DURATION_SECONDS}s" \
   http://127.0.0.1:18080/v1/chat/completions >"$tmp_dir/oha.json"
-jq -e '.summary.successRate == 1 and (.errorDistribution | length == 0)' \
+jq -e '
+  .summary.successRate == 1 and
+  (.errorDistribution | length == 0) and
+  (.statusCodeDistribution | keys == ["200"])
+' \
   "$tmp_dir/oha.json" >/dev/null
 
 artifact_dir=$(dirname "$output_path")
 mkdir -p "$artifact_dir"
-artifact_tmp=$(mktemp "$artifact_dir/.gateway-overhead.XXXXXX")
 jq -n \
   --arg captured_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
   --arg git_sha "$source_git_sha" \
@@ -281,12 +290,21 @@ jq -e '
 ' "$artifact_tmp" >/dev/null
 
 verify_source_unchanged
-if ! ln "$artifact_tmp" "$output_path"; then
+set -o noclobber
+if ! exec 3>"$output_path"; then
+  set +o noclobber
   echo "benchmark artifact already exists: $output_path" >&2
   exit 1
 fi
-rm -f "$artifact_tmp"
-artifact_tmp=""
+set +o noclobber
+artifact_reserved=true
+if ! cat "$artifact_tmp" >&3; then
+  exec 3>&-
+  echo "failed to publish benchmark artifact: $output_path" >&2
+  exit 1
+fi
+exec 3>&-
+artifact_reserved=false
 
 echo "wrote benchmark artifact: $output_path"
 jq '.results' "$output_path"

--- a/scripts/bench/run_gateway_overhead.sh
+++ b/scripts/bench/run_gateway_overhead.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly OHA_VERSION="1.16.0"
+readonly CONCURRENCY=64
+readonly WARMUP_SECONDS=10
+readonly DURATION_SECONDS=60
+readonly BUILD_FLAGS=(--release --bin gateway)
+
+repo_root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+output_path=${1:-}
+if [[ -z "$output_path" ]]; then
+  echo "usage: $0 <artifact.json>" >&2
+  exit 2
+fi
+
+for command in cargo curl git jq oha python3 rustc; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "required command is unavailable: $command" >&2
+    exit 1
+  fi
+done
+
+oha_version=$(oha --version)
+if [[ "$oha_version" != *"$OHA_VERSION"* ]]; then
+  echo "oha $OHA_VERSION is required; found: $oha_version" >&2
+  exit 1
+fi
+
+if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+  echo "benchmark evidence requires a clean Git worktree" >&2
+  exit 1
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    cpu_model=$(sysctl -n machdep.cpu.brand_string)
+    logical_cpus=$(sysctl -n hw.logicalcpu)
+    memory_bytes=$(sysctl -n hw.memsize)
+    ;;
+  Linux)
+    cpu_model=$(lscpu | awk -F: '/Model name/ {sub(/^[[:space:]]+/, "", $2); print $2; exit}')
+    logical_cpus=$(getconf _NPROCESSORS_ONLN)
+    memory_bytes=$(awk '/MemTotal/ {print $2 * 1024; exit}' /proc/meminfo)
+    ;;
+  *)
+    echo "unsupported benchmark host OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+if [[ -z "$cpu_model" || -z "$logical_cpus" || -z "$memory_bytes" ]]; then
+  echo "failed to collect required hardware metadata" >&2
+  exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+mock_pid=""
+gateway_pid=""
+cleanup() {
+  if [[ -n "$gateway_pid" ]]; then kill "$gateway_pid" 2>/dev/null || true; fi
+  if [[ -n "$mock_pid" ]]; then kill "$mock_pid" 2>/dev/null || true; fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+readonly request_body='{"model":"benchmark-model","messages":[{"role":"user","content":"ping"}],"stream":false}'
+request_file="$tmp_dir/request.json"
+printf '%s' "$request_body" >"$request_file"
+
+cd "$repo_root"
+cargo build "${BUILD_FLAGS[@]}"
+target/release/gateway --config scripts/bench/gateway-overhead.yaml validate-config
+
+python3 scripts/bench/mock_openai.py >"$tmp_dir/mock.log" 2>&1 &
+mock_pid=$!
+for _ in {1..100}; do
+  if curl --fail --silent http://127.0.0.1:18000/health >/dev/null; then break; fi
+  sleep 0.05
+done
+if ! curl --fail --silent http://127.0.0.1:18000/health >/dev/null; then
+  echo "mock upstream failed to start; log follows" >&2
+  sed -n '1,120p' "$tmp_dir/mock.log" >&2
+  exit 1
+fi
+
+target/release/gateway \
+  --config scripts/bench/gateway-overhead.yaml \
+  --log-level error serve >"$tmp_dir/gateway.log" 2>&1 &
+gateway_pid=$!
+for _ in {1..200}; do
+  if curl --fail --silent http://127.0.0.1:18080/health >/dev/null; then break; fi
+  sleep 0.05
+done
+if ! curl --fail --silent http://127.0.0.1:18080/health >/dev/null; then
+  echo "gateway failed to start; log follows" >&2
+  sed -n '1,160p' "$tmp_dir/gateway.log" >&2
+  exit 1
+fi
+
+response_file="$tmp_dir/response.json"
+curl --fail --silent \
+  -H 'content-type: application/json' \
+  --data-binary "@$request_file" \
+  http://127.0.0.1:18080/v1/chat/completions >"$response_file"
+jq -e '.choices[0].message.content == "pong"' "$response_file" >/dev/null
+
+oha_args=(
+  --no-tui
+  -w
+  --output-format json
+  -m POST
+  -H 'content-type: application/json'
+  -d "$request_body"
+  -c "$CONCURRENCY"
+)
+
+oha "${oha_args[@]}" \
+  -z "${WARMUP_SECONDS}s" \
+  http://127.0.0.1:18080/v1/chat/completions >"$tmp_dir/warmup.json"
+jq -e '.summary.successRate == 1 and (.errorDistribution | length == 0)' \
+  "$tmp_dir/warmup.json" >/dev/null
+
+oha "${oha_args[@]}" \
+  -z "${DURATION_SECONDS}s" \
+  http://127.0.0.1:18080/v1/chat/completions >"$tmp_dir/oha.json"
+jq -e '.summary.successRate == 1 and (.errorDistribution | length == 0)' \
+  "$tmp_dir/oha.json" >/dev/null
+
+mkdir -p "$(dirname "$output_path")"
+jq -n \
+  --arg captured_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  --arg git_sha "$(git rev-parse HEAD)" \
+  --arg os_name "$(uname -s)" \
+  --arg os_release "$(uname -r)" \
+  --arg architecture "$(uname -m)" \
+  --arg cpu_model "$cpu_model" \
+  --argjson logical_cpus "$logical_cpus" \
+  --argjson memory_bytes "$memory_bytes" \
+  --arg rust "$(rustc -Vv)" \
+  --arg cargo "$(cargo -V)" \
+  --arg oha "$oha_version" \
+  --argjson concurrency "$CONCURRENCY" \
+  --argjson warmup_seconds "$WARMUP_SECONDS" \
+  --argjson duration_seconds "$DURATION_SECONDS" \
+  --argjson request_bytes "$(wc -c <"$request_file" | tr -d ' ')" \
+  --argjson response_bytes "$(wc -c <"$response_file" | tr -d ' ')" \
+  --slurpfile raw "$tmp_dir/oha.json" \
+  '{
+    schema_version: 1,
+    captured_at: $captured_at,
+    source: {
+      git_sha: $git_sha,
+      git_dirty: false,
+      build_flags: ["--release", "--bin", "gateway"]
+    },
+    environment: {
+      hardware: {
+        cpu_model: $cpu_model,
+        logical_cpus: $logical_cpus,
+        memory_bytes: $memory_bytes
+      },
+      os: {name: $os_name, release: $os_release, architecture: $architecture},
+      rust: $rust,
+      cargo: $cargo,
+      oha: $oha
+    },
+    workload: {
+      concurrency: $concurrency,
+      warmup_seconds: $warmup_seconds,
+      duration_seconds: $duration_seconds,
+      request_bytes: $request_bytes,
+      response_bytes: $response_bytes,
+      protocol: "HTTP/1.1 keep-alive",
+      route: "POST /v1/chat/completions",
+      upstream: "deterministic local mock, fixed response, zero injected delay"
+    },
+    results: {
+      requests_per_second: $raw[0].summary.requestsPerSec,
+      latency_ms: {
+        p50: ($raw[0].latencyPercentiles.p50 * 1000),
+        p95: ($raw[0].latencyPercentiles.p95 * 1000),
+        p99: ($raw[0].latencyPercentiles.p99 * 1000)
+      },
+      error_rate: (1 - $raw[0].summary.successRate)
+    },
+    oha_raw: $raw[0]
+  }' >"$output_path"
+
+jq -e '
+  .source.git_sha and
+  .environment.hardware.cpu_model and
+  .environment.os.name and
+  .environment.rust and
+  .workload.request_bytes and
+  .workload.response_bytes and
+  .results.requests_per_second and
+  .results.latency_ms.p50 and
+  .results.latency_ms.p95 and
+  .results.latency_ms.p99 and
+  (.results.error_rate >= 0)
+' "$output_path" >/dev/null
+
+echo "wrote benchmark artifact: $output_path"
+jq '.results' "$output_path"

--- a/scripts/bench/run_gateway_overhead.sh
+++ b/scripts/bench/run_gateway_overhead.sh
@@ -13,6 +13,10 @@ if [[ -z "$output_path" ]]; then
   echo "usage: $0 <artifact.json>" >&2
   exit 2
 fi
+if [[ -e "$output_path" || -L "$output_path" ]]; then
+  echo "benchmark artifact already exists: $output_path" >&2
+  exit 1
+fi
 
 for command in cargo curl git jq oha python3 rustc; do
   if ! command -v "$command" >/dev/null 2>&1; then
@@ -22,15 +26,96 @@ for command in cargo curl git jq oha python3 rustc; do
 done
 
 oha_version=$(oha --version)
-if [[ "$oha_version" != *"$OHA_VERSION"* ]]; then
-  echo "oha $OHA_VERSION is required; found: $oha_version" >&2
+if [[ "$oha_version" != "oha $OHA_VERSION" ]]; then
+  echo "exact oha version 'oha $OHA_VERSION' is required; found: $oha_version" >&2
   exit 1
 fi
+
+for variable in \
+  RUSTFLAGS \
+  RUSTDOCFLAGS \
+  RUSTC_WRAPPER \
+  RUSTC_WORKSPACE_WRAPPER \
+  CARGO_ENCODED_RUSTFLAGS \
+  CARGO_BUILD_RUSTC_WRAPPER \
+  CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER \
+  CARGO_BUILD_TARGET \
+  CARGO_INCREMENTAL; do
+  if [[ ${!variable+x} ]]; then
+    echo "build override is not allowed: $variable" >&2
+    exit 1
+  fi
+done
+while IFS='=' read -r variable _; do
+  case "$variable" in
+    CARGO_PROFILE_RELEASE_* | CARGO_TARGET_*_RUSTFLAGS | CARGO_TARGET_*_LINKER)
+      echo "build override is not allowed: $variable" >&2
+      exit 1
+      ;;
+  esac
+done < <(env)
 
 if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
   echo "benchmark evidence requires a clean Git worktree" >&2
   exit 1
 fi
+source_git_sha=$(git -C "$repo_root" rev-parse HEAD)
+readonly source_git_sha
+python_version=$(python3 -VV 2>&1)
+readonly python_version
+
+verify_source_unchanged() {
+  if [[ "$(git -C "$repo_root" rev-parse HEAD)" != "$source_git_sha" ]] ||
+    [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+    echo "Git HEAD or worktree changed after the benchmark source was captured" >&2
+    return 1
+  fi
+}
+
+require_port_available() {
+  local port=$1
+  if ! python3 - "$port" <<'PY'
+import socket
+import sys
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+    listener.bind(("127.0.0.1", int(sys.argv[1])))
+PY
+  then
+    echo "benchmark port is already in use: 127.0.0.1:$port" >&2
+    return 1
+  fi
+}
+
+wait_for_child_service() {
+  local pid=$1
+  local url=$2
+  local log_path=$3
+  local attempts=$4
+  local label=$5
+  local attempt
+
+  for ((attempt = 0; attempt < attempts; attempt += 1)); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "$label process exited before becoming ready; log follows" >&2
+      sed -n '1,160p' "$log_path" >&2
+      return 1
+    fi
+    if curl --fail --silent "$url" >/dev/null; then
+      if ! kill -0 "$pid" 2>/dev/null; then
+        echo "$label process exited during its readiness check; log follows" >&2
+        sed -n '1,160p' "$log_path" >&2
+        return 1
+      fi
+      return 0
+    fi
+    sleep 0.05
+  done
+
+  echo "$label failed to become ready; log follows" >&2
+  sed -n '1,160p' "$log_path" >&2
+  return 1
+}
 
 case "$(uname -s)" in
   Darwin)
@@ -56,9 +141,11 @@ fi
 tmp_dir=$(mktemp -d)
 mock_pid=""
 gateway_pid=""
+artifact_tmp=""
 cleanup() {
   if [[ -n "$gateway_pid" ]]; then kill "$gateway_pid" 2>/dev/null || true; fi
   if [[ -n "$mock_pid" ]]; then kill "$mock_pid" 2>/dev/null || true; fi
+  if [[ -n "$artifact_tmp" ]]; then rm -f "$artifact_tmp"; fi
   rm -rf "$tmp_dir"
 }
 trap cleanup EXIT INT TERM
@@ -71,31 +158,19 @@ cd "$repo_root"
 cargo build "${BUILD_FLAGS[@]}"
 target/release/gateway --config scripts/bench/gateway-overhead.yaml validate-config
 
+require_port_available 18000
 python3 scripts/bench/mock_openai.py >"$tmp_dir/mock.log" 2>&1 &
 mock_pid=$!
-for _ in {1..100}; do
-  if curl --fail --silent http://127.0.0.1:18000/health >/dev/null; then break; fi
-  sleep 0.05
-done
-if ! curl --fail --silent http://127.0.0.1:18000/health >/dev/null; then
-  echo "mock upstream failed to start; log follows" >&2
-  sed -n '1,120p' "$tmp_dir/mock.log" >&2
-  exit 1
-fi
+wait_for_child_service \
+  "$mock_pid" http://127.0.0.1:18000/health "$tmp_dir/mock.log" 100 "mock upstream"
 
+require_port_available 18080
 target/release/gateway \
   --config scripts/bench/gateway-overhead.yaml \
   --log-level error serve >"$tmp_dir/gateway.log" 2>&1 &
 gateway_pid=$!
-for _ in {1..200}; do
-  if curl --fail --silent http://127.0.0.1:18080/health >/dev/null; then break; fi
-  sleep 0.05
-done
-if ! curl --fail --silent http://127.0.0.1:18080/health >/dev/null; then
-  echo "gateway failed to start; log follows" >&2
-  sed -n '1,160p' "$tmp_dir/gateway.log" >&2
-  exit 1
-fi
+wait_for_child_service \
+  "$gateway_pid" http://127.0.0.1:18080/health "$tmp_dir/gateway.log" 200 gateway
 
 response_file="$tmp_dir/response.json"
 curl --fail --silent \
@@ -126,10 +201,12 @@ oha "${oha_args[@]}" \
 jq -e '.summary.successRate == 1 and (.errorDistribution | length == 0)' \
   "$tmp_dir/oha.json" >/dev/null
 
-mkdir -p "$(dirname "$output_path")"
+artifact_dir=$(dirname "$output_path")
+mkdir -p "$artifact_dir"
+artifact_tmp=$(mktemp "$artifact_dir/.gateway-overhead.XXXXXX")
 jq -n \
   --arg captured_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-  --arg git_sha "$(git rev-parse HEAD)" \
+  --arg git_sha "$source_git_sha" \
   --arg os_name "$(uname -s)" \
   --arg os_release "$(uname -r)" \
   --arg architecture "$(uname -m)" \
@@ -138,6 +215,7 @@ jq -n \
   --argjson memory_bytes "$memory_bytes" \
   --arg rust "$(rustc -Vv)" \
   --arg cargo "$(cargo -V)" \
+  --arg python "$python_version" \
   --arg oha "$oha_version" \
   --argjson concurrency "$CONCURRENCY" \
   --argjson warmup_seconds "$WARMUP_SECONDS" \
@@ -162,6 +240,7 @@ jq -n \
       os: {name: $os_name, release: $os_release, architecture: $architecture},
       rust: $rust,
       cargo: $cargo,
+      python: $python,
       oha: $oha
     },
     workload: {
@@ -184,13 +263,14 @@ jq -n \
       error_rate: (1 - $raw[0].summary.successRate)
     },
     oha_raw: $raw[0]
-  }' >"$output_path"
+  }' >"$artifact_tmp"
 
 jq -e '
   .source.git_sha and
   .environment.hardware.cpu_model and
   .environment.os.name and
   .environment.rust and
+  .environment.python and
   .workload.request_bytes and
   .workload.response_bytes and
   .results.requests_per_second and
@@ -198,7 +278,15 @@ jq -e '
   .results.latency_ms.p95 and
   .results.latency_ms.p99 and
   (.results.error_rate >= 0)
-' "$output_path" >/dev/null
+' "$artifact_tmp" >/dev/null
+
+verify_source_unchanged
+if ! ln "$artifact_tmp" "$output_path"; then
+  echo "benchmark artifact already exists: $output_path" >&2
+  exit 1
+fi
+rm -f "$artifact_tmp"
+artifact_tmp=""
 
 echo "wrote benchmark artifact: $output_path"
 jq '.results' "$output_path"

--- a/scripts/bench/run_gateway_overhead.sh
+++ b/scripts/bench/run_gateway_overhead.sh
@@ -56,6 +56,27 @@ while IFS='=' read -r variable _; do
   esac
 done < <(env)
 
+cargo_home_dir=${CARGO_HOME:-${HOME:-}/.cargo}
+for cargo_config in "$cargo_home_dir/config.toml" "$cargo_home_dir/config"; do
+  if [[ -f "$cargo_config" ]]; then
+    echo "external Cargo configuration is not allowed: $cargo_config" >&2
+    exit 1
+  fi
+done
+ancestor_dir=$(dirname "$repo_root")
+while :; do
+  for cargo_config in "$ancestor_dir/.cargo/config.toml" "$ancestor_dir/.cargo/config"; do
+    if [[ -f "$cargo_config" ]]; then
+      echo "external Cargo configuration is not allowed: $cargo_config" >&2
+      exit 1
+    fi
+  done
+  if [[ "$ancestor_dir" == / ]]; then
+    break
+  fi
+  ancestor_dir=$(dirname "$ancestor_dir")
+done
+
 if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
   echo "benchmark evidence requires a clean Git worktree" >&2
   exit 1
@@ -102,7 +123,7 @@ wait_for_child_service() {
       sed -n '1,160p' "$log_path" >&2
       return 1
     fi
-    if curl --fail --silent "$url" >/dev/null; then
+    if curl --fail --silent --connect-timeout 0.2 --max-time 0.5 "$url" >/dev/null; then
       if ! kill -0 "$pid" 2>/dev/null; then
         echo "$label process exited during its readiness check; log follows" >&2
         sed -n '1,160p' "$log_path" >&2
@@ -125,7 +146,17 @@ case "$(uname -s)" in
     memory_bytes=$(sysctl -n hw.memsize)
     ;;
   Linux)
-    cpu_model=$(lscpu | awk -F: '/Model name/ {sub(/^[[:space:]]+/, "", $2); print $2; exit}')
+    cpu_model=""
+    if command -v lscpu >/dev/null 2>&1; then
+      cpu_model=$(lscpu 2>/dev/null | awk -F: '/Model name/ {sub(/^[[:space:]]+/, "", $2); print $2; exit}' || true)
+    fi
+    if [[ -z "$cpu_model" && -r /proc/cpuinfo ]]; then
+      cpu_model=$(awk -F: '
+        tolower($1) ~ /model name|hardware/ {
+          sub(/^[[:space:]]+/, "", $2); print $2; exit
+        }
+      ' /proc/cpuinfo)
+    fi
     logical_cpus=$(getconf _NPROCESSORS_ONLN)
     memory_bytes=$(awk '/MemTotal/ {print $2 * 1024; exit}' /proc/meminfo)
     ;;
@@ -176,6 +207,8 @@ wait_for_child_service \
 
 response_file="$tmp_dir/response.json"
 curl --fail --silent \
+  --connect-timeout 1 \
+  --max-time 5 \
   -H 'content-type: application/json' \
   --data-binary "@$request_file" \
   http://127.0.0.1:18080/v1/chat/completions >"$response_file"

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Contract tests for the reproducible gateway-overhead benchmark."""
+
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import subprocess
+import threading
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MOCK_PATH = REPO_ROOT / "scripts" / "bench" / "mock_openai.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "bench" / "run_gateway_overhead.sh"
+CONFIG_PATH = REPO_ROOT / "scripts" / "bench" / "gateway-overhead.yaml"
+METHODOLOGY_PATH = REPO_ROOT / "docs" / "benchmarks" / "gateway-overhead.md"
+
+
+def load_mock_module():
+    spec = importlib.util.spec_from_file_location("mock_openai", MOCK_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {MOCK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
+    def test_mock_upstream_returns_a_fixed_openai_response(self) -> None:
+        module = load_mock_module()
+        server = module.create_server("127.0.0.1", 0)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+
+        connection = http.client.HTTPConnection("127.0.0.1", server.server_port)
+        request = json.dumps(
+            {"model": "benchmark-model", "messages": [{"role": "user", "content": "ping"}]},
+            separators=(",", ":"),
+        )
+        connection.request(
+            "POST",
+            "/v1/chat/completions",
+            body=request,
+            headers={"content-type": "application/json"},
+        )
+        response = connection.getresponse()
+        first_body = response.read()
+        connection.close()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(json.loads(first_body), module.CHAT_RESPONSE)
+
+        connection = http.client.HTTPConnection("127.0.0.1", server.server_port)
+        connection.request(
+            "POST",
+            "/v1/chat/completions",
+            body=request,
+            headers={"content-type": "application/json"},
+        )
+        second_body = connection.getresponse().read()
+        connection.close()
+        self.assertEqual(first_body, second_body)
+
+    def test_runner_and_methodology_publish_the_required_contract(self) -> None:
+        subprocess.run(["bash", "-n", str(RUNNER_PATH)], check=True)
+        runner = RUNNER_PATH.read_text(encoding="utf-8")
+        methodology = METHODOLOGY_PATH.read_text(encoding="utf-8")
+        config = CONFIG_PATH.read_text(encoding="utf-8")
+
+        for field in (
+            "hardware",
+            "os",
+            "rust",
+            "build_flags",
+            "git_sha",
+            "concurrency",
+            "request_bytes",
+            "response_bytes",
+            "duration_seconds",
+            "warmup_seconds",
+            "requests_per_second",
+            "latency_ms",
+            "p50",
+            "p95",
+            "p99",
+            "error_rate",
+            "oha_raw",
+        ):
+            self.assertIn(field, runner)
+            self.assertIn(field, methodology)
+
+        for supported_oha_flag in ("-w", "-m POST", "-H", "-d", "-c", "-z"):
+            self.assertIn(supported_oha_flag, runner)
+        for nonexistent_oha_flag in ("--body", "--concurrency", "--duration"):
+            self.assertNotIn(nonexistent_oha_flag, runner)
+
+        self.assertIn("127.0.0.1:18000", config)
+        self.assertIn("endpoint_access: private_network", config)
+        self.assertIn("cache:\n  enabled: false", config)
+        self.assertIn("rate_limit:\n  enabled: false", config)
+
+    def test_readme_does_not_make_unpublished_gateway_performance_claims(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertNotIn("10,000+ requests/second", readme)
+        self.assertNotIn("<10ms routing overhead", readme)
+        self.assertIn("docs/benchmarks/gateway-overhead.md", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -37,6 +37,7 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         oha_version: str = "oha 1.16.0",
         extra_env: dict[str, str] | None = None,
         existing_output: bool = False,
+        external_cargo_config: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as directory:
             temp_dir = Path(directory)
@@ -53,6 +54,14 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
                 output.write_text("do not replace", encoding="utf-8")
             environment = os.environ.copy()
             environment["PATH"] = f"{bin_dir}{os.pathsep}{environment['PATH']}"
+            if external_cargo_config:
+                cargo_home = temp_dir / "cargo-home"
+                cargo_home.mkdir()
+                (cargo_home / "config.toml").write_text(
+                    '[build]\nrustflags = ["-C", "target-cpu=native"]\n',
+                    encoding="utf-8",
+                )
+                environment["CARGO_HOME"] = str(cargo_home)
             if extra_env:
                 environment.update(extra_env)
             return subprocess.run(
@@ -146,6 +155,8 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         self.assertIn("CARGO_PROFILE_RELEASE_", runner)
         self.assertIn('artifact_tmp="$tmp_dir/artifact.json"', runner)
         self.assertIn('.statusCodeDistribution | keys == ["200"]', runner)
+        self.assertIn("--max-time", runner)
+        self.assertIn("/proc/cpuinfo", runner)
         self.assertIn("%Y-%m-%dT%H%M%SZ", methodology)
 
     def test_runner_requires_the_exact_oha_release(self) -> None:
@@ -161,6 +172,10 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         result = self.run_preflight(extra_env={"CARGO_TARGET_DIR": "/tmp/other-target"})
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("build override is not allowed: CARGO_TARGET_DIR", result.stderr)
+
+        result = self.run_preflight(external_cargo_config=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("external Cargo configuration is not allowed", result.stderr)
 
     def test_runner_refuses_an_existing_artifact(self) -> None:
         result = self.run_preflight(existing_output=True)

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -144,6 +144,8 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         self.assertIn("kill -0", runner)
         self.assertIn("source_git_sha", runner)
         self.assertIn("CARGO_PROFILE_RELEASE_", runner)
+        self.assertIn('artifact_tmp="$tmp_dir/artifact.json"', runner)
+        self.assertIn('.statusCodeDistribution | keys == ["200"]', runner)
         self.assertIn("%Y-%m-%dT%H%M%SZ", methodology)
 
     def test_runner_requires_the_exact_oha_release(self) -> None:
@@ -155,6 +157,10 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         result = self.run_preflight(extra_env={"RUSTFLAGS": "-C target-cpu=native"})
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("build override is not allowed: RUSTFLAGS", result.stderr)
+
+        result = self.run_preflight(extra_env={"CARGO_TARGET_DIR": "/tmp/other-target"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("build override is not allowed: CARGO_TARGET_DIR", result.stderr)
 
     def test_runner_refuses_an_existing_artifact(self) -> None:
         result = self.run_preflight(existing_output=True)

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import http.client
 import importlib.util
 import json
+import os
 import subprocess
+import tempfile
 import threading
 import unittest
 from pathlib import Path
@@ -29,6 +31,39 @@ def load_mock_module():
 
 
 class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
+    def run_preflight(
+        self,
+        *,
+        oha_version: str = "oha 1.16.0",
+        extra_env: dict[str, str] | None = None,
+        existing_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            bin_dir = temp_dir / "bin"
+            bin_dir.mkdir()
+            fake_oha = bin_dir / "oha"
+            fake_oha.write_text(
+                f"#!/bin/sh\nprintf '%s\\n' '{oha_version}'\n",
+                encoding="utf-8",
+            )
+            fake_oha.chmod(0o755)
+            output = temp_dir / "artifact.json"
+            if existing_output:
+                output.write_text("do not replace", encoding="utf-8")
+            environment = os.environ.copy()
+            environment["PATH"] = f"{bin_dir}{os.pathsep}{environment['PATH']}"
+            if extra_env:
+                environment.update(extra_env)
+            return subprocess.run(
+                ["bash", str(RUNNER_PATH), str(output)],
+                cwd=REPO_ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
     def test_mock_upstream_returns_a_fixed_openai_response(self) -> None:
         module = load_mock_module()
         server = module.create_server("127.0.0.1", 0)
@@ -103,6 +138,28 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         self.assertIn("endpoint_access: private_network", config)
         self.assertIn("cache:\n  enabled: false", config)
         self.assertIn("rate_limit:\n  enabled: false", config)
+        self.assertIn("python", runner)
+        self.assertIn("python", methodology)
+        self.assertIn("python3 -VV", runner)
+        self.assertIn("kill -0", runner)
+        self.assertIn("source_git_sha", runner)
+        self.assertIn("CARGO_PROFILE_RELEASE_", runner)
+        self.assertIn("%Y-%m-%dT%H%M%SZ", methodology)
+
+    def test_runner_requires_the_exact_oha_release(self) -> None:
+        result = self.run_preflight(oha_version="oha 1.16.0-dev")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("exact oha version", result.stderr)
+
+    def test_runner_rejects_unrecorded_build_overrides(self) -> None:
+        result = self.run_preflight(extra_env={"RUSTFLAGS": "-C target-cpu=native"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("build override is not allowed: RUSTFLAGS", result.stderr)
+
+    def test_runner_refuses_an_existing_artifact(self) -> None:
+        result = self.run_preflight(existing_output=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("benchmark artifact already exists", result.stderr)
 
     def test_readme_does_not_make_unpublished_gateway_performance_claims(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- define a deterministic local OpenAI-compatible upstream and isolated gateway configuration
- add a pinned oha 1.16.0 runner that records hardware, OS, Rust, build flags, SHA, workload sizes, RPS, p50/p95/p99, error rate, and raw JSON
- replace unsupported README gateway RPS and latency numbers with the reproducible evidence contract

## Verification

- `python3 -B -m unittest scripts.test.test_gateway_overhead_benchmark -v` — 3 passed
- `bash -n scripts/bench/run_gateway_overhead.sh` — passed
- `shellcheck scripts/bench/run_gateway_overhead.sh` — passed
- `cargo fmt --check` — passed
- `cargo check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `target/debug/gateway --config scripts/bench/gateway-overhead.yaml validate-config` — passed
- full benchmark runner — passed release build, 10 s warmup, 60 s measurement, zero request errors, and artifact validation
- `cargo test` — 9,335 library tests passed and subsequent integration suites progressed successfully; the unmodified `gemini_sdk_routes::tests::runtime_provider_tests::gemini_sdk_route_executes_selected_runtime_provider_snapshot` then hung for more than six minutes, so the run was terminated (exit 143). CI should recheck this pre-existing integration path.

Fixes #1289