### PR TITLE
fix(api): distinguish legacy adapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,17 +178,23 @@ alone does not make a third-party provider routeable; use the generic
 OpenAI-compatible path for compatible endpoints, or wire a code-based provider
 into the enum, dispatch, registry metadata, and factory.
 
-> The provider and route-surface matrices below are validated against the provider registry and Tier 1 catalog. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 identity and dispatch metadata lives in [`src/core/providers/registry/types.rs`](./src/core/providers/registry/types.rs), with construction branches in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Cross-surface support lives in [`src/core/providers/registry/support_matrix.rs`](./src/core/providers/registry/support_matrix.rs). Capability columns describe which endpoints this crate exposes for the provider — `passthrough` means an implemented crate endpoint forwards the call to the upstream OpenAI-compatible endpoint without per-provider transformation.
+> The provider and legacy adapter matrices below are validated against the provider registry and Tier 1 catalog. The source of truth for Tier 1 entries is [`catalog.rs`](./src/core/providers/registry/catalog.rs); Tier 2 identity and dispatch metadata lives in [`src/core/providers/registry/types.rs`](./src/core/providers/registry/types.rs), with construction branches in [`src/core/providers/factory/registry.rs`](./src/core/providers/factory/registry.rs). Legacy adapter availability lives in [`src/core/providers/registry/support_matrix.rs`](./src/core/providers/registry/support_matrix.rs). `passthrough` means a retained adapter forwards the call to the upstream OpenAI-compatible endpoint without per-provider transformation.
 
-### Route-surface matrix
+### Legacy adapter matrix
 
-| Selector class | HTTP chat / stream | HTTP embeddings / image | SDK chat / stream / embeddings | `completion()` chat / stream | Notes |
-|----------------|--------------------|--------------------------|--------------------------------|-------------------------------|-------|
+This matrix records selector-based compatibility adapters. It is not the
+capability source for `LLMClient::from_runtime`, `DefaultRouter::from_runtime`,
+or the free `completion()` functions. Canonical runtime support is derived from
+the selected deployment's `ProviderCapability`; unsupported capabilities fail
+closed with a typed provider error.
+
+| Legacy selector class | HTTP chat / stream adapter | HTTP embeddings / image adapter | SDK chat / stream / embeddings adapter | `completion()` chat / stream adapter | Notes |
+|-----------------------|----------------------------|---------------------------------|----------------------------------------|--------------------------------------|-------|
 | `openai` | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ / ✅ | ✅ / ✅ | Reference provider across all current surfaces. |
 | `anthropic` | ✅ / ✅ | – / – | ✅ / ✅ / – | ✅ / ✅ | Native chat and streaming only. |
 | `azure` | passthrough / passthrough | `providers-extra` / `providers-extra` | – / – / ✅ | passthrough / passthrough | SDK exposes Azure embeddings; SDK chat is not implemented. |
 | `azure_ai` | passthrough / passthrough | `providers-extra` / `providers-extra` | – / – / – | `providers-extra` / `providers-extra` | `completion()` supports `azure_ai/` and `azure-ai/` routes when the native feature is enabled. |
-| `bedrock` | ✅ / ✅ | ✅ / – | – / – / – | – / – | SDK Bedrock and public `completion()` routing are not implemented. |
+| `bedrock` | ✅ / ✅ | ✅ / – | – / – / – | – / – | No legacy SDK or `completion()` adapter. Configured canonical runtimes use the deployment's chat, stream, and embedding capabilities. |
 | `databricks`, `snowflake` | passthrough / passthrough | – / – | – / – / – | – / – | Governed OpenAI-compatible chat/SSE runtimes with platform-specific identity and auth. |
 | `oci` | mode-dependent | mode-dependent / – | – / – / – | – / – | Compatible mode provides chat/SSE; IAM native mode provides embeddings and rerank. |
 | `watsonx` | ✅ / – | ✅ / – | – / – / – | – / – | Native chat, embeddings, and rerank. |

