### PR TITLE
feat(admin): show provider health

### DIFF
--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -97,6 +97,7 @@ pub fn is_public_route(path: &str) -> bool {
         "/admin/dashboard",
         "/admin/dashboard/app.css",
         "/admin/dashboard/app.js",
+        "/admin/dashboard/provider-health.js",
         "/docs",
         "/openapi.json",
     ];

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -95,6 +95,7 @@ fn test_is_public_route() {
     assert!(is_public_route("/admin/dashboard"));
     assert!(is_public_route("/admin/dashboard/app.css"));
     assert!(is_public_route("/admin/dashboard/app.js"));
+    assert!(is_public_route("/admin/dashboard/provider-health.js"));
     // /metrics requires authentication (not in PUBLIC_ROUTES)
     assert!(!is_public_route("/metrics"));
     // Prefix bypass must be prevented
@@ -102,6 +103,7 @@ fn test_is_public_route() {
     assert!(!is_public_route("/admin/dashboard/"));
     assert!(!is_public_route("/admin/dashboard/private"));
     assert!(!is_public_route("/admin/dashboard/app.js.map"));
+    assert!(!is_public_route("/admin/dashboard/provider-health.js.map"));
     assert!(!is_public_route("/healthz"));
     assert!(!is_public_route("/api/users"));
     assert!(!is_public_route("/v1/chat/completions"));

--- a/src/server/routes/admin_dashboard.rs
+++ b/src/server/routes/admin_dashboard.rs
@@ -6,6 +6,7 @@ use actix_web::{HttpResponse, web};
 const INDEX_HTML: &str = include_str!("admin_dashboard/index.html");
 const APP_CSS: &str = include_str!("admin_dashboard/app.css");
 const APP_JS: &str = include_str!("admin_dashboard/app.js");
+const PROVIDER_HEALTH_JS: &str = include_str!("admin_dashboard/provider_health.js");
 const DASHBOARD_CSP: &str = "default-src 'none'; script-src 'self'; style-src 'self'; \
     connect-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'none'; \
     form-action 'self'; frame-ancestors 'none'";
@@ -30,10 +31,18 @@ async fn javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", APP_JS)
 }
 
+async fn provider_health_javascript() -> HttpResponse {
+    embedded_asset("text/javascript; charset=utf-8", PROVIDER_HEALTH_JS)
+}
+
 /// Register the exact dashboard asset routes.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/admin/dashboard", web::get().to(dashboard))
         .route("/admin/dashboard/app.css", web::get().to(stylesheet))
+        .route(
+            "/admin/dashboard/provider-health.js",
+            web::get().to(provider_health_javascript),
+        )
         .route("/admin/dashboard/app.js", web::get().to(javascript));
 }
 
@@ -61,6 +70,11 @@ mod tests {
                 "/admin/dashboard/app.js",
                 "text/javascript; charset=utf-8",
                 "\"/auth/login\"",
+            ),
+            (
+                "/admin/dashboard/provider-health.js",
+                "text/javascript; charset=utf-8",
+                "createProviderHealthView",
             ),
         ];
 
@@ -121,19 +135,19 @@ mod tests {
         ] {
             assert!(APP_JS.contains(path), "missing API path {path}");
         }
-        for forbidden in [
-            "localStorage",
-            "sessionStorage",
-            "document.cookie",
-            "innerHTML",
-            "eval(",
-            "http://",
-            "https://",
-        ] {
-            assert!(
-                !APP_JS.contains(forbidden),
-                "unsafe asset token {forbidden}"
-            );
+        assert!(PROVIDER_HEALTH_JS.contains("\"/health/detailed\""));
+        for asset in [APP_JS, PROVIDER_HEALTH_JS] {
+            for forbidden in [
+                "localStorage",
+                "sessionStorage",
+                "document.cookie",
+                "innerHTML",
+                "eval(",
+                "http://",
+                "https://",
+            ] {
+                assert!(!asset.contains(forbidden), "unsafe asset token {forbidden}");
+            }
         }
         assert!(APP_JS.contains("AbortController"));
         assert!(APP_JS.contains("session.generation !== state.generation"));

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -8,6 +8,7 @@
   --accent: #3157d5;
   --accent-strong: #2343ac;
   --danger: #b42318;
+  --healthy: #16794a;
   --focus: #ffb020;
   --shadow: 0 16px 45px rgb(23 34 56 / 10%);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
@@ -27,6 +28,7 @@
     --accent: #86a3ff;
     --accent-strong: #abc0ff;
     --danger: #ff8a80;
+    --healthy: #73d7a3;
     --focus: #ffd166;
     --shadow: 0 18px 50px rgb(0 0 0 / 28%);
   }
