### PR TITLE
feat(admin-ui): add routing inventory dashboard view

### DIFF
--- a/scripts/verify-gh1067.sh
+++ b/scripts/verify-gh1067.sh
@@ -85,6 +85,8 @@ const trackedInputs = [
   "scripts/verify-gh1067.sh", "tests/admin_dashboard/package.json",
   "tests/admin_dashboard/package-lock.json", "tests/admin_dashboard/admin_dashboard_dom.test.mjs",
   "src/server/routes/admin_dashboard/index.html", "src/server/routes/admin_dashboard/app.js",
+  "src/server/routes/admin_dashboard/provider_health.js",
+  "src/server/routes/admin_dashboard/routing_inventory.js",
 ];
 const log = path.join(artifactDir, "admin_dashboard_dom.log");
 const files = [...trackedInputs.map((name) => path.join(root, name)), log]

--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -99,6 +99,7 @@ pub fn is_public_route(path: &str) -> bool {
         "/admin/dashboard/app.js",
         "/admin/dashboard/budget.js",
         "/admin/dashboard/provider-health.js",
+        "/admin/dashboard/routing-inventory.js",
         "/docs",
         "/openapi.json",
     ];

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -97,6 +97,7 @@ fn test_is_public_route() {
     assert!(is_public_route("/admin/dashboard/app.js"));
     assert!(is_public_route("/admin/dashboard/budget.js"));
     assert!(is_public_route("/admin/dashboard/provider-health.js"));
+    assert!(is_public_route("/admin/dashboard/routing-inventory.js"));
     // /metrics requires authentication (not in PUBLIC_ROUTES)
     assert!(!is_public_route("/metrics"));
     // Prefix bypass must be prevented
@@ -106,6 +107,9 @@ fn test_is_public_route() {
     assert!(!is_public_route("/admin/dashboard/app.js.map"));
     assert!(!is_public_route("/admin/dashboard/budget.js.map"));
     assert!(!is_public_route("/admin/dashboard/provider-health.js.map"));
+    assert!(!is_public_route(
+        "/admin/dashboard/routing-inventory.js.map"
+    ));
     assert!(!is_public_route("/healthz"));
     assert!(!is_public_route("/api/users"));
     assert!(!is_public_route("/v1/chat/completions"));

--- a/src/server/routes/admin_dashboard.rs
+++ b/src/server/routes/admin_dashboard.rs
@@ -8,6 +8,7 @@ const APP_CSS: &str = include_str!("admin_dashboard/app.css");
 const APP_JS: &str = include_str!("admin_dashboard/app.js");
 const BUDGET_JS: &str = include_str!("admin_dashboard/budget.js");
 const PROVIDER_HEALTH_JS: &str = include_str!("admin_dashboard/provider_health.js");
+const ROUTING_INVENTORY_JS: &str = include_str!("admin_dashboard/routing_inventory.js");
 const DASHBOARD_CSP: &str = "default-src 'none'; script-src 'self'; style-src 'self'; \
     connect-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'none'; \
     form-action 'self'; frame-ancestors 'none'";
@@ -36,6 +37,10 @@ async fn provider_health_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", PROVIDER_HEALTH_JS)
 }
 
+async fn routing_inventory_javascript() -> HttpResponse {
+    embedded_asset("text/javascript; charset=utf-8", ROUTING_INVENTORY_JS)
+}
+
 async fn budget_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", BUDGET_JS)
 }
@@ -47,6 +52,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/admin/dashboard/provider-health.js",
             web::get().to(provider_health_javascript),
