### PR TITLE
feat(admin-ui): add metadata-only request log explorer

### DIFF
--- a/src/server/routes/admin_dashboard.rs
+++ b/src/server/routes/admin_dashboard.rs
@@ -9,6 +9,7 @@ const APP_JS: &str = include_str!("admin_dashboard/app.js");
 const BUDGET_JS: &str = include_str!("admin_dashboard/budget.js");
 const PROVIDER_HEALTH_JS: &str = include_str!("admin_dashboard/provider_health.js");
 const ROUTING_INVENTORY_JS: &str = include_str!("admin_dashboard/routing_inventory.js");
+const REQUEST_LEDGER_JS: &str = include_str!("admin_dashboard/request_ledger.js");
 const DASHBOARD_CSP: &str = "default-src 'none'; script-src 'self'; style-src 'self'; \
     connect-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'none'; \
     form-action 'self'; frame-ancestors 'none'";
@@ -41,6 +42,10 @@ async fn routing_inventory_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", ROUTING_INVENTORY_JS)
 }
 
+async fn request_ledger_javascript() -> HttpResponse {
+    embedded_asset("text/javascript; charset=utf-8", REQUEST_LEDGER_JS)
+}
+
 async fn budget_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", BUDGET_JS)
 }
@@ -56,6 +61,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/admin/dashboard/routing-inventory.js",
             web::get().to(routing_inventory_javascript),