@@ -301,6 +303,42 @@ td code {
 .spend-grid {
   display: grid;
   gap: 1.25rem;
+}
+
+.health-summary,
+.health-notice {
+  margin: 0 0 1rem;
+}
+
+.health-summary {
+  font-weight: 730;
+}
+
+.health-notice {
+  color: var(--muted);
+}
+
+.health-state {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 730;
+  text-transform: capitalize;
+}
+
+.health-state[data-health-state="healthy"] {
+  color: var(--healthy);
+}
+
+.health-state[data-health-state="unhealthy"] {
+  color: var(--danger);
+}
+
+.health-state[data-health-state="unknown"],
+.health-state[data-health-state="disabled"] {
+  color: var(--muted);
 }
 
 .status,

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -74,6 +74,7 @@ function resetProtectedState() {
   renderKeys();
   renderTeams();
   renderSpend();
+  providerHealthView.reset();
 }
 function endSession(message = "Signed out") {
   abortActiveRequests();
@@ -89,20 +90,23 @@ function endSession(message = "Signed out") {
   byId("session-label").textContent = message;
   byId("password").value = "";
 }
-async function decodeResponse(response) {
+async function decodeResponse(response, acceptedStatuses = []) {
   const text = await response.text();
   let payload = null;
   if (text) {
     try {
       payload = JSON.parse(text);
     } catch {
-      if (!response.ok) {
+      if (!response.ok && !acceptedStatuses.includes(response.status)) {
         throw new Error(text.trim() || `Gateway request failed (${response.status}).`);
       }
       throw new Error(`Gateway returned invalid JSON (${response.status}).`);
     }
   }
-  if (!response.ok || payload?.success === false) {
+  if (
+    (!response.ok && !acceptedStatuses.includes(response.status)) ||
+    payload?.success === false
+  ) {
     const structuredError =
       typeof payload?.error === "string"
         ? payload.error
@@ -130,7 +134,12 @@ async function publicRequest(path, options, generation) {
     state.controllers.delete(controller);
   }
 }
-async function apiRequest(path, options = {}, session = captureSession()) {
+async function apiRequest(
+  path,
+  options = {},
+  session = captureSession(),
+  responsePolicy = {},
+) {
   const controller = new AbortController();
   state.controllers.add(controller);
   const headers = new Headers(options.headers || {});
@@ -152,9 +161,14 @@ async function apiRequest(path, options = {}, session = captureSession()) {
       setStatus("Session expired. Protected dashboard data was cleared.");
       throw new DOMException("Administrator session expired", "AbortError");
     }
-    const data = await decodeResponse(response);
+    const data = await decodeResponse(
+      response,
+      responsePolicy.acceptedStatuses || [],
+    );
     ensureCurrent(session);
-    return data;
+    return responsePolicy.includeStatus
+      ? { data, status: response.status }
+      : data;
   } finally {
     state.controllers.delete(controller);
   }
@@ -361,6 +375,16 @@ function renderSpend() {
   );
   byId("team-spend-empty").hidden = state.teams.length !== 0;
 }
+const providerHealthView = window.createProviderHealthView({
+  apiRequest,
+  byId,
+  captureSession,
+  clearError,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+});
 async function loadKeys(session = captureSession()) {
   const requestVersion = ++state.keyRequestVersion;
   const requestedPage = state.keyPage;
@@ -442,7 +466,11 @@ async function refreshDashboard() {
   clearError();
   setStatus("Refreshing dashboard…");
   try {
-    await Promise.all([loadKeys(session), loadTeams(session)]);
+    await Promise.all([
+      loadKeys(session),
+      loadTeams(session),
+      providerHealthView.load(session),
+    ]);
     ensureCurrent(session);
     await loadTeamUsage(session);
     ensureCurrent(session);
@@ -696,7 +724,7 @@ function showView(view) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-selected", String(active));
   }
-  for (const panel of ["keys", "teams", "spend"]) {
+  for (const panel of ["keys", "teams", "spend", "health"]) {
     byId(`${panel}-panel`).hidden = panel !== view;
   }
   if (view === "spend") {

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -6,6 +6,7 @@
   <meta name="color-scheme" content="light dark">
   <title>LiteLLM-RS Admin</title>
   <link rel="stylesheet" href="/admin/dashboard/app.css">
+  <script src="/admin/dashboard/provider-health.js" defer></script>
   <script src="/admin/dashboard/app.js" defer></script>
 </head>
 <body>
@@ -47,6 +48,8 @@
                 aria-controls="teams-panel" aria-selected="false">Teams</button>
         <button class="tab" type="button" data-view="spend"
                 aria-controls="spend-panel" aria-selected="false">Spend</button>
+        <button class="tab" type="button" data-view="health"
+                aria-controls="health-panel" aria-selected="false">Provider health</button>
       </nav>
 
       <section id="keys-panel" class="panel" aria-labelledby="keys-title">
@@ -205,6 +208,36 @@
             No teams on the current page.
           </p>
         </div>
+      </section>
+
+      <section id="health-panel" class="panel" aria-labelledby="health-title" hidden>
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Live gateway snapshot</p>
+            <h2 id="health-title">Provider health</h2>
+            <p>Enabled providers and the latest upstream probe evidence.</p>
+          </div>
+          <button id="refresh-health" class="secondary" type="button">Refresh</button>
+        </div>
+
+        <p id="health-summary" class="health-summary"></p>
+        <p id="health-notice" class="health-notice" aria-live="polite"></p>
+        <div class="table-wrap">
+          <table>
+            <caption>Configured provider health from the gateway</caption>
+            <thead>
+              <tr>
+                <th scope="col">Provider</th>
+                <th scope="col">Availability</th>
+                <th scope="col">Probe</th>
+                <th scope="col">Last probe</th>
+                <th scope="col">Detail</th>
+              </tr>
+            </thead>
+            <tbody id="health-body"></tbody>
+          </table>
+        </div>
+        <p id="health-empty" class="empty-state" hidden>No providers configured.</p>
       </section>
     </section>
   </main>

--- a/src/server/routes/admin_dashboard/provider_health.js
+++ b/src/server/routes/admin_dashboard/provider_health.js
@@ -1,0 +1,177 @@
+"use strict";
+
+window.createProviderHealthView = function createProviderHealthView({
+  apiRequest,
+  byId,
+  captureSession,
+  clearError,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+}) {
+  let snapshot = null;
+  let httpStatus = null;
+  let requestError = null;
+  let requestVersion = 0;
+
+  function formatDateTime(value) {
+    if (!value) {
+      return "Not probed";
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "Unknown" : date.toLocaleString();
+  }
+
+  function healthStateCell(status) {
+    const cell = document.createElement("td");
+    const badge = document.createElement("span");
+    badge.className = "health-state";
+    badge.dataset.healthState = status;
+    badge.textContent = status;
+    cell.append(badge);
+    return cell;
+  }
+
+  function normalizedDetails() {
+    const details = snapshot?.providers?.provider_details;
+    if (!Array.isArray(details)) {
+      return [];
+    }
+    return details.map((provider) => ({
+      ...provider,
+      status: ["healthy", "unhealthy", "unknown", "disabled"].includes(
+        provider?.status,
+      )
+        ? provider.status
+        : "unknown",
+    }));
+  }
+
+  function render() {
+    const providers = snapshot?.providers;
+    const details = normalizedDetails();
+    byId("health-body").replaceChildren(
+      ...details.map((provider) => {
+        const row = document.createElement("tr");
+        const enabled = provider.status !== "disabled";
+        const detail =
+          provider.error_message ||
+          (provider.response_time_ms == null
+            ? ""
+            : `${provider.response_time_ms} ms response`);
+        row.append(
+          textCell(provider.name),
+          textCell(enabled ? "Enabled" : "Disabled"),
+          healthStateCell(provider.status),
+          textCell(formatDateTime(provider.last_check)),
+          textCell(detail),
+        );
+        return row;
+      }),
+    );
+
+    if (!snapshot) {
+      byId("health-summary").textContent = "";
+      byId("health-notice").textContent = requestError
+        ? `Provider health unavailable: ${requestError}`
+        : "";
+      byId("health-empty").hidden = true;
+      return;
+    }
+
+    const unknownCount = details.filter(
+      (provider) => provider.status === "unknown",
+    ).length;
+    const unhealthyCount = details.filter(
+      (provider) => provider.status === "unhealthy",
+    ).length;
+    byId("health-summary").textContent = [
+      `${providers.enabled_providers ?? 0} enabled`,
+      `${providers.healthy_providers ?? 0} healthy`,
+      `${unknownCount} unknown`,
+      `${unhealthyCount} unhealthy`,
+      `${providers.total_providers ?? details.length} configured`,
+      `Aggregate: ${providers.aggregate || "unknown"}`,
+    ].join(" · ");
+
+    const notices = [];
+    if (httpStatus === 503) {
+      notices.push("Gateway reported degraded health (HTTP 503).");
+    }
+    if (unknownCount > 0) {
+      notices.push("Some enabled providers have unknown probe status.");
+    }
+    if (notices.length === 0 && snapshot.timestamp) {
+      notices.push(`Snapshot from ${formatDateTime(snapshot.timestamp)}.`);
+    }
+    byId("health-notice").textContent = notices.join(" ");
+    byId("health-empty").hidden = details.length !== 0;
+  }
+
+  function reset() {
+    requestVersion += 1;
+    snapshot = null;
+    httpStatus = null;
+    requestError = null;
+    byId("refresh-health").disabled = false;
+    render();
+  }
+
+  async function load(session = captureSession()) {
+    const version = ++requestVersion;
+    try {
+      const result = await apiRequest("/health/detailed", {}, session, {
+        acceptedStatuses: [503],
+        includeStatus: true,
+      });
+      ensureCurrent(session);
+      if (version !== requestVersion) {
+        throw new DOMException("Stale provider health response", "AbortError");
+      }
+      if (!Array.isArray(result.data?.providers?.provider_details)) {
+        throw new Error(
+          "Provider health response did not include provider details.",
+        );
+      }
+      snapshot = result.data;
+      httpStatus = result.status;
+      requestError = null;
+      render();
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        ensureCurrent(session);
+        if (version === requestVersion) {
+          snapshot = null;
+          httpStatus = null;
+          requestError = error.message || "Unknown request failure";
+          render();
+        }
+      }
+      throw error;
+    }
+  }
+
+  async function refresh(button) {
+    if (button.disabled) {
+      return;
+    }
+    button.disabled = true;
+    clearError();
+    setStatus("Refreshing provider health…");
+    try {
+      await load();
+      setStatus("Provider health refreshed.");
+    } catch (error) {
+      reportRequestError(error, "Provider health refresh failed.");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  byId("refresh-health").addEventListener("click", (event) =>
+    void refresh(event.currentTarget),
+  );
+
+  return { load, reset };
+};

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -10,6 +10,13 @@ const appSource = await readFile(
   new URL("../../src/server/routes/admin_dashboard/app.js", import.meta.url),
   "utf8",
 );
+const providerHealthSource = await readFile(
+  new URL(
+    "../../src/server/routes/admin_dashboard/provider_health.js",
+    import.meta.url,
+  ),
+  "utf8",
+);
 const immediate = () => new Promise((resolve) => setImmediate(resolve));
 async function settle(turns = 8) {
   for (let index = 0; index < turns; index += 1) {
@@ -43,17 +50,37 @@ function apiResponse(data, status = 200) {
     { status, headers: { "Content-Type": "application/json" } },
   );
 }
+function healthResponse(data, status = 200) {
+  return new Response(JSON.stringify({ success: true, data }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 function dashboard(options = {}) {
   const {
     keys = [],
     teams = [],
     usageByTeam = new Map(),
+    health = {
+      status: "degraded",
+      reason: "no providers configured",
+      timestamp: "2026-08-31T01:00:00Z",
+      providers: {
+        aggregate: "not_configured",
+        healthy_providers: 0,
+        total_providers: 0,
+        enabled_providers: 0,
+        provider_details: [],
+      },
+    },
     handler,
   } = options;
-  const htmlWithoutScript = indexHtml.replace(
-    '<script src="/admin/dashboard/app.js" defer></script>',
-    "",
-  );
+  const htmlWithoutScript = indexHtml
+    .replace(
+      '<script src="/admin/dashboard/provider-health.js" defer></script>',
+      "",
+    )
+    .replace('<script src="/admin/dashboard/app.js" defer></script>', "");
   const dom = new JSDOM(htmlWithoutScript, {
     url: "https://gateway.test/admin/dashboard",
     runScripts: "outside-only",
@@ -155,6 +182,9 @@ function dashboard(options = {}) {
         }),
       );
     }
+    if (url.pathname === "/health/detailed" && call.method === "GET") {
+      return Promise.resolve(healthResponse(health, 503));
+    }
     const usageMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/usage$/);
     if (usageMatch && call.method === "GET") {
       const result = usageByTeam.get(decodeURIComponent(usageMatch[1]));
@@ -166,6 +196,7 @@ function dashboard(options = {}) {
     }
     throw new Error(`Unexpected request: ${call.method} ${call.path}`);
   };
+  window.eval(providerHealthSource);
   window.eval(appSource);
   return context;
 }
@@ -598,4 +629,198 @@ test("B6 late refresh/create/delete responses after logout restore no protected 
     window.document.getElementById("status-region").textContent,
     /^Signed out\./,
   );
+});
+
+test("B7 provider health refresh renders enabled and probe states from a 503 snapshot", { concurrency: false }, async (t) => {
+  const refreshedHealth = deferred();
+  let healthGets = 0;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/health/detailed" && call.method === "GET") {
+        healthGets += 1;
+        if (healthGets === 2) {
+          return refreshedHealth.promise;
+        }
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+
+  const tab = window.document.querySelector('[data-view="health"]');
+  assert.ok(tab, "provider health tab is missing");
+  tab.click();
+  const refresh = window.document.getElementById("refresh-health");
+  assert.equal(refresh.type, "button");
+  assert.match(refresh.textContent, /refresh/i);
+  refresh.click();
+  await waitFor(() => healthGets === 2, "provider health refresh was not requested");
+  assert.equal(refresh.disabled, true);
+
+  refreshedHealth.resolve(
+    healthResponse(
+      {
+        status: "degraded",
+        reason: "one or more providers unhealthy",
+        timestamp: "2026-08-31T02:03:04Z",
+        providers: {
+          aggregate: "degraded",
+          healthy_providers: 1,
+          total_providers: 4,
+          enabled_providers: 3,
+          provider_details: [
+            {
+              name: "openai",
+              status: "healthy",
+              last_check: "2026-08-31T02:03:00Z",
+              response_time_ms: 18,
+              error_message: null,
+            },
+            {
+              name: "anthropic",
+              status: "unknown",
+              last_check: null,
+              response_time_ms: null,
+              error_message: "upstream health has not been established yet",
+            },
+            {
+              name: "gemini",
+              status: "unhealthy",
+              last_check: "2026-08-31T02:02:30Z",
+              response_time_ms: null,
+              error_message: "probe failed",
+            },
+            {
+              name: "ollama",
+              status: "disabled",
+              last_check: null,
+              response_time_ms: null,
+              error_message: null,
+            },
+          ],
+        },
+      },
+      503,
+    ),
+  );
+  await waitFor(() => !refresh.disabled, "provider health refresh did not settle");
+
+  assert.match(window.document.getElementById("health-summary").textContent, /3 enabled/i);
+  assert.match(window.document.getElementById("health-summary").textContent, /1 healthy/i);
+  assert.match(window.document.getElementById("health-notice").textContent, /HTTP 503/i);
+  assert.match(window.document.getElementById("health-notice").textContent, /unknown/i);
+  const rows = rowText(window, "#health-body tr");
+  assert.equal(rows.length, 4);
+  assert.match(rows[0], /openai.*enabled.*healthy/i);
+  assert.match(rows[0], /8\/31\/2026|31\/8\/2026/);
+  assert.match(rows[1], /anthropic.*enabled.*unknown.*not probed/i);
+  assert.match(rows[2], /gemini.*enabled.*unhealthy.*probe failed/i);
+  assert.match(rows[3], /ollama.*disabled/i);
+});
+
+test("B8 provider health failures are explicit and clear stale health", { concurrency: false }, async (t) => {
+  let mode = "healthy";
+  const context = dashboard({
+    health: {
+      status: "healthy",
+      reason: "ok",
+      timestamp: "2026-08-31T01:00:00Z",
+      providers: {
+        aggregate: "healthy",
+        healthy_providers: 1,
+        total_providers: 1,
+        enabled_providers: 1,
+        provider_details: [
+          { name: "openai", status: "healthy", last_check: null },
+        ],
+      },
+    },
+    handler(call) {
+      if (call.url.pathname !== "/health/detailed" || call.method !== "GET") {
+        return undefined;
+      }
+      if (mode === "network") {
+        return Promise.reject(new Error("network offline"));
+      }
+      if (mode === "unauthorized") {
+        return apiResponse("expired", 401);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  window.document.querySelector('[data-view="health"]').click();
+  assert.equal(window.document.querySelectorAll("#health-body tr").length, 1);
+
+  mode = "network";
+  window.document.getElementById("refresh-health").click();
+  await waitFor(
+    () => /network offline/i.test(window.document.getElementById("health-notice").textContent),
+    "network failure was not shown in the health view",
+  );
+  assert.equal(window.document.querySelectorAll("#health-body tr").length, 0);
+  assert.match(window.document.getElementById("error-region").textContent, /network offline/i);
+
+  mode = "unauthorized";
+  window.document.getElementById("refresh-health").click();
+  await waitFor(
+    () => !window.document.getElementById("login-panel").hidden,
+    "401 did not expire the administrator session",
+  );
+  assert.equal(window.document.getElementById("dashboard-shell").hidden, true);
+  assert.equal(window.document.getElementById("health-summary").textContent, "");
+  assert.equal(window.document.getElementById("health-notice").textContent, "");
+  assert.equal(window.document.querySelectorAll("#health-body tr").length, 0);
+  assert.match(window.document.getElementById("error-region").textContent, /session expired/i);
+});
+
+test("B9 a late provider health response after logout cannot restore stale data", { concurrency: false }, async (t) => {
+  const lateHealth = deferred();
+  let healthGets = 0;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/health/detailed" && call.method === "GET") {
+        healthGets += 1;
+        if (healthGets === 2) {
+          return lateHealth.promise;
+        }
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  window.document.querySelector('[data-view="health"]').click();
+  window.document.getElementById("refresh-health").click();
+  await waitFor(() => healthGets === 2, "late provider health request was not pending");
+
+  window.document.getElementById("sign-out").click();
+  lateHealth.resolve(
+    healthResponse({
+      status: "healthy",
+      reason: "ok",
+      timestamp: "2026-08-31T03:00:00Z",
+      providers: {
+        aggregate: "healthy",
+        healthy_providers: 1,
+        total_providers: 1,
+        enabled_providers: 1,
+        provider_details: [
+          { name: "must-not-return", status: "healthy", last_check: null },
+        ],
+      },
+    }),
+  );
+  await settle(12);
+
+  assert.equal(window.document.getElementById("dashboard-shell").hidden, true);
+  assert.equal(window.document.getElementById("health-summary").textContent, "");
+  assert.equal(window.document.getElementById("health-notice").textContent, "");
+  assert.equal(window.document.querySelectorAll("#health-body tr").length, 0);
+  assert.doesNotMatch(window.document.body.textContent, /must-not-return/);
 });


### PR DESCRIPTION
## Summary

- add a Provider health tab backed by the existing /health/detailed endpoint
- render enabled, healthy, unknown, unhealthy, disabled, and last-probe state, including usable HTTP 503 snapshots
- clear health data on network failure, 401, logout, and stale late responses
- expose the new embedded script through the exact unauthenticated asset allowlist

## Verification

- node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs (9 passed)
- cargo test admin_dashboard --lib (4 passed)
- cargo test server::middleware::tests::test_is_public_route --lib -- --exact (1 passed)
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- Patch Guard: observed 8 scoped files, including provider_health.js; no constraint violations

A full cargo test run passed the 9,335 library tests (1 ignored), 5 binary tests, api_key_budget_routes (8), audio_native_providers (19), and audio_routes (12), then hung in the batches_routes integration process for more than 13 minutes and was terminated. CI is required for final full-suite evidence.

Fixes #1262