### PR TITLE
feat(config): add a validated atomic runtime apply boundary

### DIFF
--- a/src/server/guardrails.rs
+++ b/src/server/guardrails.rs
@@ -20,25 +20,26 @@ pub(crate) async fn apply_chat_input(
     state: &AppState,
     request: &ChatCompletionRequest,
 ) -> Result<ChatCompletionRequest, GatewayError> {
-    apply_input(state.guardrails.as_ref(), request).await
+    apply_input(state.guardrails().as_ref(), request).await
 }
 
 pub(crate) async fn apply_chat_output(
     state: &AppState,
     response: &ChatCompletionResponse,
 ) -> Result<ChatCompletionResponse, GatewayError> {
-    apply_output_with_engine(state.guardrails.as_ref(), response).await
+    apply_output_with_engine(state.guardrails().as_ref(), response).await
 }
 
 pub(crate) async fn ensure_chat_input_unmodified(
     state: &AppState,
     request: &ChatCompletionRequest,
 ) -> Result<(), GatewayError> {
-    if !state.guardrails.input_checks_enabled() {
+    let guardrails = state.guardrails();
+    if !guardrails.input_checks_enabled() {
         return Ok(());
     }
-    let content = input_payload(state.guardrails.as_ref(), request)?;
-    match enforce(state.guardrails.check_input(&content).await, "input")? {
+    let content = input_payload(guardrails.as_ref(), request)?;
+    match enforce(guardrails.check_input(&content).await, "input")? {
         Enforcement::Pass => Ok(()),
         Enforcement::Mask => Err(projection_error("input")),
     }
@@ -48,15 +49,17 @@ pub(crate) async fn ensure_chat_output_unmodified(
     state: &AppState,
     response: &ChatCompletionResponse,
 ) -> Result<(), GatewayError> {
-    let content = output_scan::response_payload(state.guardrails.as_ref(), response)?;
-    match enforce(state.guardrails.check_output(&content).await, "output")? {
+    let guardrails = state.guardrails();
+    let content = output_scan::response_payload(guardrails.as_ref(), response)?;
+    match enforce(guardrails.check_output(&content).await, "output")? {
         Enforcement::Pass => Ok(()),
         Enforcement::Mask => Err(projection_error("output")),
     }
 }
 
 pub(crate) fn reject_unsupported_streaming_mask(state: &AppState) -> Result<(), GatewayError> {
-    let config = state.guardrails.config();
+    let guardrails = state.guardrails();
+    let config = guardrails.config();
     let output_masking = config.enabled
         && config.check_output
         && config.pii.as_ref().is_some_and(|policy| {

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -6,7 +6,6 @@ use crate::config::models::server::{CorsConfig, ServerConfig};
 use crate::config::{Config, Validate};
 use crate::core::audit::{AuditConfig, AuditLogger, AuditMiddleware};
 use crate::core::budget::UnifiedBudgetLimits;
-use crate::core::guardrails::GuardrailEngine;
 use crate::core::integrations::CallbackRuntime;
 use crate::core::ip_access::{IpAccessControl, IpAccessMiddleware};
 use crate::core::rate_limiter::{get_global_rate_limiter, init_global_rate_limiter_with_redis};
@@ -102,8 +101,15 @@ impl HttpServer {
         let auth =
             crate::auth::AuthSystem::new(&config.gateway.auth, Arc::new(storage.clone())).await?;
 
-        let (pricing, unified_router) =
-            super::http_runtime::build_pricing_and_router(config).await?;
+        let pricing = super::http_runtime::initialize_pricing(config).await?;
+        let revision = super::runtime::build_runtime_revision(
+            config.clone(),
+            0,
+            Arc::clone(&pricing),
+            storage.redis.clone(),
+        )
+        .await?;
+        let guardrails = Arc::clone(&revision.guardrails);
 
         let callback_runtime = crate::server::callbacks::build_callback_runtime(
             &config.gateway.monitoring.callbacks,
@@ -119,25 +125,14 @@ impl HttpServer {
         } else {
             Arc::new(AuditLogger::disabled())
         };
-        let guardrails =
-            GuardrailEngine::shared(config.gateway.guardrails.clone()).map_err(|error| {
-                GatewayError::Config(format!("Invalid guardrails configuration: {error}"))
-            })?;
         let ip_access =
             IpAccessControl::shared(config.gateway.ip_access.clone()).map_err(|error| {
                 GatewayError::Config(format!("Invalid IP access configuration: {error}"))
             })?;
-        let state = AppState::new_with_unified_router(
-            config.clone(),
-            auth,
-            unified_router,
-            storage,
-            pricing,
-            budget_limits,
-        )
-        .with_callbacks(callback_runtime.dispatcher())
-        .with_audit_logger(audit_logger)
-        .with_request_policies(guardrails, ip_access);
+        let state = AppState::new_with_runtime(revision, auth, storage, pricing, budget_limits)
+            .with_callbacks(callback_runtime.dispatcher())
+            .with_audit_logger(audit_logger)
+            .with_request_policies(guardrails, ip_access);
 
         Ok(Self {
             config: config.gateway.server.clone(),
@@ -581,7 +576,7 @@ mod tests {
             Err(error) => panic!("enabled cache should wire runtime cache: {error}"),
         };
 
-        assert!(server.state().response_cache.is_some());
+        assert!(server.state().response_cache().is_some());
     }
 
     #[tokio::test]

--- a/src/server/http_runtime.rs
+++ b/src/server/http_runtime.rs
@@ -7,9 +7,7 @@ use crate::utils::error::gateway_error::{GatewayError, Result};
 use std::sync::Arc;
 use tracing::{error, info};
 
-pub(super) async fn build_pricing_and_router(
-    config: &Config,
-) -> Result<(Arc<PricingService>, UnifiedRouter)> {
+pub(super) async fn initialize_pricing(config: &Config) -> Result<Arc<PricingService>> {
     let pricing = Arc::new(PricingService::new(config.gateway.pricing.source.clone()));
     if let Err(error) = pricing.initialize().await {
         // A `None` pricing source is disabled. A configured source failure is
@@ -30,22 +28,27 @@ pub(super) async fn build_pricing_and_router(
         info!("Pricing service initial load completed");
     }
     info!("Pricing auto-refresh task is managed by on-demand refresh checks");
+    Ok(pricing)
+}
 
+pub(super) async fn build_router_from_config(
+    config: &Config,
+    pricing: Arc<PricingService>,
+) -> Result<UnifiedRouter> {
     let router_config = crate::core::router::gateway_config::runtime_router_config_from_gateway(
         &config.gateway.router,
     )
     .map_err(|error| GatewayError::Config(format!("Invalid router config: {error}")))?;
-    let router = UnifiedRouter::from_gateway_config_with_aliases_and_pricing(
+    UnifiedRouter::from_gateway_config_with_aliases_and_pricing(
         &config.gateway.providers,
         Some(router_config),
         &config.gateway.model_aliases,
-        Arc::clone(&pricing),
+        pricing,
     )
     .await
     .map_err(|error| {
         GatewayError::Config(format!(
             "Failed to initialize unified router from config: {error}"
         ))
-    })?;
-    Ok((pricing, router))
+    })
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,6 +13,7 @@ mod guardrails;
 pub mod http;
 mod http_listener;
 mod http_runtime;
+mod runtime;
 pub mod state;
 pub(crate) mod tls;
 #[cfg(test)]

--- a/src/server/routes/admin.rs
+++ b/src/server/routes/admin.rs
@@ -27,7 +27,7 @@ struct CacheAdminResponse {
 
 async fn cache_admin_response(state: &web::Data<AppState>) -> CacheAdminResponse {
     let cfg = state.config.load();
-    if let Some(cache) = state.response_cache.as_ref() {
+    if let Some(cache) = state.response_cache() {
         return CacheAdminResponse {
             success: true,
             status: "enabled",
@@ -121,7 +121,7 @@ pub async fn clear_response_cache(
         return Ok(forbidden);
     }
 
-    if let Some(cache) = state.response_cache.as_ref() {
+    if let Some(cache) = state.response_cache() {
         cache
             .clear()
             .await

--- a/src/server/routes/admin_routing.rs
+++ b/src/server/routes/admin_routing.rs
@@ -27,7 +27,7 @@ pub(super) async fn routing_inventory(
         return Ok(forbidden);
     }
 
-    let snapshot = state.unified_router.load_routing_snapshot();
+    let snapshot = state.unified_router().load_routing_snapshot();
     let cfg = state.config.load();
     Ok(HttpResponse::Ok().json(build_inventory(&snapshot, cfg.providers())))
 }
@@ -577,7 +577,7 @@ mod tests {
     #[actix_web::test]
     async fn inventory_redacts_secrets_and_raw_config() {
         let state = test_state(base_test_config(true)).await;
-        state.unified_router.add_deployment(
+        state.unified_router().add_deployment(
             openai_deployment("secret-dep", "gpt-4", "gpt-4-turbo")
                 .await
                 .with_config(DeploymentConfig {
@@ -645,13 +645,13 @@ mod tests {
         primary.config.rpm_limit = Some(100);
         primary.config.tpm_limit = Some(1_000);
         let secondary = openai_deployment("openai-b", "gpt-4", "gpt-4-turbo").await;
-        state.unified_router.add_deployment(primary);
-        state.unified_router.add_deployment(secondary);
+        state.unified_router().add_deployment(primary);
+        state.unified_router().add_deployment(secondary);
         state
-            .unified_router
+            .unified_router()
             .add_model_alias("gpt4", "gpt-4")
             .expect("alias");
-        state.unified_router.record_success("openai-a", 25, 1_000);
+        state.unified_router().record_success("openai-a", 25, 1_000);
 
         let app = admin_app(state, Some(make_test_user(UserRole::Admin)), None).await;
         let (status, body) = get_inventory(&app).await;
@@ -675,10 +675,10 @@ mod tests {
     async fn inventory_preserves_snapshot_model_order() {
         let state = test_state(base_test_config(true)).await;
         state
-            .unified_router
+            .unified_router()
             .add_deployment(openai_deployment("dep-zeta", "zeta", "zeta").await);
         state
-            .unified_router
+            .unified_router()
             .add_deployment(openai_deployment("dep-alpha", "alpha", "alpha").await);
 
         let app = admin_app(state, Some(make_test_user(UserRole::Admin)), None).await;
@@ -700,10 +700,10 @@ mod tests {
         let state = test_state(base_test_config(true)).await;
         let unknown = openai_deployment("dep-unknown", "gpt-4", "gpt-4-turbo").await;
         let unhealthy = openai_deployment("dep-unhealthy", "gpt-4", "gpt-4-turbo").await;
-        state.unified_router.add_deployment(unknown);
-        state.unified_router.add_deployment(unhealthy);
+        state.unified_router().add_deployment(unknown);
+        state.unified_router().add_deployment(unhealthy);
         let stored = state
-            .unified_router
+            .unified_router()
             .get_deployment("dep-unhealthy")
             .expect("unhealthy deployment");
         stored

--- a/src/server/routes/ai/audio/speech.rs
+++ b/src/server/routes/ai/audio/speech.rs
@@ -93,7 +93,7 @@ pub async fn audio_speech(
     let pricing_config = state.config().gateway.pricing.clone();
 
     match run_unary(
-        &state.unified_router,
+        &state.unified_router(),
         &requested_model,
         ProviderCapability::TextToSpeech,
         move |provider, selected_model, _deployment_id| {

--- a/src/server/routes/ai/audio/transcriptions.rs
+++ b/src/server/routes/ai/audio/transcriptions.rs
@@ -156,7 +156,7 @@ pub async fn audio_transcriptions(
     let pricing_config = state.config().gateway.pricing.clone();
 
     match run_unary(
-        &state.unified_router,
+        &state.unified_router(),
         &requested_model,
         ProviderCapability::AudioTranscription,
         move |provider, selected_model, _deployment_id| {

--- a/src/server/routes/ai/audio/translations.rs
+++ b/src/server/routes/ai/audio/translations.rs
@@ -144,7 +144,7 @@ pub async fn audio_translations(
     let pricing_config = state.config().gateway.pricing.clone();
 
     match run_unary(
-        &state.unified_router,
+        &state.unified_router(),
         &requested_model,
         ProviderCapability::AudioTranslation,
         move |provider, selected_model, _deployment_id| {

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -226,7 +226,8 @@ async fn handle_chat_completion_internal(
     extensions: Vec<ChatMessageContinuation>,
     opt_in: bool,
 ) -> Result<(ChatCompletionResponseWithExtensions, CallbackLifecycle), GatewayError> {
-    let unified_router = &state.unified_router;
+    let runtime = state.pin_runtime();
+    let unified_router = runtime.unified_router.as_ref();
     let requested_model = request.model.clone();
     let core_request = ChatContinuationRequest::new(
         build_core_chat_request(request.as_ref(), requested_model, false)?,

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -71,7 +71,7 @@ pub(super) async fn handle_streaming_chat_completion(
     let api_key_budget_id = context.api_key_budget_id();
     let callback_for_execution = callback.clone();
     match run_stream(
-        state.unified_router.clone(),
+        state.unified_router().clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,
         move |provider, selected_model, _selected_deployment_id| {
@@ -161,7 +161,7 @@ pub(super) async fn handle_streaming_chat_completion(
         Ok(((mut stream, mut settlement), lease)) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
-            let guardrails = Arc::clone(&state.guardrails);
+            let guardrails = Arc::clone(&state.guardrails());
 
             tokio::spawn(async move {
                 let mut lease = Some(lease);

--- a/src/server/routes/ai/completions.rs
+++ b/src/server/routes/ai/completions.rs
@@ -125,7 +125,7 @@ async fn completions_inner(
             let response = if adapter_request.echo {
                 let echoed = chat_response_with_completion_echo(response, &masked_prompt);
                 match crate::server::guardrails::apply_output_with_engine(
-                    state.guardrails.as_ref(),
+                    state.guardrails().as_ref(),
                     &echoed,
                 )
                 .await

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -77,7 +77,7 @@ pub(super) async fn handle_streaming_completion(
     let callback_for_execution = callback.clone();
 
     match run_stream(
-        state.unified_router.clone(),
+        state.unified_router().clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,
         move |provider, selected_model, _selected_deployment_id| {
@@ -169,7 +169,7 @@ pub(super) async fn handle_streaming_completion(
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let include_usage = adapter_request.include_usage;
             let mut echo_prefix = adapter_request.echo.then_some(adapter_request.prompt);
-            let guardrails = Arc::clone(&state.guardrails);
+            let guardrails = Arc::clone(&state.guardrails());
 
             tokio::spawn(async move {
                 let mut lease = Some(lease);

--- a/src/server/routes/ai/embeddings.rs
+++ b/src/server/routes/ai/embeddings.rs
@@ -143,7 +143,7 @@ async fn handle_embedding_internal(
     let pricing_config = state.config().gateway.pricing.clone();
     let callback_for_execution = callback.clone();
     let core_response = match run_unary(
-        &state.unified_router,
+        &state.unified_router(),
         &requested_model,
         ProviderCapability::Embeddings,
         move |provider, selected_model, _deployment_id| {

--- a/src/server/routes/ai/gemini.rs
+++ b/src/server/routes/ai/gemini.rs
@@ -130,7 +130,7 @@ async fn proxy_gemini_route_inner(
         &requested_model,
         gemini_requested_max_output_tokens(&request),
     )?;
-    let requested_model = state.unified_router.resolve_model_name(&requested_model);
+    let requested_model = state.unified_router().resolve_model_name(&requested_model);
     validate_model_segment(&requested_model)?;
 
     if stream {
@@ -145,12 +145,12 @@ async fn proxy_gemini_route_inner(
         .await;
     }
 
-    let router_models = gemini_router_models(&state.unified_router, &requested_model);
+    let router_models = gemini_router_models(&state.unified_router(), &requested_model);
 
     let mut last_router_error = None;
     for router_model in router_models {
         let result = run_unary(
-            &state.unified_router,
+            &state.unified_router(),
             &router_model,
             gemini_route_capability(),
             {
@@ -227,12 +227,12 @@ async fn proxy_gemini_stream_route_inner(
     method: &'static str,
     request: Value,
 ) -> Result<HttpResponse, GatewayError> {
-    let router_models = gemini_router_models(&state.unified_router, &requested_model);
+    let router_models = gemini_router_models(&state.unified_router(), &requested_model);
     let api_key_budget_id = context.api_key_budget_id();
     let mut last_router_error = None;
     for router_model in router_models {
         let result = run_stream(
-            state.unified_router.clone(),
+            state.unified_router().clone(),
             &router_model,
             gemini_route_capability(),
             {

--- a/src/server/routes/ai/images.rs
+++ b/src/server/routes/ai/images.rs
@@ -81,7 +81,7 @@ pub async fn image_generations(
     {
         return Ok(openai_errors::gateway_error_response(&error));
     }
-    request.model = Some(state.unified_router.resolve_model_name(&requested_model));
+    request.model = Some(state.unified_router().resolve_model_name(&requested_model));
 
     handle_ai_request(&req, request, "Image generation", |request, context| {
         generation::handle_image_generation_with_state(state.get_ref(), request, context)
@@ -147,7 +147,7 @@ async fn proxy_image_multipart_endpoint(
     let form_fields = extract_image_proxy_form_fields(&body, &content_type);
     let public_model = required_image_proxy_model(&form_fields)?;
     super::context::enforce_api_key_model_and_token_limits(req, public_model, None)?;
-    let requested_model = state.unified_router.resolve_model_name(public_model);
+    let requested_model = state.unified_router().resolve_model_name(public_model);
     let body = if requested_model == public_model {
         body
     } else {
@@ -195,7 +195,7 @@ async fn proxy_image_multipart_endpoint(
         let native_edit_request_for_selection = native_edit_request.clone();
         let native_edit_request_for_operation = native_edit_request.clone();
         let result = super::execution::execute_with_selected_deployment_matching(
-            &state.unified_router,
+            &state.unified_router(),
             &router_model,
             endpoint.capability(),
             move |deployment| {
@@ -238,7 +238,7 @@ async fn proxy_image_multipart_endpoint(
                                 })?
                                 .clone()?;
                             let budget_provider = state
-                                .unified_router
+                                .unified_router()
                                 .configured_provider_name(&deployment_id)
                                 .unwrap_or_else(|| selected_provider.name().to_string());
                             let (response, tokens_used) =

--- a/src/server/routes/ai/images/generation.rs
+++ b/src/server/routes/ai/images/generation.rs
@@ -69,7 +69,7 @@ pub async fn handle_image_generation_with_state(
     let pricing_config = state.config().gateway.pricing.clone();
     let request_for_selection = core_request.clone();
     let core_response = super::super::execution::execute_with_selected_deployment_matching(
-        &state.unified_router,
+        &state.unified_router(),
         &requested_model,
         ProviderCapability::ImageGeneration,
         move |deployment| {
@@ -88,7 +88,7 @@ pub async fn handle_image_generation_with_state(
             let pricing_config = pricing_config.clone();
             async move {
                 let budget_provider = state
-                    .unified_router
+                    .unified_router()
                     .configured_provider_name(&deployment_id)
                     .unwrap_or_else(|| provider.name().to_string());
                 let mut request_pricing = super::super::spend::request_pricing_for_provider(

--- a/src/server/routes/ai/images/routing.rs
+++ b/src/server/routes/ai/images/routing.rs
@@ -26,10 +26,10 @@ pub(super) fn ensure_image_edit_candidate_configured(
     requested_model: &str,
 ) -> Result<bool, GatewayError> {
     let native_candidate = state
-        .unified_router
+        .unified_router()
         .get_deployments_for_model(requested_model)
         .into_iter()
-        .filter_map(|deployment_id| state.unified_router.get_deployment(&deployment_id))
+        .filter_map(|deployment_id| state.unified_router().get_deployment(&deployment_id))
         .any(|deployment| {
             native_edit::is_native_image_provider(&deployment.provider)
                 && deployment.provider.supports_capability_for_model(

--- a/src/server/routes/ai/models.rs
+++ b/src/server/routes/ai/models.rs
@@ -16,9 +16,9 @@ use super::openai_errors;
 pub async fn list_models(state: web::Data<AppState>) -> ActixResult<HttpResponse> {
     debug!("Listing available models");
 
-    let unified_router = &state.unified_router;
+    let unified_router = state.unified_router();
 
-    match get_models_from_router(unified_router).await {
+    match get_models_from_router(&unified_router).await {
         Ok(models) => {
             let response = ModelListResponse {
                 object: "list".to_string(),
@@ -42,9 +42,9 @@ pub async fn get_model(
 ) -> ActixResult<HttpResponse> {
     debug!("Getting model info for: {}", model_id);
 
-    let unified_router = &state.unified_router;
+    let unified_router = state.unified_router();
 
-    match get_model_from_router(unified_router, &model_id).await {
+    match get_model_from_router(&unified_router, &model_id).await {
         Ok(Some(model)) => Ok(HttpResponse::Ok().json(model)),
         Ok(None) => Ok(openai_errors::gateway_error_response(
             &GatewayError::not_found(format!("Model not found: {}", model_id)),

--- a/src/server/routes/ai/moderations.rs
+++ b/src/server/routes/ai/moderations.rs
@@ -75,7 +75,7 @@ async fn proxy_moderation(
 ) -> Result<HttpResponse, GatewayError> {
     let requested_model = validate_moderation_request(&request)?;
     super::context::enforce_api_key_model_and_token_limits(req, &requested_model, None)?;
-    let resolved_model = state.unified_router.resolve_model_name(&requested_model);
+    let resolved_model = state.unified_router().resolve_model_name(&requested_model);
     apply_resolved_moderation_model(&mut request, &resolved_model);
     ensure_moderation_proxy_candidate_configured(
         state.config().gateway.providers.as_slice(),
@@ -88,7 +88,7 @@ async fn proxy_moderation(
     let budgeted = state.budgeted.clone();
     for router_model in router_models {
         let result = run_unary(
-            &state.unified_router,
+            &state.unified_router(),
             &router_model,
             ProviderCapability::Moderation,
             {

--- a/src/server/routes/ai/rerank.rs
+++ b/src/server/routes/ai/rerank.rs
@@ -71,7 +71,7 @@ async fn handle_rerank_with_state(
     api_key_id: Option<uuid::Uuid>,
     api_key_budget_id: Option<uuid::Uuid>,
 ) -> Result<RerankResponse, GatewayError> {
-    let requested_model = state.unified_router.resolve_model_name(&request.model);
+    let requested_model = state.unified_router().resolve_model_name(&request.model);
     request.model = requested_model.clone();
     let config = state.config();
     let rerank_providers = config.gateway.providers.clone();
@@ -86,7 +86,7 @@ async fn handle_rerank_with_state(
     let pricing_config = state.config().gateway.pricing.clone();
     for router_model in router_models {
         let result = run_unary(
-            &state.unified_router,
+            &state.unified_router(),
             &router_model,
             ProviderCapability::Rerank,
             {

--- a/src/server/routes/ai/response_cache.rs
+++ b/src/server/routes/ai/response_cache.rs
@@ -60,7 +60,7 @@ pub(super) async fn lookup_chat(
     if should_bypass_chat_cache(request, context) {
         return Ok(None);
     }
-    let Some(cache) = state.response_cache.as_ref() else {
+    let Some(cache) = state.response_cache() else {
         return Ok(None);
     };
     let identity = cache_identity(context);
@@ -85,7 +85,7 @@ pub(super) async fn store_chat(
     if should_bypass_chat_cache(request, context) {
         return Ok(());
     }
-    let Some(cache) = state.response_cache.as_ref() else {
+    let Some(cache) = state.response_cache() else {
         return Ok(());
     };
     let identity = cache_identity(context);
@@ -99,7 +99,7 @@ pub(super) async fn lookup_embedding(
     request: &EmbeddingRequest,
     context: &RequestContext,
 ) -> Result<Option<EmbeddingResponse>, GatewayError> {
-    let Some(cache) = state.response_cache.as_ref() else {
+    let Some(cache) = state.response_cache() else {
         return Ok(None);
     };
     let request = embedding_request_for_cache(request, context);
@@ -118,7 +118,7 @@ pub(super) async fn store_embedding(
     response: &EmbeddingResponse,
     context: &RequestContext,
 ) -> Result<(), GatewayError> {
-    let Some(cache) = state.response_cache.as_ref() else {
+    let Some(cache) = state.response_cache() else {
         return Ok(());
     };
     let request = embedding_request_for_cache(request, context);

--- a/src/server/routes/ai/responses/input_guardrail.rs
+++ b/src/server/routes/ai/responses/input_guardrail.rs
@@ -52,7 +52,7 @@ pub(super) async fn apply(
         .transpose()
         .map_err(InputGuardrailError::Guardrail)?;
     let request = crate::server::guardrails::apply_responses_input(
-        state.guardrails.as_ref(),
+        state.guardrails().as_ref(),
         &request,
         continuation.as_ref(),
     )

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -91,7 +91,7 @@ pub(crate) async fn handle_streaming_response(
     let settlement_budgeted = state.budgeted.clone();
     let callback_for_execution = callback.clone();
     match run_stream(
-        state.unified_router.clone(),
+        state.unified_router().clone(),
         &requested_model,
         ProviderCapability::ChatCompletionStream,
         move |provider, selected_model, _selected_deployment_id| {
@@ -180,7 +180,7 @@ pub(crate) async fn handle_streaming_response(
         )) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout = state.config.load().gateway.server.stream_idle_timeout;
-            let guardrails = Arc::clone(&state.guardrails);
+            let guardrails = Arc::clone(&state.guardrails());
             let settlement = StreamBudgetSettlement {
                 pricing_service: settlement_budgeted.pricing(),
                 pricing_config: state.config().gateway.pricing.clone(),

--- a/src/server/routes/health.rs
+++ b/src/server/routes/health.rs
@@ -512,15 +512,15 @@ fn aggregate_readiness(
 async fn check_provider_health(
     state: &AppState,
 ) -> Result<ProviderHealthStatus, crate::utils::error::gateway_error::GatewayError> {
-    let cfg = state.config.load();
+    let runtime = state.pin_runtime();
     let mut provider_details = Vec::new();
 
-    for provider_config in cfg.providers() {
+    for provider_config in runtime.config.providers() {
         let (status, error_message, last_check) = if !provider_config.enabled {
             (Cow::Borrowed("disabled"), None, None)
         } else {
             health_provider_status::derive_health_for_provider(
-                &state.unified_router,
+                &runtime.unified_router,
                 &provider_config.name,
                 provider_config.enabled,
             )

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -1,0 +1,91 @@
+//! Validated atomic runtime revision for provider/router/guardrail/cache state.
+//!
+//! [`AppState::apply_runtime`] builds a complete candidate [`RuntimeRevision`]
+//! before one lock-free store publishes it. [`AppState::pin_runtime`] holds that
+//! generation for a request lifecycle. This module does not watch config files
+//! or expose admin CRUD.
+
+use crate::config::Config;
+use crate::core::cache::{DualCacheConfig, LLMCache, LLMCacheConfig};
+use crate::core::guardrails::GuardrailEngine;
+use crate::core::pricing_service::PricingService;
+use crate::core::router::UnifiedRouter;
+use crate::storage::redis::RedisPool;
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::error;
+
+use super::http_runtime::build_router_from_config;
+
+/// One consistent generation of swappable runtime-owned components.
+#[derive(Clone)]
+pub struct RuntimeRevision {
+    /// Monotonic apply generation. Startup is `0`; each successful apply adds `1`.
+    pub generation: u64,
+    /// Validated gateway configuration for this generation.
+    pub config: Arc<Config>,
+    /// Router (including provider health probes) built from this generation.
+    pub unified_router: Arc<UnifiedRouter>,
+    /// Content guardrails built from this generation.
+    pub guardrails: Arc<GuardrailEngine>,
+    /// Response cache policy built from this generation.
+    pub response_cache: Option<Arc<LLMCache>>,
+}
+
+pub(super) async fn build_runtime_revision(
+    config: Config,
+    generation: u64,
+    pricing: Arc<PricingService>,
+    redis: Arc<RedisPool>,
+) -> Result<RuntimeRevision> {
+    config.validate()?;
+    let unified_router = Arc::new(build_router_from_config(&config, pricing).await?);
+    let guardrails =
+        GuardrailEngine::shared(config.gateway.guardrails.clone()).map_err(|error| {
+            GatewayError::Config(format!("Invalid guardrails configuration: {error}"))
+        })?;
+    let response_cache = build_response_cache(&config, redis);
+    Ok(RuntimeRevision {
+        generation,
+        config: Arc::new(config),
+        unified_router,
+        guardrails,
+        response_cache,
+    })
+}
+
+pub(super) fn build_response_cache(
+    config: &Config,
+    redis: Arc<RedisPool>,
+) -> Option<Arc<LLMCache>> {
+    if !config.gateway.cache.enabled {
+        return None;
+    }
+
+    if config.gateway.cache.ttl == 0 {
+        error!("cache.enabled=true requires cache.ttl > 0; response cache disabled");
+        return None;
+    }
+
+    let ttl = Duration::from_secs(config.gateway.cache.ttl);
+    let redis_pool = (!redis.is_noop()).then_some(redis);
+    let cache_config = if redis_pool.is_some() {
+        DualCacheConfig::default()
+    } else {
+        DualCacheConfig::memory_only()
+    }
+    .with_max_size(config.gateway.cache.max_size)
+    .with_ttl(ttl);
+    let llm_config = LLMCacheConfig {
+        cache_config,
+        chat_ttl: ttl,
+        embedding_ttl: ttl,
+        user_specific: true,
+        semantic_cache_enabled: false,
+        similarity_threshold: config.gateway.cache.similarity_threshold,
+    };
+    let cache = Arc::new(LLMCache::new(llm_config, redis_pool));
+    cache.start_cleanup_tasks();
+    Some(cache)
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -5,21 +5,24 @@
 use crate::config::Config;
 use crate::core::audit::AuditLogger;
 use crate::core::budget::{BudgetManager, UnifiedBudgetLimits};
-use crate::core::cache::{DualCacheConfig, LLMCache, LLMCacheConfig};
+use crate::core::cache::LLMCache;
 use crate::core::guardrails::GuardrailEngine;
 use crate::core::ip_access::IpAccessControl;
 use crate::core::keys::{DatabaseKeyRepository, KeyManager};
 use crate::core::observability::RuntimeObservability;
 use crate::core::pricing_service::PricingService;
+use crate::core::router::UnifiedRouter;
 use crate::core::teams::TeamManager;
 use crate::core::virtual_keys::RuntimeVirtualKeyManager;
 use crate::server::routes::ai::budgeted::BudgetedExecutor;
 use crate::storage::database::SeaOrmTeamRepository;
-use crate::storage::redis::RedisPool;
+use crate::utils::error::gateway_error::{GatewayError, Result};
 use crate::utils::sync::AtomicValue;
 use std::sync::Arc;
-use std::time::Duration;
-use tracing::error;
+use tokio::sync::Mutex;
+
+pub use super::runtime::RuntimeRevision;
+use super::runtime::{build_response_cache, build_runtime_revision};
 
 /// HTTP server state shared across handlers
 ///
@@ -30,14 +33,17 @@ use tracing::error;
 /// `config` uses [`AtomicValue`] so callers can explicitly swap the entire
 /// configuration at runtime while readers obtain lock-free `Arc<Config>`
 /// snapshots. This type does not start a file watcher by itself.
+///
+/// Router, guardrails, and response cache are published together through
+/// [`Self::apply_runtime`]. [`Self::pin_runtime`] holds one generation for a
+/// request lifecycle. Live accessors load from that same bundle so HTTP traffic
+/// never stays on construction-time Arcs after a successful apply.
 #[derive(Clone)]
 pub struct AppState {
     /// Gateway configuration (atomically swappable by explicit callers)
     pub config: AtomicValue<Config>,
     /// Authentication system
     pub auth: Arc<crate::auth::AuthSystem>,
-    /// Unified router (new UnifiedRouter implementation)
-    pub unified_router: Arc<crate::core::router::UnifiedRouter>,
     /// Storage layer
     pub storage: Arc<crate::storage::StorageLayer>,
     /// Unified pricing service
@@ -52,16 +58,14 @@ pub struct AppState {
     pub key_manager: RuntimeVirtualKeyManager,
     /// Budget orchestration service for AI route reserve/call/settle lifecycles
     pub(crate) budgeted: BudgetedExecutor,
-    /// Optional deterministic response cache for non-streaming chat and embeddings
-    pub response_cache: Option<Arc<LLMCache>>,
     /// Non-blocking external request lifecycle callback dispatcher
     pub callbacks: RuntimeObservability,
     /// Explicitly configured request audit logger.
     pub audit_logger: Arc<AuditLogger>,
-    /// Content guardrails executed on real LLM request/response paths.
-    pub guardrails: Arc<GuardrailEngine>,
     /// IP policy consumed by the outer HTTP middleware.
     pub ip_access: Arc<IpAccessControl>,
+    runtime: AtomicValue<RuntimeRevision>,
+    apply_lock: Arc<Mutex<()>>,
 }
 
 impl AppState {
@@ -74,10 +78,29 @@ impl AppState {
         pricing: Arc<PricingService>,
         budget_limits: Arc<UnifiedBudgetLimits>,
     ) -> Self {
+        let redis = storage.redis.clone();
+        let config = Arc::new(config);
+        let revision = RuntimeRevision {
+            generation: 0,
+            unified_router: Arc::new(unified_router),
+            guardrails: Arc::new(GuardrailEngine::disabled()),
+            response_cache: build_response_cache(&config, redis),
+            config: Arc::clone(&config),
+        };
+        Self::new_with_runtime(revision, auth, storage, pricing, budget_limits)
+    }
+
+    /// Create AppState from a fully built runtime revision.
+    pub fn new_with_runtime(
+        revision: RuntimeRevision,
+        auth: crate::auth::AuthSystem,
+        storage: crate::storage::StorageLayer,
+        pricing: Arc<PricingService>,
+        budget_limits: Arc<UnifiedBudgetLimits>,
+    ) -> Self {
         let storage = Arc::new(storage);
-        let response_cache = build_response_cache(&config, storage.redis.clone());
         let key_manager = KeyManager::new(DatabaseKeyRepository::new(storage.clone()))
-            .with_hmac_secret(config.gateway.auth.api_key_hmac_secret.clone());
+            .with_hmac_secret(revision.config.gateway.auth.api_key_hmac_secret.clone());
         let budget_manager = Arc::new(BudgetManager::new());
         let budgeted = BudgetedExecutor::new(
             budget_limits.clone(),
@@ -89,9 +112,8 @@ impl AppState {
             storage.database.clone(),
         ))));
         Self {
-            config: AtomicValue::new(config),
+            config: AtomicValue::from(Arc::clone(&revision.config)),
             auth: Arc::new(auth),
-            unified_router: Arc::new(unified_router),
             storage,
             pricing,
             budget_limits,
@@ -99,11 +121,11 @@ impl AppState {
             team_manager,
             key_manager,
             budgeted,
-            response_cache,
             callbacks: RuntimeObservability::disabled(),
             audit_logger: Arc::new(AuditLogger::disabled()),
-            guardrails: Arc::new(GuardrailEngine::disabled()),
             ip_access: Arc::new(IpAccessControl::disabled()),
+            runtime: AtomicValue::new(revision),
+            apply_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -121,13 +143,71 @@ impl AppState {
 
     /// Attach validated content and network policy engines.
     pub fn with_request_policies(
-        mut self,
+        self,
         guardrails: Arc<GuardrailEngine>,
         ip_access: Arc<IpAccessControl>,
     ) -> Self {
-        self.guardrails = guardrails;
-        self.ip_access = ip_access;
-        self
+        let current = self.runtime.load();
+        self.runtime.store(RuntimeRevision {
+            generation: current.generation,
+            config: Arc::clone(&current.config),
+            unified_router: Arc::clone(&current.unified_router),
+            guardrails,
+            response_cache: current.response_cache.clone(),
+        });
+        let mut this = self;
+        this.ip_access = ip_access;
+        this
+    }
+
+    /// Lock-free pin of the active runtime generation.
+    ///
+    /// Clone the returned `Arc` (or clone this pin) to keep router, guardrails,
+    /// cache, config, and generation stable for the rest of a request even if
+    /// [`Self::apply_runtime`] publishes a newer revision.
+    pub fn pin_runtime(&self) -> Arc<RuntimeRevision> {
+        self.runtime.load()
+    }
+
+    /// Live router for the current generation.
+    pub fn unified_router(&self) -> Arc<UnifiedRouter> {
+        Arc::clone(&self.pin_runtime().unified_router)
+    }
+
+    /// Live guardrail engine for the current generation.
+    pub fn guardrails(&self) -> Arc<GuardrailEngine> {
+        Arc::clone(&self.pin_runtime().guardrails)
+    }
+
+    /// Live response cache for the current generation.
+    pub fn response_cache(&self) -> Option<Arc<LLMCache>> {
+        self.pin_runtime().response_cache.clone()
+    }
+
+    /// Validate and build a complete candidate revision, then publish it atomically.
+    ///
+    /// Any build failure leaves the previous revision fully active. On success,
+    /// router, provider health, guardrails, response cache, generation, and
+    /// [`Self::config`] observe one consistent generation. Pricing is reused
+    /// from [`Self::pricing`] rather than rebuilt.
+    pub async fn apply_runtime(&self, candidate: Config) -> Result<u64> {
+        let _guard = self.apply_lock.lock().await;
+        let generation = self
+            .pin_runtime()
+            .generation
+            .checked_add(1)
+            .ok_or_else(|| GatewayError::Config("runtime generation overflow".into()))?;
+        let revision = build_runtime_revision(
+            candidate,
+            generation,
+            Arc::clone(&self.pricing),
+            Arc::clone(&self.storage.redis),
+        )
+        .await?;
+        let config = Arc::clone(&revision.config);
+        self.runtime.store(revision);
+        self.config.store_arc(config);
+        Ok(generation)
     }
 
     /// Load a snapshot of the current gateway configuration.
@@ -140,34 +220,133 @@ impl AppState {
     }
 }
 
-fn build_response_cache(config: &Config, redis: Arc<RedisPool>) -> Option<Arc<LLMCache>> {
-    if !config.gateway.cache.enabled {
-        return None;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::models::provider::ProviderConfig;
+    use crate::core::guardrails::PromptInjectionConfig;
+    use crate::server::HttpServer;
+
+    async fn test_app_state() -> AppState {
+        let mut config = crate::server::valid_test_config();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = None;
+        match HttpServer::new(&config).await {
+            Ok(server) => server.state().clone(),
+            Err(error) => panic!("test AppState startup failed: {error}"),
+        }
     }
 
-    if config.gateway.cache.ttl == 0 {
-        error!("cache.enabled=true requires cache.ttl > 0; response cache disabled");
-        return None;
+    fn extra_provider(name: &str) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            provider_type: "openai".to_string(),
+            api_key: "sk-test".to_string(),
+            ..ProviderConfig::default()
+        }
     }
 
-    let ttl = Duration::from_secs(config.gateway.cache.ttl);
-    let redis_pool = (!redis.is_noop()).then_some(redis);
-    let cache_config = if redis_pool.is_some() {
-        DualCacheConfig::default()
-    } else {
-        DualCacheConfig::memory_only()
+    #[tokio::test]
+    async fn apply_runtime_successful_swap_publishes_one_generation() {
+        let state = test_app_state().await;
+        let pinned = state.pin_runtime();
+        assert_eq!(pinned.generation, 0);
+        assert!(pinned.response_cache.is_none());
+
+        let mut next = (*state.config()).clone();
+        next.gateway.cache.enabled = true;
+        next.gateway.guardrails.enabled = false;
+        next.gateway.providers.push(extra_provider("test-openai-2"));
+
+        let generation = state
+            .apply_runtime(next)
+            .await
+            .expect("valid candidate should apply");
+        assert_eq!(generation, 1);
+
+        let live = state.pin_runtime();
+        assert_eq!(live.generation, 1);
+        assert!(live.response_cache.is_some());
+        assert!(!live.guardrails.is_enabled());
+        assert!(
+            live.unified_router.list_deployments().len()
+                > pinned.unified_router.list_deployments().len()
+        );
+        assert!(Arc::ptr_eq(&live.config, &state.config.load()));
+        assert!(!Arc::ptr_eq(&live.unified_router, &pinned.unified_router));
+        assert!(!Arc::ptr_eq(&live.guardrails, &pinned.guardrails));
+
+        assert_eq!(pinned.generation, 0);
+        assert!(pinned.response_cache.is_none());
+        assert!(pinned.guardrails.is_enabled());
     }
-    .with_max_size(config.gateway.cache.max_size)
-    .with_ttl(ttl);
-    let llm_config = LLMCacheConfig {
-        cache_config,
-        chat_ttl: ttl,
-        embedding_ttl: ttl,
-        user_specific: true,
-        semantic_cache_enabled: false,
-        similarity_threshold: config.gateway.cache.similarity_threshold,
-    };
-    let cache = Arc::new(LLMCache::new(llm_config, redis_pool));
-    cache.start_cleanup_tasks();
-    Some(cache)
+
+    #[tokio::test]
+    async fn apply_runtime_failed_build_leaves_previous_revision_active() {
+        let state = test_app_state().await;
+        let before = state.pin_runtime();
+        let router = Arc::clone(&before.unified_router);
+
+        let mut invalid = (*state.config()).clone();
+        let mut injection = invalid
+            .gateway
+            .guardrails
+            .prompt_injection
+            .clone()
+            .unwrap_or_else(PromptInjectionConfig::new);
+        injection.enabled = true;
+        injection.custom_patterns.push("(".to_string());
+        invalid.gateway.guardrails.prompt_injection = Some(injection);
+
+        let error = state
+            .apply_runtime(invalid)
+            .await
+            .expect_err("invalid guardrails must fail apply");
+        match error {
+            GatewayError::Config(message) => {
+                assert!(
+                    message.to_lowercase().contains("guardrail")
+                        || message.to_lowercase().contains("pattern"),
+                    "unexpected apply error: {message}"
+                );
+            }
+            other => panic!("expected config error, got {other:?}"),
+        }
+
+        let after = state.pin_runtime();
+        assert_eq!(after.generation, before.generation);
+        assert!(Arc::ptr_eq(&after.unified_router, &router));
+        assert!(Arc::ptr_eq(&after.guardrails, &before.guardrails));
+        assert_eq!(after.generation, 0);
+    }
+
+    #[tokio::test]
+    async fn in_flight_pin_stays_on_old_generation_after_apply() {
+        let state = test_app_state().await;
+        let in_flight = Arc::clone(&state.pin_runtime());
+
+        let mut next = (*state.config()).clone();
+        next.gateway.cache.enabled = true;
+        next.gateway.guardrails.enabled = false;
+        next.gateway
+            .providers
+            .push(extra_provider("test-openai-inflight"));
+
+        state
+            .apply_runtime(next)
+            .await
+            .expect("valid candidate should apply");
+
+        let live = state.pin_runtime();
+        assert_eq!(live.generation, in_flight.generation + 1);
+        assert_eq!(in_flight.generation, 0);
+        assert!(!Arc::ptr_eq(
+            &in_flight.unified_router,
+            &live.unified_router
+        ));
+        assert!(!Arc::ptr_eq(&in_flight.guardrails, &live.guardrails));
+        assert!(in_flight.response_cache.is_none());
+        assert!(live.response_cache.is_some());
+    }
 }

--- a/tests/conformance_chat_entries.rs
+++ b/tests/conformance_chat_entries.rs
@@ -653,8 +653,8 @@ async fn http_sdk_and_completion_chat_entries_conform() {
         .await
         .unwrap_or_else(|err| panic!("gateway test server: {err}"));
     let state = server.state().clone();
-    regroup(&state.unified_router);
-    let router = state.unified_router.clone();
+    regroup(&state.unified_router());
+    let router = state.unified_router().clone();
     let binding = bind_runtime(&router);
     let app = test::init_service(
         App::new()

--- a/tests/gemini_sdk_routes.rs
+++ b/tests/gemini_sdk_routes.rs
@@ -142,7 +142,7 @@ mod tests {
         )])
         .await;
         state
-            .unified_router
+            .unified_router()
             .add_model_alias("gemini@prod", "gemini-2.5-pro")
             .expect("runtime alias should install");
         let api_key = api_key_with_allowed_model_and_max_tokens("gemini@prod", 8);
@@ -187,7 +187,7 @@ mod tests {
         )])
         .await;
         state
-            .unified_router
+            .unified_router()
             .add_model_alias("public-gemini", "gemini@prod")
             .expect("runtime alias should install");
         let app = test::init_service(

--- a/tests/gemini_sdk_routes/runtime_provider_tests.rs
+++ b/tests/gemini_sdk_routes/runtime_provider_tests.rs
@@ -390,7 +390,7 @@ async fn gemini_sdk_stream_client_cancel_is_health_neutral_and_settles_observed_
     );
     let budget_limits = state.budget_limits.clone();
     let deployment = state
-        .unified_router
+        .unified_router()
         .get_deployment("gemini-gemini-3.1-flash-lite")
         .expect("runtime deployment");
     let successes = deployment.state.success_requests.load(Ordering::Relaxed);
@@ -601,7 +601,7 @@ async fn gemini_sdk_stream_route_settles_reserved_spend_after_output_then_read_e
     let budget_manager = state.budget_manager.clone();
     let budget_limits = state.budget_limits.clone();
     let deployment = state
-        .unified_router
+        .unified_router()
         .get_deployment("gemini-gemini-3.1-flash-lite")
         .expect("runtime deployment");
     let successes = deployment.state.success_requests.load(Ordering::Relaxed);

--- a/tests/image_edit_variation_routes.rs
+++ b/tests/image_edit_variation_routes.rs
@@ -469,7 +469,7 @@ mod tests {
         ])
         .await;
         state
-            .unified_router
+            .unified_router()
             .add_model_alias("public-image", "gpt-image-1-mini")
             .expect("runtime image alias should install");
         state.budget_limits.providers.set_provider_limit(

--- a/tests/image_router_fallback_routes.rs
+++ b/tests/image_router_fallback_routes.rs
@@ -373,7 +373,7 @@ mod tests {
         .await;
         add_raw_image_alias_pricing(&state, "image-alias", "gpt-image-1-mini");
         state
-            .unified_router
+            .unified_router()
             .add_model_alias("public-image", "image-alias")
             .expect("runtime image alias should install");
         let api_key = api_key_with_allowed_models(&["public-image"]);

--- a/tests/integration/health_readiness_tests.rs
+++ b/tests/integration/health_readiness_tests.rs
@@ -99,7 +99,7 @@ mod tests {
             .migrate()
             .await
             .expect("in-memory migrations should succeed");
-        let router = Arc::clone(&state.unified_router);
+        let router = Arc::clone(&state.unified_router());
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
                 let published = router

--- a/tests/rerank_routes.rs
+++ b/tests/rerank_routes.rs
@@ -656,7 +656,7 @@ mod tests {
         ])
         .await;
         state
-            .unified_router
+            .unified_router()
             .add_model_alias("public-rerank", "rerank-english-v3.0")
             .expect("runtime rerank alias should install");
         state.budget_limits.providers.set_provider_limit(

--- a/tests/tests/image_router_fallback_routes_edit_fallback_tests.rs
+++ b/tests/tests/image_router_fallback_routes_edit_fallback_tests.rs
@@ -43,7 +43,7 @@ async fn image_edit_transport_uses_the_same_selected_deployment() {
     add_raw_image_alias_pricing(&state, "inpaint", "gpt-image-1-mini");
 
     let first = state
-        .unified_router
+        .unified_router()
         .select_deployment_lease_for_capability("inpaint", &ProviderCapability::ImageEdit)
         .expect("first image edit deployment should be selectable");
     assert!(matches!(

--- a/tests/tests/moderations_routes_proxy_selection_tests.rs
+++ b/tests/tests/moderations_routes_proxy_selection_tests.rs
@@ -110,7 +110,7 @@ async fn moderation_route_resolves_alias_to_provider_fallback_model() {
     let mock = MockModerationServer::start_moderation_mock().await;
     let state = build_test_app_state(vec![moderation_provider(&mock.base_url)]).await;
     state
-        .unified_router
+        .unified_router()
         .add_model_alias("public-moderation", "mock-openai-compatible")
         .expect("provider fallback alias should install");
     let app = test::init_service(


### PR DESCRIPTION
## What

Adds a validated atomic runtime apply boundary so provider/router/guardrail/cache-relevant state is built as one candidate generation before it becomes live.

`AppState` now stores a `RuntimeRevision` bundle (`generation`, `config`, `unified_router`, `guardrails`, `response_cache`) behind `AtomicValue`. `pin_runtime()` is a lock-free load for a request lifecycle. `apply_runtime()` validates and builds a complete new router (existing factory + live pricing Arc), new guardrails, and new response cache; any failure returns `Err` and leaves the previous revision fully active. On success one store publishes the bundle, then `AppState.config` is updated to the same `Arc<Config>` so existing `config.load()` / `config()` readers stay aligned.

Live HTTP accessors load from the bundle so traffic does not stay on construction-time Arcs. No file watcher, no admin CRUD, no distributed broadcast. IP access is unchanged. Pricing is reused, not rebuilt.

Fixes #1269

## Why

`config` could already be swapped, but router/guardrails/cache were construction-time `Arc`s. Tests and future admin apply paths could update config without rebuilding the rest, so live traffic could observe mixed generations.

## Test Plan

- [x] `cargo test --lib server::state::` (successful swap, failed guardrail build, in-flight pin)
- [x] `cargo test --lib server::http::tests`
- [x] `cargo test --lib server::routes::admin`
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] `cargo fmt --all -- --check`
- [ ] CI Fast Test SUCCESS (do not merge on cancel)
- [ ] After merge: trunk Main Full + Cross Platform on the merge SHA

## AI disclosure

Implemented with Cursor Grok 4.6.

Made with [Cursor](https://cursor.com)