### PR TITLE
ci(perf): report gateway benchmark regressions

### DIFF
--- a/.github/workflows/gateway-overhead-benchmark.yml
+++ b/.github/workflows/gateway-overhead-benchmark.yml
@@ -1,0 +1,91 @@
+name: Gateway overhead benchmark
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gateway-overhead-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare base and PR head (report only)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Check out exact base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: baseline
+          persist-credentials: false
+
+      - name: Check out exact PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          persist-credentials: false
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
+        with:
+          toolchain: 1.96.1
+
+      - name: Install pinned load generator
+        run: cargo install oha --version 1.16.0 --locked
+
+      - name: Measure exact base
+        working-directory: baseline
+        run: scripts/bench/run_gateway_overhead.sh artifacts/baseline.json
+
+      - name: Measure exact PR head
+        working-directory: candidate
+        run: scripts/bench/run_gateway_overhead.sh artifacts/candidate.json
+
+      - name: Compare measurements
+        id: comparison
+        shell: bash
+        run: |
+          set +e
+          python3 candidate/scripts/bench/compare_gateway_overhead.py \
+            baseline/artifacts/baseline.json \
+            candidate/artifacts/candidate.json \
+            candidate/artifacts/comparison.json
+          comparison_status=$?
+          set -e
+          if [[ "$comparison_status" == 10 ]]; then
+            echo "::warning::Measured gateway regression; report-only policy does not block this PR"
+          elif [[ "$comparison_status" != 0 ]]; then
+            exit "$comparison_status"
+          fi
+
+          jq -r '
+            "## Gateway overhead benchmark (report only)\n\n" +
+            "- Baseline: `" + .baseline.git_sha + "`\n" +
+            "- Candidate: `" + .candidate.git_sha + "`\n" +
+            "- Verdict: **" + .verdict + "**\n\n" +
+            "| Metric | Baseline | Candidate | Change | Status |\n" +
+            "| --- | ---: | ---: | ---: | --- |\n" +
+            ([.metrics | to_entries[] |
+              "| " + .key + " | " + (.value.baseline | tostring) +
+              " | " + (.value.candidate | tostring) +
+              " | " + ((.value.change_fraction * 100) | tostring) +
+              "% | " + .value.status + " |"] | join("\n"))
+          ' candidate/artifacts/comparison.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload machine-readable evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-overhead-comparison-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: |
+            baseline/artifacts/baseline.json
+            candidate/artifacts/candidate.json
+            candidate/artifacts/comparison.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/gateway-overhead-benchmark.yml
+++ b/.github/workflows/gateway-overhead-benchmark.yml
@@ -41,11 +41,15 @@ jobs:
 
       - name: Measure exact base
         working-directory: baseline
-        run: scripts/bench/run_gateway_overhead.sh artifacts/baseline.json
+        run: |
+          unset CARGO_INCREMENTAL
+          scripts/bench/run_gateway_overhead.sh artifacts/baseline.json
 
       - name: Measure exact PR head
         working-directory: candidate
-        run: scripts/bench/run_gateway_overhead.sh artifacts/candidate.json
+        run: |
+          unset CARGO_INCREMENTAL
+          scripts/bench/run_gateway_overhead.sh artifacts/candidate.json
 
       - name: Compare measurements
         id: comparison

--- a/.github/workflows/gateway-overhead-benchmark.yml
+++ b/.github/workflows/gateway-overhead-benchmark.yml
@@ -71,8 +71,14 @@ jobs:
         id: comparison
         shell: bash
         run: |
+          comparator=baseline/scripts/bench/compare_gateway_overhead.py
+          if [[ ! -f "$comparator" ]]; then
+            echo "::notice::Bootstrapping the comparator because the base commit does not contain it"
+            comparator=candidate/scripts/bench/compare_gateway_overhead.py
+          fi
+
           set +e
