### PR TITLE
feat(k8s): add bounded horizontal pod autoscaling

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -55,6 +55,39 @@ sudo systemctl start rust-litellm-gateway
 kubectl apply -f deployment/kubernetes/
 ```
 
+#### Horizontal pod autoscaling
+
+`kubernetes/hpa.yaml` targets the `apps/v1` Deployment `litellm-gateway` in
+the `litellm-gateway` namespace using `autoscaling/v2`. It maintains 3–10 replicas,
+with average CPU utilization of 70% and memory utilization of 80%. Utilization is
+relative to requests, not limits: the existing `250m` CPU and `256Mi` memory
+requests give targets of `175m` and `204.8Mi` per pod. Keep both requests set on
+every container, including any added sidecars. The HPA chooses the larger replica
+recommendation from the two metrics.
+
+Scale-up permits at most two additional pods per 60 seconds with no stabilization
+delay. Scale-down uses a 300-second stabilization window and removes at most one
+pod per 60 seconds. Tune these defaults for measured load and cluster capacity.
+
+The cluster must run the HPA controller and expose CPU and memory resource metrics
+through `metrics.k8s.io`, usually via [Metrics Server](https://github.com/kubernetes-sigs/metrics-server),
+with API aggregation enabled and working kubelet metric collection. The gateway's
+Prometheus `/metrics` endpoint does not supply these resource metrics. Missing
+metrics prevent normal scaling; inspect HPA conditions and Metrics Server health.
+See the [Kubernetes HPA documentation](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/).
+
+The Deployment omits `spec.replicas` so subsequent applies respect HPA ownership.
+New Deployments initially default to one replica until the HPA reconciles. If
+deploying without the HPA, explicitly set the desired fixed replica count.
+
+Validate all raw manifests without contacting a cluster using
+[kubeconform](https://github.com/yannh/kubeconform) and Kubernetes 1.35.0 schemas
+(the supported [1.35 release line](https://kubernetes.io/releases/)):
+
+```bash
+kubeconform -strict -summary -kubernetes-version 1.35.0 deployment/kubernetes/*.yaml
+```
+
 ## 📋 Prerequisites
 
 - **Rust 1.85+** for local builds

--- a/deployment/kubernetes/deployment.yaml
+++ b/deployment/kubernetes/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: litellm-gateway
     app.kubernetes.io/component: gateway
 spec:
-  replicas: 3
+  # Replica count is managed by hpa.yaml; do not reset it on each apply.
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deployment/kubernetes/hpa.yaml
+++ b/deployment/kubernetes/hpa.yaml
@@ -1,0 +1,41 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: litellm-gateway
+  namespace: litellm-gateway
+  labels:
+    app.kubernetes.io/name: litellm-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: litellm-gateway
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 60


### PR DESCRIPTION
## What

Add an `autoscaling/v2` HPA for the existing `litellm-gateway` Deployment in the `litellm-gateway` namespace:

- Keep 3–10 replicas, targeting 70% CPU and 80% memory utilization against the existing `250m` / `256Mi` requests.
- Limit growth to two pods per minute and shrinkage to one pod per minute, with a five-minute downscale stabilization window.
- Omit the Deployment's fixed replica count so subsequent applies respect HPA ownership.
- Document Metrics Server / `metrics.k8s.io`, API aggregation, request-based utilization, startup behavior, and cluster-free schema validation.

## Why

The raw Kubernetes deployment has no checked-in autoscaling policy. Refs #1285; dependency #1284 is closed and its repaired deployment is present in base `9a4e6b408fba5651f1ff1f914734c8f1f348a2fa`.

## Test Plan

All commands below exited 0 in the assigned isolated worktree:

- `kubeconform -strict -summary -kubernetes-version 1.35.0 deployment/kubernetes/*.yaml` with kubeconform v0.8.0: nine resources valid, zero invalid/errors/skipped.
- A local Python/PyYAML check verified the HPA target and namespace against the Deployment, replica ownership, CPU/memory requests and targets, and bounded policies.
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib kubernetes_manifests_match_runtime_contract -- --nocapture`: one passed.
- `cargo test`: passed, including 9,539 library tests; existing ignored tests remain ignored.
- `git diff --check` and `git diff --cached --check`

No shared databases were used. `REDIS_URL=redis://127.0.0.1:1` kept optional live Redis tests from accessing shared services; those tests use their existing unavailable-service skip path, so live Redis coverage was not obtained. Default-feature SQLite and mock tests ran normally. Compiler output and temporary test files stayed inside the assigned worktree.

Complete command output, the local HPA check, and exit-code records are retained at `/Users/apple/.cache/harness/validation/7f5fbf3b-d85c-486f-a227-c69bca059520/` on the evaluation host.

No cluster was contacted or deployed to. Runtime scaling was not exercised; validation covers schemas and manifest contracts. No implementation blockers remain. CI and independent review are pending.