+        )
+        .route(
+            "/admin/dashboard/request-ledger.js",
+            web::get().to(request_ledger_javascript),
         )
         .route(
             "/admin/dashboard/budget.js",
@@ -98,6 +107,11 @@ mod tests {
                 "/admin/dashboard/routing-inventory.js",
                 "text/javascript; charset=utf-8",
                 "createRoutingInventoryView",
+            ),
+            (
+                "/admin/dashboard/request-ledger.js",
+                "text/javascript; charset=utf-8",
+                "createRequestLedgerView",
             ),
             (
                 "/admin/dashboard/budget.js",
@@ -143,6 +157,7 @@ mod tests {
             "/admin/dashboard/app.js.map",
             "/admin/dashboard/budget.js.map",
             "/admin/dashboard/routing-inventory.js.map",
+            "/admin/dashboard/request-ledger.js.map",
             "/admin/dashboard/private",
         ] {
             let response = actix_test::call_service(
@@ -167,9 +182,16 @@ mod tests {
         }
         assert!(PROVIDER_HEALTH_JS.contains("\"/health/detailed\""));
         assert!(ROUTING_INVENTORY_JS.contains("\"/admin/routing/inventory\""));
+        assert!(REQUEST_LEDGER_JS.contains("\"/admin/request-ledger\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/providers\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/models\""));
-        for asset in [APP_JS, PROVIDER_HEALTH_JS, ROUTING_INVENTORY_JS, BUDGET_JS] {
+        for asset in [
+            APP_JS,
+            PROVIDER_HEALTH_JS,
+            ROUTING_INVENTORY_JS,
+            REQUEST_LEDGER_JS,
+            BUDGET_JS,
+        ] {
             for forbidden in [
                 "localStorage",
                 "sessionStorage",
@@ -224,6 +246,10 @@ mod tests {
             "id=\"routing-panel\"",
             "id=\"routing-body\"",
             "id=\"routing-unavailable-body\"",
+            "id=\"request-logs-panel\"",
+            "id=\"request-logs-body\"",
+            "id=\"request-logs-empty\"",
+            "id=\"request-logs-detail\"",
         ] {
             assert!(INDEX_HTML.contains(marker), "missing HTML marker {marker}");
         }

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -383,6 +383,34 @@ td code {
   color: var(--muted);
 }
 
+#request-logs-detail {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface);
+}
+
+#request-logs-detail h3 {
+  margin: 0 0 0.75rem;
+}
+
+#request-logs-detail dl {
+  display: grid;
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: 0.35rem 1rem;
+  margin: 0;
+}
+
+#request-logs-detail dt {
+  color: var(--muted);
+}
+
+#request-logs-detail dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 .health-state {
   display: inline-block;
   padding: 0.2rem 0.55rem;

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -76,6 +76,7 @@ function resetProtectedState() {
   renderSpend();
   providerHealthView.reset();
   routingInventoryView.reset();
+  requestLedgerView.reset();
   budgetView.reset();
 }
 function endSession(message = "Signed out") {
@@ -393,6 +394,17 @@ const routingInventoryView = window.createRoutingInventoryView({
   byId,
   captureSession,
   clearError,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+});
+const requestLedgerView = window.createRequestLedgerView({
+  apiRequest,
+  byId,
+  captureSession,
+  clearError,
+  createAction,
   ensureCurrent,
   reportRequestError,
   setStatus,
@@ -742,7 +754,7 @@ function showView(view) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-selected", String(active));
   }
-  for (const panel of ["keys", "teams", "spend", "budgets", "health", "routing"]) {
+  for (const panel of ["keys", "teams", "spend", "budgets", "health", "routing", "request-logs"]) {
     byId(`${panel}-panel`).hidden = panel !== view;
   }
   if (view === "spend") {
@@ -750,6 +762,9 @@ function showView(view) {
   }
   if (view === "budgets") {
     void budgetView.loadOnce();
+  }
+  if (view === "request-logs") {
+    void requestLedgerView.loadOnce();
   }
 }
 byId("login-form").addEventListener("submit", (event) => void signIn(event));

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/admin/dashboard/app.css">
   <script src="/admin/dashboard/provider-health.js" defer></script>
   <script src="/admin/dashboard/routing-inventory.js" defer></script>
+  <script src="/admin/dashboard/request-ledger.js" defer></script>
   <script src="/admin/dashboard/budget.js" defer></script>
   <script src="/admin/dashboard/app.js" defer></script>
 </head>
@@ -56,6 +57,8 @@
                 aria-controls="health-panel" aria-selected="false">Provider health</button>
         <button class="tab" type="button" data-view="routing"
                 aria-controls="routing-panel" aria-selected="false">Routing inventory</button>
+        <button class="tab" type="button" data-view="request-logs"
+                aria-controls="request-logs-panel" aria-selected="false">Request logs</button>
       </nav>
 
       <section id="keys-panel" class="panel" aria-labelledby="keys-title">
@@ -396,6 +399,67 @@
         <p id="routing-unavailable-empty" class="empty-state" hidden>
           No configured providers are missing from routing.
         </p>
+      </section>
+
+      <section id="request-logs-panel" class="panel" aria-labelledby="request-logs-title" hidden>
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Metadata only</p>
+            <h2 id="request-logs-title">Request logs</h2>
+            <p>Terminal request outcomes without prompt or response bodies.</p>
+          </div>
+          <button id="refresh-request-logs" class="secondary" type="button">Refresh</button>
+        </div>
+
+        <form id="request-logs-filter" class="form-grid">
+          <label for="request-logs-after">Finished after</label>
+          <input id="request-logs-after" name="finished_after" type="datetime-local">
+          <label for="request-logs-before">Finished before</label>
+          <input id="request-logs-before" name="finished_before" type="datetime-local">
+          <label for="request-logs-request-id">Request ID</label>
+          <input id="request-logs-request-id" name="request_id" maxlength="120">
+          <label for="request-logs-model">Model</label>
+          <input id="request-logs-model" name="model" maxlength="240">
+          <label for="request-logs-provider">Provider</label>
+          <input id="request-logs-provider" name="provider" maxlength="120">
+          <label for="request-logs-status">Status</label>
+          <select id="request-logs-status" name="terminal_status">
+            <option value="">Any</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+            <option value="cancelled">Cancelled</option>
+          </select>
+          <button type="submit">Apply filters</button>
+        </form>
+
+        <p id="request-logs-summary" class="health-summary"></p>
+        <p id="request-logs-notice" class="health-notice" aria-live="polite"></p>
+        <div class="table-wrap">
+          <table>
+            <caption>Metadata-only terminal request records</caption>
+            <thead>
+              <tr>
+                <th scope="col">Request ID</th>
+                <th scope="col">Finished</th>
+                <th scope="col">Model</th>
+                <th scope="col">Provider</th>
+                <th scope="col">Status</th>
+                <th scope="col">Code</th>
+                <th scope="col">Latency</th>
+                <th scope="col">Cost</th>
+                <th scope="col">API key</th>
+                <th scope="col">Action</th>
+              </tr>
+            </thead>
+            <tbody id="request-logs-body"></tbody>
+          </table>
+        </div>
+        <p id="request-logs-empty" class="empty-state" hidden>No request logs found.</p>
+        <div class="pagination" aria-label="Request log pages">
+          <button id="request-logs-previous" class="secondary" type="button">Previous</button>
+          <button id="request-logs-next" class="secondary" type="button">Next</button>
+        </div>
+        <div id="request-logs-detail" hidden></div>
       </section>
     </section>
   </main>

--- a/src/server/routes/admin_dashboard/request_ledger.js
+++ b/src/server/routes/admin_dashboard/request_ledger.js
@@ -1,0 +1,318 @@
+"use strict";
+
+window.createRequestLedgerView = function createRequestLedgerView({
+  apiRequest,
+  byId,
+  captureSession,
+  clearError,
+  createAction,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+}) {
+  let items = [];
+  let nextCursor = null;
+  let hasMore = false;
+  let currentCursor = null;
+  let cursorStack = [];
+  let selectedId = null;
+  let requestError = null;
+  let requestVersion = 0;
+  let loaded = false;
+  let loadPromise = null;
+
+  function labeledId(kind, value) {
+    if (value == null || value === "") {
+      return "—";
+    }
+    return `${kind} ${value}`;
+  }
+
+  function formatDateTime(value) {
+    if (!value) {
+      return "—";
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+  }
+
+  function formatMoney(value) {
+    if (value == null || value === "") {
+      return "—";
+    }
+    const number = typeof value === "number" ? value : Number(value);
+    return Number.isFinite(number) ? `$${number.toFixed(4)}` : "—";
+  }
+
+  function toRfc3339(value) {
+    const trimmed = String(value || "").trim();
+    if (!trimmed) {
+      return "";
+    }
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? trimmed : date.toISOString();
+  }
+
+  function currentFilters() {
+    return {
+      finished_after: toRfc3339(byId("request-logs-after").value),
+      finished_before: toRfc3339(byId("request-logs-before").value),
+      request_id: byId("request-logs-request-id").value.trim(),
+      model: byId("request-logs-model").value.trim(),
+      provider: byId("request-logs-provider").value.trim(),
+      terminal_status: byId("request-logs-status").value,
+    };
+  }
+
+  function buildPath(cursor) {
+    const params = new URLSearchParams();
+    const filters = currentFilters();
+    for (const [key, value] of Object.entries(filters)) {
+      if (value) {
+        params.set(key, value);
+      }
+    }
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+    const query = params.toString();
+    return query ? `/admin/request-ledger?${query}` : "/admin/request-ledger";
+  }
+
+  function selectedItem() {
+    return items.find((item) => item.request_id === selectedId) || null;
+  }
+
+  function renderDetail() {
+    const detail = byId("request-logs-detail");
+    const item = selectedItem();
+    detail.replaceChildren();
+    if (!item) {
+      detail.hidden = true;
+      return;
+    }
+    detail.hidden = false;
+    const title = document.createElement("h3");
+    title.textContent = "Request summary";
+    const list = document.createElement("dl");
+    const fields = [
+      ["Request ID", item.request_id],
+      ["Started", formatDateTime(item.started_at)],
+      ["Finished", formatDateTime(item.finished_at)],
+      ["Method", item.method || "—"],
+      ["Endpoint", item.endpoint || "—"],
+      ["Model", item.model || "—"],
+      ["Provider", item.provider || "—"],
+      ["Deployment", item.deployment || "—"],
+      ["Status code", item.status_code == null ? "—" : String(item.status_code)],
+      ["Terminal status", item.terminal_status || "—"],
+      ["Latency", item.latency_ms == null ? "—" : `${item.latency_ms} ms`],
+      ["Prompt tokens", item.prompt_tokens == null ? "—" : String(item.prompt_tokens)],
+      ["Completion tokens", item.completion_tokens == null ? "—" : String(item.completion_tokens)],
+      ["Total tokens", item.total_tokens == null ? "—" : String(item.total_tokens)],
+      ["Cost", formatMoney(item.cost)],
+      ["User", labeledId("User", item.user_id)],
+      ["API key", labeledId("Key", item.api_key_id)],
+      ["Team", labeledId("Team", item.team_id)],
+    ];
+    for (const [label, value] of fields) {
+      const term = document.createElement("dt");
+      term.textContent = label;
+      const definition = document.createElement("dd");
+      definition.textContent = value == null ? "—" : String(value);
+      list.append(term, definition);
+    }
+    detail.append(title, list);
+  }
+
+  function render() {
+    const rows = items.map((item) => {
+      const row = document.createElement("tr");
+      if (item.request_id === selectedId) {
+        row.dataset.selected = "true";
+      }
+      const action = document.createElement("td");
+      action.append(
+        createAction("View", "secondary", () => {
+          selectedId = item.request_id;
+          render();
+        }),
+      );
+      row.append(
+        textCell(item.request_id),
+        textCell(formatDateTime(item.finished_at)),
+        textCell(item.model || "—"),
+        textCell(item.provider || "—"),
+        textCell(item.terminal_status || "—"),
+        textCell(item.status_code == null ? "—" : String(item.status_code)),
+        textCell(item.latency_ms == null ? "—" : `${item.latency_ms} ms`),
+        textCell(formatMoney(item.cost)),
+        textCell(labeledId("Key", item.api_key_id)),
+        action,
+      );
+      return row;
+    });
+    byId("request-logs-body").replaceChildren(...rows);
+    byId("request-logs-empty").hidden = items.length !== 0 || Boolean(requestError);
+    byId("request-logs-notice").textContent = requestError
+      ? `Request logs unavailable: ${requestError}`
+      : "";
+    byId("request-logs-summary").textContent = requestError
+      ? ""
+      : loaded
+        ? `${items.length} request${items.length === 1 ? "" : "s"} on this page`
+        : "";
+    byId("request-logs-previous").disabled = cursorStack.length === 0;
+    byId("request-logs-next").disabled = !hasMore;
+    renderDetail();
+  }
+
+  function reset() {
+    requestVersion += 1;
+    loaded = false;
+    loadPromise = null;
+    items = [];
+    nextCursor = null;
+    hasMore = false;
+    currentCursor = null;
+    cursorStack = [];
+    selectedId = null;
+    requestError = null;
+    byId("request-logs-filter").reset();
+    byId("refresh-request-logs").disabled = false;
+    render();
+  }
+
+  async function load(session = captureSession()) {
+    const version = ++requestVersion;
+    try {
+      const data = await apiRequest(buildPath(currentCursor), {}, session);
+      ensureCurrent(session);
+      if (version !== requestVersion) {
+        throw new DOMException("Stale request log response", "AbortError");
+      }
+      if (!Array.isArray(data?.items)) {
+        throw new Error("Request ledger response did not include items.");
+      }
+      items = data.items;
+      nextCursor = data.next_cursor || null;
+      hasMore = Boolean(data.has_more);
+      if (selectedId && !items.some((item) => item.request_id === selectedId)) {
+        selectedId = null;
+      }
+      requestError = null;
+      loaded = true;
+      render();
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        ensureCurrent(session);
+        if (version === requestVersion) {
+          items = [];
+          nextCursor = null;
+          hasMore = false;
+          selectedId = null;
+          requestError = error.message || "Unknown request failure";
+          loaded = true;
+          render();
+        }
+      }
+      throw error;
+    }
+  }
+
+  function loadOnce() {
+    if (loaded || loadPromise) {
+      return loadPromise || Promise.resolve();
+    }
+    clearError();
+    setStatus("Loading request logs…");
+    const pending = load()
+      .then(() => setStatus("Request logs loaded."))
+      .catch((error) => reportRequestError(error, "Request log load failed."));
+    loadPromise = pending;
+    void pending.finally(() => {
+      if (loadPromise === pending) {
+        loadPromise = null;
+      }
+    });
+    return pending;
+  }
+
+  async function refresh(button) {
+    if (button.disabled) {
+      return;
+    }
+    button.disabled = true;
+    clearError();
+    setStatus("Refreshing request logs…");
+    try {
+      await load();
+      setStatus("Request logs refreshed.");
+    } catch (error) {
+      reportRequestError(error, "Request log refresh failed.");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  async function applyFilters(event) {
+    event.preventDefault();
+    cursorStack = [];
+    currentCursor = null;
+    selectedId = null;
+    clearError();
+    setStatus("Filtering request logs…");
+    try {
+      await load();
+      setStatus("Request logs filtered.");
+    } catch (error) {
+      reportRequestError(error, "Request log filter failed.");
+    }
+  }
+
+  async function goNext() {
+    if (!hasMore || !nextCursor) {
+      return;
+    }
+    cursorStack.push(currentCursor);
+    currentCursor = nextCursor;
+    selectedId = null;
+    clearError();
+    setStatus("Loading the next request log page…");
+    try {
+      await load();
+      setStatus("Request logs page loaded.");
+    } catch (error) {
+      currentCursor = cursorStack.pop() ?? null;
+      reportRequestError(error, "Request log page failed to load.");
+    }
+  }
+
+  async function goPrevious() {
+    if (cursorStack.length === 0) {
+      return;
+    }
+    currentCursor = cursorStack.pop() ?? null;
+    selectedId = null;
+    clearError();
+    setStatus("Loading the previous request log page…");
+    try {
+      await load();
+      setStatus("Request logs page loaded.");
+    } catch (error) {
+      reportRequestError(error, "Request log page failed to load.");
+    }
+  }
+
+  byId("refresh-request-logs").addEventListener("click", (event) =>
+    void refresh(event.currentTarget),
+  );
+  byId("request-logs-filter").addEventListener("submit", (event) =>
+    void applyFilters(event),
+  );
+  byId("request-logs-next").addEventListener("click", () => void goNext());
+  byId("request-logs-previous").addEventListener("click", () => void goPrevious());
+
+  return { load, loadOnce, reset };
+};

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -28,6 +28,13 @@ const routingInventorySource = await readFile(
   ),
   "utf8",
 );
+const requestLedgerSource = await readFile(
+  new URL(
+    "../../src/server/routes/admin_dashboard/request_ledger.js",
+    import.meta.url,
+  ),
+  "utf8",
+);
 const immediate = () => new Promise((resolve) => setImmediate(resolve));
 async function settle(turns = 8) {
   for (let index = 0; index < turns; index += 1) {
@@ -91,6 +98,11 @@ function dashboard(options = {}) {
       models: [],
       unavailable_providers: [],
     },
+    ledger = {
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    },
     handler,
   } = options;
   const htmlWithoutScript = indexHtml
@@ -100,6 +112,10 @@ function dashboard(options = {}) {
     )
     .replace(
       '<script src="/admin/dashboard/routing-inventory.js" defer></script>',
+      "",
+    )
+    .replace(
+      '<script src="/admin/dashboard/request-ledger.js" defer></script>',
       "",
     )
     .replace('<script src="/admin/dashboard/budget.js" defer></script>', "")
@@ -221,6 +237,9 @@ function dashboard(options = {}) {
     if (url.pathname === "/admin/routing/inventory" && call.method === "GET") {
       return Promise.resolve(apiResponse(inventory));
     }
+    if (url.pathname === "/admin/request-ledger" && call.method === "GET") {
+      return Promise.resolve(apiResponse(ledger));
+    }
     const usageMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/usage$/);
     if (usageMatch && call.method === "GET") {
       const result = usageByTeam.get(decodeURIComponent(usageMatch[1]));
@@ -234,6 +253,7 @@ function dashboard(options = {}) {
   };
   window.eval(providerHealthSource);
   window.eval(routingInventorySource);
+  window.eval(requestLedgerSource);
   window.eval(budgetSource);
   window.eval(appSource);
   return context;
@@ -262,6 +282,39 @@ async function signIn(context) {
         "Dashboard refreshed.",
     "dashboard did not finish signing in",
   );
+}
+
+async function openRequestLogs(context) {
+  const { window } = context;
+  window.document.querySelector('[data-view="request-logs"]').click();
+  await waitFor(
+    () => window.document.getElementById("status-region").textContent === "Request logs loaded.",
+    "request log view did not load",
+  );
+}
+
+function ledgerItem(overrides = {}) {
+  return {
+    request_id: "req-1",
+    started_at: "2026-09-05T10:00:00Z",
+    finished_at: "2026-09-05T10:00:01Z",
+    method: "POST",
+    endpoint: "/v1/chat/completions",
+    model: "gpt-4",
+    provider: "openai",
+    deployment: "openai",
+    status_code: 200,
+    terminal_status: "completed",
+    latency_ms: 12,
+    prompt_tokens: 4,
+    completion_tokens: 6,
+    total_tokens: 10,
+    cost: 0.02,
+    user_id: "user-1",
+    api_key_id: "key-1",
+    team_id: "team-1",
+    ...overrides,
+  };
 }
 
 async function openBudgets(context) {
@@ -1518,4 +1571,170 @@ test("B16 a late routing inventory response after logout cannot restore stale da
   assert.equal(window.document.getElementById("routing-summary").textContent, "");
   assert.equal(window.document.getElementById("routing-notice").textContent, "");
   assert.equal(window.document.querySelectorAll("#routing-body tr").length, 0);
+});
+
+test("B17 request logs render empty, filtered, paged, and metadata-only detail", { concurrency: false }, async (t) => {
+  let ledgerGets = 0;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname !== "/admin/request-ledger" || call.method !== "GET") {
+        return undefined;
+      }
+      ledgerGets += 1;
+      if (ledgerGets === 1) {
+        return apiResponse({ items: [], next_cursor: null, has_more: false });
+      }
+      if (call.url.searchParams.get("model") === "claude") {
+        return apiResponse({
+          items: [
+            ledgerItem({
+              request_id: "req-c",
+              model: "claude",
+              terminal_status: "failed",
+              api_key_id: "key-9",
+            }),
+          ],
+          next_cursor: null,
+          has_more: false,
+        });
+      }
+      if (call.url.searchParams.get("cursor") === "cursor-2") {
+        return apiResponse({
+          items: [ledgerItem({ request_id: "req-b" })],
+          next_cursor: null,
+          has_more: false,
+        });
+      }
+      return apiResponse({
+        items: [ledgerItem({ request_id: "req-a" })],
+        next_cursor: "cursor-2",
+        has_more: true,
+      });
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  await openRequestLogs(context);
+  const { window } = context;
+  assert.equal(window.document.querySelectorAll("#request-logs-body tr").length, 0);
+  assert.equal(window.document.getElementById("request-logs-empty").hidden, false);
+
+  window.document.getElementById("refresh-request-logs").click();
+  await waitFor(
+    () => window.document.querySelectorAll("#request-logs-body tr").length === 1,
+    "request log refresh did not render a row",
+  );
+  assert.match(rowText(window, "#request-logs-body tr")[0], /req-a.*gpt-4.*openai.*completed/i);
+  assert.equal(window.document.getElementById("request-logs-next").disabled, false);
+
+  window.document.getElementById("request-logs-next").click();
+  await waitFor(
+    () => /req-b/.test(rowText(window, "#request-logs-body tr")[0] || ""),
+    "next request log page did not load",
+  );
+  window.document.getElementById("request-logs-previous").click();
+  await waitFor(
+    () => /req-a/.test(rowText(window, "#request-logs-body tr")[0] || ""),
+    "previous request log page did not load",
+  );
+
+  window.document.getElementById("request-logs-model").value = "claude";
+  submit(window, window.document.getElementById("request-logs-filter"));
+  await waitFor(
+    () => /req-c/.test(rowText(window, "#request-logs-body tr")[0] || ""),
+    "filtered request logs did not load",
+  );
+  const filterCall = context.calls.find(
+    (call) =>
+      call.url.pathname === "/admin/request-ledger" &&
+      call.url.searchParams.get("model") === "claude",
+  );
+  assert.ok(filterCall, "filtered ledger query was not sent");
+
+  window.document.querySelector("#request-logs-body button").click();
+  const detail = window.document.getElementById("request-logs-detail");
+  assert.equal(detail.hidden, false);
+  assert.match(detail.textContent, /Request ID/);
+  assert.match(detail.textContent, /Key key-9/);
+  assert.match(detail.textContent, /User user-1/);
+  assert.match(detail.textContent, /Team team-1/);
+  assert.doesNotMatch(detail.textContent, /\bauthorization\b/i);
+  assert.doesNotMatch(detail.textContent, /\bmessages\b/i);
+  assert.doesNotMatch(detail.textContent, /\bchoices\b/i);
+  assert.equal(detail.querySelector("[data-body], [data-prompt]"), null);
+});
+
+test("B18 request log failures are explicit and clear stale rows", { concurrency: false }, async (t) => {
+  let mode = "ok";
+  const context = dashboard({
+    ledger: {
+      items: [ledgerItem()],
+      next_cursor: null,
+      has_more: false,
+    },
+    handler(call) {
+      if (call.url.pathname !== "/admin/request-ledger" || call.method !== "GET") {
+        return undefined;
+      }
+      if (mode === "error") {
+        return Promise.reject(new Error("network offline"));
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  await openRequestLogs(context);
+  const { window } = context;
+  assert.equal(window.document.querySelectorAll("#request-logs-body tr").length, 1);
+
+  mode = "error";
+  window.document.getElementById("refresh-request-logs").click();
+  await waitFor(
+    () => /network offline/i.test(window.document.getElementById("request-logs-notice").textContent),
+    "network failure was not shown in the request log view",
+  );
+  assert.equal(window.document.querySelectorAll("#request-logs-body tr").length, 0);
+
+  window.document.getElementById("sign-out").click();
+  await settle();
+  assert.equal(window.document.getElementById("request-logs-summary").textContent, "");
+  assert.equal(window.document.getElementById("request-logs-notice").textContent, "");
+  assert.equal(window.document.querySelectorAll("#request-logs-body tr").length, 0);
+  assert.equal(window.document.getElementById("request-logs-detail").hidden, true);
+});
+
+test("B19 a late request log response after logout cannot restore stale data", { concurrency: false }, async (t) => {
+  let ledgerGets = 0;
+  let late;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/admin/request-ledger" && call.method === "GET") {
+        ledgerGets += 1;
+        if (ledgerGets === 2) {
+          late = deferred();
+          return late.promise;
+        }
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  await openRequestLogs(context);
+  const { window } = context;
+  window.document.getElementById("refresh-request-logs").click();
+  await waitFor(() => ledgerGets === 2, "late request log request was not pending");
+  window.document.getElementById("sign-out").click();
+  late.resolve(
+    apiResponse({
+      items: [ledgerItem({ request_id: "must-not-return" })],
+      next_cursor: null,
+      has_more: false,
+    }),
+  );
+  await settle();
+  assert.equal(window.document.getElementById("request-logs-summary").textContent, "");
+  assert.equal(window.document.getElementById("request-logs-notice").textContent, "");
+  assert.equal(window.document.querySelectorAll("#request-logs-body tr").length, 0);
 });


### PR DESCRIPTION
## Summary
- Add a Request logs tab to the embedded admin dashboard that reads `GET /admin/request-ledger`.
- Filters, cursor pagination, and a metadata-only row summary. Prompt/body/Authorization are never rendered; user/team/key IDs use the same `User`/`Team`/`Key` masking as existing pages.
- Logout, load/empty/error, and stale-response states follow the health and routing views.

## Test plan
- [x] `node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs` (B17–B19 plus existing dashboard suite)
- [x] `cargo test --lib admin_dashboard`
- [x] PR-style clippy
- [ ] Wait for GitHub Fast Test SUCCESS before merge (do not merge a cancelled 30m job)

Fixes #1268

This PR was written with Cursor Grok 4.6.


Made with [Cursor](https://cursor.com)