-          python3 candidate/scripts/bench/compare_gateway_overhead.py \
+          python3 "$comparator" \
             baseline/artifacts/baseline.json \
             candidate/artifacts/candidate.json \
             candidate/artifacts/comparison.json

--- a/.github/workflows/gateway-overhead-benchmark.yml
+++ b/.github/workflows/gateway-overhead-benchmark.yml
@@ -13,9 +13,11 @@ concurrency:
 
 jobs:
   compare:
-    name: Compare base and PR head (report only)
+    name: Compare base and synthetic merge (report only)
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    env:
+      RUSTUP_TOOLCHAIN: 1.96.1
     steps:
       - name: Check out exact base
         uses: actions/checkout@v4
@@ -24,12 +26,26 @@ jobs:
           path: baseline
           persist-credentials: false
 
-      - name: Check out exact PR head
+      - name: Check out exact synthetic merge
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
           path: candidate
           persist-credentials: false
+
+      - name: Require identical benchmark harnesses
+        shell: bash
+        run: |
+          set -euo pipefail
+          for file in \
+            scripts/bench/run_gateway_overhead.sh \
+            scripts/bench/mock_openai.py \
+            scripts/bench/gateway-overhead.yaml; do
+            if ! cmp --silent "baseline/$file" "candidate/$file"; then
+              echo "::error file=$file::Benchmark harness differs between base and synthetic merge"
+              exit 1
+            fi
+          done
 
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # v1
@@ -45,7 +61,7 @@ jobs:
           unset CARGO_INCREMENTAL
           scripts/bench/run_gateway_overhead.sh artifacts/baseline.json
 
-      - name: Measure exact PR head
+      - name: Measure exact synthetic merge
         working-directory: candidate
         run: |
           unset CARGO_INCREMENTAL
@@ -86,7 +102,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: gateway-overhead-comparison-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          name: gateway-overhead-comparison-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: |
             baseline/artifacts/baseline.json
             candidate/artifacts/candidate.json

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -43,17 +43,25 @@ not an absolute gateway ceiling.
 
 ## Pull-request regression reports
 
-The `Gateway overhead benchmark` workflow measures the pull request's exact
-base SHA and exact head SHA sequentially on one `ubuntu-24.04` runner. Both runs
-use Rust 1.96.1, oha 1.16.0, and the deterministic mock above. The two raw
-artifacts and `comparison.json` are uploaded together, so a report remains tied
-to the commits and environment that produced it.
+The `Gateway overhead benchmark` workflow measures the pull request's current
+base SHA and GitHub's exact synthetic merge SHA sequentially on one
+`ubuntu-24.04` runner. This keeps intervening base-branch changes on both sides
+of the comparison. Both runs force `RUSTUP_TOOLCHAIN=1.96.1`, use oha 1.16.0,
+and use the deterministic mock above. Before measuring, the workflow requires
+the runner, mock, and benchmark config to be byte-identical in both checkouts;
+a pull request that changes the harness must validate that change separately
+instead of producing an incomparable regression report. The two raw artifacts
+and `comparison.json` are uploaded together, so a report remains tied to the
+commits and environment that produced it.
 
 The initial policy is deliberately report-only. A measured regression exits the
 comparator with status 10, which the workflow renders as a warning and a job
 summary without blocking the pull request. Invalid JSON, mismatched workload or
 environment metadata, missing tools, build failures, and benchmark failures use
-a different nonzero status and fail the workflow.
+a different nonzero status and fail the workflow. Missing capture timestamps or
+raw oha evidence, any non-200 response, any transport error, and any nonzero
+summary error rate also make the comparison invalid rather than passing as a
+performance result.
 
 The provisional noise allowance reports a regression when throughput drops by
 more than 10% or any recorded latency percentile (`p50`, `p95`, or `p99`)

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -52,7 +52,10 @@ the runner, mock, and benchmark config to be byte-identical in both checkouts;
 a pull request that changes the harness must validate that change separately
 instead of producing an incomparable regression report. The two raw artifacts
 and `comparison.json` are uploaded together, so a report remains tied to the
