### PR TITLE
feat(admin-ui): add provider create and edit workflow

### DIFF
--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -98,6 +98,7 @@ pub fn is_public_route(path: &str) -> bool {
         "/admin/dashboard/app.css",
         "/admin/dashboard/app.js",
         "/admin/dashboard/budget.js",
+        "/admin/dashboard/providers.js",
         "/admin/dashboard/provider-health.js",
         "/admin/dashboard/routing-inventory.js",
         "/docs",

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -96,6 +96,7 @@ fn test_is_public_route() {
     assert!(is_public_route("/admin/dashboard/app.css"));
     assert!(is_public_route("/admin/dashboard/app.js"));
     assert!(is_public_route("/admin/dashboard/budget.js"));
+    assert!(is_public_route("/admin/dashboard/providers.js"));
     assert!(is_public_route("/admin/dashboard/provider-health.js"));
     assert!(is_public_route("/admin/dashboard/routing-inventory.js"));
     // /metrics requires authentication (not in PUBLIC_ROUTES)
@@ -106,6 +107,7 @@ fn test_is_public_route() {
     assert!(!is_public_route("/admin/dashboard/private"));
     assert!(!is_public_route("/admin/dashboard/app.js.map"));
     assert!(!is_public_route("/admin/dashboard/budget.js.map"));
+    assert!(!is_public_route("/admin/dashboard/providers.js.map"));
     assert!(!is_public_route("/admin/dashboard/provider-health.js.map"));
     assert!(!is_public_route(
         "/admin/dashboard/routing-inventory.js.map"

--- a/src/server/routes/admin_dashboard.rs
+++ b/src/server/routes/admin_dashboard.rs
@@ -7,6 +7,7 @@ const INDEX_HTML: &str = include_str!("admin_dashboard/index.html");
 const APP_CSS: &str = include_str!("admin_dashboard/app.css");
 const APP_JS: &str = include_str!("admin_dashboard/app.js");
 const BUDGET_JS: &str = include_str!("admin_dashboard/budget.js");
+const PROVIDERS_JS: &str = include_str!("admin_dashboard/providers.js");
 const PROVIDER_HEALTH_JS: &str = include_str!("admin_dashboard/provider_health.js");
 const ROUTING_INVENTORY_JS: &str = include_str!("admin_dashboard/routing_inventory.js");
 const REQUEST_LEDGER_JS: &str = include_str!("admin_dashboard/request_ledger.js");
@@ -50,6 +51,10 @@ async fn budget_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", BUDGET_JS)
 }
 
+async fn providers_javascript() -> HttpResponse {
+    embedded_asset("text/javascript; charset=utf-8", PROVIDERS_JS)
+}
+
 /// Register the exact dashboard asset routes.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/admin/dashboard", web::get().to(dashboard))
@@ -69,6 +74,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/admin/dashboard/budget.js",
             web::get().to(budget_javascript),
+        )
+        .route(
+            "/admin/dashboard/providers.js",
+            web::get().to(providers_javascript),
         )
         .route("/admin/dashboard/app.js", web::get().to(javascript));
 }
@@ -118,6 +127,11 @@ mod tests {
                 "text/javascript; charset=utf-8",
                 "createBudgetView",
             ),
+            (
+                "/admin/dashboard/providers.js",
+                "text/javascript; charset=utf-8",
+                "createProviderEditorView",
+            ),
         ];
 
         for (path, content_type, marker) in cases {
@@ -158,6 +172,7 @@ mod tests {
             "/admin/dashboard/budget.js.map",
             "/admin/dashboard/routing-inventory.js.map",
             "/admin/dashboard/request-ledger.js.map",
+            "/admin/dashboard/providers.js.map",
             "/admin/dashboard/private",
         ] {
             let response = actix_test::call_service(
@@ -185,12 +200,14 @@ mod tests {
         assert!(REQUEST_LEDGER_JS.contains("\"/admin/request-ledger\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/providers\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/models\""));
+        assert!(PROVIDERS_JS.contains("\"/admin/providers\""));
         for asset in [
             APP_JS,
             PROVIDER_HEALTH_JS,
             ROUTING_INVENTORY_JS,
             REQUEST_LEDGER_JS,
             BUDGET_JS,
+            PROVIDERS_JS,
         ] {
             for forbidden in [
                 "localStorage",
@@ -250,6 +267,15 @@ mod tests {
             "id=\"request-logs-body\"",
             "id=\"request-logs-empty\"",
             "id=\"request-logs-detail\"",
+            "id=\"providers-panel\"",
+            "id=\"create-provider-form\"",
+            "id=\"edit-provider-form\"",
+            "id=\"providers-body\"",
+            "id=\"providers-empty\"",
+            "id=\"provider-create-api-key\"",
+            "id=\"provider-edit-api-key\"",
+            "id=\"provider-edit-api-key-ref\"",
+            "id=\"providers-notice\"",
         ] {
             assert!(INDEX_HTML.contains(marker), "missing HTML marker {marker}");
         }

--- a/src/server/routes/admin_dashboard/app.css
+++ b/src/server/routes/admin_dashboard/app.css
@@ -329,7 +329,8 @@ td code {
   margin: 0 0 0.65rem;
 }
 
-.budget-actions {
+.budget-actions,
+.provider-actions {
   display: flex;
   min-width: 13rem;
   gap: 0.45rem;

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -78,6 +78,7 @@ function resetProtectedState() {
   routingInventoryView.reset();
   requestLedgerView.reset();
   budgetView.reset();
+  providerEditorView.reset();
 }
 function endSession(message = "Signed out") {
   abortActiveRequests();
@@ -411,6 +412,10 @@ const requestLedgerView = window.createRequestLedgerView({
   textCell,
 });
 const budgetView = window.createBudgetView({
+  apiRequest, beginBusy, byId, captureSession, clearError, createAction, endBusy,
+  ensureCurrent, reportRequestError, setStatus, textCell,
+});
+const providerEditorView = window.createProviderEditorView({
   apiRequest, beginBusy, byId, captureSession, clearError, createAction, endBusy,
   ensureCurrent, reportRequestError, setStatus, textCell,
 });
@@ -754,7 +759,7 @@ function showView(view) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-selected", String(active));
   }
-  for (const panel of ["keys", "teams", "spend", "budgets", "health", "routing", "request-logs"]) {
+  for (const panel of ["keys", "teams", "spend", "budgets", "providers", "health", "routing", "request-logs"]) {
     byId(`${panel}-panel`).hidden = panel !== view;
   }
   if (view === "spend") {
@@ -762,6 +767,9 @@ function showView(view) {
   }
   if (view === "budgets") {
     void budgetView.loadOnce();
+  }
+  if (view === "providers") {
+    void providerEditorView.loadOnce();
   }
   if (view === "request-logs") {
     void requestLedgerView.loadOnce();

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -10,6 +10,7 @@
   <script src="/admin/dashboard/routing-inventory.js" defer></script>
   <script src="/admin/dashboard/request-ledger.js" defer></script>
   <script src="/admin/dashboard/budget.js" defer></script>
+  <script src="/admin/dashboard/providers.js" defer></script>
   <script src="/admin/dashboard/app.js" defer></script>
 </head>
 <body>
@@ -53,6 +54,8 @@
                 aria-controls="spend-panel" aria-selected="false">Spend</button>
         <button class="tab" type="button" data-view="budgets"
                 aria-controls="budgets-panel" aria-selected="false">Budgets</button>
+        <button class="tab" type="button" data-view="providers"
+                aria-controls="providers-panel" aria-selected="false">Providers</button>
         <button class="tab" type="button" data-view="health"
                 aria-controls="health-panel" aria-selected="false">Provider health</button>
         <button class="tab" type="button" data-view="routing"
@@ -313,6 +316,106 @@
             </p>
           </div>
         </div>
+      </section>
+
+      <section id="providers-panel" class="panel" aria-labelledby="providers-title" hidden>
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Runtime configuration</p>
+            <h2 id="providers-title">Providers</h2>
+            <p>Create, edit, disable, or delete providers. Secrets accept
+              replacement references only and are never loaded from GET.</p>
+          </div>
+          <button id="refresh-providers" class="secondary" type="button">Refresh</button>
+        </div>
+
+        <details class="create-card">
+          <summary>Create a provider</summary>
+          <form id="create-provider-form" class="form-grid">
+            <label for="provider-create-name">Name</label>
+            <input id="provider-create-name" name="name" required maxlength="120">
+            <label for="provider-create-type">Type</label>
+            <input id="provider-create-type" name="provider_type" required
+                   maxlength="120" placeholder="openai">
+            <label for="provider-create-api-key">API key</label>
+            <input id="provider-create-api-key" name="api_key"
+                   placeholder="replacement reference only"
+                   autocomplete="off">
+            <p class="field-help">Use a ${ENV_VAR} reference. Raw keys are rejected.</p>
+            <label for="provider-create-base-url">Base URL</label>
+            <input id="provider-create-base-url" name="base_url" maxlength="500">
+            <label for="provider-create-models">Models</label>
+            <input id="provider-create-models" name="models"
+                   placeholder="gpt-4o, gpt-4o-mini">
+            <label for="provider-create-tags">Tags</label>
+            <input id="provider-create-tags" name="tags">
+            <label for="provider-create-weight">Weight</label>
+            <input id="provider-create-weight" name="weight" type="number"
+                   step="any" value="1">
+            <label for="provider-create-priority">Priority</label>
+            <input id="provider-create-priority" name="priority" type="number"
+                   step="1" value="0">
+            <label class="checkbox-row" for="provider-create-enabled">
+              <input id="provider-create-enabled" name="enabled" type="checkbox" checked>
+              Enabled
+            </label>
+            <button type="submit">Create provider</button>
+          </form>
+        </details>
+
+        <details id="provider-editor" class="create-card" hidden>
+          <summary>Edit provider</summary>
+          <form id="edit-provider-form" class="form-grid">
+            <label for="provider-edit-name">Name</label>
+            <input id="provider-edit-name" name="name" required maxlength="120"
+                   readonly>
+            <label for="provider-edit-type">Type</label>
+            <input id="provider-edit-type" name="provider_type" required
+                   maxlength="120">
+            <label for="provider-edit-api-key">API key</label>
+            <input id="provider-edit-api-key" name="api_key"
+                   placeholder="replacement reference only"
+                   autocomplete="off">
+            <p id="provider-edit-api-key-ref" class="field-help"></p>
+            <label for="provider-edit-base-url">Base URL</label>
+            <input id="provider-edit-base-url" name="base_url" maxlength="500">
+            <label for="provider-edit-models">Models</label>
+            <input id="provider-edit-models" name="models">
+            <label for="provider-edit-tags">Tags</label>
+            <input id="provider-edit-tags" name="tags">
+            <label for="provider-edit-weight">Weight</label>
+            <input id="provider-edit-weight" name="weight" type="number" step="any">
+            <label for="provider-edit-priority">Priority</label>
+            <input id="provider-edit-priority" name="priority" type="number" step="1">
+            <label class="checkbox-row" for="provider-edit-enabled">
+              <input id="provider-edit-enabled" name="enabled" type="checkbox">
+              Enabled
+            </label>
+            <button type="submit">Save provider</button>
+            <button id="cancel-provider-edit" class="secondary" type="button">
+              Cancel edit
+            </button>
+          </form>
+        </details>
+
+        <p id="providers-notice" class="health-notice" aria-live="polite"></p>
+        <div class="table-wrap">
+          <table>
+            <caption>Configured providers from the live runtime</caption>
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Type</th>
+                <th scope="col">Enabled</th>
+                <th scope="col">Models</th>
+                <th scope="col">Secret</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody id="providers-body"></tbody>
+          </table>
+        </div>
+        <p id="providers-empty" class="empty-state" hidden>No providers configured.</p>
       </section>
 
       <section id="health-panel" class="panel" aria-labelledby="health-title" hidden>

--- a/src/server/routes/admin_dashboard/providers.js
+++ b/src/server/routes/admin_dashboard/providers.js
@@ -1,0 +1,409 @@
+"use strict";
+
+window.createProviderEditorView = function createProviderEditorView({
+  apiRequest,
+  beginBusy,
+  byId,
+  captureSession,
+  clearError,
+  createAction,
+  endBusy,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+  textCell,
+}) {
+  const RUNTIME_NOTICE = "The previous runtime revision is still active.";
+  let providers = [];
+  let requestVersion = 0;
+  let loaded = false;
+  let loadPromise = null;
+  let editingName = null;
+
+  function csvList(value) {
+    return String(value || "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  function formatList(values) {
+    return Array.isArray(values) && values.length ? values.join(", ") : "";
+  }
+
+  function numberField(id, fallback) {
+    const raw = byId(id).value;
+    if (raw === "" || raw == null) {
+      return fallback;
+    }
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      throw new Error("Weight and priority must be finite numbers.");
+    }
+    return value;
+  }
+
+  function sanitize(records) {
+    return records.map((record) => ({
+      name: record.name,
+      provider_type: record.provider_type,
+      base_url: record.base_url,
+      enabled: record.enabled !== false,
+      models: Array.isArray(record.models) ? record.models : [],
+      tags: Array.isArray(record.tags) ? record.tags : [],
+      weight: record.weight,
+      priority: record.priority,
+      api_key_ref: record.api_key_ref,
+    }));
+  }
+
+  function setNotice(message) {
+    byId("providers-notice").textContent = message || "";
+  }
+
+  function setEditorVisible(editing) {
+    byId("provider-editor").hidden = !editing;
+    byId("provider-editor").open = editing;
+  }
+
+  function secretRefText(provider) {
+    if (provider?.api_key_ref) {
+      return `Current reference: ${provider.api_key_ref}`;
+    }
+    return "No replacement reference on file.";
+  }
+
+  function clearCreateForm() {
+    byId("create-provider-form").reset();
+    byId("provider-create-enabled").checked = true;
+  }
+
+  function clearEditor() {
+    editingName = null;
+    byId("edit-provider-form").reset();
+    byId("provider-edit-api-key").value = "";
+    byId("provider-edit-api-key-ref").textContent = "";
+    setEditorVisible(false);
+  }
+
+  function fillEditor(provider) {
+    editingName = provider.name;
+    byId("provider-edit-name").value = provider.name;
+    byId("provider-edit-type").value = provider.provider_type || "";
+    byId("provider-edit-api-key").value = "";
+    byId("provider-edit-api-key-ref").textContent = secretRefText(provider);
+    byId("provider-edit-base-url").value = provider.base_url || "";
+    byId("provider-edit-models").value = formatList(provider.models);
+    byId("provider-edit-tags").value = formatList(provider.tags);
+    byId("provider-edit-weight").value =
+      provider.weight == null ? "" : String(provider.weight);
+    byId("provider-edit-priority").value =
+      provider.priority == null ? "" : String(provider.priority);
+    byId("provider-edit-enabled").checked = provider.enabled !== false;
+    setEditorVisible(true);
+    byId("provider-editor").scrollIntoView?.({
+      behavior: "smooth",
+      block: "nearest",
+    });
+    byId("provider-edit-type").focus();
+  }
+
+  function createPayload(prefix) {
+    const payload = {
+      name: byId(`${prefix}-name`).value.trim(),
+      provider_type: byId(`${prefix}-type`).value.trim(),
+      api_key: byId(`${prefix}-api-key`).value.trim(),
+      base_url: byId(`${prefix}-base-url`).value.trim() || null,
+      models: csvList(byId(`${prefix}-models`).value),
+      tags: csvList(byId(`${prefix}-tags`).value),
+      enabled: byId(`${prefix}-enabled`).checked,
+      weight: numberField(`${prefix}-weight`, 1),
+      priority: numberField(`${prefix}-priority`, 0),
+    };
+    if (!payload.name) {
+      throw new Error("Provider name cannot be empty.");
+    }
+    if (!payload.provider_type) {
+      throw new Error("Provider type cannot be empty.");
+    }
+    return payload;
+  }
+
+  function patchPayload() {
+    const payload = createPayload("provider-edit");
+    const patch = {
+      provider_type: payload.provider_type,
+      base_url: payload.base_url,
+      models: payload.models,
+      tags: payload.tags,
+      enabled: payload.enabled,
+      weight: payload.weight,
+      priority: payload.priority,
+    };
+    if (payload.api_key) {
+      patch.api_key = payload.api_key;
+    }
+    return patch;
+  }
+
+  function enabledLabel(enabled) {
+    return enabled ? "enabled" : "disabled";
+  }
+
+  function actionsCell(provider) {
+    const name = provider.name;
+    const cell = document.createElement("td");
+    cell.className = "provider-actions";
+    cell.append(
+      createAction("Edit", "secondary compact", () => fillEditor(provider)),
+      createAction(
+        provider.enabled ? "Disable" : "Enable",
+        "secondary compact",
+        (event) => {
+          void toggleProvider(provider, event.currentTarget);
+        },
+      ),
+      createAction("Delete", "danger compact", (event) => {
+        void deleteProvider(provider, event.currentTarget);
+      }),
+    );
+    cell.setAttribute("aria-label", `Provider ${name} actions`);
+    return cell;
+  }
+
+  function render() {
+    byId("providers-body").replaceChildren(
+      ...providers.map((provider) => {
+        const row = document.createElement("tr");
+        row.append(
+          textCell(provider.name),
+          textCell(provider.provider_type),
+          textCell(enabledLabel(provider.enabled)),
+          textCell(formatList(provider.models)),
+          textCell(provider.api_key_ref || "not set"),
+          actionsCell(provider),
+        );
+        return row;
+      }),
+    );
+    byId("providers-empty").hidden = providers.length !== 0;
+  }
+
+  function reset() {
+    requestVersion += 1;
+    loaded = false;
+    loadPromise = null;
+    providers = [];
+    clearCreateForm();
+    clearEditor();
+    setNotice("");
+    render();
+  }
+
+  async function load(session = captureSession()) {
+    const version = ++requestVersion;
+    const data = await apiRequest("/admin/providers", {}, session);
+    ensureCurrent(session);
+    if (version !== requestVersion) {
+      throw new DOMException("Stale provider response", "AbortError");
+    }
+    if (!Array.isArray(data?.providers)) {
+      throw new Error("Provider response did not include a list.");
+    }
+    providers = sanitize(data.providers);
+    render();
+  }
+
+  function loadOnce() {
+    if (loaded || loadPromise) {
+      return loadPromise || Promise.resolve();
+    }
+    clearError();
+    setStatus("Loading providers…");
+    const pending = load()
+      .then(() => {
+        loaded = true;
+        setStatus("Providers loaded.");
+      })
+      .catch((error) => reportRequestError(error, "Provider load failed."));
+    loadPromise = pending;
+    void pending.finally(() => {
+      if (loadPromise === pending) {
+        loadPromise = null;
+      }
+    });
+    return pending;
+  }
+
+  async function refreshAfterMutation(session, successMessage) {
+    try {
+      await load(session);
+      setStatus(successMessage);
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw error;
+      }
+      reportRequestError(
+        new Error(
+          `${successMessage} Provider list refresh failed: ${error.message}`,
+        ),
+        `${successMessage} Provider list refresh failed.`,
+      );
+    }
+  }
+
+  function reportApplyFailure(error, statusMessage) {
+    const detail = error?.message || "Unknown request failure";
+    setNotice(`${RUNTIME_NOTICE} ${detail}`);
+    reportRequestError(error, `${statusMessage} ${RUNTIME_NOTICE}`);
+  }
+
+  async function createProvider(event) {
+    event.preventDefault();
+    const button = event.submitter;
+    if (!beginBusy("create-provider", button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    setNotice("");
+    try {
+      const payload = createPayload("provider-create");
+      await apiRequest(
+        "/admin/providers",
+        { method: "POST", body: JSON.stringify(payload) },
+        session,
+      );
+      ensureCurrent(session);
+      clearCreateForm();
+      await refreshAfterMutation(session, "Provider created.");
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        reportApplyFailure(error, "Provider create failed.");
+      }
+    } finally {
+      endBusy("create-provider", button);
+    }
+  }
+
+  async function saveProvider(event) {
+    event.preventDefault();
+    const button = event.submitter;
+    if (!beginBusy("save-provider", button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    setNotice("");
+    try {
+      const name = editingName || byId("provider-edit-name").value.trim();
+      await apiRequest(
+        `/admin/providers/${encodeURIComponent(name)}`,
+        { method: "PATCH", body: JSON.stringify(patchPayload()) },
+        session,
+      );
+      ensureCurrent(session);
+      clearEditor();
+      await refreshAfterMutation(session, "Provider updated.");
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        reportApplyFailure(error, "Provider update failed.");
+      }
+    } finally {
+      endBusy("save-provider", button);
+    }
+  }
+
+  async function toggleProvider(provider, button) {
+    const nextEnabled = !provider.enabled;
+    const action = nextEnabled ? "Enable" : "Disable";
+    if (!window.confirm(`${action} provider “${provider.name}”?`)) {
+      return;
+    }
+    const busyKey = `toggle-provider:${provider.name}`;
+    if (!beginBusy(busyKey, button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    setNotice("");
+    try {
+      await apiRequest(
+        `/admin/providers/${encodeURIComponent(provider.name)}`,
+        { method: "PATCH", body: JSON.stringify({ enabled: nextEnabled }) },
+        session,
+      );
+      ensureCurrent(session);
+      await refreshAfterMutation(session, `Provider ${action.toLowerCase()}d.`);
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        reportApplyFailure(error, `Provider ${action.toLowerCase()} failed.`);
+      }
+    } finally {
+      endBusy(busyKey, button);
+    }
+  }
+
+  async function deleteProvider(provider, button) {
+    if (!window.confirm(`Delete provider “${provider.name}”?`)) {
+      return;
+    }
+    const busyKey = `delete-provider:${provider.name}`;
+    if (!beginBusy(busyKey, button)) {
+      return;
+    }
+    const session = captureSession();
+    clearError();
+    setNotice("");
+    try {
+      await apiRequest(
+        `/admin/providers/${encodeURIComponent(provider.name)}`,
+        { method: "DELETE" },
+        session,
+      );
+      ensureCurrent(session);
+      if (editingName === provider.name) {
+        clearEditor();
+      }
+      await refreshAfterMutation(session, "Provider deleted.");
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        setNotice(error.message || "Provider deletion failed.");
+        reportRequestError(error, "Provider deletion failed.");
+      }
+    } finally {
+      endBusy(busyKey, button);
+    }
+  }
+
+  async function refresh(button) {
+    if (button.disabled) {
+      return;
+    }
+    button.disabled = true;
+    clearError();
+    setNotice("");
+    setStatus("Refreshing providers…");
+    try {
+      await load();
+      setStatus("Providers refreshed.");
+    } catch (error) {
+      reportRequestError(error, "Provider refresh failed.");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  byId("create-provider-form").addEventListener("submit", (event) =>
+    void createProvider(event),
+  );
+  byId("edit-provider-form").addEventListener("submit", (event) =>
+    void saveProvider(event),
+  );
+  byId("cancel-provider-edit").addEventListener("click", clearEditor);
+  byId("refresh-providers").addEventListener("click", (event) =>
+    void refresh(event.currentTarget),
+  );
+
+  return { load, loadOnce, reset };
+};

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -35,6 +35,10 @@ const requestLedgerSource = await readFile(
   ),
   "utf8",
 );
+const providersSource = await readFile(
+  new URL("../../src/server/routes/admin_dashboard/providers.js", import.meta.url),
+  "utf8",
+);
 const immediate = () => new Promise((resolve) => setImmediate(resolve));
 async function settle(turns = 8) {
   for (let index = 0; index < turns; index += 1) {
@@ -103,6 +107,7 @@ function dashboard(options = {}) {
       next_cursor: null,
       has_more: false,
     },
+    providerList = [],
     handler,
   } = options;
   const htmlWithoutScript = indexHtml
@@ -119,6 +124,7 @@ function dashboard(options = {}) {
       "",
     )
     .replace('<script src="/admin/dashboard/budget.js" defer></script>', "")
+    .replace('<script src="/admin/dashboard/providers.js" defer></script>', "")
     .replace('<script src="/admin/dashboard/app.js" defer></script>', "");
   const dom = new JSDOM(htmlWithoutScript, {
     url: "https://gateway.test/admin/dashboard",
@@ -240,6 +246,11 @@ function dashboard(options = {}) {
     if (url.pathname === "/admin/request-ledger" && call.method === "GET") {
       return Promise.resolve(apiResponse(ledger));
     }
+    if (url.pathname === "/admin/providers" && call.method === "GET") {
+      return Promise.resolve(
+        apiResponse({ providers: providerList, generation: 1 }),
+      );
+    }
     const usageMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/usage$/);
     if (usageMatch && call.method === "GET") {
       const result = usageByTeam.get(decodeURIComponent(usageMatch[1]));
@@ -255,6 +266,7 @@ function dashboard(options = {}) {
   window.eval(routingInventorySource);
   window.eval(requestLedgerSource);
   window.eval(budgetSource);
+  window.eval(providersSource);
   window.eval(appSource);
   return context;
 }
@@ -324,6 +336,26 @@ async function openBudgets(context) {
     () => window.document.getElementById("status-region").textContent === "Budgets loaded.",
     "budget view did not load",
   );
+}
+
+async function openProviders(context) {
+  const { window } = context;
+  window.document.querySelector('[data-view="providers"]').click();
+  await waitFor(
+    () => window.document.getElementById("status-region").textContent === "Providers loaded.",
+    "provider view did not load",
+  );
+}
+
+function fillProviderCreate(window, values = {}) {
+  window.document.getElementById("provider-create-name").value =
+    values.name ?? "openai";
+  window.document.getElementById("provider-create-type").value =
+    values.provider_type ?? "openai";
+  window.document.getElementById("provider-create-api-key").value =
+    values.api_key ?? "${OPENAI_API_KEY}";
+  window.document.getElementById("provider-create-models").value =
+    values.models ?? "gpt-4o";
 }
 
 function fillKeyForm(window, name) {
@@ -1737,4 +1769,259 @@ test("B19 a late request log response after logout cannot restore stale data", {
   assert.equal(window.document.getElementById("request-logs-summary").textContent, "");
   assert.equal(window.document.getElementById("request-logs-notice").textContent, "");
   assert.equal(window.document.querySelectorAll("#request-logs-body tr").length, 0);
+});
+
+test("B20 empty provider list creates with a replacement reference and never fills secrets", { concurrency: false }, async (t) => {
+  let providerGets = 0;
+  let providerList = [];
+  const created = [];
+  const patches = [];
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/admin/providers" && call.method === "GET") {
+        providerGets += 1;
+        return apiResponse({ providers: providerList, generation: 1 });
+      }
+      if (call.url.pathname === "/admin/providers" && call.method === "POST") {
+        const payload = JSON.parse(call.init.body);
+        created.push(payload);
+        providerList = [{
+          name: payload.name,
+          provider_type: payload.provider_type,
+          enabled: payload.enabled !== false,
+          models: payload.models,
+          tags: payload.tags,
+          weight: payload.weight,
+          priority: payload.priority,
+          api_key_ref: "OPENAI_API_KEY",
+          api_key: "sk-leaked-from-get",
+        }];
+        return apiResponse({
+          provider: {
+            name: payload.name,
+            provider_type: payload.provider_type,
+            api_key_ref: "OPENAI_API_KEY",
+          },
+        });
+      }
+      if (call.url.pathname === "/admin/providers/openai" && call.method === "PATCH") {
+        const payload = JSON.parse(call.init.body);
+        patches.push(payload);
+        providerList = [{ ...providerList[0], enabled: payload.enabled }];
+        return apiResponse({ provider: providerList[0] });
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  assert.equal(providerGets, 0, "sign-in must not load the unopened providers tab");
+  await openProviders(context);
+  assert.equal(providerGets, 1);
+  window.document.querySelector('[data-view="providers"]').click();
+  await settle();
+  assert.equal(providerGets, 1, "reopening the loaded tab must not reload providers");
+  assert.equal(window.document.querySelectorAll("#providers-body tr").length, 0);
+  assert.equal(window.document.getElementById("providers-empty").hidden, false);
+  assert.equal(
+    window.document.getElementById("provider-create-api-key").placeholder,
+    "replacement reference only",
+  );
+
+  fillProviderCreate(window);
+  const createButton = submit(window, window.document.getElementById("create-provider-form"));
+  await waitFor(() => !createButton.disabled, "provider create did not settle");
+  assert.equal(created.length, 1);
+  assert.equal(created[0].api_key, "${OPENAI_API_KEY}");
+  assert.doesNotMatch(JSON.stringify(created[0]), /sk-/);
+  const row = rowText(window, "#providers-body tr")[0];
+  assert.match(row, /openai.*enabled.*gpt-4o.*OPENAI_API_KEY/i);
+  assert.doesNotMatch(row, /sk-/);
+  assert.doesNotMatch(window.document.body.textContent, /sk-leaked-from-get/);
+
+  window.document.querySelector("#providers-body button").click();
+  assert.equal(window.document.getElementById("provider-edit-api-key").value, "");
+  assert.equal(
+    window.document.getElementById("provider-edit-api-key").placeholder,
+    "replacement reference only",
+  );
+  assert.match(
+    window.document.getElementById("provider-edit-api-key-ref").textContent,
+    /OPENAI_API_KEY/,
+  );
+  assert.equal(window.document.getElementById("provider-edit-name").value, "openai");
+  assert.equal(window.document.getElementById("provider-edit-type").value, "openai");
+
+  const disable = window.document.querySelectorAll("#providers-body button")[1];
+  context.setConfirm(false);
+  disable.click();
+  await settle();
+  assert.equal(patches.length, 0);
+  context.setConfirm(true);
+  disable.click();
+  await waitFor(
+    () => /provider disabled/i.test(window.document.getElementById("status-region").textContent),
+    "provider disable did not settle",
+  );
+  assert.deepEqual(patches[0], { enabled: false });
+  assert.match(rowText(window, "#providers-body tr")[0], /disabled/i);
+});
+
+test("B21 provider apply errors keep form input and the previous runtime list", { concurrency: false }, async (t) => {
+  const existing = {
+    name: "anthropic",
+    provider_type: "anthropic",
+    enabled: true,
+    models: ["claude-3"],
+    tags: [],
+    weight: 1,
+    priority: 0,
+    api_key_ref: "ANTHROPIC_API_KEY",
+  };
+  let providerGets = 0;
+  const context = dashboard({
+    providerList: [existing],
+    handler(call) {
+      if (call.url.pathname === "/admin/providers" && call.method === "GET") {
+        providerGets += 1;
+        return apiResponse({ providers: [existing], generation: 4 });
+      }
+      if (call.url.pathname === "/admin/providers/anthropic" && call.method === "PATCH") {
+        return apiResponse("api_key must be an existing env reference of the form ${VAR}", 400);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openProviders(context);
+  const before = rowText(window, "#providers-body tr");
+  window.document.querySelector("#providers-body button").click();
+  window.document.getElementById("provider-edit-type").value = "not-a-real-provider-type";
+  window.document.getElementById("provider-edit-api-key").value = "${NEW_PROVIDER_KEY}";
+  const save = submit(window, window.document.getElementById("edit-provider-form"));
+  await waitFor(() => !save.disabled, "rejected provider update did not settle");
+
+  assert.deepEqual(rowText(window, "#providers-body tr"), before);
+  assert.equal(providerGets, 1, "a rejected mutation must not refresh or replace rows");
+  assert.equal(window.document.getElementById("provider-edit-type").value, "not-a-real-provider-type");
+  assert.equal(window.document.getElementById("provider-edit-api-key").value, "${NEW_PROVIDER_KEY}");
+  assert.match(
+    window.document.getElementById("providers-notice").textContent,
+    /previous runtime revision is still active/i,
+  );
+  assert.match(
+    window.document.getElementById("error-region").textContent,
+    /env reference/i,
+  );
+  assert.match(
+    window.document.getElementById("status-region").textContent,
+    /previous runtime revision is still active/i,
+  );
+});
+
+test("B22 provider delete requires confirmation and surfaces routing dependency conflicts", { concurrency: false }, async (t) => {
+  const existing = {
+    name: "test-openai",
+    provider_type: "openai",
+    enabled: true,
+    models: ["gpt-4o"],
+    tags: [],
+    weight: 1,
+    priority: 0,
+    api_key_ref: "OPENAI_API_KEY",
+  };
+  const conflict =
+    "Provider 'test-openai' is still referenced by live routing; disable it or remove routing references before delete";
+  const context = dashboard({
+    providerList: [existing],
+    handler(call) {
+      if (call.url.pathname === "/admin/providers/test-openai" && call.method === "DELETE") {
+        return apiResponse(conflict, 409);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openProviders(context);
+  const buttons = window.document.querySelectorAll("#providers-body button");
+  const remove = buttons[2];
+  context.setConfirm(false);
+  remove.click();
+  await settle();
+  assert.equal(
+    context.calls.filter((call) => call.method === "DELETE").length,
+    0,
+  );
+  assert.equal(window.document.querySelectorAll("#providers-body tr").length, 1);
+
+  context.setConfirm(true);
+  remove.click();
+  await waitFor(() => !remove.disabled, "rejected provider delete did not settle");
+  assert.equal(window.document.querySelectorAll("#providers-body tr").length, 1);
+  assert.match(
+    window.document.getElementById("providers-notice").textContent,
+    /still referenced by live routing/i,
+  );
+  assert.match(
+    window.document.getElementById("error-region").textContent,
+    /still referenced by live routing/i,
+  );
+  assert.match(
+    rowText(window, "#providers-body tr")[0],
+    /test-openai/,
+  );
+});
+
+test("B23 a late provider mutation after logout cannot restore protected rows", { concurrency: false }, async (t) => {
+  const lateCreate = deferred();
+  let providerGets = 0;
+  const context = dashboard({
+    handler(call) {
+      if (call.url.pathname === "/admin/providers" && call.method === "GET") {
+        providerGets += 1;
+      }
+      if (call.url.pathname === "/admin/providers" && call.method === "POST") {
+        return lateCreate.promise;
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openProviders(context);
+  fillProviderCreate(window, {
+    name: "must-not-return",
+    api_key: "${OPENAI_API_KEY}",
+  });
+  submit(window, window.document.getElementById("create-provider-form"));
+  await waitFor(
+    () => context.calls.some((call) => call.url.pathname === "/admin/providers" && call.method === "POST"),
+    "late provider create was not pending",
+  );
+  window.document.getElementById("sign-out").click();
+  lateCreate.resolve(
+    apiResponse({
+      provider: {
+        name: "must-not-return",
+        provider_type: "openai",
+        api_key_ref: "OPENAI_API_KEY",
+      },
+    }),
+  );
+  await settle(12);
+
+  assert.equal(providerGets, 1, "a stale mutation must not trigger a follow-up list request");
+  assert.equal(window.document.querySelectorAll("#providers-body tr").length, 0);
+  assert.equal(window.document.getElementById("provider-create-name").value, "");
+  assert.doesNotMatch(window.document.body.textContent, /must-not-return/);
+  await signIn(context);
+  assert.equal(providerGets, 1, "reauthentication on Keys must not reload providers");
+  assert.equal(window.document.getElementById("keys-panel").hidden, false);
+  assert.equal(window.document.getElementById("providers-panel").hidden, true);
 });


### PR DESCRIPTION
## What

Add a Providers tab to the embedded admin dashboard for create, edit, disable, and delete against the existing `/admin/providers` API.

## Why

After provider configuration mutations exist (#1323 / #1270), operators need a safe UI that never fills secrets from GET, keeps failed form input while the previous runtime stays active, and surfaces DELETE 409 routing dependencies.

## Test plan

- [x] `node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs` (B20–B23 plus existing dashboard suite)
- [x] `cargo test --lib admin_dashboard`
- [x] PR-style clippy (`clippy::collapsible-if`)
- [ ] Wait for GitHub Fast Test SUCCESS before merge (do not merge a cancelled 30m job)
- [ ] `executable-dom` must pass

Fixes #1272

This PR was written with Cursor Grok 4.6.

Made with [Cursor](https://cursor.com)