### PR TITLE
feat(budget): make provider and model reserve-settle distributed

### DIFF
--- a/src/core/budget/distributed.rs
+++ b/src/core/budget/distributed.rs
@@ -113,24 +113,27 @@ impl BudgetLeaseBackend {
             #[cfg(feature = "gateway")]
             Self::Redis { pool, lease_ttl_ms } => {
                 let lease_id = uuid::Uuid::new_v4().to_string();
-                let state = run_redis(
-                    scope,
-                    name,
-                    "reserve",
+                let pool = Arc::clone(pool);
+                let key = crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name);
+                let amount = to_i64(amount)?;
+                let max = to_i64(max)?;
+                let seed_committed = to_i64(seed_committed)?;
+                let ttl_ms = *lease_ttl_ms;
+                let now_ms = now_ms();
+                let lease_id_for_fut = lease_id.clone();
+                let state = run_redis(scope, name, "reserve", async move {
                     pool.budget_reserve(crate::storage::redis::budget::BudgetReserveArgs {
-                        key: &crate::storage::redis::RedisPool::budget_lease_key(
-                            scope.as_str(),
-                            name,
-                        ),
-                        amount: to_i64(amount)?,
-                        max: to_i64(max)?,
-                        seed_committed: to_i64(seed_committed)?,
+                        key: &key,
+                        amount,
+                        max,
+                        seed_committed,
                         period_epoch,
-                        lease_id: &lease_id,
-                        now_ms: now_ms(),
-                        ttl_ms: *lease_ttl_ms,
-                    }),
-                )?;
+                        lease_id: &lease_id_for_fut,
+                        now_ms,
+                        ttl_ms,
+                    })
+                    .await
+                })?;
                 if !state.allowed {
                     return Err(scope.exceeded_error());
                 }
@@ -158,19 +161,16 @@ impl BudgetLeaseBackend {
             Self::Unavailable => Err(BudgetReservationError::BackendUnavailable),
             #[cfg(feature = "gateway")]
             Self::Redis { pool, .. } => {
-                let state = run_redis(
-                    scope,
-                    name,
-                    "settle",
-                    pool.budget_settle(
-                        &crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name),
-                        to_i64(reserved)?,
-                        to_i64(actual)?,
-                        period_epoch,
-                        lease_id,
-                        now_ms(),
-                    ),
-                )?;
+                let pool = Arc::clone(pool);
+                let key = crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name);
+                let reserved = to_i64(reserved)?;
+                let actual = to_i64(actual)?;
+                let lease_id = lease_id.to_string();
+                let now_ms = now_ms();
+                let state = run_redis(scope, name, "settle", async move {
+                    pool.budget_settle(&key, reserved, actual, period_epoch, &lease_id, now_ms)
+                        .await
+                })?;
                 lease_snapshot(state)
             }
         }
@@ -193,18 +193,15 @@ impl BudgetLeaseBackend {
             }),
             #[cfg(feature = "gateway")]
             Self::Redis { pool, .. } => {
-                let state = run_redis(
-                    scope,
-                    name,
-                    "cancel",
-                    pool.budget_cancel(
-                        &crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name),
-                        to_i64(reserved)?,
-                        period_epoch,
-                        lease_id,
-                        now_ms(),
-                    ),
-                )?;
+                let pool = Arc::clone(pool);
+                let key = crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name);
+                let reserved = to_i64(reserved)?;
+                let lease_id = lease_id.to_string();
+                let now_ms = now_ms();
+                let state = run_redis(scope, name, "cancel", async move {
+                    pool.budget_cancel(&key, reserved, period_epoch, &lease_id, now_ms)
+                        .await
+                })?;
                 lease_snapshot(state)
             }
         }
@@ -225,14 +222,7 @@ impl BudgetLeaseBackend {
             };
             let pool = Arc::clone(pool);
             let key = crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name);
-            let Ok(handle) = tokio::runtime::Handle::try_current() else {
-                warn!(
-                    scope = scope.as_str(),
-                    name, "budget lease drop-cancel has no runtime; relying on expiry"
-                );
-                return;
-            };
-            handle.spawn(async move {
+            budget_io_handle().spawn(async move {
                 if let Err(err) = pool
                     .budget_cancel(&key, reserved, period_epoch, &lease_id, now_ms())
                     .await
@@ -266,17 +256,12 @@ impl BudgetLeaseBackend {
             }),
             #[cfg(feature = "gateway")]
             Self::Redis { pool, .. } => {
-                let state = run_redis(
-                    scope,
-                    name,
-                    "reset",
-                    pool.budget_reset(
-                        &crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name),
-                        period_epoch,
-                        now_ms(),
-                        true,
-                    ),
-                )?;
+                let pool = Arc::clone(pool);
+                let key = crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name);
+                let now_ms = now_ms();
+                let state = run_redis(scope, name, "reset", async move {
+                    pool.budget_reset(&key, period_epoch, now_ms, true).await
+                })?;
                 lease_snapshot(state)
             }
         }
@@ -335,27 +320,77 @@ fn lease_snapshot(
 }
 
 #[cfg(feature = "gateway")]
