### PR TITLE
feat(router): distribute deployment admission limits

### DIFF
--- a/src/core/router/admission.rs
+++ b/src/core/router/admission.rs
@@ -1,0 +1,250 @@
+//! Shared atomic backend for deployment admission (parallel / RPM / TPM).
+//!
+//! Local CAS remains the default. When a live Redis pool is attached,
+//! reserve/settle/cancel run as single-key Lua so replica counts cannot
+//! multiply limits. Redis errors fail closed.
+
+use super::deployment::Deployment;
+use tracing::warn;
+
+pub(crate) const DEFAULT_LEASE_TTL_MS: i64 = 600_000;
+
+#[derive(Clone, Debug)]
+pub(crate) struct AdmissionHold {
+    pub lease_id: String,
+    pub deployment_id: String,
+    pub period_epoch: i64,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) enum AdmissionBackend {
+    #[default]
+    InProcess,
+    #[cfg(feature = "gateway")]
+    Redis {
+        pool: std::sync::Arc<crate::storage::redis::RedisPool>,
+        lease_ttl_ms: i64,
+    },
+    #[cfg(test)]
+    Unavailable,
+}
+
+pub(crate) enum AdmissionReserve {
+    Skipped,
+    Denied,
+    Granted(AdmissionHold),
+}
+
+impl AdmissionBackend {
+    #[cfg(feature = "gateway")]
+    pub(crate) fn redis(pool: std::sync::Arc<crate::storage::redis::RedisPool>) -> Self {
+        if pool.is_noop() {
+            Self::InProcess
+        } else {
+            Self::Redis {
+                pool,
+                lease_ttl_ms: DEFAULT_LEASE_TTL_MS,
+            }
+        }
+    }
+
+    pub(crate) fn reserve(
+        &self,
+        deployment: &Deployment,
+        estimated_tokens: u64,
+    ) -> AdmissionReserve {
+        let max_parallel = option_limit(deployment.config.max_parallel_requests.map(i64::from));
+        let max_rpm = option_limit(deployment.config.rpm_limit.map(to_i64));
+        let max_tpm = option_limit(deployment.config.tpm_limit.map(to_i64));
+        if max_parallel < 0 && max_rpm < 0 && max_tpm < 0 {
+            return AdmissionReserve::Skipped;
+        }
+
+        match self {
+            Self::InProcess => AdmissionReserve::Skipped,
+            #[cfg(test)]
+            Self::Unavailable => {
+                warn!(
+                    deployment_id = %deployment.id,
+                    "deployment admission backend unavailable; failing closed"
+                );
+                AdmissionReserve::Denied
+            }
+            #[cfg(feature = "gateway")]
+            Self::Redis { pool, lease_ttl_ms } => {
+                let rpm_inc = i64::from(max_rpm >= 0);
+                let tpm_inc = if max_tpm >= 0 {
+                    to_i64(estimated_tokens.max(1))
+                } else {
+                    0
+                };
+                let lease_id = uuid::Uuid::new_v4().to_string();
+                let pool = std::sync::Arc::clone(pool);
+                let key = crate::storage::redis::RedisPool::admission_key(&deployment.id);
+                let ttl_ms = *lease_ttl_ms;
+                let now_ms = now_ms();
+                let window_epoch = window_epoch_secs();
+                let lease_id_for_fut = lease_id.clone();
+                let deployment_id = deployment.id.clone();
+                let state = match run_redis(&deployment_id, "reserve", async move {
+                    pool.admission_reserve(crate::storage::redis::admission::AdmissionReserveArgs {
+                        key: &key,
+                        max_parallel,
+                        max_rpm,
+                        max_tpm,
+                        rpm_inc,
+                        tpm_inc,
+                        lease_id: &lease_id_for_fut,
+                        now_ms,
+                        window_epoch,
+                        ttl_ms,
+                    })
+                    .await
+                }) {
+                    Ok(state) => state,
+                    Err(_) => return AdmissionReserve::Denied,
+                };
+                if !state.allowed {
+                    return AdmissionReserve::Denied;
+                }
+                AdmissionReserve::Granted(AdmissionHold {
+                    lease_id,
+                    deployment_id,
+                    period_epoch: window_epoch,
+                })
+            }
+        }
+    }
+
+    pub(crate) fn settle(&self, hold: &AdmissionHold, actual_tokens: u64) {
+        self.finish(hold, "settle", to_i64(actual_tokens));
+    }
+
+    pub(crate) fn cancel(&self, hold: &AdmissionHold) {
+        self.finish(hold, "cancel", 0);
+    }
+
+    fn finish(&self, hold: &AdmissionHold, op: &'static str, actual_tpm: i64) {
+        match self {
+            Self::InProcess => {}
+            #[cfg(test)]
+            Self::Unavailable => {}
+            #[cfg(feature = "gateway")]
+            Self::Redis { pool, .. } => {
+                let pool = std::sync::Arc::clone(pool);
+                let key = crate::storage::redis::RedisPool::admission_key(&hold.deployment_id);
+                let lease_id = hold.lease_id.clone();
+                let window_epoch = hold.period_epoch;
+                let now_ms = now_ms();
+                let deployment_id = hold.deployment_id.clone();
+                let _ = run_redis(&deployment_id, op, async move {
+                    if op == "settle" {
+                        pool.admission_settle(&key, &lease_id, actual_tpm, window_epoch, now_ms)
+                            .await
+                    } else {
+                        pool.admission_cancel(&key, &lease_id, window_epoch, now_ms)
+                            .await
+                    }
+                });
+            }
+        }
+    }
+}
+
+fn option_limit(limit: Option<i64>) -> i64 {
+    limit.filter(|value| *value >= 0).unwrap_or(-1)
+}
+
+fn to_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+#[cfg(feature = "gateway")]
+fn window_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| (duration.as_secs() / 60) as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(feature = "gateway")]
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(feature = "gateway")]
+fn admission_io_handle() -> tokio::runtime::Handle {
+    static HANDLE: std::sync::OnceLock<tokio::runtime::Handle> = std::sync::OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            std::thread::Builder::new()
+                .name("admission-redis-rt".into())
+                .spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(1)
+                        .enable_all()
+                        .thread_name("admission-redis")
+                        .build()
+                        .expect("admission redis runtime");
+                    let handle = runtime.handle().clone();
+                    tx.send(handle).expect("send admission redis handle");
+                    runtime.block_on(std::future::pending::<()>());
+                })
+                .expect("spawn admission redis runtime thread");
+            rx.recv().expect("admission redis runtime handle")
+        })
+        .clone()
+}
+
+#[cfg(feature = "gateway")]
+fn run_redis<T>(
+    deployment_id: &str,
+    operation: &'static str,
+    fut: impl std::future::Future<Output = crate::utils::error::gateway_error::Result<T>>
+    + Send
+    + 'static,
+) -> Result<T, ()>
+where
+    T: Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    admission_io_handle().spawn(async move {
+        let _ = tx.send(fut.await);
+    });
+    match rx.recv() {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => {
+            warn!(
+                deployment_id,
+                operation,
+                error = %err,
+                "admission redis operation failed; failing closed"
+            );
+            Err(())
+        }
+        Err(_) => {
+            warn!(
+                deployment_id,
+                operation, "admission redis worker dropped; failing closed"
+            );
+            Err(())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "gateway"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_redis_does_not_panic_on_current_thread_runtime() {
+        let result = run_redis("probe", "probe", async {
+            Ok::<i64, crate::utils::error::gateway_error::GatewayError>(7)
+        });
+        assert_eq!(result.expect("current_thread redis bridge"), 7);
+    }
+}

--- a/src/core/router/execute_impl.rs
+++ b/src/core/router/execute_impl.rs
@@ -84,7 +84,7 @@ impl Router {
         while attempt <= max_attempts {
             let start = std::time::Instant::now();
 
-            let deployment_lease = match self.select_retry_candidate(
+            let mut deployment_lease = match self.select_retry_candidate(
                 snapshot,
                 model_name,
                 capability,
@@ -142,6 +142,7 @@ impl Router {
                         tokens_used,
                         latency_us,
                     );
+                    deployment_lease.commit_admission(tokens_used);
                     drop(deployment_lease);
                     return Ok((value, deployment_id, model_used, attempt, latency_us));
                 }
@@ -544,7 +545,7 @@ impl Router {
     {
         let start = std::time::Instant::now();
 
-        let deployment_lease = self.select_deployment_lease(model_name)?;
+        let mut deployment_lease = self.select_deployment_lease(model_name)?;
         let selected_deployment = deployment_lease.clone_deployment();
         let deployment_id = selected_deployment.id.clone();
 
@@ -560,6 +561,7 @@ impl Router {
                     tokens_used,
                     latency_us,
                 );
+                deployment_lease.commit_admission(tokens_used);
                 drop(deployment_lease);
 
                 Ok(build_execution_result(

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 use url::Url;
 
 // New modular router components
+pub(crate) mod admission;
 pub mod budget_routing;
 pub mod config;
 pub mod deployment;

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -3,6 +3,7 @@
 //! This module contains the core routing logic for selecting
 //! the best deployment for a given model.
 
+use super::admission::{AdmissionBackend, AdmissionHold, AdmissionReserve};
 use super::config::RoutingStrategy;
 use super::deployment::{Deployment, DeploymentId, current_timestamp};
 use super::error::RouterError;
@@ -22,17 +23,36 @@ use std::sync::atomic::{
 ///
 /// Dropping the lease releases the selected deployment unless ownership was
 /// explicitly converted back into the legacy deployment-id API.
+#[derive(Debug)]
 pub struct DeploymentLease {
     deployment: Arc<Deployment>,
     release_on_drop: bool,
+    admission: AdmissionBackend,
+    hold: Option<AdmissionHold>,
 }
 
 impl DeploymentLease {
-    fn new(deployment: Arc<Deployment>) -> Self {
+    fn new(
+        deployment: Arc<Deployment>,
+        admission: AdmissionBackend,
+        hold: Option<AdmissionHold>,
+    ) -> Self {
         Self {
             deployment,
             release_on_drop: true,
+            admission,
+            hold,
         }
+    }
+
+    pub(crate) fn commit_admission(&mut self, actual_tokens: u64) {
+        if let Some(hold) = self.hold.take() {
+            self.admission.settle(&hold, actual_tokens);
+        }
+    }
+
+    pub(crate) fn take_admission(&mut self) -> (AdmissionBackend, Option<AdmissionHold>) {
+        (self.admission.clone(), self.hold.take())
     }
 
     pub fn deployment_id(&self) -> &str {
@@ -65,6 +85,9 @@ impl Drop for DeploymentLease {
     fn drop(&mut self) {
         if self.release_on_drop {
             Router::release_selected_deployment(self.deployment());
+            if let Some(hold) = self.hold.take() {
+                self.admission.cancel(&hold);
+            }
         }
     }
 }
@@ -97,7 +120,7 @@ impl Router {
         model_name: &str,
     ) -> Result<DeploymentLease, RouterError> {
         let snapshot = self.load_routing_snapshot();
-        self.select_deployment_matching(snapshot.as_ref(), model_name, |_| true, None)
+        self.select_deployment_matching(snapshot.as_ref(), model_name, |_| true, None, 0)
     }
 
     pub(crate) fn select_deployment_lease_matching_in_snapshot<F>(
@@ -109,7 +132,7 @@ impl Router {
     where
         F: Fn(&Deployment) -> bool,
     {
-        self.select_deployment_matching(snapshot, model_name, is_candidate, None)
+        self.select_deployment_matching(snapshot, model_name, is_candidate, None, 0)
     }
 
     /// Select the best deployment for a model that supports `capability`.
@@ -208,6 +231,7 @@ impl Router {
                     && is_candidate(deployment)
             },
             Some(no_matching_candidate_error),
+            0,
         )
     }
 
@@ -252,6 +276,7 @@ impl Router {
         model_name: &str,
         is_candidate: F,
         no_matching_candidate_error: Option<RouterError>,
+        estimated_tokens: u64,
     ) -> Result<DeploymentLease, RouterError>
     where
         F: Fn(&Deployment) -> bool,
@@ -414,7 +439,9 @@ impl Router {
                 continue;
             };
 
-            if self.try_reserve_deployment(&deployment, &resolved_name) {
+            if let Some(hold) =
+                self.try_reserve_deployment(&deployment, &resolved_name, estimated_tokens)
+            {
                 self.provider_selected_count.fetch_add(1, Relaxed);
                 self.strategy_used_count.fetch_add(1, Relaxed);
 
@@ -426,7 +453,11 @@ impl Router {
                     "deployment selected for routing"
                 );
 
-                return Ok(DeploymentLease::new(deployment));
+                return Ok(DeploymentLease::new(
+                    deployment,
+                    self.admission.clone(),
+                    hold,
+                ));
             }
 
             if let Some(pos) = routing_contexts
@@ -446,17 +477,28 @@ impl Router {
         Err(RouterError::NoAvailableDeployment(model_name.to_string()))
     }
 
-    fn try_reserve_deployment(&self, deployment: &Deployment, expected_model: &str) -> bool {
+    fn try_reserve_deployment(
+        &self,
+        deployment: &Deployment,
+        expected_model: &str,
+        estimated_tokens: u64,
+    ) -> Option<Option<AdmissionHold>> {
         if deployment.model_name != expected_model {
-            return false;
+            return None;
         }
 
-        match deployment.config.max_parallel_requests {
+        let hold = match self.admission.reserve(deployment, estimated_tokens) {
+            AdmissionReserve::Skipped => None,
+            AdmissionReserve::Denied => return None,
+            AdmissionReserve::Granted(hold) => Some(hold),
+        };
+
+        let local_ok = match deployment.config.max_parallel_requests {
             Some(limit) => {
                 let mut current = deployment.state.active_requests.load(Acquire);
                 loop {
                     if current >= limit {
-                        return false;
+                        break false;
                     }
 
                     match deployment.state.active_requests.compare_exchange_weak(
@@ -465,7 +507,7 @@ impl Router {
                         AcqRel,
                         Acquire,
                     ) {
-                        Ok(_) => return true,
+                        Ok(_) => break true,
                         Err(next) => current = next,
                     }
                 }
@@ -474,7 +516,32 @@ impl Router {
                 deployment.state.active_requests.fetch_add(1, Relaxed);
                 true
             }
+        };
+
+        if local_ok {
+            Some(hold)
+        } else {
+            if let Some(hold) = hold {
+                self.admission.cancel(&hold);
+            }
+            None
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn select_deployment_lease_with_tokens(
+        &self,
+        model_name: &str,
+        estimated_tokens: u64,
+    ) -> Result<DeploymentLease, RouterError> {
+        let snapshot = self.load_routing_snapshot();
+        self.select_deployment_matching(
+            snapshot.as_ref(),
+            model_name,
+            |_| true,
+            None,
+            estimated_tokens,
+        )
     }
 
     /// Release a deployment after request completion
@@ -530,6 +597,7 @@ impl RuntimeHandle {
             model_name,
             |_| true,
             None,
+            0,
         )
     }
 }

--- a/src/core/router/tests/admission_tests.rs
+++ b/src/core/router/tests/admission_tests.rs
@@ -1,0 +1,238 @@
+use super::router_tests::create_test_deployment;
+use crate::core::router::config::RouterConfig;
+use crate::core::router::deployment::{Deployment, DeploymentConfig};
+use crate::core::router::error::RouterError;
+use crate::core::router::unified::Router;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+#[tokio::test]
+async fn unavailable_backend_fails_closed_without_reservation() {
+    let router = Router::new(RouterConfig::default()).with_unavailable_admission();
+    let deployment = limited_deployment("closed-1", Some(1), None, None).await;
+    router.add_deployment(deployment);
+    let err = router
+        .select_deployment_lease("gpt-4")
+        .expect_err("unavailable admission must fail closed");
+    assert!(matches!(err, RouterError::NoAvailableDeployment(_)));
+    let deployment = router.get_deployment("closed-1").unwrap();
+    assert_eq!(deployment.state.active_requests.load(Ordering::Relaxed), 0);
+    assert_eq!(deployment.state.fail_requests.load(Ordering::Relaxed), 0);
+    assert!(!deployment.is_in_cooldown());
+}
+
+#[cfg(feature = "gateway")]
+mod redis {
+    use super::*;
+    use crate::config::models::storage::RedisConfig;
+    use crate::storage::redis::RedisPool;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_routers_share_max_parallel_limit() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("parallel");
+        let a = Arc::new(router_with(pool.clone()));
+        let b = Arc::new(router_with(pool.clone()));
+        seed(&a, &id, Some(1), None, None).await;
+        seed(&b, &id, Some(1), None, None).await;
+
+        let a_task = {
+            let a = Arc::clone(&a);
+            tokio::spawn(async move { a.select_deployment_lease("gpt-4") })
+        };
+        let b_task = {
+            let b = Arc::clone(&b);
+            tokio::spawn(async move { b.select_deployment_lease("gpt-4") })
+        };
+        let a_result = a_task.await.expect("join a");
+        let b_result = b_task.await.expect("join b");
+        let successes = [&a_result, &b_result]
+            .iter()
+            .filter(|result| result.is_ok())
+            .count();
+        assert_eq!(successes, 1, "replica count must not multiply max_parallel");
+
+        for result in [&a_result, &b_result] {
+            if let Err(err) = result {
+                assert!(matches!(err, RouterError::NoAvailableDeployment(_)));
+            }
+        }
+        let denied = a.get_deployment(&id).unwrap();
+        assert_eq!(denied.state.fail_requests.load(Ordering::Relaxed), 0);
+        assert!(!denied.is_in_cooldown());
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_routers_share_rpm_limit() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("rpm");
+        let a = router_with(pool.clone());
+        let b = router_with(pool.clone());
+        seed(&a, &id, None, Some(1), None).await;
+        seed(&b, &id, None, Some(1), None).await;
+
+        let mut first = a
+            .select_deployment_lease("gpt-4")
+            .expect("first rpm reserve");
+        assert!(
+            b.select_deployment_lease("gpt-4").is_err(),
+            "outstanding rpm must block the second replica"
+        );
+        first.commit_admission(0);
+        drop(first);
+        assert!(
+            b.select_deployment_lease("gpt-4").is_err(),
+            "settled rpm must still occupy the minute window"
+        );
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancel_refunds_rpm_for_the_other_replica() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("rpm-cancel");
+        let a = router_with(pool.clone());
+        let b = router_with(pool.clone());
+        seed(&a, &id, None, Some(1), None).await;
+        seed(&b, &id, None, Some(1), None).await;
+
+        drop(a.select_deployment_lease("gpt-4").expect("reserve"));
+        b.select_deployment_lease("gpt-4")
+            .expect("cancel must refund rpm so the other replica can admit");
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tpm_estimate_is_shared_and_settled() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("tpm");
+        let a = router_with(pool.clone());
+        let b = router_with(pool.clone());
+        seed(&a, &id, None, None, Some(10)).await;
+        seed(&b, &id, None, None, Some(10)).await;
+
+        let mut hold = a
+            .select_deployment_lease_with_tokens("gpt-4", 10)
+            .expect("first tpm reserve");
+        assert!(b.select_deployment_lease_with_tokens("gpt-4", 1).is_err());
+        hold.commit_admission(4);
+        drop(hold);
+        b.select_deployment_lease_with_tokens("gpt-4", 6)
+            .expect("settled 4 of 10 should leave 6");
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn current_thread_runtime_can_admit_without_panic() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("current-thread");
+        let router = router_with(pool.clone());
+        seed(&router, &id, Some(1), None, None).await;
+        let lease = router
+            .select_deployment_lease("gpt-4")
+            .expect("Actix workers use current_thread; admit must not panic");
+        drop(lease);
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_disconnect_releases_parallel_slot() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("stream-drop");
+        let a = router_with(pool.clone());
+        let b = router_with(pool.clone());
+        seed(&a, &id, Some(1), None, None).await;
+        seed(&b, &id, Some(1), None, None).await;
+
+        let lease = a.select_deployment_lease("gpt-4").expect("reserve");
+        assert!(b.select_deployment_lease("gpt-4").is_err());
+        drop(lease);
+        b.select_deployment_lease("gpt-4")
+            .expect("drop must release the shared parallel slot");
+        cleanup(&pool, &id).await;
+    }
+
+    fn router_with(pool: Arc<RedisPool>) -> Router {
+        Router::new(RouterConfig::default()).with_admission_redis(pool)
+    }
+
+    async fn seed(
+        router: &Router,
+        id: &str,
+        max_parallel: Option<u32>,
+        rpm: Option<u64>,
+        tpm: Option<u64>,
+    ) {
+        router.add_deployment(limited_deployment(id, max_parallel, rpm, tpm).await);
+    }
+
+    fn unique(prefix: &str) -> String {
+        format!("{prefix}-{}", uuid::Uuid::new_v4())
+    }
+
+    async fn cleanup(pool: &RedisPool, deployment_id: &str) {
+        let _ = pool.delete(&RedisPool::admission_key(deployment_id)).await;
+    }
+
+    async fn live_redis_pool() -> Option<Arc<RedisPool>> {
+        let redis_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+        let config = RedisConfig {
+            url: redis_url.clone(),
+            enabled: true,
+            max_connections: 10,
+            connection_timeout: 1,
+            cluster: false,
+            allow_degraded: false,
+        };
+
+        match RedisPool::new(&config).await {
+            Ok(pool) => match pool.health_check().await {
+                Ok(()) => Some(Arc::new(pool)),
+                Err(err) => {
+                    if std::env::var("CI").is_ok() {
+                        panic!("Redis should pass health check in CI at {redis_url}: {err}");
+                    }
+                    eprintln!("Skipping distributed admission Redis integration test: {err}");
+                    None
+                }
+            },
+            Err(err) => {
+                if std::env::var("CI").is_ok() {
+                    panic!("Redis should be reachable in CI at {redis_url}: {err}");
+                }
+                eprintln!("Skipping distributed admission Redis integration test: {err}");
+                None
+            }
+        }
+    }
+}
+
+async fn limited_deployment(
+    id: &str,
+    max_parallel: Option<u32>,
+    rpm: Option<u64>,
+    tpm: Option<u64>,
+) -> Deployment {
+    create_test_deployment(id, "gpt-4")
+        .await
+        .with_config(DeploymentConfig {
+            max_parallel_requests: max_parallel,
+            rpm_limit: rpm,
+            tpm_limit: tpm,
+            ..Default::default()
+        })
+}

--- a/src/core/router/tests/mod.rs
+++ b/src/core/router/tests/mod.rs
@@ -19,3 +19,6 @@ mod strategy_impl_tests;
 
 // Selection logic edge case tests (issue #343)
 mod selection_tests;
+
+// Distributed deployment admission (issue #1280)
+mod admission_tests;

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -3,6 +3,7 @@
 //! This module provides the unified Router infrastructure that manages deployments,
 //! routing strategies, and intelligent request routing across multiple providers.
 
+use super::admission::AdmissionBackend;
 use super::config::RouterConfig;
 use super::deployment::{Deployment, DeploymentId, LegacySelectorMetadata, current_timestamp};
 use super::error::CooldownReason;
@@ -335,6 +336,8 @@ pub struct Router {
     /// Single supervisor task coordinating all current health probe groups.
     pub(crate) health_probe_tasks: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
     pub(crate) health_probe_wakeup: Arc<tokio::sync::Notify>,
+    /// Shared admission backend (local atomics, or Redis when configured).
+    pub(crate) admission: AdmissionBackend,
 }
 
 impl Router {
@@ -351,7 +354,21 @@ impl Router {
             fallback_triggered_count: AtomicU64::new(0),
             health_probe_tasks: Mutex::new(HashMap::new()),
             health_probe_wakeup: Arc::new(tokio::sync::Notify::new()),
+            admission: AdmissionBackend::default(),
         }
+    }
+
+    /// Attach Redis so deployment parallel/RPM/TPM limits are shared across replicas.
+    #[cfg(feature = "gateway")]
+    pub fn with_admission_redis(mut self, pool: Arc<crate::storage::redis::RedisPool>) -> Self {
+        self.admission = AdmissionBackend::redis(pool);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_unavailable_admission(mut self) -> Self {
+        self.admission = AdmissionBackend::Unavailable;
+        self
     }
 
     /// Set fallback configuration for the router (builder pattern)

--- a/src/server/routes/ai/execution.rs
+++ b/src/server/routes/ai/execution.rs
@@ -1,4 +1,5 @@
 use crate::core::providers::{Provider, ProviderError};
+use crate::core::router::admission::{AdmissionBackend, AdmissionHold};
 use crate::core::router::deployment::Deployment;
 use crate::core::router::error::CooldownReason;
 use crate::core::router::execution::{infer_cooldown_reason, router_error_to_provider_error};
@@ -18,15 +19,25 @@ pub(super) struct StreamingDeploymentLease {
     deployment: Arc<Deployment>,
     started_at: Instant,
     finalized: bool,
+    admission: AdmissionBackend,
+    hold: Option<AdmissionHold>,
 }
 
 impl StreamingDeploymentLease {
-    fn new(router: Arc<UnifiedRouter>, deployment: Arc<Deployment>, started_at: Instant) -> Self {
+    fn new(
+        router: Arc<UnifiedRouter>,
+        deployment: Arc<Deployment>,
+        started_at: Instant,
+        admission: AdmissionBackend,
+        hold: Option<AdmissionHold>,
+    ) -> Self {
         Self {
             router,
             deployment,
             started_at,
             finalized: false,
+            admission,
+            hold,
         }
     }
 
@@ -34,6 +45,9 @@ impl StreamingDeploymentLease {
         let latency_us = self.started_at.elapsed().as_micros() as u64;
         self.router
             .record_success_for_deployment(&self.deployment, tokens_used, latency_us);
+        if let Some(hold) = self.hold.take() {
+            self.admission.settle(&hold, tokens_used);
+        }
         self.release();
     }
 
@@ -60,6 +74,9 @@ impl StreamingDeploymentLease {
     fn release(&mut self) {
         if !self.finalized {
             UnifiedRouter::release_selected_deployment(&self.deployment);
+            if let Some(hold) = self.hold.take() {
+                self.admission.cancel(&hold);
+            }
             self.finalized = true;
         }
     }
@@ -120,7 +137,7 @@ where
         // candidate was tried once, fall back to the pool minus budget
         // exclusions so single-deployment setups still get same-target
         // retries. When even that pool is empty, fail closed below.
-        let deployment_lease = match router.select_deployment_lease_for_capability_matching(
+        let mut deployment_lease = match router.select_deployment_lease_for_capability_matching(
             requested_model,
             &capability,
             |deployment| {
@@ -214,6 +231,7 @@ where
                     tokens_used,
                     latency_us,
                 );
+                deployment_lease.commit_admission(tokens_used);
                 drop(deployment_lease);
                 return Ok(value);
             }
@@ -343,7 +361,7 @@ where
         // Prefer deployments this request has not already tried; when every
         // candidate was tried once, fall back to the full pool so
         // single-deployment setups still get same-target retries.
-        let deployment_lease = match router.select_deployment_lease_for_capability_matching(
+        let mut deployment_lease = match router.select_deployment_lease_for_capability_matching(
             requested_model,
             &capability,
             |deployment| {
@@ -431,8 +449,15 @@ where
 
         match operation.clone()(provider, selected_model, selected_deployment_id).await {
             Ok(stream) => {
+                let (admission, hold) = deployment_lease.take_admission();
                 let _deployment_id = deployment_lease.into_deployment_id();
-                let lease = StreamingDeploymentLease::new(router.clone(), deployment, started_at);
+                let lease = StreamingDeploymentLease::new(
+                    router.clone(),
+                    deployment,
+                    started_at,
+                    admission,
+                    hold,
+                );
                 return Ok((stream, lease));
             }
             Err(err) => {

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -40,7 +40,11 @@ pub(super) async fn build_runtime_revision(
     redis: Arc<RedisPool>,
 ) -> Result<RuntimeRevision> {
     config.validate()?;
-    let unified_router = Arc::new(build_router_from_config(&config, pricing).await?);
+    let unified_router = Arc::new(
+        build_router_from_config(&config, pricing)
+            .await?
+            .with_admission_redis(Arc::clone(&redis)),
+    );
     let guardrails =
         GuardrailEngine::shared(config.gateway.guardrails.clone()).map_err(|error| {
             GatewayError::Config(format!("Invalid guardrails configuration: {error}"))

--- a/src/storage/redis/admission.rs
+++ b/src/storage/redis/admission.rs
@@ -1,0 +1,360 @@
+//! Single-key Lua deployment admission (cluster-safe: `KEYS[1]` only).
+
+use super::pool::{RedisLiveConnection, RedisPool};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+const ADMISSION_SCRIPT: &str = r#"
+local op = ARGV[1]
+local now = tonumber(ARGV[2]) or 0
+local epoch = tonumber(ARGV[3]) or 0
+local max_p = tonumber(ARGV[4]) or -1
+local max_r = tonumber(ARGV[5]) or -1
+local max_t = tonumber(ARGV[6]) or -1
+local rpm_inc = tonumber(ARGV[7]) or 0
+local tpm_inc = tonumber(ARGV[8]) or 0
+local lease_id = ARGV[9]
+local ttl = tonumber(ARGV[10]) or 1
+local actual_tpm = tonumber(ARGV[11]) or 0
+
+local function nums()
+  local p = tonumber(redis.call('HGET', KEYS[1], 'p') or '0') or 0
+  local r = tonumber(redis.call('HGET', KEYS[1], 'r') or '0') or 0
+  local t = tonumber(redis.call('HGET', KEYS[1], 't') or '0') or 0
+  local e = tonumber(redis.call('HGET', KEYS[1], 'e') or '0') or 0
+  return p, r, t, e
+end
+
+local function save(p, r, t, e)
+  if p < 0 then p = 0 end
+  if r < 0 then r = 0 end
+  if t < 0 then t = 0 end
+  redis.call('HSET', KEYS[1], 'p', p, 'r', r, 't', t, 'e', e)
+end
+
+local function reclaim()
+  local p, r, t, e = nums()
+  if e ~= epoch then
+    r = 0
+    t = 0
+    e = epoch
+  end
+  local fields = redis.call('HGETALL', KEYS[1])
+  for i = 1, #fields, 2 do
+    if string.sub(fields[i], 1, 2) == 'l:' then
+      local pInc, rpmInc, tpmInc, lease_epoch, expiry = string.match(
+        fields[i + 1], '^(%d+):(%d+):(%d+):(%-?%d+):(%d+)$'
+      )
+      pInc = tonumber(pInc)
+      rpmInc = tonumber(rpmInc)
+      tpmInc = tonumber(tpmInc)
+      lease_epoch = tonumber(lease_epoch)
+      expiry = tonumber(expiry)
+      if pInc == nil or expiry == nil or expiry <= now then
+        if pInc ~= nil and expiry ~= nil and expiry <= now then
+          p = p - pInc
+          if lease_epoch == e then
+            r = r - rpmInc
+            t = t - tpmInc
+          end
+        end
+        redis.call('HDEL', KEYS[1], fields[i])
+      end
+    end
+  end
+  save(p, r, t, e)
+  return p, r, t, e
+end
+
+local p, r, t, e = reclaim()
+
+if op == 'reserve' then
+  if (max_p >= 0 and p + 1 > max_p)
+      or (max_r >= 0 and r + rpm_inc > max_r)
+      or (max_t >= 0 and t + tpm_inc > max_t) then
+    return {0, p, r, t}
+  end
+  p = p + 1
+  r = r + rpm_inc
+  t = t + tpm_inc
+  if ttl < 1 then ttl = 1 end
+  save(p, r, t, e)
+  redis.call(
+    'HSET',
+    KEYS[1],
+    'l:' .. lease_id,
+    '1:' .. tostring(rpm_inc) .. ':' .. tostring(tpm_inc) .. ':' .. tostring(e) .. ':' .. tostring(now + ttl)
+  )
+  return {1, p, r, t}
+end
+
+if op == 'settle' or op == 'cancel' then
+  local field = 'l:' .. lease_id
+  local lease = redis.call('HGET', KEYS[1], field)
+  if lease then
+    local pInc, rpmInc, tpmInc, lease_epoch = string.match(lease, '^(%d+):(%d+):(%d+):(%-?%d+):')
+    pInc = tonumber(pInc) or 1
+    rpmInc = tonumber(rpmInc) or 0
+    tpmInc = tonumber(tpmInc) or 0
+    lease_epoch = tonumber(lease_epoch)
+    p = p - pInc
+    if lease_epoch == e then
+      if op == 'cancel' then
+        r = r - rpmInc
+        t = t - tpmInc
+      else
+        t = t - tpmInc + actual_tpm
+      end
+    elseif op == 'settle' then
+      t = t + actual_tpm
+    end
+    redis.call('HDEL', KEYS[1], field)
+    save(p, r, t, e)
+  end
+  return {1, p, r, t}
+end
+
+return {-1, p, r, t}
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AdmissionState {
+    pub allowed: bool,
+    pub parallel: i64,
+    pub rpm: i64,
+    pub tpm: i64,
+}
+
+pub(crate) struct AdmissionReserveArgs<'a> {
+    pub key: &'a str,
+    pub max_parallel: i64,
+    pub max_rpm: i64,
+    pub max_tpm: i64,
+    pub rpm_inc: i64,
+    pub tpm_inc: i64,
+    pub lease_id: &'a str,
+    pub now_ms: i64,
+    pub window_epoch: i64,
+    pub ttl_ms: i64,
+}
+
+fn admission_script() -> &'static redis::Script {
+    static SCRIPT: OnceLock<redis::Script> = OnceLock::new();
+    SCRIPT.get_or_init(|| redis::Script::new(ADMISSION_SCRIPT))
+}
+
+fn admission_runtime_connections()
+-> &'static tokio::sync::Mutex<HashMap<String, RedisLiveConnection>> {
+    static CACHE: OnceLock<tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+async fn connection_on_current_runtime(pool: &RedisPool) -> Result<RedisLiveConnection> {
+    let cache_key = format!("{}|{}", pool.config.url, pool.config.cluster);
+    {
+        let cache = admission_runtime_connections().lock().await;
+        if let Some(conn) = cache.get(&cache_key) {
+            return Ok(conn.clone());
+        }
+    }
+    let conn = pool.open_live_connection().await?;
+    let mut cache = admission_runtime_connections().lock().await;
+    Ok(cache.entry(cache_key).or_insert(conn).clone())
+}
+
+fn parse_admission_state(values: Vec<i64>) -> Result<AdmissionState> {
+    if values.len() != 4 {
+        return Err(GatewayError::Storage(format!(
+            "Unexpected Redis admission result length: {}",
+            values.len()
+        )));
+    }
+    if values[0] < 0 {
+        return Err(GatewayError::Storage(
+            "Redis admission script returned an error status".to_string(),
+        ));
+    }
+    Ok(AdmissionState {
+        allowed: values[0] == 1,
+        parallel: values[1].max(0),
+        rpm: values[2].max(0),
+        tpm: values[3].max(0),
+    })
+}
+
+struct AdmissionArgs<'a> {
+    op: &'a str,
+    now_ms: i64,
+    window_epoch: i64,
+    max_parallel: i64,
+    max_rpm: i64,
+    max_tpm: i64,
+    rpm_inc: i64,
+    tpm_inc: i64,
+    lease_id: &'a str,
+    ttl_ms: i64,
+    actual_tpm: i64,
+}
+
+impl RedisPool {
+    pub(crate) fn admission_key(deployment_id: &str) -> String {
+        format!("litellm-rs:admission:v1:{deployment_id}")
+    }
+
+    async fn invoke_admission(&self, key: &str, args: AdmissionArgs<'_>) -> Result<AdmissionState> {
+        if self.noop_mode {
+            return Err(GatewayError::Storage(
+                "admission redis backend is unavailable".to_string(),
+            ));
+        }
+
+        let _permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| GatewayError::Internal("Redis semaphore closed".to_string()))?;
+        let mut conn = connection_on_current_runtime(self).await?;
+
+        let values: Vec<i64> = admission_script()
+            .key(key)
+            .arg(args.op)
+            .arg(args.now_ms)
+            .arg(args.window_epoch)
+            .arg(args.max_parallel)
+            .arg(args.max_rpm)
+            .arg(args.max_tpm)
+            .arg(args.rpm_inc)
+            .arg(args.tpm_inc)
+            .arg(args.lease_id)
+            .arg(args.ttl_ms)
+            .arg(args.actual_tpm)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(GatewayError::from)?;
+        parse_admission_state(values)
+    }
+
+    pub(crate) async fn admission_reserve(
+        &self,
+        args: AdmissionReserveArgs<'_>,
+    ) -> Result<AdmissionState> {
+        self.invoke_admission(
+            args.key,
+            AdmissionArgs {
+                op: "reserve",
+                now_ms: args.now_ms,
+                window_epoch: args.window_epoch,
+                max_parallel: args.max_parallel,
+                max_rpm: args.max_rpm,
+                max_tpm: args.max_tpm,
+                rpm_inc: args.rpm_inc,
+                tpm_inc: args.tpm_inc,
+                lease_id: args.lease_id,
+                ttl_ms: args.ttl_ms,
+                actual_tpm: 0,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn admission_settle(
+        &self,
+        key: &str,
+        lease_id: &str,
+        actual_tpm: i64,
+        window_epoch: i64,
+        now_ms: i64,
+    ) -> Result<AdmissionState> {
+        self.admission_finish("settle", key, lease_id, actual_tpm, window_epoch, now_ms)
+            .await
+    }
+
+    pub(crate) async fn admission_cancel(
+        &self,
+        key: &str,
+        lease_id: &str,
+        window_epoch: i64,
+        now_ms: i64,
+    ) -> Result<AdmissionState> {
+        self.admission_finish("cancel", key, lease_id, 0, window_epoch, now_ms)
+            .await
+    }
+
+    async fn admission_finish(
+        &self,
+        op: &str,
+        key: &str,
+        lease_id: &str,
+        actual_tpm: i64,
+        window_epoch: i64,
+        now_ms: i64,
+    ) -> Result<AdmissionState> {
+        self.invoke_admission(
+            key,
+            AdmissionArgs {
+                op,
+                now_ms,
+                window_epoch,
+                max_parallel: -1,
+                max_rpm: -1,
+                max_tpm: -1,
+                rpm_inc: 0,
+                tpm_inc: 0,
+                lease_id,
+                ttl_ms: 0,
+                actual_tpm,
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::models::storage::RedisConfig;
+
+    #[test]
+    fn parses_admission_state() {
+        let allowed = parse_admission_state(vec![1, 2, 3, 4]).unwrap();
+        assert!(allowed.allowed);
+        assert_eq!(allowed.parallel, 2);
+        assert_eq!(allowed.rpm, 3);
+        assert_eq!(allowed.tpm, 4);
+
+        let denied = parse_admission_state(vec![0, 1, 0, 0]).unwrap();
+        assert!(!denied.allowed);
+        assert!(parse_admission_state(vec![-1, 0, 0, 0]).is_err());
+        assert!(parse_admission_state(vec![1, 0]).is_err());
+    }
+
+    #[tokio::test]
+    async fn noop_redis_pool_fails_closed_on_admission_reserve() {
+        let pool = RedisPool::new(&RedisConfig {
+            enabled: false,
+            ..RedisConfig::default()
+        })
+        .await
+        .expect("disabled Redis should create a no-op pool");
+
+        let err = pool
+            .admission_reserve(AdmissionReserveArgs {
+                key: "litellm-rs:admission:v1:noop-test",
+                max_parallel: 1,
+                max_rpm: -1,
+                max_tpm: -1,
+                rpm_inc: 0,
+                tpm_inc: 0,
+                lease_id: "lease",
+                now_ms: 1,
+                window_epoch: 0,
+                ttl_ms: 1_000,
+            })
+            .await
+            .expect_err("no-op Redis must not fail-open admission");
+        assert!(err.to_string().contains("unavailable"));
+    }
+}

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -12,11 +12,13 @@
 //! - `pubsub` - Pub/Sub operations (temporarily disabled)
 //! - `atomic` - Atomic operations and utilities
 //! - `budget` - Cluster-safe single-key Lua budget leases
+//! - `admission` - Cluster-safe single-key Lua deployment admission
 //! - `tests` - Module tests
 
 #![allow(dead_code)]
 
 // Module declarations
+pub(crate) mod admission;
 mod atomic;
 mod batch;
 pub(crate) mod budget;


### PR DESCRIPTION
## What

Share deployment max-parallel, RPM, and TPM admission across gateway replicas via a cluster-safe single-key Redis HASH (`litellm-rs:admission:v1:{deployment_id}`). Local atomics remain the fallback when Redis is absent.

## Why

Per-process counters multiplied effective limits by replica count. Two gateways with `max_parallel_requests=1` (or `rpm=1`) now enforce one combined limit.

Fixes #1280

## Changes

- New admission Lua (KEYS[1] only) plus dedicated multi-thread Redis runtime, matching #1331 / #1279 (no `block_in_place` on Actix `current_thread`).
- `DeploymentLease` / `StreamingDeploymentLease` own the Redis hold: drop/cancel refunds; success settles actual TPM and keeps RPM.
- Redis/backend errors fail closed (skip the deployment) and `warn!`. Limit rejection does not `record_failure` or trip cooldown.
- API-key / global RPM scripts in `src/storage/redis/rate_limit.rs` are unchanged.
- Does **not** start #1281 (circuit-breaker cross-node cooldown).

## Test Plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] Focused tests: two routers sharing Redis for parallel/RPM/TPM, cancel refund, stream/drop release, fail-closed, current_thread
- [x] Existing local max-parallel concurrent selection + stream abort tests
- [ ] Fast Test SUCCESS (~13–15m, not a 30m cancel)

## AI disclosure

Implemented with Cursor Grok 4.6.


Made with [Cursor](https://cursor.com)