--- a/src/core/pricing_service/authority.rs
+++ b/src/core/pricing_service/authority.rs
@@ -388,7 +388,7 @@ fn resolve_model_info_for_provider(
     if normalized_provider == "openai_like" {
         let parsed = ModelIdRef::parse(model);
         if let Some(prefix) = parsed.provider()
-            && crate::core::providers::registry::selector_has_matrix_entry(prefix)
+            && crate::core::providers::registry::selector_has_legacy_adapter_entry(prefix)
         {
             let prefixed_provider = canonical_pricing_selector(prefix);
             if prefixed_provider != "openai_like" {

--- a/src/core/providers/registry/mod.rs
+++ b/src/core/providers/registry/mod.rs
@@ -30,9 +30,9 @@ pub use lifecycle::{
     provider_orphan_baseline,
 };
 pub use support_matrix::{
-    ProviderRouteSurface, ProviderSurfaceSupport, SurfaceSupport, canonical_selector,
-    provider_surface_matrix, selector_has_matrix_entry, support_state_for_surface,
-    supports_provider_surface,
+    LegacyAdapterAvailability, LegacyAdapterSurface, ProviderLegacyAdapterSupport,
+    canonical_selector, legacy_adapter_availability, legacy_adapter_matrix,
+    selector_has_legacy_adapter_entry, supports_legacy_adapter,
 };
 pub use types::{
     DEFAULT_CATALOG_RUNTIME_PROVIDERS, PROVIDER_TYPE_REGISTRY, ProviderDispatchKind,

--- a/src/core/providers/registry/support_matrix.rs
+++ b/src/core/providers/registry/support_matrix.rs
@@ -1,15 +1,14 @@
-//! Cross-surface provider support matrix.
+//! Legacy adapter availability matrix.
 //!
-//! This matrix answers which provider selectors are usable through each public
-//! routing surface. Runtime capability checks still use `ProviderCapability`;
-//! this file keeps SDK and `completion()` support from drifting away from the
-//! core provider registry.
+//! This matrix records selector-based adapters from the legacy provider/config
+//! paths. Canonical runtime entry points do not consult it: they derive support
+//! from the selected deployment's `ProviderCapability`.
 
 use super::{canonical_catalog_name, entry_for_name, get_definition};
 
-/// Public route surfaces covered by the support matrix.
+/// Compatibility entry points covered by the legacy adapter matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProviderRouteSurface {
+pub enum LegacyAdapterSurface {
     HttpChat,
     HttpChatStream,
     HttpEmbeddings,
@@ -22,17 +21,17 @@ pub enum ProviderRouteSurface {
     CompletionChatStream,
 }
 
-/// Support state for one provider/surface pair.
+/// Availability state for one provider/legacy-adapter pair.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SurfaceSupport {
+pub enum LegacyAdapterAvailability {
     Supported,
     Passthrough,
     FeatureGated(&'static str),
     Unsupported,
 }
 
-impl SurfaceSupport {
-    /// True when the surface should be selected in the current binary.
+impl LegacyAdapterAvailability {
+    /// True when the legacy adapter is available in the current binary.
     pub fn is_available_in_current_build(self) -> bool {
         match self {
             Self::Supported | Self::Passthrough => true,
@@ -52,55 +51,56 @@ impl SurfaceSupport {
     }
 }
 
-/// One documented support row.
+/// One documented legacy adapter row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ProviderSurfaceSupport {
+pub struct ProviderLegacyAdapterSupport {
     pub selector: &'static str,
-    pub http_chat: SurfaceSupport,
-    pub http_chat_stream: SurfaceSupport,
-    pub http_embeddings: SurfaceSupport,
-    pub http_rerank: SurfaceSupport,
-    pub http_image_generation: SurfaceSupport,
-    pub sdk_chat: SurfaceSupport,
-    pub sdk_chat_stream: SurfaceSupport,
-    pub sdk_embeddings: SurfaceSupport,
-    pub completion_chat: SurfaceSupport,
-    pub completion_chat_stream: SurfaceSupport,
+    pub http_chat: LegacyAdapterAvailability,
+    pub http_chat_stream: LegacyAdapterAvailability,
+    pub http_embeddings: LegacyAdapterAvailability,
+    pub http_rerank: LegacyAdapterAvailability,
+    pub http_image_generation: LegacyAdapterAvailability,
+    pub sdk_chat: LegacyAdapterAvailability,
+    pub sdk_chat_stream: LegacyAdapterAvailability,
+    pub sdk_embeddings: LegacyAdapterAvailability,
+    pub completion_chat: LegacyAdapterAvailability,
+    pub completion_chat_stream: LegacyAdapterAvailability,
     pub notes: &'static str,
 }
 
-impl ProviderSurfaceSupport {
-    pub fn support_for(self, surface: ProviderRouteSurface) -> SurfaceSupport {
+impl ProviderLegacyAdapterSupport {
+    pub fn availability_for(self, surface: LegacyAdapterSurface) -> LegacyAdapterAvailability {
         match surface {
-            ProviderRouteSurface::HttpChat => self.http_chat,
-            ProviderRouteSurface::HttpChatStream => self.http_chat_stream,
-            ProviderRouteSurface::HttpEmbeddings => self.http_embeddings,
-            ProviderRouteSurface::HttpRerank => self.http_rerank,
-            ProviderRouteSurface::HttpImageGeneration => self.http_image_generation,
-            ProviderRouteSurface::SdkChat => self.sdk_chat,
-            ProviderRouteSurface::SdkChatStream => self.sdk_chat_stream,
-            ProviderRouteSurface::SdkEmbeddings => self.sdk_embeddings,
-            ProviderRouteSurface::CompletionChat => self.completion_chat,
-            ProviderRouteSurface::CompletionChatStream => self.completion_chat_stream,
+            LegacyAdapterSurface::HttpChat => self.http_chat,
+            LegacyAdapterSurface::HttpChatStream => self.http_chat_stream,
+            LegacyAdapterSurface::HttpEmbeddings => self.http_embeddings,
+            LegacyAdapterSurface::HttpRerank => self.http_rerank,
+            LegacyAdapterSurface::HttpImageGeneration => self.http_image_generation,
+            LegacyAdapterSurface::SdkChat => self.sdk_chat,
+            LegacyAdapterSurface::SdkChatStream => self.sdk_chat_stream,
+            LegacyAdapterSurface::SdkEmbeddings => self.sdk_embeddings,
+            LegacyAdapterSurface::CompletionChat => self.completion_chat,
+            LegacyAdapterSurface::CompletionChatStream => self.completion_chat_stream,
         }
     }
 }
 
-const S: SurfaceSupport = SurfaceSupport::Supported;
-const P: SurfaceSupport = SurfaceSupport::Passthrough;
-const U: SurfaceSupport = SurfaceSupport::Unsupported;
-const EXTRA: SurfaceSupport = SurfaceSupport::FeatureGated("providers-extra");
-const EXTENDED: SurfaceSupport = SurfaceSupport::FeatureGated("providers-extended");
+const S: LegacyAdapterAvailability = LegacyAdapterAvailability::Supported;
+const P: LegacyAdapterAvailability = LegacyAdapterAvailability::Passthrough;
+const U: LegacyAdapterAvailability = LegacyAdapterAvailability::Unsupported;
+const EXTRA: LegacyAdapterAvailability = LegacyAdapterAvailability::FeatureGated("providers-extra");
+const EXTENDED: LegacyAdapterAvailability =
+    LegacyAdapterAvailability::FeatureGated("providers-extended");
 
-const CATALOG_HTTP_SUPPORT: ProviderSurfaceSupport = row(
+const CATALOG_HTTP_SUPPORT: ProviderLegacyAdapterSupport = row(
     "catalog_openai_like",
     [P, P, U, U, U, U, U, U, U],
     "Generic Tier 1 catalog providers route through OpenAILike for HTTP chat/stream only.",
 );
 
 /// Explicit rows for non-catalog providers and catalog providers with
-/// additional completion() routing.
-pub static PROVIDER_SURFACE_MATRIX: &[ProviderSurfaceSupport] = &[
+/// additional legacy completion adapters.
+pub static LEGACY_ADAPTER_MATRIX: &[ProviderLegacyAdapterSupport] = &[
     row(
         "openai",
         [S, S, S, S, S, S, S, S, S],
@@ -124,7 +124,7 @@ pub static PROVIDER_SURFACE_MATRIX: &[ProviderSurfaceSupport] = &[
     row(
         "bedrock",
         [S, S, S, U, U, U, U, U, U],
-        "Core Bedrock runtime supports chat, stream, and embeddings; public completion() routing is not registered.",
+        "Core Bedrock runtime supports chat, stream, and embeddings; legacy SDK and completion adapters are absent.",
     ),
     row(
         "databricks",
@@ -156,7 +156,7 @@ pub static PROVIDER_SURFACE_MATRIX: &[ProviderSurfaceSupport] = &[
     row(
         "mistral",
         [S, S, P, U, U, U, U, U, U],
-        "Native HTTP provider; SDK/completion adapters are not implemented.",
+        "Native HTTP provider; legacy SDK/completion adapters are not implemented.",
     ),
     row(
         "cloudflare",
@@ -322,32 +322,34 @@ pub static PROVIDER_SURFACE_MATRIX: &[ProviderSurfaceSupport] = &[
     ),
 ];
 
-pub fn provider_surface_matrix() -> &'static [ProviderSurfaceSupport] {
-    PROVIDER_SURFACE_MATRIX
+pub fn legacy_adapter_matrix() -> &'static [ProviderLegacyAdapterSupport] {
+    LEGACY_ADAPTER_MATRIX
 }
 
-pub fn support_state_for_surface(
+pub fn legacy_adapter_availability(
     provider_name: &str,
-    surface: ProviderRouteSurface,
-) -> Option<SurfaceSupport> {
+    surface: LegacyAdapterSurface,
+) -> Option<LegacyAdapterAvailability> {
     let selector = canonical_selector(provider_name);
 
-    PROVIDER_SURFACE_MATRIX
+    LEGACY_ADAPTER_MATRIX
         .iter()
         .find(|entry| entry.selector == selector)
-        .map(|entry| entry.support_for(surface))
-        .or_else(|| get_definition(&selector).map(|_| CATALOG_HTTP_SUPPORT.support_for(surface)))
+        .map(|entry| entry.availability_for(surface))
+        .or_else(|| {
+            get_definition(&selector).map(|_| CATALOG_HTTP_SUPPORT.availability_for(surface))
+        })
 }
 
-pub fn supports_provider_surface(provider_name: &str, surface: ProviderRouteSurface) -> bool {
-    support_state_for_surface(provider_name, surface)
-        .map(SurfaceSupport::is_available_in_current_build)
+pub fn supports_legacy_adapter(provider_name: &str, surface: LegacyAdapterSurface) -> bool {
+    legacy_adapter_availability(provider_name, surface)
+        .map(LegacyAdapterAvailability::is_available_in_current_build)
         .unwrap_or(false)
 }
 
-pub fn selector_has_matrix_entry(provider_name: &str) -> bool {
+pub fn selector_has_legacy_adapter_entry(provider_name: &str) -> bool {
     let selector = canonical_selector(provider_name);
-    PROVIDER_SURFACE_MATRIX
+    LEGACY_ADAPTER_MATRIX
         .iter()
         .any(|entry| entry.selector == selector)
         || get_definition(&selector).is_some()
@@ -379,10 +381,10 @@ pub fn canonical_selector(provider_name: &str) -> String {
 
 const fn row(
     selector: &'static str,
-    support: [SurfaceSupport; 9],
+    support: [LegacyAdapterAvailability; 9],
     notes: &'static str,
-) -> ProviderSurfaceSupport {
-    ProviderSurfaceSupport {
+) -> ProviderLegacyAdapterSupport {
+    ProviderLegacyAdapterSupport {
         selector,
         http_chat: support[0],
         http_chat_stream: support[1],
@@ -400,10 +402,10 @@ const fn row(
 
 const fn rerank_row(
     selector: &'static str,
-    support: [SurfaceSupport; 9],
-    http_rerank: SurfaceSupport,
+    support: [LegacyAdapterAvailability; 9],
+    http_rerank: LegacyAdapterAvailability,
     notes: &'static str,
-) -> ProviderSurfaceSupport {
+) -> ProviderLegacyAdapterSupport {
     let mut result = row(selector, support, notes);
     result.http_rerank = http_rerank;
     result

--- a/src/core/providers/registry/support_matrix_tests.rs
+++ b/src/core/providers/registry/support_matrix_tests.rs
@@ -1,118 +1,135 @@
 use super::{
-    DEFAULT_CATALOG_RUNTIME_PROVIDERS, PROVIDER_CATALOG, ProviderRouteSurface, canonical_selector,
-    provider_type_registry, selector_has_matrix_entry, support_state_for_surface,
-    supports_provider_surface,
+    DEFAULT_CATALOG_RUNTIME_PROVIDERS, LegacyAdapterSurface, PROVIDER_CATALOG, canonical_selector,
+    legacy_adapter_availability, provider_type_registry, selector_has_legacy_adapter_entry,
+    supports_legacy_adapter,
 };
 use crate::core::providers::registry::{AuthType, get_definition};
 
 #[test]
-fn support_matrix_covers_registry_and_catalog_selectors() {
+fn legacy_adapter_matrix_is_distinct_from_canonical_runtime_capability() {
+    assert!(!supports_legacy_adapter(
+        "bedrock",
+        LegacyAdapterSurface::CompletionChat
+    ));
+
+    let readme = include_str!("../../../../README.md")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(readme.contains("### Legacy adapter matrix"));
+    assert!(readme.contains(
+        "Canonical runtime support is derived from the selected deployment's `ProviderCapability`"
+    ));
+}
+
+#[test]
+fn legacy_adapter_matrix_covers_registry_and_catalog_selectors() {
     for entry in provider_type_registry() {
         assert!(
-            selector_has_matrix_entry(entry.canonical_name),
-            "missing support matrix row for {}",
+            selector_has_legacy_adapter_entry(entry.canonical_name),
+            "missing legacy adapter matrix row for {}",
             entry.canonical_name
         );
     }
 
     for selector in PROVIDER_CATALOG.keys() {
         assert!(
-            selector_has_matrix_entry(selector),
-            "missing support matrix fallback for catalog selector {selector}"
+            selector_has_legacy_adapter_entry(selector),
+            "missing legacy adapter matrix fallback for catalog selector {selector}"
         );
     }
 }
 
 #[test]
-fn default_completion_catalog_routes_are_marked_supported() {
+fn default_catalog_legacy_completion_adapters_are_marked_supported() {
     for selector in DEFAULT_CATALOG_RUNTIME_PROVIDERS {
         assert!(
-            supports_provider_surface(selector, ProviderRouteSurface::CompletionChat),
-            "{selector} should support completion() chat"
+            supports_legacy_adapter(selector, LegacyAdapterSurface::CompletionChat),
+            "{selector} should have a legacy completion() chat adapter"
         );
         assert!(
-            supports_provider_surface(selector, ProviderRouteSurface::CompletionChatStream),
-            "{selector} should support completion() streaming"
+            supports_legacy_adapter(selector, LegacyAdapterSurface::CompletionChatStream),
+            "{selector} should have a legacy completion() streaming adapter"
         );
     }
 }
 
 #[test]
-fn sdk_matrix_rejects_google_chat_until_adapter_exists() {
-    assert!(supports_provider_surface(
+fn legacy_sdk_adapter_matrix_rejects_google_chat_until_adapter_exists() {
+    assert!(supports_legacy_adapter(
         "openai",
-        ProviderRouteSurface::SdkChat
+        LegacyAdapterSurface::SdkChat
     ));
-    assert!(supports_provider_surface(
+    assert!(supports_legacy_adapter(
         "anthropic",
-        ProviderRouteSurface::SdkChatStream
+        LegacyAdapterSurface::SdkChatStream
     ));
-    assert!(!supports_provider_surface(
+    assert!(!supports_legacy_adapter(
         "google",
-        ProviderRouteSurface::SdkChat
+        LegacyAdapterSurface::SdkChat
     ));
-    assert!(!supports_provider_surface(
+    assert!(!supports_legacy_adapter(
         "gemini",
-        ProviderRouteSurface::SdkChat
+        LegacyAdapterSurface::SdkChat
     ));
 }
 
 #[test]
-fn completion_matrix_matches_default_router_support() {
+fn legacy_completion_adapter_matrix_records_pre_runtime_routes() {
     for surface in [
-        ProviderRouteSurface::CompletionChat,
-        ProviderRouteSurface::CompletionChatStream,
+        LegacyAdapterSurface::CompletionChat,
+        LegacyAdapterSurface::CompletionChatStream,
     ] {
-        assert!(supports_provider_surface("azure", surface));
-        assert!(!supports_provider_surface("bedrock", surface));
+        assert!(supports_legacy_adapter("azure", surface));
+        assert!(!supports_legacy_adapter("bedrock", surface));
     }
     assert_eq!(
-        supports_provider_surface("azure_ai", ProviderRouteSurface::CompletionChat),
+        supports_legacy_adapter("azure_ai", LegacyAdapterSurface::CompletionChat),
         cfg!(feature = "providers-extra")
     );
 }
 
 #[test]
-fn catalog_fallback_is_http_chat_only() {
-    assert!(supports_provider_surface(
+fn catalog_legacy_adapter_fallback_is_http_chat_only() {
+    assert!(supports_legacy_adapter(
         "cerebras",
-        ProviderRouteSurface::HttpChat
+        LegacyAdapterSurface::HttpChat
     ));
-    assert!(supports_provider_surface(
+    assert!(supports_legacy_adapter(
         "cerebras",
-        ProviderRouteSurface::HttpChatStream
+        LegacyAdapterSurface::HttpChatStream
     ));
-    assert!(!supports_provider_surface(
+    assert!(!supports_legacy_adapter(
         "cerebras",
-        ProviderRouteSurface::CompletionChat
+        LegacyAdapterSurface::CompletionChat
     ));
-    assert!(!supports_provider_surface(
+    assert!(!supports_legacy_adapter(
         "cerebras",
-        ProviderRouteSurface::SdkChat
+        LegacyAdapterSurface::SdkChat
     ));
 }
 
 #[test]
 fn enterprise_rerank_routes_are_declared_explicitly() {
-    assert!(supports_provider_surface(
+    assert!(supports_legacy_adapter(
         "oci",
-        ProviderRouteSurface::HttpRerank
+        LegacyAdapterSurface::HttpRerank
     ));
-    assert!(supports_provider_surface(
+    assert!(supports_legacy_adapter(
         "watsonx",
-        ProviderRouteSurface::HttpRerank
+        LegacyAdapterSurface::HttpRerank
     ));
-    assert!(supports_provider_surface(
+    assert!(supports_legacy_adapter(
         "voyage",
-        ProviderRouteSurface::HttpRerank
+        LegacyAdapterSurface::HttpRerank
     ));
-    assert!(!supports_provider_surface(
+    assert!(!supports_legacy_adapter(
         "sagemaker",
-        ProviderRouteSurface::HttpRerank
+        LegacyAdapterSurface::HttpRerank
     ));
-    assert!(!supports_provider_surface(
+    assert!(!supports_legacy_adapter(
         "cerebras",
-        ProviderRouteSurface::HttpRerank
+        LegacyAdapterSurface::HttpRerank
     ));
 }
 
@@ -160,38 +177,38 @@ fn missing_text_provider_selectors_are_exact_http_only_catalog_routes() {
         assert!(definition.alternate_auth_env_vars.is_empty());
         assert!(!definition.skip_api_key);
         assert_eq!(definition.model_prefix, None);
-        assert!(supports_provider_surface(
+        assert!(supports_legacy_adapter(
             canonical,
-            ProviderRouteSurface::HttpChat
+            LegacyAdapterSurface::HttpChat
         ));
-        assert!(supports_provider_surface(
+        assert!(supports_legacy_adapter(
             canonical,
-            ProviderRouteSurface::HttpChatStream
+            LegacyAdapterSurface::HttpChatStream
         ));
         for unsupported in [
-            ProviderRouteSurface::HttpEmbeddings,
-            ProviderRouteSurface::HttpRerank,
-            ProviderRouteSurface::HttpImageGeneration,
-            ProviderRouteSurface::SdkChat,
-            ProviderRouteSurface::SdkChatStream,
-            ProviderRouteSurface::SdkEmbeddings,
-            ProviderRouteSurface::CompletionChat,
-            ProviderRouteSurface::CompletionChatStream,
+            LegacyAdapterSurface::HttpEmbeddings,
+            LegacyAdapterSurface::HttpRerank,
+            LegacyAdapterSurface::HttpImageGeneration,
+            LegacyAdapterSurface::SdkChat,
+            LegacyAdapterSurface::SdkChatStream,
+            LegacyAdapterSurface::SdkEmbeddings,
+            LegacyAdapterSurface::CompletionChat,
+            LegacyAdapterSurface::CompletionChatStream,
         ] {
-            assert!(!supports_provider_surface(canonical, unsupported));
+            assert!(!supports_legacy_adapter(canonical, unsupported));
         }
         for alias in aliases {
             assert_eq!(canonical_selector(alias), canonical);
             assert_eq!(
-                support_state_for_surface(alias, ProviderRouteSurface::HttpChat),
-                support_state_for_surface(canonical, ProviderRouteSurface::HttpChat)
+                legacy_adapter_availability(alias, LegacyAdapterSurface::HttpChat),
+                legacy_adapter_availability(canonical, LegacyAdapterSurface::HttpChat)
             );
         }
     }
 
     for wrong in ["ai-21", "huggingface_inference", "base-ten", "unknown"] {
         assert!(
-            !selector_has_matrix_entry(wrong),
+            !selector_has_legacy_adapter_entry(wrong),
             "{wrong} must fail closed"
         );
     }

--- a/src/sdk/client/completions.rs
+++ b/src/sdk/client/completions.rs
@@ -5,8 +5,8 @@ use super::provider_payloads::{
     build_anthropic_request_body, build_openai_request_body, convert_anthropic_response,
     convert_messages_to_anthropic,
 };
-use super::routing::{sdk_provider_supports_surface, unsupported_sdk_surface_error};
-use crate::core::providers::registry::ProviderRouteSurface;
+use super::routing::{sdk_provider_has_legacy_adapter, unsupported_legacy_sdk_adapter_error};
+use crate::core::providers::registry::LegacyAdapterSurface;
 use crate::sdk::{errors::*, types::*};
 use futures::StreamExt;
 use serde::de::DeserializeOwned;
@@ -106,10 +106,10 @@ impl LLMClient {
 
         debug!("Executing chat request with provider: {}", provider_id);
 
-        if !sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChat) {
-            return Err(unsupported_sdk_surface_error(
+        if !sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkChat) {
+            return Err(unsupported_legacy_sdk_adapter_error(
                 provider,
-                ProviderRouteSurface::SdkChat,
+                LegacyAdapterSurface::SdkChat,
             ));
         }
 
@@ -140,10 +140,10 @@ impl LLMClient {
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<ChatChunk>> + Send>>> {
         let provider = self.provider_config(provider_id)?;
 
-        if !sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChatStream) {
-            return Err(unsupported_sdk_surface_error(
+        if !sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkChatStream) {
+            return Err(unsupported_legacy_sdk_adapter_error(
                 provider,
-                ProviderRouteSurface::SdkChatStream,
+                LegacyAdapterSurface::SdkChatStream,
             ));
         }
 
@@ -508,9 +508,9 @@ impl LLMClient {
         provider: &crate::sdk::config::SdkProviderConfig,
         _request: SdkChatRequest,
     ) -> Result<ChatResponse> {
-        Err(unsupported_sdk_surface_error(
+        Err(unsupported_legacy_sdk_adapter_error(
             provider,
-            ProviderRouteSurface::SdkChat,
+            LegacyAdapterSurface::SdkChat,
         ))
     }
 }

--- a/src/sdk/client/embeddings.rs
+++ b/src/sdk/client/embeddings.rs
@@ -1,11 +1,11 @@
 //! Embedding methods backed by core embedding capabilities.
 
 use super::llm_client::LLMClient;
-use super::routing::{sdk_provider_supports_surface, unsupported_sdk_surface_error};
+use super::routing::{sdk_provider_has_legacy_adapter, unsupported_legacy_sdk_adapter_error};
 use crate::core::embedding::{
     EmbeddingOptions as CoreEmbeddingOptions, embedding as core_embedding,
 };
-use crate::core::providers::registry::ProviderRouteSurface;
+use crate::core::providers::registry::LegacyAdapterSurface;
 use crate::sdk::config::{ProviderType, SdkProviderConfig};
 use crate::sdk::errors::*;
 use crate::utils::net::ClientUtils;
@@ -140,10 +140,10 @@ impl LLMClient {
     }
 
     fn ensure_embedding_supported(&self, provider: &SdkProviderConfig) -> Result<()> {
-        if !sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkEmbeddings) {
-            return Err(unsupported_sdk_surface_error(
+        if !sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkEmbeddings) {
+            return Err(unsupported_legacy_sdk_adapter_error(
                 provider,
-                ProviderRouteSurface::SdkEmbeddings,
+                LegacyAdapterSurface::SdkEmbeddings,
             ));
         }
 

--- a/src/sdk/client/routing.rs
+++ b/src/sdk/client/routing.rs
@@ -2,7 +2,7 @@
 
 use super::llm_client::LLMClient;
 use super::types::{LoadBalancingStrategy, ProviderStats};
-use crate::core::providers::registry::{ProviderRouteSurface, supports_provider_surface};
+use crate::core::providers::registry::{LegacyAdapterSurface, supports_legacy_adapter};
 use crate::core::router::UnifiedRouter;
 use crate::core::router::UnifiedRoutingStrategy;
 use crate::core::router::deployment::DeploymentId;
@@ -32,12 +32,12 @@ impl LLMClient {
         }
 
         if let Some(provider) = self.default_enabled_provider() {
-            return if sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChat) {
+            return if sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkChat) {
                 Ok(provider)
             } else {
-                Err(unsupported_sdk_surface_error(
+                Err(unsupported_legacy_sdk_adapter_error(
                     provider,
-                    ProviderRouteSurface::SdkChat,
+                    LegacyAdapterSurface::SdkChat,
                 ))
             };
         }
@@ -53,12 +53,13 @@ impl LLMClient {
         _messages: &[Message],
     ) -> Result<&crate::sdk::config::SdkProviderConfig> {
         if let Some(provider) = self.default_enabled_provider() {
-            return if sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChatStream) {
+            return if sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkChatStream)
+            {
                 Ok(provider)
             } else {
-                Err(unsupported_sdk_surface_error(
+                Err(unsupported_legacy_sdk_adapter_error(
                     provider,
-                    ProviderRouteSurface::SdkChatStream,
+                    LegacyAdapterSurface::SdkChatStream,
                 ))
             };
         }
@@ -84,7 +85,7 @@ impl LoadBalancer {
             providers,
             stats,
             model,
-            ProviderRouteSurface::SdkChat,
+            LegacyAdapterSurface::SdkChat,
             supports_chat,
         )
         .await
@@ -100,7 +101,7 @@ impl LoadBalancer {
             providers,
             stats,
             None,
-            ProviderRouteSurface::SdkChatStream,
+            LegacyAdapterSurface::SdkChatStream,
             supports_stream,
         )
         .await
@@ -111,7 +112,7 @@ impl LoadBalancer {
         providers: &'a [SdkProviderConfig],
         stats: &Arc<RwLock<HashMap<String, ProviderStats>>>,
         model: Option<&str>,
-        surface: ProviderRouteSurface,
+        surface: LegacyAdapterSurface,
         supports_capability: impl Fn(&SdkProviderConfig) -> bool,
     ) -> Result<&'a SdkProviderConfig> {
         let model_candidates: Vec<&SdkProviderConfig> = providers
@@ -132,7 +133,7 @@ impl LoadBalancer {
 
         if enabled_providers.is_empty() {
             if let Some(provider) = model_candidates.first() {
-                return Err(unsupported_sdk_surface_error(provider, surface));
+                return Err(unsupported_legacy_sdk_adapter_error(provider, surface));
             }
 
             return match model {
@@ -205,18 +206,18 @@ impl LoadBalancer {
 }
 
 fn supports_chat(provider: &SdkProviderConfig) -> bool {
-    sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChat)
+    sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkChat)
 }
 
 fn supports_stream(provider: &SdkProviderConfig) -> bool {
-    sdk_provider_supports_surface(provider, ProviderRouteSurface::SdkChatStream)
+    sdk_provider_has_legacy_adapter(provider, LegacyAdapterSurface::SdkChatStream)
 }
 
-pub(crate) fn sdk_provider_supports_surface(
+pub(crate) fn sdk_provider_has_legacy_adapter(
     provider: &SdkProviderConfig,
-    surface: ProviderRouteSurface,
+    surface: LegacyAdapterSurface,
 ) -> bool {
-    supports_provider_surface(&sdk_provider_matrix_selector(provider), surface)
+    supports_legacy_adapter(&sdk_provider_matrix_selector(provider), surface)
 }
 
 pub(crate) fn sdk_provider_matrix_selector(provider: &SdkProviderConfig) -> String {
@@ -236,23 +237,23 @@ pub(crate) fn sdk_provider_matrix_selector(provider: &SdkProviderConfig) -> Stri
     .to_string()
 }
 
-pub(crate) fn unsupported_sdk_surface_error(
+pub(crate) fn unsupported_legacy_sdk_adapter_error(
     provider: &SdkProviderConfig,
-    surface: ProviderRouteSurface,
+    surface: LegacyAdapterSurface,
 ) -> SDKError {
     SDKError::NotSupported(format!(
         "SDK {} is not supported for provider '{}' ({:?})",
-        sdk_surface_name(surface),
+        legacy_sdk_adapter_name(surface),
         provider.id,
         provider.provider_type
     ))
 }
 
-fn sdk_surface_name(surface: ProviderRouteSurface) -> &'static str {
+fn legacy_sdk_adapter_name(surface: LegacyAdapterSurface) -> &'static str {
     match surface {
-        ProviderRouteSurface::SdkChat => "chat",
-        ProviderRouteSurface::SdkChatStream => "chat streaming",
-        ProviderRouteSurface::SdkEmbeddings => "embeddings",
+        LegacyAdapterSurface::SdkChat => "chat",
+        LegacyAdapterSurface::SdkChatStream => "chat streaming",
+        LegacyAdapterSurface::SdkEmbeddings => "embeddings",
         _ => "surface",
     }
 }


### PR DESCRIPTION
## Summary

- rename the old provider route-surface matrix as a legacy adapter availability contract
- make SDK compatibility call sites and typed errors use the explicit legacy-adapter terminology
- document that runtime-backed SDK and `completion()` selection derives support from the selected deployment's `ProviderCapability`
- retain fail-closed legacy adapter behavior and executable registry/catalog coverage

## Verification

- `cargo test --lib core::providers::registry::support_matrix_tests` — 9 passed
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `git diff --check`
- Patch Guard — 8 scoped files, no violations

Closes #1255