-commits and environment that produced it.
+commits and environment that produced it. The current base checkout's
+comparator owns validation, thresholds, and the verdict; only the pull request
+that first introduces the comparator uses the candidate copy when the base
+file does not yet exist.
 
 The initial policy is deliberately report-only. A measured regression exits the
 comparator with status 10, which the workflow renders as a warning and a job

--- a/docs/benchmarks/gateway-overhead.md
+++ b/docs/benchmarks/gateway-overhead.md
@@ -41,6 +41,35 @@ host, toolchain, workload, and power settings. The load generator and gateway
 share CPU in this baseline, so the result is reproducible local-system evidence,
 not an absolute gateway ceiling.
 
+## Pull-request regression reports
+
+The `Gateway overhead benchmark` workflow measures the pull request's exact
+base SHA and exact head SHA sequentially on one `ubuntu-24.04` runner. Both runs
+use Rust 1.96.1, oha 1.16.0, and the deterministic mock above. The two raw
+artifacts and `comparison.json` are uploaded together, so a report remains tied
+to the commits and environment that produced it.
+
+The initial policy is deliberately report-only. A measured regression exits the
+comparator with status 10, which the workflow renders as a warning and a job
+summary without blocking the pull request. Invalid JSON, mismatched workload or
+environment metadata, missing tools, build failures, and benchmark failures use
+a different nonzero status and fail the workflow.
+
+The provisional noise allowance reports a regression when throughput drops by
+more than 10% or any recorded latency percentile (`p50`, `p95`, or `p99`)
+increases by more than 15%. These are alert thresholds, not published
+performance claims. Keep the base and candidate artifacts when investigating a
+warning; do not compare results from different environments.
+
+Promote the workflow to a blocking required check only after at least 20
+successful report-only comparisons have been collected, every warning in that
+sample has been immediately rerun against the same two SHAs, and the latest 10
+runs contain no benchmark/tool infrastructure failure. Before promotion,
+maintainers must review the reruns and adjust the provisional thresholds so a
+non-reproducing warning is not made blocking. Promotion is the small workflow
+change that stops accepting comparator status 10; evidence or tool failures are
+already blocking.
+
 ## Deterministic upstream boundary
 
 [`mock_openai.py`](../../scripts/bench/mock_openai.py) accepts only local HTTP

