### PR TITLE
feat(api): serve stable OpenAPI contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
     "config/model_prices_extended.json",
     "config/model_catalog_authority.json",
     "config/model_catalog_decisions.json",
+    "docs/openapi/inference.json",
     "migrations/**/*",
     ".github/workflows/*.yml",
     "build.rs",

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -718,6 +718,7 @@ mod tests {
     }
 
     include!("http_cors_tests.rs");
+    include!("http_openapi_tests.rs");
     include!("http_validation_tests.rs");
 
     #[tokio::test]

--- a/src/server/http_openapi_tests.rs
+++ b/src/server/http_openapi_tests.rs
@@ -1,0 +1,49 @@
+#[tokio::test]
+async fn app_factory_serves_public_stable_inference_openapi_contract() {
+    const SENTINEL_API_KEY: &str = "sk-must-not-appear-in-openapi";
+    const SENTINEL_PROVIDER_NAME: &str = "runtime-provider-must-not-appear";
+
+    let mut config = valid_http_test_config();
+    config.gateway.providers[0].api_key = SENTINEL_API_KEY.to_string();
+    config.gateway.providers[0].name = SENTINEL_PROVIDER_NAME.to_string();
+    config.gateway.auth.enable_jwt = true;
+    config.gateway.auth.enable_api_key = true;
+    config.gateway.auth.allow_anonymous = false;
+    config.gateway.auth.jwt_secret = "AaaAaaAaaAaaAaaAaaAaaAaaAaaAaa1!".to_string();
+    config.gateway.monitoring.metrics.enabled = false;
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    config.gateway.pricing.source = None;
+
+    let server = match HttpServer::new(&config).await {
+        Ok(server) => server,
+        Err(error) => panic!("server startup failed: {error}"),
+    };
+    let app = actix_test::init_service(HttpServer::create_app(web::Data::new(
+        server.state().clone(),
+    )))
+    .await;
+
+    let request = actix_test::TestRequest::get()
+        .uri("/openapi.json")
+        .to_request();
+    let response = actix_test::call_service(&app, request).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&header::HeaderValue::from_static("application/json"))
+    );
+    let body = actix_test::read_body(response).await;
+    let contract: serde_json::Value =
+        serde_json::from_slice(&body).expect("OpenAPI response must be valid JSON");
+
+    assert_eq!(contract["openapi"], "3.2.0");
+    assert!(contract["paths"]["/v1/chat/completions"]["post"].is_object());
+    assert!(contract["paths"]["/v1/responses/{response_id}"]["get"].is_object());
+    assert!(contract["paths"]["/v1/models"]["get"].is_object());
+    assert!(contract["paths"].get("/admin").is_none());
+    let body = String::from_utf8_lossy(&body);
+    assert!(!body.contains(SENTINEL_API_KEY));
+    assert!(!body.contains(SENTINEL_PROVIDER_NAME));
+}

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -66,6 +66,8 @@ use crate::server::state::AppState;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, error::InternalError, web};
 
+const STABLE_INFERENCE_OPENAPI: &str = include_str!("../../../../docs/openapi/inference.json");
+
 /// Configure AI API routes
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     configure_routes_impl(cfg, None);
@@ -77,7 +79,15 @@ pub fn configure_routes_with_body_limit(cfg: &mut web::ServiceConfig, max_body_s
 }
 
 fn configure_routes_impl(cfg: &mut web::ServiceConfig, max_body_size: Option<usize>) {
-    cfg.service(
+    cfg.route(
+        "/openapi.json",
+        web::get().to(|| async {
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .body(STABLE_INFERENCE_OPENAPI)
+        }),
+    )
+    .service(
         web::resource("/completions")
             .app_data(openai_json_error_config(max_body_size))
             .app_data(openai_query_error_config())


### PR DESCRIPTION
## Summary

- serve the stable inference contract at public `GET /openapi.json`
- embed `docs/openapi/inference.json` at compile time so the response cannot include runtime configuration or credentials
- cover status, JSON content type, representative operations, admin exclusion, and runtime-state isolation through the real Actix app and auth middleware
- retain the existing bidirectional stable inference method/path inventory parity check from #1293

## Scope

This PR only serves and verifies the stable inference OpenAPI contract. It adds no Swagger UI, admin API schema, dependency, or runtime configuration surface.

## TDD evidence

- RED: `cargo test app_factory_serves_public_stable_inference_openapi_contract -- --nocapture` failed with `404 != 200`
- GREEN: `cargo test openapi_contract -- --nocapture` passed all 6 endpoint and contract parity tests

## Verification

- `cargo test app_factory_serves_public_stable_inference_openapi_contract`
- `cargo test openapi_contract -- --nocapture`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `bash scripts/guards/check_pr_scope.sh origin/main`
- `bash scripts/guards/check_pr_overlap.sh`
- `git diff --check`

Full tests pass. Existing deprecation warnings and credential-gated ignored live tests are unchanged.

Closes #1258