### PR TITLE
feat(guardrails): execute custom rules in the gateway runtime

### DIFF
--- a/src/config/models/guardrails.rs
+++ b/src/config/models/guardrails.rs
@@ -1,6 +1,7 @@
 //! Gateway-specific defaults and deserialization for content guardrails.
 
 use crate::core::guardrails::config::CustomRuleConfig;
+use crate::core::guardrails::custom_rules::validate_custom_rule_patterns;
 use crate::core::guardrails::{
     GuardrailAction, GuardrailConfig, OpenAIModerationConfig, PIIConfig, PromptInjectionConfig,
 };
@@ -29,9 +30,6 @@ struct GatewayGuardrailsWire {
 }
 
 pub(crate) fn validate_gateway_guardrails(config: &GuardrailConfig) -> Result<(), String> {
-    if !config.custom_rules.is_empty() {
-        return Err("guardrails.custom_rules is not supported by the gateway runtime".to_string());
-    }
     if config.default_action != GuardrailAction::Block {
         return Err(
             "guardrails.default_action is not supported; configure each enabled policy action"
@@ -52,13 +50,19 @@ pub(crate) fn validate_gateway_guardrails(config: &GuardrailConfig) -> Result<()
         || config
             .prompt_injection
             .as_ref()
-            .is_some_and(|policy| policy.enabled && policy.action == GuardrailAction::Mask);
+            .is_some_and(|policy| policy.enabled && policy.action == GuardrailAction::Mask)
+        || config
+            .custom_rules
+            .iter()
+            .any(|rule| rule.enabled && rule.action == GuardrailAction::Mask);
     if unsupported_mask {
         return Err(
             "guardrail action 'mask' is only supported for the PII policy; use block, log, or allow"
                 .to_string(),
         );
     }
+
+    validate_custom_rule_patterns(&config.custom_rules)?;
 
     Ok(())
 }
@@ -133,7 +137,6 @@ mod tests {
     #[test]
     fn gateway_rejects_guardrail_knobs_without_runtime_semantics() {
         for guardrails in [
-            serde_json::json!({"custom_rules": [{"name": "deny", "patterns": ["secret"]}]}),
             serde_json::json!({"default_action": "log"}),
             serde_json::json!({"exclude_paths": ["/v1/chat/completions"]}),
             serde_json::json!({"prompt_injection": {"enabled": true, "action": "mask"}}),
@@ -144,6 +147,62 @@ mod tests {
 
             assert!(Validate::validate(&config).is_err());
         }
+    }
+
+    #[test]
+    fn gateway_accepts_executable_custom_rules() {
+        let mut value = serde_json::to_value(GatewayConfig::default()).unwrap();
+        value["guardrails"] = serde_json::json!({
+            "custom_rules": [{
+                "name": "deny",
+                "patterns": ["forbidden-token-xyz"],
+                "action": "block"
+            }]
+        });
+        let config: GatewayConfig = serde_json::from_value(value).unwrap();
+
+        assert!(super::validate_gateway_guardrails(&config.guardrails).is_ok());
+        assert!(crate::core::guardrails::GuardrailEngine::new(config.guardrails).is_ok());
+    }
+
+    #[test]
+    fn gateway_rejects_custom_rule_mask_action() {
+        let mut value = serde_json::to_value(GatewayConfig::default()).unwrap();
+        value["guardrails"] = serde_json::json!({
+            "custom_rules": [{
+                "name": "deny",
+                "patterns": ["forbidden-token-xyz"],
+                "action": "mask"
+            }]
+        });
+        let config: GatewayConfig = serde_json::from_value(value).unwrap();
+
+        let error = super::validate_gateway_guardrails(&config.guardrails)
+            .expect_err("mask custom rules must fail");
+        assert!(error.contains("mask"), "{error}");
+    }
+
+    #[test]
+    fn gateway_rejects_invalid_custom_rule_regex_with_rule_name() {
+        let mut value = serde_json::to_value(GatewayConfig::default()).unwrap();
+        value["guardrails"] = serde_json::json!({
+            "custom_rules": [{
+                "name": "no-secrets",
+                "patterns": ["["]
+            }]
+        });
+        let config: GatewayConfig = serde_json::from_value(value).unwrap();
+
+        let error = super::validate_gateway_guardrails(&config.guardrails)
+            .expect_err("invalid regex must fail");
+        assert!(error.contains("no-secrets"), "{error}");
+        assert!(error.contains("pattern '['"), "{error}");
+
+        let engine_error = match crate::core::guardrails::GuardrailEngine::new(config.guardrails) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("engine construction must fail closed"),
+        };
+        assert!(engine_error.contains("no-secrets"), "{engine_error}");
     }
 
     #[test]

--- a/src/core/guardrails/custom_rules.rs
+++ b/src/core/guardrails/custom_rules.rs
@@ -1,0 +1,262 @@
+//! Custom regex rules
+//!
+//! Compiles configured `custom_rules` with the same `regex` crate used by PII
+//! and prompt-injection, then evaluates them through the shared `Guardrail`
+//! trait. Mask is not implemented; gateway validation rejects it.
+
+use async_trait::async_trait;
+use regex::Regex;
+use tracing::debug;
+
+use super::config::CustomRuleConfig;
+use super::traits::Guardrail;
+use super::types::{
+    CheckResult, GuardrailAction, GuardrailError, GuardrailResult, Violation, ViolationType,
+};
+
+struct CompiledCustomRule {
+    name: String,
+    action: GuardrailAction,
+    message: Option<String>,
+    patterns: Vec<Regex>,
+}
+
+/// One guardrail that owns every enabled custom rule.
+pub(crate) struct CustomRulesGuardrail {
+    rules: Vec<CompiledCustomRule>,
+}
+
+/// Compile enabled custom rules. Invalid patterns name the rule and pattern.
+fn compile_custom_rule_patterns(
+    rules: &[CustomRuleConfig],
+) -> GuardrailResult<Vec<CompiledCustomRule>> {
+    let mut compiled = Vec::new();
+    for rule in rules {
+        if !rule.enabled {
+            continue;
+        }
+        let mut patterns = Vec::with_capacity(rule.patterns.len());
+        for pattern in &rule.patterns {
+            let regex = Regex::new(pattern).map_err(|error| {
+                GuardrailError::Config(format!(
+                    "Invalid custom rule '{}' pattern '{}': {error}",
+                    rule.name, pattern
+                ))
+            })?;
+            patterns.push(regex);
+        }
+        compiled.push(CompiledCustomRule {
+            name: rule.name.clone(),
+            action: rule.action,
+            message: rule.message.clone(),
+            patterns,
+        });
+    }
+    Ok(compiled)
+}
+
+/// Fail closed on invalid enabled custom-rule patterns, naming the rule.
+pub(crate) fn validate_custom_rule_patterns(rules: &[CustomRuleConfig]) -> Result<(), String> {
+    compile_custom_rule_patterns(rules).map_err(|error| match error {
+        GuardrailError::Config(message) => message,
+        other => other.to_string(),
+    })?;
+    Ok(())
+}
+
+impl CustomRulesGuardrail {
+    /// Build a guardrail when at least one enabled rule compiles.
+    pub(crate) fn try_from_config(rules: &[CustomRuleConfig]) -> GuardrailResult<Option<Self>> {
+        let rules = compile_custom_rule_patterns(rules)?;
+        if rules.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(Self { rules }))
+        }
+    }
+
+    fn evaluate(&self, content: &str) -> CheckResult {
+        let mut violations = Vec::new();
+        let mut block = false;
+        let mut log = false;
+
+        for rule in &self.rules {
+            if !rule
+                .patterns
+                .iter()
+                .any(|pattern| pattern.is_match(content))
+            {
+                continue;
+            }
+
+            match rule.action {
+                GuardrailAction::Allow | GuardrailAction::Mask => {}
+                GuardrailAction::Block | GuardrailAction::Log => {
+                    debug!(
+                        rule = %rule.name,
+                        action = ?rule.action,
+                        "Custom guardrail rule matched"
+                    );
+                    if rule.action == GuardrailAction::Block {
+                        block = true;
+                    } else {
+                        log = true;
+                    }
+                    let message = rule
+                        .message
+                        .clone()
+                        .unwrap_or_else(|| format!("Custom rule '{}' matched", rule.name));
+                    violations.push(Violation::new(
+                        ViolationType::CustomRule(rule.name.clone()),
+                        message,
+                    ));
+                }
+            }
+        }
+
+        if block {
+            CheckResult::block(violations)
+        } else if log {
+            let mut result = CheckResult::pass();
+            result.violations = violations;
+            result.action = GuardrailAction::Log;
+            result
+        } else {
+            CheckResult::pass()
+        }
+    }
+}
+
+#[async_trait]
+impl Guardrail for CustomRulesGuardrail {
+    fn name(&self) -> &str {
+        "custom_rules"
+    }
+
+    fn description(&self) -> &str {
+        "Evaluate configured custom regex rules"
+    }
+
+    fn is_enabled(&self) -> bool {
+        !self.rules.is_empty()
+    }
+
+    fn priority(&self) -> u32 {
+        20
+    }
+
+    async fn check_input(&self, content: &str) -> GuardrailResult<CheckResult> {
+        Ok(self.evaluate(content))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(name: &str, pattern: &str, action: GuardrailAction) -> CustomRuleConfig {
+        CustomRuleConfig {
+            name: name.to_string(),
+            description: None,
+            enabled: true,
+            patterns: vec![pattern.to_string()],
+            action,
+            message: None,
+        }
+    }
+
+    fn guardrail(rules: Vec<CustomRuleConfig>) -> CustomRulesGuardrail {
+        CustomRulesGuardrail::try_from_config(&rules)
+            .expect("test rules must compile")
+            .expect("test rules must produce a guardrail")
+    }
+
+    #[test]
+    fn invalid_pattern_names_the_rule() {
+        let error = match CustomRulesGuardrail::try_from_config(&[rule(
+            "no-secrets",
+            "[",
+            GuardrailAction::Block,
+        )]) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("unterminated character class must fail"),
+        };
+        assert!(error.contains("no-secrets"), "{error}");
+        assert!(error.contains("pattern '['"), "{error}");
+    }
+
+    #[test]
+    fn disabled_rules_are_skipped() {
+        let mut disabled = rule("no-secrets", "[", GuardrailAction::Block);
+        disabled.enabled = false;
+        assert!(
+            CustomRulesGuardrail::try_from_config(&[disabled])
+                .expect("disabled invalid rules are skipped")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn block_log_and_allow_map_like_prompt_injection() {
+        let content = "hello forbidden-token-xyz";
+
+        let blocked = guardrail(vec![rule(
+            "deny-token",
+            "forbidden-token-xyz",
+            GuardrailAction::Block,
+        )])
+        .check_input(content)
+        .await
+        .unwrap();
+        assert!(blocked.is_blocked());
+        assert_eq!(
+            blocked.violations[0].violation_type,
+            ViolationType::CustomRule("deny-token".to_string())
+        );
+        assert!(!blocked.violations[0].details.contains_key("matched_text"));
+        assert!(
+            !blocked.violations[0]
+                .message
+                .contains("forbidden-token-xyz")
+        );
+
+        let logged = guardrail(vec![rule(
+            "log-token",
+            "forbidden-token-xyz",
+            GuardrailAction::Log,
+        )])
+        .check_input(content)
+        .await
+        .unwrap();
+        assert!(logged.passed);
+        assert!(!logged.is_blocked());
+        assert_eq!(logged.action, GuardrailAction::Log);
+        assert_eq!(logged.violations.len(), 1);
+
+        let allowed = guardrail(vec![rule(
+            "allow-token",
+            "forbidden-token-xyz",
+            GuardrailAction::Allow,
+        )])
+        .check_input(content)
+        .await
+        .unwrap();
+        assert!(allowed.passed);
+        assert!(!allowed.is_blocked());
+        assert!(allowed.violations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unmatched_content_passes() {
+        let result = guardrail(vec![rule(
+            "deny-token",
+            "forbidden-token-xyz",
+            GuardrailAction::Block,
+        )])
+        .check_input("hello")
+        .await
+        .unwrap();
+        assert!(result.passed);
+        assert!(result.violations.is_empty());
+    }
+}

--- a/src/core/guardrails/engine.rs
+++ b/src/core/guardrails/engine.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use super::config::GuardrailConfig;
+use super::custom_rules::CustomRulesGuardrail;
 use super::openai_moderation::OpenAIModerationGuardrail;
 use super::pii::PIIGuardrail;
 use super::prompt_injection::PromptInjectionGuardrail;
@@ -56,6 +57,11 @@ impl GuardrailEngine {
         {
             info!("Initializing prompt injection guardrail");
             let guardrail = PromptInjectionGuardrail::new(injection_config.clone())?;
+            guardrails.push(Box::new(guardrail));
+        }
+
+        if let Some(guardrail) = CustomRulesGuardrail::try_from_config(&config.custom_rules)? {
+            info!("Initializing custom rules guardrail");
             guardrails.push(Box::new(guardrail));
         }
 
@@ -266,7 +272,7 @@ impl Default for GuardrailEngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::guardrails::config::{PIIConfig, PromptInjectionConfig};
+    use crate::core::guardrails::config::{CustomRuleConfig, PIIConfig, PromptInjectionConfig};
     use crate::core::guardrails::traits::Guardrail;
     use crate::core::guardrails::types::GuardrailAction;
 
@@ -450,6 +456,43 @@ mod tests {
         let engine = GuardrailEngine::shared(config).unwrap();
 
         assert!(engine.is_enabled());
+    }
+
+    #[test]
+    fn invalid_custom_rule_regex_fails_engine_construction() {
+        let config = GuardrailConfig {
+            enabled: true,
+            custom_rules: vec![CustomRuleConfig::new("no-secrets", vec!["[".to_string()])],
+            ..Default::default()
+        };
+        let error = match GuardrailEngine::new(config) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("invalid custom regex must fail engine construction"),
+        };
+        assert!(error.contains("no-secrets"), "{error}");
+        assert!(error.contains("pattern '['"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn custom_rules_run_through_the_engine() {
+        let config = GuardrailConfig {
+            enabled: true,
+            custom_rules: vec![CustomRuleConfig::new(
+                "deny-token",
+                vec!["forbidden-token-xyz".to_string()],
+            )],
+            ..Default::default()
+        };
+        let engine = GuardrailEngine::new(config).unwrap();
+
+        assert!(engine.guardrail_names().contains(&"custom_rules"));
+        let blocked = engine
+            .check_input("hello forbidden-token-xyz")
+            .await
+            .unwrap();
+        assert!(blocked.is_blocked());
+        let passed = engine.check_input("hello").await.unwrap();
+        assert!(passed.passed);
     }
 
     // Custom guardrail for testing

--- a/src/core/guardrails/mod.rs
+++ b/src/core/guardrails/mod.rs
@@ -37,6 +37,7 @@
 //! ```
 
 pub mod config;
+pub mod custom_rules;
 pub mod engine;
 #[cfg(feature = "gateway")]
 pub mod middleware;

--- a/tests/integration/guardrail_route_tests.rs
+++ b/tests/integration/guardrail_route_tests.rs
@@ -228,6 +228,53 @@ mod tests {
             .clone()
     }
 
+    async fn app_state_with_custom_rule(
+        base_url: &str,
+        action: litellm_rs::core::guardrails::GuardrailAction,
+    ) -> litellm_rs::server::state::AppState {
+        use litellm_rs::core::guardrails::PromptInjectionConfig;
+        use litellm_rs::core::guardrails::config::CustomRuleConfig;
+
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.guardrails.prompt_injection = Some(PromptInjectionConfig {
+            enabled: false,
+            ..PromptInjectionConfig::default()
+        });
+        config.gateway.guardrails.pii = None;
+        config.gateway.guardrails.openai_moderation = None;
+        config.gateway.guardrails.custom_rules = vec![CustomRuleConfig {
+            name: "deny-forbidden-token".to_string(),
+            description: None,
+            enabled: true,
+            patterns: vec!["forbidden-token-xyz".to_string()],
+            action,
+            message: None,
+        }];
+        let mut provider = mock_provider_config(
+            "openai",
+            "openai_compatible",
+            "sk-test",
+            base_url,
+            vec!["gpt-4o".to_string()],
+        );
+        provider.settings = HashMap::from([
+            ("skip_api_key".to_string(), Value::Bool(true)),
+            (
+                "provider_name".to_string(),
+                Value::String("openai".to_string()),
+            ),
+        ]);
+        config.gateway.providers = vec![provider];
+        GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway should initialize with custom rules")
+            .state()
+            .clone()
+    }
+
     fn guardrail_chat_request(content: &str) -> Value {
         json!({
             "model": "gpt-4o",
@@ -992,5 +1039,149 @@ mod tests {
         .await;
 
         assert_blocked_stream(&body);
+    }
+
+    #[tokio::test]
+    async fn custom_rule_input_block_rejects_before_provider_execution() {
+        use litellm_rs::core::guardrails::GuardrailAction;
+
+        let provider = GuardrailTestUpstream::launch_with_output("safe response").await;
+        let state = app_state_with_custom_rule(&provider.base_url, GuardrailAction::Block).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .set_json(guardrail_chat_request("hello forbidden-token-xyz"))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert!(provider.requests.lock().unwrap().is_empty());
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn custom_rule_input_log_forwards_to_provider() {
+        use litellm_rs::core::guardrails::GuardrailAction;
+
+        let provider = GuardrailTestUpstream::launch_with_output("safe response").await;
+        let state = app_state_with_custom_rule(&provider.base_url, GuardrailAction::Log).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .set_json(guardrail_chat_request("hello forbidden-token-xyz"))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(provider.requests.lock().unwrap().len(), 1);
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn custom_rule_input_allow_forwards_to_provider() {
+        use litellm_rs::core::guardrails::GuardrailAction;
+
+        let provider = GuardrailTestUpstream::launch_with_output("safe response").await;
+        let state = app_state_with_custom_rule(&provider.base_url, GuardrailAction::Allow).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .set_json(guardrail_chat_request("hello forbidden-token-xyz"))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(provider.requests.lock().unwrap().len(), 1);
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn custom_rule_output_block_rejects_after_provider_execution() {
+        use litellm_rs::core::guardrails::GuardrailAction;
+
+        let provider =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let state = app_state_with_custom_rule(&provider.base_url, GuardrailAction::Block).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .set_json(guardrail_chat_request("hello"))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(provider.requests.lock().unwrap().len(), 1);
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn custom_rule_streaming_output_is_blocked_before_emission() {
+        use litellm_rs::core::guardrails::GuardrailAction;
+
+        let provider =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let state = app_state_with_custom_rule(&provider.base_url, GuardrailAction::Block).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .set_json(json!({
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": true
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = String::from_utf8(test::read_body(response).await.to_vec())
+            .expect("SSE response should be UTF-8");
+        assert!(body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert!(!body.contains("forbidden-token-xyz"), "{body}");
+        provider.stop_upstream().await;
     }
 }


### PR DESCRIPTION
## What

Compile enabled `custom_rules` at engine construction and run them through the existing input/output guardrail boundary.

One `CustomRulesGuardrail` owns all compiled `regex::Regex` patterns (same crate as PII / prompt-injection). Invalid patterns fail `GuardrailEngine::new` and gateway Validate with the rule name. Block / Log / Allow map like prompt-injection. Mask stays PII-only. Logging is rule name + action only — no matched text.

`enforce()` is unchanged: only `is_blocked()` fails the request. Live accessors remain `AppState::pin_runtime()` / `.guardrails()`.

Fixes #1275

## Why

The core already had custom-rule config, but gateway validation rejected any non-empty `custom_rules` and no runtime path executed them.

## Test Plan

- [x] `cargo test --lib custom_rules` (compile error names the rule; Block/Log/Allow; disabled rules skipped)
- [x] `cargo test --lib invalid_custom_rule` / `gateway_accepts_executable_custom_rules` / `gateway_rejects_custom_rule`
- [x] `cargo test --test lib custom_rule_` (input Block/Log/Allow, output Block, streaming output Block)
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] `cargo fmt --all -- --check`
- [ ] CI Fast Test SUCCESS (do not merge on cancel)
- [ ] After merge: trunk Main Full + Cross Platform on the merge SHA

## AI disclosure

Implemented with Cursor Grok 4.6.

Made with [Cursor](https://cursor.com)