### PR TITLE
feat(helm): package validated gateway manifests

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,34 @@
+name: Helm chart
+on:
+  pull_request:
+    paths:
+      - deployment/helm/**
+      - scripts/test/helm-chart.sh
+      - .github/workflows/helm.yml
+  push:
+    branches: [main]
+    paths:
+      - deployment/helm/**
+      - scripts/test/helm-chart.sh
+      - .github/workflows/helm.yml
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.17.3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+          cache: false
+      - run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0
+      - run: bash scripts/test/helm-chart.sh
+      - run: helm package deployment/helm/litellm-rs --destination /tmp/chart
+      - uses: actions/upload-artifact@v4
+        with:
+          name: litellm-rs-helm
+          path: /tmp/chart/*.tgz

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,7 +26,8 @@ jobs:
           go-version: '1.24.x'
           cache: false
       - run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0
-      - run: bash scripts/test/helm-chart*
+      - run: python3 -m pip install PyYAML==6.0.2
+      - run: bash scripts/test/helm-chart.sh
       - run: helm package deployment/helm/litellm-rs --destination /tmp/chart
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -3,13 +3,13 @@ on:
   pull_request:
     paths:
       - deployment/helm/**
-      - scripts/test/helm-chart.sh
+      - scripts/test/helm-chart*
       - .github/workflows/helm.yml
   push:
     branches: [main]
     paths:
       - deployment/helm/**
-      - scripts/test/helm-chart.sh
+      - scripts/test/helm-chart*
       - .github/workflows/helm.yml
 permissions:
   contents: read
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.24.x'
           cache: false
       - run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0
-      - run: bash scripts/test/helm-chart.sh
+      - run: bash scripts/test/helm-chart*
       - run: helm package deployment/helm/litellm-rs --destination /tmp/chart
       - uses: actions/upload-artifact@v4
         with:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -55,6 +55,8 @@ sudo systemctl start rust-litellm-gateway
 kubectl apply -f deployment/kubernetes/
 ```
 
+For a parameterized release, use the [Helm chart](helm/litellm-rs/README.md).
+
 #### Horizontal pod autoscaling
 
 `kubernetes/hpa.yaml` targets the `apps/v1` Deployment `litellm-gateway` in

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -10,6 +10,8 @@ deployment/
 │   ├── Dockerfile          # Main Docker image
 │   ├── docker-compose.yml  # Production compose
 │   └── docker-compose.dev.yml # Development compose
+├── 📁 helm/                # Parameterized gateway chart
+│   └── litellm-rs/
 ├── 📁 kubernetes/          # Kubernetes manifests
 │   └── (K8s YAML files)
 ├── 📁 systemd/             # System service files

--- a/deployment/helm/litellm-rs/Chart.yaml
+++ b/deployment/helm/litellm-rs/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: litellm-rs
+description: Self-hosted LiteLLM Rust HTTP gateway
+type: application
+version: 0.1.0
+appVersion: "0.6.0"
+kubeVersion: ">=1.25.0-0"

--- a/deployment/helm/litellm-rs/README.md
+++ b/deployment/helm/litellm-rs/README.md
@@ -3,7 +3,10 @@
 Install the gateway using existing configuration and secret resources in the release namespace.
 The ConfigMap must contain the ordinary `gateway.yaml` file. The Secret supplies its environment
 references. Use the validated examples in `deployment/kubernetes/` as the starting point.
-Configure HTTP on 8000 and metrics on 9090, matching the container ports and health probes.
+Configure HTTP on 8000, matching the container port and health probes. `/metrics` uses
+the same HTTP listener and requires gateway authentication when enabled. Configure your
+Prometheus scraper with a gateway credential from its Secret; the chart does not advertise
+an unauthenticated annotation-based scrape or create a separate metrics listener.
 For multiple replicas, configure shared PostgreSQL and Redis; the chart does not deploy databases.
 
 ```bash
@@ -30,5 +33,5 @@ bash scripts/test/helm-chart.sh
 helm package deployment/helm/litellm-rs --destination /tmp
 ```
 
-Validation uses Helm and kubeconform with Kubernetes 1.35.0 schemas. It renders the single,
+Validation uses Python with PyYAML, Helm and kubeconform with Kubernetes 1.35.0 schemas. It renders the single,
 fixed multi-replica (including ingress/TLS), and HPA fixtures before strict schema validation.

--- a/deployment/helm/litellm-rs/README.md
+++ b/deployment/helm/litellm-rs/README.md
@@ -1,0 +1,34 @@
+# LiteLLM Rust Helm chart
+
+Install the gateway using existing configuration and secret resources in the release namespace.
+The ConfigMap must contain the ordinary `gateway.yaml` file. The Secret supplies its environment
+references. Use the validated examples in `deployment/kubernetes/` as the starting point.
+Configure HTTP on 8000 and metrics on 9090, matching the container ports and health probes.
+For multiple replicas, configure shared PostgreSQL and Redis; the chart does not deploy databases.
+
+```bash
+helm upgrade --install gateway deployment/helm/litellm-rs \
+  --namespace litellm-gateway --create-namespace \
+  --set image=registry.example.com/litellm-rs:your-promoted-tag \
+  --set configMapName=litellm-gateway-config \
+  --set secretName=litellm-gateway-secrets
+```
+
+`values.yaml` lists the supported parameters. Fixed replicas default to one. With
+`autoscaling.enabled=true`, HPA owns replicas and the Deployment omits `spec.replicas`.
+HPA requires Metrics Server and CPU/memory resource requests. PDB allows one unavailable
+pod. The ingress is opt-in and exposes only HTTP; configure its class, host and TLS Secret.
+Services and PDBs select only pods belonging to their Helm release.
+
+Configuration is maintained outside Helm; restart the deployment after changing its ConfigMap
+or environment Secret. The writable data directory is ephemeral, so use PostgreSQL for durable data.
+
+Validate and package from the repository root:
+
+```bash
+bash scripts/test/helm-chart.sh
+helm package deployment/helm/litellm-rs --destination /tmp
+```
+
+Validation uses Helm and kubeconform with Kubernetes 1.35.0 schemas. It renders the single,
+fixed multi-replica (including ingress/TLS), and HPA fixtures before strict schema validation.

--- a/deployment/helm/litellm-rs/ci/hpa.yaml
+++ b/deployment/helm/litellm-rs/ci/hpa.yaml
@@ -1,0 +1,4 @@
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10

--- a/deployment/helm/litellm-rs/ci/multi.yaml
+++ b/deployment/helm/litellm-rs/ci/multi.yaml
@@ -1,0 +1,8 @@
+replicaCount: 3
+service:
+  port: 8080
+ingress:
+  enabled: true
+  className: nginx
+  host: gateway.example.com
+  tlsSecretName: gateway-tls

--- a/deployment/helm/litellm-rs/ci/single.yaml
+++ b/deployment/helm/litellm-rs/ci/single.yaml
@@ -1,0 +1,1 @@
+replicaCount: 1

--- a/deployment/helm/litellm-rs/templates/gateway.yaml
+++ b/deployment/helm/litellm-rs/templates/gateway.yaml
@@ -1,0 +1,240 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: gateway
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+      - name: gateway
+        # Replace with the immutable image promoted by your deployment pipeline.
+        image: {{ .Values.image | quote }}
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        - name: metrics
+          containerPort: 9090
+          protocol: TCP
+        env:
+        - name: RUST_LOG
+          value: "info"
+        - name: RUST_BACKTRACE
+          value: "1"
+        envFrom:
+        - secretRef:
+            name: {{ .Values.secretName | quote }}
+        volumeMounts:
+        - name: config
+          mountPath: /app/config
+          readOnly: true
+        - name: data
+          mountPath: /app/data
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Values.configMapName | quote }}
+      - name: data
+        emptyDir: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 300
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 300
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: {{ .Chart.Name }}
+                  app.kubernetes.io/instance: {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+    prometheus.io/path: "/metrics"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+  - name: metrics
+    port: 9090
+    targetPort: metrics
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+spec:
+  # Preserve capacity for multi-replica deployments without blocking
+  # voluntary disruption when operators override the Deployment to one replica.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: gateway
+{{- if .Values.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 60
+{{- end }}
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+  - hosts:
+    - {{ required "ingress.host is required when ingress is enabled" .Values.ingress.host | quote }}
+    secretName: {{ .Values.ingress.tlsSecretName | quote }}
+  {{- end }}
+  rules:
+  - host: {{ required "ingress.host is required when ingress is enabled" .Values.ingress.host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}
+            port:
+              number: {{ .Values.service.port }}
+{{- end }}

--- a/deployment/helm/litellm-rs/templates/gateway.yaml
+++ b/deployment/helm/litellm-rs/templates/gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: gateway
 spec:
@@ -18,19 +18,15 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: gateway
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: gateway
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
-        prometheus.io/path: "/metrics"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -44,9 +40,6 @@ spec:
         ports:
         - name: http
           containerPort: 8000
-          protocol: TCP
-        - name: metrics
-          containerPort: 9090
           protocol: TCP
         env:
         - name: RUST_LOG
@@ -120,13 +113,9 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: gateway
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9090"
-    prometheus.io/path: "/metrics"
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -134,12 +123,8 @@ spec:
     port: {{ .Values.service.port }}
     targetPort: http
     protocol: TCP
-  - name: metrics
-    port: 9090
-    targetPort: metrics
-    protocol: TCP
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: gateway
 
@@ -150,7 +135,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: gateway
 spec:
@@ -159,7 +144,7 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: gateway
 {{- if .Values.autoscaling.enabled }}
@@ -170,7 +155,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: gateway
 spec:

--- a/deployment/helm/litellm-rs/values.yaml
+++ b/deployment/helm/litellm-rs/values.yaml
@@ -1,0 +1,27 @@
+image: litellm-rs:0.6.0
+replicaCount: 1
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+service:
+  type: ClusterIP
+  port: 8000
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tlsSecretName: ""
+# Existing resources in the release namespace. ConfigMap must contain gateway.yaml.
+configMapName: litellm-gateway-config
+secretName: litellm-gateway-secrets

--- a/scripts/test/helm-chart-contract.py
+++ b/scripts/test/helm-chart-contract.py
@@ -1,0 +1,39 @@
+"""Check relationships that Kubernetes per-resource schemas cannot validate."""
+import sys
+import yaml
+
+resources = list(yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")))
+by_kind = {item["kind"]: item for item in resources}
+deployment = by_kind["Deployment"]
+pod = deployment["spec"]["template"]
+labels = pod["metadata"]["labels"]
+service = by_kind["Service"]
+selectors = [
+    deployment["spec"]["selector"]["matchLabels"],
+    service["spec"]["selector"],
+    by_kind["PodDisruptionBudget"]["spec"]["selector"]["matchLabels"],
+    pod["spec"]["affinity"]["podAntiAffinity"]
+    ["preferredDuringSchedulingIgnoredDuringExecution"][0]
+    ["podAffinityTerm"]["labelSelector"]["matchLabels"],
+]
+for selector in selectors:
+    assert selector.items() <= labels.items(), (selector, labels)
+    assert "app.kubernetes.io/instance" in selector
+assert pod["spec"]["containers"][0]["ports"] == [
+    {"name": "http", "containerPort": 8000, "protocol": "TCP"}
+], "gateway exposes one actual HTTP listener"
+assert all(port["targetPort"] == "http" for port in service["spec"]["ports"])
+for metadata in [pod["metadata"], service["metadata"]]:
+    assert "prometheus.io/scrape" not in metadata.get("annotations", {})
+hpa = by_kind.get("HorizontalPodAutoscaler")
+if hpa:
+    assert "replicas" not in deployment["spec"], "HPA owns replicas"
+    assert hpa["spec"]["scaleTargetRef"]["name"] == deployment["metadata"]["name"]
+else:
+    assert deployment["spec"]["replicas"] == int(sys.argv[2])
+ingress = by_kind.get("Ingress")
+if ingress:
+    backend = ingress["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]
+    assert backend["name"] == service["metadata"]["name"]
+    assert backend["port"]["number"] == service["spec"]["ports"][0]["port"]
+print("Helm resource relationships verified")

--- a/scripts/test/helm-chart.sh
+++ b/scripts/test/helm-chart.sh
@@ -8,5 +8,8 @@ for fixture in single multi hpa; do
   helm lint --strict "$chart" -f "$chart/ci/$fixture.yaml"
   helm template gateway "$chart" --namespace litellm-gateway \
     -f "$chart/ci/$fixture.yaml" > "$output/$fixture.yaml"
+  replicas=1
+  if [[ "$fixture" == multi ]]; then replicas=3; fi
+  python3 scripts/test/helm-chart-contract.py "$output/$fixture.yaml" "$replicas"
   kubeconform -strict -summary -kubernetes-version 1.35.0 "$output/$fixture.yaml"
 done

--- a/scripts/test/helm-chart.sh
+++ b/scripts/test/helm-chart.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+chart=deployment/helm/litellm-rs
+output=$(mktemp -d)
+trap 'rm -rf "$output"' EXIT
+for fixture in single multi hpa; do
+  helm lint --strict "$chart" -f "$chart/ci/$fixture.yaml"
+  helm template gateway "$chart" --namespace litellm-gateway \
+    -f "$chart/ci/$fixture.yaml" > "$output/$fixture.yaml"
+  kubeconform -strict -summary -kubernetes-version 1.35.0 "$output/$fixture.yaml"
+done


### PR DESCRIPTION
Package the validated gateway manifests as a minimal Helm chart. Operators can select image, fixed replicas or HPA, resources, service/ingress, and existing ConfigMap/Secret references. Gateway configuration remains in the ordinary gateway.yaml format.

Fixes #1287.

Validation: three fixtures (single, fixed multi with TLS ingress, HPA) pass helm lint and strict kubeconform Kubernetes 1.35.0 validation (11 resources); helm package succeeds. Full cargo fmt --check, cargo check, cargo clippy --all-targets -- -D warnings, and cargo test passed locally. Dedicated chart CI validates and uploads the packaged chart. No live cluster deployment was performed.


Review follow-up: chart files are tracked in `1a5ed668` (the repository binary ignore matched the directory name). The directory overview now includes Helm. `set -euo pipefail` already fails missing tools and failed mktemp before the cleanup trap is registered. The actual Helm 3 CI run 34193691341 successfully packaged into /tmp/chart and uploaded the artifact, so no additional filesystem fallback is required.
