### PR TITLE
feat(router): share circuit-breaker cooldown across replicas

### DIFF
--- a/src/core/router/circuit.rs
+++ b/src/core/router/circuit.rs
@@ -1,0 +1,361 @@
+//! Shared deployment circuit-breaker state.
+//!
+//! Local atomics remain the default. When a live Redis pool is attached,
+//! open/half-open/recovery run as single-key Lua so replicas share cooldown.
+//! Redis errors follow `allow_degraded` (strict = fail closed, degraded =
+//! last local snapshot).
+
+use super::config::RouterConfig;
+use super::deployment::Deployment;
+#[cfg(feature = "gateway")]
+use super::deployment::HealthStatus;
+use super::error::CooldownReason;
+#[cfg(feature = "gateway")]
+use dashmap::DashMap;
+#[cfg(feature = "gateway")]
+use std::sync::atomic::Ordering;
+#[cfg(feature = "gateway")]
+use std::time::{Duration, Instant};
+use tracing::warn;
+
+#[cfg(feature = "gateway")]
+const CACHE_TTL: Duration = Duration::from_millis(50);
+
+#[derive(Clone, Debug, Default)]
+pub(crate) enum CircuitBackend {
+    #[default]
+    InProcess,
+    #[cfg(feature = "gateway")]
+    Redis {
+        pool: std::sync::Arc<crate::storage::redis::RedisPool>,
+        probe_token: String,
+        allow_degraded: bool,
+        cache: std::sync::Arc<
+            DashMap<String, (crate::storage::redis::circuit::CircuitState, Instant)>,
+        >,
+    },
+    #[cfg(test)]
+    Unavailable { allow_degraded: bool },
+}
+
+pub(crate) enum CircuitObserve {
+    UseLocal,
+    #[cfg(feature = "gateway")]
+    Shared(crate::storage::redis::circuit::CircuitState),
+    Blocked,
+}
+
+pub(crate) enum CircuitWrite {
+    Local,
+    #[cfg(feature = "gateway")]
+    Applied(crate::storage::redis::circuit::CircuitState),
+    StrictUnavailable,
+}
+
+impl CircuitBackend {
+    #[cfg(feature = "gateway")]
+    pub(crate) fn redis(pool: std::sync::Arc<crate::storage::redis::RedisPool>) -> Self {
+        if pool.is_noop() {
+            Self::InProcess
+        } else {
+            Self::Redis {
+                allow_degraded: pool.config.allow_degraded,
+                pool,
+                probe_token: uuid::Uuid::new_v4().to_string(),
+                cache: std::sync::Arc::new(DashMap::new()),
+            }
+        }
+    }
+
+    pub(crate) fn observe(&self, deployment: &Deployment, config: &RouterConfig) -> CircuitObserve {
+        match self {
+            Self::InProcess => CircuitObserve::UseLocal,
+            #[cfg(test)]
+            Self::Unavailable { allow_degraded } => {
+                if *allow_degraded {
+                    warn!(
+                        deployment_id = %deployment.id,
+                        "circuit backend unavailable; using last local snapshot"
+                    );
+                    CircuitObserve::UseLocal
+                } else {
+                    warn!(
+                        deployment_id = %deployment.id,
+                        "circuit backend unavailable; failing closed"
+                    );
+                    CircuitObserve::Blocked
+                }
+            }
+            #[cfg(feature = "gateway")]
+            Self::Redis {
+                pool,
+                probe_token,
+                allow_degraded,
+                cache,
+            } => {
+                if let Some(entry) = cache.get(deployment.id.as_str())
+                    && entry.1.elapsed() < CACHE_TTL
+                {
+                    return CircuitObserve::Shared(entry.0);
+                }
+                match invoke(pool, &deployment.id, probe_token, config, "observe", 0) {
+                    Ok(state) => {
+                        cache.insert(deployment.id.clone(), (state, Instant::now()));
+                        CircuitObserve::Shared(state)
+                    }
+                    Err(_) => redis_loss_observe(&deployment.id, *allow_degraded),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn record_failure(
+        &self,
+        deployment: &Deployment,
+        config: &RouterConfig,
+        reason: CooldownReason,
+    ) -> CircuitWrite {
+        self.write(deployment, config, "fail", reason_code(reason))
+    }
+
+    pub(crate) fn record_success(
+        &self,
+        deployment: &Deployment,
+        config: &RouterConfig,
+    ) -> CircuitWrite {
+        self.write(deployment, config, "ok", 0)
+    }
+
+    fn write(
+        &self,
+        deployment: &Deployment,
+        config: &RouterConfig,
+        op: &'static str,
+        reason: i64,
+    ) -> CircuitWrite {
+        match self {
+            Self::InProcess => CircuitWrite::Local,
+            #[cfg(test)]
+            Self::Unavailable { allow_degraded } => {
+                if *allow_degraded {
+                    warn!(
+                        deployment_id = %deployment.id,
+                        operation = op,
+                        "circuit backend unavailable; using last local snapshot"
+                    );
+                    CircuitWrite::Local
+                } else {
+                    warn!(
+                        deployment_id = %deployment.id,
+                        operation = op,
+                        "circuit backend unavailable; failing closed"
+                    );
+                    CircuitWrite::StrictUnavailable
+                }
+            }
+            #[cfg(feature = "gateway")]
+            Self::Redis {
+                pool,
+                probe_token,
+                allow_degraded,
+                cache,
+            } => match invoke(pool, &deployment.id, probe_token, config, op, reason) {
+                Ok(state) => {
+                    cache.insert(deployment.id.clone(), (state, Instant::now()));
+                    CircuitWrite::Applied(state)
+                }
+                Err(_) if *allow_degraded => {
+                    warn!(
+                        deployment_id = %deployment.id,
+                        operation = op,
+                        "circuit redis operation failed; using last local snapshot"
+                    );
+                    CircuitWrite::Local
+                }
+                Err(_) => {
+                    warn!(
+                        deployment_id = %deployment.id,
+                        operation = op,
+                        "circuit redis operation failed; failing closed"
+                    );
+                    CircuitWrite::StrictUnavailable
+                }
+            },
+        }
+    }
+}
+
+#[cfg(feature = "gateway")]
+pub(crate) fn apply_circuit_snapshot(
+    deployment: &Deployment,
+    state: &crate::storage::redis::circuit::CircuitState,
+) {
+    deployment
+        .state
+        .cooldown_until
+        .store(state.opened_until.max(0) as u64, Ordering::Relaxed);
+    deployment
+        .state
+        .consecutive_successes
+        .store(state.consecutive_successes.max(0) as u32, Ordering::Relaxed);
+    deployment
+        .state
+        .fails_this_minute
+        .store(state.fails.max(0) as u32, Ordering::Relaxed);
+    let health = if state.status == 1 {
+        HealthStatus::Cooldown
+    } else if deployment.state.probe_unhealthy.load(Ordering::Relaxed) {
+        HealthStatus::Unhealthy
+    } else {
+        HealthStatus::from(state.health.max(0) as u8)
+    };
+    deployment
+        .state
+        .health
+        .store(health as u8, Ordering::Relaxed);
+}
+
+fn reason_code(reason: CooldownReason) -> i64 {
+    match reason {
+        CooldownReason::ConsecutiveFailures => 0,
+        CooldownReason::HighFailureRate => 2,
+        CooldownReason::RateLimit
+        | CooldownReason::AuthError
+        | CooldownReason::NotFound
+        | CooldownReason::Timeout
+        | CooldownReason::Manual => 1,
+    }
+}
+
+#[cfg(feature = "gateway")]
+fn redis_loss_observe(deployment_id: &str, allow_degraded: bool) -> CircuitObserve {
+    if allow_degraded {
+        warn!(
+            deployment_id,
+            "circuit redis operation failed; using last local snapshot"
+        );
+        CircuitObserve::UseLocal
+    } else {
+        warn!(
+            deployment_id,
+            "circuit redis operation failed; failing closed"
+        );
+        CircuitObserve::Blocked
+    }
+}
+
+#[cfg(feature = "gateway")]
+fn invoke(
+    pool: &std::sync::Arc<crate::storage::redis::RedisPool>,
+    deployment_id: &str,
+    token: &str,
+    config: &RouterConfig,
+    op: &'static str,
+    reason: i64,
+) -> Result<crate::storage::redis::circuit::CircuitState, ()> {
+    let pool = std::sync::Arc::clone(pool);
+    let key = crate::storage::redis::RedisPool::circuit_key(deployment_id);
+    let token = token.to_string();
+    let now_secs = now_secs();
+    let window_epoch = now_secs / 60;
+    let allowed_fails = i64::from(config.allowed_fails);
+    let min_requests = i64::from(config.min_requests);
+    let cooldown_secs = i64::try_from(config.cooldown_time_secs).unwrap_or(i64::MAX);
+    let success_threshold = i64::from(config.success_threshold);
+    run_redis(deployment_id, op, async move {
+        pool.circuit_invoke(
+            &key,
+            crate::storage::redis::circuit::CircuitArgs {
+                op,
+                now_secs,
+                window_epoch,
+                token: &token,
+                allowed_fails,
+                min_requests,
+                cooldown_secs,
+                success_threshold,
+                reason,
+            },
+        )
+        .await
+    })
+}
+
+#[cfg(feature = "gateway")]
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(feature = "gateway")]
+fn circuit_io_handle() -> tokio::runtime::Handle {
+    static HANDLE: std::sync::OnceLock<tokio::runtime::Handle> = std::sync::OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            std::thread::Builder::new()
+                .name("circuit-redis-rt".into())
+                .spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(1)
+                        .enable_all()
+                        .thread_name("circuit-redis")
+                        .build()
+                        .expect("circuit redis runtime");
+                    let handle = runtime.handle().clone();
+                    tx.send(handle).expect("send circuit redis handle");
+                    runtime.block_on(std::future::pending::<()>());
+                })
+                .expect("spawn circuit redis runtime thread");
+            rx.recv().expect("circuit redis runtime handle")
+        })
+        .clone()
+}
+
+#[cfg(feature = "gateway")]
+fn run_redis<T>(
+    deployment_id: &str,
+    operation: &'static str,
+    fut: impl std::future::Future<Output = crate::utils::error::gateway_error::Result<T>>
+    + Send
+    + 'static,
+) -> Result<T, ()>
+where
+    T: Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    circuit_io_handle().spawn(async move {
+        let _ = tx.send(fut.await);
+    });
+    match rx.recv() {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => {
+            warn!(
+                deployment_id,
+                operation,
+                error = %err,
+                "circuit redis operation failed"
+            );
+            Err(())
+        }
+        Err(_) => {
+            warn!(deployment_id, operation, "circuit redis worker dropped");
+            Err(())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "gateway"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_redis_does_not_panic_on_current_thread_runtime() {
+        let result = run_redis("probe", "probe", async {
+            Ok::<i64, crate::utils::error::gateway_error::GatewayError>(7)
+        });
+        assert_eq!(result.expect("current_thread redis bridge"), 7);
+    }
+}

--- a/src/core/router/mod.rs
+++ b/src/core/router/mod.rs
@@ -30,6 +30,7 @@ use url::Url;
 // New modular router components
 pub(crate) mod admission;
 pub mod budget_routing;
+pub(crate) mod circuit;
 pub mod config;
 pub mod deployment;
 pub mod error;

--- a/src/core/router/selection.rs
+++ b/src/core/router/selection.rs
@@ -331,23 +331,12 @@ impl Router {
             }
             matching_deployments += 1;
 
-            // Check cooldown first: is_in_cooldown() resets health
-            // from Cooldown to Degraded when the cooldown period expires.
-            if deployment.is_in_cooldown() {
+            // Shared circuit (or local cooldown/health) owns selection eligibility.
+            if !self.deployment_is_selectable(deployment) {
                 tracing::trace!(
                     deployment_id = id.as_str(),
                     model = %resolved_name,
-                    reason = "in_cooldown",
-                    "deployment excluded from routing candidates"
-                );
-                continue;
-            }
-
-            if !deployment.is_healthy() {
-                tracing::trace!(
-                    deployment_id = id.as_str(),
-                    model = %resolved_name,
-                    reason = "unhealthy",
+                    reason = "circuit_or_unhealthy",
                     "deployment excluded from routing candidates"
                 );
                 continue;

--- a/src/core/router/tests/circuit_tests.rs
+++ b/src/core/router/tests/circuit_tests.rs
@@ -83,6 +83,7 @@ mod redis {
         a.record_failure(&id);
         assert!(a.select_deployment_lease("gpt-4").is_ok());
         b.record_failure(&id);
+        tokio::time::sleep(Duration::from_millis(80)).await;
         assert!(
             a.select_deployment_lease("gpt-4").is_err(),
             "third shared failure must open the circuit on both nodes"

--- a/src/core/router/tests/circuit_tests.rs
+++ b/src/core/router/tests/circuit_tests.rs
@@ -1,0 +1,224 @@
+use super::router_tests::create_test_deployment;
+use crate::core::router::config::RouterConfig;
+use crate::core::router::error::{CooldownReason, RouterError};
+use crate::core::router::unified::Router;
+
+#[tokio::test]
+async fn unavailable_backend_fails_closed_without_selection() {
+    let a = Router::new(RouterConfig::default()).with_unavailable_circuit(false);
+    let b = Router::new(RouterConfig::default()).with_unavailable_circuit(false);
+    a.add_deployment(create_test_deployment("closed-1", "gpt-4").await);
+    b.add_deployment(create_test_deployment("closed-1", "gpt-4").await);
+    for router in [&a, &b] {
+        let err = router
+            .select_deployment_lease("gpt-4")
+            .expect_err("strict circuit loss must fail closed");
+        assert!(matches!(err, RouterError::NoAvailableDeployment(_)));
+    }
+}
+
+#[tokio::test]
+async fn unavailable_backend_degraded_uses_local_snapshot() {
+    let router = Router::new(RouterConfig::default()).with_unavailable_circuit(true);
+    router.add_deployment(create_test_deployment("degraded-open", "gpt-4").await);
+    router
+        .select_deployment_lease("gpt-4")
+        .expect("degraded circuit loss must use a closed local snapshot");
+
+    let blocked = Router::new(RouterConfig::default()).with_unavailable_circuit(true);
+    let deployment = create_test_deployment("degraded-open", "gpt-4").await;
+    deployment.enter_cooldown(3600);
+    blocked.add_deployment(deployment);
+    assert!(
+        blocked.select_deployment_lease("gpt-4").is_err(),
+        "degraded circuit loss must honor the last local cooldown snapshot"
+    );
+}
+
+#[cfg(feature = "gateway")]
+mod redis {
+    use super::*;
+    use crate::config::models::storage::RedisConfig;
+    use crate::storage::redis::RedisPool;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn node_a_open_stops_selection_on_node_b() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("open");
+        let a = router_with(pool.clone());
+        let b = router_with(pool.clone());
+        seed(&a, &id).await;
+        seed(&b, &id).await;
+
+        a.record_failure_with_reason(&id, CooldownReason::RateLimit);
+        assert!(
+            b.select_deployment_lease("gpt-4").is_err(),
+            "node B must skip a circuit opened on node A"
+        );
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shared_failure_threshold_is_atomic() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("threshold");
+        let config = RouterConfig {
+            allowed_fails: 3,
+            min_requests: 1,
+            cooldown_time_secs: 60,
+            ..Default::default()
+        };
+        let a = Router::new(config.clone()).with_circuit_redis(pool.clone());
+        let b = Router::new(config).with_circuit_redis(pool.clone());
+        seed(&a, &id).await;
+        seed(&b, &id).await;
+
+        a.record_failure(&id);
+        a.record_failure(&id);
+        assert!(a.select_deployment_lease("gpt-4").is_ok());
+        b.record_failure(&id);
+        assert!(
+            a.select_deployment_lease("gpt-4").is_err(),
+            "third shared failure must open the circuit on both nodes"
+        );
+        assert!(b.select_deployment_lease("gpt-4").is_err());
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cooldown_half_open_is_exclusive_then_recovers() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("half-open");
+        let config = RouterConfig {
+            cooldown_time_secs: 1,
+            success_threshold: 1,
+            ..Default::default()
+        };
+        let a = Router::new(config.clone()).with_circuit_redis(pool.clone());
+        let b = Router::new(config).with_circuit_redis(pool.clone());
+        seed(&a, &id).await;
+        seed(&b, &id).await;
+
+        a.record_failure_with_reason(&id, CooldownReason::Timeout);
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+        let a_lease = a.select_deployment_lease("gpt-4");
+        let b_lease = b.select_deployment_lease("gpt-4");
+        let successes = [&a_lease, &b_lease]
+            .iter()
+            .filter(|result| result.is_ok())
+            .count();
+        assert_eq!(successes, 1, "only the half-open owner may probe");
+
+        let (owner, other) = if a_lease.is_ok() { (&a, &b) } else { (&b, &a) };
+        drop(a_lease);
+        drop(b_lease);
+        owner.record_success(&id, 10, 1_000);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        other
+            .select_deployment_lease("gpt-4")
+            .expect("probe success must close the circuit for the other replica");
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn half_open_failure_reopens_cooldown() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("reopen");
+        let config = RouterConfig {
+            cooldown_time_secs: 1,
+            success_threshold: 3,
+            ..Default::default()
+        };
+        let a = Router::new(config.clone()).with_circuit_redis(pool.clone());
+        let b = Router::new(config).with_circuit_redis(pool.clone());
+        seed(&a, &id).await;
+        seed(&b, &id).await;
+
+        a.record_failure_with_reason(&id, CooldownReason::Manual);
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        let _probe = a
+            .select_deployment_lease("gpt-4")
+            .expect("cooldown expiry must allow one probe");
+        a.record_failure_with_reason(&id, CooldownReason::ConsecutiveFailures);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(
+            b.select_deployment_lease("gpt-4").is_err(),
+            "half-open failure must re-open cooldown on the other replica"
+        );
+        cleanup(&pool, &id).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn current_thread_runtime_can_observe_without_panic() {
+        let Some(pool) = live_redis_pool().await else {
+            return;
+        };
+        let id = unique("current-thread");
+        let router = router_with(pool.clone());
+        seed(&router, &id).await;
+        router
+            .select_deployment_lease("gpt-4")
+            .expect("Actix workers use current_thread; circuit observe must not panic");
+        cleanup(&pool, &id).await;
+    }
+
+    fn router_with(pool: Arc<RedisPool>) -> Router {
+        Router::new(RouterConfig::default()).with_circuit_redis(pool)
+    }
+
+    async fn seed(router: &Router, id: &str) {
+        router.add_deployment(create_test_deployment(id, "gpt-4").await);
+    }
+
+    fn unique(prefix: &str) -> String {
+        format!("{prefix}-{}", uuid::Uuid::new_v4())
+    }
+
+    async fn cleanup(pool: &RedisPool, deployment_id: &str) {
+        let _ = pool.delete(&RedisPool::circuit_key(deployment_id)).await;
+    }
+
+    async fn live_redis_pool() -> Option<Arc<RedisPool>> {
+        let redis_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+        let config = RedisConfig {
+            url: redis_url.clone(),
+            enabled: true,
+            max_connections: 10,
+            connection_timeout: 1,
+            cluster: false,
+            allow_degraded: false,
+        };
+
+        match RedisPool::new(&config).await {
+            Ok(pool) => match pool.health_check().await {
+                Ok(()) => Some(Arc::new(pool)),
+                Err(err) => {
+                    if std::env::var("CI").is_ok() {
+                        panic!("Redis should pass health check in CI at {redis_url}: {err}");
+                    }
+                    eprintln!("Skipping distributed circuit Redis integration test: {err}");
+                    None
+                }
+            },
+            Err(err) => {
+                if std::env::var("CI").is_ok() {
+                    panic!("Redis should be reachable in CI at {redis_url}: {err}");
+                }
+                eprintln!("Skipping distributed circuit Redis integration test: {err}");
+                None
+            }
+        }
+    }
+}

--- a/src/core/router/tests/mod.rs
+++ b/src/core/router/tests/mod.rs
@@ -22,3 +22,6 @@ mod selection_tests;
 
 // Distributed deployment admission (issue #1280)
 mod admission_tests;
+
+// Distributed deployment circuit breaker (issue #1281)
+mod circuit_tests;

--- a/src/core/router/unified.rs
+++ b/src/core/router/unified.rs
@@ -4,6 +4,9 @@
 //! routing strategies, and intelligent request routing across multiple providers.
 
 use super::admission::AdmissionBackend;
+#[cfg(feature = "gateway")]
+use super::circuit::apply_circuit_snapshot;
+use super::circuit::{CircuitBackend, CircuitObserve, CircuitWrite};
 use super::config::RouterConfig;
 use super::deployment::{Deployment, DeploymentId, LegacySelectorMetadata, current_timestamp};
 use super::error::CooldownReason;
@@ -338,6 +341,8 @@ pub struct Router {
     pub(crate) health_probe_wakeup: Arc<tokio::sync::Notify>,
     /// Shared admission backend (local atomics, or Redis when configured).
     pub(crate) admission: AdmissionBackend,
+    /// Shared circuit-breaker backend (local atomics, or Redis when configured).
+    pub(crate) circuit: CircuitBackend,
 }
 
 impl Router {
@@ -355,6 +360,7 @@ impl Router {
             health_probe_tasks: Mutex::new(HashMap::new()),
             health_probe_wakeup: Arc::new(tokio::sync::Notify::new()),
             admission: AdmissionBackend::default(),
+            circuit: CircuitBackend::default(),
         }
     }
 
@@ -365,9 +371,22 @@ impl Router {
         self
     }
 
+    /// Attach Redis so deployment circuit-breaker cooldown is shared across replicas.
+    #[cfg(feature = "gateway")]
+    pub fn with_circuit_redis(mut self, pool: Arc<crate::storage::redis::RedisPool>) -> Self {
+        self.circuit = CircuitBackend::redis(pool);
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn with_unavailable_admission(mut self) -> Self {
         self.admission = AdmissionBackend::Unavailable;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_unavailable_circuit(mut self, allow_degraded: bool) -> Self {
+        self.circuit = CircuitBackend::Unavailable { allow_degraded };
         self
     }
 
@@ -512,8 +531,7 @@ impl Router {
 
         for id in deployment_ids.iter() {
             if let Some(deployment) = snapshot.deployments.get(id.as_str())
-                && deployment.is_healthy()
-                && !deployment.is_in_cooldown()
+                && self.deployment_is_selectable(deployment)
             {
                 healthy.push(id.clone());
             }
@@ -547,7 +565,7 @@ impl Router {
                 continue;
             }
 
-            if deployment.is_in_cooldown() || !deployment.is_healthy() {
+            if !self.deployment_is_selectable(deployment) {
                 continue;
             }
 
@@ -633,8 +651,15 @@ impl Router {
         latency_us: u64,
     ) {
         deployment.record_success(tokens, latency_us);
+        match self.circuit.record_success(deployment, &self.config) {
+            CircuitWrite::Local => self.promote_from_local_success(deployment),
+            CircuitWrite::StrictUnavailable => {}
+            #[cfg(feature = "gateway")]
+            CircuitWrite::Applied(state) => apply_circuit_snapshot(deployment, &state),
+        }
+    }
 
-        // Promote Degraded -> Healthy once enough consecutive successes
+    fn promote_from_local_success(&self, deployment: &Deployment) {
         let current_health = deployment.state.health.load(Relaxed);
         if current_health == super::deployment::HealthStatus::Degraded as u8 {
             let consec = deployment.state.consecutive_successes.load(Relaxed);
@@ -657,23 +682,10 @@ impl Router {
     }
 
     pub(crate) fn record_failure_for_deployment(&self, deployment: &Deployment) {
-        let minute = deployment.record_failure_with_minute_counters();
-        let fails = minute.failures;
-        let successes_this_minute = minute.rpm;
-        let total_this_minute = successes_this_minute + fails as u64;
-        if fails >= self.config.allowed_fails
-            && total_this_minute >= self.config.min_requests as u64
-        {
-            tracing::info!(
-                deployment_id = %deployment.id,
-                model = %deployment.model_name,
-                reason = "consecutive_failures",
-                cooldown_secs = self.config.cooldown_time_secs,
-                fails_this_minute = fails,
-                "deployment entering cooldown"
-            );
-            deployment.enter_cooldown(self.config.cooldown_time_secs);
-        }
+        self.record_failure_with_reason_for_deployment(
+            deployment,
+            CooldownReason::ConsecutiveFailures,
+        );
     }
 
     /// Record a failed request with a specific reason
@@ -689,6 +701,24 @@ impl Router {
         deployment: &Deployment,
         reason: CooldownReason,
     ) {
+        match self
+            .circuit
+            .record_failure(deployment, &self.config, reason)
+        {
+            CircuitWrite::Local => self.record_local_failure(deployment, reason),
+            CircuitWrite::StrictUnavailable => {
+                let _ = deployment.record_failure_with_minute_counters();
+                deployment.enter_cooldown(self.config.cooldown_time_secs);
+            }
+            #[cfg(feature = "gateway")]
+            CircuitWrite::Applied(state) => {
+                let _ = deployment.record_failure_with_minute_counters();
+                apply_circuit_snapshot(deployment, &state);
+            }
+        }
+    }
+
+    fn record_local_failure(&self, deployment: &Deployment, reason: CooldownReason) {
         let minute = deployment.record_failure_with_minute_counters();
 
         let should_cooldown = match reason {
@@ -722,6 +752,18 @@ impl Router {
                 "deployment entering cooldown"
             );
             deployment.enter_cooldown(self.config.cooldown_time_secs);
+        }
+    }
+
+    pub(crate) fn deployment_is_selectable(&self, deployment: &Deployment) -> bool {
+        match self.circuit.observe(deployment, &self.config) {
+            CircuitObserve::UseLocal => !deployment.is_in_cooldown() && deployment.is_healthy(),
+            CircuitObserve::Blocked => false,
+            #[cfg(feature = "gateway")]
+            CircuitObserve::Shared(state) => {
+                apply_circuit_snapshot(deployment, &state);
+                !state.blocks_selection() && deployment.is_healthy()
+            }
         }
     }
 

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -43,7 +43,8 @@ pub(super) async fn build_runtime_revision(
     let unified_router = Arc::new(
         build_router_from_config(&config, pricing)
             .await?
-            .with_admission_redis(Arc::clone(&redis)),
+            .with_admission_redis(Arc::clone(&redis))
+            .with_circuit_redis(Arc::clone(&redis)),
     );
     let guardrails =
         GuardrailEngine::shared(config.gateway.guardrails.clone()).map_err(|error| {

--- a/src/storage/redis/circuit.rs
+++ b/src/storage/redis/circuit.rs
@@ -1,0 +1,278 @@
+//! Single-key Lua deployment circuit state (cluster-safe: `KEYS[1]` only).
+
+use super::pool::{RedisLiveConnection, RedisPool};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+const CIRCUIT_SCRIPT: &str = r#"
+local op = ARGV[1]
+local now = tonumber(ARGV[2]) or 0
+local epoch = tonumber(ARGV[3]) or 0
+local token = ARGV[4]
+local allowed = tonumber(ARGV[5]) or 3
+local min_req = tonumber(ARGV[6]) or 10
+local cooldown = tonumber(ARGV[7]) or 5
+local success_th = tonumber(ARGV[8]) or 3
+local reason = tonumber(ARGV[9]) or 0
+
+local function load_state()
+  local f = tonumber(redis.call('HGET', KEYS[1], 'f') or '0') or 0
+  local r = tonumber(redis.call('HGET', KEYS[1], 'r') or '0') or 0
+  local tot = tonumber(redis.call('HGET', KEYS[1], 'tot') or '0') or 0
+  local fail = tonumber(redis.call('HGET', KEYS[1], 'fail') or '0') or 0
+  local opened = tonumber(redis.call('HGET', KEYS[1], 'opened') or '0') or 0
+  local consec = tonumber(redis.call('HGET', KEYS[1], 'consec') or '0') or 0
+  local e = tonumber(redis.call('HGET', KEYS[1], 'e') or '0') or 0
+  local h = tonumber(redis.call('HGET', KEYS[1], 'h') or '1') or 1
+  local owner = redis.call('HGET', KEYS[1], 'owner')
+  if not owner then owner = '' end
+  return f, r, tot, fail, opened, consec, e, h, owner
+end
+
+local function save(f, r, tot, fail, opened, consec, e, h, owner)
+  redis.call('HSET', KEYS[1], 'f', f, 'r', r, 'tot', tot, 'fail', fail,
+    'opened', opened, 'consec', consec, 'e', e, 'h', h, 'owner', owner)
+end
+
+local f, r, tot, fail, opened, consec, e, h, owner = load_state()
+if e ~= epoch then
+  f = 0
+  r = 0
+  e = epoch
+end
+
+if op == 'fail' then
+  tot = tot + 1
+  fail = fail + 1
+  f = f + 1
+  consec = 0
+  if opened > now then
+    h = 4
+  elseif opened > 0 then
+    opened = now + cooldown
+    owner = ''
+    h = 4
+  else
+    local trip = 0
+    if reason == 1 then
+      trip = 1
+    elseif reason == 2 then
+      if tot >= min_req and (fail * 100 / tot) > 50 then trip = 1 end
+    elseif f >= allowed and (r + f) >= min_req then
+      trip = 1
+    end
+    if trip == 1 then
+      opened = now + cooldown
+      owner = ''
+      h = 4
+    elseif h == 1 or h == 0 then
+      h = 2
+    end
+  end
+elseif op == 'ok' then
+  tot = tot + 1
+  r = r + 1
+  consec = consec + 1
+  if opened > now then
+    h = 4
+  elseif opened > 0 then
+    if owner == token or owner == '' then
+      if consec >= success_th then
+        opened = 0
+        owner = ''
+        h = 1
+      else
+        h = 2
+        if owner == '' then owner = token end
+      end
+    end
+  elseif h == 2 and consec >= success_th then
+    h = 1
+  end
+end
+
+local status = 0
+local owned = 1
+if opened > now then
+  status = 1
+  owned = 0
+elseif opened > 0 then
+  status = 2
+  if owner == '' then
+    owner = token
+    h = 2
+  end
+  if owner == token then owned = 1 else owned = 0 end
+end
+
+if op ~= 'observe' or opened > 0 then
+  save(f, r, tot, fail, opened, consec, e, h, owner)
+end
+return {status, opened, f, consec, h, owned}
+"#;
+
+const STATUS_OPEN: i64 = 1;
+const STATUS_HALF: i64 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CircuitState {
+    pub status: i64,
+    pub opened_until: i64,
+    pub fails: i64,
+    pub consecutive_successes: i64,
+    pub health: i64,
+    pub owned: bool,
+}
+
+impl CircuitState {
+    pub(crate) fn blocks_selection(self) -> bool {
+        self.status == STATUS_OPEN || (self.status == STATUS_HALF && !self.owned)
+    }
+}
+
+pub(crate) struct CircuitArgs<'a> {
+    pub op: &'a str,
+    pub now_secs: i64,
+    pub window_epoch: i64,
+    pub token: &'a str,
+    pub allowed_fails: i64,
+    pub min_requests: i64,
+    pub cooldown_secs: i64,
+    pub success_threshold: i64,
+    pub reason: i64,
+}
+
+fn circuit_script() -> &'static redis::Script {
+    static SCRIPT: OnceLock<redis::Script> = OnceLock::new();
+    SCRIPT.get_or_init(|| redis::Script::new(CIRCUIT_SCRIPT))
+}
+
+fn circuit_runtime_connections() -> &'static tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>
+{
+    static CACHE: OnceLock<tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+async fn connection_on_current_runtime(pool: &RedisPool) -> Result<RedisLiveConnection> {
+    let cache_key = format!("{}|{}", pool.config.url, pool.config.cluster);
+    {
+        let cache = circuit_runtime_connections().lock().await;
+        if let Some(conn) = cache.get(&cache_key) {
+            return Ok(conn.clone());
+        }
+    }
+    let conn = pool.open_live_connection().await?;
+    let mut cache = circuit_runtime_connections().lock().await;
+    Ok(cache.entry(cache_key).or_insert(conn).clone())
+}
+
+fn parse_circuit_state(values: Vec<i64>) -> Result<CircuitState> {
+    if values.len() != 6 {
+        return Err(GatewayError::Storage(format!(
+            "Unexpected Redis circuit result length: {}",
+            values.len()
+        )));
+    }
+    Ok(CircuitState {
+        status: values[0],
+        opened_until: values[1].max(0),
+        fails: values[2].max(0),
+        consecutive_successes: values[3].max(0),
+        health: values[4],
+        owned: values[5] == 1,
+    })
+}
+
+impl RedisPool {
+    pub(crate) fn circuit_key(deployment_id: &str) -> String {
+        format!("litellm-rs:circuit:v1:{deployment_id}")
+    }
+
+    pub(crate) async fn circuit_invoke(
+        &self,
+        key: &str,
+        args: CircuitArgs<'_>,
+    ) -> Result<CircuitState> {
+        if self.noop_mode {
+            return Err(GatewayError::Storage(
+                "circuit redis backend is unavailable".to_string(),
+            ));
+        }
+
+        let _permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| GatewayError::Internal("Redis semaphore closed".to_string()))?;
+        let mut conn = connection_on_current_runtime(self).await?;
+
+        let values: Vec<i64> = circuit_script()
+            .key(key)
+            .arg(args.op)
+            .arg(args.now_secs)
+            .arg(args.window_epoch)
+            .arg(args.token)
+            .arg(args.allowed_fails)
+            .arg(args.min_requests)
+            .arg(args.cooldown_secs)
+            .arg(args.success_threshold)
+            .arg(args.reason)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(GatewayError::from)?;
+        parse_circuit_state(values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::models::storage::RedisConfig;
+
+    #[test]
+    fn parses_circuit_state() {
+        let open = parse_circuit_state(vec![1, 10, 3, 0, 4, 0]).unwrap();
+        assert!(open.blocks_selection());
+        assert_eq!(open.opened_until, 10);
+
+        let half_owned = parse_circuit_state(vec![2, 5, 3, 1, 2, 1]).unwrap();
+        assert!(!half_owned.blocks_selection());
+        assert!(half_owned.owned);
+
+        let half_foreign = parse_circuit_state(vec![2, 5, 3, 0, 2, 0]).unwrap();
+        assert!(half_foreign.blocks_selection());
+        assert!(parse_circuit_state(vec![1, 0]).is_err());
+    }
+
+    #[tokio::test]
+    async fn noop_redis_pool_fails_closed_on_circuit_observe() {
+        let pool = RedisPool::new(&RedisConfig {
+            enabled: false,
+            ..RedisConfig::default()
+        })
+        .await
+        .expect("disabled Redis should create a no-op pool");
+
+        let err = pool
+            .circuit_invoke(
+                "litellm-rs:circuit:v1:noop-test",
+                CircuitArgs {
+                    op: "observe",
+                    now_secs: 1,
+                    window_epoch: 0,
+                    token: "tok",
+                    allowed_fails: 3,
+                    min_requests: 1,
+                    cooldown_secs: 5,
+                    success_threshold: 1,
+                    reason: 0,
+                },
+            )
+            .await
+            .expect_err("no-op Redis must not fail-open circuit observe");
+        assert!(err.to_string().contains("unavailable"));
+    }
+}

--- a/src/storage/redis/circuit.rs
+++ b/src/storage/redis/circuit.rs
@@ -27,15 +27,29 @@ local function load_state()
   local h = tonumber(redis.call('HGET', KEYS[1], 'h') or '1') or 1
   local owner = redis.call('HGET', KEYS[1], 'owner')
   if not owner then owner = '' end
-  return f, r, tot, fail, opened, consec, e, h, owner
+  local own_until = tonumber(redis.call('HGET', KEYS[1], 'own_until') or '0') or 0
+  return f, r, tot, fail, opened, consec, e, h, owner, own_until
 end
 
-local function save(f, r, tot, fail, opened, consec, e, h, owner)
+local function save(f, r, tot, fail, opened, consec, e, h, owner, own_until)
   redis.call('HSET', KEYS[1], 'f', f, 'r', r, 'tot', tot, 'fail', fail,
-    'opened', opened, 'consec', consec, 'e', e, 'h', h, 'owner', owner)
+    'opened', opened, 'consec', consec, 'e', e, 'h', h, 'owner', owner,
+    'own_until', own_until)
 end
 
-local f, r, tot, fail, opened, consec, e, h, owner = load_state()
+local f, r, tot, fail, opened, consec, e, h, owner, own_until = load_state()
+local function claim_owner()
+  if owner == '' or own_until <= now then
+    owner = token
+    own_until = now + cooldown
+    if own_until < now + 1 then own_until = now + 1 end
+    h = 2
+  end
+end
+local function clear_owner()
+  owner = ''
+  own_until = 0
+end
 if e ~= epoch then
   f = 0
   r = 0
@@ -51,7 +65,7 @@ if op == 'fail' then
     h = 4
   elseif opened > 0 then
     opened = now + cooldown
-    owner = ''
+    clear_owner()
     h = 4
   else
     local trip = 0
@@ -64,7 +78,7 @@ if op == 'fail' then
     end
     if trip == 1 then
       opened = now + cooldown
-      owner = ''
+      clear_owner()
       h = 4
     elseif h == 1 or h == 0 then
       h = 2
@@ -77,14 +91,13 @@ elseif op == 'ok' then
   if opened > now then
     h = 4
   elseif opened > 0 then
-    if owner == token or owner == '' then
+    if owner == token or owner == '' or own_until <= now then
       if consec >= success_th then
         opened = 0
-        owner = ''
+        clear_owner()
         h = 1
       else
-        h = 2
-        if owner == '' then owner = token end
+        claim_owner()
       end
     end
   elseif h == 2 and consec >= success_th then
@@ -99,15 +112,12 @@ if opened > now then
   owned = 0
 elseif opened > 0 then
   status = 2
-  if owner == '' then
-    owner = token
-    h = 2
-  end
+  claim_owner()
   if owner == token then owned = 1 else owned = 0 end
 end
 
 if op ~= 'observe' or opened > 0 then
-  save(f, r, tot, fail, opened, consec, e, h, owner)
+  save(f, r, tot, fail, opened, consec, e, h, owner, own_until)
 end
 return {status, opened, f, consec, h, owned}
 "#;

--- a/src/storage/redis/circuit.rs
+++ b/src/storage/redis/circuit.rs
@@ -40,6 +40,7 @@ end
 local f, r, tot, fail, opened, consec, e, h, owner, own_until = load_state()
 local function claim_owner()
   if owner == '' or own_until <= now then
+    consec = 0
     owner = token
     own_until = now + cooldown
     if own_until < now + 1 then own_until = now + 1 end
@@ -87,11 +88,13 @@ if op == 'fail' then
 elseif op == 'ok' then
   tot = tot + 1
   r = r + 1
-  consec = consec + 1
+  if opened == 0 or (owner == token and own_until > now) then
+    consec = consec + 1
+  end
   if opened > now then
     h = 4
   elseif opened > 0 then
-    if owner == token or owner == '' or own_until <= now then
+    if owner == token and own_until > now then
       if consec >= success_th then
         opened = 0
         clear_owner()
@@ -158,23 +161,23 @@ fn circuit_script() -> &'static redis::Script {
     SCRIPT.get_or_init(|| redis::Script::new(CIRCUIT_SCRIPT))
 }
 
-fn circuit_runtime_connections() -> &'static tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>
+fn circuit_runtime_connections() -> &'static parking_lot::Mutex<HashMap<String, RedisLiveConnection>>
 {
-    static CACHE: OnceLock<tokio::sync::Mutex<HashMap<String, RedisLiveConnection>>> =
+    static CACHE: OnceLock<parking_lot::Mutex<HashMap<String, RedisLiveConnection>>> =
         OnceLock::new();
-    CACHE.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+    CACHE.get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
 }
 
 async fn connection_on_current_runtime(pool: &RedisPool) -> Result<RedisLiveConnection> {
     let cache_key = format!("{}|{}", pool.config.url, pool.config.cluster);
     {
-        let cache = circuit_runtime_connections().lock().await;
+        let cache = circuit_runtime_connections().lock();
         if let Some(conn) = cache.get(&cache_key) {
             return Ok(conn.clone());
         }
     }
     let conn = pool.open_live_connection().await?;
-    let mut cache = circuit_runtime_connections().lock().await;
+    let mut cache = circuit_runtime_connections().lock();
     Ok(cache.entry(cache_key).or_insert(conn).clone())
 }
 
@@ -241,6 +244,83 @@ impl RedisPool {
 mod tests {
     use super::*;
     use crate::config::models::storage::RedisConfig;
+
+    #[tokio::test]
+    async fn expired_probe_owner_cannot_supply_recovery_successes() {
+        let Ok(url) = std::env::var("REDIS_URL") else {
+            assert!(std::env::var("CI").is_err(), "REDIS_URL is required in CI");
+            return;
+        };
+        let pool = RedisPool::new(&RedisConfig {
+            url,
+            enabled: true,
+            allow_degraded: false,
+            ..RedisConfig::default()
+        })
+        .await
+        .unwrap();
+        let key = RedisPool::circuit_key(&uuid::Uuid::new_v4().to_string());
+        async fn invoke(
+            pool: &RedisPool,
+            key: &str,
+            op: &str,
+            now: i64,
+            token: &str,
+        ) -> CircuitState {
+            // This test owns a short-lived runtime; do not populate the
+            // production bridge's process-lifetime connection cache.
+            let mut conn = pool.open_live_connection().await.unwrap();
+            let values = circuit_script()
+                .key(key)
+                .arg(op)
+                .arg(now)
+                .arg(0)
+                .arg(token)
+                .arg(1)
+                .arg(1)
+                .arg(10)
+                .arg(2)
+                .arg(1)
+                .invoke_async(&mut conn)
+                .await
+                .unwrap();
+            parse_circuit_state(values).unwrap()
+        }
+        assert!(
+            invoke(&pool, &key, "fail", 100, "a")
+                .await
+                .blocks_selection()
+        );
+        assert!(
+            !invoke(&pool, &key, "observe", 110, "a")
+                .await
+                .blocks_selection()
+        );
+        assert!(
+            invoke(&pool, &key, "observe", 119, "b")
+                .await
+                .blocks_selection()
+        );
+        assert!(
+            !invoke(&pool, &key, "observe", 120, "b")
+                .await
+                .blocks_selection()
+        );
+        invoke(&pool, &key, "ok", 121, "a").await;
+        let first = invoke(&pool, &key, "ok", 122, "b").await;
+        assert_eq!(
+            first.status, STATUS_HALF,
+            "expired owner's late success must not close the circuit"
+        );
+        assert_eq!(first.consecutive_successes, 1);
+        assert!(
+            invoke(&pool, &key, "observe", 122, "a")
+                .await
+                .blocks_selection()
+        );
+        assert_eq!(invoke(&pool, &key, "ok", 123, "b").await.status, 0);
+        pool.delete(&key).await.unwrap();
+    }
 
     #[test]
     fn parses_circuit_state() {

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -13,6 +13,7 @@
 //! - `atomic` - Atomic operations and utilities
 //! - `budget` - Cluster-safe single-key Lua budget leases
 //! - `admission` - Cluster-safe single-key Lua deployment admission
+//! - `circuit` - Cluster-safe single-key Lua deployment circuit state
 //! - `tests` - Module tests
 
 #![allow(dead_code)]
@@ -23,6 +24,7 @@ mod atomic;
 mod batch;
 pub(crate) mod budget;
 mod cache;
+pub(crate) mod circuit;
 mod collections;
 mod hash;
 mod pool;


### PR DESCRIPTION
## What

Share deployment circuit-breaker cooldown across gateway replicas via a single-key Redis HASH, matching the #1331 budget and #1332 admission pattern.

Fixes #1281

## Why

Failure counters and cooldown were local, so node B kept selecting an upstream that node A had already opened.

## Changes

- Per-deployment Redis HASH (`fails` window, `opened_until`, half-open owner token, consecutive successes) with single-key Lua for Redis Cluster.
- `record_failure*` writes Redis then the local snapshot; selection observes Redis (50ms cache) so node B skips an opened circuit within a bounded interval.
- Half-open probe ownership is exclusive; success closes, failure re-opens cooldown.
- Without Redis, local atomics are unchanged.
- Backend loss is explicit: `storage.redis.allow_degraded=false` fail-closes (treat as cooldown); `true` uses the last local snapshot. Both paths `warn!`.
- Dedicated `circuit-redis-rt` multi-thread runtime — no `block_in_place` on Actix `current_thread`.
- Budget / guardrail / admission rejects still do not count as provider failures.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests --bins --features "postgres sqlite redis s3 metrics tracing websockets analytics" -- -D warnings --force-warn clippy::collapsible-if`
- [x] Two-router Redis tests: open, shared threshold, cooldown expiry, exclusive half-open, recovery, half-open reopen
- [x] Strict vs degraded backend-loss tests
- [x] `current_thread` Redis observe (Actix workers)
- [x] Existing local cooldown + admission tests still pass
- [x] Fast Test CI on 2bd0270c (successful)

## AI disclosure

Implemented with Cursor Grok 4.6. Out of scope: config broadcast (#1282) and two-gateway HA (#1283).

Made with [Cursor](https://cursor.com)

## Follow-up verification

Commit `2bd0270c` fences late successes from expired probe owners and resets consecutive successes when ownership changes. A deterministic real-Redis Lua regression covers lease reclaim and late results. The connection-cache mutex is synchronous because no guard spans await; the used OnceLock script helper remains.

Fresh local `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, and full `cargo test` passed. Two actual gateway processes with shared PostgreSQL 16 and Redis 7 proved: A upstream failure 429; B rejected with 503 without another upstream call; B recovered with 200 after cooldown. The 15-second cooldown exceeds the HTTP router retry window.
