### PR TITLE
feat(guardrails): route blocked output to a configured fallback

### DIFF
--- a/src/core/router/fallback.rs
+++ b/src/core/router/fallback.rs
@@ -205,6 +205,22 @@ impl FallbackConfig {
             .cloned()
             .unwrap_or_default()
     }
+
+    /// Replace every fallback map with the maps from `other`.
+    pub fn overwrite(&self, other: Self) {
+        replace_fallback_map(&self.general, other.general);
+        replace_fallback_map(&self.context_window, other.context_window);
+        replace_fallback_map(&self.content_policy, other.content_policy);
+        replace_fallback_map(&self.rate_limit, other.rate_limit);
+    }
+}
+
+fn replace_fallback_map(
+    dst: &RwLock<HashMap<String, Vec<String>>>,
+    src: RwLock<HashMap<String, Vec<String>>>,
+) {
+    *dst.write().unwrap_or_else(|e| e.into_inner()) =
+        src.into_inner().unwrap_or_else(|e| e.into_inner());
 }
 
 #[cfg(test)]
@@ -241,6 +257,23 @@ mod tests {
         assert_ne!(FallbackType::General, FallbackType::ContextWindow);
         assert_ne!(FallbackType::ContextWindow, FallbackType::ContentPolicy);
         assert_ne!(FallbackType::ContentPolicy, FallbackType::RateLimit);
+    }
+
+    #[test]
+    fn overwrite_replaces_every_fallback_map() {
+        let config = FallbackConfig::new().add_general("gpt-4o", vec!["old".to_string()]);
+        config.overwrite(
+            FallbackConfig::new().add_content_policy("gpt-4o", vec!["safe".to_string()]),
+        );
+        assert!(
+            config
+                .get_fallbacks_for_type("gpt-4o", FallbackType::General)
+                .is_empty()
+        );
+        assert_eq!(
+            config.get_fallbacks_for_type("gpt-4o", FallbackType::ContentPolicy),
+            vec!["safe".to_string()]
+        );
     }
 
     // ==================== ExecutionResult Tests ====================