+        )
+        .route(
+            "/admin/dashboard/routing-inventory.js",
+            web::get().to(routing_inventory_javascript),
         )
         .route(
             "/admin/dashboard/budget.js",
@@ -84,6 +93,11 @@ mod tests {
                 "/admin/dashboard/provider-health.js",
                 "text/javascript; charset=utf-8",
                 "createProviderHealthView",
+            ),
+            (
+                "/admin/dashboard/routing-inventory.js",
+                "text/javascript; charset=utf-8",
+                "createRoutingInventoryView",
             ),
             (
                 "/admin/dashboard/budget.js",
@@ -128,6 +142,7 @@ mod tests {
             "/admin/dashboard/",
             "/admin/dashboard/app.js.map",
             "/admin/dashboard/budget.js.map",
+            "/admin/dashboard/routing-inventory.js.map",
             "/admin/dashboard/private",
         ] {
             let response = actix_test::call_service(
@@ -151,9 +166,10 @@ mod tests {
             assert!(APP_JS.contains(path), "missing API path {path}");
         }
         assert!(PROVIDER_HEALTH_JS.contains("\"/health/detailed\""));
+        assert!(ROUTING_INVENTORY_JS.contains("\"/admin/routing/inventory\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/providers\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/models\""));
-        for asset in [APP_JS, PROVIDER_HEALTH_JS, BUDGET_JS] {
+        for asset in [APP_JS, PROVIDER_HEALTH_JS, ROUTING_INVENTORY_JS, BUDGET_JS] {
             for forbidden in [
                 "localStorage",
                 "sessionStorage",
@@ -205,6 +221,9 @@ mod tests {
             "id=\"budget-form\"",
             "id=\"provider-budgets-body\"",
             "id=\"model-budgets-body\"",
+            "id=\"routing-panel\"",
+            "id=\"routing-body\"",
+            "id=\"routing-unavailable-body\"",
         ] {
             assert!(INDEX_HTML.contains(marker), "missing HTML marker {marker}");
         }

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -402,7 +402,8 @@ td code {
 }
 
 .health-state[data-health-state="unknown"],
-.health-state[data-health-state="disabled"] {
+.health-state[data-health-state="disabled"],
+.health-state[data-health-state="degraded"] {
   color: var(--muted);
 }
 

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -75,6 +75,7 @@ function resetProtectedState() {
   renderTeams();
   renderSpend();
   providerHealthView.reset();
+  routingInventoryView.reset();
   budgetView.reset();
 }
 function endSession(message = "Signed out") {
@@ -387,6 +388,16 @@ const providerHealthView = window.createProviderHealthView({
   setStatus,
   textCell,
 });
+const routingInventoryView = window.createRoutingInventoryView({
+  apiRequest,
+  byId,
+  captureSession,
+  clearError,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+});
 const budgetView = window.createBudgetView({
   apiRequest, beginBusy, byId, captureSession, clearError, createAction, endBusy,
   ensureCurrent, reportRequestError, setStatus, textCell,
@@ -476,6 +487,7 @@ async function refreshDashboard() {
       loadKeys(session),
       loadTeams(session),
       providerHealthView.load(session),
+      routingInventoryView.load(session),
     ]);
     ensureCurrent(session);
     await loadTeamUsage(session);
@@ -730,7 +742,7 @@ function showView(view) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-selected", String(active));
   }
-  for (const panel of ["keys", "teams", "spend", "budgets", "health"]) {
+  for (const panel of ["keys", "teams", "spend", "budgets", "health", "routing"]) {
     byId(`${panel}-panel`).hidden = panel !== view;
   }
   if (view === "spend") {

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -7,6 +7,7 @@
   <title>LiteLLM-RS Admin</title>
   <link rel="stylesheet" href="/admin/dashboard/app.css">
   <script src="/admin/dashboard/provider-health.js" defer></script>
+  <script src="/admin/dashboard/routing-inventory.js" defer></script>
   <script src="/admin/dashboard/budget.js" defer></script>
   <script src="/admin/dashboard/app.js" defer></script>
 </head>
@@ -53,6 +54,8 @@
                 aria-controls="budgets-panel" aria-selected="false">Budgets</button>
         <button class="tab" type="button" data-view="health"
                 aria-controls="health-panel" aria-selected="false">Provider health</button>
+        <button class="tab" type="button" data-view="routing"
+                aria-controls="routing-panel" aria-selected="false">Routing inventory</button>
       </nav>
 
       <section id="keys-panel" class="panel" aria-labelledby="keys-title">
@@ -337,6 +340,62 @@
           </table>
         </div>
         <p id="health-empty" class="empty-state" hidden>No providers configured.</p>
+      </section>
+
+      <section id="routing-panel" class="panel" aria-labelledby="routing-title" hidden>
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Live routing snapshot</p>
+            <h2 id="routing-title">Routing inventory</h2>
+            <p>Public models, deployments, and configured providers that are not routed.</p>
+          </div>
+          <button id="refresh-routing" class="secondary" type="button">Refresh</button>
+        </div>
+
+        <p id="routing-summary" class="health-summary"></p>
+        <p id="routing-notice" class="health-notice" aria-live="polite"></p>
+        <div class="table-wrap">
+          <table>
+            <caption>Deployments from the live routing snapshot</caption>
+            <thead>
+              <tr>
+                <th scope="col">Public model</th>
+                <th scope="col">Aliases</th>
+                <th scope="col">Provider</th>
+                <th scope="col">Deployment</th>
+                <th scope="col">Wire model</th>
+                <th scope="col">Capabilities</th>
+                <th scope="col">Health</th>
+                <th scope="col">Availability</th>
+                <th scope="col">Unavailable reasons</th>
+                <th scope="col">Cooldown</th>
+                <th scope="col">RPM</th>
+                <th scope="col">TPM</th>
+                <th scope="col">Active</th>
+              </tr>
+            </thead>
+            <tbody id="routing-body"></tbody>
+          </table>
+        </div>
+        <p id="routing-empty" class="empty-state" hidden>No routed deployments.</p>
+        <div class="table-wrap">
+          <table>
+            <caption>Configured providers missing from the live snapshot</caption>
+            <thead>
+              <tr>
+                <th scope="col">Provider</th>
+                <th scope="col">Type</th>
+                <th scope="col">Public models</th>
+                <th scope="col">Availability</th>
+                <th scope="col">Unavailable reasons</th>
+              </tr>
+            </thead>
+            <tbody id="routing-unavailable-body"></tbody>
+          </table>
+        </div>
+        <p id="routing-unavailable-empty" class="empty-state" hidden>
+          No configured providers are missing from routing.
+        </p>
       </section>
     </section>
   </main>

--- a/src/server/routes/admin_dashboard/routing_inventory.js
+++ b/src/server/routes/admin_dashboard/routing_inventory.js
@@ -1,0 +1,232 @@
+"use strict";
+
+window.createRoutingInventoryView = function createRoutingInventoryView({
+  apiRequest,
+  byId,
+  captureSession,
+  clearError,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+}) {
+  let snapshot = null;
+  let requestError = null;
+  let requestVersion = 0;
+
+  function healthStateCell(status) {
+    const cell = document.createElement("td");
+    const badge = document.createElement("span");
+    badge.className = "health-state";
+    const health = ["unknown", "healthy", "degraded", "unhealthy"].includes(
+      status,
+    )
+      ? status
+      : "unknown";
+    badge.dataset.healthState = health;
+    badge.textContent = health;
+    cell.append(badge);
+    return cell;
+  }
+
+  function formatList(values) {
+    if (!Array.isArray(values) || values.length === 0) {
+      return "None";
+    }
+    return values.join(", ");
+  }
+
+  function formatRate(window) {
+    if (!window || typeof window !== "object") {
+      return "—";
+    }
+    const usage =
+      window.current_usage == null ? "—" : String(window.current_usage);
+    const limit =
+      window.configured_limit == null
+        ? "unlimited"
+        : String(window.configured_limit);
+    return `${usage} / ${limit}`;
+  }
+
+  function formatCooldown(cooldown) {
+    if (!cooldown || typeof cooldown !== "object") {
+      return "None";
+    }
+    if (cooldown.remaining_secs == null) {
+      return "Active";
+    }
+    return `${cooldown.remaining_secs}s remaining`;
+  }
+
+  function models() {
+    return Array.isArray(snapshot?.models) ? snapshot.models : [];
+  }
+
+  function unavailableProviders() {
+    return Array.isArray(snapshot?.unavailable_providers)
+      ? snapshot.unavailable_providers
+      : [];
+  }
+
+  function appendDeploymentRows(rows, model) {
+    const deployments = Array.isArray(model.deployments)
+      ? model.deployments
+      : [];
+    for (const deployment of deployments) {
+      const row = document.createElement("tr");
+      const reasons = Array.isArray(deployment.unavailable_reasons)
+        ? deployment.unavailable_reasons
+        : [];
+      row.append(
+        textCell(model.public_model),
+        textCell(formatList(model.aliases)),
+        textCell(deployment.provider),
+        textCell(deployment.deployment),
+        textCell(deployment.model),
+        textCell(formatList(deployment.capabilities)),
+        healthStateCell(deployment.health),
+        textCell(deployment.available ? "Available" : "Unavailable"),
+        textCell(formatList(reasons)),
+        textCell(formatCooldown(deployment.cooldown)),
+        textCell(formatRate(deployment.rpm)),
+        textCell(formatRate(deployment.tpm)),
+        textCell(
+          deployment.active_requests == null
+            ? "—"
+            : String(deployment.active_requests),
+        ),
+      );
+      rows.push(row);
+    }
+  }
+
+  function render() {
+    const deploymentRows = [];
+    for (const model of models()) {
+      appendDeploymentRows(deploymentRows, model);
+    }
+    byId("routing-body").replaceChildren(...deploymentRows);
+    byId("routing-unavailable-body").replaceChildren(
+      ...unavailableProviders().map((provider) => {
+        const row = document.createElement("tr");
+        const reasons = Array.isArray(provider.unavailable_reasons)
+          ? provider.unavailable_reasons
+          : [];
+        row.append(
+          textCell(provider.provider),
+          textCell(provider.provider_type),
+          textCell(formatList(provider.public_models)),
+          textCell(provider.available ? "Available" : "Unavailable"),
+          textCell(formatList(reasons)),
+        );
+        return row;
+      }),
+    );
+
+    if (!snapshot) {
+      byId("routing-summary").textContent = "";
+      byId("routing-notice").textContent = requestError
+        ? `Routing inventory unavailable: ${requestError}`
+        : "";
+      byId("routing-empty").hidden = true;
+      byId("routing-unavailable-empty").hidden = true;
+      return;
+    }
+
+    const deployments = models().flatMap((model) =>
+      Array.isArray(model.deployments) ? model.deployments : [],
+    );
+    const gatedCount = unavailableProviders().filter((provider) =>
+      (provider.unavailable_reasons || []).includes("feature_gated"),
+    ).length;
+    const unknownCount = deployments.filter(
+      (deployment) => deployment.health === "unknown",
+    ).length;
+    const unhealthyCount = deployments.filter(
+      (deployment) => deployment.health === "unhealthy",
+    ).length;
+    byId("routing-summary").textContent = [
+      `Generation ${snapshot.snapshot_generation ?? "unknown"}`,
+      `${models().length} public models`,
+      `${deploymentRows.length} deployments`,
+      `${unknownCount} unknown`,
+      `${unhealthyCount} unhealthy`,
+      `${unavailableProviders().length} unavailable providers`,
+    ].join(" · ");
+
+    const notices = [];
+    if (gatedCount > 0) {
+      notices.push(
+        `${gatedCount} configured provider(s) are feature-gated and never became deployments.`,
+      );
+    }
+    if (unknownCount > 0) {
+      notices.push("Some deployments have unknown probe health, not healthy.");
+    }
+    byId("routing-notice").textContent = notices.join(" ");
+    byId("routing-empty").hidden = deploymentRows.length !== 0;
+    byId("routing-unavailable-empty").hidden =
+      unavailableProviders().length !== 0;
+  }
+
+  function reset() {
+    requestVersion += 1;
+    snapshot = null;
+    requestError = null;
+    byId("refresh-routing").disabled = false;
+    render();
+  }
+
+  async function load(session = captureSession()) {
+    const version = ++requestVersion;
+    try {
+      const data = await apiRequest("/admin/routing/inventory", {}, session);
+      ensureCurrent(session);
+      if (version !== requestVersion) {
+        throw new DOMException("Stale routing inventory response", "AbortError");
+      }
+      if (!Array.isArray(data?.models) || !Array.isArray(data?.unavailable_providers)) {
+        throw new Error(
+          "Routing inventory response did not include models and unavailable providers.",
+        );
+      }
+      snapshot = data;
+      requestError = null;
+      render();
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        ensureCurrent(session);
+        if (version === requestVersion) {
+          snapshot = null;
+          requestError = error.message || "Unknown request failure";
+          render();
+        }
+      }
+      throw error;
+    }
+  }
+
+  async function refresh(button) {
+    if (button.disabled) {
+      return;
+    }
+    button.disabled = true;
+    clearError();
+    setStatus("Refreshing routing inventory…");
+    try {
+      await load();
+      setStatus("Routing inventory refreshed.");
+    } catch (error) {
+      reportRequestError(error, "Routing inventory refresh failed.");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  byId("refresh-routing").addEventListener("click", (event) =>
+    void refresh(event.currentTarget),
+  );
+
+  return { load, reset };
+};

--- a/src/server/routes/admin_dashboard/routing_inventory.js
+++ b/src/server/routes/admin_dashboard/routing_inventory.js
@@ -36,16 +36,16 @@ window.createRoutingInventoryView = function createRoutingInventoryView({
     return values.join(", ");
   }
 
-  function formatRate(window) {
-    if (!window || typeof window !== "object") {
+  function formatRate(rateWindow) {
+    if (!rateWindow || typeof rateWindow !== "object") {
       return "—";
     }
     const usage =
-      window.current_usage == null ? "—" : String(window.current_usage);
+      rateWindow.current_usage == null ? "—" : String(rateWindow.current_usage);
     const limit =
-      window.configured_limit == null
+      rateWindow.configured_limit == null
         ? "unlimited"
-        : String(window.configured_limit);
+        : String(rateWindow.configured_limit);
     return `${usage} / ${limit}`;
   }
 

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -21,6 +21,13 @@ const providerHealthSource = await readFile(
   ),
   "utf8",
 );
+const routingInventorySource = await readFile(
+  new URL(
+    "../../src/server/routes/admin_dashboard/routing_inventory.js",
+    import.meta.url,
+  ),
+  "utf8",
+);
 const immediate = () => new Promise((resolve) => setImmediate(resolve));
 async function settle(turns = 8) {
   for (let index = 0; index < turns; index += 1) {
@@ -79,11 +86,20 @@ function dashboard(options = {}) {
         provider_details: [],
       },
     },
+    inventory = {
+      snapshot_generation: 1,
+      models: [],
+      unavailable_providers: [],
+    },
     handler,
   } = options;
   const htmlWithoutScript = indexHtml
     .replace(
       '<script src="/admin/dashboard/provider-health.js" defer></script>',
+      "",
+    )
+    .replace(
+      '<script src="/admin/dashboard/routing-inventory.js" defer></script>',
       "",
     )
     .replace('<script src="/admin/dashboard/budget.js" defer></script>', "")
@@ -202,6 +218,9 @@ function dashboard(options = {}) {
     if (url.pathname === "/health/detailed" && call.method === "GET") {
       return Promise.resolve(healthResponse(health, 503));
     }
+    if (url.pathname === "/admin/routing/inventory" && call.method === "GET") {
+      return Promise.resolve(apiResponse(inventory));
+    }
     const usageMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/usage$/);
     if (usageMatch && call.method === "GET") {
       const result = usageByTeam.get(decodeURIComponent(usageMatch[1]));
@@ -214,6 +233,7 @@ function dashboard(options = {}) {
     throw new Error(`Unexpected request: ${call.method} ${call.path}`);
   };
   window.eval(providerHealthSource);
+  window.eval(routingInventorySource);
   window.eval(budgetSource);
   window.eval(appSource);
   return context;
@@ -1294,4 +1314,208 @@ test("B16 a committed save clears edit state before a superseded refresh settles
   assert.equal(window.document.getElementById("budget-name").value, "");
   assert.equal(window.document.getElementById("budget-scope").disabled, false);
   assert.equal(window.document.getElementById("budget-name").readOnly, false);
+});
+
+test("B14 routing inventory renders empty, unknown, unhealthy, and feature-gated rows", { concurrency: false }, async (t) => {
+  const inventory = {
+    snapshot_generation: 9,
+    models: [],
+    unavailable_providers: [],
+  };
+  let inventoryGets = 0;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/admin/routing/inventory" && call.method === "GET") {
+        inventoryGets += 1;
+        if (inventoryGets === 2) {
+          return apiResponse({
+            snapshot_generation: 12,
+            models: [
+              {
+                public_model: "gpt-4",
+                aliases: ["gpt4"],
+                deployments: [
+                  {
+                    provider: "openai",
+                    deployment: "dep-unknown",
+                    public_model: "gpt-4",
+                    model: "gpt-4-turbo",
+                    capabilities: ["chat_completion"],
+                    health: "unknown",
+                    available: true,
+                    unavailable_reasons: [],
+                    rpm: { configured_limit: 100 },
+                    tpm: { configured_limit: null },
+                    active_requests: 0,
+                  },
+                  {
+                    provider: "openai",
+                    deployment: "dep-unhealthy",
+                    public_model: "gpt-4",
+                    model: "gpt-4-turbo",
+                    capabilities: ["chat_completion"],
+                    health: "unhealthy",
+                    available: false,
+                    unavailable_reasons: ["unhealthy"],
+                    cooldown: { until_unix_secs: 1, remaining_secs: 12 },
+                    rpm: { configured_limit: 50, current_usage: 50 },
+                    tpm: { configured_limit: 1000, current_usage: 25 },
+                    active_requests: 3,
+                  },
+                ],
+              },
+            ],
+            unavailable_providers: [
+              {
+                provider: "offline-pydantic",
+                provider_type: "pydantic_ai",
+                public_models: ["agent-model"],
+                available: false,
+                unavailable_reasons: ["feature_gated"],
+              },
+            ],
+          });
+        }
+        return apiResponse(inventory);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  window.document.querySelector('[data-view="routing"]').click();
+  assert.equal(window.document.querySelectorAll("#routing-body tr").length, 0);
+  assert.equal(window.document.getElementById("routing-empty").hidden, false);
+
+  window.document.getElementById("refresh-routing").click();
+  await waitFor(() => inventoryGets === 2, "routing inventory refresh was not requested");
+  await waitFor(
+    () => window.document.querySelectorAll("#routing-body tr").length === 2,
+    "routing inventory rows did not render",
+  );
+
+  assert.match(window.document.getElementById("routing-summary").textContent, /Generation 12/);
+  assert.match(window.document.getElementById("routing-notice").textContent, /feature-gated/i);
+  assert.match(window.document.getElementById("routing-notice").textContent, /unknown/i);
+  const rows = rowText(window, "#routing-body tr");
+  assert.match(rows[0], /gpt-4.*gpt4.*dep-unknown.*unknown.*Available/i);
+  assert.match(rows[1], /dep-unhealthy.*unhealthy.*Unavailable.*unhealthy.*12s remaining/i);
+  const missing = rowText(window, "#routing-unavailable-body tr");
+  assert.match(missing[0], /offline-pydantic.*pydantic_ai.*feature_gated/i);
+  assert.equal(window.document.getElementById("routing-empty").hidden, true);
+});
+
+test("B15 routing inventory failures are explicit and clear stale rows", { concurrency: false }, async (t) => {
+  let mode = "ok";
+  const context = dashboard({
+    inventory: {
+      snapshot_generation: 2,
+      models: [
+        {
+          public_model: "gpt-4",
+          aliases: [],
+          deployments: [
+            {
+              provider: "openai",
+              deployment: "dep-ok",
+              public_model: "gpt-4",
+              model: "gpt-4",
+              capabilities: ["chat_completion"],
+              health: "healthy",
+              available: true,
+              unavailable_reasons: [],
+              rpm: { configured_limit: null },
+              tpm: { configured_limit: null },
+              active_requests: 0,
+            },
+          ],
+        },
+      ],
+      unavailable_providers: [],
+    },
+    handler(call) {
+      if (call.url.pathname !== "/admin/routing/inventory" || call.method !== "GET") {
+        return undefined;
+      }
+      if (mode === "error") {
+        return Promise.reject(new Error("network offline"));
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  window.document.querySelector('[data-view="routing"]').click();
+  assert.equal(window.document.querySelectorAll("#routing-body tr").length, 1);
+
+  mode = "error";
+  window.document.getElementById("refresh-routing").click();
+  await waitFor(
+    () => /network offline/i.test(window.document.getElementById("routing-notice").textContent),
+    "network failure was not shown in the routing view",
+  );
+  assert.equal(window.document.querySelectorAll("#routing-body tr").length, 0);
+
+  window.document.getElementById("sign-out").click();
+  await settle();
+  assert.equal(window.document.getElementById("routing-summary").textContent, "");
+  assert.equal(window.document.getElementById("routing-notice").textContent, "");
+  assert.equal(window.document.querySelectorAll("#routing-body tr").length, 0);
+});
+
+test("B16 a late routing inventory response after logout cannot restore stale data", { concurrency: false }, async (t) => {
+  let inventoryGets = 0;
+  let late;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/admin/routing/inventory" && call.method === "GET") {
+        inventoryGets += 1;
+        if (inventoryGets === 2) {
+          late = deferred();
+          return late.promise;
+        }
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  window.document.querySelector('[data-view="routing"]').click();
+  window.document.getElementById("refresh-routing").click();
+  await waitFor(() => inventoryGets === 2, "late routing inventory request was not pending");
+  window.document.getElementById("sign-out").click();
+  late.resolve(
+    apiResponse({
+      snapshot_generation: 99,
+      models: [
+        {
+          public_model: "must-not-return",
+          aliases: [],
+          deployments: [
+            {
+              provider: "openai",
+              deployment: "stale",
+              public_model: "must-not-return",
+              model: "stale",
+              capabilities: [],
+              health: "healthy",
+              available: true,
+              unavailable_reasons: [],
+              rpm: { configured_limit: null },
+              tpm: { configured_limit: null },
+              active_requests: 0,
+            },
+          ],
+        },
+      ],
+      unavailable_providers: [],
+    }),
+  );
+  await settle();
+  assert.equal(window.document.getElementById("routing-summary").textContent, "");
+  assert.equal(window.document.getElementById("routing-notice").textContent, "");
+  assert.equal(window.document.querySelectorAll("#routing-body tr").length, 0);
 });


### PR DESCRIPTION
## Summary
- Add a read-only Routing tab that renders `GET /admin/routing/inventory` as provider → deployment → model/alias rows, including capabilities, probe health, cooldown, RPM/TPM, and active requests.
- Keep routing decisions on the server: the dashboard only displays DTO fields and distinguishes unknown vs unhealthy vs feature-gated without re-deriving availability in JS.
- Cover empty, unknown, unhealthy, feature-gated, fetch-error, and logout-race cases in DOM tests, and hash the new script in `scripts/verify-gh1067.sh`.

Fixes #1265

## Test plan
- [x] `node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs`
- [x] `cargo test --lib admin_dashboard`
- [x] `cargo test --lib test_is_public_route`
- [x] `cargo fmt --all`
- [x] `bash scripts/guards/check_pr_scope.sh origin/main`
- [x] `bash scripts/guards/check_pr_overlap.sh`
- [ ] CI Fast Test job is SUCCESS (not cancelled at 30m)

This change was implemented with Cursor Grok 4.6.


Made with [Cursor](https://cursor.com)