### PR TITLE
feat(request-ledger): persist metadata-only terminal records

### DIFF
--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -138,7 +138,8 @@ storage:
   # prompt, response body, Authorization, raw API keys, or provider secrets.
   # write_failure: continue logs persist errors; fail returns HTTP 503 on unary
   # requests when the row cannot be written. retention_days bounds table size
-  # (indexes: finished_at, model, provider, terminal_status).
+  # via a throttled write-path prune (indexes: finished_at, model, provider,
+  # terminal_status).
   # request_ledger:
   #   enabled: false
   #   write_failure: continue

--- a/config/gateway.yaml.example
+++ b/config/gateway.yaml.example
@@ -134,6 +134,15 @@ storage:
     max_connections: 20
     connection_timeout: 5
     cluster: false
+  # Metadata-only terminal request log. Disabled by default. Never stores
+  # prompt, response body, Authorization, raw API keys, or provider secrets.
+  # write_failure: continue logs persist errors; fail returns HTTP 503 on unary
+  # requests when the row cannot be written. retention_days bounds table size
+  # (indexes: finished_at, model, provider, terminal_status).
+  # request_ledger:
+  #   enabled: false
+  #   write_failure: continue
+  #   retention_days: 30
   vector_db: null
 
 auth:

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use guardrails::validate_gateway_guardrails;
 pub mod monitoring;
 pub mod provider;
 pub mod rate_limit;
+pub mod request_ledger;
 pub mod router;
 pub mod server;
 pub mod storage;

--- a/src/config/models/request_ledger.rs
+++ b/src/config/models/request_ledger.rs
@@ -26,7 +26,8 @@ pub enum RequestLedgerWriteFailure {
 ///
 /// Owned by `storage.request_ledger`. The table never stores prompt, response
 /// body, Authorization, raw API keys, or provider secrets. Rows older than
-/// `retention_days` are deleted on subsequent writes so retention stays bounded.
+/// `retention_days` are deleted from the write path, throttled so retention
+/// stays bounded without a delete on every request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct RequestLedgerConfig {

--- a/src/config/models/request_ledger.rs
+++ b/src/config/models/request_ledger.rs
@@ -1,0 +1,103 @@
+//! Metadata-only request ledger persistence configuration.
+
+use serde::{Deserialize, Serialize};
+
+/// Default retention window for terminal request-ledger rows.
+pub const DEFAULT_REQUEST_LEDGER_RETENTION_DAYS: u32 = 30;
+/// Inclusive upper bound for configured ledger retention.
+pub const MAX_REQUEST_LEDGER_RETENTION_DAYS: u32 = 366;
+
+/// How a request-ledger write failure is handled.
+///
+/// `continue` logs the error and keeps serving the request. `fail` surfaces the
+/// error on unary responses that have not yet committed a body. Streaming
+/// responses are already committed, so `fail` is still logged and never silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestLedgerWriteFailure {
+    /// Reject unary requests when persistence fails.
+    Fail,
+    /// Log persistence failures and continue serving the request.
+    #[default]
+    Continue,
+}
+
+/// Persistence policy for one metadata-only terminal row per gateway request.
+///
+/// Owned by `storage.request_ledger`. The table never stores prompt, response
+/// body, Authorization, raw API keys, or provider secrets. Rows older than
+/// `retention_days` are deleted on subsequent writes so retention stays bounded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct RequestLedgerConfig {
+    /// Persist terminal request metadata. Disabled by default.
+    pub enabled: bool,
+    /// Fail or continue when a ledger write fails.
+    pub write_failure: RequestLedgerWriteFailure,
+    /// Delete rows whose `finished_at` is older than this many days (1–366).
+    pub retention_days: u32,
+}
+
+impl Default for RequestLedgerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            write_failure: RequestLedgerWriteFailure::Continue,
+            retention_days: DEFAULT_REQUEST_LEDGER_RETENTION_DAYS,
+        }
+    }
+}
+
+impl RequestLedgerConfig {
+    /// Merge layered storage overlays. A non-default overlay replaces the base.
+    pub fn merge(self, other: Self) -> Self {
+        if other == Self::default() {
+            self
+        } else {
+            other
+        }
+    }
+
+    /// Reject unbounded or zero retention.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.retention_days == 0 || self.retention_days > MAX_REQUEST_LEDGER_RETENTION_DAYS {
+            return Err(format!(
+                "storage.request_ledger.retention_days must be between 1 and {MAX_REQUEST_LEDGER_RETENTION_DAYS}"
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled_continue_with_bounded_retention() {
+        let config = RequestLedgerConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.write_failure, RequestLedgerWriteFailure::Continue);
+        assert_eq!(config.retention_days, DEFAULT_REQUEST_LEDGER_RETENTION_DAYS);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn deserializes_fail_policy() {
+        let config: RequestLedgerConfig =
+            serde_yml::from_str("enabled: true\nwrite_failure: fail\nretention_days: 7\n")
+                .expect("valid request ledger yaml");
+        assert!(config.enabled);
+        assert_eq!(config.write_failure, RequestLedgerWriteFailure::Fail);
+        assert_eq!(config.retention_days, 7);
+    }
+
+    #[test]
+    fn rejects_unbounded_retention() {
+        let config = RequestLedgerConfig {
+            retention_days: 0,
+            ..RequestLedgerConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+}

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -8,6 +8,7 @@ use super::*;
 use serde::{Deserialize, Serialize};
 
 mod redis_config;
+pub use super::request_ledger::{RequestLedgerConfig, RequestLedgerWriteFailure};
 pub use redis_config::RedisConfig;
 
 /// Storage configuration
@@ -24,6 +25,9 @@ pub struct StorageConfig {
     /// Vector database configuration (optional)
     #[serde(default)]
     pub vector_db: Option<VectorDbConfig>,
+    /// Metadata-only terminal request ledger. Disabled by default.
+    #[serde(default)]
+    pub request_ledger: RequestLedgerConfig,
 }
 
 impl StorageConfig {
@@ -46,6 +50,7 @@ impl StorageConfig {
         if other.vector_db.is_some() {
             self.vector_db = other.vector_db;
         }
+        self.request_ledger = self.request_ledger.merge(other.request_ledger);
         self
     }
 }
@@ -592,6 +597,8 @@ mod tests {
         assert_eq!(config.redis.url, "redis://localhost:6379");
         assert_eq!(config.files.storage_type, "local");
         assert!(config.vector_db.is_none());
+        assert!(!config.request_ledger.enabled);
+        assert_eq!(config.request_ledger.retention_days, 30);
     }
 
     #[test]
@@ -601,6 +608,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
         assert!(config.vector_db.is_none());
     }
@@ -645,6 +653,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
         let merged = base.merge(other);
         assert_eq!(merged.database.url, "postgresql://new/db");
@@ -711,6 +720,7 @@ mod tests {
                 s3: None,
             },
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let merged = base.merge(other);

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -23,6 +23,8 @@ impl Validate for StorageConfig {
             vector_db.validate()?;
         }
 
+        self.request_ledger.validate()?;
+
         Ok(())
     }
 }

--- a/src/core/audit/middleware.rs
+++ b/src/core/audit/middleware.rs
@@ -2,14 +2,19 @@
 //!
 //! This module provides middleware for automatic request/response logging.
 
+use crate::core::request_ledger::{
+    RequestLedgerFacts, RequestLedgerRecord, RequestLedgerRuntime, SharedRequestLedgerFacts,
+    persist_with_policy, scope_facts, snapshot_facts,
+};
 use crate::core::types::context::{RequestContext, SharedRequestContext};
 use actix_web::body::{BodySize, MessageBody};
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::http::header::CONTENT_TYPE;
 use actix_web::{Error, HttpMessage};
+use chrono::{DateTime, Utc};
 use futures::future::{LocalBoxFuture, Ready, ready};
 use std::rc::Rc;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 use tracing::debug;
 
@@ -18,6 +23,8 @@ use super::logger::AuditLogger;
 pub use super::middleware_body::AuditResponseBody;
 use super::middleware_body::{AuditBodyOutcome, AuditTerminalRecorder};
 use super::types::{AuditError, RequestLog};
+
+const OPERATIONAL_LEDGER_PATHS: &[&str] = &["/health", "/metrics", "/ready", "/live", "/healthz"];
 
 #[derive(Clone, Default)]
 struct AuditPrincipal {
@@ -50,6 +57,7 @@ pub(crate) fn record_authenticated_principal(message: &impl HttpMessage, context
 pub struct AuditMiddleware {
     logger: Arc<AuditLogger>,
     trusted_proxies: Arc<Vec<String>>,
+    ledger: Option<Arc<RequestLedgerRuntime>>,
 }
 
 impl AuditMiddleware {
@@ -58,6 +66,7 @@ impl AuditMiddleware {
         Self {
             logger,
             trusted_proxies: Arc::new(Vec::new()),
+            ledger: None,
         }
     }
 
@@ -66,7 +75,14 @@ impl AuditMiddleware {
         Self {
             logger,
             trusted_proxies: Arc::new(trusted_proxies),
+            ledger: None,
         }
+    }
+
+    /// Persist one metadata-only terminal request-ledger row per request.
+    pub fn with_request_ledger(mut self, ledger: Arc<RequestLedgerRuntime>) -> Self {
+        self.ledger = Some(ledger);
+        self
     }
 }
 
@@ -87,6 +103,7 @@ where
             service: Rc::new(service),
             logger: self.logger.clone(),
             trusted_proxies: Arc::clone(&self.trusted_proxies),
+            ledger: self.ledger.clone(),
         }))
     }
 }
