### PR TITLE
feat(admin): manage provider and model budgets

### DIFF
--- a/src/core/budget/mod.rs
+++ b/src/core/budget/mod.rs
@@ -72,6 +72,7 @@ mod provider_limits;
 mod provider_reservations;
 mod tracker;
 mod types;
+mod unified_limits;
 
 #[cfg(test)]
 mod manager_tests;
@@ -98,7 +99,7 @@ pub use middleware::{
     BudgetCheckMiddleware, BudgetCheckMiddlewareService, BudgetMiddleware, BudgetMiddlewareService,
     BudgetRecorder, BudgetRecorderExt,
 };
-pub use provider_limits::{ModelBudgetManager, ProviderBudgetManager, UnifiedBudgetLimits};
+pub use provider_limits::{ModelBudgetManager, ProviderBudgetManager};
 pub use provider_reservations::{
     ModelBudgetReservation, ProviderBudgetReservation, UnifiedBudgetReservation,
 };
@@ -108,6 +109,7 @@ pub use types::{
     BudgetStatus, Currency, ModelBudget, ModelUsageStats, ProviderBudget, ProviderUsageStats,
     ResetPeriod,
 };
+pub use unified_limits::UnifiedBudgetLimits;
 
 const BUDGET_AMOUNT_SCALE: f64 = 1_000_000_000.0;
 