+fn budget_io_handle() -> tokio::runtime::Handle {
+    static HANDLE: std::sync::OnceLock<tokio::runtime::Handle> = std::sync::OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            std::thread::Builder::new()
+                .name("budget-redis-rt".into())
+                .spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(1)
+                        .enable_all()
+                        .thread_name("budget-redis")
+                        .build()
+                        .expect("budget redis runtime");
+                    let handle = runtime.handle().clone();
+                    tx.send(handle).expect("send budget redis handle");
+                    runtime.block_on(std::future::pending::<()>());
+                })
+                .expect("spawn budget redis runtime thread");
+            rx.recv().expect("budget redis runtime handle")
+        })
+        .clone()
+}
+
+#[cfg(feature = "gateway")]
 fn run_redis<T>(
     scope: BudgetLeaseScope,
     name: &str,
     operation: &'static str,
-    fut: impl std::future::Future<Output = crate::utils::error::gateway_error::Result<T>>,
-) -> Result<T, BudgetReservationError> {
-    let handle = tokio::runtime::Handle::try_current().map_err(|_| {
-        warn!(
-            scope = scope.as_str(),
-            name, operation, "budget redis called without a tokio runtime; failing closed"
-        );
-        BudgetReservationError::BackendUnavailable
-    })?;
-    tokio::task::block_in_place(|| handle.block_on(fut)).map_err(|err| {
-        warn!(
-            scope = scope.as_str(),
-            name,
-            operation,
-            error = %err,
-            "budget redis operation failed; failing closed"
-        );
-        BudgetReservationError::BackendUnavailable
-    })
+    fut: impl std::future::Future<Output = crate::utils::error::gateway_error::Result<T>>
+    + Send
+    + 'static,
+) -> Result<T, BudgetReservationError>
+where
+    T: Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    budget_io_handle().spawn(async move {
+        let _ = tx.send(fut.await);
+    });
+    match rx.recv() {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => {
+            warn!(
+                scope = scope.as_str(),
+                name,
+                operation,
+                error = %err,
+                "budget redis operation failed; failing closed"
+            );
+            Err(BudgetReservationError::BackendUnavailable)
+        }
+        Err(_) => {
+            warn!(
+                scope = scope.as_str(),
+                name, operation, "budget redis worker dropped; failing closed"
+            );
+            Err(BudgetReservationError::BackendUnavailable)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "gateway"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_redis_does_not_panic_on_current_thread_runtime() {
+        let result = run_redis(BudgetLeaseScope::Provider, "probe", "probe", async {
+            Ok::<i64, crate::utils::error::gateway_error::GatewayError>(7)
+        });
+        assert_eq!(result.expect("current_thread redis bridge"), 7);
+    }
 }

--- a/src/core/budget/distributed.rs
+++ b/src/core/budget/distributed.rs
@@ -1,0 +1,361 @@
+//! Shared atomic backend for provider/model budget leases.
+//!
+//! In-process DashMap remains the default. When a live Redis pool is attached,
+//! reserve/settle/cancel run as single-key Lua so multiple gateways cannot
+//! overspend. Redis errors fail closed.
+
+use super::BudgetAmount;
+#[cfg(feature = "gateway")]
+use super::BudgetAmountError;
+use super::tracker::BudgetReservationError;
+use super::types::ResetPeriod;
+use chrono::{Datelike, NaiveDate, Utc, Weekday};
+#[cfg(feature = "gateway")]
+use std::sync::Arc;
+#[cfg(feature = "gateway")]
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::warn;
+
+pub(crate) const DEFAULT_LEASE_TTL_MS: i64 = 600_000;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum BudgetLeaseScope {
+    Provider,
+    Model,
+}
+
+impl BudgetLeaseScope {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Provider => "provider",
+            Self::Model => "model",
+        }
+    }
+
+    pub(crate) fn exceeded_error(self) -> BudgetReservationError {
+        match self {
+            Self::Provider => BudgetReservationError::ProviderBudgetExceeded,
+            Self::Model => BudgetReservationError::ModelBudgetExceeded,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) enum BudgetLeaseBackend {
+    #[default]
+    InProcess,
+    #[cfg(feature = "gateway")]
+    Redis {
+        pool: Arc<crate::storage::redis::RedisPool>,
+        lease_ttl_ms: i64,
+    },
+    #[cfg(test)]
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LeaseSnapshot {
+    pub committed: BudgetAmount,
+    pub outstanding: BudgetAmount,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReservedLease {
+    pub lease_id: String,
+    pub period_epoch: i64,
+    pub snapshot: LeaseSnapshot,
+}
+
+impl BudgetLeaseBackend {
+    #[cfg(feature = "gateway")]
+    pub(crate) fn redis(pool: Arc<crate::storage::redis::RedisPool>) -> Self {
+        Self::redis_with_ttl(pool, DEFAULT_LEASE_TTL_MS)
+    }
+
+    #[cfg(feature = "gateway")]
+    pub(crate) fn redis_with_ttl(
+        pool: Arc<crate::storage::redis::RedisPool>,
+        lease_ttl_ms: i64,
+    ) -> Self {
+        if pool.is_noop() {
+            Self::InProcess
+        } else {
+            Self::Redis {
+                pool,
+                lease_ttl_ms: lease_ttl_ms.max(1),
+            }
+        }
+    }
+
+    pub(crate) fn is_distributed(&self) -> bool {
+        !matches!(self, Self::InProcess)
+    }
+
+    pub(crate) fn reserve(
+        &self,
+        scope: BudgetLeaseScope,
+        name: &str,
+        amount: BudgetAmount,
+        max: BudgetAmount,
+        seed_committed: BudgetAmount,
+        period_epoch: i64,
+    ) -> Result<ReservedLease, BudgetReservationError> {
+        match self {
+            Self::InProcess => Err(BudgetReservationError::BackendUnavailable),
+            #[cfg(test)]
+            Self::Unavailable => {
+                warn!(
+                    scope = scope.as_str(),
+                    name, "budget reserve backend unavailable; failing closed"
+                );
+                Err(BudgetReservationError::BackendUnavailable)
+            }
+            #[cfg(feature = "gateway")]
+            Self::Redis { pool, lease_ttl_ms } => {
+                let lease_id = uuid::Uuid::new_v4().to_string();
+                let state = run_redis(
+                    scope,
+                    name,
+                    "reserve",
+                    pool.budget_reserve(crate::storage::redis::budget::BudgetReserveArgs {
+                        key: &crate::storage::redis::RedisPool::budget_lease_key(
+                            scope.as_str(),
+                            name,
+                        ),
+                        amount: to_i64(amount)?,
+                        max: to_i64(max)?,
+                        seed_committed: to_i64(seed_committed)?,
+                        period_epoch,
+                        lease_id: &lease_id,
+                        now_ms: now_ms(),
+                        ttl_ms: *lease_ttl_ms,
+                    }),
+                )?;
+                if !state.allowed {
+                    return Err(scope.exceeded_error());
+                }
+                Ok(ReservedLease {
+                    lease_id,
+                    period_epoch,
+                    snapshot: lease_snapshot(state)?,
+                })
+            }
+        }
+    }
+
+    pub(crate) fn settle(
+        &self,
+        scope: BudgetLeaseScope,
+        name: &str,
+        lease_id: &str,
+        reserved: BudgetAmount,
+        actual: BudgetAmount,
+        period_epoch: i64,
+    ) -> Result<LeaseSnapshot, BudgetReservationError> {
+        match self {
+            Self::InProcess => Err(BudgetReservationError::BackendUnavailable),
+            #[cfg(test)]
+            Self::Unavailable => Err(BudgetReservationError::BackendUnavailable),
+            #[cfg(feature = "gateway")]
+            Self::Redis { pool, .. } => {
+                let state = run_redis(
+                    scope,
+                    name,
+                    "settle",
+                    pool.budget_settle(
+                        &crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name),
+                        to_i64(reserved)?,
+                        to_i64(actual)?,
+                        period_epoch,
+                        lease_id,
+                        now_ms(),
+                    ),
+                )?;
+                lease_snapshot(state)
+            }
+        }
+    }
+
+    pub(crate) fn cancel(
+        &self,
+        scope: BudgetLeaseScope,
+        name: &str,
+        lease_id: &str,
+        reserved: BudgetAmount,
+        period_epoch: i64,
+    ) -> Result<LeaseSnapshot, BudgetReservationError> {
+        match self {
+            Self::InProcess => Err(BudgetReservationError::BackendUnavailable),
+            #[cfg(test)]
+            Self::Unavailable => Ok(LeaseSnapshot {
+                committed: BudgetAmount::zero(),
+                outstanding: BudgetAmount::zero(),
+            }),
+            #[cfg(feature = "gateway")]
+            Self::Redis { pool, .. } => {
+                let state = run_redis(
+                    scope,
+                    name,
+                    "cancel",
+                    pool.budget_cancel(
+                        &crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name),
+                        to_i64(reserved)?,
+                        period_epoch,
+                        lease_id,
+                        now_ms(),
+                    ),
+                )?;
+                lease_snapshot(state)
+            }
+        }
+    }
+
+    pub(crate) fn spawn_cancel(
+        &self,
+        scope: BudgetLeaseScope,
+        name: &str,
+        lease_id: String,
+        reserved: BudgetAmount,
+        period_epoch: i64,
+    ) {
+        #[cfg(feature = "gateway")]
+        if let Self::Redis { pool, .. } = self {
+            let Ok(reserved) = to_i64(reserved) else {
+                return;
+            };
+            let pool = Arc::clone(pool);
+            let key = crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name);
+            let Ok(handle) = tokio::runtime::Handle::try_current() else {
+                warn!(
+                    scope = scope.as_str(),
+                    name, "budget lease drop-cancel has no runtime; relying on expiry"
+                );
+                return;
+            };
+            handle.spawn(async move {
+                if let Err(err) = pool
+                    .budget_cancel(&key, reserved, period_epoch, &lease_id, now_ms())
+                    .await
+                {
+                    warn!(
+                        error = %err,
+                        "budget lease drop-cancel failed; relying on expiry"
+                    );
+                }
+            });
+            return;
+        }
+        let _ = (scope, name, lease_id, reserved, period_epoch);
+    }
+
+    pub(crate) fn reset(
+        &self,
+        scope: BudgetLeaseScope,
+        name: &str,
+        period_epoch: i64,
+    ) -> Result<LeaseSnapshot, BudgetReservationError> {
+        match self {
+            Self::InProcess => Ok(LeaseSnapshot {
+                committed: BudgetAmount::zero(),
+                outstanding: BudgetAmount::zero(),
+            }),
+            #[cfg(test)]
+            Self::Unavailable => Ok(LeaseSnapshot {
+                committed: BudgetAmount::zero(),
+                outstanding: BudgetAmount::zero(),
+            }),
+            #[cfg(feature = "gateway")]
+            Self::Redis { pool, .. } => {
+                let state = run_redis(
+                    scope,
+                    name,
+                    "reset",
+                    pool.budget_reset(
+                        &crate::storage::redis::RedisPool::budget_lease_key(scope.as_str(), name),
+                        period_epoch,
+                        now_ms(),
+                        true,
+                    ),
+                )?;
+                lease_snapshot(state)
+            }
+        }
+    }
+}
+
+pub(crate) fn budget_period_epoch(period: ResetPeriod, now: chrono::DateTime<Utc>) -> i64 {
+    match period {
+        ResetPeriod::Never => -1,
+        ResetPeriod::Daily => now
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .map(|ndt| ndt.and_utc().timestamp())
+            .unwrap_or(0),
+        ResetPeriod::Weekly => {
+            let iso = now.iso_week();
+            NaiveDate::from_isoywd_opt(iso.year(), iso.week(), Weekday::Mon)
+                .and_then(|d| d.and_hms_opt(0, 0, 0))
+                .map(|ndt| ndt.and_utc().timestamp())
+                .unwrap_or(0)
+        }
+        ResetPeriod::Monthly => NaiveDate::from_ymd_opt(now.year(), now.month(), 1)
+            .and_then(|d| d.and_hms_opt(0, 0, 0))
+            .map(|ndt| ndt.and_utc().timestamp())
+            .unwrap_or(0),
+    }
+}
+
+#[cfg(feature = "gateway")]
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(feature = "gateway")]
+fn to_i64(amount: BudgetAmount) -> Result<i64, BudgetReservationError> {
+    i64::try_from(amount.as_scaled())
+        .map_err(|_| BudgetReservationError::InvalidAmount(BudgetAmountError::Overflow))
+}
+
+#[cfg(feature = "gateway")]
+fn from_i64(value: i64) -> BudgetAmount {
+    BudgetAmount::from_scaled(i128::from(value.max(0)))
+}
+
+#[cfg(feature = "gateway")]
+fn lease_snapshot(
+    state: crate::storage::redis::budget::BudgetLeaseState,
+) -> Result<LeaseSnapshot, BudgetReservationError> {
+    Ok(LeaseSnapshot {
+        committed: from_i64(state.committed),
+        outstanding: from_i64(state.outstanding),
+    })
+}
+
+#[cfg(feature = "gateway")]
+fn run_redis<T>(
+    scope: BudgetLeaseScope,
+    name: &str,
+    operation: &'static str,
+    fut: impl std::future::Future<Output = crate::utils::error::gateway_error::Result<T>>,
+) -> Result<T, BudgetReservationError> {
+    let handle = tokio::runtime::Handle::try_current().map_err(|_| {
+        warn!(
+            scope = scope.as_str(),
+            name, operation, "budget redis called without a tokio runtime; failing closed"
+        );
+        BudgetReservationError::BackendUnavailable
+    })?;
+    tokio::task::block_in_place(|| handle.block_on(fut)).map_err(|err| {
+        warn!(
+            scope = scope.as_str(),
+            name,
+            operation,
+            error = %err,
+            "budget redis operation failed; failing closed"
+        );
+        BudgetReservationError::BackendUnavailable
+    })
+}