@@ -96,6 +113,7 @@ pub struct AuditMiddlewareService<S> {
     service: Rc<S>,
     logger: Arc<AuditLogger>,
     trusted_proxies: Arc<Vec<String>>,
+    ledger: Option<Arc<RequestLedgerRuntime>>,
 }
 
 impl<S, B> Service<ServiceRequest> for AuditMiddlewareService<S>
@@ -114,11 +132,12 @@ where
         let logger = self.logger.clone();
         let service = Rc::clone(&self.service);
         let trusted_proxies = Arc::clone(&self.trusted_proxies);
+        let ledger = self.ledger.clone();
         let path = req.path().to_string();
         let method = req.method().to_string();
+        let persist_ledger = ledger.is_some() && !OPERATIONAL_LEDGER_PATHS.contains(&path.as_str());
 
-        // Check if path should be logged
-        if !logger.should_log_path(&path) {
+        if !logger.should_log_path(&path) && !persist_ledger {
             let fut = service.call(req);
             return Box::pin(async move {
                 fut.await.map(|response| {
@@ -130,8 +149,9 @@ where
         let principal = Arc::new(RwLock::new(AuditPrincipal::default()));
         req.extensions_mut()
             .insert::<SharedAuditPrincipal>(Arc::clone(&principal));
+        let facts = SharedRequestLedgerFacts::new(Mutex::new(RequestLedgerFacts::default()));
+        req.extensions_mut().insert(Arc::clone(&facts));
 
-        // Generate request ID
         let request_id = req
             .headers()
             .get("x-request-id")
@@ -139,7 +159,6 @@ where
             .map(|s| s.to_string())
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-        // Extract request info
         let client_ip = trusted_client_ip(&req, &trusted_proxies);
 
         let user_agent = req
@@ -148,7 +167,6 @@ where
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
-        // Create request log
         let mut request_log = RequestLog::new(&request_id, &method, &path);
         if let Some(ip) = client_ip {
             request_log = request_log.with_client_ip(ip);
@@ -157,12 +175,11 @@ where
             request_log = request_log.with_user_agent(ua);
         }
 
-        // Log request started
         let start_event = AuditEvent::request_started(&request_id, &path).with_request(request_log);
-
         let start_time = Instant::now();
+        let started_at = Utc::now();
 
-        Box::pin(async move {
+        Box::pin(scope_facts(Arc::clone(&facts), async move {
             let cancellation_request_id = request_id.clone();
             let cancellation_principal = Arc::clone(&principal);
             let terminal_permit = logger
@@ -185,6 +202,22 @@ where
                         &Self::recorded_principal(&principal),
                     );
                     Self::complete_terminal(&logger, terminal_permit, event);
+                    if persist_ledger {
+                        let principal = Self::recorded_principal(&principal);
+                        Self::persist_ledger(
+                            ledger.as_ref(),
+                            &request_id,
+                            &method,
+                            &path,
+                            started_at,
+                            start_time,
+                            0,
+                            "failed",
+                            &principal,
+                            &facts,
+                        )
+                        .await?;
+                    }
                     debug!("Request {} failed: {}", request_id, error);
                     return Err(error);
                 }
@@ -192,6 +225,22 @@ where
 
             let status_code = response.status().as_u16();
             let principal = Self::response_principal(&response, &principal);
+            let is_stream = matches!(response.response().body().size(), BodySize::Stream);
+            if persist_ledger && !is_stream {
+                Self::persist_ledger(
+                    ledger.as_ref(),
+                    &request_id,
+                    &method,
+                    &path,
+                    started_at,
+                    start_time,
+                    status_code,
+                    "completed",
+                    &principal,
+                    &facts,
+                )
+                .await?;
+            }
             let recorder = Self::terminal_recorder(
                 Arc::clone(&logger),
                 terminal_permit,
@@ -199,8 +248,12 @@ where
                 status_code,
                 start_time,
                 principal,
+                ledger.filter(|_| persist_ledger && is_stream),
+                facts,
+                method,
+                path,
+                started_at,
             );
-            let is_stream = matches!(response.response().body().size(), BodySize::Stream);
             let is_sse = response
                 .headers()
                 .get(CONTENT_TYPE)
@@ -214,7 +267,7 @@ where
                     AuditResponseBody::passthrough(body)
                 }
             }))
-        })
+        }))
     }
 }
 
