### PR TITLE
feat(openai-compatible): forward image generation through the generic provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ a gateway video route.
 | Ollama (`ollama`) | native factory (`providers-extended`) | ✅ | ✅ | ✅ | – | – | Uses native `/api/chat` NDJSON streaming, `/api/embed`, and model tags/show endpoints. Localhost defaults to private-network endpoint policy; explicit endpoints keep their configured policy. |
 | GitHub Models (`github`) | catalog-only (`OpenAILike`) | ✅ | ✅ | – | – | – | Native module retained behind `providers-extended`, but runtime construction is catalog metadata. |
 | GitHub Copilot (`github_copilot`) | native factory (`providers-extended`) | ✅ | ✅ | – | – | – | Uses native GitHub Copilot auth and model access when `providers-extended` is enabled; otherwise explicitly unsupported. |
-| Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | passthrough | – | – | For self-hosted / unlisted OpenAI-compatible chat and embeddings endpoints. |
+| Generic OpenAI-compatible (`openai_compatible`) | always | ✅ | ✅ | passthrough | passthrough | – | For self-hosted / unlisted OpenAI-compatible chat, embeddings, and image endpoints. |
 
 ### Tier 1 — catalog providers (OpenAI-compatible, always available)
 

--- a/src/core/providers/openai_like/provider.rs
+++ b/src/core/providers/openai_like/provider.rs
@@ -17,7 +17,7 @@ use crate::core::types::{
     context::RequestContext,
     embedding::EmbeddingRequest,
     health::HealthStatus,
-    image::ImageEditRequest,
+    image::{ImageEditRequest, ImageGenerationRequest},
     model::{ModelInfo, ProviderCapability},
     responses::{ChatChunk, ChatResponse, EmbeddingResponse, ImageGenerationResponse},
 };
@@ -41,6 +41,7 @@ pub(crate) static OPENAI_COMPATIBLE_PROXY_CAPABILITIES: &[ProviderCapability] = 
     ProviderCapability::ChatCompletion,
     ProviderCapability::ChatCompletionStream,
     ProviderCapability::Embeddings,
+    ProviderCapability::ImageGeneration,
     ProviderCapability::ImageEdit,
     ProviderCapability::ImageVariation,
     ProviderCapability::Moderation,
