### PR TITLE
feat(k8s): add a gateway PodDisruptionBudget

### DIFF
--- a/deployment/kubernetes/poddisruptionbudget.yaml
+++ b/deployment/kubernetes/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: litellm-gateway
+  namespace: litellm-gateway
+  labels:
+    app.kubernetes.io/name: litellm-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  # Preserve capacity for multi-replica deployments without blocking
+  # voluntary disruption when operators override the Deployment to one replica.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: litellm-gateway
+      app.kubernetes.io/component: gateway

--- a/src/config/kubernetes_tests.rs
+++ b/src/config/kubernetes_tests.rs
@@ -57,6 +57,10 @@ fn kubernetes_manifests_match_runtime_contract() {
         Some(&serde_json::json!("policy/v1"))
     );
     assert_eq!(
+        pdb.pointer("/metadata/namespace"),
+        deployment.pointer("/metadata/namespace")
+    );
+    assert_eq!(
         pdb.pointer("/spec/selector"),
         deployment.pointer("/spec/selector")
     );

--- a/src/config/kubernetes_tests.rs
+++ b/src/config/kubernetes_tests.rs
@@ -49,4 +49,24 @@ fn kubernetes_manifests_match_runtime_contract() {
         deployment.pointer("/spec/template/spec/containers/0/imagePullPolicy"),
         Some(&serde_json::json!("Always"))
     );
+
+    let pdb = std::fs::read_to_string(manifest_dir.join("poddisruptionbudget.yaml")).unwrap();
+    let pdb: serde_json::Value = serde_yml::from_str(&pdb).unwrap();
+    assert_eq!(
+        pdb.pointer("/apiVersion"),
+        Some(&serde_json::json!("policy/v1"))
+    );
+    assert_eq!(
+        pdb.pointer("/spec/selector"),
+        deployment.pointer("/spec/selector")
+    );
+    assert_eq!(
+        pdb.pointer("/spec/maxUnavailable"),
+        Some(&serde_json::json!(1)),
+        "one unavailable pod preserves availability with multiple replicas without blocking a single-replica override"
+    );
+    assert!(
+        pdb.pointer("/spec/minAvailable").is_none(),
+        "minAvailable would block voluntary disruption for a single replica"
+    );
 }


### PR DESCRIPTION
## Summary

- add a policy/v1 PodDisruptionBudget for the gateway
- use maxUnavailable: 1 so multi-replica deployments retain ready capacity without blocking a single-replica override
- assert the PDB selector exactly matches the Deployment selector

## Verification

- cargo test --lib kubernetes_manifests_match_runtime_contract -- --nocapture
- go run github.com/yannh/kubeconform/cmd/kubeconform@v0.8.0 -strict -summary deployment/kubernetes/*.yaml
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test

Fixes #1286