@@ -285,6 +338,7 @@ impl<S> AuditMiddlewareService<S> {
         principal
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn terminal_recorder(
         logger: Arc<AuditLogger>,
         permit: super::logger::AuditEventPermit,
@@ -292,6 +346,11 @@ impl<S> AuditMiddlewareService<S> {
         status_code: u16,
         start_time: Instant,
         principal: AuditPrincipal,
+        ledger: Option<Arc<RequestLedgerRuntime>>,
+        facts: SharedRequestLedgerFacts,
+        method: String,
+        path: String,
+        started_at: DateTime<Utc>,
     ) -> AuditTerminalRecorder {
         AuditTerminalRecorder::new(move |outcome| {
             let duration_ms = start_time.elapsed().as_millis() as u64;
@@ -304,6 +363,27 @@ impl<S> AuditMiddlewareService<S> {
                 }
             };
             Self::complete_terminal(&logger, permit, Self::with_principal(event, &principal));
+            if let Some(runtime) = ledger {
+                let terminal_status = match outcome {
+                    AuditBodyOutcome::Completed => "completed",
+                    AuditBodyOutcome::Failed(_) => "failed",
+                };
+                let record = ledger_record(
+                    &request_id,
+                    &method,
+                    &path,
+                    started_at,
+                    start_time,
+                    status_code,
+                    terminal_status,
+                    &principal,
+                    &snapshot_facts(&facts),
+                );
+                let policy = runtime.write_failure;
+                actix_web::rt::spawn(async move {
+                    let _ = persist_with_policy(runtime.writer.as_ref(), record, policy).await;
+                });
+            }
             debug!(
                 "Request {} terminated: status={}, duration={}ms",
                 request_id, status_code, duration_ms
@@ -320,6 +400,75 @@ impl<S> AuditMiddlewareService<S> {
             tracing::error!("Failed to record reserved audit terminal event: {error}");
         }
     }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn persist_ledger(
+        ledger: Option<&Arc<RequestLedgerRuntime>>,
+        request_id: &str,
+        method: &str,
+        path: &str,
+        started_at: DateTime<Utc>,
+        start_time: Instant,
+        status_code: u16,
+        terminal_status: &str,
+        principal: &AuditPrincipal,
+        facts: &SharedRequestLedgerFacts,
+    ) -> Result<(), Error> {
+        let Some(runtime) = ledger else {
+            return Ok(());
+        };
+        let record = ledger_record(
+            request_id,
+            method,
+            path,
+            started_at,
+            start_time,
+            status_code,
+            terminal_status,
+            principal,
+            &snapshot_facts(facts),
+        );
+        persist_with_policy(runtime.writer.as_ref(), record, runtime.write_failure)
+            .await
+            .map_err(|error| {
+                tracing::error!("request ledger unavailable: {error}");
+                actix_web::error::ErrorServiceUnavailable("request ledger unavailable")
+            })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ledger_record(
+    request_id: &str,
+    method: &str,
+    path: &str,
+    started_at: DateTime<Utc>,
+    start_time: Instant,
+    status_code: u16,
+    terminal_status: &str,
+    principal: &AuditPrincipal,
+    facts: &RequestLedgerFacts,
+) -> RequestLedgerRecord {
+    RequestLedgerRecord {
+        request_id: request_id.to_string(),
+        started_at,
+        finished_at: Utc::now(),
+        method: method.to_string(),
+        endpoint: path.to_string(),
+        model: facts.model.clone(),
+        provider: facts.provider.clone(),
+        deployment: facts.deployment.clone(),
+        status_code: i32::from(status_code),
+        terminal_status: terminal_status.to_string(),
+        latency_ms: start_time.elapsed().as_millis() as i64,
+        prompt_tokens: facts.prompt_tokens,
+        completion_tokens: facts.completion_tokens,
+        total_tokens: facts.total_tokens,
+        cost: facts.cost,
+        user_id: principal.user_id.clone(),
+        api_key_id: principal.api_key_id.clone(),
+        team_id: principal.team_id.clone(),
+    }
 }
 
 #[cfg(test)]
@@ -332,7 +481,9 @@ mod tests {
     use crate::core::audit::types::AuditResult;
     use crate::core::ip_access::{IpAccessConfig, IpAccessControl, IpAccessMiddleware};
     use crate::core::types::context::RequestContext;
-    use actix_web::{App, HttpRequest, HttpResponse, http::StatusCode, test as actix_test, web};
+    use actix_web::{
+        App, HttpRequest, HttpResponse, dev::Service, http::StatusCode, test as actix_test, web,
+    };
     use bytes::Bytes;
     use tokio::sync::Mutex;
 
@@ -682,5 +833,142 @@ mod tests {
         assert_eq!(events[1].user_id.as_deref(), Some("user-after-start"));
         assert_eq!(events[1].api_key_id.as_deref(), Some("key-after-start"));
         assert_eq!(events[1].team_id.as_deref(), Some("team-after-start"));
+    }
+
+    struct MemoryLedgerWriter {
+        rows: std::sync::Mutex<Vec<RequestLedgerRecord>>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::core::request_ledger::RequestLedgerWriter for MemoryLedgerWriter {
+        async fn persist(&self, record: RequestLedgerRecord) -> Result<(), String> {
+            if self.fail {
+                return Err("ledger unavailable".to_string());
+            }
+            self.rows.lock().expect("ledger lock").push(record);
+            Ok(())
+        }
+    }
+
+    #[actix_web::test]
+    async fn request_ledger_persists_one_unary_metadata_row() {
+        let writer = Arc::new(MemoryLedgerWriter {
+            rows: std::sync::Mutex::new(Vec::new()),
+            fail: false,
+        });
+        let runtime = Arc::new(RequestLedgerRuntime {
+            writer: writer.clone(),
+            write_failure:
+                crate::config::models::request_ledger::RequestLedgerWriteFailure::Continue,
+        });
+        let app = actix_test::init_service(
+            App::new()
+                .wrap(
+                    AuditMiddleware::new(Arc::new(AuditLogger::disabled()))
+                        .with_request_ledger(runtime),
+                )
+                .route(
+                    "/v1/chat/completions",
+                    web::post().to(|| async { HttpResponse::Ok().finish() }),
+                ),
+        )
+        .await;
+        let request = actix_test::TestRequest::post()
+            .uri("/v1/chat/completions")
+            .insert_header(("x-request-id", "req-ledger-unary"))
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let rows = writer.rows.lock().expect("ledger lock");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].request_id, "req-ledger-unary");
+        assert_eq!(rows[0].endpoint, "/v1/chat/completions");
+        assert_eq!(rows[0].terminal_status, "completed");
+        let json = serde_json::to_value(&rows[0]).expect("serialize");
+        assert!(json.get("body").is_none());
+        assert!(json.get("authorization").is_none());
+    }
+
+    #[actix_web::test]
+    async fn request_ledger_fail_policy_rejects_unary_write_errors() {
+        let writer = Arc::new(MemoryLedgerWriter {
+            rows: std::sync::Mutex::new(Vec::new()),
+            fail: true,
+        });
+        let runtime = Arc::new(RequestLedgerRuntime {
+            writer: writer.clone(),
+            write_failure: crate::config::models::request_ledger::RequestLedgerWriteFailure::Fail,
+        });
+        let app = actix_test::init_service(
+            App::new()
+                .wrap(
+                    AuditMiddleware::new(Arc::new(AuditLogger::disabled()))
+                        .with_request_ledger(runtime),
+                )
+                .route(
+                    "/v1/models",
+                    web::get().to(|| async { HttpResponse::Ok().finish() }),
+                ),
+        )
+        .await;
+        let request = actix_test::TestRequest::get()
+            .uri("/v1/models")
+            .to_request();
+        let result = app.call(request).await;
+        assert!(
+            result.is_err(),
+            "fail policy must surface persist errors before the response is committed"
+        );
+    }
+
+    #[actix_web::test]
+    async fn request_ledger_records_stream_disconnect() {
+        let writer = Arc::new(MemoryLedgerWriter {
+            rows: std::sync::Mutex::new(Vec::new()),
+            fail: false,
+        });
+        let runtime = Arc::new(RequestLedgerRuntime {
+            writer: writer.clone(),
+            write_failure:
+                crate::config::models::request_ledger::RequestLedgerWriteFailure::Continue,
+        });
+        let app = actix_test::init_service(
+            App::new()
+                .wrap(
+                    AuditMiddleware::new(Arc::new(AuditLogger::disabled()))
+                        .with_request_ledger(runtime),
+                )
+                .route(
+                    "/v1/chat/completions",
+                    web::get().to(|| async {
+                        let body = futures::stream::iter(vec![Ok::<_, actix_web::Error>(
+                            Bytes::from_static(b"data: hi\n\n"),
+                        )]);
+                        HttpResponse::Ok()
+                            .insert_header((CONTENT_TYPE, "text/event-stream"))
+                            .streaming(body)
+                    }),
+                ),
+        )
+        .await;
+        let request = actix_test::TestRequest::get()
+            .uri("/v1/chat/completions")
+            .to_request();
+        let response = actix_test::call_service(&app, request).await;
+        drop(actix_test::read_body(response).await);
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if writer.rows.lock().expect("ledger lock").len() == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("stream ledger row");
+        let rows = writer.rows.lock().expect("ledger lock");
+        assert_eq!(rows[0].endpoint, "/v1/chat/completions");
+        assert!(rows[0].terminal_status == "completed" || rows[0].terminal_status == "failed");
     }
 }

--- a/src/core/audit/middleware_body.rs
+++ b/src/core/audit/middleware_body.rs
@@ -4,6 +4,7 @@ use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+#[derive(Clone, Copy)]
 pub(super) enum AuditBodyOutcome {
     Completed,
     Failed(&'static str),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,6 +22,7 @@ pub mod a2a; // Experimental module-only A2A gateway; see subsystem_registry.
 pub mod analytics;
 pub mod audio; // Audio API (transcription, translation, speech)
 pub mod audit; // Audit logging system
+pub mod request_ledger; // Metadata-only terminal request ledger
 // pub mod base_provider;  // Removed: unused dead code
 #[cfg(feature = "storage")]
 pub mod batch;

--- a/src/core/request_ledger.rs
+++ b/src/core/request_ledger.rs
@@ -1,0 +1,330 @@
+//! Metadata-only request ledger facts captured during a gateway request.
+
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::config::models::request_ledger::RequestLedgerWriteFailure;
+
+tokio::task_local! {
+    static REQUEST_LEDGER_FACTS: SharedRequestLedgerFacts;
+}
+
+/// Shared mutable facts attached to one in-flight request.
+pub type SharedRequestLedgerFacts = Arc<Mutex<RequestLedgerFacts>>;
+
+/// Selected routing and settlement metadata. Never holds bodies or secrets.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct RequestLedgerFacts {
+    /// Requested or served model id.
+    pub model: Option<String>,
+    /// Selected provider name.
+    pub provider: Option<String>,
+    /// Selected deployment name when distinct from the provider.
+    pub deployment: Option<String>,
+    /// Prompt / input tokens.
+    pub prompt_tokens: Option<i64>,
+    /// Completion / output tokens.
+    pub completion_tokens: Option<i64>,
+    /// Total tokens.
+    pub total_tokens: Option<i64>,
+    /// Settled cost in the gateway pricing currency.
+    pub cost: Option<f64>,
+}
+
+impl RequestLedgerFacts {
+    /// Merge settlement metadata into the request-scoped facts handle.
+    pub fn record_settlement(
+        &mut self,
+        provider: &str,
+        model: &str,
+        prompt_tokens: Option<i64>,
+        completion_tokens: Option<i64>,
+        total_tokens: Option<i64>,
+        cost: Option<f64>,
+    ) {
+        self.provider = Some(provider.to_string());
+        self.model = Some(model.to_string());
+        if self.deployment.is_none() {
+            self.deployment = Some(provider.to_string());
+        }
+        if prompt_tokens.is_some() {
+            self.prompt_tokens = prompt_tokens;
+        }
+        if completion_tokens.is_some() {
+            self.completion_tokens = completion_tokens;
+        }
+        if total_tokens.is_some() {
+            self.total_tokens = total_tokens;
+        }
+        if cost.is_some() {
+            self.cost = cost;
+        }
+    }
+}
+
+/// One terminal metadata row. Column names are the persistence contract: no
+/// prompt, body, Authorization, raw API key, or provider secret fields exist.
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestLedgerRecord {
+    /// Gateway request id.
+    pub request_id: String,
+    /// Request start timestamp.
+    pub started_at: DateTime<Utc>,
+    /// Terminal timestamp.
+    pub finished_at: DateTime<Utc>,
+    /// HTTP method.
+    pub method: String,
+    /// Request path.
+    pub endpoint: String,
+    /// Served model when known.
+    pub model: Option<String>,
+    /// Selected provider when known.
+    pub provider: Option<String>,
+    /// Selected deployment when known.
+    pub deployment: Option<String>,
+    /// HTTP status code, or 0 when the request future failed without a response.
+    pub status_code: i32,
+    /// `completed`, `failed`, or `cancelled`.
+    pub terminal_status: String,
+    /// End-to-end latency in milliseconds.
+    pub latency_ms: i64,
+    /// Prompt tokens when settled.
+    pub prompt_tokens: Option<i64>,
+    /// Completion tokens when settled.
+    pub completion_tokens: Option<i64>,
+    /// Total tokens when settled.
+    pub total_tokens: Option<i64>,
+    /// Settled cost when priced.
+    pub cost: Option<f64>,
+    /// Authenticated user id.
+    pub user_id: Option<String>,
+    /// API key id (never the raw secret).
+    pub api_key_id: Option<String>,
+    /// Team id.
+    pub team_id: Option<String>,
+}
+
+/// Persistence backend for terminal request-ledger rows.
+#[async_trait::async_trait]
+pub trait RequestLedgerWriter: Send + Sync {
+    /// Insert or merge one terminal metadata row.
+    async fn persist(&self, record: RequestLedgerRecord) -> Result<(), String>;
+}
+
+/// Runtime handle passed to HTTP middleware when the ledger is enabled.
+#[derive(Clone)]
+pub struct RequestLedgerRuntime {
+    /// Persistence backend.
+    pub writer: Arc<dyn RequestLedgerWriter>,
+    /// Fail or continue when a write fails.
+    pub write_failure: RequestLedgerWriteFailure,
+}
+
+/// Apply the configured write-failure policy. Continue logs at error level.
+pub async fn persist_with_policy(
+    writer: &dyn RequestLedgerWriter,
+    record: RequestLedgerRecord,
+    policy: RequestLedgerWriteFailure,
+) -> Result<(), String> {
+    let request_id = record.request_id.clone();
+    match writer.persist(record).await {
+        Ok(()) => Ok(()),
+        Err(error) => match policy {
+            RequestLedgerWriteFailure::Continue => {
+                tracing::error!(
+                    request_id = %request_id,
+                    error = %error,
+                    "request ledger persist failed; continuing"
+                );
+                Ok(())
+            }
+            RequestLedgerWriteFailure::Fail => {
+                tracing::error!(
+                    request_id = %request_id,
+                    error = %error,
+                    "request ledger persist failed; failing request"
+                );
+                Err(error)
+            }
+        },
+    }
+}
+
+/// Install request-scoped facts for the remainder of the current task.
+pub async fn scope_facts<F>(facts: SharedRequestLedgerFacts, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    REQUEST_LEDGER_FACTS.scope(facts, future).await
+}
+
+/// Current request facts when the caller is inside [`scope_facts`].
+pub fn current_facts() -> Option<SharedRequestLedgerFacts> {
+    REQUEST_LEDGER_FACTS.try_with(Arc::clone).ok()
+}
+
+/// Update the current request facts from spend settlement.
+pub fn record_current_settlement(
+    provider: &str,
+    model: &str,
+    prompt_tokens: Option<i64>,
+    completion_tokens: Option<i64>,
+    total_tokens: Option<i64>,
+    cost: Option<f64>,
+) {
+    let Some(facts) = current_facts() else {
+        return;
+    };
+    apply_settlement(
+        &facts,
+        provider,
+        model,
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+        cost,
+    );
+}
+
+/// Update a captured facts handle from spend settlement.
+pub fn apply_settlement(
+    facts: &SharedRequestLedgerFacts,
+    provider: &str,
+    model: &str,
+    prompt_tokens: Option<i64>,
+    completion_tokens: Option<i64>,
+    total_tokens: Option<i64>,
+    cost: Option<f64>,
+) {
+    let mut facts = match facts.lock() {
+        Ok(facts) => facts,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    facts.record_settlement(
+        provider,
+        model,
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+        cost,
+    );
+}
+
+/// Snapshot facts without cloning mutex poison into callers.
+pub fn snapshot_facts(facts: &SharedRequestLedgerFacts) -> RequestLedgerFacts {
+    match facts.lock() {
+        Ok(facts) => facts.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FailingWriter;
+
+    #[async_trait::async_trait]
+    impl RequestLedgerWriter for FailingWriter {
+        async fn persist(&self, _record: RequestLedgerRecord) -> Result<(), String> {
+            Err("disk full".to_string())
+        }
+    }
+
+    fn sample_record() -> RequestLedgerRecord {
+        RequestLedgerRecord {
+            request_id: "req-1".to_string(),
+            started_at: Utc::now(),
+            finished_at: Utc::now(),
+            method: "POST".to_string(),
+            endpoint: "/v1/chat/completions".to_string(),
+            model: Some("gpt-4".to_string()),
+            provider: Some("openai".to_string()),
+            deployment: Some("openai".to_string()),
+            status_code: 200,
+            terminal_status: "completed".to_string(),
+            latency_ms: 12,
+            prompt_tokens: Some(3),
+            completion_tokens: Some(5),
+            total_tokens: Some(8),
+            cost: Some(0.01),
+            user_id: None,
+            api_key_id: Some("key-1".to_string()),
+            team_id: None,
+        }
+    }
+
+    #[test]
+    fn serialized_record_has_no_body_or_secret_fields() {
+        let json = serde_json::to_value(sample_record()).expect("record serializes");
+        let keys: Vec<&str> = json
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        for forbidden in [
+            "body",
+            "prompt",
+            "authorization",
+            "header",
+            "secret",
+            "api_key",
+            "raw_key",
+        ] {
+            assert!(
+                !keys.contains(&forbidden),
+                "{forbidden} must not be a ledger column, got {keys:?}"
+            );
+        }
+        assert!(keys.contains(&"api_key_id"));
+        assert!(keys.contains(&"request_id"));
+    }
+
+    #[tokio::test]
+    async fn continue_policy_logs_and_succeeds() {
+        persist_with_policy(
+            &FailingWriter,
+            sample_record(),
+            RequestLedgerWriteFailure::Continue,
+        )
+        .await
+        .expect("continue must not fail the caller");
+    }
+
+    #[tokio::test]
+    async fn fail_policy_returns_the_write_error() {
+        let error = persist_with_policy(
+            &FailingWriter,
+            sample_record(),
+            RequestLedgerWriteFailure::Fail,
+        )
+        .await
+        .expect_err("fail must surface the write error");
+        assert_eq!(error, "disk full");
+    }
+
+    #[test]
+    fn settlement_does_not_store_authorization_or_bodies() {
+        let facts = SharedRequestLedgerFacts::new(Mutex::new(RequestLedgerFacts::default()));
+        apply_settlement(
+            &facts,
+            "openai",
+            "gpt-4",
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(0.2),
+        );
+        let snapshot = snapshot_facts(&facts);
+        let json = serde_json::to_value(&snapshot).expect("facts serialize");
+        let text = json.to_string().to_lowercase();
+        assert!(!text.contains("authorization"));
+        assert!(!text.contains("bearer"));
+        assert!(!text.contains("sk-"));
+        assert_eq!(snapshot.model.as_deref(), Some("gpt-4"));
+    }
+}

--- a/src/core/subsystem_registry.rs
+++ b/src/core/subsystem_registry.rs
@@ -238,6 +238,12 @@ pub const CORE_SUBSYSTEMS: &[CoreSubsystem] = &[
         note: "Realtime module is excluded from the default build behind the websockets feature.",
     },
     CoreSubsystem {
+        name: "request_ledger",
+        decision: SubsystemDecision::Wired,
+        runtime_path: Some("AppState RequestLedgerRuntime and AuditMiddleware"),
+        note: "storage.request_ledger persists one metadata-only terminal row per request when enabled; the default remains disabled.",
+    },
+    CoreSubsystem {
         name: "rerank",
         decision: SubsystemDecision::Wired,
         runtime_path: Some("/v1/rerank route"),

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -189,6 +189,16 @@ impl HttpServer {
         let audit_enabled = state.audit_logger.is_enabled();
         let audit_logger = Arc::clone(&state.audit_logger);
         let trusted_proxies = cfg.gateway.server.trusted_proxies.clone();
+        let ledger_enabled = cfg.gateway.storage.request_ledger.enabled;
+        let request_ledger = ledger_enabled.then(|| {
+            Arc::new(crate::core::request_ledger::RequestLedgerRuntime {
+                writer: Arc::new(crate::storage::database::RequestLedgerSink::new(
+                    Arc::clone(&state.storage.database),
+                    cfg.gateway.storage.request_ledger.retention_days,
+                )),
+                write_failure: cfg.gateway.storage.request_ledger.write_failure,
+            })
+        });
         let ip_access = Arc::clone(&state.ip_access);
         let cors = Self::build_cors_for_app_factory(cors_config);
         let max_body_size = cfg.gateway.server.max_body_size;
@@ -221,10 +231,14 @@ impl HttpServer {
             // IP policy remains before authentication/provider side effects.
             .wrap(IpAccessMiddleware::new(ip_access))
             // Audit wraps IP denials; request IDs wrap the complete lifecycle.
-            .wrap(Condition::new(
-                audit_enabled,
-                AuditMiddleware::with_trusted_proxies(audit_logger, trusted_proxies),
-            ))
+            .wrap(Condition::new(audit_enabled || ledger_enabled, {
+                let mut audit =
+                    AuditMiddleware::with_trusted_proxies(audit_logger, trusted_proxies);
+                if let Some(request_ledger) = request_ledger {
+                    audit = audit.with_request_ledger(request_ledger);
+                }
+                audit
+            }))
             .wrap(RequestIdMiddleware)
             .configure(routes::health::configure_routes)
             .configure(routes::auth::configure_routes)

--- a/src/server/routes/ai/budgeted.rs
+++ b/src/server/routes/ai/budgeted.rs
@@ -368,6 +368,7 @@ pub(super) struct SettledStream {
     pub(super) request_pricing: spend::RequestPricing,
     pub(super) budget_reservation: Option<UnifiedBudgetReservation>,
     pub(super) key_budget_reservation: Option<BudgetReservation>,
+    pub(super) ledger_facts: Option<crate::core::request_ledger::SharedRequestLedgerFacts>,
 }
 
 impl SettledStream {
@@ -376,7 +377,8 @@ impl SettledStream {
         usage: Option<&Usage>,
         saw_upstream_output: bool,
     ) {
-        spend::record_finished_stream_spend_with_reservation_with_policy(
+        let facts = self.ledger_facts.clone();
+        let fut = spend::record_finished_stream_spend_with_reservation_with_policy(
             self.pricing_service.as_ref(),
             &self.pricing_config,
             spend::StreamSpendSettlement {
@@ -391,12 +393,16 @@ impl SettledStream {
                 budget_reservation: self.budget_reservation.take(),
                 key_budget_reservation: self.key_budget_reservation.take(),
             },
-        )
-        .await;
+        );
+        match facts {
+            Some(facts) => crate::core::request_ledger::scope_facts(facts, fut).await,
+            None => fut.await,
+        }
     }
 
     pub(super) async fn record_disconnect(&mut self, usage: Option<&Usage>) {
-        spend::record_stream_disconnect_spend_with_reservation_with_policy(
+        let facts = self.ledger_facts.clone();
+        let fut = spend::record_stream_disconnect_spend_with_reservation_with_policy(
             self.pricing_service.as_ref(),
             &self.pricing_config,
             spend::usage_spend_settlement_with_request_pricing(
@@ -410,8 +416,11 @@ impl SettledStream {
                 self.budget_reservation.take(),
                 self.key_budget_reservation.take(),
             ),
-        )
-        .await;
+        );
+        match facts {
+            Some(facts) => crate::core::request_ledger::scope_facts(facts, fut).await,
+            None => fut.await,
+        }
     }
 }
 
@@ -744,6 +753,7 @@ mod tests {
             request_pricing,
             budget_reservation: reservation,
             key_budget_reservation: None,
+            ledger_facts: None,
         }
     }
 

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -150,6 +150,7 @@ pub(super) async fn handle_streaming_chat_completion(
                     request_pricing,
                     budget_reservation,
                     key_budget_reservation,
+                    ledger_facts: crate::core::request_ledger::current_facts(),
                 };
                 Ok((stream, settlement))
             }

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -156,6 +156,7 @@ pub(super) async fn handle_streaming_completion(
                     request_pricing,
                     budget_reservation,
                     key_budget_reservation,
+                    ledger_facts: crate::core::request_ledger::current_facts(),
                 };
                 Ok((stream, settlement))
             }

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -192,6 +192,7 @@ pub(crate) async fn handle_streaming_response(
                 request_pricing,
                 budget_reservation,
                 key_budget_reservation,
+                ledger_facts: crate::core::request_ledger::current_facts(),
             };
 
             tokio::spawn(async move {

--- a/src/server/routes/ai/responses_stream_tests.rs
+++ b/src/server/routes/ai/responses_stream_tests.rs
@@ -233,6 +233,7 @@ async fn disconnect_after_upstream_output_settles_reserved_budget() {
         request_pricing,
         budget_reservation: Some(reservation),
         key_budget_reservation: None,
+        ledger_facts: None,
     };
 
     settlement.record_disconnect(None).await;
@@ -285,6 +286,7 @@ async fn completed_stream_without_usage_after_output_settles_reserved_budget() {
         request_pricing,
         budget_reservation: Some(reservation),
         key_budget_reservation: None,
+        ledger_facts: None,
     };
 
     settlement.record_completion(None, true).await;

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -18,6 +18,7 @@ use crate::core::budget::{
 use crate::core::keys::KeyManager;
 use crate::core::pricing_service::{PricingService, PricingUsage};
 use crate::core::providers::unified_provider::ProviderError;
+use crate::core::request_ledger::{SharedRequestLedgerFacts, apply_settlement, current_facts};
 use crate::core::types::responses::{ChatChunk, Usage};
 #[cfg(test)]
 use std::sync::LazyLock;
@@ -141,6 +142,7 @@ pub(super) struct UsageSpendSettlement<'a> {
     pub(super) usage: Option<&'a Usage>,
     pub(super) budget_reservation: Option<UnifiedBudgetReservation>,
     pub(super) key_budget_reservation: Option<BudgetReservation>,
+    pub(super) ledger_facts: Option<SharedRequestLedgerFacts>,
 }
 
 pub(super) fn usage_spend_settlement<'a>(
@@ -181,6 +183,47 @@ pub(super) fn usage_spend_settlement_with_pricing<'a>(
         usage,
         budget_reservation,
         key_budget_reservation,
+        ledger_facts: current_facts(),
+    }
+}
+
+impl UsageSpendSettlement<'_> {
+    pub(super) fn with_ledger_facts(mut self, facts: Option<SharedRequestLedgerFacts>) -> Self {
+        if facts.is_some() {
+            self.ledger_facts = facts;
+        }
+        self
+    }
+}
+
+fn capture_ledger_settlement(
+    facts: Option<&SharedRequestLedgerFacts>,
+    provider: &str,
+    model: &str,
+    usage: Option<&Usage>,
+    cost: Option<f64>,
+) {
+    let prompt_tokens = usage.map(|usage| i64::from(usage.prompt_tokens));
+    let completion_tokens = usage.map(|usage| i64::from(usage.completion_tokens));
+    let total_tokens = usage.map(|usage| i64::from(usage.total_tokens));
+    match facts {
+        Some(facts) => apply_settlement(
+            facts,
+            provider,
+            model,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            cost,
+        ),
+        None => crate::core::request_ledger::record_current_settlement(
+            provider,
+            model,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            cost,
+        ),
     }
 }
 
@@ -237,9 +280,11 @@ pub(super) async fn record_completion_spend_with_reservation_with_policy(
         usage,
         budget_reservation,
         key_budget_reservation,
+        ledger_facts,
     } = settlement;
 
     let Some(usage) = usage else {
+        capture_ledger_settlement(ledger_facts.as_ref(), provider, model, None, None);
         record_reserved_spend_without_usage(
             key_manager,
             api_key_id,
@@ -285,9 +330,18 @@ pub(super) async fn record_completion_spend_with_reservation_with_policy(
                 "completion spend pricing unavailable",
             )
             .await;
+            capture_ledger_settlement(ledger_facts.as_ref(), provider, model, Some(usage), None);
             return;
         }
     };
+
+    capture_ledger_settlement(
+        ledger_facts.as_ref(),
+        provider,
+        model,
+        Some(usage),
+        Some(cost),
+    );
 
     if let Some(reservation) = budget_reservation {
         if let Err(error) = reservation.settle(cost) {
@@ -405,6 +459,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation_with_policy(
         usage,
         budget_reservation,
         key_budget_reservation,
+        ledger_facts,
     } = settlement;
 
     if let Some(usage) = usage {
@@ -424,7 +479,8 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation_with_policy(
                 budget_reservation,
                 key_budget_reservation,
             )
-        };
+        }
+        .with_ledger_facts(ledger_facts);
         record_completion_spend_with_reservation_with_policy(
             pricing_service,
             pricing_config,
@@ -434,6 +490,7 @@ pub(super) async fn record_stream_disconnect_spend_with_reservation_with_policy(
         return;
     }
 
+    capture_ledger_settlement(ledger_facts.as_ref(), provider, model, None, None);
     record_reserved_spend_without_usage(
         key_manager,
         api_key_id,

--- a/src/storage/database/entities/mod.rs
+++ b/src/storage/database/entities/mod.rs
@@ -10,6 +10,8 @@ pub mod password_reset_token;
 pub mod pricing;
 /// Pricing history entity module
 pub mod pricing_history;
+/// Request ledger entity module
+pub mod request_ledger;
 /// User entity module
 pub mod user;
 /// User session entity module
@@ -21,6 +23,7 @@ pub use budget_limit_snapshot::Entity as BudgetLimitSnapshot;
 pub use password_reset_token::Entity as PasswordResetToken;
 pub use pricing::Entity as ModelPricing;
 pub use pricing_history::Entity as PricingHistory;
+pub use request_ledger::Entity as RequestLedger;
 pub use user::Entity as User;
 // UserSession is available but not currently used
 #[allow(unused_imports)]

--- a/src/storage/database/entities/request_ledger.rs
+++ b/src/storage/database/entities/request_ledger.rs
@@ -1,0 +1,52 @@
+use sea_orm::entity::prelude::*;
+
+/// Metadata-only terminal request ledger row.
+///
+/// This entity must never grow prompt, response body, Authorization, raw API
+/// key, or provider secret columns.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "request_ledger")]
+pub struct Model {
+    /// Gateway request id (one terminal row per request).
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub request_id: String,
+    /// Request start timestamp.
+    pub started_at: DateTimeWithTimeZone,
+    /// Terminal timestamp.
+    pub finished_at: DateTimeWithTimeZone,
+    /// HTTP method.
+    pub method: String,
+    /// Request path.
+    pub endpoint: String,
+    /// Served model when known.
+    pub model: Option<String>,
+    /// Selected provider when known.
+    pub provider: Option<String>,
+    /// Selected deployment when known.
+    pub deployment: Option<String>,
+    /// HTTP status code.
+    pub status_code: i32,
+    /// `completed`, `failed`, or `cancelled`.
+    pub terminal_status: String,
+    /// End-to-end latency in milliseconds.
+    pub latency_ms: i64,
+    /// Prompt tokens when settled.
+    pub prompt_tokens: Option<i64>,
+    /// Completion tokens when settled.
+    pub completion_tokens: Option<i64>,
+    /// Total tokens when settled.
+    pub total_tokens: Option<i64>,
+    /// Settled cost when priced.
+    pub cost: Option<f64>,
+    /// Authenticated user id.
+    pub user_id: Option<String>,
+    /// API key id (never the raw secret).
+    pub api_key_id: Option<String>,
+    /// Team id.
+    pub team_id: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/storage/database/migration/m20260906_000001_create_request_ledger.rs
+++ b/src/storage/database/migration/m20260906_000001_create_request_ledger.rs
@@ -1,6 +1,8 @@
 //! Migration: create metadata-only request_ledger table.
 //!
-//! Retention is enforced at write time using `storage.request_ledger.retention_days`.
+//! Retention is enforced on the write path using
+//! `storage.request_ledger.retention_days`, throttled so expired rows are not
+//! deleted on every request.
 //! Indexes are bounded to time-range, request id, model, provider, and terminal
 //! status filters used by the later admin query API.
 

--- a/src/storage/database/migration/m20260906_000001_create_request_ledger.rs
+++ b/src/storage/database/migration/m20260906_000001_create_request_ledger.rs
@@ -1,0 +1,155 @@
+//! Migration: create metadata-only request_ledger table.
+//!
+//! Retention is enforced at write time using `storage.request_ledger.retention_days`.
+//! Indexes are bounded to time-range, request id, model, provider, and terminal
+//! status filters used by the later admin query API.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(RequestLedger::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(RequestLedger::RequestId)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::StartedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::FinishedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(RequestLedger::Method).string().not_null())
+                    .col(ColumnDef::new(RequestLedger::Endpoint).string().not_null())
+                    .col(ColumnDef::new(RequestLedger::Model).string().null())
+                    .col(ColumnDef::new(RequestLedger::Provider).string().null())
+                    .col(ColumnDef::new(RequestLedger::Deployment).string().null())
+                    .col(
+                        ColumnDef::new(RequestLedger::StatusCode)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::TerminalStatus)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::LatencyMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::PromptTokens)
+                            .big_integer()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::CompletionTokens)
+                            .big_integer()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(RequestLedger::TotalTokens)
+                            .big_integer()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(RequestLedger::Cost).double().null())
+                    .col(ColumnDef::new(RequestLedger::UserId).string().null())
+                    .col(ColumnDef::new(RequestLedger::ApiKeyId).string().null())
+                    .col(ColumnDef::new(RequestLedger::TeamId).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_request_ledger_finished_at")
+                    .table(RequestLedger::Table)
+                    .col(RequestLedger::FinishedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_request_ledger_model_finished_at")
+                    .table(RequestLedger::Table)
+                    .col(RequestLedger::Model)
+                    .col(RequestLedger::FinishedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_request_ledger_provider_finished_at")
+                    .table(RequestLedger::Table)
+                    .col(RequestLedger::Provider)
+                    .col(RequestLedger::FinishedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_request_ledger_status_finished_at")
+                    .table(RequestLedger::Table)
+                    .col(RequestLedger::TerminalStatus)
+                    .col(RequestLedger::FinishedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(RequestLedger::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum RequestLedger {
+    Table,
+    RequestId,
+    StartedAt,
+    FinishedAt,
+    Method,
+    Endpoint,
+    Model,
+    Provider,
+    Deployment,
+    StatusCode,
+    TerminalStatus,
+    LatencyMs,
+    PromptTokens,
+    CompletionTokens,
+    TotalTokens,
+    Cost,
+    UserId,
+    ApiKeyId,
+    TeamId,
+}

--- a/src/storage/database/migration/mod.rs
+++ b/src/storage/database/migration/mod.rs
@@ -14,6 +14,7 @@ mod m20240301_000002_create_teams_table;
 mod m20240301_000003_create_virtual_keys_table;
 mod m20240501_000001_create_budget_limit_snapshots;
 mod m20260712_000001_restrict_api_key_owner_deletion;
+mod m20260906_000001_create_request_ledger;
 
 /// Database migrator for SeaORM
 pub struct Migrator;
@@ -71,6 +72,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240301_000003_create_virtual_keys_table::Migration),
             Box::new(m20240501_000001_create_budget_limit_snapshots::Migration),
             Box::new(m20260712_000001_restrict_api_key_owner_deletion::Migration),
+            Box::new(m20260906_000001_create_request_ledger::Migration),
         ]
     }
 }

--- a/src/storage/database/mod.rs
+++ b/src/storage/database/mod.rs
@@ -12,7 +12,7 @@ pub mod seaorm_db;
 
 // Re-export the main database interface
 pub use seaorm_db::SeaOrmDatabase as Database;
-pub use seaorm_db::{DatabaseBackendType, DatabaseStats, SeaOrmTeamRepository};
+pub use seaorm_db::{DatabaseBackendType, DatabaseStats, RequestLedgerSink, SeaOrmTeamRepository};
 
 /// Returns the default absolute path for the SQLite fallback database.
 ///

--- a/src/storage/database/seaorm_db/api_key_owner_migration_tests.rs
+++ b/src/storage/database/seaorm_db/api_key_owner_migration_tests.rs
@@ -7,13 +7,13 @@ use chrono::Utc;
 use sea_orm::{ConnectionTrait, EntityTrait};
 #[cfg(feature = "sqlite")]
 use sea_orm::{DbBackend, Statement};
-#[cfg(feature = "sqlite")]
 use sea_orm_migration::MigratorTrait;
 use std::collections::HashMap;
 use std::error::Error;
 use uuid::Uuid;
 
 const PRE_OWNER_RESTRICT_MIGRATION_COUNT: u32 = 10;
+const OWNER_RESTRICT_MIGRATION: &str = "m20260712_000001_restrict_api_key_owner_deletion";
 type TestResult<T = ()> = Result<T, Box<dyn Error>>;
 
 #[test]
@@ -76,6 +76,33 @@ fn api_key(name: &str, user_id: Option<Uuid>) -> ApiKey {
     }
 }
 
+async fn applied_migration_names(db: &SeaOrmDatabase) -> TestResult<Vec<String>> {
+    Ok(Migrator::get_applied_migrations(db.connection())
+        .await?
+        .into_iter()
+        .map(|migration| migration.name().to_string())
+        .collect())
+}
+
+async fn rollback_migrations_after(db: &SeaOrmDatabase, name: &str) -> TestResult {
+    let applied = applied_migration_names(db).await?;
+    let steps = applied
+        .iter()
+        .rev()
+        .take_while(|applied_name| applied_name.as_str() != name)
+        .count();
+    if steps > 0 {
+        Migrator::down(db.connection(), Some(u32::try_from(steps)?)).await?;
+    }
+    Ok(())
+}
+
+async fn rollback_through(db: &SeaOrmDatabase, name: &str) -> TestResult {
+    rollback_migrations_after(db, name).await?;
+    Migrator::down(db.connection(), Some(1)).await?;
+    Ok(())
+}
+
 async fn stored_key(db: &SeaOrmDatabase, key_id: Uuid) -> TestResult<entities::api_key::Model> {
     entities::ApiKey::find_by_id(key_id)
         .one(db.connection())
@@ -128,7 +155,7 @@ async fn assert_owner_restrict_upgrade_contract(db: &SeaOrmDatabase) -> TestResu
     assert!(db.create_api_key(&duplicate_hash).await.is_err());
     assert_eq!(stored_key(db, global_key.metadata.id).await?, global_before);
 
-    Migrator::down(db.connection(), Some(1)).await?;
+    rollback_through(db, OWNER_RESTRICT_MIGRATION).await?;
     let deleted_owner = entities::User::delete_by_id(owner.id())
         .exec(db.connection())
         .await?;
@@ -198,11 +225,7 @@ async fn owner_restrict_sqlite_upgrade_rolls_back_on_dangling_owner() -> TestRes
     assert!(sqlite_object_exists(&db, "index", "idx_api_keys_key_hash").await?);
     assert_eq!(stored_key(&db, dangling_key.metadata.id).await?, before);
     let pending = Migrator::get_pending_migrations(db.connection()).await?;
-    assert_eq!(pending.len(), 1);
-    assert_eq!(
-        pending[0].name(),
-        "m20260712_000001_restrict_api_key_owner_deletion"
-    );
+    assert_eq!(pending[0].name(), OWNER_RESTRICT_MIGRATION);
     Ok(())
 }
 
@@ -225,11 +248,7 @@ async fn owner_restrict_sqlite_ledger_insert_failure_rolls_back_schema() -> Test
 
     assert!(db.migrate().await.is_err());
     let pending = Migrator::get_pending_migrations(db.connection()).await?;
-    assert_eq!(pending.len(), 1);
-    assert_eq!(
-        pending[0].name(),
-        "m20260712_000001_restrict_api_key_owner_deletion"
-    );
+    assert_eq!(pending[0].name(), OWNER_RESTRICT_MIGRATION);
     let deleted = entities::User::delete_by_id(owner.id())
         .exec(db.connection())
         .await?;
@@ -247,6 +266,7 @@ async fn owner_restrict_sqlite_ledger_delete_failure_rolls_back_schema() -> Test
     let owned_key = api_key("ledger-delete-key", Some(owner.id()));
     db.create_api_key(&owned_key).await?;
     db.migrate().await?;
+    rollback_migrations_after(&db, OWNER_RESTRICT_MIGRATION).await?;
     db.connection()
         .execute_unprepared(
             "CREATE TRIGGER fail_owner_restrict_ledger_delete \
@@ -260,7 +280,7 @@ async fn owner_restrict_sqlite_ledger_delete_failure_rolls_back_schema() -> Test
     let applied = Migrator::get_applied_migrations(db.connection()).await?;
     assert_eq!(
         applied.last().map(|migration| migration.name()),
-        Some("m20260712_000001_restrict_api_key_owner_deletion")
+        Some(OWNER_RESTRICT_MIGRATION)
     );
     assert!(
         entities::User::delete_by_id(owner.id())

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -8,6 +8,7 @@ mod api_key_owner_migration_tests;
 mod batch_ops;
 mod budget_limit_ops;
 mod connection;
+mod request_ledger_ops;
 mod team_repository;
 #[cfg(test)]
 mod team_repository_tests;
@@ -22,5 +23,6 @@ mod user_state_corruption_tests;
 mod virtual_key_ops;
 
 // Re-export public types
+pub use request_ledger_ops::RequestLedgerSink;
 pub use team_repository::SeaOrmTeamRepository;
 pub use types::{DatabaseBackendType, DatabaseStats, SeaOrmDatabase};

--- a/src/storage/database/seaorm_db/request_ledger_ops.rs
+++ b/src/storage/database/seaorm_db/request_ledger_ops.rs
@@ -1,0 +1,225 @@
+use crate::core::request_ledger::{RequestLedgerRecord, RequestLedgerWriter};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use chrono::{Duration, Utc};
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use std::sync::Arc;
+use tracing::debug;
+
+use super::super::entities::{self, request_ledger};
+use super::types::SeaOrmDatabase;
+
+/// Database-backed request ledger writer with bounded retention.
+#[derive(Clone)]
+pub struct RequestLedgerSink {
+    db: Arc<SeaOrmDatabase>,
+    retention_days: u32,
+}
+
+impl RequestLedgerSink {
+    /// Create a sink that stores terminal rows and prunes by `retention_days`.
+    pub fn new(db: Arc<SeaOrmDatabase>, retention_days: u32) -> Self {
+        Self { db, retention_days }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestLedgerWriter for RequestLedgerSink {
+    async fn persist(&self, record: RequestLedgerRecord) -> std::result::Result<(), String> {
+        self.db
+            .store_request_ledger(&record, self.retention_days)
+            .await
+            .map_err(|error| error.to_string())
+    }
+}
+
+impl SeaOrmDatabase {
+    /// Persist one metadata-only terminal request-ledger row and prune expired rows.
+    pub async fn store_request_ledger(
+        &self,
+        record: &RequestLedgerRecord,
+        retention_days: u32,
+    ) -> Result<()> {
+        debug!("Persisting request ledger row {}", record.request_id);
+
+        let active_model = request_ledger::ActiveModel {
+            request_id: Set(record.request_id.clone()),
+            started_at: Set(record.started_at.into()),
+            finished_at: Set(record.finished_at.into()),
+            method: Set(record.method.clone()),
+            endpoint: Set(record.endpoint.clone()),
+            model: Set(record.model.clone()),
+            provider: Set(record.provider.clone()),
+            deployment: Set(record.deployment.clone()),
+            status_code: Set(record.status_code),
+            terminal_status: Set(record.terminal_status.clone()),
+            latency_ms: Set(record.latency_ms),
+            prompt_tokens: Set(record.prompt_tokens),
+            completion_tokens: Set(record.completion_tokens),
+            total_tokens: Set(record.total_tokens),
+            cost: Set(record.cost),
+            user_id: Set(record.user_id.clone()),
+            api_key_id: Set(record.api_key_id.clone()),
+            team_id: Set(record.team_id.clone()),
+        };
+
+        entities::RequestLedger::insert(active_model)
+            .on_conflict(
+                OnConflict::column(request_ledger::Column::RequestId)
+                    .update_columns([
+                        request_ledger::Column::StartedAt,
+                        request_ledger::Column::FinishedAt,
+                        request_ledger::Column::Method,
+                        request_ledger::Column::Endpoint,
+                        request_ledger::Column::Model,
+                        request_ledger::Column::Provider,
+                        request_ledger::Column::Deployment,
+                        request_ledger::Column::StatusCode,
+                        request_ledger::Column::TerminalStatus,
+                        request_ledger::Column::LatencyMs,
+                        request_ledger::Column::PromptTokens,
+                        request_ledger::Column::CompletionTokens,
+                        request_ledger::Column::TotalTokens,
+                        request_ledger::Column::Cost,
+                        request_ledger::Column::UserId,
+                        request_ledger::Column::ApiKeyId,
+                        request_ledger::Column::TeamId,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await
+            .map_err(GatewayError::from)?;
+
+        let cutoff = Utc::now() - Duration::days(i64::from(retention_days.max(1)));
+        entities::RequestLedger::delete_many()
+            .filter(request_ledger::Column::FinishedAt.lt(cutoff))
+            .exec(&self.db)
+            .await
+            .map_err(GatewayError::from)?;
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn find_request_ledger(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<request_ledger::Model>> {
+        entities::RequestLedger::find_by_id(request_id.to_string())
+            .one(&self.db)
+            .await
+            .map_err(GatewayError::from)
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use crate::config::models::storage::DatabaseConfig;
+    use crate::core::request_ledger::RequestLedgerRecord;
+    use crate::storage::database::migration::Migrator;
+    use chrono::Utc;
+    use sea_orm::IdenStatic;
+    use sea_orm::Iterable;
+
+    async fn test_db() -> SeaOrmDatabase {
+        let db = SeaOrmDatabase::new(&DatabaseConfig {
+            enabled: false,
+            ..DatabaseConfig::default()
+        })
+        .await
+        .expect("in-memory sqlite");
+        Migrator::up(db.connection(), None)
+            .await
+            .expect("migrations");
+        db
+    }
+
+    fn record(request_id: &str, finished_at: chrono::DateTime<Utc>) -> RequestLedgerRecord {
+        RequestLedgerRecord {
+            request_id: request_id.to_string(),
+            started_at: finished_at,
+            finished_at,
+            method: "POST".to_string(),
+            endpoint: "/v1/chat/completions".to_string(),
+            model: Some("gpt-4".to_string()),
+            provider: Some("openai".to_string()),
+            deployment: Some("openai".to_string()),
+            status_code: 200,
+            terminal_status: "completed".to_string(),
+            latency_ms: 9,
+            prompt_tokens: Some(4),
+            completion_tokens: Some(6),
+            total_tokens: Some(10),
+            cost: Some(0.02),
+            user_id: None,
+            api_key_id: Some("key-id".to_string()),
+            team_id: Some("team-id".to_string()),
+        }
+    }
+
+    #[test]
+    fn request_ledger_columns_are_metadata_only() {
+        let names: Vec<String> = request_ledger::Column::iter()
+            .map(|column| column.as_str().to_lowercase())
+            .collect();
+        for forbidden in [
+            "body",
+            "prompt",
+            "authorization",
+            "header",
+            "secret",
+            "api_key",
+            "raw_key",
+        ] {
+            assert!(
+                !names.iter().any(|name| name == forbidden),
+                "{forbidden} must not be a ledger column: {names:?}"
+            );
+        }
+        assert!(names.iter().any(|name| name == "api_key_id"));
+        assert!(names.iter().any(|name| name == "request_id"));
+    }
+
+    #[tokio::test]
+    async fn store_request_ledger_writes_one_terminal_row() {
+        let db = test_db().await;
+        db.store_request_ledger(&record("req-store", Utc::now()), 30)
+            .await
+            .expect("store");
+        let stored = db
+            .find_request_ledger("req-store")
+            .await
+            .expect("lookup")
+            .expect("row");
+        assert_eq!(stored.endpoint, "/v1/chat/completions");
+        assert_eq!(stored.model.as_deref(), Some("gpt-4"));
+        assert_eq!(stored.api_key_id.as_deref(), Some("key-id"));
+        assert!(stored.prompt_tokens.is_some());
+    }
+
+    #[tokio::test]
+    async fn store_request_ledger_prunes_rows_older_than_retention() {
+        let db = test_db().await;
+        let old = Utc::now() - Duration::days(40);
+        db.store_request_ledger(&record("req-old", old), 365)
+            .await
+            .expect("old row");
+        db.store_request_ledger(&record("req-new", Utc::now()), 30)
+            .await
+            .expect("new row");
+        assert!(
+            db.find_request_ledger("req-old")
+                .await
+                .expect("lookup old")
+                .is_none()
+        );
+        assert!(
+            db.find_request_ledger("req-new")
+                .await
+                .expect("lookup new")
+                .is_some()
+        );
+    }
+}

--- a/src/storage/database/seaorm_db/request_ledger_ops.rs
+++ b/src/storage/database/seaorm_db/request_ledger_ops.rs
@@ -4,22 +4,54 @@ use chrono::{Duration, Utc};
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
 use super::super::entities::{self, request_ledger};
 use super::types::SeaOrmDatabase;
+
+/// Minimum seconds between write-path retention deletes on one sink.
+const REQUEST_LEDGER_PRUNE_INTERVAL_SECS: i64 = 3600;
 
 /// Database-backed request ledger writer with bounded retention.
 #[derive(Clone)]
 pub struct RequestLedgerSink {
     db: Arc<SeaOrmDatabase>,
     retention_days: u32,
+    last_prune_unix: Arc<AtomicI64>,
 }
 
 impl RequestLedgerSink {
     /// Create a sink that stores terminal rows and prunes by `retention_days`.
     pub fn new(db: Arc<SeaOrmDatabase>, retention_days: u32) -> Self {
-        Self { db, retention_days }
+        Self {
+            db,
+            retention_days,
+            last_prune_unix: Arc::new(AtomicI64::new(0)),
+        }
+    }
+
+    fn claim_prune_slot(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| i64::try_from(duration.as_secs()).unwrap_or(i64::MAX))
+            .unwrap_or(0);
+        loop {
+            let last = self.last_prune_unix.load(Ordering::Relaxed);
+            if last != 0 && now.saturating_sub(last) < REQUEST_LEDGER_PRUNE_INTERVAL_SECS {
+                return false;
+            }
+            match self.last_prune_unix.compare_exchange_weak(
+                last,
+                now.max(1),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(_) => continue,
+            }
+        }
     }
 }
 
@@ -27,9 +59,16 @@ impl RequestLedgerSink {
 impl RequestLedgerWriter for RequestLedgerSink {
     async fn persist(&self, record: RequestLedgerRecord) -> std::result::Result<(), String> {
         self.db
-            .store_request_ledger(&record, self.retention_days)
+            .upsert_request_ledger(&record)
             .await
-            .map_err(|error| error.to_string())
+            .map_err(|error| error.to_string())?;
+        if self.claim_prune_slot() {
+            self.db
+                .prune_expired_request_ledger(self.retention_days)
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        Ok(())
     }
 }
 
@@ -40,6 +79,11 @@ impl SeaOrmDatabase {
         record: &RequestLedgerRecord,
         retention_days: u32,
     ) -> Result<()> {
+        self.upsert_request_ledger(record).await?;
+        self.prune_expired_request_ledger(retention_days).await
+    }
+
+    async fn upsert_request_ledger(&self, record: &RequestLedgerRecord) -> Result<()> {
         debug!("Persisting request ledger row {}", record.request_id);
 
         let active_model = request_ledger::ActiveModel {
@@ -90,14 +134,16 @@ impl SeaOrmDatabase {
             .exec(&self.db)
             .await
             .map_err(GatewayError::from)?;
+        Ok(())
+    }
 
+    async fn prune_expired_request_ledger(&self, retention_days: u32) -> Result<()> {
         let cutoff = Utc::now() - Duration::days(i64::from(retention_days.max(1)));
         entities::RequestLedger::delete_many()
             .filter(request_ledger::Column::FinishedAt.lt(cutoff))
             .exec(&self.db)
             .await
             .map_err(GatewayError::from)?;
-
         Ok(())
     }
 
@@ -221,5 +267,12 @@ mod tests {
                 .expect("lookup new")
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn request_ledger_sink_throttles_write_path_prune() {
+        let sink = RequestLedgerSink::new(Arc::new(test_db().await), 30);
+        assert!(sink.claim_prune_slot());
+        assert!(!sink.claim_prune_slot());
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -494,7 +494,7 @@ pub struct StorageHealthStatus {
 mod tests {
     use super::*;
     use crate::config::models::file_storage::FileStorageConfig;
-    use crate::config::models::storage::{DatabaseConfig, RedisConfig};
+    use crate::config::models::storage::{DatabaseConfig, RedisConfig, RequestLedgerConfig};
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -521,6 +521,7 @@ mod tests {
             },
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         // This test would require actual database connections
@@ -542,6 +543,7 @@ mod tests {
                 s3: None,
             },
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let storage = StorageLayer::new(&config)
@@ -569,6 +571,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let storage = StorageLayer::new(&config)
@@ -600,6 +603,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let err = match StorageLayer::new(&config).await {
@@ -620,6 +624,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let storage = match StorageLayer::new(&config).await {
@@ -641,6 +646,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let storage = StorageLayer::new(&config)
@@ -687,6 +693,7 @@ mod tests {
             redis: unreachable_redis_config(false),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let result = StorageLayer::new(&config).await;
@@ -703,6 +710,7 @@ mod tests {
             redis: unreachable_redis_config(true),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let storage = StorageLayer::new(&config)
@@ -726,6 +734,7 @@ mod tests {
             redis,
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         };
 
         let storage = StorageLayer::new(&config)

--- a/src/storage/vector_startup_tests.rs
+++ b/src/storage/vector_startup_tests.rs
@@ -64,6 +64,7 @@ fn storage_with_vector(
         redis: RedisConfig::default(),
         files: FileStorageConfig::default(),
         vector_db,
+        request_ledger: crate::config::models::storage::RequestLedgerConfig::default(),
     }
 }
 

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -7,7 +7,7 @@
 mod tests {
     use litellm_rs::config::models::file_storage::FileStorageConfig;
     use litellm_rs::config::models::storage::DatabaseConfig;
-    use litellm_rs::config::models::storage::{RedisConfig, StorageConfig};
+    use litellm_rs::config::models::storage::{RedisConfig, RequestLedgerConfig, StorageConfig};
     use litellm_rs::core::batch::{BatchRequest, BatchStatus, BatchType};
     use litellm_rs::core::models::user::types::User;
     use litellm_rs::core::models::{ApiKey, Metadata, RateLimits, UsageStats};
@@ -76,6 +76,7 @@ mod tests {
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
             vector_db: None,
+            request_ledger: RequestLedgerConfig::default(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Persist one metadata-only terminal row per gateway request from the existing audit/request lifecycle (`storage.request_ledger`, disabled by default).
- Rows store request id, timestamps, endpoint, model/provider/deployment, status, latency, tokens, cost, and key/team ids. They never store prompt, response body, Authorization, raw API keys, or provider secrets.
- Write failures are explicit: `write_failure: continue` (default, logged) or `fail` (unary requests error before commit). Retention is bounded (`retention_days`, pruned on write) with indexes for later #1267 filters.

## Test plan
- [x] `cargo test --lib request_ledger --all-features` (config, persist, prune, metadata-only columns, unary/stream/fail-policy)
- [x] `cargo test --lib core::audit::middleware --all-features`
- [x] PR-style clippy (`--lib --tests --bins` with CI feature set)
- [ ] Wait for GitHub Fast Test SUCCESS before merge (do not merge a cancelled 30m job)

Fixes #1266

This PR was written with Cursor Grok 4.6.


Made with [Cursor](https://cursor.com)