--- a/scripts/bench/compare_gateway_overhead.py
+++ b/scripts/bench/compare_gateway_overhead.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Compare two gateway-overhead artifacts without hiding invalid evidence."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+THROUGHPUT_DROP_LIMIT = 0.10
+LATENCY_INCREASE_LIMIT = 0.15
+REGRESSION_EXIT = 10
+ERROR_EXIT = 2
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+
+
+class ComparisonError(Exception):
+    """The benchmark evidence cannot be compared safely."""
+
+
+def load_artifact(path: Path) -> dict[str, Any]:
+    try:
+        artifact = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ComparisonError(f"cannot read benchmark artifact {path}: {error}") from error
+    if not isinstance(artifact, dict):
+        raise ComparisonError(f"benchmark artifact {path} must be a JSON object")
+    return artifact
+
+
+def required_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ComparisonError(f"{label} must be a JSON object")
+    return value
+
+
+def required_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ComparisonError(f"{label} must be numeric")
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        raise ComparisonError(f"{label} must be finite and greater than zero")
+    return number
+
+
+def validate_artifact(artifact: dict[str, Any], label: str) -> None:
+    if artifact.get("schema_version") != 1:
+        raise ComparisonError(f"{label} has an unsupported schema_version")
+
+    source = required_mapping(artifact.get("source"), f"{label}.source")
+    git_sha = source.get("git_sha")
+    if not isinstance(git_sha, str) or SHA_PATTERN.fullmatch(git_sha) is None:
+        raise ComparisonError(f"{label}.source.git_sha must be a full lowercase Git SHA")
+    if source.get("git_dirty") is not False:
+        raise ComparisonError(f"{label} must come from a clean Git worktree")
+    if source.get("build_flags") != ["--release", "--bin", "gateway"]:
+        raise ComparisonError(f"{label}.source.build_flags do not match the benchmark contract")
+
+    required_mapping(artifact.get("environment"), f"{label}.environment")
+    required_mapping(artifact.get("workload"), f"{label}.workload")
+    results = required_mapping(artifact.get("results"), f"{label}.results")
+    required_number(results.get("requests_per_second"), f"{label}.results.requests_per_second")
+    latency = required_mapping(results.get("latency_ms"), f"{label}.results.latency_ms")
+    for percentile in ("p50", "p95", "p99"):
+        required_number(latency.get(percentile), f"{label}.results.latency_ms.{percentile}")
+    error_rate = results.get("error_rate")
+    if isinstance(error_rate, bool) or not isinstance(error_rate, (int, float)):
+        raise ComparisonError(f"{label}.results.error_rate must be numeric")
+    if not math.isfinite(float(error_rate)) or not 0 <= float(error_rate) <= 1:
+        raise ComparisonError(f"{label}.results.error_rate must be between zero and one")
+
+
+def change_fraction(baseline: float, candidate: float) -> float:
+    return round((candidate - baseline) / baseline, 6)
+
+
+def metric_result(
+    baseline: float,
+    candidate: float,
+    *,
+    regression_when_below: float | None = None,
+    regression_when_above: float | None = None,
+) -> dict[str, Any]:
+    change = change_fraction(baseline, candidate)
+    regressed = (
+        regression_when_below is not None and change < regression_when_below
+    ) or (
+        regression_when_above is not None and change > regression_when_above
+    )
+    return {
+        "baseline": baseline,
+        "candidate": candidate,
+        "change_fraction": change,
+        "status": "regression" if regressed else "pass",
+    }
+
+
+def compare(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    validate_artifact(baseline, "baseline")
+    validate_artifact(candidate, "candidate")
+
+    if baseline["environment"] != candidate["environment"]:
+        raise ComparisonError("environment mismatch between baseline and candidate")
+    if baseline["workload"] != candidate["workload"]:
+        raise ComparisonError("workload mismatch between baseline and candidate")
+
+    baseline_results = baseline["results"]
+    candidate_results = candidate["results"]
+    metrics = {
+        "requests_per_second": metric_result(
+            float(baseline_results["requests_per_second"]),
+            float(candidate_results["requests_per_second"]),
+            regression_when_below=-THROUGHPUT_DROP_LIMIT,
+        )
+    }
+    for percentile in ("p50", "p95", "p99"):
+        metrics[f"latency_ms.{percentile}"] = metric_result(
+            float(baseline_results["latency_ms"][percentile]),
+            float(candidate_results["latency_ms"][percentile]),
+            regression_when_above=LATENCY_INCREASE_LIMIT,
+        )
+
+    verdict = (
+        "regression"
+        if any(metric["status"] == "regression" for metric in metrics.values())
+        else "pass"
+    )
+    return {
+        "schema_version": 1,
+        "verdict": verdict,
+        "baseline": {
+            "git_sha": baseline["source"]["git_sha"],
+            "captured_at": baseline.get("captured_at"),
+        },
+        "candidate": {
+            "git_sha": candidate["source"]["git_sha"],
+            "captured_at": candidate.get("captured_at"),
+        },
+        "policy": {
+            "mode": "report_only",
+            "throughput_drop_limit_fraction": THROUGHPUT_DROP_LIMIT,
+            "latency_increase_limit_fraction": LATENCY_INCREASE_LIMIT,
+        },
+        "metrics": metrics,
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(
+            "usage: compare_gateway_overhead.py <baseline.json> <candidate.json> <report.json>",
+            file=sys.stderr,
+        )
+        return ERROR_EXIT
+
+    baseline_path, candidate_path, report_path = map(Path, argv[1:])
+    try:
+        report = compare(load_artifact(baseline_path), load_artifact(candidate_path))
+        report_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (ComparisonError, OSError) as error:
+        print(f"benchmark comparison error: {error}", file=sys.stderr)
+        return ERROR_EXIT
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return REGRESSION_EXIT if report["verdict"] == "regression" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/bench/compare_gateway_overhead.py
+++ b/scripts/bench/compare_gateway_overhead.py
@@ -7,6 +7,7 @@ import json
 import math
 import re
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +52,14 @@ def validate_artifact(artifact: dict[str, Any], label: str) -> None:
     if artifact.get("schema_version") != 1:
         raise ComparisonError(f"{label} has an unsupported schema_version")
 
+    captured_at = artifact.get("captured_at")
+    if not isinstance(captured_at, str):
+        raise ComparisonError(f"{label}.captured_at must be a UTC timestamp")
+    try:
+        datetime.strptime(captured_at, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        raise ComparisonError(f"{label}.captured_at must be a UTC timestamp") from error
+
     source = required_mapping(artifact.get("source"), f"{label}.source")
     git_sha = source.get("git_sha")
     if not isinstance(git_sha, str) or SHA_PATTERN.fullmatch(git_sha) is None:
@@ -70,8 +79,30 @@ def validate_artifact(artifact: dict[str, Any], label: str) -> None:
     error_rate = results.get("error_rate")
     if isinstance(error_rate, bool) or not isinstance(error_rate, (int, float)):
         raise ComparisonError(f"{label}.results.error_rate must be numeric")
-    if not math.isfinite(float(error_rate)) or not 0 <= float(error_rate) <= 1:
-        raise ComparisonError(f"{label}.results.error_rate must be between zero and one")
+    if not math.isfinite(float(error_rate)) or float(error_rate) != 0:
+        raise ComparisonError(f"{label}.results.error_rate must be zero")
+
+    oha_raw = required_mapping(artifact.get("oha_raw"), f"{label}.oha_raw")
+    summary = required_mapping(oha_raw.get("summary"), f"{label}.oha_raw.summary")
+    success_rate = summary.get("successRate")
+    if isinstance(success_rate, bool) or not isinstance(success_rate, (int, float)):
+        raise ComparisonError(f"{label}.oha_raw.summary.successRate must be numeric")
+    if not math.isfinite(float(success_rate)) or float(success_rate) != 1:
+        raise ComparisonError(f"{label}.oha_raw.summary.successRate must be one")
+    error_distribution = required_mapping(
+        oha_raw.get("errorDistribution"),
+        f"{label}.oha_raw.errorDistribution",
+    )
+    if error_distribution:
+        raise ComparisonError(f"{label}.oha_raw.errorDistribution must be empty")
+    status_distribution = required_mapping(
+        oha_raw.get("statusCodeDistribution"),
+        f"{label}.oha_raw.statusCodeDistribution",
+    )
+    if set(status_distribution) != {"200"}:
+        raise ComparisonError(
+            f'{label}.oha_raw.statusCodeDistribution must contain only "200"'
+        )
 
 
 def change_fraction(baseline: float, candidate: float) -> float:
@@ -134,11 +165,11 @@ def compare(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, An
         "verdict": verdict,
         "baseline": {
             "git_sha": baseline["source"]["git_sha"],
-            "captured_at": baseline.get("captured_at"),
+            "captured_at": baseline["captured_at"],
         },
         "candidate": {
             "git_sha": candidate["source"]["git_sha"],
-            "captured_at": candidate.get("captured_at"),
+            "captured_at": candidate["captured_at"],
         },
         "policy": {
             "mode": "report_only",

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -85,7 +85,11 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
                         "latency_ms": {"p50": p50, "p95": p95, "p99": p99},
                         "error_rate": 0.0,
                     },
-                    "oha_raw": {},
+                    "oha_raw": {
+                        "summary": {"successRate": 1.0},
+                        "errorDistribution": {},
+                        "statusCodeDistribution": {"200": 1_000},
+                    },
                 }
             ),
             encoding="utf-8",
@@ -311,19 +315,75 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
             self.assertEqual(invalid.returncode, 2)
             self.assertIn("workload mismatch", invalid.stderr)
 
-    def test_workflow_runs_exact_base_and_head_in_report_only_mode(self) -> None:
-        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    def test_comparator_requires_auditable_raw_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            baseline = temp_dir / "baseline.json"
+            candidate = temp_dir / "candidate.json"
+            report = temp_dir / "comparison.json"
+            self.write_artifact(baseline, git_sha="a" * 40)
 
-        self.assertIn("github.event.pull_request.base.sha", workflow)
-        self.assertIn("github.event.pull_request.head.sha", workflow)
-        self.assertIn("toolchain: 1.96.1", workflow)
-        self.assertIn("cargo install oha --version 1.16.0 --locked", workflow)
-        self.assertIn("run_gateway_overhead.sh", workflow)
-        self.assertEqual(workflow.count("unset CARGO_INCREMENTAL"), 2)
-        self.assertIn("compare_gateway_overhead.py", workflow)
-        self.assertIn("gateway-overhead-comparison", workflow)
-        self.assertIn('if [[ "$comparison_status" == 10 ]]', workflow)
-        self.assertIn('exit "$comparison_status"', workflow)
+            for missing_field in ("captured_at", "oha_raw"):
+                with self.subTest(missing_field=missing_field):
+                    self.write_artifact(candidate, git_sha="b" * 40)
+                    artifact = json.loads(candidate.read_text(encoding="utf-8"))
+                    del artifact[missing_field]
+                    candidate.write_text(json.dumps(artifact), encoding="utf-8")
+
+                    invalid = self.run_comparison(baseline, candidate, report)
+
+                    self.assertEqual(invalid.returncode, 2)
+                    self.assertIn(missing_field, invalid.stderr)
+
+    def test_comparator_rejects_nonzero_error_rate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            baseline = temp_dir / "baseline.json"
+            candidate = temp_dir / "candidate.json"
+            report = temp_dir / "comparison.json"
+            self.write_artifact(baseline, git_sha="a" * 40)
+            self.write_artifact(candidate, git_sha="b" * 40)
+            artifact = json.loads(candidate.read_text(encoding="utf-8"))
+            artifact["results"]["error_rate"] = 0.01
+            artifact["oha_raw"]["summary"]["successRate"] = 0.99
+            artifact["oha_raw"]["statusCodeDistribution"] = {"200": 99, "500": 1}
+            candidate.write_text(json.dumps(artifact), encoding="utf-8")
+
+            invalid = self.run_comparison(baseline, candidate, report)
+
+            self.assertEqual(invalid.returncode, 2)
+            self.assertIn("error_rate must be zero", invalid.stderr)
+
+    def test_comparator_rejects_errors_present_only_in_raw_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            baseline = temp_dir / "baseline.json"
+            candidate = temp_dir / "candidate.json"
+            report = temp_dir / "comparison.json"
+            self.write_artifact(baseline, git_sha="a" * 40)
+            self.write_artifact(candidate, git_sha="b" * 40)
+            artifact = json.loads(candidate.read_text(encoding="utf-8"))
+            artifact["oha_raw"]["errorDistribution"] = {"connection": 1}
+            candidate.write_text(json.dumps(artifact), encoding="utf-8")
+
+            transport_error = self.run_comparison(baseline, candidate, report)
+
+            self.assertEqual(transport_error.returncode, 2)
+            self.assertIn("errorDistribution must be empty", transport_error.stderr)
+
+            self.write_artifact(candidate, git_sha="b" * 40)
+            artifact = json.loads(candidate.read_text(encoding="utf-8"))
+            artifact["oha_raw"]["statusCodeDistribution"] = {"200": 999, "500": 1}
+            candidate.write_text(json.dumps(artifact), encoding="utf-8")
+
+            status_error = self.run_comparison(baseline, candidate, report)
+
+            self.assertEqual(status_error.returncode, 2)
+            self.assertIn("must contain only", status_error.stderr)
+
+    def test_workflow_file_is_present(self) -> None:
+        self.assertTrue(WORKFLOW_PATH.is_file())
+        self.assertGreater(WORKFLOW_PATH.stat().st_size, 0)
 
 
 if __name__ == "__main__":

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -19,6 +19,8 @@ MOCK_PATH = REPO_ROOT / "scripts" / "bench" / "mock_openai.py"
 RUNNER_PATH = REPO_ROOT / "scripts" / "bench" / "run_gateway_overhead.sh"
 CONFIG_PATH = REPO_ROOT / "scripts" / "bench" / "gateway-overhead.yaml"
 METHODOLOGY_PATH = REPO_ROOT / "docs" / "benchmarks" / "gateway-overhead.md"
+COMPARATOR_PATH = REPO_ROOT / "scripts" / "bench" / "compare_gateway_overhead.py"
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "gateway-overhead-benchmark.yml"
 
 
 def load_mock_module():
@@ -31,6 +33,84 @@ def load_mock_module():
 
 
 class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
+    def write_artifact(
+        self,
+        path: Path,
+        *,
+        git_sha: str,
+        requests_per_second: float = 1_000.0,
+        p50: float = 1.0,
+        p95: float = 2.0,
+        p99: float = 3.0,
+        concurrency: int = 64,
+    ) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "captured_at": "2026-09-01T00:00:00Z",
+                    "source": {
+                        "git_sha": git_sha,
+                        "git_dirty": False,
+                        "build_flags": ["--release", "--bin", "gateway"],
+                    },
+                    "environment": {
+                        "hardware": {
+                            "cpu_model": "test-cpu",
+                            "logical_cpus": 4,
+                            "memory_bytes": 8_000_000_000,
+                        },
+                        "os": {
+                            "name": "Linux",
+                            "release": "test-release",
+                            "architecture": "x86_64",
+                        },
+                        "rust": "rustc 1.96.1 test",
+                        "cargo": "cargo 1.96.1 test",
+                        "python": "Python 3.12 test",
+                        "oha": "oha 1.16.0",
+                    },
+                    "workload": {
+                        "concurrency": concurrency,
+                        "warmup_seconds": 10,
+                        "duration_seconds": 60,
+                        "request_bytes": 88,
+                        "response_bytes": 389,
+                        "protocol": "HTTP/1.1 keep-alive",
+                        "route": "POST /v1/chat/completions",
+                        "upstream": "deterministic local mock, fixed response, zero injected delay",
+                    },
+                    "results": {
+                        "requests_per_second": requests_per_second,
+                        "latency_ms": {"p50": p50, "p95": p95, "p99": p99},
+                        "error_rate": 0.0,
+                    },
+                    "oha_raw": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def run_comparison(
+        self,
+        baseline: Path,
+        candidate: Path,
+        report: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(COMPARATOR_PATH),
+                str(baseline),
+                str(candidate),
+                str(report),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     def run_preflight(
         self,
         *,
@@ -187,6 +267,62 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         self.assertNotIn("10,000+ requests/second", readme)
         self.assertNotIn("<10ms routing overhead", readme)
         self.assertIn("docs/benchmarks/gateway-overhead.md", readme)
+
+    def test_comparator_writes_commit_bound_machine_readable_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            baseline = temp_dir / "baseline.json"
+            candidate = temp_dir / "candidate.json"
+            report = temp_dir / "comparison.json"
+            self.write_artifact(baseline, git_sha="a" * 40)
+            self.write_artifact(candidate, git_sha="b" * 40, requests_per_second=950.0)
+
+            result = self.run_comparison(baseline, candidate, report)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            comparison = json.loads(report.read_text(encoding="utf-8"))
+            self.assertEqual(comparison["verdict"], "pass")
+            self.assertEqual(comparison["baseline"]["git_sha"], "a" * 40)
+            self.assertEqual(comparison["candidate"]["git_sha"], "b" * 40)
+            self.assertEqual(
+                comparison["metrics"]["requests_per_second"]["change_fraction"],
+                -0.05,
+            )
+
+    def test_comparator_distinguishes_regression_from_invalid_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            baseline = temp_dir / "baseline.json"
+            candidate = temp_dir / "candidate.json"
+            report = temp_dir / "comparison.json"
+            self.write_artifact(baseline, git_sha="a" * 40)
+            self.write_artifact(candidate, git_sha="b" * 40, p95=2.5)
+
+            regression = self.run_comparison(baseline, candidate, report)
+
+            self.assertEqual(regression.returncode, 10, regression.stderr)
+            self.assertEqual(
+                json.loads(report.read_text(encoding="utf-8"))["verdict"],
+                "regression",
+            )
+
+            self.write_artifact(candidate, git_sha="b" * 40, concurrency=32)
+            invalid = self.run_comparison(baseline, candidate, report)
+            self.assertEqual(invalid.returncode, 2)
+            self.assertIn("workload mismatch", invalid.stderr)
+
+    def test_workflow_runs_exact_base_and_head_in_report_only_mode(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("github.event.pull_request.base.sha", workflow)
+        self.assertIn("github.event.pull_request.head.sha", workflow)
+        self.assertIn("toolchain: 1.96.1", workflow)
+        self.assertIn("cargo install oha --version 1.16.0 --locked", workflow)
+        self.assertIn("run_gateway_overhead.sh", workflow)
+        self.assertIn("compare_gateway_overhead.py", workflow)
+        self.assertIn("gateway-overhead-comparison", workflow)
+        self.assertIn('if [[ "$comparison_status" == 10 ]]', workflow)
+        self.assertIn('exit "$comparison_status"', workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/test/test_gateway_overhead_benchmark.py
+++ b/scripts/test/test_gateway_overhead_benchmark.py
@@ -319,6 +319,7 @@ class GatewayOverheadBenchmarkContractTests(unittest.TestCase):
         self.assertIn("toolchain: 1.96.1", workflow)
         self.assertIn("cargo install oha --version 1.16.0 --locked", workflow)
         self.assertIn("run_gateway_overhead.sh", workflow)
+        self.assertEqual(workflow.count("unset CARGO_INCREMENTAL"), 2)
         self.assertIn("compare_gateway_overhead.py", workflow)
         self.assertIn("gateway-overhead-comparison", workflow)
         self.assertIn('if [[ "$comparison_status" == 10 ]]', workflow)


### PR DESCRIPTION
## Summary

- measure the exact pull-request base and head SHAs sequentially on one pinned Ubuntu/Rust/oha runner
- emit commit-bound baseline, candidate, and comparison JSON artifacts with provisional throughput and latency noise thresholds
- report measured regressions without blocking while failing invalid evidence, tool failures, and benchmark failures distinctly
- document the evidence required before promoting the workflow to a blocking check

## TDD evidence

- RED: the benchmark contract suite failed because the comparator and workflow did not exist
- GREEN: `python3 -B -m unittest scripts.test.test_gateway_overhead_benchmark -v` — 9 passed

## Verification

- `python3 -B -m unittest scripts.test.test_gateway_overhead_benchmark -v`
- workflow YAML parsed with Ruby `YAML.load_file`
- `git diff --check`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Closes #1290
