### PR TITLE
feat(cluster): broadcast configuration revision IDs

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -92,6 +92,8 @@ Validate all raw manifests without contacting a cluster using
 kubeconform -strict -summary -kubernetes-version 1.35.0 deployment/kubernetes/*.yaml
 ```
 
+For shared hot configuration across replicas, see [runtime configuration revisions](configuration-revisions/README.md).
+
 ## 📋 Prerequisites
 
 - **Rust 1.85+** for local builds

--- a/deployment/configuration-revisions/README.md
+++ b/deployment/configuration-revisions/README.md
@@ -1,0 +1,65 @@
+# Runtime configuration revisions
+
+Opt in to shared runtime configuration using the same PostgreSQL database, Redis service,
+and dedicated encryption key on every gateway replica:
+
+```yaml
+storage:
+  config_sync_key_env: LITELLM_CONFIG_SYNC_KEY
+  database:
+    enabled: true
+    url: "${DATABASE_URL}"
+    fallback_to_sqlite: false
+  redis:
+    enabled: true
+    url: "${REDIS_URL}"
+```
+
+Set `LITELLM_CONFIG_SYNC_KEY` through the deployment's Secret/environment. Generate at least
+32 random bytes (for example, `openssl rand -hex 32`), retain the key with database backups,
+and use a separate key from JWT signing or API-key hashing. Only the **environment variable
+name** belongs in the YAML. Run `gateway --config gateway.yaml database migrate` before
+starting with a database role that cannot run migrations. Missing/short keys, missing schema,
+or failure to decrypt the authoritative snapshot fail startup explicitly.
+
+The first successful runtime mutation commits revision 1 from the bootstrap configuration.
+Subsequent admin provider/routing mutations build a complete candidate before a database
+compare-and-swap commits the encrypted snapshot. Stale concurrent writers receive HTTP 409
+and must reload before retrying. Rejected candidates leave the authoritative revision unchanged.
+Each process applies its own runtime bundle atomically; a failing replica retains its previous
+bundle without rolling back replicas that applied successfully.
+
+The snapshot contains providers (including resolved credentials), router policy, aliases,
+guardrails, and response-cache settings. Listener ports, auth settings, database/Redis URLs,
+and telemetry remain node-local. Environment-backed provider credentials are captured at
+mutation time; updating the environment alone does not change a stored snapshot. To rotate
+credentials, update them through the provider API using the new environment reference.
+
+Redis channel `litellm-rs:config:revisions` carries only decimal revision IDs. It is a wake-up
+hint; the PostgreSQL row is the authority. Subscribers connect before fetching the latest
+revision, ignore old/duplicate notifications, and reconcile every second while connected.
+After a disconnect they reconnect and fetch the latest database snapshot. Global Redis
+Pub/Sub works through any reachable configured Cluster seed. A committed update whose
+notification fails returns an explicit error identifying the committed revision; do not assume
+that an error means the mutation was rolled back. Missed notifications are repaired by the
+periodic database read/reconnect. Database outages preserve the last active runtime and are
+visible in diagnostics; they never write to a local fallback store.
+
+`GET /admin/routing/revision` requires the same Admin authorization as the existing routing
+API. It returns `active_revision`, `observed_revision`, `last_apply_error`, and
+`last_sync_error`, without keys, ciphertext, provider data, or raw backend error messages.
+An observed revision ahead of the active revision with an apply error identifies a node that
+failed to apply. Do not serve that node as current until the error is repaired.
+
+The encryption key must remain stable for the lifetime of the stored snapshot; automatic key
+rotation/backfill is not implemented. Databases without an authoritative snapshot continue to
+bootstrap from their normal gateway configuration until the first mutation. Existing sanitized
+provider/routing revision records remain audit records, not a configuration restore format.
+
+## Design decision
+
+Adopt the existing AES-256-GCM helper, SeaORM, and atomic runtime builder. Use one PostgreSQL
+row with a monotonic CAS revision, not Redis as a second configuration store. Redis Pub/Sub
+is [at-most-once](https://redis.io/docs/latest/develop/pubsub/#delivery-semantics), so subscribe-
+then-read plus periodic database reconciliation is required for lost notifications. No gossip,
+new event bus, database polling options, or second gateway configuration schema is added.

--- a/deployment/configuration-revisions/README.md
+++ b/deployment/configuration-revisions/README.md
@@ -12,6 +12,7 @@ storage:
     fallback_to_sqlite: false
   redis:
     enabled: true
+    allow_degraded: false
     url: "${REDIS_URL}"
 ```
 
@@ -40,7 +41,7 @@ hint; the PostgreSQL row is the authority. Subscribers connect before fetching t
 revision, ignore old/duplicate notifications, and reconcile every second while connected.
 After a disconnect they reconnect and fetch the latest database snapshot. Global Redis
 Pub/Sub works through any reachable configured Cluster seed. A committed update whose
-notification fails returns an explicit error identifying the committed revision; do not assume
+notification fails still records the sanitized revision/audit event, then returns an explicit error identifying the committed revision; do not assume
 that an error means the mutation was rolled back. Missed notifications are repaired by the
 periodic database read/reconnect. Database outages preserve the last active runtime and are
 visible in diagnostics; they never write to a local fallback store.

--- a/docs/openapi/admin.json
+++ b/docs/openapi/admin.json
@@ -319,6 +319,31 @@
         }
       }
     },
+    "/admin/routing/revision": {
+      "get": {
+        "operationId": "getRuntimeRevision",
+        "summary": "Inspect this node's active configuration revision",
+        "description": "Requires Admin role. Returns sanitized apply/synchronization diagnostics; no configuration payload or secret values.",
+        "tags": ["Routing"],
+        "responses": {
+          "200": {
+            "description": "Node-local revision status",
+            "content": { "application/json": { "schema": {
+              "type": "object",
+              "required": ["active_revision", "observed_revision", "last_apply_error", "last_sync_error"],
+              "properties": {
+                "active_revision": { "type": "integer", "minimum": 0 },
+                "observed_revision": { "type": "integer", "minimum": 0 },
+                "last_apply_error": { "type": ["string", "null"] },
+                "last_sync_error": { "type": ["string", "null"] }
+              }
+            } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
     "/admin/routing/inventory": {
       "get": {
         "operationId": "getAdminRoutingInventory",

--- a/src/config/models/storage.rs
+++ b/src/config/models/storage.rs
@@ -15,6 +15,10 @@ pub use redis_config::RedisConfig;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct StorageConfig {
+    /// Environment variable containing a dedicated (at least 32-byte) encryption key.
+    /// Setting this enables authoritative PostgreSQL runtime revisions and Redis notifications.
+    #[serde(default)]
+    pub config_sync_key_env: Option<String>,
     /// Database configuration
     pub database: DatabaseConfig,
     /// Redis configuration
@@ -42,6 +46,9 @@ impl StorageConfig {
         other: Self,
         redis_cluster: Option<bool>,
     ) -> Self {
+        if other.config_sync_key_env.is_some() {
+            self.config_sync_key_env = other.config_sync_key_env;
+        }
         self.database = self.database.merge(other.database);
         self.redis = self
             .redis
@@ -604,6 +611,7 @@ mod tests {
     #[test]
     fn test_storage_config_structure() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig::default(),
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
@@ -645,6 +653,7 @@ mod tests {
     fn test_storage_config_merge() {
         let base = StorageConfig::default();
         let other = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig {
                 url: "postgresql://new/db".to_string(),
                 connection_timeout: 30,
@@ -712,6 +721,7 @@ mod tests {
     fn test_storage_config_merge_files() {
         let base = StorageConfig::default();
         let other = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig::default(),
             redis: RedisConfig::default(),
             files: FileStorageConfig {

--- a/src/config/validation/storage_tests.rs
+++ b/src/config/validation/storage_tests.rs
@@ -189,3 +189,22 @@ fn redis_validation_accepts_standalone_when_enabled() {
     };
     assert!(Validate::validate(&config).is_ok());
 }
+
+#[test]
+fn configuration_sync_rejects_permanent_redis_degradation() {
+    let mut config = crate::config::models::storage::StorageConfig {
+        config_sync_key_env: Some("TEST_SYNC_KEY".into()),
+        ..Default::default()
+    };
+    config.database.enabled = true;
+    config.database.url = "postgresql://localhost/litellm".into();
+    config.database.fallback_to_sqlite = false;
+    config.redis.enabled = true;
+    config.redis.allow_degraded = true;
+    assert!(
+        config
+            .validate()
+            .unwrap_err()
+            .contains("without degraded mode")
+    );
+}

--- a/src/config/validation/storage_tests.rs
+++ b/src/config/validation/storage_tests.rs
@@ -83,6 +83,7 @@ fn database_validation_rejects_sqlite_dependent_runtime_modes() {
     assert!(error.to_string().contains("enabled=false"), "got: {error}");
     assert!(error.contains("`sqlite` feature"), "got: {error}");
     let storage = StorageConfig {
+        config_sync_key_env: None,
         database: disabled,
         ..StorageConfig::default()
     };

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -12,6 +12,15 @@ impl Validate for StorageConfig {
     fn validate(&self) -> Result<(), String> {
         debug!("Validating storage configuration");
 
+        if let Some(key_env) = &self.config_sync_key_env
+            && (key_env.trim().is_empty()
+                || !self.database.enabled
+                || !self.redis.enabled
+                || !self.database.url.starts_with("postgres")
+                || self.database.fallback_to_sqlite)
+        {
+            return Err("config_sync_key_env requires a nonempty env name, PostgreSQL without SQLite fallback, and enabled Redis".into());
+        }
         self.database.validate()?;
         if self.redis.enabled {
             self.redis.validate()?;

--- a/src/config/validation/storage_validators.rs
+++ b/src/config/validation/storage_validators.rs
@@ -16,10 +16,11 @@ impl Validate for StorageConfig {
             && (key_env.trim().is_empty()
                 || !self.database.enabled
                 || !self.redis.enabled
+                || self.redis.allow_degraded
                 || !self.database.url.starts_with("postgres")
                 || self.database.fallback_to_sqlite)
         {
-            return Err("config_sync_key_env requires a nonempty env name, PostgreSQL without SQLite fallback, and enabled Redis".into());
+            return Err("config_sync_key_env requires a nonempty env name, PostgreSQL without SQLite fallback, and enabled Redis without degraded mode".into());
         }
         self.database.validate()?;
         if self.redis.enabled {

--- a/src/server/config_sync.rs
+++ b/src/server/config_sync.rs
@@ -1,0 +1,223 @@
+//! Authoritative encrypted runtime snapshots. Redis carries only revision IDs.
+use super::{runtime::build_runtime_revision, state::AppState};
+use crate::config::{
+    Config,
+    models::{cache::CacheConfig, provider::ProviderConfig, router::GatewayRouterConfig},
+};
+use crate::core::guardrails::GuardrailConfig;
+use crate::utils::{
+    auth::crypto::encryption::{decrypt_data, encrypt_data},
+    error::gateway_error::{GatewayError, Result},
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+pub(crate) const REVISION_CHANNEL: &str = "litellm-rs:config:revisions";
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Public diagnostics contain no configuration values or backend error bodies.
+#[derive(Clone, Default, Serialize)]
+pub struct ConfigSyncStatus {
+    /// Revision currently serving requests on this node.
+    pub active_revision: u64,
+    /// Most recent authoritative revision read by this node.
+    pub observed_revision: u64,
+    /// Failed apply stage, kept until an authoritative snapshot applies successfully.
+    pub last_apply_error: Option<String>,
+    /// Failed storage/notification stage, cleared on successful synchronization.
+    pub last_sync_error: Option<String>,
+}
+
+pub(crate) struct ConfigSync {
+    key: Vec<u8>,
+    pub(crate) status: parking_lot::RwLock<ConfigSyncStatus>,
+}
+
+// Node-local listener/auth/storage/telemetry settings are deliberately excluded.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredRuntime {
+    revision: u64,
+    providers: Vec<ProviderConfig>,
+    router: GatewayRouterConfig,
+    model_aliases: HashMap<String, String>,
+    guardrails: GuardrailConfig,
+    cache: CacheConfig,
+}
+
+impl ConfigSync {
+    pub(crate) fn from_config(config: &Config) -> Result<Option<Arc<Self>>> {
+        let Some(env_name) = &config.gateway.storage.config_sync_key_env else {
+            return Ok(None);
+        };
+        let key = std::env::var(env_name).map_err(|_| {
+            GatewayError::Config(
+                "Configuration sync encryption key environment variable is missing".into(),
+            )
+        })?;
+        if key.len() < 32 {
+            return Err(GatewayError::Config(
+                "Configuration sync requires a dedicated encryption key of at least 32 bytes"
+                    .into(),
+            ));
+        }
+        Ok(Some(Arc::new(Self {
+            key: key.into_bytes(),
+            status: Default::default(),
+        })))
+    }
+
+    pub(crate) fn encrypt(&self, config: &Config, revision: u64) -> Result<String> {
+        let payload = StoredRuntime {
+            revision,
+            providers: config.gateway.providers.clone(),
+            router: config.gateway.router.clone(),
+            model_aliases: config.gateway.model_aliases.clone(),
+            guardrails: config.gateway.guardrails.clone(),
+            cache: config.gateway.cache.clone(),
+        };
+        let json = serde_json::to_string(&payload)
+            .map_err(|_| GatewayError::Config("Runtime snapshot serialization failed".into()))?;
+        encrypt_data(&self.key, &json)
+    }
+
+    fn candidate(&self, base: &Config, revision: u64, ciphertext: &str) -> Result<Config> {
+        let json = decrypt_data(&self.key, ciphertext).map_err(|_| {
+            GatewayError::Config(
+                "Runtime snapshot decryption failed; check the shared encryption key".into(),
+            )
+        })?;
+        let payload: StoredRuntime = serde_json::from_str(&json)
+            .map_err(|_| GatewayError::Config("Runtime snapshot decoding failed".into()))?;
+        if payload.revision != revision {
+            return Err(GatewayError::Config(
+                "Runtime snapshot revision does not match its authenticated payload".into(),
+            ));
+        }
+        let mut candidate = base.clone();
+        candidate.gateway.providers = payload.providers;
+        candidate.gateway.router = payload.router;
+        candidate.gateway.model_aliases = payload.model_aliases;
+        candidate.gateway.guardrails = payload.guardrails;
+        candidate.gateway.cache = payload.cache;
+        Ok(candidate)
+    }
+}
+
+impl AppState {
+    /// Current node's revision and sanitized synchronization diagnostics.
+    pub fn config_sync_status(&self) -> ConfigSyncStatus {
+        let mut status = self
+            .config_sync
+            .as_ref()
+            .map(|sync| sync.status.read().clone())
+            .unwrap_or_default();
+        status.active_revision = self.pin_runtime().generation;
+        status
+    }
+
+    pub(crate) async fn reconcile_runtime_config(&self) -> Result<()> {
+        let Some(sync) = &self.config_sync else {
+            return Ok(());
+        };
+        let _guard = self.apply_lock.lock().await;
+        let row = self.storage.database.runtime_config().await.map_err(|_| {
+            sync.status.write().last_sync_error =
+                Some("Authoritative configuration read failed".into());
+            GatewayError::Storage("Authoritative configuration read failed".into())
+        })?;
+        let revision = u64::try_from(row.revision).map_err(|_| {
+            GatewayError::Storage("Invalid authoritative configuration revision".into())
+        })?;
+        sync.status.write().observed_revision = revision;
+        if revision <= self.pin_runtime().generation {
+            return Ok(());
+        }
+        let apply = async {
+            let ciphertext = row.encrypted_payload.as_deref().ok_or_else(|| {
+                GatewayError::Storage("Authoritative configuration payload is missing".into())
+            })?;
+            let candidate = sync.candidate(&self.config(), revision, ciphertext)?;
+            let built = build_runtime_revision(
+                candidate,
+                revision,
+                self.pricing.clone(),
+                self.storage.redis.clone(),
+            )
+            .await
+            .map_err(|_| {
+                GatewayError::Config("Authoritative runtime validation/build failed".into())
+            })?;
+            self.publish_runtime(built);
+            Ok::<_, GatewayError>(())
+        }
+        .await;
+        let mut status = sync.status.write();
+        match apply {
+            Ok(()) => {
+                status.last_apply_error = None;
+                Ok(())
+            }
+            Err(error) => {
+                status.last_apply_error = Some(error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    async fn observe_revision(&self, message: redis::Msg) -> Result<()> {
+        let revision = message.get_payload::<u64>().map_err(|_| {
+            GatewayError::Storage("Invalid configuration revision notification".into())
+        })?;
+        if revision > self.pin_runtime().generation {
+            self.reconcile_runtime_config().await?;
+        }
+        Ok(())
+    }
+}
+
+/// Owns the subscriber so dropping/stopping a server also stops its worker.
+pub(super) struct ConfigSyncTask(tokio::task::JoinHandle<()>);
+impl Drop for ConfigSyncTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+pub(super) fn start(state: AppState) -> Option<ConfigSyncTask> {
+    let sync = state.config_sync.clone()?;
+    Some(ConfigSyncTask(tokio::spawn(async move {
+        loop {
+            let result: Result<()> = async {
+                let mut subscription = state
+                    .storage
+                    .redis
+                    .subscribe(&[REVISION_CHANNEL.to_string()])
+                    .await?;
+                // Subscribe before loading, closing the reconnect read/subscribe race.
+                state.reconcile_runtime_config().await?;
+                loop {
+                    match tokio::time::timeout(RECONCILE_INTERVAL, subscription.next_message())
+                        .await
+                    {
+                        Ok(Ok(message)) => state.observe_revision(message).await?,
+                        Ok(Err(error)) => return Err(error),
+                        Err(_) => state.reconcile_runtime_config().await?,
+                    }
+                    sync.status.write().last_sync_error = None;
+                }
+            }
+            .await;
+            if let Err(error) = result {
+                sync.status.write().last_sync_error =
+                    Some("Configuration synchronization failed; retrying".into());
+                tracing::error!(error = %error, "Configuration synchronization failed");
+            }
+            tokio::time::sleep(RECONCILE_INTERVAL).await;
+        }
+    })))
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+#[path = "config_sync_tests.rs"]
+mod tests;

--- a/src/server/config_sync.rs
+++ b/src/server/config_sync.rs
@@ -209,8 +209,7 @@ pub(super) fn start(state: AppState) -> Option<ConfigSyncTask> {
             }
             .await;
             if let Err(error) = result {
-                sync.status.write().last_sync_error =
-                    Some("Configuration synchronization failed; retrying".into());
+                sync.status.write().last_sync_error = Some(error.to_string());
                 tracing::error!(error = %error, "Configuration synchronization failed");
             }
             tokio::time::sleep(RECONCILE_INTERVAL).await;

--- a/src/server/config_sync_tests.rs
+++ b/src/server/config_sync_tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+use crate::server::HttpServer;
+
+fn sync(key: u8) -> Arc<ConfigSync> {
+    Arc::new(ConfigSync {
+        key: vec![key; 32],
+        status: Default::default(),
+    })
+}
+
+async fn state() -> AppState {
+    let mut config = crate::server::valid_test_config();
+    config.gateway.storage.database.enabled = false;
+    config.gateway.storage.redis.enabled = false;
+    config.gateway.pricing.source = None;
+    config.gateway.auth.enable_jwt = false;
+    config.gateway.auth.enable_api_key = false;
+    config.gateway.auth.allow_anonymous = true;
+    let server = HttpServer::new(&config).await.unwrap();
+    let mut state = server.state().clone();
+    state.config_sync = Some(sync(7));
+    state
+}
+
+#[test]
+fn snapshot_is_authenticated_and_excludes_node_local_settings() {
+    let mut config = crate::server::valid_test_config();
+    config.gateway.providers[0].api_key = "secret-provider-sentinel".into();
+    let crypt = sync(7);
+    let ciphertext = crypt.encrypt(&config, 4).unwrap();
+    assert!(!ciphertext.contains("secret-provider-sentinel"));
+    let json = decrypt_data(&crypt.key, &ciphertext).unwrap();
+    assert!(json.contains("secret-provider-sentinel"));
+    assert!(!json.contains("jwt_secret"));
+    assert!(!json.contains("database"));
+    let mut other = config.clone();
+    other.gateway.server.port = 8123;
+    let restored = crypt.candidate(&other, 4, &ciphertext).unwrap();
+    assert_eq!(restored.gateway.server.port, 8123);
+    assert_eq!(
+        restored.gateway.providers[0].api_key,
+        "secret-provider-sentinel"
+    );
+    assert!(crypt.candidate(&other, 5, &ciphertext).is_err());
+    assert!(sync(9).candidate(&other, 4, &ciphertext).is_err());
+}
+
+#[tokio::test]
+async fn two_nodes_converge_and_duplicates_do_not_rebuild() {
+    let a = state().await;
+    let mut b = state().await;
+    b.storage = a.storage.clone();
+    let mut candidate = (*a.config()).clone();
+    candidate.gateway.providers[0].weight = 7.0;
+    // Disabled Redis makes notification fail after the durable commit.
+    assert!(a.apply_runtime_at(candidate, 0).await.is_err());
+    assert_eq!(a.pin_runtime().generation, 1);
+    assert!(a.config_sync_status().last_sync_error.is_some());
+    b.reconcile_runtime_config().await.unwrap();
+    assert_eq!(b.pin_runtime().generation, 1);
+    assert_eq!(b.config().gateway.providers[0].weight, 7.0);
+    let pin = b.pin_runtime();
+    b.reconcile_runtime_config().await.unwrap();
+    assert!(Arc::ptr_eq(&pin, &b.pin_runtime()));
+    assert!(matches!(
+        b.apply_runtime_at((*b.config()).clone(), 0).await,
+        Err(GatewayError::Conflict(_))
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_database_writers_cannot_overwrite_a_new_revision() {
+    let a = state().await;
+    let mut b = state().await;
+    b.storage = a.storage.clone();
+    let mut first = (*a.config()).clone();
+    first.gateway.providers[0].weight = 3.0;
+    let mut second = (*b.config()).clone();
+    second.gateway.providers[0].weight = 8.0;
+    let (left, right) = tokio::join!(a.apply_runtime_at(first, 0), b.apply_runtime_at(second, 0));
+    assert_eq!(
+        [left, right]
+            .iter()
+            .filter(|r| matches!(r, Err(GatewayError::Conflict(_))))
+            .count(),
+        1
+    );
+    a.reconcile_runtime_config().await.unwrap();
+    b.reconcile_runtime_config().await.unwrap();
+    assert_eq!(a.pin_runtime().generation, 1);
+    assert_eq!(b.pin_runtime().generation, 1);
+    assert_eq!(
+        a.config().gateway.providers[0].weight,
+        b.config().gateway.providers[0].weight
+    );
+}
+
+#[tokio::test]
+async fn one_nodes_decryption_failure_keeps_healthy_nodes_active_and_is_visible() {
+    let a = state().await;
+    let mut b = state().await;
+    b.storage = a.storage.clone();
+    b.config_sync = Some(sync(9));
+    let before = b.pin_runtime();
+    assert!(a.apply_runtime_at((*a.config()).clone(), 0).await.is_err());
+    assert!(b.reconcile_runtime_config().await.is_err());
+    assert!(Arc::ptr_eq(&before, &b.pin_runtime()));
+    assert_eq!(a.pin_runtime().generation, 1);
+    let status = b.config_sync_status();
+    assert_eq!(status.observed_revision, 1);
+    assert!(
+        status
+            .last_apply_error
+            .unwrap()
+            .contains("decryption failed")
+    );
+    b.config_sync = Some(sync(7));
+    b.reconcile_runtime_config().await.unwrap();
+    assert_eq!(b.pin_runtime().generation, 1);
+    assert!(b.config_sync_status().last_apply_error.is_none());
+}
+
+#[tokio::test]
+async fn invalid_candidate_never_changes_authoritative_revision() {
+    let state = state().await;
+    let mut candidate = (*state.config()).clone();
+    candidate.gateway.providers[0].weight = -1.0;
+    assert!(state.apply_runtime_at(candidate, 0).await.is_err());
+    assert_eq!(
+        state
+            .storage
+            .database
+            .runtime_config()
+            .await
+            .unwrap()
+            .revision,
+        0
+    );
+    assert_eq!(state.pin_runtime().generation, 0);
+    assert!(state.config_sync_status().last_apply_error.is_some());
+}
+
+#[tokio::test]
+async fn revision_diagnostics_require_authentication_and_never_return_ciphertext() {
+    use actix_web::{http::StatusCode, test, web};
+    let state = state().await;
+    let app = test::init_service(HttpServer::create_app(web::Data::new(state.clone()))).await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/admin/routing/revision")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(body["active_revision"], 0);
+    assert!(body.get("encrypted_payload").is_none());
+    let mut config = (*state.config()).clone();
+    config.gateway.auth.enable_api_key = true;
+    state.config.store(config);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/admin/routing/revision")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn redis_broadcasts_only_ids_and_reconnect_reads_latest() {
+    let Ok(url) = std::env::var("REDIS_URL") else {
+        assert!(std::env::var("CI").is_err(), "REDIS_URL is required in CI");
+        return;
+    };
+    let mut a = state().await;
+    let mut storage = (*a.storage).clone();
+    storage.redis = Arc::new(
+        crate::storage::redis::RedisPool::new(&crate::config::models::storage::RedisConfig {
+            url,
+            enabled: true,
+            allow_degraded: false,
+            ..Default::default()
+        })
+        .await
+        .unwrap(),
+    );
+    a.storage = Arc::new(storage);
+    let mut b = state().await;
+    b.storage = a.storage.clone();
+    let mut capture = a
+        .storage
+        .redis
+        .subscribe(&[REVISION_CHANNEL.into()])
+        .await
+        .unwrap();
+    a.apply_runtime_at((*a.config()).clone(), 0).await.unwrap();
+    let message = tokio::time::timeout(Duration::from_secs(3), capture.next_message())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(message.get_payload::<String>().unwrap(), "1");
+    let task = start(b.clone()).unwrap();
+    async fn reached(state: &AppState, revision: u64) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while state.pin_runtime().generation != revision {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("node must converge");
+    }
+    reached(&b, 1).await;
+    drop(task); // Lose notifications while disconnected.
+    a.apply_runtime_at((*a.config()).clone(), 1).await.unwrap();
+    a.apply_runtime_at((*a.config()).clone(), 2).await.unwrap();
+    let _task = start(b.clone()).unwrap();
+    reached(&b, 3).await;
+    let pin = b.pin_runtime();
+    a.storage
+        .redis
+        .publish(REVISION_CHANNEL, "3")
+        .await
+        .unwrap();
+    a.storage
+        .redis
+        .publish(REVISION_CHANNEL, "1")
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        Arc::ptr_eq(&pin, &b.pin_runtime()),
+        "duplicate/out-of-order events must not rebuild"
+    );
+    capture.unsubscribe_all().await.unwrap();
+}

--- a/src/server/config_sync_tests.rs
+++ b/src/server/config_sync_tests.rs
@@ -53,7 +53,7 @@ async fn two_nodes_converge_and_duplicates_do_not_rebuild() {
     let mut candidate = (*a.config()).clone();
     candidate.gateway.providers[0].weight = 7.0;
     // Disabled Redis makes notification fail after the durable commit.
-    assert!(a.apply_runtime_at(candidate, 0).await.is_err());
+    assert!(a.apply_runtime(candidate).await.is_err());
     assert_eq!(a.pin_runtime().generation, 1);
     assert!(a.config_sync_status().last_sync_error.is_some());
     b.reconcile_runtime_config().await.unwrap();
@@ -77,7 +77,7 @@ async fn concurrent_database_writers_cannot_overwrite_a_new_revision() {
     first.gateway.providers[0].weight = 3.0;
     let mut second = (*b.config()).clone();
     second.gateway.providers[0].weight = 8.0;
-    let (left, right) = tokio::join!(a.apply_runtime_at(first, 0), b.apply_runtime_at(second, 0));
+    let (left, right) = tokio::join!(a.apply_runtime(first), b.apply_runtime(second));
     assert_eq!(
         [left, right]
             .iter()
@@ -102,7 +102,7 @@ async fn one_nodes_decryption_failure_keeps_healthy_nodes_active_and_is_visible(
     b.storage = a.storage.clone();
     b.config_sync = Some(sync(9));
     let before = b.pin_runtime();
-    assert!(a.apply_runtime_at((*a.config()).clone(), 0).await.is_err());
+    assert!(a.apply_runtime((*a.config()).clone()).await.is_err());
     assert!(b.reconcile_runtime_config().await.is_err());
     assert!(Arc::ptr_eq(&before, &b.pin_runtime()));
     assert_eq!(a.pin_runtime().generation, 1);
@@ -196,7 +196,7 @@ async fn redis_broadcasts_only_ids_and_reconnect_reads_latest() {
         .subscribe(&[REVISION_CHANNEL.into()])
         .await
         .unwrap();
-    a.apply_runtime_at((*a.config()).clone(), 0).await.unwrap();
+    a.apply_runtime((*a.config()).clone()).await.unwrap();
     let message = tokio::time::timeout(Duration::from_secs(3), capture.next_message())
         .await
         .unwrap()
@@ -214,8 +214,8 @@ async fn redis_broadcasts_only_ids_and_reconnect_reads_latest() {
     }
     reached(&b, 1).await;
     drop(task); // Lose notifications while disconnected.
-    a.apply_runtime_at((*a.config()).clone(), 1).await.unwrap();
-    a.apply_runtime_at((*a.config()).clone(), 2).await.unwrap();
+    a.apply_runtime((*a.config()).clone()).await.unwrap();
+    a.apply_runtime((*a.config()).clone()).await.unwrap();
     let _task = start(b.clone()).unwrap();
     reached(&b, 3).await;
     let pin = b.pin_runtime();
@@ -235,4 +235,65 @@ async fn redis_broadcasts_only_ids_and_reconnect_reads_latest() {
         "duplicate/out-of-order events must not rebuild"
     );
     capture.unsubscribe_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn notification_failure_preserves_committed_admin_revision_records() {
+    use actix_web::{http::StatusCode, test, web};
+    let state = state().await;
+    let provider = state.config().gateway.providers[0].name.clone();
+    let app = test::init_service(HttpServer::create_app(web::Data::new(state.clone()))).await;
+    for (path, body, method) in [
+        (
+            format!("/admin/providers/{provider}"),
+            serde_json::json!({"weight": 2}),
+            "PATCH",
+        ),
+        (
+            "/admin/routing/policy".into(),
+            serde_json::json!({"model_aliases": {}}),
+            "PUT",
+        ),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::default()
+                .method(method.parse().unwrap())
+                .uri(&path)
+                .set_json(body)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(response).await;
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("committed and applied")
+        );
+    }
+    assert_eq!(state.pin_runtime().generation, 2);
+    assert_eq!(
+        state
+            .storage
+            .database
+            .latest_provider_config_revision()
+            .await
+            .unwrap()
+            .unwrap()
+            .generation,
+        1
+    );
+    assert_eq!(
+        state
+            .storage
+            .database
+            .latest_routing_policy_revision()
+            .await
+            .unwrap()
+            .unwrap()
+            .generation,
+        2
+    );
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -39,6 +39,7 @@ pub struct HttpServer {
     tls: Option<crate::server::tls::ListenerTls>,
     /// Background worker that drains budget persistence events on shutdown.
     budget_persistence_task: Option<JoinHandle<()>>,
+    config_sync_task: Option<super::config_sync::ConfigSyncTask>,
     /// Background worker that delivers configured callback events.
     callback_runtime: CallbackRuntime,
 }
@@ -129,16 +130,21 @@ impl HttpServer {
             IpAccessControl::shared(config.gateway.ip_access.clone()).map_err(|error| {
                 GatewayError::Config(format!("Invalid IP access configuration: {error}"))
             })?;
-        let state = AppState::new_with_runtime(revision, auth, storage, pricing, budget_limits)
+        let mut state = AppState::new_with_runtime(revision, auth, storage, pricing, budget_limits)
             .with_callbacks(callback_runtime.dispatcher())
             .with_audit_logger(audit_logger)
             .with_request_policies(guardrails, ip_access);
+
+        state.config_sync = super::config_sync::ConfigSync::from_config(config)?;
+        state.reconcile_runtime_config().await?;
+        let config_sync_task = super::config_sync::start(state.clone());
 
         Ok(Self {
             config: config.gateway.server.clone(),
             state,
             tls,
             budget_persistence_task,
+            config_sync_task,
             callback_runtime,
         })
     }
@@ -316,6 +322,7 @@ impl HttpServer {
         let bind_addr = format!("{}:{}", self.config.host, self.config.port);
         let port = self.config.port;
         let budget_persistence_task = self.budget_persistence_task.take();
+        let config_sync_task = self.config_sync_task.take();
         let callback_runtime =
             std::mem::replace(&mut self.callback_runtime, CallbackRuntime::disabled());
 
@@ -420,6 +427,7 @@ impl HttpServer {
         info!("Draining audit worker");
         let audit_shutdown = audit_logger.shutdown().await;
 
+        drop(config_sync_task);
         info!("Closing storage layer");
         if let Err(e) = storage.close().await {
             warn!("Storage close reported an error: {}", e);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,6 +9,7 @@ pub mod routes;
 // New modular server components
 pub mod builder;
 mod callbacks;
+mod config_sync;
 mod guardrails;
 pub mod http;
 mod http_listener;

--- a/src/server/routes/admin_openapi.rs
+++ b/src/server/routes/admin_openapi.rs
@@ -46,6 +46,10 @@ struct AdminControlPlaneRoute {
 #[cfg(test)]
 const ADMIN_CONTROL_PLANE_ROUTES: &[AdminControlPlaneRoute] = &[
     AdminControlPlaneRoute {
+        path: "/admin/routing/revision",
+        method: AdminMethod::Get,
+    },
+    AdminControlPlaneRoute {
         path: "/admin/openapi.json",
         method: AdminMethod::Get,
     },

--- a/src/server/routes/admin_providers.rs
+++ b/src/server/routes/admin_providers.rs
@@ -155,7 +155,8 @@ async fn create_provider(
         ));
     }
 
-    let mut candidate = (*state.pin_runtime().config).clone();
+    let runtime = state.pin_runtime();
+    let mut candidate = (*runtime.config).clone();
     if candidate
         .gateway
         .providers
@@ -173,7 +174,7 @@ async fn create_provider(
     candidate.gateway.providers.push(incoming);
     apply_and_persist(
         &state,
-        candidate,
+        (candidate, runtime.generation),
         actor,
         "create",
         Some(&created_name),
@@ -196,7 +197,8 @@ async fn update_provider(
     let name = path.into_inner();
     let patch = body.into_inner();
 
-    let mut candidate = (*state.pin_runtime().config).clone();
+    let runtime = state.pin_runtime();
+    let mut candidate = (*runtime.config).clone();
     let Some(index) = candidate
         .gateway
         .providers
@@ -225,7 +227,7 @@ async fn update_provider(
 
     apply_and_persist(
         &state,
-        candidate,
+        (candidate, runtime.generation),
         actor,
         "update",
         Some(&name),
@@ -275,7 +277,7 @@ async fn delete_provider(
     let before = public_providers(&runtime.config, &api_key_refs_from_live(&state).await);
     apply_and_persist(
         &state,
-        candidate,
+        (candidate, runtime.generation),
         actor,
         "delete",
         Some(&name),
@@ -287,7 +289,7 @@ async fn delete_provider(
 
 async fn apply_and_persist(
     state: &web::Data<AppState>,
-    candidate: Config,
+    candidate: (Config, u64),
     actor: String,
     operation: &str,
     focus: Option<&str>,
@@ -304,8 +306,8 @@ async fn apply_and_persist(
         refs.remove(name);
     }
 
-    let after = public_providers(&candidate, &refs);
-    match state.apply_runtime(candidate).await {
+    let after = public_providers(&candidate.0, &refs);
+    match state.apply_runtime_at(candidate.0, candidate.1).await {
         Ok(generation) => {
             let payload = json!({
                 "operation": operation,

--- a/src/server/routes/admin_providers.rs
+++ b/src/server/routes/admin_providers.rs
@@ -330,6 +330,9 @@ async fn apply_and_persist(
                 ));
             }
             emit_audit(state, &actor, generation, operation, payload).await;
+            if let Err(error) = state.notify_runtime_revision(generation).await {
+                return Ok(apply_failure_response(error));
+            }
             let provider =
                 focus.and_then(|name| after.into_iter().find(|provider| provider.name == name));
             Ok(HttpResponse::Ok().json(ProviderMutationResponse {

--- a/src/server/routes/admin_routing.rs
+++ b/src/server/routes/admin_routing.rs
@@ -36,6 +36,7 @@ pub(super) fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/admin/routing")
             .route("/inventory", web::get().to(routing_inventory))
+            .route("/revision", web::get().to(runtime_revision))
             .route(
                 "/policy",
                 web::get().to(super::admin_routing_policy::get_routing_policy),
@@ -341,6 +342,17 @@ fn configured_provider_reason(selector: &str) -> UnavailableReason {
         }
         _ => UnavailableReason::Unavailable,
     }
+}
+
+/// Node-local synchronization status for operators.
+async fn runtime_revision(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+) -> actix_web::Result<HttpResponse> {
+    if let Some(forbidden) = require_admin(&req, &state, "inspect runtime revision", ADMIN_ERROR) {
+        return Ok(forbidden);
+    }
+    Ok(HttpResponse::Ok().json(state.config_sync_status()))
 }
 
 #[cfg(test)]

--- a/src/server/routes/admin_routing_policy.rs
+++ b/src/server/routes/admin_routing_policy.rs
@@ -167,6 +167,9 @@ async fn apply_and_persist(
                 ));
             }
             emit_audit(state, &actor, generation, payload).await;
+            if let Err(error) = state.notify_runtime_revision(generation).await {
+                return Ok(apply_failure_response(error));
+            }
             Ok(HttpResponse::Ok().json(RoutingPolicyResponse {
                 success: true,
                 generation,

--- a/src/server/routes/admin_routing_policy.rs
+++ b/src/server/routes/admin_routing_policy.rs
@@ -135,17 +135,18 @@ pub(super) async fn put_routing_policy(
         candidate.gateway.model_aliases = model_aliases;
     }
 
-    apply_and_persist(&state, candidate, actor, before).await
+    apply_and_persist(&state, candidate, runtime.generation, actor, before).await
 }
 
 async fn apply_and_persist(
     state: &web::Data<AppState>,
     candidate: Config,
+    expected: u64,
     actor: String,
     before: RoutingPolicyView,
 ) -> actix_web::Result<HttpResponse> {
     let after = policy_from_config(&candidate);
-    match state.apply_runtime(candidate).await {
+    match state.apply_runtime_at(candidate, expected).await {
         Ok(generation) => {
             let payload = json!({
                 "diff": {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -41,7 +41,7 @@ use super::runtime::{build_response_cache, build_runtime_revision};
 #[derive(Clone)]
 pub struct AppState {
     /// Gateway configuration (atomically swappable by explicit callers)
-    pub config: AtomicValue<Config>,
+    pub config: Arc<AtomicValue<Config>>,
     /// Authentication system
     pub auth: Arc<crate::auth::AuthSystem>,
     /// Storage layer
@@ -64,8 +64,9 @@ pub struct AppState {
     pub audit_logger: Arc<AuditLogger>,
     /// IP policy consumed by the outer HTTP middleware.
     pub ip_access: Arc<IpAccessControl>,
-    runtime: AtomicValue<RuntimeRevision>,
-    apply_lock: Arc<Mutex<()>>,
+    pub(super) runtime: Arc<AtomicValue<RuntimeRevision>>,
+    pub(super) apply_lock: Arc<Mutex<()>>,
+    pub(super) config_sync: Option<Arc<super::config_sync::ConfigSync>>,
 }
 
 impl AppState {
@@ -112,7 +113,7 @@ impl AppState {
             storage.database.clone(),
         ))));
         Self {
-            config: AtomicValue::from(Arc::clone(&revision.config)),
+            config: Arc::new(AtomicValue::from(Arc::clone(&revision.config))),
             auth: Arc::new(auth),
             storage,
             pricing,
@@ -124,8 +125,9 @@ impl AppState {
             callbacks: RuntimeObservability::disabled(),
             audit_logger: Arc::new(AuditLogger::disabled()),
             ip_access: Arc::new(IpAccessControl::disabled()),
-            runtime: AtomicValue::new(revision),
+            runtime: Arc::new(AtomicValue::new(revision)),
             apply_lock: Arc::new(Mutex::new(())),
+            config_sync: None,
         }
     }
 
@@ -191,10 +193,18 @@ impl AppState {
     /// [`Self::config`] observe one consistent generation. Pricing is reused
     /// from [`Self::pricing`] rather than rebuilt.
     pub async fn apply_runtime(&self, candidate: Config) -> Result<u64> {
+        self.apply_runtime_at(candidate, self.pin_runtime().generation)
+            .await
+    }
+
+    pub(crate) async fn apply_runtime_at(&self, candidate: Config, expected: u64) -> Result<u64> {
         let _guard = self.apply_lock.lock().await;
-        let generation = self
-            .pin_runtime()
-            .generation
+        if self.pin_runtime().generation != expected {
+            return Err(GatewayError::Conflict(
+                "Runtime revision changed; reload configuration before retrying".into(),
+            ));
+        }
+        let generation = expected
             .checked_add(1)
             .ok_or_else(|| GatewayError::Config("runtime generation overflow".into()))?;
         let revision = build_runtime_revision(
@@ -203,11 +213,52 @@ impl AppState {
             Arc::clone(&self.pricing),
             Arc::clone(&self.storage.redis),
         )
-        .await?;
+        .await
+        .inspect_err(|_| {
+            if let Some(sync) = &self.config_sync {
+                sync.status.write().last_apply_error =
+                    Some("Runtime candidate validation/build failed".into());
+            }
+        })?;
+        if let Some(sync) = &self.config_sync {
+            let ciphertext = sync.encrypt(&revision.config, generation)?;
+            self.storage
+                .database
+                .commit_runtime_config(expected, ciphertext)
+                .await
+                .inspect_err(|_| {
+                    sync.status.write().last_sync_error =
+                        Some("Authoritative configuration commit failed".into());
+                })?;
+            sync.status.write().observed_revision = generation;
+        }
+        self.publish_runtime(revision);
+        if let Some(sync) = &self.config_sync {
+            sync.status.write().last_apply_error = None;
+            let published = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                self.storage.redis.publish(
+                    super::config_sync::REVISION_CHANNEL,
+                    &generation.to_string(),
+                ),
+            )
+            .await;
+            if !matches!(published, Ok(Ok(()))) {
+                sync.status.write().last_sync_error =
+                    Some("Revision committed but notification failed".into());
+                return Err(GatewayError::Storage(format!(
+                    "Runtime revision {generation} committed and applied, but notification failed; peers reconcile from the database"
+                )));
+            }
+            sync.status.write().last_sync_error = None;
+        }
+        Ok(generation)
+    }
+
+    pub(super) fn publish_runtime(&self, revision: RuntimeRevision) {
         let config = Arc::clone(&revision.config);
         self.runtime.store(revision);
         self.config.store_arc(config);
-        Ok(generation)
     }
 
     /// Load a snapshot of the current gateway configuration.

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -193,8 +193,11 @@ impl AppState {
     /// [`Self::config`] observe one consistent generation. Pricing is reused
     /// from [`Self::pricing`] rather than rebuilt.
     pub async fn apply_runtime(&self, candidate: Config) -> Result<u64> {
-        self.apply_runtime_at(candidate, self.pin_runtime().generation)
-            .await
+        let generation = self
+            .apply_runtime_at(candidate, self.pin_runtime().generation)
+            .await?;
+        self.notify_runtime_revision(generation).await?;
+        Ok(generation)
     }
 
     pub(crate) async fn apply_runtime_at(&self, candidate: Config, expected: u64) -> Result<u64> {
@@ -235,6 +238,13 @@ impl AppState {
         self.publish_runtime(revision);
         if let Some(sync) = &self.config_sync {
             sync.status.write().last_apply_error = None;
+        }
+        Ok(generation)
+    }
+
+    /// Notify only after callers have recorded the committed mutation's audit data.
+    pub(crate) async fn notify_runtime_revision(&self, generation: u64) -> Result<()> {
+        if let Some(sync) = &self.config_sync {
             let published = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 self.storage.redis.publish(
@@ -252,7 +262,7 @@ impl AppState {
             }
             sync.status.write().last_sync_error = None;
         }
-        Ok(generation)
+        Ok(())
     }
 
     pub(super) fn publish_runtime(&self, revision: RuntimeRevision) {

--- a/src/storage/database/entities/mod.rs
+++ b/src/storage/database/entities/mod.rs
@@ -34,3 +34,6 @@ pub use user::Entity as User;
 // UserSession is available but not currently used
 #[allow(unused_imports)]
 pub use user_session::Entity as UserSession;
+
+/// Encrypted authoritative runtime configuration.
+pub mod runtime_config;

--- a/src/storage/database/entities/runtime_config.rs
+++ b/src/storage/database/entities/runtime_config.rs
@@ -1,0 +1,17 @@
+use sea_orm::entity::prelude::*;
+
+/// Singleton authoritative runtime configuration. Payload is AES-GCM ciphertext.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "runtime_config")]
+pub struct Model {
+    /// Singleton key (1).
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: i32,
+    /// Monotonic compare-and-swap revision.
+    pub revision: i64,
+    /// None only before the first committed runtime mutation.
+    pub encrypted_payload: Option<String>,
+}
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/storage/database/migration/m20260908_000001_create_runtime_config.rs
+++ b/src/storage/database/migration/m20260908_000001_create_runtime_config.rs
@@ -1,0 +1,57 @@
+//! One authoritative encrypted runtime configuration with a monotonic revision.
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(RuntimeConfig::Table)
+                    .col(
+                        ColumnDef::new(RuntimeConfig::Id)
+                            .integer()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(RuntimeConfig::Revision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RuntimeConfig::EncryptedPayload)
+                            .text()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .exec_stmt(
+                Query::insert()
+                    .into_table(RuntimeConfig::Table)
+                    .columns([RuntimeConfig::Id, RuntimeConfig::Revision])
+                    .values_panic([1.into(), 0.into()])
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(RuntimeConfig::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum RuntimeConfig {
+    Table,
+    Id,
+    Revision,
+    EncryptedPayload,
+}

--- a/src/storage/database/migration/mod.rs
+++ b/src/storage/database/migration/mod.rs
@@ -18,6 +18,8 @@ mod m20260906_000001_create_request_ledger;
 mod m20260906_000002_create_provider_config_revisions;
 mod m20260906_000003_create_routing_policy_revisions;
 
+mod m20260908_000001_create_runtime_config;
+
 /// Database migrator for SeaORM
 pub struct Migrator;
 
@@ -77,6 +79,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260906_000001_create_request_ledger::Migration),
             Box::new(m20260906_000002_create_provider_config_revisions::Migration),
             Box::new(m20260906_000003_create_routing_policy_revisions::Migration),
+            Box::new(m20260908_000001_create_runtime_config::Migration),
         ]
     }
 }

--- a/src/storage/database/seaorm_db/mod.rs
+++ b/src/storage/database/seaorm_db/mod.rs
@@ -11,6 +11,7 @@ mod connection;
 mod provider_config_ops;
 mod request_ledger_ops;
 mod routing_policy_ops;
+mod runtime_config_ops;
 mod team_repository;
 #[cfg(test)]
 mod team_repository_tests;

--- a/src/storage/database/seaorm_db/runtime_config_ops.rs
+++ b/src/storage/database/seaorm_db/runtime_config_ops.rs
@@ -1,0 +1,34 @@
+use super::types::SeaOrmDatabase;
+use crate::storage::database::entities::runtime_config::{self, Column, Entity};
+use crate::utils::error::gateway_error::{GatewayError, Result};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
+
+impl SeaOrmDatabase {
+    /// Load the authoritative encrypted snapshot, including its revision.
+    pub async fn runtime_config(&self) -> Result<runtime_config::Model> {
+        Entity::find_by_id(1).one(&self.db).await?.ok_or_else(|| {
+            GatewayError::Storage("runtime configuration row is missing; run migrations".into())
+        })
+    }
+
+    /// Persist only if the caller built its candidate from the latest revision.
+    pub async fn commit_runtime_config(&self, expected: u64, ciphertext: String) -> Result<u64> {
+        let revision = i64::try_from(expected)
+            .ok()
+            .and_then(|v| v.checked_add(1))
+            .ok_or_else(|| GatewayError::Storage("runtime revision overflow".into()))?;
+        let result = Entity::update_many()
+            .col_expr(Column::Revision, Expr::value(revision))
+            .col_expr(Column::EncryptedPayload, Expr::value(ciphertext))
+            .filter(Column::Id.eq(1))
+            .filter(Column::Revision.eq(revision - 1))
+            .exec(&self.db)
+            .await?;
+        if result.rows_affected != 1 {
+            return Err(GatewayError::Conflict(
+                "Runtime revision changed; reload configuration before retrying".into(),
+            ));
+        }
+        Ok(revision as u64)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -500,6 +500,7 @@ mod tests {
     #[tokio::test]
     async fn test_storage_layer_creation() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig {
                 url: "postgresql://localhost:5432/test".to_string(),
                 max_connections: 5,
@@ -535,6 +536,7 @@ mod tests {
         let temp_dir = TempDir::new().expect("temp dir should be created");
         let configured_path = temp_dir.path().join("configured-files");
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig::default(),
             redis: RedisConfig::default(),
             files: FileStorageConfig {
@@ -567,6 +569,7 @@ mod tests {
     #[tokio::test]
     async fn default_storage_layer_runs_in_memory_sqlite_migrations() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig::default(),
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
@@ -589,6 +592,7 @@ mod tests {
     #[tokio::test]
     async fn configured_database_without_auto_migrate_requires_existing_schema() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig {
                 url: "sqlite::memory:".to_string(),
                 max_connections: 1,
@@ -620,6 +624,7 @@ mod tests {
     #[tokio::test]
     async fn configured_database_with_auto_migrate_runs_startup_migrations() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: sqlite_db_config(),
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
@@ -642,6 +647,7 @@ mod tests {
     #[tokio::test]
     async fn storage_layer_migrate_is_idempotent_after_startup_migration() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: DatabaseConfig::default(),
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),
@@ -689,6 +695,7 @@ mod tests {
     #[tokio::test]
     async fn redis_enabled_failing_without_allow_degraded_fails_startup() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: sqlite_db_config(),
             redis: unreachable_redis_config(false),
             files: FileStorageConfig::default(),
@@ -706,6 +713,7 @@ mod tests {
     #[tokio::test]
     async fn redis_enabled_failing_with_allow_degraded_continues_with_noop() {
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: sqlite_db_config(),
             redis: unreachable_redis_config(true),
             files: FileStorageConfig::default(),
@@ -730,6 +738,7 @@ mod tests {
             ..RedisConfig::default()
         };
         let config = StorageConfig {
+            config_sync_key_env: None,
             database: sqlite_db_config(),
             redis,
             files: FileStorageConfig::default(),

--- a/src/storage/redis/pubsub.rs
+++ b/src/storage/redis/pubsub.rs
@@ -1,62 +1,69 @@
-//! Redis Pub/Sub operations
-//!
-//! This module provides publish/subscribe messaging functionality.
-//! Subscription is stubbed out pending redis crate API stabilisation;
-//! only `publish` is fully operational.
-
-use super::pool::RedisPool;
+//! Redis global Pub/Sub, including subscriptions through Redis Cluster seeds.
+use super::pool::{RedisPool, cluster_seed_urls};
 use crate::utils::error::gateway_error::{GatewayError, Result};
+use futures::StreamExt;
 use redis::AsyncCommands;
+use std::time::Duration;
 
-/// Handle for an active Redis pub/sub subscription.
-///
-/// Subscription is currently disabled at the API level.  When the redis
-/// crate exposes a stable async subscribe API this type will be backed by
-/// a real `redis::aio::PubSub` handle.
+/// A dedicated async Pub/Sub connection.
 pub struct Subscription {
-    _placeholder: (),
+    pubsub: redis::aio::PubSub,
 }
 
 impl RedisPool {
     /// Publish a message to the given channel.
     pub async fn publish(&self, channel: &str, message: &str) -> Result<()> {
         if self.noop_mode {
-            return Ok(());
+            return Err(GatewayError::Storage("Redis Pub/Sub is unavailable".into()));
         }
-
         let mut conn = self.get_connection().await?;
-        if let Some(ref mut c) = conn.conn {
-            let _: () = c
-                .publish(channel, message)
-                .await
-                .map_err(GatewayError::from)?;
-        }
+        let c = conn
+            .conn
+            .as_mut()
+            .ok_or_else(|| GatewayError::Storage("Redis Pub/Sub is unavailable".into()))?;
+        let _: () = c.publish(channel, message).await?;
         Ok(())
     }
 
-    /// Subscribe to one or more Redis channels.
-    ///
-    /// Currently returns an error stub; re-enable once the redis crate
-    /// exposes a stable `async-std`/`tokio` subscribe interface.
-    pub async fn subscribe(&self, _channels: &[String]) -> Result<Subscription> {
+    /// Subscribe through any reachable seed. Global Pub/Sub propagates across cluster nodes.
+    pub async fn subscribe(&self, channels: &[String]) -> Result<Subscription> {
+        if self.noop_mode {
+            return Err(GatewayError::Storage("Redis Pub/Sub is unavailable".into()));
+        }
+        for seed in cluster_seed_urls(&self.config.url) {
+            let attempt = async {
+                let client = redis::Client::open(seed)?;
+                let mut pubsub = client.get_async_pubsub().await?;
+                pubsub.subscribe(channels).await?;
+                Ok::<_, redis::RedisError>(Subscription { pubsub })
+            };
+            if let Ok(Ok(subscription)) =
+                tokio::time::timeout(Duration::from_secs(self.config.connection_timeout), attempt)
+                    .await
+            {
+                return Ok(subscription);
+            }
+        }
         Err(GatewayError::Storage(
-            "PubSub subscribe is not yet implemented".to_string(),
+            "No Redis seed accepted the Pub/Sub subscription".into(),
         ))
     }
 }
 
 impl Subscription {
-    /// Receive the next pub/sub message.
-    ///
-    /// Stub — always returns an error until subscribe is implemented.
+    /// Wait for a message, failing explicitly when the connection closes.
     pub async fn next_message(&mut self) -> Result<redis::Msg> {
-        Err(GatewayError::Storage(
-            "PubSub subscribe is not yet implemented".to_string(),
-        ))
+        self.pubsub
+            .on_message()
+            .next()
+            .await
+            .ok_or_else(|| GatewayError::Storage("Redis subscription disconnected".into()))
     }
 
-    /// Unsubscribe from all channels.
+    /// Remove all subscriptions from this connection.
     pub async fn unsubscribe_all(&mut self) -> Result<()> {
+        self.pubsub.punsubscribe("*").await?;
+        self.pubsub.unsubscribe(&[] as &[String]).await?;
         Ok(())
     }
 }

--- a/src/storage/redis/tests.rs
+++ b/src/storage/redis/tests.rs
@@ -105,6 +105,7 @@ async fn cluster_mode_fails_to_connect_to_unreachable_seed() {
 #[tokio::test]
 async fn storage_unreachable_cluster_fails_startup_unless_degraded() {
     let mut config = StorageConfig {
+        config_sync_key_env: None,
         redis: unreachable_cluster_config(false),
         ..StorageConfig::default()
     };

--- a/src/storage/vector_startup_tests.rs
+++ b/src/storage/vector_startup_tests.rs
@@ -60,6 +60,7 @@ fn storage_with_vector(
     vector_db: Option<crate::config::models::file_storage::VectorDbConfig>,
 ) -> StorageConfig {
     StorageConfig {
+        config_sync_key_env: None,
         database: sqlite_db_config(),
         redis: RedisConfig::default(),
         files: FileStorageConfig::default(),

--- a/tests/integration/database_tests.rs
+++ b/tests/integration/database_tests.rs
@@ -72,6 +72,7 @@ mod tests {
 
     fn storage_config(database: DatabaseConfig) -> StorageConfig {
         StorageConfig {
+            config_sync_key_env: None,
             database,
             redis: RedisConfig::default(),
             files: FileStorageConfig::default(),


### PR DESCRIPTION
Runtime provider/routing changes now converge across gateway processes. PostgreSQL stores an AES-256-GCM authenticated snapshot with a monotonic compare-and-swap revision; Redis carries only the decimal revision ID. Each replica reloads the authoritative snapshot and atomically applies it, preserving its previous runtime on failure. Reconnect and periodic reconciliation recover missed notifications.

Opt in with `storage.config_sync_key_env` naming a dedicated shared encryption key. Node-local auth, listeners and storage settings stay outside the snapshot. `/admin/routing/revision` exposes active/observed revisions and sanitized errors through existing Admin authorization. Concurrent stale writers receive HTTP 409; notification failures explicitly identify an already committed revision.

Validation:
- `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings` passed.
- `REDIS_URL=... cargo test -- --test-threads=1` passed the full suite. Initial parallel execution hung in the existing embeddings cache integration test; its focused rerun and the full serial run passed. No assertions or test infrastructure were weakened.
- `cargo build --bin gateway --features postgres` passed.
- Two real gateway processes against PostgreSQL 16 and Redis 7 passed configuration convergence, wrong-key isolation, subscriber reconnect, ID-only payload capture, budget/admission/circuit checks and actual 600-second owner lease recovery. The reusable isolated CI suite is a separate PR for #1283.

Review follow-up:
- Reject Redis degraded mode when shared config is enabled; a permanently disabled pool cannot drive convergence.
- Persist sanitized revision records and emit audit events before notifying. A notification failure still reports the committed revision. Added a regression covering both provider and routing APIs.
- Preserve the specific sanitized sync failure in diagnostics.
- Retain one-second reconciliation intentionally: a single indexed singleton-row read per replica bounds recovery of missed notifications to one second while connected. No evidence of database load requires a new tuning surface or a longer inconsistency window.
- Full local formatting/check/clippy and serial test suite passed again after these fixes.

Review required before merge: dedicated secret-key loading and encrypted credential persistence, per repository SEC-11 human-review requirement. Setup and failure semantics are documented in `deployment/configuration-revisions/README.md`.

Fixes #1282
