### PR TITLE
feat(admin-ui): add constrained routing policy editor

### DIFF
--- a/src/server/routes/admin_dashboard.rs
+++ b/src/server/routes/admin_dashboard.rs
@@ -8,6 +8,7 @@ const APP_CSS: &str = include_str!("admin_dashboard/app.css");
 const APP_JS: &str = include_str!("admin_dashboard/app.js");
 const BUDGET_JS: &str = include_str!("admin_dashboard/budget.js");
 const PROVIDERS_JS: &str = include_str!("admin_dashboard/providers.js");
+const ROUTING_POLICY_JS: &str = include_str!("admin_dashboard/routing_policy.js");
 const PROVIDER_HEALTH_JS: &str = include_str!("admin_dashboard/provider_health.js");
 const ROUTING_INVENTORY_JS: &str = include_str!("admin_dashboard/routing_inventory.js");
 const REQUEST_LEDGER_JS: &str = include_str!("admin_dashboard/request_ledger.js");
@@ -55,6 +56,10 @@ async fn providers_javascript() -> HttpResponse {
     embedded_asset("text/javascript; charset=utf-8", PROVIDERS_JS)
 }
 
+async fn routing_policy_javascript() -> HttpResponse {
+    embedded_asset("text/javascript; charset=utf-8", ROUTING_POLICY_JS)
+}
+
 /// Register the exact dashboard asset routes.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/admin/dashboard", web::get().to(dashboard))
@@ -78,6 +83,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/admin/dashboard/providers.js",
             web::get().to(providers_javascript),
+        )
+        .route(
+            "/admin/dashboard/routing-policy.js",
+            web::get().to(routing_policy_javascript),
         )
         .route("/admin/dashboard/app.js", web::get().to(javascript));
 }
@@ -132,6 +141,11 @@ mod tests {
                 "text/javascript; charset=utf-8",
                 "createProviderEditorView",
             ),
