### PR TITLE
feat(storage): support configured Redis Cluster connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "itoa",
+ "log",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ rmp-serde = "1.3"
 # NOTE: default-features = false is critical to avoid pulling in sqlx-mysql and its vulnerable RSA dependency
 sea-orm = { version = "1.1", features = ["macros", "with-chrono", "with-uuid", "with-json"], default-features = false, optional = true }
 sea-orm-migration = { version = "1.1", default-features = false, optional = true }
-redis = { version = "1.0", features = ["tokio-comp", "cluster", "streams", "aio", "connection-manager"], optional = true }
+redis = { version = "1.0", features = ["tokio-comp", "cluster", "cluster-async", "streams", "aio", "connection-manager"], optional = true }
 
 # Caching
 lru = "0.16"

--- a/src/config/models/gateway_env_tests.rs
+++ b/src/config/models/gateway_env_tests.rs
@@ -297,7 +297,7 @@ fn standalone_gateway_env_loader_preserves_jwt_requirement() {
 }
 
 #[test]
-fn config_environment_overlay_defers_final_cluster_validation() {
+fn config_environment_overlay_accepts_cluster_mode() {
     let _guard = GATEWAY_ENV_LOCK.blocking_lock();
     let _env = EnvGuard::cleared();
     unsafe {
@@ -309,15 +309,16 @@ fn config_environment_overlay_defers_final_cluster_validation() {
         env::set_var(ENV_REDIS_CLUSTER, "true");
     }
 
-    assert!(crate::config::Config::from_env().is_err());
+    let config = crate::config::Config::from_env()
+        .expect("cluster=true with the default Redis URL should validate");
+    assert!(config.gateway.storage.redis.enabled);
+    assert!(config.gateway.storage.redis.cluster);
+
     let layer = crate::config::Config::overlay_from_env()
-        .expect("environment overlay should parse before final validation")
+        .expect("environment overlay should parse")
         .into_config();
-    assert!(
-        layer
-            .validate()
-            .expect_err("materialized cluster layer must remain invalid before merge")
-            .to_string()
-            .contains("storage.redis.cluster=false")
-    );
+    layer
+        .validate()
+        .expect("materialized cluster layer must be a valid configuration");
+    assert!(layer.gateway.storage.redis.cluster);
 }

--- a/src/config/models/storage/redis_config.rs
+++ b/src/config/models/storage/redis_config.rs
@@ -16,8 +16,9 @@ pub struct RedisConfig {
     /// Connection timeout in seconds.
     #[serde(default = "default_connection_timeout")]
     pub connection_timeout: u64,
-    /// Enable cluster mode. Not implemented: startup validation rejects
-    /// `cluster=true` instead of silently using a standalone connection.
+    /// Enable Redis Cluster. When true, `url` is a cluster seed (`redis://`
+    /// or `rediss://`); comma-separated seeds are also accepted. Defaults to
+    /// standalone (`false`).
     #[serde(default)]
     pub cluster: bool,
     /// When `enabled` is true and Redis init fails, allow the gateway to keep

--- a/src/config/validation/storage_tests.rs
+++ b/src/config/validation/storage_tests.rs
@@ -148,7 +148,7 @@ fn redis_validation_skips_when_disabled() {
 }
 
 #[test]
-fn redis_validation_rejects_unimplemented_cluster_mode_with_actionable_remedy() {
+fn redis_validation_accepts_cluster_mode_when_url_is_valid() {
     let config = RedisConfig {
         enabled: true,
         url: "redis://localhost:6379".to_string(),
@@ -158,14 +158,22 @@ fn redis_validation_rejects_unimplemented_cluster_mode_with_actionable_remedy() 
         allow_degraded: false,
     };
 
-    let error = Validate::validate(&config).unwrap_err();
+    assert!(Validate::validate(&config).is_ok());
+}
 
-    assert!(error.contains("cluster"), "got: {error}");
-    assert!(error.contains("not implemented"), "got: {error}");
-    assert!(
-        error.contains("storage.redis.cluster=false"),
-        "got: {error}"
-    );
+#[test]
+fn redis_validation_rejects_cluster_mode_with_empty_url() {
+    let config = RedisConfig {
+        enabled: true,
+        url: String::new(),
+        max_connections: 10,
+        connection_timeout: 5,
+        cluster: true,
+        allow_degraded: false,
+    };
+
+    let error = Validate::validate(&config).unwrap_err();
+    assert!(error.contains("Redis URL cannot be empty"), "got: {error}");
 }
 
 #[test]

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -122,17 +122,6 @@ impl Validate for RedisConfig {
             return Ok(());
         }
 
-        if self.cluster {
-            return Err(
-                "storage.redis.cluster=true is declared but not implemented yet. \
-                 A standalone client against a cluster node only fails later \
-                 with MOVED errors, so cluster mode is rejected at startup. \
-                 Set storage.redis.cluster=false and point storage.redis.url \
-                 at a standalone or primary endpoint."
-                    .to_string(),
-            );
-        }
-
         if self.url.is_empty() {
             return Err("Redis URL cannot be empty".to_string());
         }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -119,25 +119,35 @@ async fn test_server_builder_requires_config() {
 }
 
 #[tokio::test]
-async fn server_builder_rejects_redis_cluster_before_client_initialization() {
-    let mut config = crate::config::Config::default();
+async fn server_builder_fails_unreachable_redis_cluster_unless_degraded() {
+    let mut config = valid_programmatic_config();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.pricing.source = None;
     config.gateway.storage.redis.enabled = true;
     config.gateway.storage.redis.cluster = true;
+    config.gateway.storage.redis.url = "redis://127.0.0.1:1".to_string();
+    config.gateway.storage.redis.connection_timeout = 1;
+    config.gateway.storage.redis.allow_degraded = false;
 
-    let error = match ServerBuilder::new().with_config(config).build().await {
+    let error = match ServerBuilder::new()
+        .with_config(config.clone())
+        .build()
+        .await
+    {
         Err(error) => error,
-        Ok(_) => panic!("server builder must reject unsupported Redis cluster mode"),
+        Ok(_) => panic!("unreachable Redis Cluster must fail startup in strict mode"),
     };
+    assert!(
+        !error.to_string().contains("not implemented"),
+        "cluster mode is valid config; got: {error}"
+    );
 
-    let message = error.to_string();
-    assert!(
-        message.contains("storage.redis.cluster=true"),
-        "got: {message}"
-    );
-    assert!(
-        message.contains("storage.redis.cluster=false"),
-        "got: {message}"
-    );
+    config.gateway.storage.redis.allow_degraded = true;
+    ServerBuilder::new()
+        .with_config(config)
+        .build()
+        .await
+        .expect("allow_degraded must start the gateway with a no-op Redis pool");
 }
 
 #[tokio::test]

--- a/src/storage/redis/batch.rs
+++ b/src/storage/redis/batch.rs
@@ -7,10 +7,22 @@ use crate::utils::error::gateway_error::{GatewayError, Result};
 use redis::AsyncCommands;
 
 impl RedisPool {
-    /// Get multiple keys at once
+    /// Get multiple keys at once.
+    ///
+    /// Standalone mode uses `MGET`. Cluster mode issues per-key `GET` so keys
+    /// in different hash slots do not trigger CROSSSLOT errors. Result order
+    /// matches `keys`.
     pub async fn mget(&self, keys: &[String]) -> Result<Vec<Option<String>>> {
         if self.noop_mode {
             return Ok(vec![None; keys.len()]);
+        }
+
+        if self.is_cluster() {
+            let mut values = Vec::with_capacity(keys.len());
+            for key in keys {
+                values.push(self.get(key).await?);
+            }
+            return Ok(values);
         }
 
         let mut conn = self.get_connection().await?;
@@ -22,9 +34,19 @@ impl RedisPool {
         }
     }
 
-    /// Set multiple key-value pairs with optional TTL
+    /// Set multiple key-value pairs with optional TTL.
+    ///
+    /// Standalone mode uses an atomic pipeline. Cluster mode issues per-key
+    /// `SET`/`SETEX` to stay slot-safe.
     pub async fn mset(&self, pairs: &[(String, String)], ttl: Option<u64>) -> Result<()> {
         if self.noop_mode || pairs.is_empty() {
+            return Ok(());
+        }
+
+        if self.is_cluster() {
+            for (key, value) in pairs {
+                self.set(key, value, ttl).await?;
+            }
             return Ok(());
         }
 

--- a/src/storage/redis/cache.rs
+++ b/src/storage/redis/cache.rs
@@ -2,9 +2,11 @@
 //!
 //! This module provides core key-value caching operations including get, set, delete, exists, expire, and ttl.
 
-use super::pool::RedisPool;
+use super::pool::{RedisLiveConnection, RedisPool};
 use crate::utils::error::gateway_error::{GatewayError, Result};
-use redis::{AsyncCommands, RedisResult};
+use redis::cluster_async::ClusterConnection;
+use redis::cluster_routing::{RoutingInfo, SingleNodeRoutingInfo};
+use redis::{AsyncCommands, Value};
 
 impl RedisPool {
     /// Get a value from cache
@@ -15,12 +17,8 @@ impl RedisPool {
 
         let mut conn = self.get_connection().await?;
         if let Some(ref mut c) = conn.conn {
-            let result: RedisResult<String> = c.get(key).await;
-            match result {
-                Ok(value) => Ok(Some(value)),
-                Err(e) if e.kind() == redis::ErrorKind::UnexpectedReturnType => Ok(None),
-                Err(e) => Err(GatewayError::from(e)),
-            }
+            let value: Option<String> = c.get(key).await.map_err(GatewayError::from)?;
+            Ok(value)
         } else {
             Ok(None)
         }
@@ -66,41 +64,11 @@ impl RedisPool {
         }
 
         let mut conn = self.get_connection().await?;
-        let Some(ref mut c) = conn.conn else {
-            return Ok(0);
-        };
-
-        let pattern = format!("{prefix}*");
-        let mut cursor = 0_u64;
-        let mut deleted = 0_usize;
-
-        loop {
-            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                .arg(cursor)
-                .arg("MATCH")
-                .arg(&pattern)
-                .arg("COUNT")
-                .arg(100_usize)
-                .query_async(&mut *c)
-                .await
-                .map_err(GatewayError::from)?;
-
-            if !keys.is_empty() {
-                let count: usize = redis::cmd("DEL")
-                    .arg(&keys)
-                    .query_async(&mut *c)
-                    .await
-                    .map_err(GatewayError::from)?;
-                deleted += count;
-            }
-
-            if next_cursor == 0 {
-                break;
-            }
-            cursor = next_cursor;
+        match conn.conn.as_mut() {
+            Some(RedisLiveConnection::Standalone(c)) => scan_and_delete_standalone(c, prefix).await,
+            Some(RedisLiveConnection::Cluster(c)) => scan_and_delete_cluster(c, prefix).await,
+            None => Ok(0),
         }
-
-        Ok(deleted)
     }
 
     /// Check if a key exists
@@ -148,4 +116,152 @@ impl RedisPool {
             Ok(-2)
         }
     }
+}
+
+async fn scan_and_delete_standalone(
+    conn: &mut redis::aio::MultiplexedConnection,
+    prefix: &str,
+) -> Result<usize> {
+    let pattern = format!("{prefix}*");
+    let mut cursor = 0_u64;
+    let mut deleted = 0_usize;
+
+    loop {
+        let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("MATCH")
+            .arg(&pattern)
+            .arg("COUNT")
+            .arg(100_usize)
+            .query_async(&mut *conn)
+            .await
+            .map_err(GatewayError::from)?;
+
+        if !keys.is_empty() {
+            let count: usize = redis::cmd("DEL")
+                .arg(&keys)
+                .query_async(&mut *conn)
+                .await
+                .map_err(GatewayError::from)?;
+            deleted += count;
+        }
+
+        if next_cursor == 0 {
+            break;
+        }
+        cursor = next_cursor;
+    }
+
+    Ok(deleted)
+}
+
+async fn scan_and_delete_cluster(conn: &mut ClusterConnection, prefix: &str) -> Result<usize> {
+    let slots: Value = redis::cmd("CLUSTER")
+        .arg("SLOTS")
+        .query_async(&mut *conn)
+        .await
+        .map_err(GatewayError::from)?;
+    let masters = cluster_master_addrs(&slots);
+
+    if masters.is_empty() {
+        return scan_node_and_delete(conn, None, prefix).await;
+    }
+
+    let mut deleted = 0_usize;
+    for (host, port) in masters {
+        deleted += scan_node_and_delete(conn, Some((host, port)), prefix).await?;
+    }
+    Ok(deleted)
+}
+
+async fn scan_node_and_delete(
+    conn: &mut ClusterConnection,
+    master: Option<(String, u16)>,
+    prefix: &str,
+) -> Result<usize> {
+    let pattern = format!("{prefix}*");
+    let mut cursor = 0_u64;
+    let mut deleted = 0_usize;
+
+    loop {
+        let mut cmd = redis::cmd("SCAN");
+        cmd.arg(cursor)
+            .arg("MATCH")
+            .arg(&pattern)
+            .arg("COUNT")
+            .arg(100_usize);
+
+        let scanned = match &master {
+            Some((host, port)) => conn
+                .route_command(
+                    cmd,
+                    RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+                        host: host.clone(),
+                        port: *port,
+                    }),
+                )
+                .await
+                .map_err(GatewayError::from)?,
+            None => cmd.query_async(conn).await.map_err(GatewayError::from)?,
+        };
+
+        let (next_cursor, keys) = parse_scan_page(scanned)?;
+        for key in keys {
+            let count: usize = redis::cmd("DEL")
+                .arg(&key)
+                .query_async(&mut *conn)
+                .await
+                .map_err(GatewayError::from)?;
+            deleted += count;
+        }
+
+        if next_cursor == 0 {
+            break;
+        }
+        cursor = next_cursor;
+    }
+
+    Ok(deleted)
+}
+
+fn cluster_master_addrs(slots: &Value) -> Vec<(String, u16)> {
+    let Value::Array(ranges) = slots else {
+        return Vec::new();
+    };
+
+    let mut masters = Vec::new();
+    for range in ranges {
+        let Value::Array(item) = range else {
+            continue;
+        };
+        if item.len() < 3 {
+            continue;
+        }
+        let Value::Array(node) = &item[2] else {
+            continue;
+        };
+        if node.len() < 2 {
+            continue;
+        }
+        let host = match &node[0] {
+            Value::BulkString(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            _ => continue,
+        };
+        let port = match node[1] {
+            Value::Int(port) => port as u16,
+            _ => continue,
+        };
+        if !masters
+            .iter()
+            .any(|(existing, p)| existing == &host && *p == port)
+        {
+            masters.push((host, port));
+        }
+    }
+    masters
+}
+
+fn parse_scan_page(value: Value) -> Result<(u64, Vec<String>)> {
+    redis::from_redis_value(value)
+        .map_err(|error| GatewayError::Storage(format!("Invalid Redis SCAN response: {error}")))
 }

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -28,5 +28,5 @@ mod rate_limit;
 mod tests;
 
 // Re-export public types
-pub use pool::{RedisConnection, RedisPool};
+pub use pool::{RedisConnection, RedisPool, cluster_hash_tag};
 pub use pubsub::Subscription;

--- a/src/storage/redis/pool.rs
+++ b/src/storage/redis/pool.rs
@@ -4,18 +4,84 @@
 
 use crate::config::models::storage::RedisConfig;
 use crate::utils::error::gateway_error::{GatewayError, Result};
-use redis::{AsyncConnectionConfig, Client, aio::MultiplexedConnection};
+use redis::aio::{ConnectionLike, MultiplexedConnection};
+use redis::cluster::ClusterClient;
+use redis::cluster_async::ClusterConnection;
+use redis::{AsyncConnectionConfig, Client, Cmd, Pipeline, RedisFuture, Value};
+use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info};
+
+/// Format a Redis Cluster hash-tagged key so related keys map to one hash slot.
+///
+/// Cluster hashes only the substring between `{` and `}`. Use this when multiple
+/// keys must participate in one atomic Lua script or MULTI/EXEC. Single-key
+/// operations (including the rate-limit scripts, which use `KEYS[1]` only) do
+/// not need a hash tag.
+pub fn cluster_hash_tag(tag: &str, suffix: &str) -> String {
+    format!("{{{tag}}}{suffix}")
+}
+
+/// Split `storage.redis.url` into cluster seed nodes. A single seed is enough;
+/// comma-separated `redis://` / `rediss://` URLs are also accepted.
+pub(crate) fn cluster_seed_urls(url: &str) -> Vec<&str> {
+    url.split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect()
+}
+
+/// Live Redis connection used by both standalone and cluster modes.
+#[derive(Clone)]
+pub(crate) enum RedisLiveConnection {
+    Standalone(MultiplexedConnection),
+    Cluster(ClusterConnection),
+}
+
+impl fmt::Debug for RedisLiveConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Standalone(_) => write!(f, "Standalone"),
+            Self::Cluster(_) => write!(f, "Cluster"),
+        }
+    }
+}
+
+impl ConnectionLike for RedisLiveConnection {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        match self {
+            Self::Standalone(conn) => conn.req_packed_command(cmd),
+            Self::Cluster(conn) => conn.req_packed_command(cmd),
+        }
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        pipeline: &'a Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<'a, Vec<Value>> {
+        match self {
+            Self::Standalone(conn) => conn.req_packed_commands(pipeline, offset, count),
+            Self::Cluster(conn) => conn.req_packed_commands(pipeline, offset, count),
+        }
+    }
+
+    fn get_db(&self) -> i64 {
+        match self {
+            Self::Standalone(conn) => conn.get_db(),
+            Self::Cluster(conn) => conn.get_db(),
+        }
+    }
+}
 
 /// Redis connection pool (supports no-op mode when Redis is unavailable)
 #[derive(Debug, Clone)]
 pub struct RedisPool {
-    /// Redis client (None in no-op mode)
-    pub(crate) client: Option<Client>,
-    /// Connection manager (None in no-op mode)
-    pub(crate) connection_manager: Option<MultiplexedConnection>,
+    /// Live connection (None in no-op mode)
+    pub(crate) connection: Option<RedisLiveConnection>,
     /// Configuration
     pub(crate) config: RedisConfig,
     /// Whether this is a no-op pool (Redis unavailable)
@@ -26,7 +92,7 @@ pub struct RedisPool {
 
 /// Redis connection wrapper
 pub struct RedisConnection {
-    pub(crate) conn: Option<MultiplexedConnection>,
+    pub(crate) conn: Option<RedisLiveConnection>,
     /// Held permit that is released when the connection is dropped
     pub(crate) _permit: Option<OwnedSemaphorePermit>,
 }
@@ -40,70 +106,92 @@ impl RedisPool {
 
         if !config.enabled {
             info!("Redis disabled in config; using no-op Redis pool");
-            return Ok(Self {
-                client: None,
-                connection_manager: None,
-                config: config.clone(),
-                noop_mode: true,
-                semaphore: Arc::new(Semaphore::new(1)),
-            });
+            return Ok(Self::noop_from_config(config));
         }
 
-        info!("Creating Redis connection pool");
         debug!("Redis URL: {}", Self::sanitize_url(&config.url));
         debug!(
-            "Redis max_connections: {}, connection_timeout: {}s",
-            config.max_connections, config.connection_timeout
+            "Redis max_connections: {}, connection_timeout: {}s, cluster: {}",
+            config.max_connections, config.connection_timeout, config.cluster
         );
 
-        let client = Client::open(config.url.as_str()).map_err(GatewayError::from)?;
-
-        let async_config = AsyncConnectionConfig::new().set_connection_timeout(Some(
-            std::time::Duration::from_secs(config.connection_timeout),
-        ));
-
-        let connection_manager = client
-            .get_multiplexed_async_connection_with_config(&async_config)
-            .await
-            .map_err(GatewayError::from)?;
+        let connection = if config.cluster {
+            info!("Creating Redis Cluster connection pool");
+            Some(Self::connect_cluster(config).await?)
+        } else {
+            info!("Creating Redis connection pool");
+            Some(Self::connect_standalone(config).await?)
+        };
 
         let max_connections = config.max_connections.max(1) as usize;
 
         info!(
-            "Redis connection pool created successfully (max_connections={})",
-            max_connections
+            "Redis connection pool created successfully (max_connections={}, cluster={})",
+            max_connections, config.cluster
         );
         Ok(Self {
-            client: Some(client),
-            connection_manager: Some(connection_manager),
+            connection,
             config: config.clone(),
             noop_mode: false,
             semaphore: Arc::new(Semaphore::new(max_connections)),
         })
     }
 
-    /// Create a no-op Redis pool (for when Redis is unavailable)
-    pub fn create_noop() -> Self {
-        info!("Creating no-op Redis pool (Redis unavailable)");
+    async fn connect_standalone(config: &RedisConfig) -> Result<RedisLiveConnection> {
+        let client = Client::open(config.url.as_str()).map_err(GatewayError::from)?;
+        let async_config = AsyncConnectionConfig::new()
+            .set_connection_timeout(Some(Duration::from_secs(config.connection_timeout)));
+        let connection = client
+            .get_multiplexed_async_connection_with_config(&async_config)
+            .await
+            .map_err(GatewayError::from)?;
+        Ok(RedisLiveConnection::Standalone(connection))
+    }
+
+    async fn connect_cluster(config: &RedisConfig) -> Result<RedisLiveConnection> {
+        let seeds = cluster_seed_urls(&config.url);
+        let timeout = Duration::from_secs(config.connection_timeout);
+        let client = ClusterClient::builder(seeds)
+            .connection_timeout(timeout)
+            .build()
+            .map_err(GatewayError::from)?;
+        let connection = client
+            .get_async_connection()
+            .await
+            .map_err(GatewayError::from)?;
+        Ok(RedisLiveConnection::Cluster(connection))
+    }
+
+    fn noop_from_config(config: &RedisConfig) -> Self {
         Self {
-            client: None,
-            connection_manager: None,
-            config: RedisConfig {
-                url: String::new(),
-                enabled: false,
-                max_connections: 0,
-                connection_timeout: 0,
-                cluster: false,
-                allow_degraded: false,
-            },
+            connection: None,
+            config: config.clone(),
             noop_mode: true,
             semaphore: Arc::new(Semaphore::new(1)),
         }
     }
 
+    /// Create a no-op Redis pool (for when Redis is unavailable)
+    pub fn create_noop() -> Self {
+        info!("Creating no-op Redis pool (Redis unavailable)");
+        Self::noop_from_config(&RedisConfig {
+            url: String::new(),
+            enabled: false,
+            max_connections: 0,
+            connection_timeout: 0,
+            cluster: false,
+            allow_degraded: false,
+        })
+    }
+
     /// Check if this is a no-op pool
     pub fn is_noop(&self) -> bool {
         self.noop_mode
+    }
+
+    /// Whether this pool uses Redis Cluster routing.
+    pub(crate) fn is_cluster(&self) -> bool {
+        self.config.cluster && !self.noop_mode
     }
 
     /// Get a connection from the pool.
@@ -127,7 +215,7 @@ impl RedisPool {
             .map_err(|_| GatewayError::Internal("Redis semaphore closed".to_string()))?;
 
         Ok(RedisConnection {
-            conn: self.connection_manager.clone(),
+            conn: self.connection.clone(),
             _permit: Some(permit),
         })
     }
@@ -171,5 +259,27 @@ impl RedisPool {
         } else {
             "invalid_url".to_string()
         }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::{cluster_hash_tag, cluster_seed_urls};
+
+    #[test]
+    fn cluster_hash_tag_wraps_only_the_tag() {
+        assert_eq!(cluster_hash_tag("cache", ":user:1"), "{cache}:user:1");
+    }
+
+    #[test]
+    fn cluster_seed_urls_split_comma_separated_seeds() {
+        assert_eq!(
+            cluster_seed_urls("redis://127.0.0.1:7000, redis://127.0.0.1:7001"),
+            vec!["redis://127.0.0.1:7000", "redis://127.0.0.1:7001"]
+        );
+        assert_eq!(
+            cluster_seed_urls("redis://127.0.0.1:7000"),
+            vec!["redis://127.0.0.1:7000"]
+        );
     }
 }

--- a/src/storage/redis/rate_limit.rs
+++ b/src/storage/redis/rate_limit.rs
@@ -1,4 +1,7 @@
 //! Redis-backed rate limit operations.
+//!
+//! Lua scripts below use a single `KEYS[1]` so they stay cluster-safe without
+//! a hash tag. Multi-key atomics should use [`super::cluster_hash_tag`].
 
 use super::pool::RedisPool;
 use crate::core::rate_limiter::RateLimitResult;

--- a/src/storage/redis/tests.rs
+++ b/src/storage/redis/tests.rs
@@ -3,8 +3,15 @@
 use super::pool::RedisPool;
 use crate::config::models::storage::{RedisConfig, StorageConfig};
 use crate::storage::StorageLayer;
+use crate::storage::dependency_status::DependencyStatus;
 use crate::utils::error::gateway_error::GatewayError;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 
 #[test]
 fn test_sanitize_url() {
@@ -86,6 +93,40 @@ async fn test_redis_pool_creation_returns_error_for_unreachable_endpoint() {
 }
 
 #[tokio::test]
+async fn cluster_mode_fails_to_connect_to_unreachable_seed() {
+    let config = unreachable_cluster_config(true);
+
+    let error = RedisPool::new(&config)
+        .await
+        .expect_err("unreachable cluster seed must fail instead of using a standalone client");
+    assert!(matches!(error, GatewayError::Storage(_)));
+}
+
+#[tokio::test]
+async fn storage_unreachable_cluster_fails_startup_unless_degraded() {
+    let mut config = StorageConfig {
+        redis: unreachable_cluster_config(false),
+        ..StorageConfig::default()
+    };
+
+    let error = StorageLayer::new(&config)
+        .await
+        .expect_err("strict cluster mode must fail startup when the seed is unreachable");
+    assert!(matches!(error, GatewayError::Storage(_)));
+    assert!(
+        !error.to_string().contains("not implemented"),
+        "got: {error}"
+    );
+
+    config.redis.allow_degraded = true;
+    let storage = StorageLayer::new(&config)
+        .await
+        .expect("allow_degraded must continue with a no-op pool");
+    assert!(storage.redis.is_noop());
+    assert_eq!(storage.redis_status, DependencyStatus::Degraded);
+}
+
+#[tokio::test]
 async fn test_redis_pool_disabled_is_noop() {
     let config = RedisConfig {
         url: "redis://127.0.0.1:1".to_string(),
@@ -103,47 +144,6 @@ async fn test_redis_pool_disabled_is_noop() {
 }
 
 #[tokio::test]
-async fn cluster_mode_is_rejected_before_standalone_connection_attempt() {
-    let config = RedisConfig {
-        url: "redis://127.0.0.1:1".to_string(),
-        enabled: true,
-        max_connections: 10,
-        connection_timeout: 1,
-        cluster: true,
-        allow_degraded: true,
-    };
-
-    let error = RedisPool::new(&config)
-        .await
-        .expect_err("cluster mode must fail instead of degrading or connecting");
-    let message = error.to_string();
-
-    assert!(
-        message.contains("storage.redis.cluster=true"),
-        "got: {message}"
-    );
-    assert!(
-        message.contains("storage.redis.cluster=false"),
-        "got: {message}"
-    );
-}
-
-#[tokio::test]
-async fn storage_rejects_cluster_mode_before_optional_dependency_initialization() {
-    let mut config = StorageConfig::default();
-    config.redis.enabled = true;
-    config.redis.cluster = true;
-    config.redis.allow_degraded = true;
-
-    let error = StorageLayer::new(&config)
-        .await
-        .expect_err("cluster mode must be rejected rather than degraded");
-
-    assert!(matches!(error, GatewayError::Config(_)));
-    assert!(error.to_string().contains("storage.redis.cluster=false"));
-}
-
-#[tokio::test]
 async fn test_redis_delete_by_prefix_disabled_is_noop() {
     let pool = RedisPool::create_noop();
 
@@ -152,6 +152,94 @@ async fn test_redis_delete_by_prefix_disabled_is_noop() {
         .await
         .expect("disabled redis prefix delete should not fail");
     assert_eq!(deleted, 0);
+}
+
+#[tokio::test]
+async fn cluster_mock_supports_get_set_mget_and_prefix_delete() {
+    let mock = MockCluster::bind(false).await;
+    let pool = cluster_pool_for(&mock.url).await;
+
+    pool.set("alpha", "1", None)
+        .await
+        .expect("cluster set should succeed");
+    pool.set("beta", "2", None)
+        .await
+        .expect("cluster set should succeed");
+
+    assert_eq!(pool.get("alpha").await.expect("get"), Some("1".to_string()));
+
+    let values = pool
+        .mget(&[
+            "alpha".to_string(),
+            "missing".to_string(),
+            "beta".to_string(),
+        ])
+        .await
+        .expect("cluster mget should preserve order without CROSSSLOT");
+    assert_eq!(
+        values,
+        vec![Some("1".to_string()), None, Some("2".to_string())]
+    );
+
+    pool.mset(
+        &[
+            ("gamma".to_string(), "3".to_string()),
+            ("delta".to_string(), "4".to_string()),
+        ],
+        None,
+    )
+    .await
+    .expect("cluster mset should issue per-key SET");
+    assert_eq!(pool.get("gamma").await.expect("get"), Some("3".to_string()));
+
+    let deleted = pool
+        .delete_by_prefix("g")
+        .await
+        .expect("cluster prefix delete should SCAN masters");
+    assert_eq!(deleted, 1);
+    assert!(pool.get("gamma").await.expect("get").is_none());
+    assert_eq!(pool.get("delta").await.expect("get"), Some("4".to_string()));
+}
+
+#[tokio::test]
+async fn cluster_mock_follows_moved_redirection() {
+    let mock = MockCluster::bind(true).await;
+    let pool = cluster_pool_for(&mock.url).await;
+
+    pool.set("moved-key", "ok", None)
+        .await
+        .expect("set before redirected get");
+    let value = pool
+        .get("moved-key")
+        .await
+        .expect("cluster client should retry after MOVED");
+    assert_eq!(value.as_deref(), Some("ok"));
+    assert!(mock.redirected.load(Ordering::SeqCst));
+}
+
+async fn cluster_pool_for(url: &str) -> RedisPool {
+    let config = RedisConfig {
+        url: url.to_string(),
+        enabled: true,
+        max_connections: 4,
+        connection_timeout: 2,
+        cluster: true,
+        allow_degraded: false,
+    };
+    RedisPool::new(&config)
+        .await
+        .unwrap_or_else(|error| panic!("mock cluster should accept ClusterClient: {error}"))
+}
+
+fn unreachable_cluster_config(allow_degraded: bool) -> RedisConfig {
+    RedisConfig {
+        url: "redis://127.0.0.1:1".to_string(),
+        enabled: true,
+        max_connections: 10,
+        connection_timeout: 1,
+        cluster: true,
+        allow_degraded,
+    }
 }
 
 async fn live_redis_pool() -> Option<RedisPool> {
@@ -194,4 +282,220 @@ fn unique_test_key(suffix: &str) -> String {
         .expect("system time should be after unix epoch")
         .as_nanos();
     format!("litellm-rs:test:{suffix}:{nanos}")
+}
+
+/// In-process Redis Cluster RESP mock (PING / CLUSTER SLOTS / GET / SET / SCAN / DEL).
+///
+/// CI does not run a real cluster. This handshake is the minimum
+/// `redis::cluster_async::ClusterClient` accepts for a single-node mapping.
+struct MockCluster {
+    url: String,
+    redirected: Arc<AtomicBool>,
+}
+
+impl MockCluster {
+    async fn bind(redirect_first_get: bool) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock cluster should bind");
+        let addr = listener.local_addr().expect("mock cluster address");
+        let store = Arc::new(Mutex::new(HashMap::<String, String>::new()));
+        let redirected = Arc::new(AtomicBool::new(false));
+        let pending_redirect = Arc::new(AtomicBool::new(redirect_first_get));
+        let host = addr.ip().to_string();
+        let port = addr.port();
+        let accept_redirected = Arc::clone(&redirected);
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let store = Arc::clone(&store);
+                let pending_redirect = Arc::clone(&pending_redirect);
+                let redirected = Arc::clone(&accept_redirected);
+                let host = host.clone();
+                tokio::spawn(async move {
+                    serve_mock_cluster(stream, store, pending_redirect, redirected, host, port)
+                        .await;
+                });
+            }
+        });
+
+        Self {
+            url: format!("redis://{addr}"),
+            redirected,
+        }
+    }
+}
+
+async fn serve_mock_cluster(
+    mut stream: tokio::net::TcpStream,
+    store: Arc<Mutex<HashMap<String, String>>>,
+    pending_redirect: Arc<AtomicBool>,
+    redirected: Arc<AtomicBool>,
+    host: String,
+    port: u16,
+) {
+    let mut buf = Vec::new();
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let n = match stream.read(&mut chunk).await {
+            Ok(0) | Err(_) => return,
+            Ok(n) => n,
+        };
+        buf.extend_from_slice(&chunk[..n]);
+
+        while let Some((args, consumed)) = parse_resp_array(&buf) {
+            buf.drain(..consumed);
+            let reply =
+                handle_mock_command(&args, &store, &pending_redirect, &redirected, &host, port)
+                    .await;
+            if stream.write_all(&reply).await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+async fn handle_mock_command(
+    args: &[Vec<u8>],
+    store: &Arc<Mutex<HashMap<String, String>>>,
+    pending_redirect: &Arc<AtomicBool>,
+    redirected: &Arc<AtomicBool>,
+    host: &str,
+    port: u16,
+) -> Vec<u8> {
+    let name = args
+        .first()
+        .map(|arg| String::from_utf8_lossy(arg).to_ascii_uppercase())
+        .unwrap_or_default();
+    match name.as_str() {
+        "PING" => b"+PONG\r\n".to_vec(),
+        "READONLY" | "CLIENT" | "OK" => b"+OK\r\n".to_vec(),
+        "CLUSTER"
+            if args
+                .get(1)
+                .is_some_and(|arg| eq_ignore_ascii(arg, b"SLOTS")) =>
+        {
+            cluster_slots_resp(host, port)
+        }
+        "GET" => {
+            let key = arg_str(args, 1);
+            if pending_redirect.swap(false, Ordering::SeqCst) {
+                redirected.store(true, Ordering::SeqCst);
+                return format!("-MOVED 123 {host}:{port}\r\n").into_bytes();
+            }
+            match store.lock().await.get(&key) {
+                Some(value) => bulk_string(value),
+                None => b"$-1\r\n".to_vec(),
+            }
+        }
+        "SET" | "SETEX" => {
+            let (key, value) = if name == "SETEX" {
+                (arg_str(args, 1), arg_str(args, 3))
+            } else {
+                (arg_str(args, 1), arg_str(args, 2))
+            };
+            store.lock().await.insert(key, value);
+            b"+OK\r\n".to_vec()
+        }
+        "DEL" => {
+            let key = arg_str(args, 1);
+            let removed = store.lock().await.remove(&key).is_some() as i64;
+            format!(":{removed}\r\n").into_bytes()
+        }
+        "SCAN" => {
+            let pattern = scan_pattern(args);
+            let keys: Vec<String> = store
+                .lock()
+                .await
+                .keys()
+                .filter(|key| glob_prefix_match(key, &pattern))
+                .cloned()
+                .collect();
+            scan_resp(&keys)
+        }
+        "EXISTS" => {
+            let present = store.lock().await.contains_key(&arg_str(args, 1)) as i64;
+            format!(":{present}\r\n").into_bytes()
+        }
+        _ => b"-ERR unknown command\r\n".to_vec(),
+    }
+}
+
+fn arg_str(args: &[Vec<u8>], index: usize) -> String {
+    args.get(index)
+        .map(|arg| String::from_utf8_lossy(arg).into_owned())
+        .unwrap_or_default()
+}
+
+fn eq_ignore_ascii(value: &[u8], expected: &[u8]) -> bool {
+    value.eq_ignore_ascii_case(expected)
+}
+
+fn scan_pattern(args: &[Vec<u8>]) -> String {
+    args.windows(2)
+        .find(|pair| eq_ignore_ascii(&pair[0], b"MATCH"))
+        .map(|pair| String::from_utf8_lossy(&pair[1]).into_owned())
+        .unwrap_or_else(|| "*".to_string())
+}
+
+fn glob_prefix_match(key: &str, pattern: &str) -> bool {
+    pattern
+        .strip_suffix('*')
+        .map(|prefix| key.starts_with(prefix))
+        .unwrap_or_else(|| key == pattern)
+}
+
+fn bulk_string(value: &str) -> Vec<u8> {
+    format!("${}\r\n{}\r\n", value.len(), value).into_bytes()
+}
+
+fn cluster_slots_resp(host: &str, port: u16) -> Vec<u8> {
+    format!(
+        "*1\r\n*3\r\n:0\r\n:16383\r\n*2\r\n${}\r\n{host}\r\n:{port}\r\n",
+        host.len()
+    )
+    .into_bytes()
+}
+
+fn scan_resp(keys: &[String]) -> Vec<u8> {
+    let mut out = format!("*2\r\n$1\r\n0\r\n*{}\r\n", keys.len()).into_bytes();
+    for key in keys {
+        out.extend(bulk_string(key));
+    }
+    out
+}
+
+fn parse_resp_array(buf: &[u8]) -> Option<(Vec<Vec<u8>>, usize)> {
+    if buf.first()? != &b'*' {
+        return None;
+    }
+    let (count, mut pos) = parse_crlf_int(buf, 1)?;
+    if count < 0 {
+        return None;
+    }
+    let mut args = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        if buf.get(pos)? != &b'$' {
+            return None;
+        }
+        let (len, next) = parse_crlf_int(buf, pos + 1)?;
+        pos = next;
+        let len = usize::try_from(len).ok()?;
+        if buf.len() < pos + len + 2 || &buf[pos + len..pos + len + 2] != b"\r\n" {
+            return None;
+        }
+        args.push(buf[pos..pos + len].to_vec());
+        pos += len + 2;
+    }
+    Some((args, pos))
+}
+
+fn parse_crlf_int(buf: &[u8], start: usize) -> Option<(i64, usize)> {
+    let rest = buf.get(start..)?;
+    let cr = rest.windows(2).position(|window| window == b"\r\n")?;
+    let value = std::str::from_utf8(rest.get(..cr)?).ok()?.parse().ok()?;
+    Some((value, start + cr + 2))
 }

--- a/tests/integration/config_validation_tests.rs
+++ b/tests/integration/config_validation_tests.rs
@@ -521,14 +521,10 @@ mod tests {
         .await
         .expect("overlay config should be written");
 
-        let standalone_error = Config::from_file(&base_path)
+        let loaded = Config::from_file(&base_path)
             .await
-            .expect_err("standalone cluster config must still fail final validation");
-        assert!(
-            standalone_error
-                .to_string()
-                .contains("storage.redis.cluster=false")
-        );
+            .expect("cluster=true with a valid Redis URL should pass validation");
+        assert!(loaded.gateway.storage.redis.cluster);
 
         let base = Config::overlay_from_file(base_path)
             .await


### PR DESCRIPTION
## What

Honor `storage.redis.cluster=true` through the existing `RedisPool` API. Standalone still uses a multiplexed client; cluster mode uses `ClusterClient` from the configured seed URL(s).

## Why

Cluster mode was rejected at validation, so shared-state deployments that already run Redis Cluster could not start. This keeps one storage API and makes multi-key ops slot-safe.

Fixes #1278

## Changes

- Drop the validation reject of `cluster=true` (empty/invalid URLs still fail).
- Add an internal `RedisLiveConnection` enum so `get`/`set`/`del`/`eval` share `AsyncCommands`.
- Cluster `mget`/`mset` use per-key GET/SET; `delete_by_prefix` SCAN's each master.
- Unreachable cluster follows `allow_degraded` via the existing `StorageLayer` path.
- CI-safe mock RESP cluster (PING / CLUSTER SLOTS / GET/SET / optional `MOVED`).

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] Focused Redis/storage/config tests (standalone live pool, unreachable cluster, mock cluster + MOVED, validation)
- [ ] Fast Test CI SUCCESS (rerun if the 30m job is cancelled)

## AI disclosure

Implemented with Cursor Grok 4.6.

Made with [Cursor](https://cursor.com)