--- a/src/core/budget/distributed_reservation_tests.rs
+++ b/src/core/budget/distributed_reservation_tests.rs
@@ -1,0 +1,226 @@
+use super::{
+    BudgetReservationError, ModelLimitConfig, ProviderLimitConfig, ResetPeriod, UnifiedBudgetLimits,
+};
+
+#[test]
+fn unavailable_backend_fails_closed_without_overspend() {
+    let limits = UnifiedBudgetLimits::with_unavailable_backend();
+    limits.providers.set_provider_limit(
+        "openai",
+        ProviderLimitConfig::new(10.0, ResetPeriod::Monthly),
+    );
+
+    assert!(matches!(
+        limits.providers.reserve_provider_spend("openai", 1.0),
+        Err(BudgetReservationError::BackendUnavailable)
+    ));
+    assert_eq!(
+        limits
+            .providers
+            .get_provider_usage("openai")
+            .unwrap()
+            .current_spend,
+        0.0
+    );
+}
+
+#[cfg(feature = "gateway")]
+mod redis {
+    use super::*;
+    use crate::config::models::storage::RedisConfig;
+    use crate::storage::redis::RedisPool;
+    use std::sync::Arc;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_managers_last_token_allows_one_reservation() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let provider = unique("provider-race");
+        let model = unique("model-race");
+        let a = Arc::new(seeded(pool.clone(), &provider, &model, 10.0));
+        let b = Arc::new(seeded(pool.clone(), &provider, &model, 10.0));
+
+        let a_task = {
+            let a = Arc::clone(&a);
+            let provider = provider.clone();
+            let model = model.clone();
+            tokio::spawn(async move { a.reserve_spend(&provider, &model, 10.0) })
+        };
+        let b_task = {
+            let b = Arc::clone(&b);
+            let provider = provider.clone();
+            let model = model.clone();
+            tokio::spawn(async move { b.reserve_spend(&provider, &model, 10.0) })
+        };
+
+        let a_result = a_task.await.expect("join a");
+        let b_result = b_task.await.expect("join b");
+        let successes = [&a_result, &b_result]
+            .iter()
+            .filter(|result| result.is_ok())
+            .count();
+        assert_eq!(
+            successes,
+            1,
+            "exactly one of two competing last-token reservations should succeed (a_ok={}, b_ok={})",
+            a_result.is_ok(),
+            b_result.is_ok()
+        );
+        cleanup(&pool, &provider, &model).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn model_deny_rolls_back_provider_outstanding() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let provider = unique("provider-rollback");
+        let model = unique("model-rollback");
+        let limits = seeded(pool.clone(), &provider, &model, 100.0);
+        limits
+            .models
+            .set_model_limit(&model, ModelLimitConfig::new(5.0, ResetPeriod::Monthly));
+
+        assert!(matches!(
+            limits.reserve_spend(&provider, &model, 10.0),
+            Err(BudgetReservationError::ModelBudgetExceeded)
+        ));
+
+        let other = seeded(pool.clone(), &provider, &model, 100.0);
+        other
+            .models
+            .set_model_limit(&model, ModelLimitConfig::new(5.0, ResetPeriod::Monthly));
+        other
+            .providers
+            .reserve_provider_spend(&provider, 100.0)
+            .expect("rolled-back provider outstanding should free the full budget");
+        cleanup(&pool, &provider, &model).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_and_cancel_keep_committed_and_outstanding_distinct() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let provider = unique("provider-distinct");
+        let model = unique("model-distinct");
+        let limits = seeded(pool.clone(), &provider, &model, 10.0);
+        let other = seeded(pool.clone(), &provider, &model, 10.0);
+
+        let reservation = limits.reserve_spend(&provider, &model, 10.0).unwrap();
+        assert!(
+            other.reserve_spend(&provider, &model, 1.0).is_err(),
+            "outstanding hold must block the remaining budget"
+        );
+        reservation.settle(3.0).unwrap();
+
+        other
+            .reserve_spend(&provider, &model, 7.0)
+            .expect("committed 3 should leave 7 of 10");
+        cleanup(&pool, &provider, &model).await;
+
+        let provider = unique("provider-cancel");
+        let model = unique("model-cancel");
+        let limits = seeded(pool.clone(), &provider, &model, 10.0);
+        let other = seeded(pool.clone(), &provider, &model, 10.0);
+        let reservation = limits.reserve_spend(&provider, &model, 10.0).unwrap();
+        reservation.cancel();
+        other
+            .reserve_spend(&provider, &model, 10.0)
+            .expect("cancel must release outstanding without committing spend");
+        cleanup(&pool, &provider, &model).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn abandoned_lease_is_recovered_after_expiry() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let provider = unique("provider-expire");
+        let model = unique("model-expire");
+        let limits = UnifiedBudgetLimits::new().with_redis_lease_ttl(pool.clone(), 1_000);
+        limits.providers.set_provider_limit(
+            &provider,
+            ProviderLimitConfig::new(10.0, ResetPeriod::Monthly),
+        );
+        limits
+            .models
+            .set_model_limit(&model, ModelLimitConfig::new(10.0, ResetPeriod::Monthly));
+
+        let reservation = limits.reserve_spend(&provider, &model, 10.0).unwrap();
+        std::mem::forget(reservation);
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+
+        let other = UnifiedBudgetLimits::new().with_redis_lease_ttl(pool.clone(), 1_000);
+        other.providers.set_provider_limit(
+            &provider,
+            ProviderLimitConfig::new(10.0, ResetPeriod::Monthly),
+        );
+        other
+            .models
+            .set_model_limit(&model, ModelLimitConfig::new(10.0, ResetPeriod::Monthly));
+        other
+            .reserve_spend(&provider, &model, 10.0)
+            .expect("expired lease must be reclaimed for a later reserve");
+        cleanup(&pool, &provider, &model).await;
+    }
+
+    fn seeded(redis: Arc<RedisPool>, provider: &str, model: &str, max: f64) -> UnifiedBudgetLimits {
+        let limits = UnifiedBudgetLimits::new().with_redis(redis);
+        limits.providers.set_provider_limit(
+            provider,
+            ProviderLimitConfig::new(max, ResetPeriod::Monthly),
+        );
+        limits
+            .models
+            .set_model_limit(model, ModelLimitConfig::new(max, ResetPeriod::Monthly));
+        limits
+    }
+
+    fn unique(prefix: &str) -> String {
+        format!("{prefix}-{}", uuid::Uuid::new_v4())
+    }
+
+    async fn cleanup(pool: &RedisPool, provider: &str, model: &str) {
+        let _ = pool
+            .delete(&RedisPool::budget_lease_key("provider", provider))
+            .await;
+        let _ = pool
+            .delete(&RedisPool::budget_lease_key("model", model))
+            .await;
+    }
+
+    async fn live_redis_pool() -> Option<Arc<RedisPool>> {
+        let redis_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+        let config = RedisConfig {
+            url: redis_url.clone(),
+            enabled: true,
+            max_connections: 10,
+            connection_timeout: 1,
+            cluster: false,
+            allow_degraded: false,
+        };
+
+        match RedisPool::new(&config).await {
+            Ok(pool) => match pool.health_check().await {
+                Ok(()) => Some(Arc::new(pool)),
+                Err(err) => {
+                    if std::env::var("CI").is_ok() {
+                        panic!("Redis should pass health check in CI at {redis_url}: {err}");
+                    }
+                    eprintln!("Skipping distributed budget Redis integration test: {err}");
+                    None
+                }
+            },
+            Err(err) => {
+                if std::env::var("CI").is_ok() {
+                    panic!("Redis should be reachable in CI at {redis_url}: {err}");
+                }
+                eprintln!("Skipping distributed budget Redis integration test: {err}");
+                None
+            }
+        }
+    }
+}