--- a/src/core/budget/provider_limits.rs
+++ b/src/core/budget/provider_limits.rs
@@ -149,12 +149,20 @@ impl ProviderBudgetManager {
         budget.currency = config.currency;
         budget.enabled = config.enabled;
 
+        let reserved = self
+            .reserved_spend
+            .remove(provider)
+            .map(|(_, amount)| amount)
+            .unwrap_or_else(BudgetAmount::zero);
+        if let Some(previous) = self.budgets.get(provider) {
+            budget.current_spend = committed_spend(previous.current_spend, reserved);
+        }
+
         info!(
             "Setting provider budget limit for '{}': ${:.2} ({})",
             provider, config.max_budget, config.reset_period
         );
 
-        self.reserved_spend.remove(provider);
         let snapshot = self.snapshot_for(&budget);
         self.budgets.insert(provider.to_string(), budget);
         self.request_counts.entry(provider.to_string()).or_default();
@@ -177,6 +185,11 @@ impl ProviderBudgetManager {
     }
     pub fn has_provider_limit(&self, provider: &str) -> bool {
         self.budgets.contains_key(provider)
+    }
+    pub fn get_provider_soft_limit_percentage(&self, provider: &str) -> Option<f64> {
+        self.budgets
+            .get(provider)
+            .map(|budget| budget.soft_limit / budget.max_budget)
     }
     pub fn check_provider_budget(&self, provider: &str) -> BudgetStatus {
         if !self.is_enabled() {
@@ -488,12 +501,20 @@ impl ModelBudgetManager {
         budget.currency = config.currency;
         budget.enabled = config.enabled;
 
+        let reserved = self
+            .reserved_spend
+            .remove(model)
+            .map(|(_, amount)| amount)
+            .unwrap_or_else(BudgetAmount::zero);
+        if let Some(previous) = self.budgets.get(model) {
+            budget.current_spend = committed_spend(previous.current_spend, reserved);
+        }
+
         info!(
             "Setting model budget limit for '{}': ${:.2} ({})",
             model, config.max_budget, config.reset_period
         );
 
-        self.reserved_spend.remove(model);
         let snapshot = self.snapshot_for(&budget);
         self.budgets.insert(model.to_string(), budget);
         self.request_counts.entry(model.to_string()).or_default();
@@ -516,6 +537,11 @@ impl ModelBudgetManager {
     }
     pub fn has_model_limit(&self, model: &str) -> bool {
         self.budgets.contains_key(model)
+    }
+    pub fn get_model_soft_limit_percentage(&self, model: &str) -> Option<f64> {
+        self.budgets
+            .get(model)
+            .map(|budget| budget.soft_limit / budget.max_budget)
     }
     pub fn check_model_budget(&self, model: &str) -> BudgetStatus {
         if !self.is_enabled() {

--- a/src/core/budget/provider_limits.rs
+++ b/src/core/budget/provider_limits.rs
@@ -136,6 +136,9 @@ impl ProviderBudgetManager {
         mut config: ProviderLimitConfig,
         percentage: Option<f64>,
     ) {
+        if let Some(percentage) = percentage {
+            config.soft_limit_percentage = percentage;
+        }
         if !config.max_budget.is_finite() || config.max_budget <= 0.0 {
             warn!(
                 "Rejected invalid provider budget limit for '{}': {}",
@@ -503,6 +506,9 @@ impl ModelBudgetManager {
         mut config: ModelLimitConfig,
         percentage: Option<f64>,
     ) {
+        if let Some(percentage) = percentage {
+            config.soft_limit_percentage = percentage;
+        }
         if !config.max_budget.is_finite() || config.max_budget <= 0.0 {
             warn!(
                 "Rejected invalid model budget limit for '{}': {}",

--- a/src/core/budget/provider_limits.rs
+++ b/src/core/budget/provider_limits.rs
@@ -127,6 +127,15 @@ impl ProviderBudgetManager {
         self.enabled.store(enabled, Ordering::Relaxed);
     }
     pub fn set_provider_limit(&self, provider: &str, config: ProviderLimitConfig) {
+        let percentage = config.soft_limit_percentage;
+        self.set_provider_limit_optional(provider, config, Some(percentage));
+    }
+    pub fn set_provider_limit_optional(
+        &self,
+        provider: &str,
+        mut config: ProviderLimitConfig,
+        percentage: Option<f64>,
+    ) {
         if !config.max_budget.is_finite() || config.max_budget <= 0.0 {
             warn!(
                 "Rejected invalid provider budget limit for '{}': {}",
@@ -150,6 +159,8 @@ impl ProviderBudgetManager {
         let snapshot = match self.budgets.entry(provider.to_string()) {
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 let budget = entry.get_mut();
+                config.soft_limit_percentage =
+                    percentage.unwrap_or_else(|| budget.soft_limit / budget.max_budget);
                 budget.max_budget = config.max_budget;
                 budget.soft_limit = config.max_budget * config.soft_limit_percentage;
                 budget.reset_period = config.reset_period;
@@ -483,6 +494,15 @@ impl ModelBudgetManager {
         self.enabled.store(enabled, Ordering::Relaxed);
     }
     pub fn set_model_limit(&self, model: &str, config: ModelLimitConfig) {
+        let percentage = config.soft_limit_percentage;
+        self.set_model_limit_optional(model, config, Some(percentage));
+    }
+    pub fn set_model_limit_optional(
+        &self,
+        model: &str,
+        mut config: ModelLimitConfig,
+        percentage: Option<f64>,
+    ) {
         if !config.max_budget.is_finite() || config.max_budget <= 0.0 {
             warn!(
                 "Rejected invalid model budget limit for '{}': {}",
@@ -506,6 +526,8 @@ impl ModelBudgetManager {
         let snapshot = match self.budgets.entry(model.to_string()) {
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 let budget = entry.get_mut();
+                config.soft_limit_percentage =
+                    percentage.unwrap_or_else(|| budget.soft_limit / budget.max_budget);
                 budget.max_budget = config.max_budget;
                 budget.soft_limit = config.max_budget * config.soft_limit_percentage;
                 budget.reset_period = config.reset_period;
@@ -715,69 +737,4 @@ fn committed_spend(current_spend: f64, reserved: BudgetAmount) -> f64 {
     release_budget_spend(current_spend, reserved, true)
         .map(|amount| amount.as_f64())
         .unwrap_or(current_spend)
-}
-#[derive(Clone)]
-pub struct UnifiedBudgetLimits {
-    pub providers: ProviderBudgetManager,
-    pub models: ModelBudgetManager,
-}
-
-impl Default for UnifiedBudgetLimits {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl UnifiedBudgetLimits {
-    pub fn new() -> Self {
-        Self {
-            providers: ProviderBudgetManager::new(),
-            models: ModelBudgetManager::new(),
-        }
-    }
-    pub fn with_persistence(persistence_tx: BudgetPersistenceSender) -> Self {
-        Self {
-            providers: ProviderBudgetManager::new().with_persistence(persistence_tx.clone()),
-            models: ModelBudgetManager::new().with_persistence(persistence_tx),
-        }
-    }
-    pub fn from_snapshots_with_persistence(
-        snapshots: impl IntoIterator<Item = BudgetLimitSnapshot>,
-        persistence_tx: BudgetPersistenceSender,
-    ) -> Self {
-        let limits = Self::with_persistence(persistence_tx);
-        for snapshot in snapshots {
-            match snapshot.kind {
-                BudgetLimitKind::Provider => limits.providers.restore_snapshot(&snapshot),
-                BudgetLimitKind::Model => limits.models.restore_snapshot(&snapshot),
-            }
-        }
-        limits
-    }
-    pub fn can_spend(&self, provider: &str, model: &str, amount: f64) -> bool {
-        self.providers.can_provider_spend(provider, amount)
-            && self.models.can_model_spend(model, amount)
-    }
-    pub fn record_spend(&self, provider: &str, model: &str, amount: f64) {
-        self.providers.record_provider_spend(provider, amount);
-        self.models.record_model_spend(model, amount);
-    }
-    pub fn filter_available_providers(&self, providers: Vec<String>) -> Vec<String> {
-        let exceeded = self.providers.get_exceeded_providers();
-        providers
-            .into_iter()
-            .filter(|p| !exceeded.contains(p))
-            .collect()
-    }
-    pub fn is_provider_available(&self, provider: &str) -> bool {
-        self.providers.check_provider_budget(provider) != BudgetStatus::Exceeded
-    }
-    pub fn is_model_available(&self, model: &str) -> bool {
-        self.models.check_model_budget(model) != BudgetStatus::Exceeded
-    }
-    pub fn reset_due_budgets(&self) -> (Vec<String>, Vec<String>) {
-        let providers = self.providers.reset_due_budgets();
-        let models = self.models.reset_due_budgets();
-        (providers, models)
-    }
 }

--- a/src/core/budget/provider_limits.rs
+++ b/src/core/budget/provider_limits.rs
@@ -143,28 +143,32 @@ impl ProviderBudgetManager {
             );
             return;
         }
-        let mut budget = ProviderBudget::new(provider, config.max_budget);
-        budget.soft_limit = config.max_budget * config.soft_limit_percentage;
-        budget.reset_period = config.reset_period;
-        budget.currency = config.currency;
-        budget.enabled = config.enabled;
-
-        let reserved = self
-            .reserved_spend
-            .remove(provider)
-            .map(|(_, amount)| amount)
-            .unwrap_or_else(BudgetAmount::zero);
-        if let Some(previous) = self.budgets.get(provider) {
-            budget.current_spend = committed_spend(previous.current_spend, reserved);
-        }
-
         info!(
             "Setting provider budget limit for '{}': ${:.2} ({})",
             provider, config.max_budget, config.reset_period
         );
-
-        let snapshot = self.snapshot_for(&budget);
-        self.budgets.insert(provider.to_string(), budget);
+        let snapshot = match self.budgets.entry(provider.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let budget = entry.get_mut();
+                budget.max_budget = config.max_budget;
+                budget.soft_limit = config.max_budget * config.soft_limit_percentage;
+                budget.reset_period = config.reset_period;
+                budget.currency = config.currency;
+                budget.enabled = config.enabled;
+                budget.updated_at = chrono::Utc::now();
+                self.snapshot_for(budget)
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let mut budget = ProviderBudget::new(provider, config.max_budget);
+                budget.soft_limit = config.max_budget * config.soft_limit_percentage;
+                budget.reset_period = config.reset_period;
+                budget.currency = config.currency;
+                budget.enabled = config.enabled;
+                let snapshot = self.snapshot_for(&budget);
+                entry.insert(budget);
+                snapshot
+            }
+        };
         self.request_counts.entry(provider.to_string()).or_default();
         self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
     }
@@ -495,28 +499,32 @@ impl ModelBudgetManager {
             );
             return;
         }
-        let mut budget = ModelBudget::new(model, config.max_budget);
-        budget.soft_limit = config.max_budget * config.soft_limit_percentage;
-        budget.reset_period = config.reset_period;
-        budget.currency = config.currency;
-        budget.enabled = config.enabled;
-
-        let reserved = self
-            .reserved_spend
-            .remove(model)
-            .map(|(_, amount)| amount)
-            .unwrap_or_else(BudgetAmount::zero);
-        if let Some(previous) = self.budgets.get(model) {
-            budget.current_spend = committed_spend(previous.current_spend, reserved);
-        }
-
         info!(
             "Setting model budget limit for '{}': ${:.2} ({})",
             model, config.max_budget, config.reset_period
         );
-
-        let snapshot = self.snapshot_for(&budget);
-        self.budgets.insert(model.to_string(), budget);
+        let snapshot = match self.budgets.entry(model.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let budget = entry.get_mut();
+                budget.max_budget = config.max_budget;
+                budget.soft_limit = config.max_budget * config.soft_limit_percentage;
+                budget.reset_period = config.reset_period;
+                budget.currency = config.currency;
+                budget.enabled = config.enabled;
+                budget.updated_at = chrono::Utc::now();
+                self.snapshot_for(budget)
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let mut budget = ModelBudget::new(model, config.max_budget);
+                budget.soft_limit = config.max_budget * config.soft_limit_percentage;
+                budget.reset_period = config.reset_period;
+                budget.currency = config.currency;
+                budget.enabled = config.enabled;
+                let snapshot = self.snapshot_for(&budget);
+                entry.insert(budget);
+                snapshot
+            }
+        };
         self.request_counts.entry(model.to_string()).or_default();
         self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
     }

--- a/src/core/budget/provider_reservation_tests.rs
+++ b/src/core/budget/provider_reservation_tests.rs
@@ -301,7 +301,7 @@ fn overlapping_reservation_persistence_excludes_other_temporary_holds() {
 }
 
 #[test]
-fn replacing_limits_preserves_committed_spend_and_drops_stale_outstanding_holds() {
+fn replacing_limits_preserves_reset_epoch_and_outstanding_holds() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let limits = UnifiedBudgetLimits::with_persistence(tx);
     limits.providers.set_provider_limit(
@@ -322,13 +322,23 @@ fn replacing_limits_preserves_committed_spend_and_drops_stale_outstanding_holds(
     while rx.try_recv().is_ok() {}
 
     let reservation = limits.reserve_spend("openai", "gpt-4", 10.0).unwrap();
+    let provider_reset_at = limits
+        .providers
+        .get_provider_usage("openai")
+        .unwrap()
+        .last_reset_at;
+    let model_reset_at = limits
+        .models
+        .get_model_usage("gpt-4")
+        .unwrap()
+        .last_reset_at;
     limits.providers.set_provider_limit(
         "openai",
-        ProviderLimitConfig::new(100.0, ResetPeriod::Monthly),
+        ProviderLimitConfig::new(200.0, ResetPeriod::Monthly),
     );
     limits
         .models
-        .set_model_limit("gpt-4", ModelLimitConfig::new(100.0, ResetPeriod::Monthly));
+        .set_model_limit("gpt-4", ModelLimitConfig::new(200.0, ResetPeriod::Monthly));
 
     let mut replacement_snapshots = Vec::new();
     for _ in 0..2 {
@@ -352,6 +362,14 @@ fn replacing_limits_preserves_committed_spend_and_drops_stale_outstanding_holds(
             .iter()
             .any(|(_, name, current_spend)| name == "gpt-4" && *current_spend == 6.0)
     );
+    let provider_usage = limits.providers.get_provider_usage("openai").unwrap();
+    assert_eq!(provider_usage.current_spend, 16.0);
+    assert_eq!(provider_usage.max_budget, 200.0);
+    assert_eq!(provider_usage.last_reset_at, provider_reset_at);
+    let model_usage = limits.models.get_model_usage("gpt-4").unwrap();
+    assert_eq!(model_usage.current_spend, 16.0);
+    assert_eq!(model_usage.max_budget, 200.0);
+    assert_eq!(model_usage.last_reset_at, model_reset_at);
 
     assert_eq!(
         reservation.settle(4.0).unwrap(),

--- a/src/core/budget/provider_reservation_tests.rs
+++ b/src/core/budget/provider_reservation_tests.rs
@@ -301,7 +301,7 @@ fn overlapping_reservation_persistence_excludes_other_temporary_holds() {
 }
 
 #[test]
-fn replacing_limits_drops_stale_outstanding_holds() {
+fn replacing_limits_preserves_committed_spend_and_drops_stale_outstanding_holds() {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let limits = UnifiedBudgetLimits::with_persistence(tx);
     limits.providers.set_provider_limit(
@@ -311,6 +311,14 @@ fn replacing_limits_drops_stale_outstanding_holds() {
     limits
         .models
         .set_model_limit("gpt-4", ModelLimitConfig::new(100.0, ResetPeriod::Monthly));
+    assert_eq!(
+        limits.providers.record_provider_spend("openai", 6.0),
+        Some(BudgetStatus::Ok)
+    );
+    assert_eq!(
+        limits.models.record_model_spend("gpt-4", 6.0),
+        Some(BudgetStatus::Ok)
+    );
     while rx.try_recv().is_ok() {}
 
     let reservation = limits.reserve_spend("openai", "gpt-4", 10.0).unwrap();
@@ -337,12 +345,12 @@ fn replacing_limits_drops_stale_outstanding_holds() {
     assert!(
         replacement_snapshots
             .iter()
-            .any(|(_, name, current_spend)| name == "openai" && *current_spend == 0.0)
+            .any(|(_, name, current_spend)| name == "openai" && *current_spend == 6.0)
     );
     assert!(
         replacement_snapshots
             .iter()
-            .any(|(_, name, current_spend)| name == "gpt-4" && *current_spend == 0.0)
+            .any(|(_, name, current_spend)| name == "gpt-4" && *current_spend == 6.0)
     );
 
     assert_eq!(
@@ -355,7 +363,7 @@ fn replacing_limits_drops_stale_outstanding_holds() {
             .get_provider_usage("openai")
             .unwrap()
             .current_spend,
-        4.0
+        10.0
     );
     assert_eq!(
         limits
@@ -363,7 +371,7 @@ fn replacing_limits_drops_stale_outstanding_holds() {
             .get_model_usage("gpt-4")
             .unwrap()
             .current_spend,
-        4.0
+        10.0
     );
 }
 

--- a/src/core/budget/provider_reservations.rs
+++ b/src/core/budget/provider_reservations.rs
@@ -1,10 +1,10 @@
 use super::config::BudgetPersistenceEvent;
-use super::provider_limits::{ModelBudgetManager, ProviderBudgetManager, UnifiedBudgetLimits};
 use super::tracker::BudgetReservationError;
 use super::types::BudgetStatus;
 use super::{
     BudgetAmount, add_budget_spend, budget_can_spend, release_budget_spend, settle_budget_spend,
 };
+use super::{ModelBudgetManager, ProviderBudgetManager, UnifiedBudgetLimits};
 use std::sync::atomic::Ordering;
 
 impl ProviderBudgetManager {

--- a/src/core/budget/tests.rs
+++ b/src/core/budget/tests.rs
@@ -739,3 +739,39 @@ fn test_provider_budget_manager_concurrent_access() {
     assert_eq!(usage.current_spend, 1000.0);
     assert_eq!(usage.request_count, 1000);
 }
+
+#[test]
+fn optional_soft_limit_updates_resolve_inside_the_entry() {
+    let providers = ProviderBudgetManager::new();
+    let mut provider = ProviderLimitConfig::new(100.0, ResetPeriod::Monthly);
+    provider.soft_limit_percentage = 0.5;
+    providers.set_provider_limit("openai", provider);
+    providers.set_provider_limit_optional(
+        "openai",
+        ProviderLimitConfig::new(200.0, ResetPeriod::Weekly),
+        None,
+    );
+    assert_eq!(
+        providers.get_provider_soft_limit_percentage("openai"),
+        Some(0.5)
+    );
+
+    let models = ModelBudgetManager::new();
+    let mut model = ModelLimitConfig::new(100.0, ResetPeriod::Monthly);
+    model.soft_limit_percentage = 0.75;
+    models.set_model_limit("gpt-4o", model);
+    models.set_model_limit_optional(
+        "gpt-4o",
+        ModelLimitConfig::new(250.0, ResetPeriod::Daily),
+        None,
+    );
+    assert_eq!(models.get_model_soft_limit_percentage("gpt-4o"), Some(0.75));
+
+    let mut new_provider = ProviderLimitConfig::new(50.0, ResetPeriod::Daily);
+    new_provider.soft_limit_percentage = 0.6;
+    providers.set_provider_limit_optional("anthropic", new_provider, None);
+    assert_eq!(
+        providers.get_provider_soft_limit_percentage("anthropic"),
+        Some(0.6)
+    );
+}

--- a/src/core/budget/tests.rs
+++ b/src/core/budget/tests.rs
@@ -774,4 +774,20 @@ fn optional_soft_limit_updates_resolve_inside_the_entry() {
         providers.get_provider_soft_limit_percentage("anthropic"),
         Some(0.6)
     );
+
+    providers.set_provider_limit_optional(
+        "openai",
+        ProviderLimitConfig::new(300.0, ResetPeriod::Daily),
+        Some(1.5),
+    );
+    assert_eq!(
+        providers.get_provider_usage("openai").unwrap().max_budget,
+        200.0
+    );
+    models.set_model_limit_optional(
+        "gpt-4o",
+        ModelLimitConfig::new(300.0, ResetPeriod::Daily),
+        Some(f64::NAN),
+    );
+    assert_eq!(models.get_model_usage("gpt-4o").unwrap().max_budget, 250.0);
 }

--- a/src/core/budget/unified_limits.rs
+++ b/src/core/budget/unified_limits.rs
@@ -1,0 +1,70 @@
+use super::{
+    BudgetLimitKind, BudgetLimitSnapshot, BudgetPersistenceSender, BudgetStatus,
+    ModelBudgetManager, ProviderBudgetManager,
+};
+
+#[derive(Clone)]
+pub struct UnifiedBudgetLimits {
+    pub providers: ProviderBudgetManager,
+    pub models: ModelBudgetManager,
+}
+
+impl Default for UnifiedBudgetLimits {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UnifiedBudgetLimits {
+    pub fn new() -> Self {
+        Self {
+            providers: ProviderBudgetManager::new(),
+            models: ModelBudgetManager::new(),
+        }
+    }
+    pub fn with_persistence(persistence_tx: BudgetPersistenceSender) -> Self {
+        Self {
+            providers: ProviderBudgetManager::new().with_persistence(persistence_tx.clone()),
+            models: ModelBudgetManager::new().with_persistence(persistence_tx),
+        }
+    }
+    pub fn from_snapshots_with_persistence(
+        snapshots: impl IntoIterator<Item = BudgetLimitSnapshot>,
+        persistence_tx: BudgetPersistenceSender,
+    ) -> Self {
+        let limits = Self::with_persistence(persistence_tx);
+        for snapshot in snapshots {
+            match snapshot.kind {
+                BudgetLimitKind::Provider => limits.providers.restore_snapshot(&snapshot),
+                BudgetLimitKind::Model => limits.models.restore_snapshot(&snapshot),
+            }
+        }
+        limits
+    }
+    pub fn can_spend(&self, provider: &str, model: &str, amount: f64) -> bool {
+        self.providers.can_provider_spend(provider, amount)
+            && self.models.can_model_spend(model, amount)
+    }
+    pub fn record_spend(&self, provider: &str, model: &str, amount: f64) {
+        self.providers.record_provider_spend(provider, amount);
+        self.models.record_model_spend(model, amount);
+    }
+    pub fn filter_available_providers(&self, providers: Vec<String>) -> Vec<String> {
+        let exceeded = self.providers.get_exceeded_providers();
+        providers
+            .into_iter()
+            .filter(|provider| !exceeded.contains(provider))
+            .collect()
+    }
+    pub fn is_provider_available(&self, provider: &str) -> bool {
+        self.providers.check_provider_budget(provider) != BudgetStatus::Exceeded
+    }
+    pub fn is_model_available(&self, model: &str) -> bool {
+        self.models.check_model_budget(model) != BudgetStatus::Exceeded
+    }
+    pub fn reset_due_budgets(&self) -> (Vec<String>, Vec<String>) {
+        let providers = self.providers.reset_due_budgets();
+        let models = self.models.reset_due_budgets();
+        (providers, models)
+    }
+}

--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -97,6 +97,7 @@ pub fn is_public_route(path: &str) -> bool {
         "/admin/dashboard",
         "/admin/dashboard/app.css",
         "/admin/dashboard/app.js",
+        "/admin/dashboard/budget.js",
         "/admin/dashboard/provider-health.js",
         "/docs",
         "/openapi.json",

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -95,6 +95,7 @@ fn test_is_public_route() {
     assert!(is_public_route("/admin/dashboard"));
     assert!(is_public_route("/admin/dashboard/app.css"));
     assert!(is_public_route("/admin/dashboard/app.js"));
+    assert!(is_public_route("/admin/dashboard/budget.js"));
     assert!(is_public_route("/admin/dashboard/provider-health.js"));
     // /metrics requires authentication (not in PUBLIC_ROUTES)
     assert!(!is_public_route("/metrics"));
@@ -103,6 +104,7 @@ fn test_is_public_route() {
     assert!(!is_public_route("/admin/dashboard/"));
     assert!(!is_public_route("/admin/dashboard/private"));
     assert!(!is_public_route("/admin/dashboard/app.js.map"));
+    assert!(!is_public_route("/admin/dashboard/budget.js.map"));
     assert!(!is_public_route("/admin/dashboard/provider-health.js.map"));
     assert!(!is_public_route("/healthz"));
     assert!(!is_public_route("/api/users"));

--- a/src/server/routes/admin_dashboard.rs
+++ b/src/server/routes/admin_dashboard.rs
@@ -6,6 +6,7 @@ use actix_web::{HttpResponse, web};
 const INDEX_HTML: &str = include_str!("admin_dashboard/index.html");
 const APP_CSS: &str = include_str!("admin_dashboard/app.css");
 const APP_JS: &str = include_str!("admin_dashboard/app.js");
+const BUDGET_JS: &str = include_str!("admin_dashboard/budget.js");
 const PROVIDER_HEALTH_JS: &str = include_str!("admin_dashboard/provider_health.js");
 const DASHBOARD_CSP: &str = "default-src 'none'; script-src 'self'; style-src 'self'; \
     connect-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'none'; \
@@ -35,6 +36,10 @@ async fn provider_health_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", PROVIDER_HEALTH_JS)
 }
 
+async fn budget_javascript() -> HttpResponse {
+    embedded_asset("text/javascript; charset=utf-8", BUDGET_JS)
+}
+
 /// Register the exact dashboard asset routes.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/admin/dashboard", web::get().to(dashboard))
@@ -42,6 +47,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/admin/dashboard/provider-health.js",
             web::get().to(provider_health_javascript),
+        )
+        .route(
+            "/admin/dashboard/budget.js",
+            web::get().to(budget_javascript),
         )
         .route("/admin/dashboard/app.js", web::get().to(javascript));
 }
@@ -75,6 +84,11 @@ mod tests {
                 "/admin/dashboard/provider-health.js",
                 "text/javascript; charset=utf-8",
                 "createProviderHealthView",
+            ),
+            (
+                "/admin/dashboard/budget.js",
+                "text/javascript; charset=utf-8",
+                "createBudgetView",
             ),
         ];
 
@@ -113,6 +127,7 @@ mod tests {
         for path in [
             "/admin/dashboard/",
             "/admin/dashboard/app.js.map",
+            "/admin/dashboard/budget.js.map",
             "/admin/dashboard/private",
         ] {
             let response = actix_test::call_service(
@@ -136,7 +151,9 @@ mod tests {
             assert!(APP_JS.contains(path), "missing API path {path}");
         }
         assert!(PROVIDER_HEALTH_JS.contains("\"/health/detailed\""));
-        for asset in [APP_JS, PROVIDER_HEALTH_JS] {
+        assert!(BUDGET_JS.contains("\"/v1/budget/providers\""));
+        assert!(BUDGET_JS.contains("\"/v1/budget/models\""));
+        for asset in [APP_JS, PROVIDER_HEALTH_JS, BUDGET_JS] {
             for forbidden in [
                 "localStorage",
                 "sessionStorage",
@@ -184,6 +201,10 @@ mod tests {
             "id=\"team-spend-empty\"",
             "aria-describedby=\"team-name-help\"",
             "id=\"team-name-help\"",
+            "id=\"budgets-panel\"",
+            "id=\"budget-form\"",
+            "id=\"provider-budgets-body\"",
+            "id=\"model-budgets-body\"",
         ] {
             assert!(INDEX_HTML.contains(marker), "missing HTML marker {marker}");
         }

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -9,6 +9,7 @@
   --accent-strong: #2343ac;
   --danger: #b42318;
   --healthy: #16794a;
+  --warning: #8a4f00;
   --focus: #ffb020;
   --shadow: 0 16px 45px rgb(23 34 56 / 10%);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
@@ -29,6 +30,7 @@
     --accent-strong: #abc0ff;
     --danger: #ff8a80;
     --healthy: #73d7a3;
+    --warning: #ffc66d;
     --focus: #ffd166;
     --shadow: 0 18px 50px rgb(0 0 0 / 28%);
   }
@@ -80,6 +82,13 @@ button.danger {
   border-color: var(--danger);
   color: var(--danger);
   background: transparent;
+}
+
+button.compact {
+  min-height: 2rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  font-size: 0.82rem;
 }
 
 :focus-visible {
@@ -178,6 +187,12 @@ select {
   border-radius: 0.55rem;
   color: var(--text);
   background: var(--surface);
+}
+
+input[type="checkbox"] {
+  width: 1rem;
+  min-height: 1rem;
+  accent-color: var(--accent);
 }
 
 .tabs {
@@ -305,6 +320,71 @@ td code {
   gap: 1.25rem;
 }
 
+.budget-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.budget-grid h3 {
+  margin: 0 0 0.65rem;
+}
+
+.budget-actions {
+  display: flex;
+  min-width: 13rem;
+  gap: 0.45rem;
+}
+
+.budget-state {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 730;
+  text-transform: capitalize;
+}
+
+.budget-state[data-budget-state="ok"] {
+  color: var(--healthy);
+}
+
+.budget-state[data-budget-state="warning"] {
+  color: var(--warning);
+}
+
+.budget-state[data-budget-state="exceeded"] {
+  color: var(--danger);
+}
+
+.budget-state[data-budget-state="unknown"] {
+  color: var(--muted);
+}
+
+.input-suffix {
+  position: relative;
+}
+
+.input-suffix input {
+  padding-right: 2.2rem;
+}
+
+.input-suffix span {
+  position: absolute;
+  top: 50%;
+  right: 0.8rem;
+  color: var(--muted);
+  transform: translateY(-50%);
+}
+
+.checkbox-row {
+  display: flex;
+  grid-column: 2;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0;
+}
+
 .health-summary,
 .health-notice {
   margin: 0 0 1rem;
@@ -408,7 +488,8 @@ dialog pre {
   }
 
   .form-grid button,
-  .form-grid .field-help {
+  .form-grid .field-help,
+  .checkbox-row {
     grid-column: 1;
   }
 

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -361,22 +361,6 @@ td code {
   color: var(--muted);
 }
 
-.input-suffix {
-  position: relative;
-}
-
-.input-suffix input {
-  padding-right: 2.2rem;
-}
-
-.input-suffix span {
-  position: absolute;
-  top: 50%;
-  right: 0.8rem;
-  color: var(--muted);
-  transform: translateY(-50%);
-}
-
 .checkbox-row {
   display: flex;
   grid-column: 2;

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -357,7 +357,8 @@ td code {
   color: var(--danger);
 }
 
-.budget-state[data-budget-state="unknown"] {
+.budget-state[data-budget-state="unknown"],
+.budget-state[data-budget-state="disabled"] {
   color: var(--muted);
 }
 

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -75,6 +75,7 @@ function resetProtectedState() {
   renderTeams();
   renderSpend();
   providerHealthView.reset();
+  budgetView.reset();
 }
 function endSession(message = "Signed out") {
   abortActiveRequests();
@@ -385,6 +386,10 @@ const providerHealthView = window.createProviderHealthView({
   setStatus,
   textCell,
 });
+const budgetView = window.createBudgetView({
+  apiRequest, beginBusy, byId, captureSession, clearError, createAction, endBusy,
+  ensureCurrent, reportRequestError, setStatus, textCell,
+});
 async function loadKeys(session = captureSession()) {
   const requestVersion = ++state.keyRequestVersion;
   const requestedPage = state.keyPage;
@@ -470,6 +475,7 @@ async function refreshDashboard() {
       loadKeys(session),
       loadTeams(session),
       providerHealthView.load(session),
+      budgetView.load(session),
     ]);
     ensureCurrent(session);
     await loadTeamUsage(session);
@@ -724,7 +730,7 @@ function showView(view) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-selected", String(active));
   }
-  for (const panel of ["keys", "teams", "spend", "health"]) {
+  for (const panel of ["keys", "teams", "spend", "budgets", "health"]) {
     byId(`${panel}-panel`).hidden = panel !== view;
   }
   if (view === "spend") {

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -475,7 +475,6 @@ async function refreshDashboard() {
       loadKeys(session),
       loadTeams(session),
       providerHealthView.load(session),
-      budgetView.load(session),
     ]);
     ensureCurrent(session);
     await loadTeamUsage(session);
@@ -735,6 +734,9 @@ function showView(view) {
   }
   if (view === "spend") {
     void refreshDashboard();
+  }
+  if (view === "budgets") {
+    void budgetView.loadOnce();
   }
 }
 byId("login-form").addEventListener("submit", (event) => void signIn(event));

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -85,6 +85,7 @@ function endSession(message = "Signed out") {
   state.adminName = null;
   state.busy.clear();
   resetProtectedState();
+  showView("keys");
   loginPanel.hidden = false;
   dashboardShell.hidden = true;
   byId("sign-out").hidden = true;

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -270,8 +270,8 @@ window.createBudgetView = function createBudgetView({
         session,
       );
       ensureCurrent(session);
-      await refreshAfterMutation(session, `${config.label} budget saved.`);
       clearEditor();
+      await refreshAfterMutation(session, `${config.label} budget saved.`);
     } catch (error) {
       if (error?.name !== "AbortError") {
         reportRequestError(error, "Budget save failed.");

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -16,6 +16,8 @@ window.createBudgetView = function createBudgetView({
   let providers = [];
   let models = [];
   let requestVersion = 0;
+  let loaded = false;
+  let loadPromise = null;
 
   const scopeConfig = {
     provider: {
@@ -125,6 +127,8 @@ window.createBudgetView = function createBudgetView({
 
   function reset() {
     requestVersion += 1;
+    loaded = false;
+    loadPromise = null;
     providers = [];
     models = [];
     clearEditor();
@@ -150,6 +154,27 @@ window.createBudgetView = function createBudgetView({
     providers = providerData.providers;
     models = modelData.models;
     render();
+  }
+
+  function loadOnce() {
+    if (loaded || loadPromise) {
+      return loadPromise || Promise.resolve();
+    }
+    clearError();
+    setStatus("Loading budgets…");
+    const pending = load()
+      .then(() => {
+        loaded = true;
+        setStatus("Budgets loaded.");
+      })
+      .catch((error) => reportRequestError(error, "Budget load failed."));
+    loadPromise = pending;
+    void pending.finally(() => {
+      if (loadPromise === pending) {
+        loadPromise = null;
+      }
+    });
+    return pending;
   }
 
   async function refreshAfterMutation(session, successMessage) {
@@ -180,7 +205,22 @@ window.createBudgetView = function createBudgetView({
     byId("cancel-budget-edit").hidden = !editing;
   }
 
+  function setCurrency(currency) {
+    const select = byId("budget-currency");
+    select.querySelector("[data-preserved-currency]")?.remove();
+    const value = String(currency || "USD").toUpperCase();
+    if (![...select.options].some((option) => option.value === value)) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      option.dataset.preservedCurrency = "true";
+      select.append(option);
+    }
+    select.value = value;
+  }
+
   function clearEditor() {
+    byId("budget-currency").querySelector("[data-preserved-currency]")?.remove();
     byId("budget-form").reset();
     setEditMode(false);
     updateScopeLabel();
@@ -193,7 +233,7 @@ window.createBudgetView = function createBudgetView({
     byId("budget-name").value = budgetName(scope, budget);
     byId("budget-max").value = budget.max_budget;
     byId("budget-reset-period").value = budget.reset_period;
-    byId("budget-currency").value = String(budget.currency || "USD").toUpperCase();
+    setCurrency(budget.currency);
     byId("budget-enabled").checked = budget.enabled !== false;
     setEditMode(true);
     byId("budget-editor").open = true;
@@ -317,5 +357,5 @@ window.createBudgetView = function createBudgetView({
   );
   updateScopeLabel();
 
-  return { load, reset };
+  return { load, loadOnce, reset };
 };

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -18,6 +18,7 @@ window.createBudgetView = function createBudgetView({
   let requestVersion = 0;
   let loaded = false;
   let loadPromise = null;
+  let editingKey = null;
 
   const scopeConfig = {
     provider: {
@@ -220,6 +221,7 @@ window.createBudgetView = function createBudgetView({
   }
 
   function clearEditor() {
+    editingKey = null;
     byId("budget-currency").querySelector("[data-preserved-currency]")?.remove();
     byId("budget-form").reset();
     setEditMode(false);
@@ -228,6 +230,7 @@ window.createBudgetView = function createBudgetView({
 
   function editBudget(scope, budget) {
     const form = byId("budget-form");
+    editingKey = { scope, name: budgetName(scope, budget) };
     byId("budget-scope").value = scope;
     updateScopeLabel();
     byId("budget-name").value = budgetName(scope, budget);
@@ -251,9 +254,9 @@ window.createBudgetView = function createBudgetView({
     const session = captureSession();
     clearError();
     try {
-      const scope = byId("budget-scope").value;
+      const scope = editingKey?.scope || byId("budget-scope").value;
       const config = configFor(scope);
-      const name = byId("budget-name").value.trim();
+      const name = editingKey?.name || byId("budget-name").value.trim();
       const payload = {
         [config.field]: name,
         max_budget: Number(byId("budget-max").value),

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -147,6 +147,21 @@ window.createBudgetView = function createBudgetView({
     render();
   }
 
+  async function refreshAfterMutation(session, successMessage) {
+    try {
+      await load(session);
+      setStatus(successMessage);
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw error;
+      }
+      reportRequestError(
+        new Error(`${successMessage} Budget list refresh failed: ${error.message}`),
+        `${successMessage} Budget list refresh failed.`,
+      );
+    }
+  }
+
   function updateScopeLabel() {
     const scope = byId("budget-scope").value;
     const config = configFor(scope);
@@ -185,7 +200,6 @@ window.createBudgetView = function createBudgetView({
         [config.field]: name,
         max_budget: Number(byId("budget-max").value),
         reset_period: byId("budget-reset-period").value,
-        soft_limit_percentage: Number(byId("budget-soft-limit").value) / 100,
         currency: byId("budget-currency").value,
         enabled: byId("budget-enabled").checked,
       };
@@ -195,10 +209,9 @@ window.createBudgetView = function createBudgetView({
         session,
       );
       ensureCurrent(session);
-      await load(session);
+      await refreshAfterMutation(session, `${config.label} budget saved.`);
       form.reset();
       updateScopeLabel();
-      setStatus(`${config.label} budget saved.`);
     } catch (error) {
       if (error?.name !== "AbortError") {
         reportRequestError(error, "Budget save failed.");
@@ -227,8 +240,7 @@ window.createBudgetView = function createBudgetView({
         session,
       );
       ensureCurrent(session);
-      await load(session);
-      setStatus(`${config.label} budget reset.`);
+      await refreshAfterMutation(session, `${config.label} budget reset.`);
     } catch (error) {
       reportRequestError(error, "Budget reset failed.");
     } finally {
@@ -255,8 +267,7 @@ window.createBudgetView = function createBudgetView({
         session,
       );
       ensureCurrent(session);
-      await load(session);
-      setStatus(`${config.label} budget deleted.`);
+      await refreshAfterMutation(session, `${config.label} budget deleted.`);
     } catch (error) {
       reportRequestError(error, "Budget deletion failed.");
     } finally {

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -58,10 +58,10 @@ window.createBudgetView = function createBudgetView({
         style: "currency",
         currency: unit,
         minimumFractionDigits: 2,
-        maximumFractionDigits: 4,
+        maximumFractionDigits: 9,
       }).format(amount);
     } catch {
-      return `${unit} ${amount.toFixed(4)}`;
+      return `${unit} ${amount.toFixed(9)}`;
     }
   }
 
@@ -327,6 +327,9 @@ window.createBudgetView = function createBudgetView({
         session,
       );
       ensureCurrent(session);
+      if (editingKey?.scope === scope && editingKey.name === name) {
+        clearEditor();
+      }
       await refreshAfterMutation(session, `${config.label} budget deleted.`);
     } catch (error) {
       reportRequestError(error, "Budget deletion failed.");

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -62,10 +62,13 @@ window.createBudgetView = function createBudgetView({
     }
   }
 
-  function statusCell(status) {
-    const value = ["ok", "warning", "exceeded"].includes(status)
-      ? status
-      : "unknown";
+  function statusCell(status, enabled) {
+    let value = "disabled";
+    if (enabled) {
+      value = ["ok", "warning", "exceeded"].includes(status)
+        ? status
+        : "unknown";
+    }
     const cell = document.createElement("td");
     const badge = document.createElement("span");
     badge.className = "budget-state";
@@ -102,7 +105,10 @@ window.createBudgetView = function createBudgetView({
           textCell(budgetName(scope, budget)),
           textCell(formatAmount(budget.current_spend, budget.currency)),
           textCell(formatAmount(budget.remaining, budget.currency)),
-          statusCell(String(budget.status || "").toLowerCase()),
+          statusCell(
+            String(budget.status || "").toLowerCase(),
+            budget.enabled !== false,
+          ),
           textCell(budget.reset_period),
           actionsCell(scope, budget),
         );
@@ -121,8 +127,7 @@ window.createBudgetView = function createBudgetView({
     requestVersion += 1;
     providers = [];
     models = [];
-    byId("budget-form").reset();
-    updateScopeLabel();
+    clearEditor();
     render();
   }
 
@@ -169,6 +174,18 @@ window.createBudgetView = function createBudgetView({
     byId("budget-name").placeholder = scope === "provider" ? "openai" : "gpt-4o";
   }
 
+  function setEditMode(editing) {
+    byId("budget-scope").disabled = editing;
+    byId("budget-name").readOnly = editing;
+    byId("cancel-budget-edit").hidden = !editing;
+  }
+
+  function clearEditor() {
+    byId("budget-form").reset();
+    setEditMode(false);
+    updateScopeLabel();
+  }
+
   function editBudget(scope, budget) {
     const form = byId("budget-form");
     byId("budget-scope").value = scope;
@@ -178,6 +195,7 @@ window.createBudgetView = function createBudgetView({
     byId("budget-reset-period").value = budget.reset_period;
     byId("budget-currency").value = String(budget.currency || "USD").toUpperCase();
     byId("budget-enabled").checked = budget.enabled !== false;
+    setEditMode(true);
     byId("budget-editor").open = true;
     form.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
     byId("budget-max").focus();
@@ -210,8 +228,7 @@ window.createBudgetView = function createBudgetView({
       );
       ensureCurrent(session);
       await refreshAfterMutation(session, `${config.label} budget saved.`);
-      form.reset();
-      updateScopeLabel();
+      clearEditor();
     } catch (error) {
       if (error?.name !== "AbortError") {
         reportRequestError(error, "Budget save failed.");
@@ -294,6 +311,7 @@ window.createBudgetView = function createBudgetView({
 
   byId("budget-scope").addEventListener("change", updateScopeLabel);
   byId("budget-form").addEventListener("submit", (event) => void saveBudget(event));
+  byId("cancel-budget-edit").addEventListener("click", clearEditor);
   byId("refresh-budgets").addEventListener("click", (event) =>
     void refresh(event.currentTarget),
   );

--- a/src/server/routes/admin_dashboard/budget.js
+++ b/src/server/routes/admin_dashboard/budget.js
@@ -1,0 +1,292 @@
+"use strict";
+
+window.createBudgetView = function createBudgetView({
+  apiRequest,
+  beginBusy,
+  byId,
+  captureSession,
+  clearError,
+  createAction,
+  endBusy,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+}) {
+  let providers = [];
+  let models = [];
+  let requestVersion = 0;
+
+  const scopeConfig = {
+    provider: {
+      collection: "providers",
+      field: "provider",
+      label: "Provider",
+      rows: () => providers,
+    },
+    model: {
+      collection: "models",
+      field: "model",
+      label: "Model",
+      rows: () => models,
+    },
+  };
+
+  function configFor(scope) {
+    const config = scopeConfig[scope];
+    if (!config) {
+      throw new Error("Choose a provider or model budget scope.");
+    }
+    return config;
+  }
+
+  function budgetName(scope, budget) {
+    return budget[configFor(scope).field];
+  }
+
+  function formatAmount(value, currency) {
+    const amount = Number(value);
+    const unit = String(currency || "USD").toUpperCase();
+    if (!Number.isFinite(amount)) {
+      return "";
+    }
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: unit,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 4,
+      }).format(amount);
+    } catch {
+      return `${unit} ${amount.toFixed(4)}`;
+    }
+  }
+
+  function statusCell(status) {
+    const value = ["ok", "warning", "exceeded"].includes(status)
+      ? status
+      : "unknown";
+    const cell = document.createElement("td");
+    const badge = document.createElement("span");
+    badge.className = "budget-state";
+    badge.dataset.budgetState = value;
+    badge.textContent = value;
+    cell.append(badge);
+    return cell;
+  }
+
+  function actionsCell(scope, budget) {
+    const name = budgetName(scope, budget);
+    const cell = document.createElement("td");
+    cell.className = "budget-actions";
+    cell.append(
+      createAction("Edit", "secondary compact", () => editBudget(scope, budget)),
+      createAction("Reset", "secondary compact", (event) => {
+        void resetBudget(scope, budget, event.currentTarget);
+      }),
+      createAction("Delete", "danger compact", (event) => {
+        void deleteBudget(scope, budget, event.currentTarget);
+      }),
+    );
+    cell.setAttribute("aria-label", `${configFor(scope).label} ${name} actions`);
+    return cell;
+  }
+
+  function renderRows(scope) {
+    const config = configFor(scope);
+    const rows = config.rows();
+    byId(`${scope}-budgets-body`).replaceChildren(
+      ...rows.map((budget) => {
+        const row = document.createElement("tr");
+        row.append(
+          textCell(budgetName(scope, budget)),
+          textCell(formatAmount(budget.current_spend, budget.currency)),
+          textCell(formatAmount(budget.remaining, budget.currency)),
+          statusCell(String(budget.status || "").toLowerCase()),
+          textCell(budget.reset_period),
+          actionsCell(scope, budget),
+        );
+        return row;
+      }),
+    );
+    byId(`${scope}-budgets-empty`).hidden = rows.length !== 0;
+  }
+
+  function render() {
+    renderRows("provider");
+    renderRows("model");
+  }
+
+  function reset() {
+    requestVersion += 1;
+    providers = [];
+    models = [];
+    byId("budget-form").reset();
+    updateScopeLabel();
+    render();
+  }
+
+  async function load(session = captureSession()) {
+    const version = ++requestVersion;
+    const [providerData, modelData] = await Promise.all([
+      apiRequest("/v1/budget/providers", {}, session),
+      apiRequest("/v1/budget/models", {}, session),
+    ]);
+    ensureCurrent(session);
+    if (version !== requestVersion) {
+      throw new DOMException("Stale budget response", "AbortError");
+    }
+    if (!Array.isArray(providerData?.providers)) {
+      throw new Error("Provider budget response did not include a list.");
+    }
+    if (!Array.isArray(modelData?.models)) {
+      throw new Error("Model budget response did not include a list.");
+    }
+    providers = providerData.providers;
+    models = modelData.models;
+    render();
+  }
+
+  function updateScopeLabel() {
+    const scope = byId("budget-scope").value;
+    const config = configFor(scope);
+    byId("budget-name-label").textContent = `${config.label} name`;
+    byId("budget-name").placeholder = scope === "provider" ? "openai" : "gpt-4o";
+  }
+
+  function editBudget(scope, budget) {
+    const form = byId("budget-form");
+    byId("budget-scope").value = scope;
+    updateScopeLabel();
+    byId("budget-name").value = budgetName(scope, budget);
+    byId("budget-max").value = budget.max_budget;
+    byId("budget-reset-period").value = budget.reset_period;
+    byId("budget-currency").value = String(budget.currency || "USD").toUpperCase();
+    byId("budget-enabled").checked = budget.enabled !== false;
+    byId("budget-editor").open = true;
+    form.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
+    byId("budget-max").focus();
+  }
+
+  async function saveBudget(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const button = event.submitter;
+    if (!beginBusy("save-budget", button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    try {
+      const scope = byId("budget-scope").value;
+      const config = configFor(scope);
+      const name = byId("budget-name").value.trim();
+      const payload = {
+        [config.field]: name,
+        max_budget: Number(byId("budget-max").value),
+        reset_period: byId("budget-reset-period").value,
+        soft_limit_percentage: Number(byId("budget-soft-limit").value) / 100,
+        currency: byId("budget-currency").value,
+        enabled: byId("budget-enabled").checked,
+      };
+      await apiRequest(
+        `/v1/budget/${config.collection}`,
+        { method: "POST", body: JSON.stringify(payload) },
+        session,
+      );
+      ensureCurrent(session);
+      await load(session);
+      form.reset();
+      updateScopeLabel();
+      setStatus(`${config.label} budget saved.`);
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        reportRequestError(error, "Budget save failed.");
+      }
+    } finally {
+      endBusy("save-budget", button);
+    }
+  }
+
+  async function resetBudget(scope, budget, button) {
+    const config = configFor(scope);
+    const name = budgetName(scope, budget);
+    if (!window.confirm(`Reset ${scope} budget “${name}” to zero spend?`)) {
+      return;
+    }
+    const busyKey = `reset-${scope}-budget:${name}`;
+    if (!beginBusy(busyKey, button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    try {
+      await apiRequest(
+        `/v1/budget/${config.collection}/${encodeURIComponent(name)}/reset`,
+        { method: "POST" },
+        session,
+      );
+      ensureCurrent(session);
+      await load(session);
+      setStatus(`${config.label} budget reset.`);
+    } catch (error) {
+      reportRequestError(error, "Budget reset failed.");
+    } finally {
+      endBusy(busyKey, button);
+    }
+  }
+
+  async function deleteBudget(scope, budget, button) {
+    const config = configFor(scope);
+    const name = budgetName(scope, budget);
+    if (!window.confirm(`Delete ${scope} budget “${name}”?`)) {
+      return;
+    }
+    const busyKey = `delete-${scope}-budget:${name}`;
+    if (!beginBusy(busyKey, button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    try {
+      await apiRequest(
+        `/v1/budget/${config.collection}/${encodeURIComponent(name)}`,
+        { method: "DELETE" },
+        session,
+      );
+      ensureCurrent(session);
+      await load(session);
+      setStatus(`${config.label} budget deleted.`);
+    } catch (error) {
+      reportRequestError(error, "Budget deletion failed.");
+    } finally {
+      endBusy(busyKey, button);
+    }
+  }
+
+  async function refresh(button) {
+    if (button.disabled) {
+      return;
+    }
+    button.disabled = true;
+    clearError();
+    setStatus("Refreshing budgets…");
+    try {
+      await load();
+      setStatus("Budgets refreshed.");
+    } catch (error) {
+      reportRequestError(error, "Budget refresh failed.");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  byId("budget-scope").addEventListener("change", updateScopeLabel);
+  byId("budget-form").addEventListener("submit", (event) => void saveBudget(event));
+  byId("refresh-budgets").addEventListener("click", (event) =>
+    void refresh(event.currentTarget),
+  );
+  updateScopeLabel();
+
+  return { load, reset };
+};

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -236,7 +236,7 @@
                    placeholder="openai">
             <label for="budget-max">Maximum budget</label>
             <input id="budget-max" name="max_budget" type="number" required
-                   min="0.0001" step="0.0001" inputmode="decimal">
+                   step="any" inputmode="decimal">
             <label for="budget-reset-period">Reset period</label>
             <select id="budget-reset-period" name="reset_period">
               <option value="daily">Daily</option>
@@ -247,10 +247,6 @@
             <label for="budget-currency">Currency</label>
             <select id="budget-currency" name="currency">
               <option value="USD">USD</option>
-              <option value="EUR">EUR</option>
-              <option value="GBP">GBP</option>
-              <option value="JPY">JPY</option>
-              <option value="CNY">CNY</option>
             </select>
             <label class="checkbox-row" for="budget-enabled">
               <input id="budget-enabled" name="enabled" type="checkbox" checked>

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -7,6 +7,7 @@
   <title>LiteLLM-RS Admin</title>
   <link rel="stylesheet" href="/admin/dashboard/app.css">
   <script src="/admin/dashboard/provider-health.js" defer></script>
+  <script src="/admin/dashboard/budget.js" defer></script>
   <script src="/admin/dashboard/app.js" defer></script>
 </head>
 <body>
@@ -48,6 +49,8 @@
                 aria-controls="teams-panel" aria-selected="false">Teams</button>
         <button class="tab" type="button" data-view="spend"
                 aria-controls="spend-panel" aria-selected="false">Spend</button>
+        <button class="tab" type="button" data-view="budgets"
+                aria-controls="budgets-panel" aria-selected="false">Budgets</button>
         <button class="tab" type="button" data-view="health"
                 aria-controls="health-panel" aria-selected="false">Provider health</button>
       </nav>
@@ -207,6 +210,109 @@
           <p id="team-spend-empty" class="empty-state" hidden>
             No teams on the current page.
           </p>
+        </div>
+      </section>
+
+      <section id="budgets-panel" class="panel" aria-labelledby="budgets-title" hidden>
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Cost controls</p>
+            <h2 id="budgets-title">Provider and model budgets</h2>
+            <p>Set enforced gateway limits and monitor remaining spend.</p>
+          </div>
+          <button id="refresh-budgets" class="secondary" type="button">Refresh</button>
+        </div>
+
+        <details id="budget-editor" class="create-card">
+          <summary>Create or update a budget</summary>
+          <form id="budget-form" class="form-grid">
+            <label for="budget-scope">Scope</label>
+            <select id="budget-scope" name="scope">
+              <option value="provider">Provider</option>
+              <option value="model">Model</option>
+            </select>
+            <label id="budget-name-label" for="budget-name">Provider name</label>
+            <input id="budget-name" name="name" required maxlength="240"
+                   placeholder="openai">
+            <label for="budget-max">Maximum budget</label>
+            <input id="budget-max" name="max_budget" type="number" required
+                   min="0.0001" step="0.0001" inputmode="decimal">
+            <label for="budget-reset-period">Reset period</label>
+            <select id="budget-reset-period" name="reset_period">
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly" selected>Monthly</option>
+              <option value="never">Never</option>
+            </select>
+            <label for="budget-soft-limit">Warning threshold</label>
+            <div class="input-suffix">
+              <input id="budget-soft-limit" name="soft_limit_percentage"
+                     type="number" required min="0" max="100" step="1" value="80">
+              <span aria-hidden="true">%</span>
+            </div>
+            <label for="budget-currency">Currency</label>
+            <select id="budget-currency" name="currency">
+              <option value="USD">USD</option>
+              <option value="EUR">EUR</option>
+              <option value="GBP">GBP</option>
+              <option value="JPY">JPY</option>
+              <option value="CNY">CNY</option>
+            </select>
+            <label class="checkbox-row" for="budget-enabled">
+              <input id="budget-enabled" name="enabled" type="checkbox" checked>
+              Enforce this budget
+            </label>
+            <p class="field-help">Saving an existing scope updates it. The warning
+              threshold is submitted explicitly because the list API does not return it.</p>
+            <button type="submit">Save budget</button>
+          </form>
+        </details>
+
+        <div class="budget-grid">
+          <div>
+            <h3>Providers</h3>
+            <div class="table-wrap">
+              <table>
+                <caption>Provider budget limits</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Provider</th>
+                    <th scope="col">Current</th>
+                    <th scope="col">Remaining</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Reset</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="provider-budgets-body"></tbody>
+              </table>
+            </div>
+            <p id="provider-budgets-empty" class="empty-state" hidden>
+              No provider budgets configured.
+            </p>
+          </div>
+          <div>
+            <h3>Models</h3>
+            <div class="table-wrap">
+              <table>
+                <caption>Model budget limits</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Model</th>
+                    <th scope="col">Current</th>
+                    <th scope="col">Remaining</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Reset</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="model-budgets-body"></tbody>
+              </table>
+            </div>
+            <p id="model-budgets-empty" class="empty-state" hidden>
+              No model budgets configured.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -244,12 +244,6 @@
               <option value="monthly" selected>Monthly</option>
               <option value="never">Never</option>
             </select>
-            <label for="budget-soft-limit">Warning threshold</label>
-            <div class="input-suffix">
-              <input id="budget-soft-limit" name="soft_limit_percentage"
-                     type="number" required min="0" max="100" step="1" value="80">
-              <span aria-hidden="true">%</span>
-            </div>
             <label for="budget-currency">Currency</label>
             <select id="budget-currency" name="currency">
               <option value="USD">USD</option>
@@ -262,8 +256,8 @@
               <input id="budget-enabled" name="enabled" type="checkbox" checked>
               Enforce this budget
             </label>
-            <p class="field-help">Saving an existing scope updates it. The warning
-              threshold is submitted explicitly because the list API does not return it.</p>
+            <p class="field-help">Saving an existing scope updates its settings
+              without resetting accrued spend or its warning threshold.</p>
             <button type="submit">Save budget</button>
           </form>
         </details>

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -259,6 +259,9 @@
             <p class="field-help">Saving an existing scope updates its settings
               without resetting accrued spend or its warning threshold.</p>
             <button type="submit">Save budget</button>
+            <button id="cancel-budget-edit" class="secondary" type="button" hidden>
+              Cancel edit
+            </button>
           </form>
         </details>
 

--- a/src/server/routes/budget.rs
+++ b/src/server/routes/budget.rs
@@ -262,24 +262,21 @@ pub async fn set_provider_budget(
         )));
     }
 
-    let soft_limit_percentage = request.soft_limit_percentage.unwrap_or_else(|| {
-        budget_limits
-            .providers
-            .get_provider_soft_limit_percentage(&request.provider)
-            .unwrap_or_else(default_soft_limit_percentage)
-    });
-
     let config = ProviderLimitConfig {
         max_budget: request.max_budget,
         reset_period: request.reset_period,
-        soft_limit_percentage,
+        soft_limit_percentage: request
+            .soft_limit_percentage
+            .unwrap_or_else(default_soft_limit_percentage),
         currency: request.currency,
         enabled: request.enabled,
     };
 
-    budget_limits
-        .providers
-        .set_provider_limit(&request.provider, config);
+    budget_limits.providers.set_provider_limit_optional(
+        &request.provider,
+        config,
+        request.soft_limit_percentage,
+    );
 
     info!(
         "Set provider budget for '{}': ${:.2} ({})",
@@ -518,22 +515,21 @@ pub async fn set_model_budget(
         )));
     }
 
-    let soft_limit_percentage = request.soft_limit_percentage.unwrap_or_else(|| {
-        budget_limits
-            .models
-            .get_model_soft_limit_percentage(&request.model)
-            .unwrap_or_else(default_soft_limit_percentage)
-    });
-
     let config = ModelLimitConfig {
         max_budget: request.max_budget,
         reset_period: request.reset_period,
-        soft_limit_percentage,
+        soft_limit_percentage: request
+            .soft_limit_percentage
+            .unwrap_or_else(default_soft_limit_percentage),
         currency: request.currency,
         enabled: request.enabled,
     };
 
-    budget_limits.models.set_model_limit(&request.model, config);
+    budget_limits.models.set_model_limit_optional(
+        &request.model,
+        config,
+        request.soft_limit_percentage,
+    );
 
     info!(
         "Set model budget for '{}': ${:.2} ({})",

--- a/src/server/routes/budget.rs
+++ b/src/server/routes/budget.rs
@@ -30,8 +30,8 @@ pub struct SetProviderBudgetRequest {
     #[serde(default = "default_reset_period")]
     pub reset_period: ResetPeriod,
     /// Soft limit percentage (0.0 to 1.0)
-    #[serde(default = "default_soft_limit_percentage")]
-    pub soft_limit_percentage: f64,
+    #[serde(default)]
+    pub soft_limit_percentage: Option<f64>,
     /// Currency
     #[serde(default)]
     pub currency: Currency,
@@ -63,8 +63,8 @@ pub struct SetModelBudgetRequest {
     #[serde(default = "default_reset_period")]
     pub reset_period: ResetPeriod,
     /// Soft limit percentage (0.0 to 1.0)
-    #[serde(default = "default_soft_limit_percentage")]
-    pub soft_limit_percentage: f64,
+    #[serde(default)]
+    pub soft_limit_percentage: Option<f64>,
     /// Currency
     #[serde(default)]
     pub currency: Currency,
@@ -241,7 +241,6 @@ pub async fn set_provider_budget(
         return Ok(forbidden);
     }
 
-    // Validate request
     if request.provider.trim().is_empty() {
         return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(
             "Provider name cannot be empty".to_string(),
@@ -254,19 +253,26 @@ pub async fn set_provider_budget(
         )));
     }
 
-    if !request.soft_limit_percentage.is_finite()
-        || request.soft_limit_percentage < 0.0
-        || request.soft_limit_percentage > 1.0
+    if request
+        .soft_limit_percentage
+        .is_some_and(|percentage| !percentage.is_finite() || !(0.0..=1.0).contains(&percentage))
     {
         return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(
             "soft_limit_percentage must be finite and between 0.0 and 1.0".to_string(),
         )));
     }
 
+    let soft_limit_percentage = request.soft_limit_percentage.unwrap_or_else(|| {
+        budget_limits
+            .providers
+            .get_provider_soft_limit_percentage(&request.provider)
+            .unwrap_or_else(default_soft_limit_percentage)
+    });
+
     let config = ProviderLimitConfig {
         max_budget: request.max_budget,
         reset_period: request.reset_period,
-        soft_limit_percentage: request.soft_limit_percentage,
+        soft_limit_percentage,
         currency: request.currency,
         enabled: request.enabled,
     };
@@ -280,7 +286,6 @@ pub async fn set_provider_budget(
         request.provider, request.max_budget, request.reset_period
     );
 
-    // Return the created/updated budget
     match budget_limits
         .providers
         .get_provider_usage(&request.provider)
@@ -321,7 +326,6 @@ pub async fn list_provider_budgets(
     let providers: Vec<ProviderBudgetResponse> = usage_list
         .into_iter()
         .map(|usage| {
-            // Get the budget to get currency and enabled status
             let budgets = budget_limits.providers.list_provider_budgets();
             let budget = budgets
                 .iter()
@@ -493,7 +497,6 @@ pub async fn set_model_budget(
         return Ok(forbidden);
     }
 
-    // Validate request
     if request.model.trim().is_empty() {
         return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(
             "Model name cannot be empty".to_string(),
@@ -506,19 +509,26 @@ pub async fn set_model_budget(
         )));
     }
 
-    if !request.soft_limit_percentage.is_finite()
-        || request.soft_limit_percentage < 0.0
-        || request.soft_limit_percentage > 1.0
+    if request
+        .soft_limit_percentage
+        .is_some_and(|percentage| !percentage.is_finite() || !(0.0..=1.0).contains(&percentage))
     {
         return Ok(HttpResponse::BadRequest().json(ApiResponse::<()>::error(
             "soft_limit_percentage must be finite and between 0.0 and 1.0".to_string(),
         )));
     }
 
+    let soft_limit_percentage = request.soft_limit_percentage.unwrap_or_else(|| {
+        budget_limits
+            .models
+            .get_model_soft_limit_percentage(&request.model)
+            .unwrap_or_else(default_soft_limit_percentage)
+    });
+
     let config = ModelLimitConfig {
         max_budget: request.max_budget,
         reset_period: request.reset_period,
-        soft_limit_percentage: request.soft_limit_percentage,
+        soft_limit_percentage,
         currency: request.currency,
         enabled: request.enabled,
     };
@@ -530,7 +540,6 @@ pub async fn set_model_budget(
         request.model, request.max_budget, request.reset_period
     );
 
-    // Return the created/updated budget
     match budget_limits.models.get_model_usage(&request.model) {
         Some(usage) => {
             let response = ModelBudgetResponse {
@@ -762,7 +771,6 @@ pub async fn get_budget_summary(
 pub fn configure_budget_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/v1/budget")
-            // Provider budget routes
             .route("/providers", web::post().to(set_provider_budget))
             .route("/providers", web::get().to(list_provider_budgets))
             .route("/providers/{name}", web::get().to(get_provider_budget))
@@ -774,13 +782,11 @@ pub fn configure_budget_routes(cfg: &mut web::ServiceConfig) {
                 "/providers/{name}/reset",
                 web::post().to(reset_provider_budget),
             )
-            // Model budget routes
             .route("/models", web::post().to(set_model_budget))
             .route("/models", web::get().to(list_model_budgets))
             .route("/models/{name}", web::get().to(get_model_budget))
             .route("/models/{name}", web::delete().to(delete_model_budget))
             .route("/models/{name}/reset", web::post().to(reset_model_budget))
-            // Summary
             .route("/summary", web::get().to(get_budget_summary)),
     );
 }

--- a/src/server/routes/budget.rs
+++ b/src/server/routes/budget.rs
@@ -16,6 +16,7 @@ use crate::server::routes::ApiResponse;
 use crate::server::state::AppState;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -319,14 +320,17 @@ pub async fn list_provider_budgets(
     budget_limits: web::Data<Arc<UnifiedBudgetLimits>>,
 ) -> ActixResult<HttpResponse> {
     let usage_list = budget_limits.providers.list_provider_usage();
+    let budgets: HashMap<_, _> = budget_limits
+        .providers
+        .list_provider_budgets()
+        .into_iter()
+        .map(|budget| (budget.provider_name.clone(), budget))
+        .collect();
 
     let providers: Vec<ProviderBudgetResponse> = usage_list
         .into_iter()
         .map(|usage| {
-            let budgets = budget_limits.providers.list_provider_budgets();
-            let budget = budgets
-                .iter()
-                .find(|b| b.provider_name == usage.provider_name);
+            let budget = budgets.get(&usage.provider_name);
 
             ProviderBudgetResponse {
                 provider: usage.provider_name,
@@ -569,12 +573,17 @@ pub async fn list_model_budgets(
     budget_limits: web::Data<Arc<UnifiedBudgetLimits>>,
 ) -> ActixResult<HttpResponse> {
     let usage_list = budget_limits.models.list_model_usage();
+    let budgets: HashMap<_, _> = budget_limits
+        .models
+        .list_model_budgets()
+        .into_iter()
+        .map(|budget| (budget.model_name.clone(), budget))
+        .collect();
 
     let models: Vec<ModelBudgetResponse> = usage_list
         .into_iter()
         .map(|usage| {
-            let budgets = budget_limits.models.list_model_budgets();
-            let budget = budgets.iter().find(|b| b.model_name == usage.model_name);
+            let budget = budgets.get(&usage.model_name);
 
             ModelBudgetResponse {
                 model: usage.model_name,

--- a/src/server/routes/budget/tests.rs
+++ b/src/server/routes/budget/tests.rs
@@ -15,7 +15,7 @@ fn provider_request(provider: &str, max_budget: f64) -> SetProviderBudgetRequest
         provider: provider.to_string(),
         max_budget,
         reset_period: ResetPeriod::Monthly,
-        soft_limit_percentage: 0.8,
+        soft_limit_percentage: Some(0.8),
         currency: Currency::USD,
         enabled: true,
     }
@@ -26,7 +26,7 @@ fn model_request(model: &str, max_budget: f64) -> SetModelBudgetRequest {
         model: model.to_string(),
         max_budget,
         reset_period: ResetPeriod::Monthly,
-        soft_limit_percentage: 0.8,
+        soft_limit_percentage: Some(0.8),
         currency: Currency::USD,
         enabled: true,
     }
@@ -255,6 +255,82 @@ async fn test_list_model_budgets() {
         .to_request();
     let resp: actix_web::dev::ServiceResponse = test::call_service(&app, req).await;
     assert!(resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn omitted_soft_limit_preserves_existing_budget_state() {
+    let budget_limits = seeded_budget_limits();
+    let mut provider_config = ProviderLimitConfig::new(1000.0, ResetPeriod::Monthly);
+    provider_config.soft_limit_percentage = 0.5;
+    budget_limits
+        .providers
+        .set_provider_limit("openai", provider_config);
+    let mut model_config = ModelLimitConfig::new(500.0, ResetPeriod::Monthly);
+    model_config.soft_limit_percentage = 0.75;
+    budget_limits.models.set_model_limit("gpt-4", model_config);
+    budget_limits
+        .providers
+        .record_provider_spend("openai", 25.0);
+    budget_limits.models.record_model_spend("gpt-4", 10.0);
+    let admin = make_test_user(UserRole::Admin);
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(move |req, srv| {
+                req.extensions_mut().insert::<User>(admin.clone());
+                srv.call(req)
+            })
+            .app_data(web::Data::new(Arc::clone(&budget_limits)))
+            .configure(configure_budget_routes),
+    )
+    .await;
+
+    for (path, body) in [
+        (
+            "/v1/budget/providers",
+            serde_json::json!({
+                "provider": "openai",
+                "max_budget": 200.0,
+                "reset_period": "weekly"
+            }),
+        ),
+        (
+            "/v1/budget/models",
+            serde_json::json!({
+                "model": "gpt-4",
+                "max_budget": 150.0,
+                "reset_period": "daily"
+            }),
+        ),
+    ] {
+        let request = test::TestRequest::post()
+            .uri(path)
+            .set_json(body)
+            .to_request();
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), 201, "{path}");
+    }
+
+    let provider = budget_limits
+        .providers
+        .get_provider_usage("openai")
+        .unwrap();
+    assert_eq!(provider.current_spend, 25.0);
+    assert_eq!(provider.max_budget, 200.0);
+    assert_eq!(
+        budget_limits
+            .providers
+            .get_provider_soft_limit_percentage("openai"),
+        Some(0.5)
+    );
+    let model = budget_limits.models.get_model_usage("gpt-4").unwrap();
+    assert_eq!(model.current_spend, 10.0);
+    assert_eq!(model.max_budget, 150.0);
+    assert_eq!(
+        budget_limits
+            .models
+            .get_model_soft_limit_percentage("gpt-4"),
+        Some(0.75)
+    );
 }
 
 #[actix_web::test]

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -10,6 +10,10 @@ const appSource = await readFile(
   new URL("../../src/server/routes/admin_dashboard/app.js", import.meta.url),
   "utf8",
 );
+const budgetSource = await readFile(
+  new URL("../../src/server/routes/admin_dashboard/budget.js", import.meta.url),
+  "utf8",
+);
 const providerHealthSource = await readFile(
   new URL(
     "../../src/server/routes/admin_dashboard/provider_health.js",
@@ -60,6 +64,8 @@ function dashboard(options = {}) {
   const {
     keys = [],
     teams = [],
+    providerBudgets = [],
+    modelBudgets = [],
     usageByTeam = new Map(),
     health = {
       status: "degraded",
@@ -80,6 +86,7 @@ function dashboard(options = {}) {
       '<script src="/admin/dashboard/provider-health.js" defer></script>',
       "",
     )
+    .replace('<script src="/admin/dashboard/budget.js" defer></script>', "")
     .replace('<script src="/admin/dashboard/app.js" defer></script>', "");
   const dom = new JSDOM(htmlWithoutScript, {
     url: "https://gateway.test/admin/dashboard",
@@ -182,6 +189,16 @@ function dashboard(options = {}) {
         }),
       );
     }
+    if (url.pathname === "/v1/budget/providers" && call.method === "GET") {
+      return Promise.resolve(
+        apiResponse({ providers: providerBudgets, total: providerBudgets.length }),
+      );
+    }
+    if (url.pathname === "/v1/budget/models" && call.method === "GET") {
+      return Promise.resolve(
+        apiResponse({ models: modelBudgets, total: modelBudgets.length }),
+      );
+    }
     if (url.pathname === "/health/detailed" && call.method === "GET") {
       return Promise.resolve(healthResponse(health, 503));
     }
@@ -197,6 +214,7 @@ function dashboard(options = {}) {
     throw new Error(`Unexpected request: ${call.method} ${call.path}`);
   };
   window.eval(providerHealthSource);
+  window.eval(budgetSource);
   window.eval(appSource);
   return context;
 }
@@ -231,6 +249,15 @@ function fillKeyForm(window, name) {
   window.document.getElementById("key-models").value = "model-*";
   window.document.getElementById("key-endpoints").value =
     "/v1/chat/completions";
+}
+
+function fillBudgetForm(window, scope, name, maximum) {
+  window.document.getElementById("budget-scope").value = scope;
+  window.document.getElementById("budget-scope").dispatchEvent(
+    new window.Event("change", { bubbles: true }),
+  );
+  window.document.getElementById("budget-name").value = name;
+  window.document.getElementById("budget-max").value = String(maximum);
 }
 
 async function assertCopyCleared(context) {
@@ -823,4 +850,260 @@ test("B9 a late provider health response after logout cannot restore stale data"
   assert.equal(window.document.getElementById("health-notice").textContent, "");
   assert.equal(window.document.querySelectorAll("#health-body tr").length, 0);
   assert.doesNotMatch(window.document.body.textContent, /must-not-return/);
+});
+
+test("B10 budget view renders limits and supports create and update", { concurrency: false }, async (t) => {
+  let providers = [
+    {
+      provider: "openai",
+      max_budget: 100,
+      current_spend: 25,
+      remaining: 75,
+      status: "ok",
+      reset_period: "monthly",
+      currency: "USD",
+      enabled: true,
+    },
+  ];
+  let models = [];
+  const saved = [];
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        return apiResponse({ providers, total: providers.length });
+      }
+      if (call.url.pathname === "/v1/budget/models" && call.method === "GET") {
+        return apiResponse({ models, total: models.length });
+      }
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "POST") {
+        const payload = JSON.parse(call.init.body);
+        saved.push(payload);
+        providers = [{
+          ...providers[0],
+          max_budget: payload.max_budget,
+          remaining: payload.max_budget - providers[0].current_spend,
+          reset_period: payload.reset_period,
+        }];
+        return apiResponse(providers[0], 201);
+      }
+      if (call.url.pathname === "/v1/budget/models" && call.method === "POST") {
+        const payload = JSON.parse(call.init.body);
+        saved.push(payload);
+        models = [{
+          model: payload.model,
+          max_budget: payload.max_budget,
+          current_spend: 0,
+          remaining: payload.max_budget,
+          status: "ok",
+          reset_period: payload.reset_period,
+          currency: payload.currency,
+          enabled: payload.enabled,
+        }];
+        return apiResponse(models[0], 201);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  window.document.querySelector('[data-view="budgets"]').click();
+
+  let providerRows = rowText(window, "#provider-budgets-body tr");
+  assert.equal(providerRows.length, 1);
+  assert.match(providerRows[0], /openai.*\$25\.00.*\$75\.00.*ok.*monthly/i);
+  assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 0);
+
+  window.document.querySelector("#provider-budgets-body button").click();
+  assert.equal(window.document.getElementById("budget-name").value, "openai");
+  window.document.getElementById("budget-max").value = "200";
+  const updateButton = submit(window, window.document.getElementById("budget-form"));
+  await waitFor(
+    () => !updateButton.disabled,
+    "provider budget update did not settle",
+  );
+  assert.match(
+    window.document.getElementById("status-region").textContent,
+    /provider budget saved/i,
+    window.document.getElementById("error-region").textContent,
+  );
+  assert.deepEqual(saved[0], {
+    provider: "openai",
+    max_budget: 200,
+    reset_period: "monthly",
+    soft_limit_percentage: 0.8,
+    currency: "USD",
+    enabled: true,
+  });
+  providerRows = rowText(window, "#provider-budgets-body tr");
+  assert.match(providerRows[0], /\$25\.00.*\$175\.00/);
+
+  fillBudgetForm(window, "model", "gpt-4o", 50);
+  window.document.getElementById("budget-reset-period").value = "weekly";
+  submit(window, window.document.getElementById("budget-form"));
+  await waitFor(
+    () => /model budget saved/i.test(window.document.getElementById("status-region").textContent),
+    "model budget create did not settle",
+  );
+  assert.equal(saved[1].model, "gpt-4o");
+  assert.equal(saved[1].max_budget, 50);
+  assert.match(rowText(window, "#model-budgets-body tr")[0], /gpt-4o.*\$0\.00.*\$50\.00.*weekly/i);
+});
+
+test("B11 rejected budget saves keep rendered state and expose server errors", { concurrency: false }, async (t) => {
+  const provider = {
+    provider: "anthropic",
+    max_budget: 80,
+    current_spend: 12,
+    remaining: 68,
+    status: "warning",
+    reset_period: "daily",
+    currency: "USD",
+    enabled: true,
+  };
+  let providerGets = 0;
+  const context = dashboard({
+    providerBudgets: [provider],
+    handler(call) {
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        providerGets += 1;
+      }
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "POST") {
+        return apiResponse("max_budget must be finite and greater than 0", 400);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  const before = rowText(window, "#provider-budgets-body tr");
+  fillBudgetForm(window, "provider", "anthropic", 90);
+  const save = submit(window, window.document.getElementById("budget-form"));
+  await waitFor(() => !save.disabled, "rejected budget save did not settle");
+
+  assert.deepEqual(rowText(window, "#provider-budgets-body tr"), before);
+  assert.equal(providerGets, 1, "a rejected mutation must not refresh or replace rows");
+  assert.match(window.document.getElementById("error-region").textContent, /max_budget/i);
+  assert.match(window.document.getElementById("status-region").textContent, /budget save failed/i);
+});
+
+test("B12 budget reset and delete require confirmation and update only after success", { concurrency: false }, async (t) => {
+  const resetRequest = deferred();
+  const deleteRequest = deferred();
+  let providers = [{
+    provider: "openai",
+    max_budget: 100,
+    current_spend: 40,
+    remaining: 60,
+    status: "ok",
+    reset_period: "monthly",
+    currency: "USD",
+    enabled: true,
+  }];
+  let models = [{
+    model: "gpt-4o",
+    max_budget: 30,
+    current_spend: 5,
+    remaining: 25,
+    status: "ok",
+    reset_period: "weekly",
+    currency: "USD",
+    enabled: true,
+  }];
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        return apiResponse({ providers, total: providers.length });
+      }
+      if (call.url.pathname === "/v1/budget/models" && call.method === "GET") {
+        return apiResponse({ models, total: models.length });
+      }
+      if (call.path === "/v1/budget/providers/openai/reset" && call.method === "POST") {
+        return resetRequest.promise;
+      }
+      if (call.path === "/v1/budget/models/gpt-4o" && call.method === "DELETE") {
+        return deleteRequest.promise;
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  const providerButtons = window.document.querySelectorAll("#provider-budgets-body button");
+  const modelButtons = window.document.querySelectorAll("#model-budgets-body button");
+  context.setConfirm(false);
+  providerButtons[1].click();
+  modelButtons[2].click();
+  await settle();
+  assert.equal(
+    context.calls.filter((call) => call.path.includes("/v1/budget/") && ["POST", "DELETE"].includes(call.method)).length,
+    0,
+  );
+
+  context.setConfirm(true);
+  providerButtons[1].click();
+  await waitFor(() => providerButtons[1].disabled, "reset request was not pending");
+  assert.match(rowText(window, "#provider-budgets-body tr")[0], /\$40\.00.*\$60\.00/);
+  providers = [{ ...providers[0], current_spend: 0, remaining: 100 }];
+  resetRequest.resolve(apiResponse(providers[0]));
+  await waitFor(
+    () => /\$0\.00.*\$100\.00/.test(rowText(window, "#provider-budgets-body tr")[0]),
+    "reset result was not rendered after refresh",
+  );
+
+  modelButtons[2].click();
+  await waitFor(() => modelButtons[2].disabled, "delete request was not pending");
+  assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 1);
+  models = [];
+  deleteRequest.resolve(apiResponse({ success: true }));
+  await waitFor(
+    () => window.document.querySelectorAll("#model-budgets-body tr").length === 0,
+    "deleted model remained after the successful refresh",
+  );
+});
+
+test("B13 a late budget mutation after logout cannot restore protected data", { concurrency: false }, async (t) => {
+  const lateSave = deferred();
+  let providerGets = 0;
+  const context = dashboard({
+    providerBudgets: [{
+      provider: "openai",
+      max_budget: 100,
+      current_spend: 10,
+      remaining: 90,
+      status: "ok",
+      reset_period: "monthly",
+      currency: "USD",
+      enabled: true,
+    }],
+    handler(call) {
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        providerGets += 1;
+      }
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "POST") {
+        return lateSave.promise;
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  fillBudgetForm(window, "provider", "must-not-return", 999);
+  submit(window, window.document.getElementById("budget-form"));
+  await waitFor(
+    () => context.calls.some((call) => call.url.pathname === "/v1/budget/providers" && call.method === "POST"),
+    "late budget save was not pending",
+  );
+  window.document.getElementById("sign-out").click();
+  lateSave.resolve(apiResponse({ provider: "must-not-return" }, 201));
+  await settle(12);
+
+  assert.equal(providerGets, 1, "a stale mutation must not trigger a follow-up list request");
+  assert.equal(window.document.querySelectorAll("#provider-budgets-body tr").length, 0);
+  assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 0);
+  assert.equal(window.document.getElementById("budget-name").value, "");
+  assert.doesNotMatch(window.document.body.textContent, /must-not-return|\$999/);
 });

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -244,6 +244,15 @@ async function signIn(context) {
   );
 }
 
+async function openBudgets(context) {
+  const { window } = context;
+  window.document.querySelector('[data-view="budgets"]').click();
+  await waitFor(
+    () => window.document.getElementById("status-region").textContent === "Budgets loaded.",
+    "budget view did not load",
+  );
+}
+
 function fillKeyForm(window, name) {
   window.document.getElementById("key-name").value = name;
   window.document.getElementById("key-models").value = "model-*";
@@ -853,6 +862,7 @@ test("B9 a late provider health response after logout cannot restore stale data"
 });
 
 test("B10 budget view renders limits and supports create and update", { concurrency: false }, async (t) => {
+  let budgetGets = 0;
   let providers = [
     {
       provider: "openai",
@@ -870,9 +880,11 @@ test("B10 budget view renders limits and supports create and update", { concurre
   const context = dashboard({
     handler(call) {
       if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        budgetGets += 1;
         return apiResponse({ providers, total: providers.length });
       }
       if (call.url.pathname === "/v1/budget/models" && call.method === "GET") {
+        budgetGets += 1;
         return apiResponse({ models, total: models.length });
       }
       if (call.url.pathname === "/v1/budget/providers" && call.method === "POST") {
@@ -907,7 +919,12 @@ test("B10 budget view renders limits and supports create and update", { concurre
   t.after(() => context.window.close());
   await signIn(context);
   const { window } = context;
+  assert.equal(budgetGets, 0, "sign-in must not load unopened budget collections");
+  await openBudgets(context);
+  assert.equal(budgetGets, 2);
   window.document.querySelector('[data-view="budgets"]').click();
+  await settle();
+  assert.equal(budgetGets, 2, "reopening the loaded tab must not reload budgets");
 
   let providerRows = rowText(window, "#provider-budgets-body tr");
   assert.equal(providerRows.length, 1);
@@ -955,7 +972,7 @@ test("B10 budget view renders limits and supports create and update", { concurre
   assert.match(rowText(window, "#model-budgets-body tr")[0], /gpt-4o.*\$0\.00.*\$50\.00.*weekly/i);
 });
 
-test("B15 disabled budgets render distinctly and edit keys can be cancelled", { concurrency: false }, async (t) => {
+test("B15 disabled and legacy-currency budgets remain editable", { concurrency: false }, async (t) => {
   const context = dashboard({
     providerBudgets: [{
       provider: "openai",
@@ -964,13 +981,14 @@ test("B15 disabled budgets render distinctly and edit keys can be cancelled", { 
       remaining: 0,
       status: "exceeded",
       reset_period: "monthly",
-      currency: "USD",
+      currency: "EUR",
       enabled: false,
     }],
   });
   t.after(() => context.window.close());
   await signIn(context);
   const { window } = context;
+  await openBudgets(context);
 
   assert.equal(window.document.getElementById("budget-max").step, "any");
   assert.equal(window.document.getElementById("budget-max").hasAttribute("min"), false);
@@ -984,10 +1002,19 @@ test("B15 disabled budgets render distinctly and edit keys can be cancelled", { 
   window.document.querySelector("#provider-budgets-body button").click();
   assert.equal(window.document.getElementById("budget-scope").disabled, true);
   assert.equal(window.document.getElementById("budget-name").readOnly, true);
+  assert.equal(window.document.getElementById("budget-currency").value, "EUR");
+  assert.deepEqual(
+    [...window.document.getElementById("budget-currency").options].map((option) => option.value),
+    ["USD", "EUR"],
+  );
   window.document.getElementById("cancel-budget-edit").click();
   assert.equal(window.document.getElementById("budget-name").value, "");
   assert.equal(window.document.getElementById("budget-scope").disabled, false);
   assert.equal(window.document.getElementById("budget-name").readOnly, false);
+  assert.deepEqual(
+    [...window.document.getElementById("budget-currency").options].map((option) => option.value),
+    ["USD"],
+  );
 });
 
 test("B11 rejected budget saves keep rendered state and expose server errors", { concurrency: false }, async (t) => {
@@ -1017,6 +1044,7 @@ test("B11 rejected budget saves keep rendered state and expose server errors", {
   t.after(() => context.window.close());
   await signIn(context);
   const { window } = context;
+  await openBudgets(context);
   const before = rowText(window, "#provider-budgets-body tr");
   fillBudgetForm(window, "provider", "anthropic", 90);
   const save = submit(window, window.document.getElementById("budget-form"));
@@ -1071,6 +1099,7 @@ test("B12 budget reset and delete require confirmation and update only after suc
   t.after(() => context.window.close());
   await signIn(context);
   const { window } = context;
+  await openBudgets(context);
   const providerButtons = window.document.querySelectorAll("#provider-budgets-body button");
   const modelButtons = window.document.querySelectorAll("#model-budgets-body button");
   context.setConfirm(false);
@@ -1131,6 +1160,7 @@ test("B13 a late budget mutation after logout cannot restore protected data", { 
   t.after(() => context.window.close());
   await signIn(context);
   const { window } = context;
+  await openBudgets(context);
   fillBudgetForm(window, "provider", "must-not-return", 999);
   submit(window, window.document.getElementById("budget-form"));
   await waitFor(
@@ -1180,6 +1210,7 @@ test("B14 a committed mutation reports a later list refresh failure separately",
   t.after(() => context.window.close());
   await signIn(context);
   const { window } = context;
+  await openBudgets(context);
   const before = rowText(window, "#provider-budgets-body tr");
   fillBudgetForm(window, "provider", "openai", 200);
   const save = submit(window, window.document.getElementById("budget-form"));

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -931,7 +931,6 @@ test("B10 budget view renders limits and supports create and update", { concurre
     provider: "openai",
     max_budget: 200,
     reset_period: "monthly",
-    soft_limit_percentage: 0.8,
     currency: "USD",
     enabled: true,
   });
@@ -1106,4 +1105,53 @@ test("B13 a late budget mutation after logout cannot restore protected data", { 
   assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 0);
   assert.equal(window.document.getElementById("budget-name").value, "");
   assert.doesNotMatch(window.document.body.textContent, /must-not-return|\$999/);
+});
+
+test("B14 a committed mutation reports a later list refresh failure separately", { concurrency: false }, async (t) => {
+  const provider = {
+    provider: "openai",
+    max_budget: 100,
+    current_spend: 10,
+    remaining: 90,
+    status: "ok",
+    reset_period: "monthly",
+    currency: "USD",
+    enabled: true,
+  };
+  let providerGets = 0;
+  let saves = 0;
+  const context = dashboard({
+    providerBudgets: [provider],
+    handler(call) {
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        providerGets += 1;
+        if (providerGets === 2) {
+          return apiResponse("budget list unavailable", 503);
+        }
+      }
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "POST") {
+        saves += 1;
+        return apiResponse({ ...provider, max_budget: 200 }, 201);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  const before = rowText(window, "#provider-budgets-body tr");
+  fillBudgetForm(window, "provider", "openai", 200);
+  const save = submit(window, window.document.getElementById("budget-form"));
+  await waitFor(() => !save.disabled, "committed save did not settle");
+
+  assert.equal(saves, 1);
+  assert.deepEqual(rowText(window, "#provider-budgets-body tr"), before);
+  assert.match(
+    window.document.getElementById("status-region").textContent,
+    /provider budget saved.*refresh failed/i,
+  );
+  assert.match(
+    window.document.getElementById("error-region").textContent,
+    /provider budget saved.*budget list refresh failed.*budget list unavailable/i,
+  );
 });

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -972,6 +972,12 @@ test("B15 disabled budgets render distinctly and edit keys can be cancelled", { 
   await signIn(context);
   const { window } = context;
 
+  assert.equal(window.document.getElementById("budget-max").step, "any");
+  assert.equal(window.document.getElementById("budget-max").hasAttribute("min"), false);
+  assert.deepEqual(
+    [...window.document.getElementById("budget-currency").options].map((option) => option.value),
+    ["USD"],
+  );
   const row = rowText(window, "#provider-budgets-body tr")[0];
   assert.match(row, /disabled/i);
   assert.doesNotMatch(row, /exceeded/i);

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -976,9 +976,9 @@ test("B15 disabled and legacy-currency budgets remain editable", { concurrency: 
   const context = dashboard({
     providerBudgets: [{
       provider: "openai",
-      max_budget: 100,
-      current_spend: 100,
-      remaining: 0,
+      max_budget: 0.000003,
+      current_spend: 0.000001,
+      remaining: 0.000002,
       status: "exceeded",
       reset_period: "monthly",
       currency: "EUR",
@@ -999,6 +999,7 @@ test("B15 disabled and legacy-currency budgets remain editable", { concurrency: 
   const row = rowText(window, "#provider-budgets-body tr")[0];
   assert.match(row, /disabled/i);
   assert.doesNotMatch(row, /exceeded/i);
+  assert.match(row, /0\.000001.*0\.000002/);
   window.document.querySelector("#provider-budgets-body button").click();
   assert.equal(window.document.getElementById("budget-scope").disabled, true);
   assert.equal(window.document.getElementById("budget-name").readOnly, true);
@@ -1059,6 +1060,8 @@ test("B11 rejected budget saves keep rendered state and expose server errors", {
 test("B12 budget reset and delete require confirmation and update only after success", { concurrency: false }, async (t) => {
   const resetRequest = deferred();
   const deleteRequest = deferred();
+  const modelDeleteRefresh = deferred();
+  let modelGets = 0;
   let providers = [{
     provider: "openai",
     max_budget: 100,
@@ -1085,6 +1088,10 @@ test("B12 budget reset and delete require confirmation and update only after suc
         return apiResponse({ providers, total: providers.length });
       }
       if (call.url.pathname === "/v1/budget/models" && call.method === "GET") {
+        modelGets += 1;
+        if (modelGets === 3) {
+          return modelDeleteRefresh.promise;
+        }
         return apiResponse({ models, total: models.length });
       }
       if (call.path === "/v1/budget/providers/openai/reset" && call.method === "POST") {
@@ -1122,11 +1129,19 @@ test("B12 budget reset and delete require confirmation and update only after suc
     "reset result was not rendered after refresh",
   );
 
-  modelButtons[2].click();
-  await waitFor(() => modelButtons[2].disabled, "delete request was not pending");
+  const currentModelButtons = window.document.querySelectorAll("#model-budgets-body button");
+  currentModelButtons[0].click();
+  assert.equal(window.document.getElementById("budget-name").value, "gpt-4o");
+  currentModelButtons[2].click();
+  await waitFor(() => currentModelButtons[2].disabled, "delete request was not pending");
   assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 1);
   models = [];
   deleteRequest.resolve(apiResponse({ success: true }));
+  await waitFor(() => modelGets === 3, "delete refresh was not pending");
+  assert.equal(window.document.getElementById("budget-name").value, "");
+  assert.equal(window.document.getElementById("budget-scope").disabled, false);
+  assert.equal(window.document.getElementById("budget-name").readOnly, false);
+  modelDeleteRefresh.resolve(apiResponse({ models, total: 0 }));
   await waitFor(
     () => window.document.querySelectorAll("#model-budgets-body tr").length === 0,
     "deleted model remained after the successful refresh",

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -916,6 +916,9 @@ test("B10 budget view renders limits and supports create and update", { concurre
 
   window.document.querySelector("#provider-budgets-body button").click();
   assert.equal(window.document.getElementById("budget-name").value, "openai");
+  assert.equal(window.document.getElementById("budget-scope").disabled, true);
+  assert.equal(window.document.getElementById("budget-name").readOnly, true);
+  assert.equal(window.document.getElementById("cancel-budget-edit").hidden, false);
   window.document.getElementById("budget-max").value = "200";
   const updateButton = submit(window, window.document.getElementById("budget-form"));
   await waitFor(
@@ -934,6 +937,9 @@ test("B10 budget view renders limits and supports create and update", { concurre
     currency: "USD",
     enabled: true,
   });
+  assert.equal(window.document.getElementById("budget-scope").disabled, false);
+  assert.equal(window.document.getElementById("budget-name").readOnly, false);
+  assert.equal(window.document.getElementById("cancel-budget-edit").hidden, true);
   providerRows = rowText(window, "#provider-budgets-body tr");
   assert.match(providerRows[0], /\$25\.00.*\$175\.00/);
 
@@ -947,6 +953,35 @@ test("B10 budget view renders limits and supports create and update", { concurre
   assert.equal(saved[1].model, "gpt-4o");
   assert.equal(saved[1].max_budget, 50);
   assert.match(rowText(window, "#model-budgets-body tr")[0], /gpt-4o.*\$0\.00.*\$50\.00.*weekly/i);
+});
+
+test("B15 disabled budgets render distinctly and edit keys can be cancelled", { concurrency: false }, async (t) => {
+  const context = dashboard({
+    providerBudgets: [{
+      provider: "openai",
+      max_budget: 100,
+      current_spend: 100,
+      remaining: 0,
+      status: "exceeded",
+      reset_period: "monthly",
+      currency: "USD",
+      enabled: false,
+    }],
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+
+  const row = rowText(window, "#provider-budgets-body tr")[0];
+  assert.match(row, /disabled/i);
+  assert.doesNotMatch(row, /exceeded/i);
+  window.document.querySelector("#provider-budgets-body button").click();
+  assert.equal(window.document.getElementById("budget-scope").disabled, true);
+  assert.equal(window.document.getElementById("budget-name").readOnly, true);
+  window.document.getElementById("cancel-budget-edit").click();
+  assert.equal(window.document.getElementById("budget-name").value, "");
+  assert.equal(window.document.getElementById("budget-scope").disabled, false);
+  assert.equal(window.document.getElementById("budget-name").readOnly, false);
 });
 
 test("B11 rejected budget saves keep rendered state and expose server errors", { concurrency: false }, async (t) => {

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -1231,3 +1231,52 @@ test("B14 a committed mutation reports a later list refresh failure separately",
     /provider budget saved.*budget list refresh failed.*budget list unavailable/i,
   );
 });
+
+test("B16 a committed save clears edit state before a superseded refresh settles", { concurrency: false }, async (t) => {
+  const provider = {
+    provider: "openai", max_budget: 100, current_spend: 10, remaining: 90,
+    status: "ok", reset_period: "monthly", currency: "USD", enabled: true,
+  };
+  const providerRefresh = deferred();
+  const modelRefresh = deferred();
+  let providerGets = 0;
+  let modelGets = 0;
+  const context = dashboard({
+    providerBudgets: [provider],
+    handler(call) {
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "GET") {
+        providerGets += 1;
+        if (providerGets === 2) return providerRefresh.promise;
+      }
+      if (call.url.pathname === "/v1/budget/models" && call.method === "GET") {
+        modelGets += 1;
+        if (modelGets === 2) return modelRefresh.promise;
+      }
+      if (call.url.pathname === "/v1/budget/providers" && call.method === "POST") {
+        return apiResponse({ ...provider, max_budget: 200 }, 201);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openBudgets(context);
+  window.document.querySelector("#provider-budgets-body button").click();
+  window.document.getElementById("budget-max").value = "200";
+  submit(window, window.document.getElementById("budget-form"));
+  await waitFor(() => providerGets === 2 && modelGets === 2, "post-save refresh was not pending");
+
+  assert.equal(window.document.getElementById("budget-name").value, "");
+  assert.equal(window.document.getElementById("budget-scope").disabled, false);
+  assert.equal(window.document.getElementById("budget-name").readOnly, false);
+  window.document.getElementById("refresh-budgets").click();
+  await waitFor(() => providerGets === 3 && modelGets === 3, "manual refresh did not supersede save refresh");
+  providerRefresh.resolve(apiResponse({ providers: [provider], total: 1 }));
+  modelRefresh.resolve(apiResponse({ models: [], total: 0 }));
+  await settle();
+
+  assert.equal(window.document.getElementById("budget-name").value, "");
+  assert.equal(window.document.getElementById("budget-scope").disabled, false);
+  assert.equal(window.document.getElementById("budget-name").readOnly, false);
+});

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -865,7 +865,7 @@ test("B10 budget view renders limits and supports create and update", { concurre
   let budgetGets = 0;
   let providers = [
     {
-      provider: "openai",
+      provider: " openai ",
       max_budget: 100,
       current_spend: 25,
       remaining: 75,
@@ -932,7 +932,7 @@ test("B10 budget view renders limits and supports create and update", { concurre
   assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 0);
 
   window.document.querySelector("#provider-budgets-body button").click();
-  assert.equal(window.document.getElementById("budget-name").value, "openai");
+  assert.equal(window.document.getElementById("budget-name").value, " openai ");
   assert.equal(window.document.getElementById("budget-scope").disabled, true);
   assert.equal(window.document.getElementById("budget-name").readOnly, true);
   assert.equal(window.document.getElementById("cancel-budget-edit").hidden, false);
@@ -948,7 +948,7 @@ test("B10 budget view renders limits and supports create and update", { concurre
     window.document.getElementById("error-region").textContent,
   );
   assert.deepEqual(saved[0], {
-    provider: "openai",
+    provider: " openai ",
     max_budget: 200,
     reset_period: "monthly",
     currency: "USD",
@@ -1176,6 +1176,10 @@ test("B13 a late budget mutation after logout cannot restore protected data", { 
   assert.equal(window.document.querySelectorAll("#model-budgets-body tr").length, 0);
   assert.equal(window.document.getElementById("budget-name").value, "");
   assert.doesNotMatch(window.document.body.textContent, /must-not-return|\$999/);
+  await signIn(context);
+  assert.equal(providerGets, 1, "reauthentication on Keys must not reload budgets");
+  assert.equal(window.document.getElementById("keys-panel").hidden, false);
+  assert.equal(window.document.getElementById("budgets-panel").hidden, true);
 });
 
 test("B14 a committed mutation reports a later list refresh failure separately", { concurrency: false }, async (t) => {


### PR DESCRIPTION
## Summary

- add a Budgets dashboard tab for provider and model budget lists
- support create/update, reset, and delete through the existing `/v1/budget` APIs
- preserve accrued spend and existing warning thresholds when limits are updated
- keep mutations server-authoritative, require confirmation for reset/delete, and clear stale data on logout
- distinguish committed mutations from follow-up list refresh failures
- embed the budget view as an exact dashboard asset and cover it with executable DOM tests

## Verification

- `node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs` (14 passed)
- `cargo test admin_dashboard --lib` (4 passed)
- `cargo test server::middleware::tests::test_is_public_route --lib -- --exact` (1 passed)
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (9394 library passed, 230 integration passed, doctests passed; 0 failed)

Fixes #1263