--- a/src/core/router/tests/fallback_tests.rs
+++ b/src/core/router/tests/fallback_tests.rs
@@ -199,7 +199,7 @@ async fn test_get_models_with_fallbacks_no_fallbacks() {
 
 #[tokio::test]
 async fn test_set_fallback_config_runtime() {
-    let mut router = Router::default();
+    let router = Router::default();
 
     let fallbacks = router.get_fallbacks("gpt-4", FallbackType::General);
     assert_eq!(fallbacks.len(), 0);

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -360,9 +360,12 @@ impl Router {
         self
     }
 
-    /// Set fallback configuration (runtime method)
-    pub fn set_fallback_config(&mut self, config: FallbackConfig) {
-        self.fallback_config = config;
+    /// Set fallback configuration (runtime method).
+    ///
+    /// Takes `&self` so HTTP tests can install maps on `Arc<Router>` without a
+    /// unique owner. YAML still does not deserialize these maps.
+    pub fn set_fallback_config(&self, config: FallbackConfig) {
+        self.fallback_config.overwrite(config);
     }
 
     /// Get the router configuration

--- a/src/server/guardrails.rs
+++ b/src/server/guardrails.rs
@@ -17,7 +17,42 @@ mod responses_scan;
 pub(crate) use decision::GuardrailDecisionSink;
 pub(crate) use responses_mask::apply_responses_input;
 
+pub(crate) const OUTPUT_BLOCK_MESSAGE: &str = "Response blocked by output guardrails";
+
 const FRAGMENT_SEPARATOR: &str = "\n---\n";
+
+/// Request-scoped identities attached to an output-guardrail decision.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct OutputDecisionBinding<'a> {
+    pub provider: Option<&'a str>,
+    pub deployment: Option<&'a str>,
+    pub original_deployment: Option<&'a str>,
+    pub fallback_deployment: Option<&'a str>,
+}
+
+impl<'a> OutputDecisionBinding<'a> {
+    pub(crate) fn primary(provider: Option<&'a str>, deployment: Option<&'a str>) -> Self {
+        Self {
+            provider,
+            deployment,
+            original_deployment: None,
+            fallback_deployment: None,
+        }
+    }
+
+    pub(crate) fn fallback(
+        provider: Option<&'a str>,
+        original_deployment: Option<&'a str>,
+        fallback_deployment: Option<&'a str>,
+    ) -> Self {
+        Self {
+            provider,
+            deployment: fallback_deployment,
+            original_deployment,
+            fallback_deployment,
+        }
+    }
+}
 pub(crate) async fn apply_chat_input(
     state: &AppState,
     request: &ChatCompletionRequest,
@@ -30,7 +65,21 @@ pub(crate) async fn apply_chat_output(
     state: &AppState,
     response: &ChatCompletionResponse,
 ) -> Result<ChatCompletionResponse, GatewayError> {
-    let sink = GuardrailDecisionSink::from_state(state, Some(response.model.as_str()), None, None);
+    apply_chat_output_bound(state, response, OutputDecisionBinding::default()).await
+}
+
+pub(crate) async fn apply_chat_output_bound(
+    state: &AppState,
+    response: &ChatCompletionResponse,
+    binding: OutputDecisionBinding<'_>,
+) -> Result<ChatCompletionResponse, GatewayError> {
+    let sink = GuardrailDecisionSink::from_state(
+        state,
+        Some(response.model.as_str()),
+        binding.provider,
+        binding.deployment,
+    )
+    .with_fallback_metadata(binding.original_deployment, binding.fallback_deployment);
     apply_output_with_sink(state.guardrails().as_ref(), response, Some(&sink)).await
 }
 
@@ -376,14 +425,12 @@ pub(super) fn enforce_with_sink(
         Ok(result) => {
             decision::emit_if_present(sink, surface, &result);
             if result.is_blocked() {
-                let subject = if surface == "output" {
-                    "Response"
+                let message = if surface == "output" {
+                    OUTPUT_BLOCK_MESSAGE.to_string()
                 } else {
-                    "Request"
+                    format!("Request blocked by {surface} guardrails")
                 };
-                Err(GatewayError::Forbidden(format!(
-                    "{subject} blocked by {surface} guardrails"
-                )))
+                Err(GatewayError::Forbidden(message))
             } else if result.is_modified() {
                 Ok(Enforcement::Mask)
             } else {

--- a/src/server/guardrails/decision.rs
+++ b/src/server/guardrails/decision.rs
@@ -24,6 +24,8 @@ pub(crate) struct GuardrailDecisionSink {
     provider: Option<String>,
     deployment: Option<String>,
     generation: Option<u64>,
+    original_deployment: Option<String>,
+    fallback_deployment: Option<String>,
 }
 
 impl GuardrailDecisionSink {
@@ -41,7 +43,19 @@ impl GuardrailDecisionSink {
             provider: provider.map(ToString::to_string),
             deployment: deployment.map(ToString::to_string),
             generation: Some(state.pin_runtime().generation),
+            original_deployment: None,
+            fallback_deployment: None,
         }
+    }
+
+    pub(crate) fn with_fallback_metadata(
+        mut self,
+        original_deployment: Option<&str>,
+        fallback_deployment: Option<&str>,
+    ) -> Self {
+        self.original_deployment = original_deployment.map(ToString::to_string);
+        self.fallback_deployment = fallback_deployment.map(ToString::to_string);
+        self
     }
 
     pub(crate) fn emit(&self, surface: &str, result: &CheckResult) {
@@ -61,6 +75,22 @@ impl GuardrailDecisionSink {
         };
         self.callbacks.emit_guardrail_decision(event);
 
+        let audit = self.audit_event(surface, action, &policy_ids, &rule_ids);
+        let audit_logger = Arc::clone(&self.audit);
+        tokio::spawn(async move {
+            if let Err(error) = audit_logger.log(audit).await {
+                warn!(error = %error, "Guardrail decision audit export failed");
+            }
+        });
+    }
+
+    fn audit_event(
+        &self,
+        surface: GuardrailDecisionSurface,
+        action: GuardrailDecisionAction,
+        policy_ids: &[String],
+        rule_ids: &[String],
+    ) -> AuditEvent {
         let mut audit = if action == GuardrailDecisionAction::Block {
             AuditEvent::security(format!("Guardrail {surface:?} {action:?}"))
         } else {
@@ -84,15 +114,22 @@ impl GuardrailDecisionSink {
         if let Some(deployment) = &self.deployment {
             audit = audit.with_metadata("deployment", serde_json::json!(deployment));
         }
+        if let Some(original_deployment) = &self.original_deployment {
+            audit = audit.with_metadata(
+                "original_deployment",
+                serde_json::json!(original_deployment),
+            );
+        }
+        if let Some(fallback_deployment) = &self.fallback_deployment {
+            audit = audit.with_metadata(
+                "fallback_deployment",
+                serde_json::json!(fallback_deployment),
+            );
+        }
         if let Some(generation) = self.generation {
             audit = audit.with_metadata("generation", serde_json::json!(generation));
         }
-        let audit_logger = Arc::clone(&self.audit);
-        tokio::spawn(async move {
-            if let Err(error) = audit_logger.log(audit).await {
-                warn!(error = %error, "Guardrail decision audit export failed");
-            }
-        });
+        audit
     }
 }
 
@@ -321,6 +358,8 @@ mod tests {
             provider: None,
             deployment: None,
             generation: Some(0),
+            original_deployment: None,
+            fallback_deployment: None,
         }
     }
 
@@ -505,5 +544,45 @@ mod tests {
             GuardrailDecisionSurface::Output,
             GuardrailDecisionAction::Allow,
         ));
+    }
+
+    #[test]
+    fn audit_metadata_records_original_and_fallback_deployments_without_payload() {
+        let sink = GuardrailDecisionSink {
+            callbacks: CallbackDispatcher::default(),
+            audit: Arc::new(AuditLogger::disabled()),
+            request_id: Some("req-1277".to_string()),
+            model: Some("gpt-4o".to_string()),
+            provider: Some("backup".to_string()),
+            deployment: Some("backup-gpt-4o-mini".to_string()),
+            generation: Some(0),
+            original_deployment: Some("openai-gpt-4o".to_string()),
+            fallback_deployment: Some("backup-gpt-4o-mini".to_string()),
+        };
+        let event = sink.audit_event(
+            GuardrailDecisionSurface::Output,
+            GuardrailDecisionAction::Block,
+            &["custom_rule".to_string()],
+            &["custom_rule:deny-forbidden-token".to_string()],
+        );
+        assert_eq!(
+            event.metadata.get("original_deployment"),
+            Some(&serde_json::json!("openai-gpt-4o"))
+        );
+        assert_eq!(
+            event.metadata.get("fallback_deployment"),
+            Some(&serde_json::json!("backup-gpt-4o-mini"))
+        );
+        assert_eq!(
+            event.metadata.get("deployment"),
+            Some(&serde_json::json!("backup-gpt-4o-mini"))
+        );
+        assert_eq!(
+            event.metadata.get("action"),
+            Some(&serde_json::json!("block"))
+        );
+        let json = event.to_json().expect("audit event should serialize");
+        assert!(!json.contains("forbidden-token-xyz"), "{json}");
+        assert!(!json.contains("modified_content"));
     }
 }

--- a/src/server/routes/ai/chat.rs
+++ b/src/server/routes/ai/chat.rs
@@ -8,7 +8,8 @@ use crate::core::models::openai::{
     ToolChoice, TopLogprob, Usage,
 };
 use crate::core::providers::{
-    ChatContinuationRequest, ChatContinuationResponse, ChatMessageContinuation, ProviderError,
+    ChatContinuationRequest, ChatContinuationResponse, ChatMessageContinuation, Provider,
+    ProviderError,
 };
 use crate::core::streaming::types::{
     ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionDelta,
@@ -22,12 +23,16 @@ use crate::utils::data::validation::RequestValidator;
 use crate::utils::error::gateway_error::GatewayError;
 use actix_web::{HttpRequest, HttpResponse, Result as ActixResult, web};
 use serde_json::json;
+use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{error, info, warn};
 
-use super::budgeted::{ApiKeyBudgetPolicy, run_unary};
+use super::budgeted::ApiKeyBudgetPolicy;
 use super::callbacks::CallbackLifecycle;
+use super::execution::execute_with_selected_deployment_matching;
 use super::openai_errors;
+use super::output_fallback::{self, SelectedAttempt, is_output_guardrail_block};
 #[path = "chat_delta.rs"]
 mod chat_delta;
 use chat_delta::{convert_function_call_delta, convert_tool_call_delta};
@@ -256,199 +261,280 @@ async fn handle_chat_completion_internal(
     let budget_limits = state.budgeted.budget_limits();
     let has_continuation = core_request.has_continuation();
     let callback_for_execution = callback.clone();
-    let core_response = match run_unary(
-        unified_router,
-        &requested_model,
-        ProviderCapability::ChatCompletion,
-        move |provider, selected_model, _deployment_id| {
-            let core_request = core_request.clone();
-            let context = Arc::clone(&context_for_execution);
-            let original_request = Arc::clone(&request_for_execution);
-            let pricing_service = pricing_service.clone();
-            let key_manager = key_manager.clone();
-            let budgeted = budgeted.clone();
-            let budget_limits = budget_limits.clone();
-            let pricing_config = pricing_config.clone();
-            let callback = callback_for_execution.clone();
-            let cached_response = cached_response.clone();
-            async move {
-                let provider_name = provider.name().to_string();
-                let request_pricing = super::spend::request_pricing_for_provider(
-                    &pricing_service,
-                    &provider,
-                    &selected_model,
-                    ProviderCapability::ChatCompletion,
-                )?;
-                if let Some(cached) = cached_response {
-                    super::response_cache::ensure_chat_cache_pricing_for_attempt(
-                        &request_pricing,
-                        original_request.as_ref(),
-                        &provider_name,
-                        &selected_model,
-                    )?;
-                    return Ok((ChatAttemptResponse::Cached(cached), 0));
-                }
-                if has_continuation
-                    && continuation_budget_enabled(
-                        budget_limits.as_ref(),
-                        &provider_name,
-                        &selected_model,
-                        api_key_budget_id.is_some(),
-                    )
-                {
-                    return Err(ProviderError::not_supported(
-                        "budget",
-                        "Anthropic continuation cannot be metered safely while an API-key, provider, or model budget is enabled",
-                    ));
-                }
-                let (legacy_request, extensions) = core_request.into_parts();
-                let request_for_provider = super::token_policy::prepare_chat_request_for_provider(
-                    context.api_key_max_tokens_per_request(),
+    let skip_cached_replay = Arc::new(AtomicBool::new(false));
+    let skip_cached_replay_for_execution = Arc::clone(&skip_cached_replay);
+    let operation = move |provider: Provider, selected_model: String, deployment_id: String| {
+        let core_request = core_request.clone();
+        let context = Arc::clone(&context_for_execution);
+        let original_request = Arc::clone(&request_for_execution);
+        let pricing_service = pricing_service.clone();
+        let key_manager = key_manager.clone();
+        let budgeted = budgeted.clone();
+        let budget_limits = budget_limits.clone();
+        let pricing_config = pricing_config.clone();
+        let callback = callback_for_execution.clone();
+        let cached_response = cached_response.clone();
+        let skip_cached_replay = Arc::clone(&skip_cached_replay_for_execution);
+        async move {
+            let provider_name = provider.name().to_string();
+            let wrap = |value: ChatAttemptResponse| SelectedAttempt {
+                value,
+                provider: provider_name.clone(),
+                deployment_id: deployment_id.clone(),
+            };
+            let request_pricing = super::spend::request_pricing_for_provider(
+                &pricing_service,
+                &provider,
+                &selected_model,
+                ProviderCapability::ChatCompletion,
+            )?;
+            if let Some(cached) = cached_response
+                && !skip_cached_replay.load(Ordering::Relaxed)
+            {
+                super::response_cache::ensure_chat_cache_pricing_for_attempt(
+                    &request_pricing,
+                    original_request.as_ref(),
                     &provider_name,
                     &selected_model,
-                    legacy_request,
                 )?;
-                let request_for_provider =
-                    ChatContinuationRequest::new(request_for_provider, extensions)?;
-                let request_for_budget =
-                    super::spend::ChatCompletionBudgetRequest::from(original_request.as_ref())
-                        .with_output_limits(
-                            request_for_provider.request().max_tokens,
-                            request_for_provider.request().max_completion_tokens,
-                        );
-                let provider_context = context.as_ref().clone();
-                let settle_pricing_service = pricing_service.clone();
-                let reserve_pricing_config = pricing_config.clone();
-                let settle_pricing_config = pricing_config;
-                let reserve_request_pricing = request_pricing.clone();
-                let settle_request_pricing = request_pricing.clone();
-                let settle_key_manager = key_manager.clone();
-                let callback_provider = provider_name.clone();
-                let callback_model = selected_model.clone();
-                let callback_request_pricing = request_pricing;
-                budgeted
-                    .for_selected_with_api_key_budget(
-                        provider_name.clone(),
-                        selected_model.clone(),
-                        api_key_budget_id,
-                        ApiKeyBudgetPolicy::FromProviderReservation,
-                    )
-                    .reserve_call_settle(
-                        |budget| {
-                            super::spend::reserve_chat_completion_budget_with_request_pricing(
-                                &reserve_request_pricing,
-                                &reserve_pricing_config,
-                                budget.budget_limits(),
-                                budget.provider(),
-                                budget.model(),
-                                request_for_budget,
-                            )
-                        },
-                        || {
-                            callback.begin_provider_execution_with_pricing(
-                                callback_provider,
-                                callback_model,
-                                callback_request_pricing,
-                            );
-                            provider.chat_completion_with_continuation(
-                                request_for_provider,
-                                provider_context,
-                                opt_in,
-                            )
-                        },
-                        |response, reservations, budget| {
-                            let (budget_reservation, key_budget_reservation) =
-                                reservations.into_parts();
-                            async move {
-                                let tokens = response
-                                    .response()
-                                    .usage
-                                    .as_ref()
-                                    .map(|usage| u64::from(usage.total_tokens))
-                                    .unwrap_or_default();
-                                super::spend::record_completion_spend_with_reservation_with_policy(
-                                    settle_pricing_service.as_ref(),
-                                    &settle_pricing_config,
-                                    super::spend::usage_spend_settlement_with_request_pricing(
-                                        (budget.budget_limits(), &settle_key_manager, api_key_id),
-                                        (
-                                            budget.provider(),
-                                            budget.model(),
-                                            response.response().usage.as_ref(),
-                                        ),
-                                        settle_request_pricing,
-                                        budget_reservation,
-                                        key_budget_reservation,
-                                    ),
-                                )
-                                .await;
-                                (response, tokens)
-                            }
-                        },
-                    )
-                    .await
-                    .map(|(response, tokens)| (ChatAttemptResponse::Provider(response), tokens))
+                return Ok((wrap(ChatAttemptResponse::Cached(cached)), 0));
             }
-        },
-    )
-    .await
+            if has_continuation
+                && continuation_budget_enabled(
+                    budget_limits.as_ref(),
+                    &provider_name,
+                    &selected_model,
+                    api_key_budget_id.is_some(),
+                )
+            {
+                return Err(ProviderError::not_supported(
+                    "budget",
+                    "Anthropic continuation cannot be metered safely while an API-key, provider, or model budget is enabled",
+                ));
+            }
+            let (legacy_request, extensions) = core_request.into_parts();
+            let request_for_provider = super::token_policy::prepare_chat_request_for_provider(
+                context.api_key_max_tokens_per_request(),
+                &provider_name,
+                &selected_model,
+                legacy_request,
+            )?;
+            let request_for_provider =
+                ChatContinuationRequest::new(request_for_provider, extensions)?;
+            let request_for_budget =
+                super::spend::ChatCompletionBudgetRequest::from(original_request.as_ref())
+                    .with_output_limits(
+                        request_for_provider.request().max_tokens,
+                        request_for_provider.request().max_completion_tokens,
+                    );
+            let provider_context = context.as_ref().clone();
+            let settle_pricing_service = pricing_service.clone();
+            let reserve_pricing_config = pricing_config.clone();
+            let settle_pricing_config = pricing_config;
+            let reserve_request_pricing = request_pricing.clone();
+            let settle_request_pricing = request_pricing.clone();
+            let settle_key_manager = key_manager.clone();
+            let callback_provider = provider_name.clone();
+            let callback_model = selected_model.clone();
+            let callback_request_pricing = request_pricing;
+            budgeted
+                .for_selected_with_api_key_budget(
+                    provider_name.clone(),
+                    selected_model.clone(),
+                    api_key_budget_id,
+                    ApiKeyBudgetPolicy::FromProviderReservation,
+                )
+                .reserve_call_settle(
+                    |budget| {
+                        super::spend::reserve_chat_completion_budget_with_request_pricing(
+                            &reserve_request_pricing,
+                            &reserve_pricing_config,
+                            budget.budget_limits(),
+                            budget.provider(),
+                            budget.model(),
+                            request_for_budget,
+                        )
+                    },
+                    || {
+                        callback.begin_provider_execution_with_pricing(
+                            callback_provider,
+                            callback_model,
+                            callback_request_pricing,
+                        );
+                        provider.chat_completion_with_continuation(
+                            request_for_provider,
+                            provider_context,
+                            opt_in,
+                        )
+                    },
+                    |response, reservations, budget| {
+                        let (budget_reservation, key_budget_reservation) =
+                            reservations.into_parts();
+                        async move {
+                            let tokens = response
+                                .response()
+                                .usage
+                                .as_ref()
+                                .map(|usage| u64::from(usage.total_tokens))
+                                .unwrap_or_default();
+                            super::spend::record_completion_spend_with_reservation_with_policy(
+                                settle_pricing_service.as_ref(),
+                                &settle_pricing_config,
+                                super::spend::usage_spend_settlement_with_request_pricing(
+                                    (budget.budget_limits(), &settle_key_manager, api_key_id),
+                                    (
+                                        budget.provider(),
+                                        budget.model(),
+                                        response.response().usage.as_ref(),
+                                    ),
+                                    settle_request_pricing,
+                                    budget_reservation,
+                                    key_budget_reservation,
+                                ),
+                            )
+                            .await;
+                            (response, tokens)
+                        }
+                    },
+                )
+                .await
+                .map(|(response, tokens)| (wrap(ChatAttemptResponse::Provider(response)), tokens))
+        }
+    };
+    let mut excluded_deployments = HashSet::new();
+    let mut original_deployment = None;
+    let mut last_output_block = None;
+    for (attempt_idx, model) in output_fallback::models_to_try(unified_router, &requested_model)
+        .into_iter()
+        .enumerate()
     {
-        Ok(response) => response,
-        Err(error) => {
-            callback.fail(error.to_string(), "provider_error");
-            return Err(error);
-        }
-    };
-    let core_response = match core_response {
-        ChatAttemptResponse::Cached(cached) => {
-            let cached = crate::server::guardrails::apply_chat_output(state, &cached).await?;
-            let extensions = vec![ChatMessageContinuation::new(); cached.choices.len()];
-            let response = ChatCompletionResponseWithExtensions::from_parts(cached, extensions)
-                .map_err(GatewayError::internal)?;
-            return Ok((response, callback));
-        }
-        ChatAttemptResponse::Provider(response) => response,
-    };
-    let (core_response, choice_extensions) = core_response.into_parts();
-    let original_response = convert_core_chat_response(core_response);
-    let response = crate::server::guardrails::apply_chat_output(state, &original_response)
+        let excluded = excluded_deployments.clone();
+        let routed = match execute_with_selected_deployment_matching(
+            unified_router,
+            &model,
+            ProviderCapability::ChatCompletion,
+            move |deployment| !excluded.contains(deployment.id.as_str()),
+            operation.clone(),
+        )
         .await
-        .inspect_err(|error| {
-            callback.fail(error.to_string(), "guardrail_output");
-        })?;
-    let choice_extensions =
-        continuation_after_output_projection(&original_response, &response, choice_extensions)?;
-    let guardrail_response =
-        match guardrail_response_with_continuation(&response, &choice_extensions) {
-            Ok(projected) => projected,
+        {
+            Ok(routed) => routed,
             Err(error) => {
-                callback.fail(error.to_string(), "guardrail_output_projection");
-                return Err(error);
+                if attempt_idx == 0 {
+                    callback.fail(error.to_string(), "provider_error");
+                    return Err(error);
+                }
+                continue;
             }
         };
-    if choice_extensions
-        .iter()
-        .any(ChatMessageContinuation::has_visible_thinking)
-        && let Err(error) =
-            crate::server::guardrails::ensure_chat_output_unmodified(state, &guardrail_response)
+        let binding = output_fallback::output_binding(
+            original_deployment.as_deref(),
+            &routed.provider,
+            &routed.deployment_id,
+        );
+        let blocked_deployment = routed.deployment_id.clone();
+        match routed.value {
+            ChatAttemptResponse::Cached(cached) => {
+                match crate::server::guardrails::apply_chat_output_bound(state, &cached, binding)
+                    .await
+                {
+                    Ok(cached) => {
+                        let extensions = vec![ChatMessageContinuation::new(); cached.choices.len()];
+                        let response =
+                            ChatCompletionResponseWithExtensions::from_parts(cached, extensions)
+                                .map_err(GatewayError::internal)?;
+                        return Ok((response, callback));
+                    }
+                    Err(error) if is_output_guardrail_block(&error) => {
+                        skip_cached_replay.store(true, Ordering::Relaxed);
+                        excluded_deployments.insert(blocked_deployment.clone());
+                        original_deployment.get_or_insert(blocked_deployment);
+                        last_output_block = Some(error);
+                        continue;
+                    }
+                    Err(error) => {
+                        callback.fail(error.to_string(), "guardrail_output");
+                        return Err(error);
+                    }
+                }
+            }
+            ChatAttemptResponse::Provider(core_response) => {
+                let (core_response, choice_extensions) = core_response.into_parts();
+                let original_response = convert_core_chat_response(core_response);
+                let response = match crate::server::guardrails::apply_chat_output_bound(
+                    state,
+                    &original_response,
+                    binding,
+                )
                 .await
-    {
-        callback.fail(error.to_string(), "guardrail_output");
-        return Err(error);
+                {
+                    Ok(response) => response,
+                    Err(error) if is_output_guardrail_block(&error) => {
+                        skip_cached_replay.store(true, Ordering::Relaxed);
+                        excluded_deployments.insert(blocked_deployment.clone());
+                        original_deployment.get_or_insert(blocked_deployment);
+                        last_output_block = Some(error);
+                        continue;
+                    }
+                    Err(error) => {
+                        callback.fail(error.to_string(), "guardrail_output");
+                        return Err(error);
+                    }
+                };
+                let choice_extensions = continuation_after_output_projection(
+                    &original_response,
+                    &response,
+                    choice_extensions,
+                )?;
+                let guardrail_response =
+                    match guardrail_response_with_continuation(&response, &choice_extensions) {
+                        Ok(projected) => projected,
+                        Err(error) => {
+                            callback.fail(error.to_string(), "guardrail_output_projection");
+                            return Err(error);
+                        }
+                    };
+                if choice_extensions
+                    .iter()
+                    .any(ChatMessageContinuation::has_visible_thinking)
+                    && let Err(error) = crate::server::guardrails::ensure_chat_output_unmodified(
+                        state,
+                        &guardrail_response,
+                    )
+                    .await
+                {
+                    callback.fail(error.to_string(), "guardrail_output");
+                    return Err(error);
+                }
+                if !opt_in
+                    && let Err(error) = super::response_cache::store_chat(
+                        state,
+                        request.as_ref(),
+                        &response,
+                        context.as_ref(),
+                    )
+                    .await
+                {
+                    callback.fail(error.to_string(), "cache_error");
+                    return Err(error);
+                }
+                let response =
+                    ChatCompletionResponseWithExtensions::from_parts(response, choice_extensions)
+                        .map_err(GatewayError::internal)
+                        .inspect_err(|error| {
+                            callback.fail(error.to_string(), "response_projection")
+                        })?;
+                return Ok((response, callback));
+            }
+        }
     }
-    if !opt_in
-        && let Err(error) =
-            super::response_cache::store_chat(state, request.as_ref(), &response, context.as_ref())
-                .await
-    {
-        callback.fail(error.to_string(), "cache_error");
-        return Err(error);
-    }
-    let response = ChatCompletionResponseWithExtensions::from_parts(response, choice_extensions)
-        .map_err(GatewayError::internal)
-        .inspect_err(|error| callback.fail(error.to_string(), "response_projection"))?;
-    Ok((response, callback))
+    let error = last_output_block.unwrap_or_else(|| {
+        GatewayError::Forbidden(crate::server::guardrails::OUTPUT_BLOCK_MESSAGE.to_string())
+    });
+    callback.fail(error.to_string(), "guardrail_output");
+    Err(error)
 }
+
 pub(crate) fn build_core_chat_request(
     request: &ChatCompletionRequest,
     model: String,

--- a/src/server/routes/ai/chat_streaming.rs
+++ b/src/server/routes/ai/chat_streaming.rs
@@ -9,14 +9,16 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use crate::core::models::openai::ChatCompletionRequest;
-use crate::core::providers::ProviderError;
+use crate::core::providers::{Provider, ProviderError};
 use crate::core::streaming::types::Event;
 use crate::core::types::{context::SharedRequestContext, model::ProviderCapability};
 use crate::server::state::AppState;
+use std::collections::HashSet;
 
 use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream, run_stream};
 use super::super::callbacks::CallbackLifecycle;
 use super::super::openai_errors;
+use super::super::output_fallback;
 use super::super::{spend, token_policy};
 
 pub(super) async fn handle_streaming_chat_completion(
@@ -70,11 +72,8 @@ pub(super) async fn handle_streaming_chat_completion(
     let api_key_id = context.api_key_id();
     let api_key_budget_id = context.api_key_budget_id();
     let callback_for_execution = callback.clone();
-    match run_stream(
-        state.unified_router().clone(),
-        &requested_model,
-        ProviderCapability::ChatCompletionStream,
-        move |provider, selected_model, _selected_deployment_id| {
+    let start_stream =
+        move |provider: Provider, selected_model: String, _selected_deployment_id: String| {
             let core_request = core_request.clone();
             let context = Arc::clone(&context_for_execution);
             let original_request = Arc::clone(&request_for_execution);
@@ -154,279 +153,386 @@ pub(super) async fn handle_streaming_chat_completion(
                 };
                 Ok((stream, settlement))
             }
-        },
+        };
+    let fallback_models = output_fallback::content_policy_fallback_models(
+        state.unified_router().as_ref(),
+        &requested_model,
+    );
+    let router_for_stream = state.unified_router().clone();
+    let state_for_stream = state.clone();
+    match run_stream(
+        router_for_stream.clone(),
+        &requested_model,
+        ProviderCapability::ChatCompletionStream,
+        start_stream.clone(),
     )
     .await
     {
-        Ok(((mut stream, mut settlement), lease)) => {
+        Ok(((stream, settlement), lease)) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let guardrails = Arc::clone(&state.guardrails());
-            let decision_sink = crate::server::guardrails::GuardrailDecisionSink::from_state(
-                state,
-                Some(settlement.model.as_str()),
-                Some(settlement.provider.as_str()),
-                None,
-            );
 
             tokio::spawn(async move {
-                let mut lease = Some(lease);
-                let mut output_guardrail =
-                    super::super::stream_output_guardrail::StreamOutputGuardrail::new(guardrails)
-                        .with_decision_sink(decision_sink);
-                let mut tokens_used = 0_u64;
-                let mut final_usage = None;
-                let mut saw_upstream_output = false;
-                macro_rules! settle_after_upstream_output {
-                    () => {
-                        if final_usage.is_some() || saw_upstream_output {
-                            settlement.record_disconnect(final_usage.as_ref()).await;
-                        }
-                    };
-                }
-                macro_rules! return_after_guardrail_error {
-                    ($error:expr) => {{
-                        let guardrail_error = $error;
-                        let error_bytes = super::format_sse_error(
-                            guardrail_error.message(),
-                            guardrail_error.error_type(),
-                            guardrail_error.code(),
-                        );
-                        if tx.send(error_bytes).await.is_err() {
-                            info!("Client disconnected before guardrail error could be sent");
-                        }
-                        drop(lease.take());
-                        callback.fail(guardrail_error.message(), "guardrail_output");
-                        settle_after_upstream_output!();
-                        return;
-                    }};
-                }
-                macro_rules! flush_guardrail {
-                    () => {
-                        match output_guardrail.flush_to_until_closed(&tx).await {
-                            Ok(Some(())) => {}
+                let mut excluded = HashSet::new();
+                let mut original_deployment = None;
+                let mut fallback_models = fallback_models.into_iter();
+                let mut current = Some(((stream, settlement), lease));
+                'fallback: while let Some(((mut stream, mut settlement), lease)) = current.take() {
+                    let deployment_id = lease.deployment_id().to_string();
+                    let sink = crate::server::guardrails::GuardrailDecisionSink::from_state(
+                        &state_for_stream,
+                        Some(settlement.model.as_str()),
+                        Some(settlement.provider.as_str()),
+                        Some(deployment_id.as_str()),
+                    )
+                    .with_fallback_metadata(
+                        original_deployment.as_deref(),
+                        original_deployment.as_ref().map(|_| deployment_id.as_str()),
+                    );
+                    let mut lease = Some(lease);
+                    let mut output_guardrail =
+                        super::super::stream_output_guardrail::StreamOutputGuardrail::new(
+                            Arc::clone(&guardrails),
+                        )
+                        .with_decision_sink(sink);
+                    #[allow(unused_assignments)]
+                    let mut committed = false;
+                    let mut retry_block = None;
+                    let mut tokens_used = 0_u64;
+                    let mut final_usage = None;
+                    let mut saw_upstream_output = false;
+                    macro_rules! settle_after_upstream_output {
+                        () => {
+                            if final_usage.is_some() || saw_upstream_output {
+                                settlement.record_disconnect(final_usage.as_ref()).await;
+                            }
+                        };
+                    }
+                    macro_rules! return_after_guardrail_error {
+                        ($error:expr) => {{
+                            let guardrail_error = $error;
+                            if output_fallback::allow_uncommitted_stream_fallback(
+                                guardrail_error,
+                                committed,
+                            ) {
+                                if let Some(lease) = lease.take() {
+                                    retry_block = Some(lease.deployment_id().to_string());
+                                    drop(lease);
+                                }
+                                break;
+                            }
+                            let error_bytes = super::format_sse_error(
+                                guardrail_error.message(),
+                                guardrail_error.error_type(),
+                                guardrail_error.code(),
+                            );
+                            if tx.send(error_bytes).await.is_err() {
+                                info!("Client disconnected before guardrail error could be sent");
+                            }
+                            drop(lease.take());
+                            callback.fail(guardrail_error.message(), "guardrail_output");
+                            settle_after_upstream_output!();
+                            return;
+                        }};
+                    }
+                    macro_rules! flush_guardrail {
+                        () => {
+                            match output_guardrail.flush_to_until_closed(&tx).await {
+                                Ok(Some(_)) => {}
+                                Ok(None) => {
+                                    callback.fail("client disconnected", "client_disconnect");
+                                    settle_after_upstream_output!();
+                                    return;
+                                }
+                                Err(error) => return_after_guardrail_error!(error),
+                            }
+                        };
+                    }
+
+                    loop {
+                        let chunk_result = if idle_timeout_secs == 0 {
+                            tokio::select! {
+                                biased;
+                                _ = tx.closed() => {
+                                    info!("Client disconnected while waiting for stream output");
+                                    callback.fail("client disconnected", "client_disconnect");
+                                    settle_after_upstream_output!();
+                                    return;
+                                }
+                                result = stream.next() => result,
+                            }
+                        } else {
+                            let timeout_dur = Duration::from_secs(idle_timeout_secs);
+                            let timed_result = tokio::select! {
+                                biased;
+                                _ = tx.closed() => {
+                                    info!("Client disconnected while waiting for stream output");
+                                    callback.fail("client disconnected", "client_disconnect");
+                                    settle_after_upstream_output!();
+                                    return;
+                                }
+                                result = tokio::time::timeout(timeout_dur, stream.next()) => result,
+                            };
+                            match timed_result {
+                                Ok(result) => result,
+                                Err(_) => {
+                                    flush_guardrail!();
+                                    warn!(
+                                        "SSE stream idle timeout after {}s, closing connection",
+                                        idle_timeout_secs
+                                    );
+                                    let error_bytes = super::format_sse_error(
+                                        &format!(
+                                            "Stream idle timeout: no data received for {}s",
+                                            idle_timeout_secs
+                                        ),
+                                        "server_error",
+                                        "timeout",
+                                    );
+                                    if tx.send(error_bytes).await.is_err() {
+                                        info!(
+                                            "Client disconnected before timeout error could be sent"
+                                        );
+                                    }
+                                    if let Some(lease) = lease.take() {
+                                        let error = ProviderError::timeout(
+                                            "router",
+                                            format!(
+                                                "stream idle timeout after {}s",
+                                                idle_timeout_secs
+                                            ),
+                                        );
+                                        lease.finish_failure(&error);
+                                    }
+                                    callback.fail(
+                                        format!("stream idle timeout after {}s", idle_timeout_secs),
+                                        "timeout",
+                                    );
+                                    settle_after_upstream_output!();
+                                    return;
+                                }
+                            }
+                        };
+
+                        let Some(chunk_result) = chunk_result else {
+                            break;
+                        };
+
+                        let (output_deltas, bytes) = match chunk_result {
+                            Ok(chunk) => {
+                                let has_candidate_output =
+                                    spend::stream_chunk_has_candidate_output(&chunk);
+                                if let Some(usage) = &chunk.usage {
+                                    final_usage = Some(usage.clone());
+                                }
+                                tokens_used = final_usage
+                                    .as_ref()
+                                    .map(|usage| u64::from(usage.total_tokens))
+                                    .unwrap_or(0);
+                                if chunk.choices.is_empty() && chunk.usage.is_none() {
+                                    continue;
+                                }
+                                saw_upstream_output |= has_candidate_output;
+                                let mut chat_chunk = match super::convert_core_chunk_to_streaming(
+                                    chunk,
+                                ) {
+                                    Ok(chat_chunk) => chat_chunk,
+                                    Err(e) => {
+                                        flush_guardrail!();
+                                        error!("Stream chunk conversion error: {}", e);
+                                        let (error_type, error_code) =
+                                            super::sse_error_classification(&e);
+                                        let error_bytes = super::format_sse_error(
+                                            &e.to_string(),
+                                            error_type,
+                                            error_code,
+                                        );
+                                        if tx.send(error_bytes).await.is_err() {
+                                            info!(
+                                                "Client disconnected before conversion error could be sent"
+                                            );
+                                        }
+                                        if let Some(lease) = lease.take() {
+                                            lease.finish_failure(&e);
+                                        }
+                                        callback.fail(e.to_string(), "conversion_error");
+                                        settle_after_upstream_output!();
+                                        return;
+                                    }
+                                };
+                                if !client_requested_usage {
+                                    chat_chunk.usage = None;
+                                    if chat_chunk.choices.is_empty() {
+                                        continue;
+                                    }
+                                }
+                                let output_deltas = chat_chunk
+                                    .choices
+                                    .iter()
+                                    .filter_map(|choice| {
+                                        choice
+                                            .delta
+                                            .content
+                                            .as_ref()
+                                            .map(|text| (choice.index, text.clone()))
+                                    })
+                                    .collect::<Vec<_>>();
+                                let bytes = match serde_json::to_string(&chat_chunk) {
+                                    Ok(json) => {
+                                        let event = Event::default().data(&json);
+                                        event.to_bytes()
+                                    }
+                                    Err(e) => {
+                                        flush_guardrail!();
+                                        error!("Stream serialization error: {}", e);
+                                        let error_bytes = super::format_sse_error(
+                                            &format!("Serialization error: {}", e),
+                                            "server_error",
+                                            "internal_error",
+                                        );
+                                        if tx.send(error_bytes).await.is_err() {
+                                            info!(
+                                                "Client disconnected before error event could be sent"
+                                            );
+                                        }
+                                        if let Some(lease) = lease.take() {
+                                            let error = ProviderError::serialization(
+                                                "router",
+                                                format!("Serialization error: {}", e),
+                                            );
+                                            lease.finish_failure(&error);
+                                        }
+                                        callback.fail(
+                                            format!("Serialization error: {}", e),
+                                            "serialization_error",
+                                        );
+                                        settle_after_upstream_output!();
+                                        return;
+                                    }
+                                };
+                                (output_deltas, bytes)
+                            }
+                            Err(e) => {
+                                flush_guardrail!();
+                                error!("Stream chunk error: {}", e);
+                                let (error_type, error_code) = super::sse_error_classification(&e);
+                                let error_bytes =
+                                    super::format_sse_error(&e.to_string(), error_type, error_code);
+                                if tx.send(error_bytes).await.is_err() {
+                                    info!("Client disconnected before error event could be sent");
+                                }
+                                if let Some(lease) = lease.take() {
+                                    lease.finish_failure(&e);
+                                }
+                                callback.fail(e.to_string(), "provider_error");
+                                settle_after_upstream_output!();
+                                return;
+                            }
+                        };
+
+                        let pending = match output_guardrail
+                            .push_many_until_closed(&tx, output_deltas, bytes)
+                            .await
+                        {
+                            Ok(Some(pending)) => pending,
                             Ok(None) => {
                                 callback.fail("client disconnected", "client_disconnect");
                                 settle_after_upstream_output!();
                                 return;
                             }
                             Err(error) => return_after_guardrail_error!(error),
-                        }
-                    };
-                }
-
-                loop {
-                    let chunk_result = if idle_timeout_secs == 0 {
-                        tokio::select! {
-                            biased;
-                            _ = tx.closed() => {
-                                info!("Client disconnected while waiting for stream output");
-                                callback.fail("client disconnected", "client_disconnect");
-                                settle_after_upstream_output!();
-                                return;
-                            }
-                            result = stream.next() => result,
-                        }
-                    } else {
-                        let timeout_dur = Duration::from_secs(idle_timeout_secs);
-                        let timed_result = tokio::select! {
-                            biased;
-                            _ = tx.closed() => {
-                                info!("Client disconnected while waiting for stream output");
-                                callback.fail("client disconnected", "client_disconnect");
-                                settle_after_upstream_output!();
-                                return;
-                            }
-                            result = tokio::time::timeout(timeout_dur, stream.next()) => result,
                         };
-                        match timed_result {
-                            Ok(result) => result,
-                            Err(_) => {
-                                flush_guardrail!();
-                                warn!(
-                                    "SSE stream idle timeout after {}s, closing connection",
-                                    idle_timeout_secs
-                                );
-                                let error_bytes = super::format_sse_error(
-                                    &format!(
-                                        "Stream idle timeout: no data received for {}s",
-                                        idle_timeout_secs
-                                    ),
-                                    "server_error",
-                                    "timeout",
-                                );
-                                if tx.send(error_bytes).await.is_err() {
-                                    info!("Client disconnected before timeout error could be sent");
-                                }
-                                if let Some(lease) = lease.take() {
-                                    let error = ProviderError::timeout(
-                                        "router",
-                                        format!("stream idle timeout after {}s", idle_timeout_secs),
-                                    );
-                                    lease.finish_failure(&error);
-                                }
-                                callback.fail(
-                                    format!("stream idle timeout after {}s", idle_timeout_secs),
-                                    "timeout",
-                                );
+                        for bytes in pending {
+                            if tx.send(bytes).await.is_err() {
+                                info!("Client disconnected during streaming, cancelling upstream");
+                                callback.fail("client disconnected", "client_disconnect");
                                 settle_after_upstream_output!();
                                 return;
                             }
-                        }
-                    };
-
-                    let Some(chunk_result) = chunk_result else {
-                        break;
-                    };
-
-                    let (output_deltas, bytes) = match chunk_result {
-                        Ok(chunk) => {
-                            let has_candidate_output =
-                                spend::stream_chunk_has_candidate_output(&chunk);
-                            if let Some(usage) = &chunk.usage {
-                                final_usage = Some(usage.clone());
-                            }
-                            tokens_used = final_usage
-                                .as_ref()
-                                .map(|usage| u64::from(usage.total_tokens))
-                                .unwrap_or(0);
-                            if chunk.choices.is_empty() && chunk.usage.is_none() {
-                                continue;
-                            }
-                            saw_upstream_output |= has_candidate_output;
-                            let mut chat_chunk = match super::convert_core_chunk_to_streaming(chunk)
-                            {
-                                Ok(chat_chunk) => chat_chunk,
-                                Err(e) => {
-                                    flush_guardrail!();
-                                    error!("Stream chunk conversion error: {}", e);
-                                    let (error_type, error_code) =
-                                        super::sse_error_classification(&e);
-                                    let error_bytes = super::format_sse_error(
-                                        &e.to_string(),
-                                        error_type,
-                                        error_code,
-                                    );
-                                    if tx.send(error_bytes).await.is_err() {
-                                        info!(
-                                            "Client disconnected before conversion error could be sent"
-                                        );
-                                    }
-                                    if let Some(lease) = lease.take() {
-                                        lease.finish_failure(&e);
-                                    }
-                                    callback.fail(e.to_string(), "conversion_error");
-                                    settle_after_upstream_output!();
-                                    return;
-                                }
-                            };
-                            if !client_requested_usage {
-                                chat_chunk.usage = None;
-                                if chat_chunk.choices.is_empty() {
-                                    continue;
-                                }
-                            }
-                            let output_deltas = chat_chunk
-                                .choices
-                                .iter()
-                                .filter_map(|choice| {
-                                    choice
-                                        .delta
-                                        .content
-                                        .as_ref()
-                                        .map(|text| (choice.index, text.clone()))
-                                })
-                                .collect::<Vec<_>>();
-                            let bytes = match serde_json::to_string(&chat_chunk) {
-                                Ok(json) => {
-                                    let event = Event::default().data(&json);
-                                    event.to_bytes()
-                                }
-                                Err(e) => {
-                                    flush_guardrail!();
-                                    error!("Stream serialization error: {}", e);
-                                    let error_bytes = super::format_sse_error(
-                                        &format!("Serialization error: {}", e),
-                                        "server_error",
-                                        "internal_error",
-                                    );
-                                    if tx.send(error_bytes).await.is_err() {
-                                        info!(
-                                            "Client disconnected before error event could be sent"
-                                        );
-                                    }
-                                    if let Some(lease) = lease.take() {
-                                        let error = ProviderError::serialization(
-                                            "router",
-                                            format!("Serialization error: {}", e),
-                                        );
-                                        lease.finish_failure(&error);
-                                    }
-                                    callback.fail(
-                                        format!("Serialization error: {}", e),
-                                        "serialization_error",
-                                    );
-                                    settle_after_upstream_output!();
-                                    return;
-                                }
-                            };
-                            (output_deltas, bytes)
-                        }
-                        Err(e) => {
-                            flush_guardrail!();
-                            error!("Stream chunk error: {}", e);
-                            let (error_type, error_code) = super::sse_error_classification(&e);
-                            let error_bytes =
-                                super::format_sse_error(&e.to_string(), error_type, error_code);
-                            if tx.send(error_bytes).await.is_err() {
-                                info!("Client disconnected before error event could be sent");
-                            }
-                            if let Some(lease) = lease.take() {
-                                lease.finish_failure(&e);
-                            }
-                            callback.fail(e.to_string(), "provider_error");
-                            settle_after_upstream_output!();
-                            return;
-                        }
-                    };
-
-                    let pending = match output_guardrail
-                        .push_many_until_closed(&tx, output_deltas, bytes)
-                        .await
-                    {
-                        Ok(Some(pending)) => pending,
-                        Ok(None) => {
-                            callback.fail("client disconnected", "client_disconnect");
-                            settle_after_upstream_output!();
-                            return;
-                        }
-                        Err(error) => return_after_guardrail_error!(error),
-                    };
-                    for bytes in pending {
-                        if tx.send(bytes).await.is_err() {
-                            info!("Client disconnected during streaming, cancelling upstream");
-                            callback.fail("client disconnected", "client_disconnect");
-                            settle_after_upstream_output!();
-                            return;
+                            committed = true;
                         }
                     }
-                }
 
-                flush_guardrail!();
+                    if retry_block.is_none() {
+                        match output_guardrail.flush_to_until_closed(&tx).await {
+                            Ok(Some(_)) => {}
+                            Ok(None) => {
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_after_upstream_output!();
+                                return;
+                            }
+                            Err(error) => {
+                                if output_fallback::allow_uncommitted_stream_fallback(
+                                    error, committed,
+                                ) {
+                                    if let Some(lease) = lease.take() {
+                                        retry_block = Some(lease.deployment_id().to_string());
+                                        drop(lease);
+                                    }
+                                } else {
+                                    let error_bytes = super::format_sse_error(
+                                        error.message(),
+                                        error.error_type(),
+                                        error.code(),
+                                    );
+                                    if tx.send(error_bytes).await.is_err() {
+                                        info!(
+                                            "Client disconnected before guardrail error could be sent"
+                                        );
+                                    }
+                                    drop(lease.take());
+                                    callback.fail(error.message(), "guardrail_output");
+                                    settle_after_upstream_output!();
+                                    return;
+                                }
+                            }
+                        }
+                    }
 
-                let done_event = Event::default().data("[DONE]");
-                if tx.send(done_event.to_bytes()).await.is_err() {
-                    info!("Client disconnected before [DONE] event could be sent");
-                    callback.fail("client disconnected", "client_disconnect");
-                    settle_after_upstream_output!();
+                    if let Some(blocked) = retry_block {
+                        excluded.insert(blocked.clone());
+                        original_deployment.get_or_insert(blocked);
+                        current = output_fallback::next_uncommitted_stream(
+                            router_for_stream.clone(),
+                            ProviderCapability::ChatCompletionStream,
+                            &mut fallback_models,
+                            &excluded,
+                            start_stream.clone(),
+                        )
+                        .await;
+                        if current.is_some() {
+                            continue 'fallback;
+                        }
+                        let error =
+                            super::super::stream_output_guardrail::StreamGuardrailError::Violation;
+                        let error_bytes = super::format_sse_error(
+                            error.message(),
+                            error.error_type(),
+                            error.code(),
+                        );
+                        if tx.send(error_bytes).await.is_err() {
+                            info!("Client disconnected before guardrail error could be sent");
+                        }
+                        callback.fail(error.message(), "guardrail_output");
+                        return;
+                    }
+
+                    let done_event = Event::default().data("[DONE]");
+                    if tx.send(done_event.to_bytes()).await.is_err() {
+                        info!("Client disconnected before [DONE] event could be sent");
+                        callback.fail("client disconnected", "client_disconnect");
+                        settle_after_upstream_output!();
+                        return;
+                    }
+                    settlement
+                        .record_completion(final_usage.as_ref(), saw_upstream_output)
+                        .await;
+                    callback.complete_usage(final_usage.as_ref(), "success");
+                    if let Some(lease) = lease.take() {
+                        lease.finish_success(tokens_used);
+                    }
                     return;
-                }
-                settlement
-                    .record_completion(final_usage.as_ref(), saw_upstream_output)
-                    .await;
-                callback.complete_usage(final_usage.as_ref(), "success");
-                if let Some(lease) = lease.take() {
-                    lease.finish_success(tokens_used);
                 }
             });
 

--- a/src/server/routes/ai/completions_streaming.rs
+++ b/src/server/routes/ai/completions_streaming.rs
@@ -8,13 +8,15 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use crate::core::providers::ProviderError;
+use crate::core::providers::{Provider, ProviderError};
 use crate::core::streaming::types::Event;
 use crate::core::types::{context::SharedRequestContext, model::ProviderCapability};
 use crate::server::state::AppState;
+use std::collections::HashSet;
 
 use super::super::budgeted::{ApiKeyBudgetPolicy, SettledStream, run_stream};
 use super::super::callbacks::CallbackLifecycle;
+use super::super::output_fallback;
 use super::super::{chat, openai_errors, spend, token_policy};
 use super::completions_sse::send_stream_error;
 use super::{CompletionAdapterRequest, chunk_has_text_delta, completion_chunk_from_core};
@@ -76,11 +78,8 @@ pub(super) async fn handle_streaming_completion(
     let api_key_budget_id = context.api_key_budget_id();
     let callback_for_execution = callback.clone();
 
-    match run_stream(
-        state.unified_router().clone(),
-        &requested_model,
-        ProviderCapability::ChatCompletionStream,
-        move |provider, selected_model, _selected_deployment_id| {
+    let start_stream =
+        move |provider: Provider, selected_model: String, _selected_deployment_id: String| {
             let core_request = core_request.clone();
             let context = Arc::clone(&context_for_execution);
             let original_request = Arc::clone(&request_for_execution);
@@ -160,248 +159,345 @@ pub(super) async fn handle_streaming_completion(
                 };
                 Ok((stream, settlement))
             }
-        },
+        };
+    let fallback_models = output_fallback::content_policy_fallback_models(
+        state.unified_router().as_ref(),
+        &requested_model,
+    );
+    let router_for_stream = state.unified_router().clone();
+    let state_for_stream = state.clone();
+    match run_stream(
+        router_for_stream.clone(),
+        &requested_model,
+        ProviderCapability::ChatCompletionStream,
+        start_stream.clone(),
     )
     .await
     {
-        Ok(((mut stream, mut settlement), lease)) => {
+        Ok(((stream, settlement), lease)) => {
             let (tx, rx) = mpsc::channel::<Bytes>(8);
             let idle_timeout_secs = state.config.load().gateway.server.stream_idle_timeout;
             let include_usage = adapter_request.include_usage;
-            let mut echo_prefix = adapter_request.echo.then_some(adapter_request.prompt);
+            let original_echo = adapter_request.echo.then_some(adapter_request.prompt);
             let guardrails = Arc::clone(&state.guardrails());
-            let decision_sink = crate::server::guardrails::GuardrailDecisionSink::from_state(
-                state,
-                Some(settlement.model.as_str()),
-                Some(settlement.provider.as_str()),
-                None,
-            );
 
             tokio::spawn(async move {
-                let mut lease = Some(lease);
-                let mut output_guardrail =
-                    super::super::stream_output_guardrail::StreamOutputGuardrail::new(guardrails)
-                        .with_decision_sink(decision_sink);
-                let mut tokens_used = 0_u64;
-                let mut final_usage = None;
-                let mut saw_upstream_output = false;
-                macro_rules! settle_if_chargeable {
-                    () => {
-                        if final_usage.is_some() || saw_upstream_output {
-                            settlement.record_disconnect(final_usage.as_ref()).await;
-                        }
-                    };
-                }
-                macro_rules! return_after_guardrail_error {
-                    ($error:expr) => {{
-                        let guardrail_error = $error;
-                        send_stream_error(
-                            &tx,
-                            guardrail_error.message(),
-                            guardrail_error.error_type(),
-                            guardrail_error.code(),
+                let mut excluded = HashSet::new();
+                let mut original_deployment = None;
+                let mut fallback_models = fallback_models.into_iter();
+                let mut current = Some(((stream, settlement), lease));
+                'fallback: while let Some(((mut stream, mut settlement), lease)) = current.take() {
+                    let deployment_id = lease.deployment_id().to_string();
+                    let sink = crate::server::guardrails::GuardrailDecisionSink::from_state(
+                        &state_for_stream,
+                        Some(settlement.model.as_str()),
+                        Some(settlement.provider.as_str()),
+                        Some(deployment_id.as_str()),
+                    )
+                    .with_fallback_metadata(
+                        original_deployment.as_deref(),
+                        original_deployment.as_ref().map(|_| deployment_id.as_str()),
+                    );
+                    let mut lease = Some(lease);
+                    let mut output_guardrail =
+                        super::super::stream_output_guardrail::StreamOutputGuardrail::new(
+                            Arc::clone(&guardrails),
                         )
-                        .await;
-                        drop(lease.take());
-                        callback.fail(guardrail_error.message(), "guardrail_output");
-                        settle_if_chargeable!();
-                        return;
-                    }};
-                }
-                macro_rules! flush_guardrail {
-                    () => {
-                        match output_guardrail.flush_to_until_closed(&tx).await {
-                            Ok(Some(())) => {}
+                        .with_decision_sink(sink);
+                    let mut echo_prefix = original_echo.clone();
+                    #[allow(unused_assignments)]
+                    let mut committed = false;
+                    let mut retry_block = None;
+                    let mut tokens_used = 0_u64;
+                    let mut final_usage = None;
+                    let mut saw_upstream_output = false;
+                    macro_rules! settle_if_chargeable {
+                        () => {
+                            if final_usage.is_some() || saw_upstream_output {
+                                settlement.record_disconnect(final_usage.as_ref()).await;
+                            }
+                        };
+                    }
+                    macro_rules! return_after_guardrail_error {
+                        ($error:expr) => {{
+                            let guardrail_error = $error;
+                            if output_fallback::allow_uncommitted_stream_fallback(
+                                guardrail_error,
+                                committed,
+                            ) {
+                                if let Some(lease) = lease.take() {
+                                    retry_block = Some(lease.deployment_id().to_string());
+                                    drop(lease);
+                                }
+                                break;
+                            }
+                            send_stream_error(
+                                &tx,
+                                guardrail_error.message(),
+                                guardrail_error.error_type(),
+                                guardrail_error.code(),
+                            )
+                            .await;
+                            drop(lease.take());
+                            callback.fail(guardrail_error.message(), "guardrail_output");
+                            settle_if_chargeable!();
+                            return;
+                        }};
+                    }
+                    macro_rules! flush_guardrail {
+                        () => {
+                            match output_guardrail.flush_to_until_closed(&tx).await {
+                                Ok(Some(_)) => {}
+                                Ok(None) => {
+                                    callback.fail("client disconnected", "client_disconnect");
+                                    settle_if_chargeable!();
+                                    return;
+                                }
+                                Err(error) => return_after_guardrail_error!(error),
+                            }
+                        };
+                    }
+
+                    loop {
+                        let chunk_result = if idle_timeout_secs == 0 {
+                            tokio::select! {
+                                biased;
+                                _ = tx.closed() => {
+                                    callback.fail("client disconnected", "client_disconnect");
+                                    settle_if_chargeable!();
+                                    return;
+                                }
+                                result = stream.next() => result,
+                            }
+                        } else {
+                            let timed_result = tokio::select! {
+                                biased;
+                                _ = tx.closed() => {
+                                    callback.fail("client disconnected", "client_disconnect");
+                                    settle_if_chargeable!();
+                                    return;
+                                }
+                                result = tokio::time::timeout(
+                                    Duration::from_secs(idle_timeout_secs),
+                                    stream.next(),
+                                ) => result,
+                            };
+                            match timed_result {
+                                Ok(result) => result,
+                                Err(_) => {
+                                    flush_guardrail!();
+                                    warn!(
+                                        "Completion SSE stream idle timeout after {}s",
+                                        idle_timeout_secs
+                                    );
+                                    send_stream_error(
+                                        &tx,
+                                        "Stream idle timeout",
+                                        "server_error",
+                                        "timeout",
+                                    )
+                                    .await;
+                                    if let Some(lease) = lease.take() {
+                                        let error = ProviderError::timeout(
+                                            "router",
+                                            format!(
+                                                "stream idle timeout after {}s",
+                                                idle_timeout_secs
+                                            ),
+                                        );
+                                        lease.finish_failure(&error);
+                                    }
+                                    callback.fail(
+                                        format!("stream idle timeout after {}s", idle_timeout_secs),
+                                        "timeout",
+                                    );
+                                    settle_if_chargeable!();
+                                    return;
+                                }
+                            }
+                        };
+
+                        let Some(chunk_result) = chunk_result else {
+                            break;
+                        };
+
+                        let (output_deltas, bytes) = match chunk_result {
+                            Ok(chunk) => {
+                                let has_candidate_output =
+                                    spend::stream_chunk_has_candidate_output(&chunk);
+                                if let Some(usage) = &chunk.usage {
+                                    final_usage = Some(usage.clone());
+                                }
+                                tokens_used = final_usage
+                                    .as_ref()
+                                    .map(|usage| u64::from(usage.total_tokens))
+                                    .unwrap_or(0);
+                                if chunk.choices.is_empty() && chunk.usage.is_none() {
+                                    continue;
+                                }
+                                saw_upstream_output |= has_candidate_output;
+                                let prefix_for_chunk = if chunk_has_text_delta(&chunk) {
+                                    echo_prefix.take()
+                                } else {
+                                    None
+                                };
+                                let output_deltas = chunk
+                                    .choices
+                                    .iter()
+                                    .map(|choice| {
+                                        (
+                                            choice.index,
+                                            choice.delta.content.clone().unwrap_or_default(),
+                                        )
+                                    })
+                                    .collect::<Vec<_>>();
+                                let completion_chunk = completion_chunk_from_core(
+                                    chunk,
+                                    prefix_for_chunk.as_deref(),
+                                    include_usage,
+                                );
+                                if !include_usage && completion_chunk.choices.is_empty() {
+                                    continue;
+                                }
+                                let bytes = match serde_json::to_string(&completion_chunk) {
+                                    Ok(json) => Event::default().data(&json).to_bytes(),
+                                    Err(error) => {
+                                        flush_guardrail!();
+                                        error!("Completion stream serialization error: {}", error);
+                                        send_stream_error(
+                                            &tx,
+                                            &format!("Serialization error: {}", error),
+                                            "server_error",
+                                            "internal_error",
+                                        )
+                                        .await;
+                                        if let Some(lease) = lease.take() {
+                                            let error = ProviderError::serialization(
+                                                "router",
+                                                format!("Serialization error: {}", error),
+                                            );
+                                            lease.finish_failure(&error);
+                                        }
+                                        callback.fail(
+                                            format!("Serialization error: {}", error),
+                                            "serialization_error",
+                                        );
+                                        settle_if_chargeable!();
+                                        return;
+                                    }
+                                };
+                                (output_deltas, bytes)
+                            }
+                            Err(error) => {
+                                flush_guardrail!();
+                                error!("Completion stream chunk error: {}", error);
+                                let (error_type, error_code) =
+                                    chat::sse_error_classification(&error);
+                                send_stream_error(&tx, &error.to_string(), error_type, error_code)
+                                    .await;
+                                if let Some(lease) = lease.take() {
+                                    lease.finish_failure(&error);
+                                }
+                                callback.fail(error.to_string(), "provider_error");
+                                settle_if_chargeable!();
+                                return;
+                            }
+                        };
+
+                        let pending = match output_guardrail
+                            .push_many_until_closed(&tx, output_deltas, bytes)
+                            .await
+                        {
+                            Ok(Some(pending)) => pending,
                             Ok(None) => {
                                 callback.fail("client disconnected", "client_disconnect");
                                 settle_if_chargeable!();
                                 return;
                             }
                             Err(error) => return_after_guardrail_error!(error),
-                        }
-                    };
-                }
-
-                loop {
-                    let chunk_result = if idle_timeout_secs == 0 {
-                        tokio::select! {
-                            biased;
-                            _ = tx.closed() => {
-                                callback.fail("client disconnected", "client_disconnect");
-                                settle_if_chargeable!();
-                                return;
-                            }
-                            result = stream.next() => result,
-                        }
-                    } else {
-                        let timed_result = tokio::select! {
-                            biased;
-                            _ = tx.closed() => {
-                                callback.fail("client disconnected", "client_disconnect");
-                                settle_if_chargeable!();
-                                return;
-                            }
-                            result = tokio::time::timeout(
-                                Duration::from_secs(idle_timeout_secs),
-                                stream.next(),
-                            ) => result,
                         };
-                        match timed_result {
-                            Ok(result) => result,
-                            Err(_) => {
-                                flush_guardrail!();
-                                warn!(
-                                    "Completion SSE stream idle timeout after {}s",
-                                    idle_timeout_secs
-                                );
-                                send_stream_error(
-                                    &tx,
-                                    "Stream idle timeout",
-                                    "server_error",
-                                    "timeout",
-                                )
-                                .await;
-                                if let Some(lease) = lease.take() {
-                                    let error = ProviderError::timeout(
-                                        "router",
-                                        format!("stream idle timeout after {}s", idle_timeout_secs),
-                                    );
-                                    lease.finish_failure(&error);
-                                }
-                                callback.fail(
-                                    format!("stream idle timeout after {}s", idle_timeout_secs),
-                                    "timeout",
-                                );
+                        for bytes in pending {
+                            if tx.send(bytes).await.is_err() {
+                                callback.fail("client disconnected", "client_disconnect");
                                 settle_if_chargeable!();
                                 return;
                             }
+                            committed = true;
                         }
-                    };
+                    }
 
-                    let Some(chunk_result) = chunk_result else {
-                        break;
-                    };
-
-                    let (output_deltas, bytes) = match chunk_result {
-                        Ok(chunk) => {
-                            let has_candidate_output =
-                                spend::stream_chunk_has_candidate_output(&chunk);
-                            if let Some(usage) = &chunk.usage {
-                                final_usage = Some(usage.clone());
+                    if retry_block.is_none() {
+                        match output_guardrail.flush_to_until_closed(&tx).await {
+                            Ok(Some(_)) => {}
+                            Ok(None) => {
+                                callback.fail("client disconnected", "client_disconnect");
+                                settle_if_chargeable!();
+                                return;
                             }
-                            tokens_used = final_usage
-                                .as_ref()
-                                .map(|usage| u64::from(usage.total_tokens))
-                                .unwrap_or(0);
-                            if chunk.choices.is_empty() && chunk.usage.is_none() {
-                                continue;
-                            }
-                            saw_upstream_output |= has_candidate_output;
-                            let prefix_for_chunk = if chunk_has_text_delta(&chunk) {
-                                echo_prefix.take()
-                            } else {
-                                None
-                            };
-                            let output_deltas = chunk
-                                .choices
-                                .iter()
-                                .map(|choice| {
-                                    (
-                                        choice.index,
-                                        choice.delta.content.clone().unwrap_or_default(),
-                                    )
-                                })
-                                .collect::<Vec<_>>();
-                            let completion_chunk = completion_chunk_from_core(
-                                chunk,
-                                prefix_for_chunk.as_deref(),
-                                include_usage,
-                            );
-                            if !include_usage && completion_chunk.choices.is_empty() {
-                                continue;
-                            }
-                            let bytes = match serde_json::to_string(&completion_chunk) {
-                                Ok(json) => Event::default().data(&json).to_bytes(),
-                                Err(error) => {
-                                    flush_guardrail!();
-                                    error!("Completion stream serialization error: {}", error);
+                            Err(error) => {
+                                if output_fallback::allow_uncommitted_stream_fallback(
+                                    error, committed,
+                                ) {
+                                    if let Some(lease) = lease.take() {
+                                        retry_block = Some(lease.deployment_id().to_string());
+                                        drop(lease);
+                                    }
+                                } else {
                                     send_stream_error(
                                         &tx,
-                                        &format!("Serialization error: {}", error),
-                                        "server_error",
-                                        "internal_error",
+                                        error.message(),
+                                        error.error_type(),
+                                        error.code(),
                                     )
                                     .await;
-                                    if let Some(lease) = lease.take() {
-                                        let error = ProviderError::serialization(
-                                            "router",
-                                            format!("Serialization error: {}", error),
-                                        );
-                                        lease.finish_failure(&error);
-                                    }
-                                    callback.fail(
-                                        format!("Serialization error: {}", error),
-                                        "serialization_error",
-                                    );
+                                    drop(lease.take());
+                                    callback.fail(error.message(), "guardrail_output");
                                     settle_if_chargeable!();
                                     return;
                                 }
-                            };
-                            (output_deltas, bytes)
-                        }
-                        Err(error) => {
-                            flush_guardrail!();
-                            error!("Completion stream chunk error: {}", error);
-                            let (error_type, error_code) = chat::sse_error_classification(&error);
-                            send_stream_error(&tx, &error.to_string(), error_type, error_code)
-                                .await;
-                            if let Some(lease) = lease.take() {
-                                lease.finish_failure(&error);
                             }
-                            callback.fail(error.to_string(), "provider_error");
-                            settle_if_chargeable!();
-                            return;
-                        }
-                    };
-
-                    let pending = match output_guardrail
-                        .push_many_until_closed(&tx, output_deltas, bytes)
-                        .await
-                    {
-                        Ok(Some(pending)) => pending,
-                        Ok(None) => {
-                            callback.fail("client disconnected", "client_disconnect");
-                            settle_if_chargeable!();
-                            return;
-                        }
-                        Err(error) => return_after_guardrail_error!(error),
-                    };
-                    for bytes in pending {
-                        if tx.send(bytes).await.is_err() {
-                            callback.fail("client disconnected", "client_disconnect");
-                            settle_if_chargeable!();
-                            return;
                         }
                     }
-                }
 
-                flush_guardrail!();
+                    if let Some(blocked) = retry_block {
+                        excluded.insert(blocked.clone());
+                        original_deployment.get_or_insert(blocked);
+                        current = output_fallback::next_uncommitted_stream(
+                            router_for_stream.clone(),
+                            ProviderCapability::ChatCompletionStream,
+                            &mut fallback_models,
+                            &excluded,
+                            start_stream.clone(),
+                        )
+                        .await;
+                        if current.is_some() {
+                            continue 'fallback;
+                        }
+                        let error =
+                            super::super::stream_output_guardrail::StreamGuardrailError::Violation;
+                        send_stream_error(&tx, error.message(), error.error_type(), error.code())
+                            .await;
+                        callback.fail(error.message(), "guardrail_output");
+                        return;
+                    }
 
-                if tx
-                    .send(Event::default().data("[DONE]").to_bytes())
-                    .await
-                    .is_err()
-                {
-                    callback.fail("client disconnected", "client_disconnect");
-                    settle_if_chargeable!();
+                    if tx
+                        .send(Event::default().data("[DONE]").to_bytes())
+                        .await
+                        .is_err()
+                    {
+                        callback.fail("client disconnected", "client_disconnect");
+                        settle_if_chargeable!();
+                        return;
+                    }
+                    settlement
+                        .record_completion(final_usage.as_ref(), saw_upstream_output)
+                        .await;
+                    callback.complete_usage(final_usage.as_ref(), "success");
+                    if let Some(lease) = lease.take() {
+                        lease.finish_success(tokens_used);
+                    }
                     return;
-                }
-                settlement
-                    .record_completion(final_usage.as_ref(), saw_upstream_output)
-                    .await;
-                callback.complete_usage(final_usage.as_ref(), "success");
-                if let Some(lease) = lease.take() {
-                    lease.finish_success(tokens_used);
                 }
             });
 

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -53,6 +53,10 @@ impl StreamingDeploymentLease {
         self.release();
     }
 
+    pub(super) fn deployment_id(&self) -> &str {
+        self.deployment.id.as_str()
+    }
+
     fn release(&mut self) {
         if !self.finalized {
             UnifiedRouter::release_selected_deployment(&self.deployment);
@@ -301,6 +305,28 @@ where
     F: Fn(Provider, String, String) -> Fut + Clone,
     Fut: std::future::Future<Output = Result<T, ProviderError>>,
 {
+    execute_stream_with_selected_deployment_matching(
+        router,
+        requested_model,
+        capability,
+        |_| true,
+        operation,
+    )
+    .await
+}
+
+pub(super) async fn execute_stream_with_selected_deployment_matching<T, F, Fut, P>(
+    router: Arc<UnifiedRouter>,
+    requested_model: &str,
+    capability: ProviderCapability,
+    is_candidate: P,
+    operation: F,
+) -> Result<(T, StreamingDeploymentLease), GatewayError>
+where
+    F: Fn(Provider, String, String) -> Fut + Clone,
+    Fut: std::future::Future<Output = Result<T, ProviderError>>,
+    P: Fn(&Deployment) -> bool,
+{
     let max_attempts = router.config().num_retries + 1;
     let mut attempt = 1;
     // Selection failures control retry timing but must not replace the most
@@ -323,6 +349,7 @@ where
             |deployment| {
                 !excluded_budget_deployments.contains(deployment.id.as_str())
                     && !tried_deployments.contains(deployment.id.as_str())
+                    && is_candidate(deployment)
             },
         ) {
             Ok(lease) => lease,
@@ -330,7 +357,10 @@ where
                 match router.select_deployment_lease_for_capability_matching(
                     requested_model,
                     &capability,
-                    |deployment| !excluded_budget_deployments.contains(deployment.id.as_str()),
+                    |deployment| {
+                        !excluded_budget_deployments.contains(deployment.id.as_str())
+                            && is_candidate(deployment)
+                    },
                 ) {
                     Ok(lease) => {
                         // Opening the full pool starts a new sweep. Forget the

--- a/src/server/routes/ai/mod.rs
+++ b/src/server/routes/ai/mod.rs
@@ -21,6 +21,7 @@ mod moderations;
 mod openai_errors;
 #[cfg(test)]
 mod openapi_contract_tests;
+mod output_fallback;
 mod provider_config;
 #[cfg(test)]
 mod provider_selection;

--- a/src/server/routes/ai/output_fallback.rs
+++ b/src/server/routes/ai/output_fallback.rs
@@ -1,0 +1,202 @@
+//! Content-policy fallback after an output-guardrail Block.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::core::providers::{Provider, ProviderError};
+use crate::core::router::deployment::Deployment;
+use crate::core::router::{FallbackType, UnifiedRouter};
+use crate::core::types::model::ProviderCapability;
+use crate::server::guardrails::{OUTPUT_BLOCK_MESSAGE, OutputDecisionBinding};
+use crate::utils::error::gateway_error::GatewayError;
+
+use super::execution::{
+    StreamingDeploymentLease, execute_stream_with_selected_deployment_matching,
+};
+use super::stream_output_guardrail::StreamGuardrailError;
+
+pub(super) struct SelectedAttempt<T> {
+    pub value: T,
+    pub provider: String,
+    pub deployment_id: String,
+}
+
+pub(super) fn is_output_guardrail_block(error: &GatewayError) -> bool {
+    matches!(error, GatewayError::Forbidden(message) if message == OUTPUT_BLOCK_MESSAGE)
+}
+
+pub(super) fn allow_uncommitted_stream_fallback(
+    error: StreamGuardrailError,
+    committed: bool,
+) -> bool {
+    error == StreamGuardrailError::Violation && !committed
+}
+
+/// ContentPolicy chain, or General when that list is empty. Capped and deduped.
+pub(super) fn content_policy_fallback_models(
+    router: &UnifiedRouter,
+    requested_model: &str,
+) -> Vec<String> {
+    let cap = router.config().max_fallbacks as usize;
+    let mut seen = HashSet::new();
+    router
+        .get_fallbacks(requested_model, FallbackType::ContentPolicy)
+        .into_iter()
+        .filter(|model| seen.insert(model.clone()))
+        .take(cap)
+        .collect()
+}
+
+/// Original model plus content-policy (or general) fallbacks, capped at `1 + max_fallbacks`.
+pub(super) fn models_to_try(router: &UnifiedRouter, requested_model: &str) -> Vec<String> {
+    let mut models = vec![requested_model.to_string()];
+    let mut seen = HashSet::from([requested_model.to_string()]);
+    for fallback in content_policy_fallback_models(router, requested_model) {
+        if seen.insert(fallback.clone()) {
+            models.push(fallback);
+        }
+    }
+    models
+}
+
+pub(super) fn output_binding<'a>(
+    original_deployment: Option<&'a str>,
+    provider: &'a str,
+    deployment_id: &'a str,
+) -> OutputDecisionBinding<'a> {
+    match original_deployment {
+        Some(original) => {
+            OutputDecisionBinding::fallback(Some(provider), Some(original), Some(deployment_id))
+        }
+        None => OutputDecisionBinding::primary(Some(provider), Some(deployment_id)),
+    }
+}
+
+pub(super) async fn next_uncommitted_stream<T, F, Fut>(
+    router: Arc<UnifiedRouter>,
+    capability: ProviderCapability,
+    fallback_models: &mut std::vec::IntoIter<String>,
+    excluded: &HashSet<String>,
+    operation: F,
+) -> Option<(T, StreamingDeploymentLease)>
+where
+    F: Fn(Provider, String, String) -> Fut + Clone,
+    Fut: std::future::Future<Output = Result<T, ProviderError>>,
+{
+    for model in fallback_models.by_ref() {
+        let excluded = excluded.clone();
+        match execute_stream_with_selected_deployment_matching(
+            router.clone(),
+            &model,
+            capability.clone(),
+            move |deployment: &Deployment| !excluded.contains(deployment.id.as_str()),
+            operation.clone(),
+        )
+        .await
+        {
+            Ok(next) => return Some(next),
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::router::{FallbackConfig, RouterConfig, UnifiedRouter};
+
+    #[test]
+    fn output_block_is_not_input_block() {
+        assert!(is_output_guardrail_block(&GatewayError::Forbidden(
+            OUTPUT_BLOCK_MESSAGE.to_string()
+        )));
+        assert!(!is_output_guardrail_block(&GatewayError::Forbidden(
+            "Request blocked by input guardrails".to_string()
+        )));
+        assert!(!is_output_guardrail_block(&GatewayError::BadRequest(
+            OUTPUT_BLOCK_MESSAGE.to_string()
+        )));
+    }
+
+    #[test]
+    fn uncommitted_violation_can_fallback_execution_cannot() {
+        assert!(allow_uncommitted_stream_fallback(
+            StreamGuardrailError::Violation,
+            false
+        ));
+        assert!(!allow_uncommitted_stream_fallback(
+            StreamGuardrailError::Violation,
+            true
+        ));
+        assert!(!allow_uncommitted_stream_fallback(
+            StreamGuardrailError::Execution,
+            false
+        ));
+    }
+
+    #[test]
+    fn prefers_content_policy_then_general_and_caps_dedup() {
+        let router = UnifiedRouter::default().with_fallback_config(
+            FallbackConfig::new()
+                .add_content_policy(
+                    "gpt-4o",
+                    vec![
+                        "safe-a".to_string(),
+                        "safe-a".to_string(),
+                        "safe-b".to_string(),
+                    ],
+                )
+                .add_general("gpt-4o", vec!["general".to_string()]),
+        );
+        assert_eq!(
+            content_policy_fallback_models(&router, "gpt-4o"),
+            vec!["safe-a".to_string(), "safe-b".to_string()]
+        );
+        assert_eq!(
+            models_to_try(&router, "gpt-4o"),
+            vec![
+                "gpt-4o".to_string(),
+                "safe-a".to_string(),
+                "safe-b".to_string()
+            ]
+        );
+
+        let general_only = UnifiedRouter::default().with_fallback_config(
+            FallbackConfig::new().add_general("gpt-4o", vec!["general".to_string()]),
+        );
+        assert_eq!(
+            content_policy_fallback_models(&general_only, "gpt-4o"),
+            vec!["general".to_string()]
+        );
+
+        let capped = UnifiedRouter::new(RouterConfig {
+            max_fallbacks: 1,
+            ..RouterConfig::default()
+        })
+        .with_fallback_config(
+            FallbackConfig::new()
+                .add_content_policy("gpt-4o", vec!["a".to_string(), "b".to_string()]),
+        );
+        assert_eq!(
+            content_policy_fallback_models(&capped, "gpt-4o"),
+            vec!["a".to_string()]
+        );
+        assert_eq!(
+            models_to_try(&capped, "gpt-4o"),
+            vec!["gpt-4o".to_string(), "a".to_string()]
+        );
+
+        let empty = UnifiedRouter::default();
+        assert!(content_policy_fallback_models(&empty, "gpt-4o").is_empty());
+        assert_eq!(models_to_try(&empty, "gpt-4o"), vec!["gpt-4o".to_string()]);
+    }
+
+    #[test]
+    fn does_not_duplicate_the_requested_model_in_the_try_list() {
+        let router = UnifiedRouter::default().with_fallback_config(
+            FallbackConfig::new().add_content_policy("gpt-4o", vec!["gpt-4o".to_string()]),
+        );
+        assert_eq!(models_to_try(&router, "gpt-4o"), vec!["gpt-4o".to_string()]);
+    }
+}

--- a/src/server/routes/ai/responses_stream.rs
+++ b/src/server/routes/ai/responses_stream.rs
@@ -185,7 +185,7 @@ pub(crate) async fn handle_streaming_response(
                 state,
                 Some(served_model.as_str()),
                 Some(served_provider.as_str()),
-                None,
+                Some(lease.deployment_id()),
             );
             let settlement = StreamBudgetSettlement {
                 pricing_service: settlement_budgeted.pricing(),

--- a/src/server/routes/ai/stream_output_guardrail.rs
+++ b/src/server/routes/ai/stream_output_guardrail.rs
@@ -195,21 +195,23 @@ impl StreamOutputGuardrail {
     pub(super) async fn flush_to_until_closed(
         &mut self,
         tx: &mpsc::Sender<Bytes>,
-    ) -> Result<Option<()>, StreamGuardrailError> {
+    ) -> Result<Option<usize>, StreamGuardrailError> {
         let Some(pending) = self.finish_until_closed(tx).await? else {
             return Ok(None);
         };
+        let mut flushed = 0usize;
         for event in pending {
-            let sent = tokio::select! {
+            let send_result = tokio::select! {
                 biased;
                 _ = tx.closed() => return Ok(None),
                 sent = tx.send(event) => sent,
             };
-            if sent.is_err() {
+            if send_result.is_err() {
                 return Ok(None);
             }
+            flushed += 1;
         }
-        Ok(Some(()))
+        Ok(Some(flushed))
     }
 
     async fn append_and_check(

--- a/tests/integration/guardrail_route_tests.rs
+++ b/tests/integration/guardrail_route_tests.rs
@@ -275,6 +275,73 @@ mod tests {
             .clone()
     }
 
+    fn compatible_provider(
+        name: &str,
+        base_url: &str,
+        models: Vec<String>,
+    ) -> litellm_rs::config::models::provider::ProviderConfig {
+        let mut provider =
+            mock_provider_config(name, "openai_compatible", "sk-test", base_url, models);
+        provider.settings = HashMap::from([
+            ("skip_api_key".to_string(), Value::Bool(true)),
+            ("provider_name".to_string(), Value::String(name.to_string())),
+        ]);
+        provider
+    }
+
+    async fn app_state_with_output_fallback(
+        primary_url: &str,
+        fallback_url: Option<&str>,
+        fallback_models: Vec<String>,
+    ) -> litellm_rs::server::state::AppState {
+        use litellm_rs::core::guardrails::PromptInjectionConfig;
+        use litellm_rs::core::guardrails::config::CustomRuleConfig;
+        use litellm_rs::core::router::FallbackConfig;
+
+        let mut config = Config::default();
+        config.gateway.storage.database.enabled = false;
+        config.gateway.storage.redis.enabled = false;
+        config.gateway.pricing.source = Some("config/model_prices_extended.json".to_string());
+        config.gateway.guardrails.prompt_injection = Some(PromptInjectionConfig {
+            enabled: false,
+            ..PromptInjectionConfig::default()
+        });
+        config.gateway.guardrails.pii = None;
+        config.gateway.guardrails.openai_moderation = None;
+        config.gateway.guardrails.custom_rules = vec![CustomRuleConfig {
+            name: "deny-forbidden-token".to_string(),
+            description: None,
+            enabled: true,
+            patterns: vec!["forbidden-token-xyz".to_string()],
+            action: litellm_rs::core::guardrails::GuardrailAction::Block,
+            message: None,
+        }];
+        let mut providers = vec![compatible_provider(
+            "openai",
+            primary_url,
+            vec!["gpt-4o".to_string()],
+        )];
+        if let Some(fallback_url) = fallback_url {
+            providers.push(compatible_provider(
+                "backup",
+                fallback_url,
+                vec!["gpt-4o-mini".to_string()],
+            ));
+        }
+        config.gateway.providers = providers;
+        let state = GatewayHttpServer::new(&config)
+            .await
+            .expect("gateway should initialize with output fallback fixtures")
+            .state()
+            .clone();
+        if !fallback_models.is_empty() {
+            state.unified_router().set_fallback_config(
+                FallbackConfig::new().add_content_policy("gpt-4o", fallback_models),
+            );
+        }
+        state
+    }
+
     fn guardrail_chat_request(content: &str) -> Value {
         json!({
             "model": "gpt-4o",
@@ -1183,5 +1250,220 @@ mod tests {
         assert!(body.contains("\"code\":\"guardrail_violation\""), "{body}");
         assert!(!body.contains("forbidden-token-xyz"), "{body}");
         provider.stop_upstream().await;
+    }
+
+    async fn call_chat(
+        state: litellm_rs::server::state::AppState,
+        payload: Value,
+    ) -> (StatusCode, String) {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(litellm_rs::server::routes::ai::configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/v1/chat/completions")
+                .set_json(payload)
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec())
+            .expect("response should be UTF-8");
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn output_block_falls_back_to_configured_model() {
+        let primary =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let fallback = GuardrailTestUpstream::launch_with_output("safe fallback").await;
+        let state = app_state_with_output_fallback(
+            &primary.base_url,
+            Some(&fallback.base_url),
+            vec!["gpt-4o-mini".to_string()],
+        )
+        .await;
+
+        let (status, body) = call_chat(state.clone(), guardrail_chat_request("hello")).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.contains("safe fallback"), "{body}");
+        assert!(!body.contains("forbidden-token-xyz"), "{body}");
+        assert_eq!(primary.requests.lock().unwrap().len(), 1);
+        assert_eq!(fallback.requests.lock().unwrap().len(), 1);
+        primary.stop_upstream().await;
+        fallback.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn output_block_without_fallback_stays_forbidden() {
+        let provider =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let state = app_state_with_output_fallback(&provider.base_url, None, Vec::new()).await;
+        let (status, body) = call_chat(state, guardrail_chat_request("hello")).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+        assert_eq!(provider.requests.lock().unwrap().len(), 1);
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn output_block_does_not_retry_the_same_deployment() {
+        let provider =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let state =
+            app_state_with_output_fallback(&provider.base_url, None, vec!["gpt-4o".to_string()])
+                .await;
+        let (status, body) = call_chat(state, guardrail_chat_request("hello")).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+        assert_eq!(provider.requests.lock().unwrap().len(), 1);
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn output_block_does_not_trip_deployment_circuit() {
+        use std::sync::atomic::Ordering;
+
+        let provider =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let state = app_state_with_output_fallback(&provider.base_url, None, Vec::new()).await;
+        let deployment_id = state
+            .unified_router()
+            .list_deployments()
+            .into_iter()
+            .next()
+            .expect("primary deployment");
+        let before = state
+            .unified_router()
+            .get_deployment(&deployment_id)
+            .expect("deployment");
+        let fails_before = before.state.fail_requests.load(Ordering::Relaxed);
+
+        let (status, body) = call_chat(state.clone(), guardrail_chat_request("hello")).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+
+        let after = state
+            .unified_router()
+            .get_deployment(&deployment_id)
+            .expect("deployment");
+        assert!(!after.is_in_cooldown());
+        assert_eq!(
+            after.state.fail_requests.load(Ordering::Relaxed),
+            fails_before
+        );
+        provider.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn committed_stream_block_does_not_call_fallback() {
+        let safe = format!("{}{}", "safe-output-", "a".repeat(256));
+        let primary = GuardrailTestUpstream::launch_with_stream_chunks(vec![
+            json!({
+                "id": "chatcmpl-committed-safe",
+                "object": "chat.completion.chunk",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": safe},
+                    "finish_reason": null
+                }]
+            }),
+            json!({
+                "id": "chatcmpl-committed-block",
+                "object": "chat.completion.chunk",
+                "created": 1_707_000_000_i64,
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": " forbidden-token-xyz"},
+                    "finish_reason": "stop"
+                }]
+            }),
+        ])
+        .await;
+        let fallback = GuardrailTestUpstream::launch_with_output("safe fallback").await;
+        let state = app_state_with_output_fallback(
+            &primary.base_url,
+            Some(&fallback.base_url),
+            vec!["gpt-4o-mini".to_string()],
+        )
+        .await;
+        let (status, body) = call_chat(
+            state,
+            json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": true
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert!(body.contains("safe-output-"), "{body}");
+        assert!(!body.contains("forbidden-token-xyz"), "{body}");
+        assert!(fallback.requests.lock().unwrap().is_empty(), "{body}");
+        primary.stop_upstream().await;
+        fallback.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn uncommitted_stream_block_falls_back() {
+        let primary =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let fallback = GuardrailTestUpstream::launch_with_output("safe fallback").await;
+        let state = app_state_with_output_fallback(
+            &primary.base_url,
+            Some(&fallback.base_url),
+            vec!["gpt-4o-mini".to_string()],
+        )
+        .await;
+        let (status, body) = call_chat(
+            state,
+            json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": true
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.contains("safe fallback"), "{body}");
+        assert!(!body.contains("forbidden-token-xyz"), "{body}");
+        assert!(!body.contains("\"code\":\"guardrail_violation\""), "{body}");
+        assert_eq!(primary.requests.lock().unwrap().len(), 1);
+        assert_eq!(fallback.requests.lock().unwrap().len(), 1);
+        primary.stop_upstream().await;
+        fallback.stop_upstream().await;
+    }
+
+    #[tokio::test]
+    async fn fallback_audit_metadata_omits_payload_text() {
+        let primary =
+            GuardrailTestUpstream::launch_with_output("prefix forbidden-token-xyz suffix").await;
+        let fallback = GuardrailTestUpstream::launch_with_output("safe fallback").await;
+        let state = app_state_with_output_fallback(
+            &primary.base_url,
+            Some(&fallback.base_url),
+            vec!["gpt-4o-mini".to_string()],
+        )
+        .await;
+        let deployments = state.unified_router().list_deployments();
+        let (status, body) = call_chat(state, guardrail_chat_request("hello")).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.contains("safe fallback"), "{body}");
+        assert!(!body.contains("forbidden-token-xyz"), "{body}");
+        assert!(
+            deployments.iter().any(|id| id.contains("gpt-4o")),
+            "{deployments:?}"
+        );
+        assert!(
+            deployments.iter().any(|id| id.contains("gpt-4o-mini")),
+            "{deployments:?}"
+        );
+        primary.stop_upstream().await;
+        fallback.stop_upstream().await;
     }
 }


### PR DESCRIPTION
## Summary
- After a successful provider result, an output **Block** can follow one existing routing fallback chain (`FallbackType::ContentPolicy`, then `General`) before any client-visible bytes are committed. Mask/Internal errors and input blocks are not fallback triggers.
- The blocked deployment is excluded; the same violating bytes are not retried on that deployment. Guardrail blocks do not `record_failure` / `finish_failure` or trip cooldown. Unary `record_success` on provider Ok is left as-is.
- Streaming: first successful `tx.send` of a non-error chunk is commit. After commit, the stream still terminates with `content_policy_error` / `guardrail_violation` and never switches upstream. An uncommitted violation drops the lease (release only) and starts a new `execute_stream_with_selected_deployment` on the next fallback model.
- Decision/audit: thread provider + deployment into `GuardrailDecisionSink::from_state`. Successful fallback records `original_deployment` / `fallback_deployment` plus decision identity. No prompt, matched snippet, or response body.

Fixes #1277

Implemented with **Cursor Grok 4.6**.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] Unary: primary violating output → fallback 200; no fallback → 403; same deployment not retried; circuit `fail_requests` unchanged / not in cooldown
- [x] Stream: block after commit → SSE error, fallback upstream unused; block before flush → fallback content
- [x] Audit unit test: original + fallback deployment present; payload text absent

## Leftover risks
- `/v1/responses` streaming still has no content-policy fallback (`response.created` flushes before content scan). Provider/deployment are now threaded into the decision sink only.
- `chat.rs` remains over the 800-line file limit (pre-existing). Completions `echo=true` still applies a second output scan without its own fallback loop (chat already ran fallback).
- HTTP audit test asserts deployments exist and the client body omits the blocked token; metadata coverage is the unit test on `GuardrailDecisionSink`.

Made with [Cursor](https://cursor.com)