### PR TITLE
fix(middleware): allowlist dashboard request-ledger and routing-policy assets

### DIFF
--- a/src/server/middleware/helpers.rs
+++ b/src/server/middleware/helpers.rs
@@ -101,6 +101,8 @@ pub fn is_public_route(path: &str) -> bool {
         "/admin/dashboard/providers.js",
         "/admin/dashboard/provider-health.js",
         "/admin/dashboard/routing-inventory.js",
+        "/admin/dashboard/request-ledger.js",
+        "/admin/dashboard/routing-policy.js",
         "/docs",
         "/openapi.json",
     ];

--- a/src/server/middleware/tests.rs
+++ b/src/server/middleware/tests.rs
@@ -99,6 +99,8 @@ fn test_is_public_route() {
     assert!(is_public_route("/admin/dashboard/providers.js"));
     assert!(is_public_route("/admin/dashboard/provider-health.js"));
     assert!(is_public_route("/admin/dashboard/routing-inventory.js"));
+    assert!(is_public_route("/admin/dashboard/request-ledger.js"));
+    assert!(is_public_route("/admin/dashboard/routing-policy.js"));
     // /metrics requires authentication (not in PUBLIC_ROUTES)
     assert!(!is_public_route("/metrics"));
     // Prefix bypass must be prevented
@@ -112,6 +114,8 @@ fn test_is_public_route() {
     assert!(!is_public_route(
         "/admin/dashboard/routing-inventory.js.map"
     ));
+    assert!(!is_public_route("/admin/dashboard/request-ledger.js.map"));
+    assert!(!is_public_route("/admin/dashboard/routing-policy.js.map"));
     assert!(!is_public_route("/healthz"));
     assert!(!is_public_route("/api/users"));
     assert!(!is_public_route("/v1/chat/completions"));


### PR DESCRIPTION
## Summary
- Add `/admin/dashboard/request-ledger.js` and `/admin/dashboard/routing-policy.js` to `PUBLIC_ROUTES` so browser `<script>` loads succeed when auth is enabled.
- Extend `test_is_public_route` with positive allowlist asserts and negative `.map` prefix-bypass asserts matching existing dashboard assets.

Closes #1338

## Test plan
- [x] `cargo test --lib server::middleware::tests::test_is_public_route --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (currently fails on pre-existing `is_retryable` deprecation in `ollama/runtime_tests.rs`, unrelated to this change)


Made with [Cursor](https://cursor.com)