--- a/src/core/budget/distributed_reservation_tests.rs
+++ b/src/core/budget/distributed_reservation_tests.rs
@@ -132,6 +132,21 @@ mod redis {
         cleanup(&pool, &provider, &model).await;
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn current_thread_runtime_can_reserve_without_panic() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let provider = unique("provider-current-thread");
+        let model = unique("model-current-thread");
+        let limits = seeded(pool.clone(), &provider, &model, 10.0);
+        let reservation = limits
+            .reserve_spend(&provider, &model, 4.0)
+            .expect("Actix workers use current_thread; reserve must not panic");
+        reservation.settle(4.0).unwrap();
+        cleanup(&pool, &provider, &model).await;
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn abandoned_lease_is_recovered_after_expiry() {
         let Some(pool) = live_redis_pool().await else {

--- a/src/core/budget/mod.rs
+++ b/src/core/budget/mod.rs
@@ -65,6 +65,7 @@
 
 mod alerts;
 mod config;
+mod distributed;
 mod manager;
 #[cfg(feature = "gateway")]
 mod middleware;
@@ -74,6 +75,8 @@ mod tracker;
 mod types;
 mod unified_limits;
 
+#[cfg(test)]
+mod distributed_reservation_tests;
 #[cfg(test)]
 mod manager_tests;
 #[cfg(test)]
@@ -161,6 +164,14 @@ impl BudgetAmount {
 
     pub fn saturating_sub(self, other: Self) -> Self {
         Self(self.0.saturating_sub(other.0).max(0))
+    }
+
+    pub(crate) fn as_scaled(self) -> i128 {
+        self.0
+    }
+
+    pub(crate) fn from_scaled(value: i128) -> Self {
+        Self(value.max(0))
     }
 }
 

--- a/src/core/budget/provider_limits.rs
+++ b/src/core/budget/provider_limits.rs
@@ -4,6 +4,9 @@ use super::config::{
     BudgetLimitKind, BudgetLimitSnapshot, BudgetPersistenceEvent, BudgetPersistenceSender,
     ModelLimitConfig, ProviderLimitConfig,
 };
+use super::distributed::{
+    BudgetLeaseBackend, BudgetLeaseScope, LeaseSnapshot, budget_period_epoch,
+};
 use super::types::{
     BudgetStatus, ModelBudget, ModelUsageStats, ProviderBudget, ProviderUsageStats,
 };
@@ -32,6 +35,7 @@ pub struct ProviderBudgetManager {
     pub(crate) reserved_spend: Arc<DashMap<String, BudgetAmount>>,
     pub(crate) enabled: Arc<std::sync::atomic::AtomicBool>,
     persistence_tx: Option<BudgetPersistenceSender>,
+    pub(crate) backend: BudgetLeaseBackend,
 }
 
 impl Default for ProviderBudgetManager {
@@ -48,6 +52,7 @@ impl ProviderBudgetManager {
             reserved_spend: Arc::new(DashMap::new()),
             enabled: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             persistence_tx: None,
+            backend: BudgetLeaseBackend::InProcess,
         }
     }
     pub fn with_capacity(capacity: usize) -> Self {
@@ -57,11 +62,58 @@ impl ProviderBudgetManager {
             reserved_spend: Arc::new(DashMap::with_capacity(capacity)),
             enabled: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             persistence_tx: None,
+            backend: BudgetLeaseBackend::InProcess,
         }
     }
     pub fn with_persistence(mut self, persistence_tx: BudgetPersistenceSender) -> Self {
         self.persistence_tx = Some(persistence_tx);
         self
+    }
+    #[cfg(feature = "gateway")]
+    pub fn with_redis(mut self, redis: Arc<crate::storage::redis::RedisPool>) -> Self {
+        self.backend = BudgetLeaseBackend::redis(redis);
+        self
+    }
+    #[cfg(all(test, feature = "gateway"))]
+    pub fn with_redis_lease_ttl(
+        mut self,
+        redis: Arc<crate::storage::redis::RedisPool>,
+        lease_ttl_ms: i64,
+    ) -> Self {
+        self.backend = BudgetLeaseBackend::redis_with_ttl(redis, lease_ttl_ms);
+        self
+    }
+
+    pub(crate) fn sync_lease_snapshot(&self, name: &str, snapshot: LeaseSnapshot) {
+        if let Some(mut budget) = self.budgets.get_mut(name) {
+            budget.current_spend = snapshot
+                .committed
+                .checked_add(snapshot.outstanding)
+                .unwrap_or(snapshot.committed)
+                .as_f64();
+            budget.updated_at = chrono::Utc::now();
+        }
+        if snapshot.outstanding == BudgetAmount::zero() {
+            self.reserved_spend.remove(name);
+        } else {
+            self.reserved_spend
+                .insert(name.to_string(), snapshot.outstanding);
+        }
+    }
+
+    fn reset_distributed_lease(&self, name: &str, reset_period: super::types::ResetPeriod) {
+        if !self.backend.is_distributed() {
+            return;
+        }
+        let epoch = budget_period_epoch(reset_period, chrono::Utc::now());
+        match self.backend.reset(BudgetLeaseScope::Provider, name, epoch) {
+            Ok(snapshot) => self.sync_lease_snapshot(name, snapshot),
+            Err(err) => warn!(
+                provider = name,
+                error = ?err,
+                "failed to reset distributed provider budget lease; failing closed on later reserves"
+            ),
+        }
     }
 
     pub(crate) fn send_persistence_event(&self, event: BudgetPersistenceEvent) {
@@ -360,6 +412,7 @@ impl ProviderBudgetManager {
                 "Resetting provider '{}' budget (was ${:.2})",
                 provider, budget.current_spend
             );
+            let reset_period = budget.reset_period;
             budget.reset();
             if let Some(counter) = self.request_counts.get(provider) {
                 counter.count.store(0, Ordering::Relaxed);
@@ -368,6 +421,7 @@ impl ProviderBudgetManager {
 
             let snapshot = self.snapshot_for(&budget);
             drop(budget);
+            self.reset_distributed_lease(provider, reset_period);
             self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
             true
         } else {
@@ -385,6 +439,7 @@ impl ProviderBudgetManager {
                     provider,
                     entry.value().current_spend
                 );
+                let reset_period = entry.value().reset_period;
                 entry.value_mut().reset();
                 if let Some(counter) = self.request_counts.get(&provider) {
                     counter.count.store(0, Ordering::Relaxed);
@@ -393,11 +448,15 @@ impl ProviderBudgetManager {
 
                 let snapshot = self.snapshot_for(entry.value());
                 self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
-                reset_providers.push(provider);
+                reset_providers.push((provider, reset_period));
             }
         }
 
-        reset_providers
+        for (provider, reset_period) in &reset_providers {
+            self.reset_distributed_lease(provider, *reset_period);
+        }
+
+        reset_providers.into_iter().map(|(name, _)| name).collect()
     }
     pub fn provider_count(&self) -> usize {
         self.budgets.len()
@@ -411,6 +470,7 @@ pub struct ModelBudgetManager {
     pub(crate) reserved_spend: Arc<DashMap<String, BudgetAmount>>,
     pub(crate) enabled: Arc<std::sync::atomic::AtomicBool>,
     persistence_tx: Option<BudgetPersistenceSender>,
+    pub(crate) backend: BudgetLeaseBackend,
 }
 
 impl Default for ModelBudgetManager {
@@ -427,11 +487,58 @@ impl ModelBudgetManager {
             reserved_spend: Arc::new(DashMap::new()),
             enabled: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             persistence_tx: None,
+            backend: BudgetLeaseBackend::InProcess,
         }
     }
     pub fn with_persistence(mut self, persistence_tx: BudgetPersistenceSender) -> Self {
         self.persistence_tx = Some(persistence_tx);
         self
+    }
+    #[cfg(feature = "gateway")]
+    pub fn with_redis(mut self, redis: Arc<crate::storage::redis::RedisPool>) -> Self {
+        self.backend = BudgetLeaseBackend::redis(redis);
+        self
+    }
+    #[cfg(all(test, feature = "gateway"))]
+    pub fn with_redis_lease_ttl(
+        mut self,
+        redis: Arc<crate::storage::redis::RedisPool>,
+        lease_ttl_ms: i64,
+    ) -> Self {
+        self.backend = BudgetLeaseBackend::redis_with_ttl(redis, lease_ttl_ms);
+        self
+    }
+
+    pub(crate) fn sync_lease_snapshot(&self, name: &str, snapshot: LeaseSnapshot) {
+        if let Some(mut budget) = self.budgets.get_mut(name) {
+            budget.current_spend = snapshot
+                .committed
+                .checked_add(snapshot.outstanding)
+                .unwrap_or(snapshot.committed)
+                .as_f64();
+            budget.updated_at = chrono::Utc::now();
+        }
+        if snapshot.outstanding == BudgetAmount::zero() {
+            self.reserved_spend.remove(name);
+        } else {
+            self.reserved_spend
+                .insert(name.to_string(), snapshot.outstanding);
+        }
+    }
+
+    fn reset_distributed_lease(&self, name: &str, reset_period: super::types::ResetPeriod) {
+        if !self.backend.is_distributed() {
+            return;
+        }
+        let epoch = budget_period_epoch(reset_period, chrono::Utc::now());
+        match self.backend.reset(BudgetLeaseScope::Model, name, epoch) {
+            Ok(snapshot) => self.sync_lease_snapshot(name, snapshot),
+            Err(err) => warn!(
+                model = name,
+                error = ?err,
+                "failed to reset distributed model budget lease; failing closed on later reserves"
+            ),
+        }
     }
 
     pub(crate) fn send_persistence_event(&self, event: BudgetPersistenceEvent) {
@@ -693,6 +800,7 @@ impl ModelBudgetManager {
                 "Resetting model '{}' budget (was ${:.2})",
                 model, budget.current_spend
             );
+            let reset_period = budget.reset_period;
             budget.reset();
 
             if let Some(counter) = self.request_counts.get(model) {
@@ -702,6 +810,7 @@ impl ModelBudgetManager {
 
             let snapshot = self.snapshot_for(&budget);
             drop(budget);
+            self.reset_distributed_lease(model, reset_period);
             self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
             true
         } else {
@@ -719,6 +828,7 @@ impl ModelBudgetManager {
                     model,
                     entry.value().current_spend
                 );
+                let reset_period = entry.value().reset_period;
                 entry.value_mut().reset();
 
                 if let Some(counter) = self.request_counts.get(&model) {
@@ -728,11 +838,15 @@ impl ModelBudgetManager {
 
                 let snapshot = self.snapshot_for(entry.value());
                 self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
-                reset_models.push(model);
+                reset_models.push((model, reset_period));
             }
         }
 
-        reset_models
+        for (model, reset_period) in &reset_models {
+            self.reset_distributed_lease(model, *reset_period);
+        }
+
+        reset_models.into_iter().map(|(name, _)| name).collect()
     }
     pub fn model_count(&self) -> usize {
         self.budgets.len()

--- a/src/core/budget/provider_reservations.rs
+++ b/src/core/budget/provider_reservations.rs
@@ -1,4 +1,5 @@
 use super::config::BudgetPersistenceEvent;
+use super::distributed::{BudgetLeaseScope, budget_period_epoch};
 use super::tracker::BudgetReservationError;
 use super::types::BudgetStatus;
 use super::{
@@ -34,6 +35,36 @@ impl ProviderBudgetManager {
                 provider.to_string(),
                 reserved,
             ));
+        }
+        if self.backend.is_distributed() {
+            let max = BudgetAmount::from_f64(budget.max_budget)?;
+            let period_epoch = budget_period_epoch(budget.reset_period, chrono::Utc::now());
+            let outstanding = self
+                .reserved_spend
+                .get(provider)
+                .map(|value| *value)
+                .unwrap_or_else(BudgetAmount::zero);
+            let seed_committed = BudgetAmount::from_f64(budget.current_spend)
+                .unwrap_or_else(|_| BudgetAmount::zero())
+                .saturating_sub(outstanding);
+            let reservation_reset_at = budget.last_reset_at;
+            drop(budget);
+            let lease = self.backend.reserve(
+                BudgetLeaseScope::Provider,
+                provider,
+                reserved,
+                max,
+                seed_committed,
+                period_epoch,
+            )?;
+            self.sync_lease_snapshot(provider, lease.snapshot);
+            return Ok(ProviderBudgetReservation::tracked(
+                self.clone(),
+                provider.to_string(),
+                reserved,
+                reservation_reset_at,
+            )
+            .with_lease(lease.lease_id, lease.period_epoch));
         }
         if !budget_can_spend(budget.current_spend, budget.max_budget, true, max_amount)? {
             return Err(BudgetReservationError::ProviderBudgetExceeded);
@@ -132,6 +163,18 @@ impl ProviderBudgetManager {
         }
     }
 
+    fn finish_distributed_settle(&self, provider: &str) -> Option<BudgetStatus> {
+        if let Some(counter) = self.request_counts.get(provider) {
+            counter.count.fetch_add(1, Ordering::Relaxed);
+        }
+        let budget = self.budgets.get(provider)?;
+        let status = budget.status();
+        let snapshot = self.snapshot_for(&budget);
+        drop(budget);
+        self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
+        Some(status)
+    }
+
     fn add_provider_outstanding_reservation(
         &self,
         provider: &str,
@@ -193,6 +236,36 @@ impl ModelBudgetManager {
                 model.to_string(),
                 reserved,
             ));
+        }
+        if self.backend.is_distributed() {
+            let max = BudgetAmount::from_f64(budget.max_budget)?;
+            let period_epoch = budget_period_epoch(budget.reset_period, chrono::Utc::now());
+            let outstanding = self
+                .reserved_spend
+                .get(model)
+                .map(|value| *value)
+                .unwrap_or_else(BudgetAmount::zero);
+            let seed_committed = BudgetAmount::from_f64(budget.current_spend)
+                .unwrap_or_else(|_| BudgetAmount::zero())
+                .saturating_sub(outstanding);
+            let reservation_reset_at = budget.last_reset_at;
+            drop(budget);
+            let lease = self.backend.reserve(
+                BudgetLeaseScope::Model,
+                model,
+                reserved,
+                max,
+                seed_committed,
+                period_epoch,
+            )?;
+            self.sync_lease_snapshot(model, lease.snapshot);
+            return Ok(ModelBudgetReservation::tracked(
+                self.clone(),
+                model.to_string(),
+                reserved,
+                reservation_reset_at,
+            )
+            .with_lease(lease.lease_id, lease.period_epoch));
         }
         if !budget_can_spend(budget.current_spend, budget.max_budget, true, max_amount)? {
             return Err(BudgetReservationError::ModelBudgetExceeded);
@@ -291,6 +364,18 @@ impl ModelBudgetManager {
         }
     }
 
+    fn finish_distributed_settle(&self, model: &str) -> Option<BudgetStatus> {
+        if let Some(counter) = self.request_counts.get(model) {
+            counter.count.fetch_add(1, Ordering::Relaxed);
+        }
+        let budget = self.budgets.get(model)?;
+        let status = budget.status();
+        let snapshot = self.snapshot_for(&budget);
+        drop(budget);
+        self.send_persistence_event(BudgetPersistenceEvent::Upsert(snapshot));
+        Some(status)
+    }
+
     fn add_model_outstanding_reservation(
         &self,
         model: &str,
@@ -355,6 +440,8 @@ pub struct ProviderBudgetReservation {
     reservation_reset_at: Option<chrono::DateTime<chrono::Utc>>,
     tracked: bool,
     settled: bool,
+    lease_id: Option<String>,
+    period_epoch: i64,
 }
 
 impl ProviderBudgetReservation {
@@ -371,6 +458,8 @@ impl ProviderBudgetReservation {
             reservation_reset_at,
             tracked: true,
             settled: false,
+            lease_id: None,
+            period_epoch: 0,
         }
     }
 
@@ -386,7 +475,15 @@ impl ProviderBudgetReservation {
             reservation_reset_at: None,
             tracked: false,
             settled: false,
+            lease_id: None,
+            period_epoch: 0,
         }
+    }
+
+    fn with_lease(mut self, lease_id: String, period_epoch: i64) -> Self {
+        self.lease_id = Some(lease_id);
+        self.period_epoch = period_epoch;
+        self
     }
 
     pub fn provider(&self) -> &str {
@@ -406,6 +503,20 @@ impl ProviderBudgetReservation {
         actual_amount: f64,
     ) -> Result<Option<BudgetStatus>, BudgetReservationError> {
         let actual = BudgetAmount::from_f64(actual_amount)?;
+        if let Some(lease_id) = self.lease_id.clone() {
+            let snapshot = self.manager.backend.settle(
+                BudgetLeaseScope::Provider,
+                &self.provider,
+                &lease_id,
+                self.reserved,
+                actual,
+                self.period_epoch,
+            )?;
+            self.manager.sync_lease_snapshot(&self.provider, snapshot);
+            let status = self.manager.finish_distributed_settle(&self.provider);
+            self.settled = true;
+            return Ok(status);
+        }
         let status = if self.tracked {
             self.manager.settle_provider_reservation(
                 &self.provider,
@@ -422,6 +533,26 @@ impl ProviderBudgetReservation {
     }
 
     pub fn cancel(mut self) {
+        if let Some(lease_id) = self.lease_id.clone() {
+            match self.manager.backend.cancel(
+                BudgetLeaseScope::Provider,
+                &self.provider,
+                &lease_id,
+                self.reserved,
+                self.period_epoch,
+            ) {
+                Ok(snapshot) => self.manager.sync_lease_snapshot(&self.provider, snapshot),
+                Err(_) => self.manager.backend.spawn_cancel(
+                    BudgetLeaseScope::Provider,
+                    &self.provider,
+                    lease_id,
+                    self.reserved,
+                    self.period_epoch,
+                ),
+            }
+            self.settled = true;
+            return;
+        }
         if self.tracked {
             self.manager.release_provider_reservation(
                 &self.provider,
@@ -436,11 +567,21 @@ impl ProviderBudgetReservation {
 impl Drop for ProviderBudgetReservation {
     fn drop(&mut self) {
         if self.tracked && !self.settled {
-            self.manager.release_provider_reservation(
-                &self.provider,
-                self.reserved,
-                self.reservation_reset_at,
-            );
+            if let Some(lease_id) = self.lease_id.clone() {
+                self.manager.backend.spawn_cancel(
+                    BudgetLeaseScope::Provider,
+                    &self.provider,
+                    lease_id,
+                    self.reserved,
+                    self.period_epoch,
+                );
+            } else {
+                self.manager.release_provider_reservation(
+                    &self.provider,
+                    self.reserved,
+                    self.reservation_reset_at,
+                );
+            }
         }
     }
 }
@@ -452,6 +593,8 @@ pub struct ModelBudgetReservation {
     reservation_reset_at: Option<chrono::DateTime<chrono::Utc>>,
     tracked: bool,
     settled: bool,
+    lease_id: Option<String>,
+    period_epoch: i64,
 }
 
 impl ModelBudgetReservation {
@@ -468,6 +611,8 @@ impl ModelBudgetReservation {
             reservation_reset_at,
             tracked: true,
             settled: false,
+            lease_id: None,
+            period_epoch: 0,
         }
     }
 
@@ -483,7 +628,15 @@ impl ModelBudgetReservation {
             reservation_reset_at: None,
             tracked: false,
             settled: false,
+            lease_id: None,
+            period_epoch: 0,
         }
+    }
+
+    fn with_lease(mut self, lease_id: String, period_epoch: i64) -> Self {
+        self.lease_id = Some(lease_id);
+        self.period_epoch = period_epoch;
+        self
     }
 
     pub fn model(&self) -> &str {
@@ -503,6 +656,20 @@ impl ModelBudgetReservation {
         actual_amount: f64,
     ) -> Result<Option<BudgetStatus>, BudgetReservationError> {
         let actual = BudgetAmount::from_f64(actual_amount)?;
+        if let Some(lease_id) = self.lease_id.clone() {
+            let snapshot = self.manager.backend.settle(
+                BudgetLeaseScope::Model,
+                &self.model,
+                &lease_id,
+                self.reserved,
+                actual,
+                self.period_epoch,
+            )?;
+            self.manager.sync_lease_snapshot(&self.model, snapshot);
+            let status = self.manager.finish_distributed_settle(&self.model);
+            self.settled = true;
+            return Ok(status);
+        }
         let status = if self.tracked {
             self.manager.settle_model_reservation(
                 &self.model,
@@ -519,6 +686,26 @@ impl ModelBudgetReservation {
     }
 
     pub fn cancel(mut self) {
+        if let Some(lease_id) = self.lease_id.clone() {
+            match self.manager.backend.cancel(
+                BudgetLeaseScope::Model,
+                &self.model,
+                &lease_id,
+                self.reserved,
+                self.period_epoch,
+            ) {
+                Ok(snapshot) => self.manager.sync_lease_snapshot(&self.model, snapshot),
+                Err(_) => self.manager.backend.spawn_cancel(
+                    BudgetLeaseScope::Model,
+                    &self.model,
+                    lease_id,
+                    self.reserved,
+                    self.period_epoch,
+                ),
+            }
+            self.settled = true;
+            return;
+        }
         if self.tracked {
             self.manager.release_model_reservation(
                 &self.model,
@@ -533,11 +720,21 @@ impl ModelBudgetReservation {
 impl Drop for ModelBudgetReservation {
     fn drop(&mut self) {
         if self.tracked && !self.settled {
-            self.manager.release_model_reservation(
-                &self.model,
-                self.reserved,
-                self.reservation_reset_at,
-            );
+            if let Some(lease_id) = self.lease_id.clone() {
+                self.manager.backend.spawn_cancel(
+                    BudgetLeaseScope::Model,
+                    &self.model,
+                    lease_id,
+                    self.reserved,
+                    self.period_epoch,
+                );
+            } else {
+                self.manager.release_model_reservation(
+                    &self.model,
+                    self.reserved,
+                    self.reservation_reset_at,
+                );
+            }
         }
     }
 }

--- a/src/core/budget/tracker.rs
+++ b/src/core/budget/tracker.rs
@@ -475,6 +475,8 @@ pub enum BudgetReservationError {
     ProviderBudgetExceeded,
     ModelBudgetExceeded,
     ActualExceedsReservation,
+    /// Shared Redis/backend was unreachable. Fail closed rather than overspend.
+    BackendUnavailable,
 }
 
 impl From<BudgetAmountError> for BudgetReservationError {

--- a/src/core/budget/unified_limits.rs
+++ b/src/core/budget/unified_limits.rs
@@ -41,6 +41,33 @@ impl UnifiedBudgetLimits {
         }
         limits
     }
+    #[cfg(feature = "gateway")]
+    pub fn with_redis(self, redis: std::sync::Arc<crate::storage::redis::RedisPool>) -> Self {
+        Self {
+            providers: self.providers.with_redis(std::sync::Arc::clone(&redis)),
+            models: self.models.with_redis(redis),
+        }
+    }
+    #[cfg(all(test, feature = "gateway"))]
+    pub fn with_redis_lease_ttl(
+        self,
+        redis: std::sync::Arc<crate::storage::redis::RedisPool>,
+        lease_ttl_ms: i64,
+    ) -> Self {
+        Self {
+            providers: self
+                .providers
+                .with_redis_lease_ttl(std::sync::Arc::clone(&redis), lease_ttl_ms),
+            models: self.models.with_redis_lease_ttl(redis, lease_ttl_ms),
+        }
+    }
+    #[cfg(test)]
+    pub(crate) fn with_unavailable_backend() -> Self {
+        let mut limits = Self::new();
+        limits.providers.backend = super::distributed::BudgetLeaseBackend::Unavailable;
+        limits.models.backend = super::distributed::BudgetLeaseBackend::Unavailable;
+        limits
+    }
     pub fn can_spend(&self, provider: &str, model: &str, amount: f64) -> bool {
         self.providers.can_provider_spend(provider, amount)
             && self.models.can_model_spend(model, amount)

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -69,10 +69,10 @@ impl HttpServer {
                     Arc::clone(&storage.database).start_budget_limit_persistence_task();
                 budget_persistence_task = Some(persistence_task);
                 info!("Loaded {} persisted budget limit snapshots", count);
-                Arc::new(UnifiedBudgetLimits::from_snapshots_with_persistence(
-                    snapshots,
-                    persistence_tx,
-                ))
+                Arc::new(
+                    UnifiedBudgetLimits::from_snapshots_with_persistence(snapshots, persistence_tx)
+                        .with_redis(storage.redis.clone()),
+                )
             }
             Err(e) => {
                 if config.gateway.storage.database.allow_degraded
@@ -85,7 +85,7 @@ impl HttpServer {
                         config.gateway.storage.database.enabled,
                         e
                     );
-                    Arc::new(UnifiedBudgetLimits::new())
+                    Arc::new(UnifiedBudgetLimits::new().with_redis(storage.redis.clone()))
                 } else {
                     error!(
                         "Budget limit persistence load failed and \

--- a/src/server/routes/ai/gemini/spend.rs
+++ b/src/server/routes/ai/gemini/spend.rs
@@ -325,6 +325,7 @@ fn reservation_error_to_gateway_error(
             "actual spend exceeded reserved budget for '{}/{}'",
             provider.provider_name, provider.model
         ),
+        BudgetReservationError::BackendUnavailable => "budget backend unavailable".to_string(),
     };
     match error {
         BudgetReservationError::BudgetExceeded
@@ -335,6 +336,9 @@ fn reservation_error_to_gateway_error(
         BudgetReservationError::InvalidAmount(_)
         | BudgetReservationError::ActualExceedsReservation => {
             GatewayError::from(ProviderError::invalid_request("budget", message))
+        }
+        BudgetReservationError::BackendUnavailable => {
+            GatewayError::from(ProviderError::provider_unavailable("budget", message))
         }
     }
 }

--- a/src/server/routes/ai/spend.rs
+++ b/src/server/routes/ai/spend.rs
@@ -120,6 +120,10 @@ pub(in crate::server::routes::ai) fn reservation_error_to_provider_error(
             "budget",
             format!("actual spend exceeded reserved budget for '{provider}'/'{model}'"),
         ),
+        BudgetReservationError::BackendUnavailable => ProviderError::provider_unavailable(
+            "budget",
+            format!("budget backend unavailable for '{provider}'/'{model}'"),
+        ),
     }
 }
 

--- a/src/server/routes/ai/spend/key_budget.rs
+++ b/src/server/routes/ai/spend/key_budget.rs
@@ -97,6 +97,10 @@ fn key_reservation_error_to_provider_error(
             "budget",
             format!("API key budget '{budget_id}' exceeded"),
         ),
+        BudgetReservationError::BackendUnavailable => ProviderError::provider_unavailable(
+            "budget",
+            format!("budget backend unavailable for API key budget '{budget_id}'"),
+        ),
     }
 }
 

--- a/src/storage/redis/budget.rs
+++ b/src/storage/redis/budget.rs
@@ -1,0 +1,372 @@
+//! Single-key Lua budget lease operations (cluster-safe: `KEYS[1]` only).
+
+use super::pool::RedisPool;
+use crate::utils::error::gateway_error::{GatewayError, Result};
+
+const BUDGET_LEASE_SCRIPT: &str = r#"
+local op = ARGV[1]
+local now = tonumber(ARGV[2]) or 0
+local period_epoch = tonumber(ARGV[3]) or -1
+
+local function delete_leases()
+  local fields = redis.call('HGETALL', KEYS[1])
+  for i = 1, #fields, 2 do
+    if string.sub(fields[i], 1, 2) == 'l:' then
+      redis.call('HDEL', KEYS[1], fields[i])
+    end
+  end
+end
+
+local function seed(seed_committed)
+  local epoch = period_epoch
+  if epoch < 0 then epoch = 0 end
+  redis.call('HSETNX', KEYS[1], 'c', seed_committed)
+  redis.call('HSETNX', KEYS[1], 'o', 0)
+  redis.call('HSETNX', KEYS[1], 'e', epoch)
+end
+
+local function read_state()
+  local committed = tonumber(redis.call('HGET', KEYS[1], 'c') or '0') or 0
+  local outstanding = tonumber(redis.call('HGET', KEYS[1], 'o') or '0') or 0
+  local epoch = tonumber(redis.call('HGET', KEYS[1], 'e') or '0') or 0
+  return committed, outstanding, epoch
+end
+
+local function write_state(committed, outstanding, epoch)
+  redis.call('HSET', KEYS[1], 'c', committed, 'o', outstanding, 'e', epoch)
+end
+
+local function maybe_period_reset()
+  if period_epoch < 0 then
+    return
+  end
+  local _, _, epoch = read_state()
+  if epoch ~= period_epoch then
+    delete_leases()
+    write_state(0, 0, period_epoch)
+  end
+end
+
+local function reclaim()
+  local committed, outstanding, epoch = read_state()
+  local fields = redis.call('HGETALL', KEYS[1])
+  for i = 1, #fields, 2 do
+    local field = fields[i]
+    if string.sub(field, 1, 2) == 'l:' then
+      local amount, expiry, lease_epoch = string.match(fields[i + 1], '^(%d+):(%d+):(%-?%d+)$')
+      amount = tonumber(amount)
+      expiry = tonumber(expiry)
+      lease_epoch = tonumber(lease_epoch)
+      if amount ~= nil and expiry ~= nil and expiry <= now then
+        if lease_epoch == epoch then
+          outstanding = outstanding - amount
+          if outstanding < 0 then outstanding = 0 end
+        end
+        redis.call('HDEL', KEYS[1], field)
+      end
+    end
+  end
+  redis.call('HSET', KEYS[1], 'o', outstanding)
+  return committed, outstanding, epoch
+end
+
+seed(tonumber(ARGV[6]) or 0)
+maybe_period_reset()
+local committed, outstanding, epoch = reclaim()
+
+if op == 'reset' then
+  local force = tonumber(ARGV[5]) or 0
+  if force == 1 then
+    delete_leases()
+    local new_epoch = epoch
+    if period_epoch >= 0 then new_epoch = period_epoch end
+    write_state(0, 0, new_epoch)
+    return {1, 0, 0}
+  end
+  return {1, committed, outstanding}
+end
+
+if op == 'reserve' then
+  local amount = tonumber(ARGV[4]) or 0
+  local max = tonumber(ARGV[5]) or 0
+  if committed + outstanding + amount > max then
+    return {0, committed, outstanding}
+  end
+  outstanding = outstanding + amount
+  local lease_id = ARGV[7]
+  local ttl = tonumber(ARGV[8]) or 0
+  if ttl < 1 then ttl = 1 end
+  write_state(committed, outstanding, epoch)
+  redis.call(
+    'HSET',
+    KEYS[1],
+    'l:' .. lease_id,
+    tostring(amount) .. ':' .. tostring(now + ttl) .. ':' .. tostring(epoch)
+  )
+  return {1, committed, outstanding}
+end
+
+if op == 'settle' then
+  local reserved = tonumber(ARGV[4]) or 0
+  local actual = tonumber(ARGV[5]) or 0
+  local field = 'l:' .. ARGV[7]
+  local lease = redis.call('HGET', KEYS[1], field)
+  if lease then
+    local amount, _, lease_epoch = string.match(lease, '^(%d+):(%d+):(%-?%d+)$')
+    amount = tonumber(amount) or reserved
+    lease_epoch = tonumber(lease_epoch)
+    if lease_epoch == epoch then
+      outstanding = outstanding - amount
+      if outstanding < 0 then outstanding = 0 end
+    end
+    redis.call('HDEL', KEYS[1], field)
+  end
+  committed = committed + actual
+  write_state(committed, outstanding, epoch)
+  return {1, committed, outstanding}
+end
+
+if op == 'cancel' then
+  local reserved = tonumber(ARGV[4]) or 0
+  local field = 'l:' .. ARGV[7]
+  local lease = redis.call('HGET', KEYS[1], field)
+  if lease then
+    local amount, _, lease_epoch = string.match(lease, '^(%d+):(%d+):(%-?%d+)$')
+    amount = tonumber(amount) or reserved
+    lease_epoch = tonumber(lease_epoch)
+    if lease_epoch == epoch then
+      outstanding = outstanding - amount
+      if outstanding < 0 then outstanding = 0 end
+    end
+    redis.call('HDEL', KEYS[1], field)
+  end
+  write_state(committed, outstanding, epoch)
+  return {1, committed, outstanding}
+end
+
+return {-1, committed, outstanding}
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BudgetLeaseState {
+    pub allowed: bool,
+    pub committed: i64,
+    pub outstanding: i64,
+}
+
+struct BudgetLeaseArgs<'a> {
+    op: &'a str,
+    now_ms: i64,
+    period_epoch: i64,
+    amount: i64,
+    max_or_actual_or_force: i64,
+    seed_committed: i64,
+    lease_id: &'a str,
+    ttl_ms: i64,
+}
+
+pub(crate) struct BudgetReserveArgs<'a> {
+    pub key: &'a str,
+    pub amount: i64,
+    pub max: i64,
+    pub seed_committed: i64,
+    pub period_epoch: i64,
+    pub lease_id: &'a str,
+    pub now_ms: i64,
+    pub ttl_ms: i64,
+}
+
+fn parse_budget_lease_state(values: Vec<i64>) -> Result<BudgetLeaseState> {
+    if values.len() != 3 {
+        return Err(GatewayError::Storage(format!(
+            "Unexpected Redis budget-lease result length: {}",
+            values.len()
+        )));
+    }
+    if values[0] < 0 {
+        return Err(GatewayError::Storage(
+            "Redis budget-lease script returned an error status".to_string(),
+        ));
+    }
+    Ok(BudgetLeaseState {
+        allowed: values[0] == 1,
+        committed: values[1].max(0),
+        outstanding: values[2].max(0),
+    })
+}
+
+impl RedisPool {
+    pub(crate) fn budget_lease_key(scope: &str, name: &str) -> String {
+        format!("litellm-rs:budget:v1:{scope}:{name}")
+    }
+
+    async fn invoke_budget_lease(
+        &self,
+        key: &str,
+        args: BudgetLeaseArgs<'_>,
+    ) -> Result<BudgetLeaseState> {
+        if self.noop_mode {
+            return Err(GatewayError::Storage(
+                "budget redis backend is unavailable".to_string(),
+            ));
+        }
+
+        let mut conn = self.get_connection().await?;
+        let Some(ref mut c) = conn.conn else {
+            return Err(GatewayError::Storage(
+                "budget redis backend is unavailable".to_string(),
+            ));
+        };
+
+        let values: Vec<i64> = redis::Script::new(BUDGET_LEASE_SCRIPT)
+            .key(key)
+            .arg(args.op)
+            .arg(args.now_ms)
+            .arg(args.period_epoch)
+            .arg(args.amount)
+            .arg(args.max_or_actual_or_force)
+            .arg(args.seed_committed)
+            .arg(args.lease_id)
+            .arg(args.ttl_ms)
+            .invoke_async(c)
+            .await
+            .map_err(GatewayError::from)?;
+        parse_budget_lease_state(values)
+    }
+
+    pub(crate) async fn budget_reserve(
+        &self,
+        args: BudgetReserveArgs<'_>,
+    ) -> Result<BudgetLeaseState> {
+        self.invoke_budget_lease(
+            args.key,
+            BudgetLeaseArgs {
+                op: "reserve",
+                now_ms: args.now_ms,
+                period_epoch: args.period_epoch,
+                amount: args.amount,
+                max_or_actual_or_force: args.max,
+                seed_committed: args.seed_committed,
+                lease_id: args.lease_id,
+                ttl_ms: args.ttl_ms,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn budget_settle(
+        &self,
+        key: &str,
+        reserved: i64,
+        actual: i64,
+        period_epoch: i64,
+        lease_id: &str,
+        now_ms: i64,
+    ) -> Result<BudgetLeaseState> {
+        self.invoke_budget_lease(
+            key,
+            BudgetLeaseArgs {
+                op: "settle",
+                now_ms,
+                period_epoch,
+                amount: reserved,
+                max_or_actual_or_force: actual,
+                seed_committed: 0,
+                lease_id,
+                ttl_ms: 0,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn budget_cancel(
+        &self,
+        key: &str,
+        reserved: i64,
+        period_epoch: i64,
+        lease_id: &str,
+        now_ms: i64,
+    ) -> Result<BudgetLeaseState> {
+        self.invoke_budget_lease(
+            key,
+            BudgetLeaseArgs {
+                op: "cancel",
+                now_ms,
+                period_epoch,
+                amount: reserved,
+                max_or_actual_or_force: 0,
+                seed_committed: 0,
+                lease_id,
+                ttl_ms: 0,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn budget_reset(
+        &self,
+        key: &str,
+        period_epoch: i64,
+        now_ms: i64,
+        force: bool,
+    ) -> Result<BudgetLeaseState> {
+        self.invoke_budget_lease(
+            key,
+            BudgetLeaseArgs {
+                op: "reset",
+                now_ms,
+                period_epoch,
+                amount: 0,
+                max_or_actual_or_force: if force { 1 } else { 0 },
+                seed_committed: 0,
+                lease_id: "",
+                ttl_ms: 0,
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::models::storage::RedisConfig;
+
+    #[test]
+    fn parses_budget_lease_state() {
+        let allowed = parse_budget_lease_state(vec![1, 3, 4]).unwrap();
+        assert!(allowed.allowed);
+        assert_eq!(allowed.committed, 3);
+        assert_eq!(allowed.outstanding, 4);
+
+        let denied = parse_budget_lease_state(vec![0, 10, 0]).unwrap();
+        assert!(!denied.allowed);
+        assert!(parse_budget_lease_state(vec![-1, 0, 0]).is_err());
+        assert!(parse_budget_lease_state(vec![1, 0]).is_err());
+    }
+
+    #[tokio::test]
+    async fn noop_redis_pool_fails_closed_on_budget_reserve() {
+        let pool = RedisPool::new(&RedisConfig {
+            enabled: false,
+            ..RedisConfig::default()
+        })
+        .await
+        .expect("disabled Redis should create a no-op pool");
+
+        let err = pool
+            .budget_reserve(BudgetReserveArgs {
+                key: "litellm-rs:budget:v1:provider:noop-test",
+                amount: 1,
+                max: 10,
+                seed_committed: 0,
+                period_epoch: 0,
+                lease_id: "lease",
+                now_ms: 1,
+                ttl_ms: 1_000,
+            })
+            .await
+            .expect_err("no-op Redis must not fail-open budget reservations");
+        assert!(err.to_string().contains("unavailable"));
+    }
+}

--- a/src/storage/redis/budget.rs
+++ b/src/storage/redis/budget.rs
@@ -1,7 +1,9 @@
 //! Single-key Lua budget lease operations (cluster-safe: `KEYS[1]` only).
 
-use super::pool::RedisPool;
+use super::pool::{RedisLiveConnection, RedisPool};
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
 const BUDGET_LEASE_SCRIPT: &str = r#"
 local op = ARGV[1]
@@ -62,6 +64,8 @@ local function reclaim()
           outstanding = outstanding - amount
           if outstanding < 0 then outstanding = 0 end
         end
+        redis.call('HDEL', KEYS[1], field)
+      elseif amount == nil or expiry == nil or lease_epoch == nil then
         redis.call('HDEL', KEYS[1], field)
       end
     end
@@ -176,6 +180,26 @@ pub(crate) struct BudgetReserveArgs<'a> {
     pub ttl_ms: i64,
 }
 
+fn budget_runtime_connections() -> &'static tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>
+{
+    static CACHE: OnceLock<tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+async fn connection_on_current_runtime(pool: &RedisPool) -> Result<RedisLiveConnection> {
+    let cache_key = format!("{}|{}", pool.config.url, pool.config.cluster);
+    {
+        let cache = budget_runtime_connections().lock().await;
+        if let Some(conn) = cache.get(&cache_key) {
+            return Ok(conn.clone());
+        }
+    }
+    let conn = pool.open_live_connection().await?;
+    let mut cache = budget_runtime_connections().lock().await;
+    Ok(cache.entry(cache_key).or_insert(conn).clone())
+}
+
 fn parse_budget_lease_state(values: Vec<i64>) -> Result<BudgetLeaseState> {
     if values.len() != 3 {
         return Err(GatewayError::Storage(format!(
@@ -211,12 +235,13 @@ impl RedisPool {
             ));
         }
 
-        let mut conn = self.get_connection().await?;
-        let Some(ref mut c) = conn.conn else {
-            return Err(GatewayError::Storage(
-                "budget redis backend is unavailable".to_string(),
-            ));
-        };
+        let _permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| GatewayError::Internal("Redis semaphore closed".to_string()))?;
+        let mut conn = connection_on_current_runtime(self).await?;
 
         let values: Vec<i64> = redis::Script::new(BUDGET_LEASE_SCRIPT)
             .key(key)
@@ -228,7 +253,7 @@ impl RedisPool {
             .arg(args.seed_committed)
             .arg(args.lease_id)
             .arg(args.ttl_ms)
-            .invoke_async(c)
+            .invoke_async(&mut conn)
             .await
             .map_err(GatewayError::from)?;
         parse_budget_lease_state(values)

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -11,6 +11,7 @@
 //! - `hash` - Hash and Sorted Set operations
 //! - `pubsub` - Pub/Sub operations (temporarily disabled)
 //! - `atomic` - Atomic operations and utilities
+//! - `budget` - Cluster-safe single-key Lua budget leases
 //! - `tests` - Module tests
 
 #![allow(dead_code)]
@@ -18,6 +19,7 @@
 // Module declarations
 mod atomic;
 mod batch;
+pub(crate) mod budget;
 mod cache;
 mod collections;
 mod hash;

--- a/src/storage/redis/pool.rs
+++ b/src/storage/redis/pool.rs
@@ -194,6 +194,23 @@ impl RedisPool {
         self.config.cluster && !self.noop_mode
     }
 
+    /// Open a live connection on the current Tokio runtime.
+    ///
+    /// Budget Lua runs on a dedicated runtime so Actix `current_thread` workers
+    /// can block without parking the multiplexed-connection driver.
+    pub(crate) async fn open_live_connection(&self) -> Result<RedisLiveConnection> {
+        if self.noop_mode {
+            return Err(GatewayError::Storage(
+                "budget redis backend is unavailable".to_string(),
+            ));
+        }
+        if self.config.cluster {
+            Self::connect_cluster(&self.config).await
+        } else {
+            Self::connect_standalone(&self.config).await
+        }
+    }
+
     /// Get a connection from the pool.
     ///
     /// The returned [`RedisConnection`] holds a semaphore permit that limits


### PR DESCRIPTION
## What

Move provider and model budget reserve/settle/cancel onto a shared Redis backend so multiple gateways cannot overspend the same remaining budget.

When a live `RedisPool` is configured, each provider or model scope uses a **single-key** Lua script (`KEYS[1]` only, cluster-safe like rate limiting). The hash stores committed spend, outstanding holds, period epoch, and per-lease expiry. Reserve increments outstanding only; settle moves reserved → committed; cancel/expiry decrement outstanding only. Crashed-process holds are reclaimed on the next op against the same key.

Without Redis (or a no-op pool), the existing in-process DashMap path is unchanged. Postgres snapshots remain committed config/spend persistence, not the atomic lease backend.

Redis errors **fail closed** via `BudgetReservationError::BackendUnavailable` (no fail-open overspend). Provider then model still roll back on half-success.

## Why

Provider/model reservations were atomic only inside one process. Two gateways racing the last remaining budget could both pass `budget_can_spend`.

Fixes #1279

## Scope note

13 files / ~1340 lines (over the 800-line preference): Lua lease script, sync Redis bridge, dual provider/model wiring, error mapping, and two-manager Redis tests. Kept as one issue / one PR.

Out of scope: #1280 admission limits, #1281 circuit-breaker gossip, event bus, multi-key Redis transactions.

## Test Plan

- [x] Existing in-process provider/model reservation tests still pass without Redis
- [x] Unavailable backend returns `BackendUnavailable` and does not mutate spend
- [x] No-op Redis pool fails closed (does not admit spend)
- [x] Two `UnifiedBudgetLimits` sharing Redis: last-token race → exactly one success
- [x] Model deny rolls back provider outstanding
- [x] Settle vs cancel keep committed vs outstanding distinct
- [x] Abandoned lease recovered after TTL so a later reserve can use the funds
- [x] `cargo fmt --all`
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`

Distributed Redis cases skip locally without `REDIS_URL` and run against CI `redis:7`.

## AI disclosure

Implemented with **Cursor Grok 4.6**.

Made with [Cursor](https://cursor.com)