+            (
+                "/admin/dashboard/routing-policy.js",
+                "text/javascript; charset=utf-8",
+                "createRoutingPolicyView",
+            ),
         ];
 
         for (path, content_type, marker) in cases {
@@ -173,6 +187,7 @@ mod tests {
             "/admin/dashboard/routing-inventory.js.map",
             "/admin/dashboard/request-ledger.js.map",
             "/admin/dashboard/providers.js.map",
+            "/admin/dashboard/routing-policy.js.map",
             "/admin/dashboard/private",
         ] {
             let response = actix_test::call_service(
@@ -201,6 +216,7 @@ mod tests {
         assert!(BUDGET_JS.contains("\"/v1/budget/providers\""));
         assert!(BUDGET_JS.contains("\"/v1/budget/models\""));
         assert!(PROVIDERS_JS.contains("\"/admin/providers\""));
+        assert!(ROUTING_POLICY_JS.contains("\"/admin/routing/policy\""));
         for asset in [
             APP_JS,
             PROVIDER_HEALTH_JS,
@@ -208,6 +224,7 @@ mod tests {
             REQUEST_LEDGER_JS,
             BUDGET_JS,
             PROVIDERS_JS,
+            ROUTING_POLICY_JS,
         ] {
             for forbidden in [
                 "localStorage",
@@ -276,6 +293,14 @@ mod tests {
             "id=\"provider-edit-api-key\"",
             "id=\"provider-edit-api-key-ref\"",
             "id=\"providers-notice\"",
+            "id=\"routing-policy-panel\"",
+            "id=\"routing-policy-form\"",
+            "id=\"routing-policy-generation\"",
+            "id=\"routing-policy-strategy\"",
+            "id=\"routing-policy-aliases-body\"",
+            "id=\"routing-policy-providers-body\"",
+            "id=\"routing-policy-notice\"",
+            "id=\"routing-policy-add-alias\"",
         ] {
             assert!(INDEX_HTML.contains(marker), "missing HTML marker {marker}");
         }

--- a/src/server/routes/admin_dashboard/app.js
+++ b/src/server/routes/admin_dashboard/app.js
@@ -79,6 +79,7 @@ function resetProtectedState() {
   requestLedgerView.reset();
   budgetView.reset();
   providerEditorView.reset();
+  routingPolicyView.reset();
 }
 function endSession(message = "Signed out") {
   abortActiveRequests();
@@ -418,6 +419,10 @@ const budgetView = window.createBudgetView({
 const providerEditorView = window.createProviderEditorView({
   apiRequest, beginBusy, byId, captureSession, clearError, createAction, endBusy,
   ensureCurrent, reportRequestError, setStatus, textCell,
+});
+const routingPolicyView = window.createRoutingPolicyView({
+  apiRequest, beginBusy, byId, captureSession, clearError, createAction, endBusy,
+  ensureCurrent, reportRequestError, setStatus,
 });
 async function loadKeys(session = captureSession()) {
   const requestVersion = ++state.keyRequestVersion;
@@ -759,7 +764,7 @@ function showView(view) {
     button.classList.toggle("active", active);
     button.setAttribute("aria-selected", String(active));
   }
-  for (const panel of ["keys", "teams", "spend", "budgets", "providers", "health", "routing", "request-logs"]) {
+  for (const panel of ["keys", "teams", "spend", "budgets", "providers", "health", "routing", "routing-policy", "request-logs"]) {
     byId(`${panel}-panel`).hidden = panel !== view;
   }
   if (view === "spend") {
@@ -770,6 +775,9 @@ function showView(view) {
   }
   if (view === "providers") {
     void providerEditorView.loadOnce();
+  }
+  if (view === "routing-policy") {
+    void routingPolicyView.loadOnce();
   }
   if (view === "request-logs") {
     void requestLedgerView.loadOnce();

--- a/src/server/routes/admin_dashboard/index.html
+++ b/src/server/routes/admin_dashboard/index.html
@@ -11,6 +11,7 @@
   <script src="/admin/dashboard/request-ledger.js" defer></script>
   <script src="/admin/dashboard/budget.js" defer></script>
   <script src="/admin/dashboard/providers.js" defer></script>
+  <script src="/admin/dashboard/routing-policy.js" defer></script>
   <script src="/admin/dashboard/app.js" defer></script>
 </head>
 <body>
@@ -60,6 +61,8 @@
                 aria-controls="health-panel" aria-selected="false">Provider health</button>
         <button class="tab" type="button" data-view="routing"
                 aria-controls="routing-panel" aria-selected="false">Routing inventory</button>
+        <button class="tab" type="button" data-view="routing-policy"
+                aria-controls="routing-policy-panel" aria-selected="false">Routing policy</button>
         <button class="tab" type="button" data-view="request-logs"
                 aria-controls="request-logs-panel" aria-selected="false">Request logs</button>
       </nav>
@@ -502,6 +505,98 @@
         <p id="routing-unavailable-empty" class="empty-state" hidden>
           No configured providers are missing from routing.
         </p>
+      </section>
+
+      <section id="routing-policy-panel" class="panel" aria-labelledby="routing-policy-title" hidden>
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Runtime configuration</p>
+            <h2 id="routing-policy-title">Routing policy</h2>
+            <p>Edit strategy, circuit breaker, load balancer, aliases, and
+              named provider weight/priority. Unknown fields are not sent.</p>
+          </div>
+          <button id="refresh-routing-policy" class="secondary" type="button">Refresh</button>
+        </div>
+
+        <p id="routing-policy-generation" class="health-summary">Active revision: —</p>
+        <p id="routing-policy-notice" class="health-notice" aria-live="polite"></p>
+
+        <form id="routing-policy-form">
+          <div class="form-grid">
+            <label for="routing-policy-strategy">Strategy</label>
+            <select id="routing-policy-strategy" name="strategy">
+              <option value="simple_shuffle">simple_shuffle</option>
+              <option value="least_busy">least_busy</option>
+              <option value="usage_based">usage_based</option>
+              <option value="latency_based">latency_based</option>
+              <option value="priority_based">priority_based</option>
+              <option value="rate_limit_aware">rate_limit_aware</option>
+              <option value="round_robin">round_robin</option>
+            </select>
+            <label for="routing-policy-failure-threshold">Failure threshold</label>
+            <input id="routing-policy-failure-threshold" name="failure_threshold"
+                   type="number" min="0" step="1">
+            <label for="routing-policy-recovery-timeout">Recovery timeout</label>
+            <input id="routing-policy-recovery-timeout" name="recovery_timeout"
+                   type="number" min="0" step="1">
+            <label for="routing-policy-min-requests">Minimum requests</label>
+            <input id="routing-policy-min-requests" name="min_requests"
+                   type="number" min="0" step="1">
+            <label for="routing-policy-success-threshold">Success threshold</label>
+            <input id="routing-policy-success-threshold" name="success_threshold"
+                   type="number" min="0" step="1">
+            <label class="checkbox-row" for="routing-policy-health-check-enabled">
+              <input id="routing-policy-health-check-enabled" name="health_check_enabled"
+                     type="checkbox" checked>
+              Health checks enabled
+            </label>
+            <label class="checkbox-row" for="routing-policy-sticky-sessions">
+              <input id="routing-policy-sticky-sessions" name="sticky_sessions"
+                     type="checkbox">
+              Sticky sessions
+            </label>
+            <label for="routing-policy-session-timeout">Session timeout</label>
+            <input id="routing-policy-session-timeout" name="session_timeout"
+                   type="number" min="0" step="1">
+          </div>
+
+          <h3>Model aliases</h3>
+          <div class="table-wrap">
+            <table>
+              <caption>Name to canonical model target</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Alias</th>
+                  <th scope="col">Target</th>
+                  <th scope="col">Action</th>
+                </tr>
+              </thead>
+              <tbody id="routing-policy-aliases-body"></tbody>
+            </table>
+          </div>
+          <button id="routing-policy-add-alias" class="secondary" type="button">
+            Add alias
+          </button>
+
+          <h3>Provider weight and priority</h3>
+          <div class="table-wrap">
+            <table>
+              <caption>Named providers from the live policy</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Provider</th>
+                  <th scope="col">Weight</th>
+                  <th scope="col">Priority</th>
+                </tr>
+              </thead>
+              <tbody id="routing-policy-providers-body"></tbody>
+            </table>
+          </div>
+          <p id="routing-policy-providers-empty" class="empty-state" hidden>
+            No named providers in the current policy.
+          </p>
+          <button type="submit">Apply routing policy</button>
+        </form>
       </section>
 
       <section id="request-logs-panel" class="panel" aria-labelledby="request-logs-title" hidden>

--- a/src/server/routes/admin_dashboard/routing_policy.js
+++ b/src/server/routes/admin_dashboard/routing_policy.js
@@ -1,0 +1,366 @@
+"use strict";
+
+window.createRoutingPolicyView = function createRoutingPolicyView({
+  apiRequest,
+  beginBusy,
+  byId,
+  captureSession,
+  clearError,
+  createAction,
+  endBusy,
+  ensureCurrent,
+  reportRequestError,
+  setStatus,
+}) {
+  const STRATEGIES = [
+    "simple_shuffle",
+    "least_busy",
+    "usage_based",
+    "latency_based",
+    "priority_based",
+    "rate_limit_aware",
+    "round_robin",
+  ];
+  const RUNTIME_NOTICE = "The previous runtime revision is still active.";
+  let activeGeneration = null;
+  let knownProviders = [];
+  let requestVersion = 0;
+  let loaded = false;
+  let loadPromise = null;
+
+  function setNotice(message) {
+    byId("routing-policy-notice").textContent = message || "";
+  }
+
+  function setGeneration(generation) {
+    activeGeneration = generation;
+    const label =
+      generation == null || generation === "" ? "—" : String(generation);
+    byId("routing-policy-generation").textContent = `Active revision: ${label}`;
+  }
+
+  function integerValue(raw, label) {
+    const value = Number(raw);
+    if (!Number.isInteger(value) || value < 0) {
+      throw new Error(`${label} must be a non-negative integer.`);
+    }
+    return value;
+  }
+
+  function finiteValue(raw, label) {
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      throw new Error(`${label} must be a finite number.`);
+    }
+    return value;
+  }
+
+  function addAliasRow(alias = {}) {
+    const row = document.createElement("tr");
+    const nameCell = document.createElement("td");
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.maxLength = 240;
+    nameInput.value = alias.name || "";
+    nameInput.setAttribute("aria-label", "Alias name");
+    nameCell.append(nameInput);
+    const targetCell = document.createElement("td");
+    const targetInput = document.createElement("input");
+    targetInput.type = "text";
+    targetInput.maxLength = 240;
+    targetInput.value = alias.target || "";
+    targetInput.setAttribute("aria-label", "Alias target");
+    targetCell.append(targetInput);
+    const actionCell = document.createElement("td");
+    actionCell.className = "provider-actions";
+    actionCell.append(
+      createAction("Remove", "secondary compact", () => {
+        row.remove();
+      }),
+    );
+    row.append(nameCell, targetCell, actionCell);
+    byId("routing-policy-aliases-body").append(row);
+  }
+
+  function renderAliases(aliases) {
+    byId("routing-policy-aliases-body").replaceChildren();
+    const entries = Object.entries(aliases || {}).sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+    for (const [name, target] of entries) {
+      addAliasRow({ name, target: String(target || "") });
+    }
+  }
+
+  function renderProviders(providers) {
+    const names = Object.keys(providers || {}).sort();
+    knownProviders = names;
+    byId("routing-policy-providers-body").replaceChildren(
+      ...names.map((name) => {
+        const record = providers[name] || {};
+        const row = document.createElement("tr");
+        row.dataset.providerName = name;
+        const nameCell = document.createElement("td");
+        nameCell.textContent = name;
+        const weightCell = document.createElement("td");
+        const weightInput = document.createElement("input");
+        weightInput.type = "number";
+        weightInput.step = "any";
+        weightInput.value = record.weight == null ? "" : String(record.weight);
+        weightInput.setAttribute("aria-label", `${name} weight`);
+        weightInput.dataset.field = "weight";
+        weightCell.append(weightInput);
+        const priorityCell = document.createElement("td");
+        const priorityInput = document.createElement("input");
+        priorityInput.type = "number";
+        priorityInput.step = "1";
+        priorityInput.value =
+          record.priority == null ? "" : String(record.priority);
+        priorityInput.setAttribute("aria-label", `${name} priority`);
+        priorityInput.dataset.field = "priority";
+        priorityCell.append(priorityInput);
+        row.append(nameCell, weightCell, priorityCell);
+        return row;
+      }),
+    );
+    byId("routing-policy-providers-empty").hidden = names.length !== 0;
+  }
+
+  function fillForm(policy) {
+    const strategy = String(policy.strategy || "");
+    const select = byId("routing-policy-strategy");
+    if (STRATEGIES.includes(strategy)) {
+      select.value = strategy;
+    }
+    const breaker = policy.circuit_breaker || {};
+    byId("routing-policy-failure-threshold").value =
+      breaker.failure_threshold == null ? "" : String(breaker.failure_threshold);
+    byId("routing-policy-recovery-timeout").value =
+      breaker.recovery_timeout == null ? "" : String(breaker.recovery_timeout);
+    byId("routing-policy-min-requests").value =
+      breaker.min_requests == null ? "" : String(breaker.min_requests);
+    byId("routing-policy-success-threshold").value =
+      breaker.success_threshold == null ? "" : String(breaker.success_threshold);
+    const balancer = policy.load_balancer || {};
+    byId("routing-policy-health-check-enabled").checked =
+      balancer.health_check_enabled !== false;
+    byId("routing-policy-sticky-sessions").checked = Boolean(
+      balancer.sticky_sessions,
+    );
+    byId("routing-policy-session-timeout").value =
+      balancer.session_timeout == null ? "" : String(balancer.session_timeout);
+    renderAliases(policy.model_aliases);
+    renderProviders(policy.providers);
+  }
+
+  function collectAliases() {
+    const aliases = {};
+    for (const row of byId("routing-policy-aliases-body").querySelectorAll("tr")) {
+      const inputs = row.querySelectorAll("input");
+      const name = String(inputs[0]?.value || "").trim();
+      const target = String(inputs[1]?.value || "").trim();
+      if (!name && !target) {
+        continue;
+      }
+      if (!name || !target) {
+        throw new Error("Each alias needs both a name and a target.");
+      }
+      if (Object.hasOwn(aliases, name)) {
+        throw new Error(`Duplicate alias '${name}'.`);
+      }
+      aliases[name] = target;
+    }
+    return aliases;
+  }
+
+  function collectProviders() {
+    if (!knownProviders.length) {
+      return null;
+    }
+    const rows = [...byId("routing-policy-providers-body").querySelectorAll("tr")];
+    const providers = {};
+    for (const name of knownProviders) {
+      const row = rows.find((entry) => entry.dataset.providerName === name);
+      if (!row) {
+        throw new Error(`Provider '${name}' is missing from the editor.`);
+      }
+      providers[name] = {
+        weight: finiteValue(
+          row.querySelector('input[data-field="weight"]')?.value,
+          `${name} weight`,
+        ),
+        priority: integerValue(
+          row.querySelector('input[data-field="priority"]')?.value,
+          `${name} priority`,
+        ),
+      };
+    }
+    return providers;
+  }
+
+  function buildPayload() {
+    const strategy = byId("routing-policy-strategy").value;
+    if (!STRATEGIES.includes(strategy)) {
+      throw new Error("Choose a supported routing strategy.");
+    }
+    const payload = {
+      strategy,
+      circuit_breaker: {
+        failure_threshold: integerValue(
+          byId("routing-policy-failure-threshold").value,
+          "Failure threshold",
+        ),
+        recovery_timeout: integerValue(
+          byId("routing-policy-recovery-timeout").value,
+          "Recovery timeout",
+        ),
+        min_requests: integerValue(
+          byId("routing-policy-min-requests").value,
+          "Minimum requests",
+        ),
+        success_threshold: integerValue(
+          byId("routing-policy-success-threshold").value,
+          "Success threshold",
+        ),
+      },
+      load_balancer: {
+        health_check_enabled: byId("routing-policy-health-check-enabled")
+          .checked,
+        sticky_sessions: byId("routing-policy-sticky-sessions").checked,
+        session_timeout: integerValue(
+          byId("routing-policy-session-timeout").value,
+          "Session timeout",
+        ),
+      },
+      model_aliases: collectAliases(),
+    };
+    const providers = collectProviders();
+    if (providers) {
+      payload.providers = providers;
+    }
+    return payload;
+  }
+
+  function applyPolicy(data) {
+    if (data?.generation == null || typeof data.policy !== "object" || !data.policy) {
+      throw new Error("Routing policy response did not include generation and policy.");
+    }
+    setGeneration(data.generation);
+    fillForm(data.policy);
+  }
+
+  function clearDraft() {
+    knownProviders = [];
+    byId("routing-policy-form").reset();
+    byId("routing-policy-aliases-body").replaceChildren();
+    byId("routing-policy-providers-body").replaceChildren();
+    byId("routing-policy-providers-empty").hidden = false;
+    setGeneration(null);
+    setNotice("");
+  }
+
+  function reset() {
+    requestVersion += 1;
+    loaded = false;
+    loadPromise = null;
+    byId("refresh-routing-policy").disabled = false;
+    clearDraft();
+  }
+
+  async function load(session = captureSession()) {
+    const version = ++requestVersion;
+    const data = await apiRequest("/admin/routing/policy", {}, session);
+    ensureCurrent(session);
+    if (version !== requestVersion) {
+      throw new DOMException("Stale routing policy response", "AbortError");
+    }
+    applyPolicy(data);
+  }
+
+  function loadOnce() {
+    if (loaded || loadPromise) {
+      return loadPromise || Promise.resolve();
+    }
+    clearError();
+    setStatus("Loading routing policy…");
+    const pending = load()
+      .then(() => {
+        loaded = true;
+        setStatus("Routing policy loaded.");
+      })
+      .catch((error) => reportRequestError(error, "Routing policy load failed."));
+    loadPromise = pending;
+    void pending.finally(() => {
+      if (loadPromise === pending) {
+        loadPromise = null;
+      }
+    });
+    return pending;
+  }
+
+  function reportApplyFailure(error, statusMessage) {
+    const detail = error?.message || "Unknown request failure";
+    setNotice(`${RUNTIME_NOTICE} ${detail}`);
+    reportRequestError(error, `${statusMessage} ${RUNTIME_NOTICE}`);
+  }
+
+  async function save(event) {
+    event.preventDefault();
+    const button = event.submitter;
+    if (!beginBusy("save-routing-policy", button)) {
+      return;
+    }
+    const session = captureSession();
+    const version = requestVersion;
+    clearError();
+    setNotice("");
+    try {
+      const payload = buildPayload();
+      const data = await apiRequest(
+        "/admin/routing/policy",
+        { method: "PUT", body: JSON.stringify(payload) },
+        session,
+      );
+      ensureCurrent(session);
+      if (version !== requestVersion) {
+        throw new DOMException("Stale routing policy response", "AbortError");
+      }
+      applyPolicy(data);
+      setStatus("Routing policy updated.");
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        reportApplyFailure(error, "Routing policy update failed.");
+      }
+    } finally {
+      endBusy("save-routing-policy", button);
+    }
+  }
+
+  async function refresh(button) {
+    if (button.disabled) {
+      return;
+    }
+    button.disabled = true;
+    clearError();
+    setNotice("");
+    setStatus("Refreshing routing policy…");
+    try {
+      await load();
+      setStatus("Routing policy refreshed.");
+    } catch (error) {
+      reportRequestError(error, "Routing policy refresh failed.");
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  byId("routing-policy-form").addEventListener("submit", (event) =>
+    void save(event),
+  );
+  byId("routing-policy-add-alias").addEventListener("click", () => addAliasRow());
+  byId("refresh-routing-policy").addEventListener("click", (event) =>
+    void refresh(event.currentTarget),
+  );
+
+  return { load, loadOnce, reset };
+};

--- a/tests/admin_dashboard/admin_dashboard_dom.test.mjs
+++ b/tests/admin_dashboard/admin_dashboard_dom.test.mjs
@@ -39,6 +39,13 @@ const providersSource = await readFile(
   new URL("../../src/server/routes/admin_dashboard/providers.js", import.meta.url),
   "utf8",
 );
+const routingPolicySource = await readFile(
+  new URL(
+    "../../src/server/routes/admin_dashboard/routing_policy.js",
+    import.meta.url,
+  ),
+  "utf8",
+);
 const immediate = () => new Promise((resolve) => setImmediate(resolve));
 async function settle(turns = 8) {
   for (let index = 0; index < turns; index += 1) {
@@ -108,6 +115,25 @@ function dashboard(options = {}) {
       has_more: false,
     },
     providerList = [],
+    routingPolicy = {
+      generation: 1,
+      policy: {
+        strategy: "round_robin",
+        circuit_breaker: {
+          failure_threshold: 5,
+          recovery_timeout: 60,
+          min_requests: 10,
+          success_threshold: 3,
+        },
+        load_balancer: {
+          health_check_enabled: true,
+          sticky_sessions: false,
+          session_timeout: 3600,
+        },
+        model_aliases: {},
+        providers: {},
+      },
+    },
     handler,
   } = options;
   const htmlWithoutScript = indexHtml
@@ -125,6 +151,10 @@ function dashboard(options = {}) {
     )
     .replace('<script src="/admin/dashboard/budget.js" defer></script>', "")
     .replace('<script src="/admin/dashboard/providers.js" defer></script>', "")
+    .replace(
+      '<script src="/admin/dashboard/routing-policy.js" defer></script>',
+      "",
+    )
     .replace('<script src="/admin/dashboard/app.js" defer></script>', "");
   const dom = new JSDOM(htmlWithoutScript, {
     url: "https://gateway.test/admin/dashboard",
@@ -251,6 +281,9 @@ function dashboard(options = {}) {
         apiResponse({ providers: providerList, generation: 1 }),
       );
     }
+    if (url.pathname === "/admin/routing/policy" && call.method === "GET") {
+      return Promise.resolve(apiResponse(routingPolicy));
+    }
     const usageMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/usage$/);
     if (usageMatch && call.method === "GET") {
       const result = usageByTeam.get(decodeURIComponent(usageMatch[1]));
@@ -267,6 +300,7 @@ function dashboard(options = {}) {
   window.eval(requestLedgerSource);
   window.eval(budgetSource);
   window.eval(providersSource);
+  window.eval(routingPolicySource);
   window.eval(appSource);
   return context;
 }
@@ -344,6 +378,17 @@ async function openProviders(context) {
   await waitFor(
     () => window.document.getElementById("status-region").textContent === "Providers loaded.",
     "provider view did not load",
+  );
+}
+
+async function openRoutingPolicy(context) {
+  const { window } = context;
+  window.document.querySelector('[data-view="routing-policy"]').click();
+  await waitFor(
+    () =>
+      window.document.getElementById("status-region").textContent ===
+      "Routing policy loaded.",
+    "routing policy view did not load",
   );
 }
 
@@ -2025,3 +2070,239 @@ test("B23 a late provider mutation after logout cannot restore protected rows", 
   assert.equal(window.document.getElementById("keys-panel").hidden, false);
   assert.equal(window.document.getElementById("providers-panel").hidden, true);
 });
+
+function sampleRoutingPolicy(overrides = {}) {
+  return {
+    generation: overrides.generation ?? 4,
+    policy: {
+      strategy: "least_busy",
+      circuit_breaker: {
+        failure_threshold: 5,
+        recovery_timeout: 60,
+        min_requests: 10,
+        success_threshold: 3,
+      },
+      load_balancer: {
+        health_check_enabled: true,
+        sticky_sessions: false,
+        session_timeout: 3600,
+      },
+      model_aliases: { "prod-chat": "gpt-4o" },
+      providers: { openai: { weight: 1, priority: 0 } },
+      ...(overrides.policy || {}),
+    },
+  };
+}
+
+test("B24 routing policy load shows generation and a successful PUT updates it", { concurrency: false }, async (t) => {
+  let policyGets = 0;
+  const puts = [];
+  let current = sampleRoutingPolicy();
+  const context = dashboard({
+    routingPolicy: current,
+    handler(call) {
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "GET") {
+        policyGets += 1;
+        return apiResponse(current);
+      }
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "PUT") {
+        const payload = JSON.parse(call.init.body);
+        puts.push(payload);
+        current = {
+          generation: current.generation + 1,
+          policy: {
+            ...current.policy,
+            strategy: payload.strategy,
+            circuit_breaker: payload.circuit_breaker,
+            load_balancer: payload.load_balancer,
+            model_aliases: payload.model_aliases,
+            providers: payload.providers || current.policy.providers,
+          },
+        };
+        return apiResponse(current);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  assert.equal(policyGets, 0, "sign-in must not load the unopened routing policy tab");
+  await openRoutingPolicy(context);
+  assert.equal(policyGets, 1);
+  window.document.querySelector('[data-view="routing-policy"]').click();
+  await settle();
+  assert.equal(policyGets, 1, "reopening the loaded tab must not reload routing policy");
+  assert.equal(
+    window.document.getElementById("routing-policy-generation").textContent,
+    "Active revision: 4",
+  );
+  assert.equal(window.document.getElementById("routing-policy-strategy").value, "least_busy");
+  assert.equal(
+    window.document.querySelector('#routing-policy-aliases-body input[aria-label="Alias target"]').value,
+    "gpt-4o",
+  );
+
+  window.document.getElementById("routing-policy-strategy").value = "round_robin";
+  window.document.querySelector('#routing-policy-providers-body input[data-field="weight"]').value = "2";
+  const save = submit(window, window.document.getElementById("routing-policy-form"));
+  await waitFor(() => !save.disabled, "routing policy put did not settle");
+  assert.equal(puts.length, 1);
+  assert.deepEqual(Object.keys(puts[0]).sort(), [
+    "circuit_breaker",
+    "load_balancer",
+    "model_aliases",
+    "providers",
+    "strategy",
+  ]);
+  assert.equal(puts[0].strategy, "round_robin");
+  assert.equal(puts[0].model_aliases["prod-chat"], "gpt-4o");
+  assert.equal(puts[0].providers.openai.weight, 2);
+  assert.equal(puts[0].providers.openai.priority, 0);
+  assert.equal(puts[0].generation, undefined);
+  assert.equal(
+    window.document.getElementById("routing-policy-generation").textContent,
+    "Active revision: 5",
+  );
+  assert.equal(window.document.getElementById("routing-policy-strategy").value, "round_robin");
+  assert.match(
+    window.document.getElementById("status-region").textContent,
+    /routing policy updated/i,
+  );
+});
+
+test("B25 routing policy validation errors keep the draft and previous generation", { concurrency: false }, async (t) => {
+  let policyGets = 0;
+  const context = dashboard({
+    routingPolicy: sampleRoutingPolicy(),
+    handler(call) {
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "GET") {
+        policyGets += 1;
+        return apiResponse(sampleRoutingPolicy());
+      }
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "PUT") {
+        return apiResponse("Model alias 'prod-chat' references unknown model 'missing-model-1273'", 400);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openRoutingPolicy(context);
+  const target = window.document.querySelector(
+    '#routing-policy-aliases-body input[aria-label="Alias target"]',
+  );
+  target.value = "missing-model-1273";
+  const save = submit(window, window.document.getElementById("routing-policy-form"));
+  await waitFor(() => !save.disabled, "rejected routing policy put did not settle");
+
+  assert.equal(policyGets, 1, "a rejected mutation must not refresh the policy");
+  assert.equal(target.value, "missing-model-1273");
+  assert.equal(
+    window.document.getElementById("routing-policy-generation").textContent,
+    "Active revision: 4",
+  );
+  assert.match(
+    window.document.getElementById("routing-policy-notice").textContent,
+    /previous runtime revision is still active/i,
+  );
+  assert.match(
+    window.document.getElementById("error-region").textContent,
+    /unknown model/i,
+  );
+  assert.match(
+    window.document.getElementById("status-region").textContent,
+    /previous runtime revision is still active/i,
+  );
+});
+
+test("B26 routing policy conflicts keep the draft and previous generation", { concurrency: false }, async (t) => {
+  const context = dashboard({
+    routingPolicy: sampleRoutingPolicy(),
+    handler(call) {
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "PUT") {
+        return apiResponse("Routing policy conflict: another revision is active", 409);
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openRoutingPolicy(context);
+  window.document.getElementById("routing-policy-strategy").value = "latency_based";
+  const save = submit(window, window.document.getElementById("routing-policy-form"));
+  await waitFor(() => !save.disabled, "conflicted routing policy put did not settle");
+
+  assert.equal(window.document.getElementById("routing-policy-strategy").value, "latency_based");
+  assert.equal(
+    window.document.getElementById("routing-policy-generation").textContent,
+    "Active revision: 4",
+  );
+  assert.match(
+    window.document.getElementById("error-region").textContent,
+    /another revision is active/i,
+  );
+  assert.match(
+    window.document.getElementById("routing-policy-notice").textContent,
+    /previous runtime revision is still active/i,
+  );
+});
+
+test("B27 a late routing policy PUT after logout cannot restore the draft", { concurrency: false }, async (t) => {
+  const latePut = deferred();
+  let policyGets = 0;
+  const context = dashboard({
+    routingPolicy: sampleRoutingPolicy(),
+    handler(call) {
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "GET") {
+        policyGets += 1;
+      }
+      if (call.url.pathname === "/admin/routing/policy" && call.method === "PUT") {
+        return latePut.promise;
+      }
+      return undefined;
+    },
+  });
+  t.after(() => context.window.close());
+  await signIn(context);
+  const { window } = context;
+  await openRoutingPolicy(context);
+  window.document.querySelector(
+    '#routing-policy-aliases-body input[aria-label="Alias target"]',
+  ).value = "must-not-return";
+  submit(window, window.document.getElementById("routing-policy-form"));
+  await waitFor(
+    () => context.calls.some((call) => call.url.pathname === "/admin/routing/policy" && call.method === "PUT"),
+    "late routing policy put was not pending",
+  );
+  window.document.getElementById("sign-out").click();
+  latePut.resolve(
+    apiResponse({
+      generation: 99,
+      policy: {
+        strategy: "usage_based",
+        circuit_breaker: { failure_threshold: 1, recovery_timeout: 1, min_requests: 1, success_threshold: 1 },
+        load_balancer: { health_check_enabled: false, sticky_sessions: true, session_timeout: 1 },
+        model_aliases: { restored: "must-not-return" },
+        providers: { openai: { weight: 9, priority: 9 } },
+      },
+    }),
+  );
+  await settle(12);
+
+  assert.equal(policyGets, 1, "a stale mutation must not trigger a follow-up policy request");
+  assert.equal(window.document.querySelectorAll("#routing-policy-aliases-body tr").length, 0);
+  assert.equal(window.document.querySelectorAll("#routing-policy-providers-body tr").length, 0);
+  assert.equal(
+    window.document.getElementById("routing-policy-generation").textContent,
+    "Active revision: —",
+  );
+  assert.doesNotMatch(window.document.body.textContent, /must-not-return/);
+  await signIn(context);
+  assert.equal(policyGets, 1, "reauthentication on Keys must not reload routing policy");
+  assert.equal(window.document.getElementById("keys-panel").hidden, false);
+  assert.equal(window.document.getElementById("routing-policy-panel").hidden, true);
+});
+


### PR DESCRIPTION
## What

Adds a **Routing policy** dashboard tab (distinct from Routing inventory) so operators can edit the existing finite `/admin/routing/policy` fields: strategy enum, circuit breaker, load balancer, alias name→target rows, and weight/priority only for provider names already returned by GET.

## Why

Issue #1273 needs a constrained visual editor after routing policy mutations exist. The UI cannot submit arbitrary expressions or unknown JSON keys; failed applies keep the previous generation visible and the draft recoverable.

Fixes #1273

## Test Plan

- [x] `cargo test --lib admin_dashboard`
- [x] `node --test tests/admin_dashboard/admin_dashboard_dom.test.mjs` (B24 load+success, B25 validation 400, B26 conflict 409, B27 stale PUT after logout)
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] `cargo fmt --all`
- [ ] Fast Test SUCCESS (not cancelled)
- [ ] executable-dom SUCCESS

## AI disclosure

Implemented with Cursor Grok 4.6.

Made with [Cursor](https://cursor.com)