@@ -310,6 +311,49 @@ impl OpenAILikeProvider {
     ) -> Result<EmbeddingResponse, OpenAILikeError> {
         request.model = self.rewrite_request_model(&request.model);
         let url = format!("{}/embeddings", self.config.get_api_base());
+        let headers = self.get_request_headers();
+        let body = Some(
+            serde_json::to_value(&request)
+                .map_err(|e| OpenAILikeError::serialization(PROVIDER_NAME, e.to_string()))?,
+        );
+
+        let response = self
+            .pool_manager
+            .execute_request(&url, HttpMethod::POST, headers, body)
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.map_err(|error| {
+                self.map_error_response(
+                    status.as_u16(),
+                    &format!("failed to read upstream error body: {error}"),
+                )
+            })?;
+            return Err(self.map_error_response(status.as_u16(), &body));
+        }
+
+        let response_bytes = response
+            .bytes()
+            .await
+            .map_err(|e| OpenAILikeError::network(PROVIDER_NAME, e.to_string()))?;
+
+        serde_json::from_slice(&response_bytes)
+            .map_err(|e| OpenAILikeError::response_parsing(PROVIDER_NAME, e.to_string()))
+    }
+
+    async fn execute_image_generation(
+        &self,
+        mut request: ImageGenerationRequest,
+    ) -> Result<ImageGenerationResponse, OpenAILikeError> {
+        request.model = match request.model {
+            Some(model) => Some(self.rewrite_request_model(&model)),
+            None => self
+                .model_identity
+                .as_ref()
+                .map(|binding| binding.identity().wire_model().to_string()),
+        };
+        let url = format!("{}/images/generations", self.config.get_api_base());
         let headers = self.get_request_headers();
         let body = Some(
             serde_json::to_value(&request)
@@ -739,6 +783,14 @@ impl LLMProvider for OpenAILikeProvider {
         _context: RequestContext,
     ) -> Result<EmbeddingResponse, ProviderError> {
         self.execute_embeddings(request).await
+    }
+
+    async fn image_generation(
+        &self,
+        request: ImageGenerationRequest,
+        _context: RequestContext,
+    ) -> Result<ImageGenerationResponse, ProviderError> {
+        self.execute_image_generation(request).await
     }
 
     async fn image_edit(

--- a/src/core/providers/openai_like/provider/tests.rs
+++ b/src/core/providers/openai_like/provider/tests.rs
@@ -7,6 +7,7 @@ use crate::core::types::chat::ChatMessage;
 use crate::core::types::context::RequestContext;
 use crate::core::types::embedding::{EmbeddingInput, EmbeddingRequest};
 use crate::core::types::health::HealthStatus;
+use crate::core::types::image::ImageGenerationRequest;
 use crate::core::types::message::{MessageContent, MessageRole};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -347,7 +348,9 @@ async fn openai_compatible_declares_executable_proxy_capabilities() {
         OPENAI_COMPATIBLE_PROXY_CAPABILITIES
     );
     assert!(OPENAI_COMPATIBLE_PROXY_CAPABILITIES.contains(&ProviderCapability::Embeddings));
+    assert!(OPENAI_COMPATIBLE_PROXY_CAPABILITIES.contains(&ProviderCapability::ImageGeneration));
     assert!(!OPENAI_LIKE_CATALOG_CAPABILITIES.contains(&ProviderCapability::Embeddings));
+    assert!(!OPENAI_LIKE_CATALOG_CAPABILITIES.contains(&ProviderCapability::ImageGeneration));
 }
 
 #[tokio::test]
@@ -359,6 +362,8 @@ async fn openai_like_catalog_rejects_invalid_capability_profiles() {
     ];
     static UNIMPLEMENTED: &[ProviderCapability] = &[ProviderCapability::ImageEdit];
     static UNIMPLEMENTED_EMBEDDINGS: &[ProviderCapability] = &[ProviderCapability::Embeddings];
+    static UNIMPLEMENTED_IMAGE_GENERATION: &[ProviderCapability] =
+        &[ProviderCapability::ImageGeneration];
 
     let config = OpenAILikeConfig::new(TEST_PUBLIC_API_BASE).with_skip_api_key(true);
     for (profile, expected) in [
@@ -367,6 +372,10 @@ async fn openai_like_catalog_rejects_invalid_capability_profiles() {
         (UNIMPLEMENTED, "not executable for this OpenAI-like profile"),
         (
             UNIMPLEMENTED_EMBEDDINGS,
+            "not executable for this OpenAI-like profile",
+        ),
+        (
+            UNIMPLEMENTED_IMAGE_GENERATION,
             "not executable for this OpenAI-like profile",
         ),
     ] {
@@ -1085,6 +1094,134 @@ async fn openai_compatible_embeddings_malformed_200_is_parse_error()
             "text-embedding-3-small",
             EmbeddingInput::Text("hello".to_string()),
         ),
+        RequestContext::default(),
+    )
+    .await
+    .expect_err("malformed 200 must not become an empty success");
+
+    match err {
+        ProviderError::ResponseParsing { provider, .. } => {
+            assert_eq!(provider, PROVIDER_NAME);
+        }
+        other => panic!("expected response parsing error, got {other:?}"),
+    }
+    Ok(())
+}
+
+fn image_generation_request(model: &str) -> ImageGenerationRequest {
+    ImageGenerationRequest {
+        prompt: "a red cube".to_string(),
+        model: Some(model.to_string()),
+        n: Some(1),
+        size: Some("1024x1024".to_string()),
+        quality: None,
+        response_format: Some("url".to_string()),
+        style: None,
+        user: None,
+    }
+}
+
+const IMAGE_GENERATION_SUCCESS_BODY: &str = r#"{
+    "created": 1710000000,
+    "data": [
+        {
+            "url": "https://images.example.test/gen.png"
+        }
+    ]
+}"#;
+
+#[tokio::test]
+async fn openai_compatible_image_generation_forwards_success_response()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (api_base, captured) =
+        openai_like_json_response_url("200 OK", IMAGE_GENERATION_SUCCESS_BODY).await?;
+    let provider = openai_compatible_embeddings_provider(api_base).await;
+
+    let response = LLMProvider::image_generation(
+        &provider,
+        image_generation_request("gpt-image-1-mini"),
+        RequestContext::default(),
+    )
+    .await?;
+
+    assert_eq!(response.created, 1_710_000_000);
+    assert_eq!(
+        response.data[0].url.as_deref(),
+        Some("https://images.example.test/gen.png")
+    );
+
+    let captured = captured
+        .lock()
+        .expect("captured request mutex")
+        .clone()
+        .expect("image generation request should reach upstream");
+    assert_eq!(captured.path, "/images/generations");
+    let body = captured.json_body();
+    assert_eq!(body["model"], "gpt-image-1-mini");
+    assert_eq!(body["prompt"], "a red cube");
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_compatible_image_generation_rewrites_prefixed_model()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (api_base, captured) =
+        openai_like_json_response_url("200 OK", IMAGE_GENERATION_SUCCESS_BODY).await?;
+    let mut config = private_openai_like_config(api_base);
+    config.model_prefix = Some("custom/".to_string());
+    let provider = OpenAILikeProvider::new_openai_compatible(config).await?;
+
+    LLMProvider::image_generation(
+        &provider,
+        image_generation_request("custom/gpt-image-1-mini"),
+        RequestContext::default(),
+    )
+    .await?;
+
+    let captured = captured
+        .lock()
+        .expect("captured request mutex")
+        .clone()
+        .expect("image generation request should reach upstream");
+    let body = captured.json_body();
+    assert_eq!(body["model"], "gpt-image-1-mini");
+    assert_ne!(body["model"], "custom/gpt-image-1-mini");
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_compatible_image_generation_maps_401_before_deserialize()
+-> Result<(), Box<dyn std::error::Error>> {
+    let body = r#"{"error":{"type":"authentication_error","message":"invalid api key"}}"#;
+    let (api_base, _) = openai_like_json_response_url("401 Unauthorized", body).await?;
+    let provider = openai_compatible_embeddings_provider(api_base).await;
+
+    let err = LLMProvider::image_generation(
+        &provider,
+        image_generation_request("gpt-image-1-mini"),
+        RequestContext::default(),
+    )
+    .await
+    .expect_err("401 must map to authentication before deserialize");
+
+    match err {
+        ProviderError::Authentication { provider, .. } => {
+            assert_eq!(provider, PROVIDER_NAME);
+        }
+        other => panic!("expected authentication error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn openai_compatible_image_generation_malformed_200_is_parse_error()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (api_base, _) = openai_like_json_response_url("200 OK", r#"{"created":1}"#).await?;
+    let provider = openai_compatible_embeddings_provider(api_base).await;
+
+    let err = LLMProvider::image_generation(
+        &provider,
+        image_generation_request("gpt-image-1-mini"),
         RequestContext::default(),
     )
     .await

--- a/src/core/providers/registry/readme_tests.rs
+++ b/src/core/providers/registry/readme_tests.rs
@@ -144,9 +144,10 @@ fn expected_readme_tier2_row(entry: &ProviderRegistryEntry) -> Option<ExpectedRe
         ProviderType::Oci => Some(expected("always", ["✅", "✅", "✅", "–", "–"])),
         ProviderType::Watsonx => Some(expected("always", ["✅", "–", "✅", "–", "–"])),
         ProviderType::SageMaker => Some(expected("always", ["✅", "–", "–", "–", "–"])),
-        ProviderType::OpenAICompatible => {
-            Some(expected("always", ["✅", "✅", "passthrough", "–", "–"]))
-        }
+        ProviderType::OpenAICompatible => Some(expected(
+            "always",
+            ["✅", "✅", "passthrough", "passthrough", "–"],
+        )),
         ProviderType::Azure | ProviderType::AzureAI => Some(expected(
             "native factory (`providers-extra`); OpenAILike fallback",
             ["✅", "✅", "✅", "✅", "–"],

--- a/src/core/providers/registry/support_matrix.rs
+++ b/src/core/providers/registry/support_matrix.rs
@@ -232,8 +232,8 @@ pub static LEGACY_ADAPTER_MATRIX: &[ProviderLegacyAdapterSupport] = &[
     ),
     row(
         "openai_compatible",
-        [P, P, P, U, U, U, U, S, S],
-        "HTTP chat/embeddings and completion() OpenAI-compatible passthrough.",
+        [P, P, P, P, U, U, U, S, S],
+        "HTTP chat/embeddings/image generation and completion() OpenAI-compatible passthrough.",
     ),
     row(
         "sdk_custom",

--- a/tests/integration/http_routes_tests.rs
+++ b/tests/integration/http_routes_tests.rs
@@ -227,6 +227,25 @@ mod tests {
         build_state_with_config(config).await
     }
 
+    async fn build_openai_compatible_image_state(base_url: &str) -> AppState {
+        let mut config = Config::default();
+        config.gateway.auth.enable_jwt = false;
+        config.gateway.auth.enable_api_key = false;
+        config.gateway.auth.allow_anonymous = true;
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.providers = vec![mock_provider_config(
+            "mock-openai-compatible",
+            "openai_compatible",
+            "sk-test",
+            base_url,
+            vec!["gpt-image-1-mini".to_string()],
+        )];
+
+        build_state_with_config(config).await
+    }
+
     async fn mock_embeddings(
         captured_requests: web::Data<Arc<Mutex<Vec<Value>>>>,
         payload: web::Json<Value>,
@@ -246,6 +265,20 @@ mod tests {
                 "completion_tokens": 0,
                 "total_tokens": 1
             }
+        }))
+    }
+
+    async fn mock_image_generations(
+        captured_requests: web::Data<Arc<Mutex<Vec<Value>>>>,
+        payload: web::Json<Value>,
+    ) -> HttpResponse {
+        captured_requests.lock().unwrap().push(payload.into_inner());
+
+        HttpResponse::Ok().json(serde_json::json!({
+            "created": 1710000000,
+            "data": [{
+                "url": "https://images.example.test/gen.png"
+            }]
         }))
     }
 
@@ -823,6 +856,56 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0]["model"], "text-embedding-3-small");
         assert_eq!(requests[0]["input"], "hello");
+    }
+
+    #[tokio::test]
+    async fn test_image_generations_route_proxies_openai_compatible_provider() {
+        let captured_requests = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock server should have local address");
+        let captured_for_server = Arc::clone(&captured_requests);
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(Arc::clone(&captured_for_server)))
+                .route(
+                    "/images/generations",
+                    web::post().to(mock_image_generations),
+                )
+        })
+        .listen(listener)
+        .expect("mock server should listen")
+        .run();
+        let handle = server.handle();
+        let task = tokio::spawn(server);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let state = build_openai_compatible_image_state(&format!("http://{address}")).await;
+        let app = test::init_service(build_test_app(state)).await;
+
+        let req = test::TestRequest::post()
+            .uri("/v1/images/generations")
+            .set_json(serde_json::json!({
+                "model": "gpt-image-1-mini",
+                "prompt": "a red cube"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        handle.stop(true).await;
+        let _ = task.await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["data"][0]["url"],
+            "https://images.example.test/gen.png"
+        );
+        let requests = captured_requests.lock().unwrap().clone();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["model"], "gpt-image-1-mini");
+        assert_eq!(requests[0]["prompt"], "a red cube");
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## What

Forward `/v1/images/generations` through the explicit `openai_compatible` provider profile. Multipart edit/variation already existed; catalog OpenAI-like providers stay chat/tools-only.

## Why

Explicit OpenAI-compatible deployments could generate images via native OpenAI, but not via a generic OpenAI-compatible proxy even when the upstream implements `/images/generations`.

Fixes #1260

## Test Plan

- [x] `openai_compatible_image_generation_*` unit tests (success, prefix rewrite, 401 mapping, malformed 200)
- [x] Catalog still rejects `ImageGeneration`
- [x] HTTP `test_image_generations_route_proxies_openai_compatible_provider`
- [ ] Tested manually

## AI usage

This PR was authored with Cursor (Grok 4.6).

Made with [Cursor](https://cursor.com)